### PR TITLE
feat: add sn_keccak

### DIFF
--- a/internal/chainid.go
+++ b/internal/chainid.go
@@ -1,4 +1,4 @@
-package chainid
+package internal
 
 import "github.com/ethereum/go-ethereum/common/hexutil"
 

--- a/internal/chainid_test.go
+++ b/internal/chainid_test.go
@@ -1,4 +1,4 @@
-package chainid
+package internal
 
 import "testing"
 

--- a/internal/sn_keccak.go
+++ b/internal/sn_keccak.go
@@ -1,4 +1,4 @@
-package sn_keccak
+package internal
 
 import "github.com/ethereum/go-ethereum/crypto"
 

--- a/internal/sn_keccak.go
+++ b/internal/sn_keccak.go
@@ -1,0 +1,15 @@
+package sn_keccak
+
+import "github.com/ethereum/go-ethereum/crypto"
+
+func SnKeccak(data []byte) []byte {
+	b := crypto.Keccak256(data)
+	// Extract most significant byte to bitmask last 6 bits
+	msb := b[0]
+	// Bitmask with 0000 0011 to remove last 6 bits
+	bitmask := uint8(3)
+	new_msb := []byte{msb & bitmask}
+	// Concatenate new most significant byte with remaining 31 bytes
+	res := append(new_msb, b[1:]...)
+	return res
+}

--- a/internal/sn_keccak_test.go
+++ b/internal/sn_keccak_test.go
@@ -1,0 +1,29 @@
+package sn_keccak
+
+import (
+	"github.com/ethereum/go-ethereum/common/hexutil"
+	"testing"
+)
+
+func TestSnKeccak(t *testing.T) {
+	derivedHash := hexutil.Encode(SnKeccak([]byte("hello")))
+	// Original value: 0x1c8aff950685c2ed4bc3174f3472287b56d9517b9c948127319a09a7a36deac8
+	expectedHash := "0x008aff950685c2ed4bc3174f3472287b56d9517b9c948127319a09a7a36deac8"
+	if derivedHash != expectedHash {
+		t.Errorf("Got %q, expected %q", derivedHash, expectedHash)
+	}
+
+	derivedHash2 := hexutil.Encode(SnKeccak([]byte("hello world")))
+	// Original value: 0x47173285a8d7341e5e972fc677286384f802f8ef42a5ec5f03bbfa254cb01fad
+	expectedHash2 := "0x03173285a8d7341e5e972fc677286384f802f8ef42a5ec5f03bbfa254cb01fad"
+	if derivedHash2 != expectedHash2 {
+		t.Errorf("Got %q, expected %q", derivedHash2, expectedHash2)
+	}
+
+	derivedHash3 := hexutil.Encode(SnKeccak([]byte("constructor")))
+	// Original value: 0x968ffe4ff0f226a9107253e17a904099aa4f63a02a5621de0576e5aa71bc5194
+	expectedHash3 := "0x028ffe4ff0f226a9107253e17a904099aa4f63a02a5621de0576e5aa71bc5194"
+	if derivedHash3 != expectedHash3 {
+		t.Errorf("Got %q, expected %q", derivedHash3, expectedHash3)
+	}
+}

--- a/internal/sn_keccak_test.go
+++ b/internal/sn_keccak_test.go
@@ -1,4 +1,4 @@
-package sn_keccak
+package internal
 
 import (
 	"github.com/ethereum/go-ethereum/common/hexutil"


### PR DESCRIPTION
Closes #30 

As per [Starknet's documentation](https://starknet.io/documentation/transaction-structure-and-hash/):
`The sn_keccak function is a keccak function, with the result masked to 250 bits.`

## Changes:
Add `sn_keccak`.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Other (please describe): 

## Testing
**Requires testing**

- [X] Yes
- [ ] No

**In case you checked yes, did you write tests??**

- [X] Yes
- [ ] No

**Comments about testing , should you have some** (optional)

NA

## Further comments (optional)

NA
