### PR TITLE
Implement NumberOfItems for the KeyValueDb

### DIFF
--- a/pkg/crypto/weierstrass/weierstrass.go
+++ b/pkg/crypto/weierstrass/weierstrass.go
@@ -389,6 +389,7 @@ func GenerateKey(
 		pvt[1] ^= 0x42
 
 		// If the scalar is out of range, sample another random number.
+		// notest
 		if new(big.Int).SetBytes(pvt).Cmp(N) >= 0 {
 			continue
 		}

--- a/pkg/db/db.go
+++ b/pkg/db/db.go
@@ -152,8 +152,8 @@ func (d *KeyValueDb) Delete(key []byte) error {
 	return err
 }
 
-// Count returns the number of items in the database.
-func (d *KeyValueDb) Count() (uint64, error) {
+// NumberOfItems returns the number of items in the database.
+func (d *KeyValueDb) NumberOfItems() (uint64, error) {
 	log.Default.Info("Getting the number of items in the database.")
 	stats, err := d.env.Stat()
 	if err != nil {

--- a/pkg/db/db_test.go
+++ b/pkg/db/db_test.go
@@ -32,7 +32,7 @@ func TestAddKey(t *testing.T) {
 // TestNumberOfItems Checks that in every moment the collection contains the right amount of items
 func TestNumberOfItems(t *testing.T) {
 	database := setupDatabaseForTest(t.TempDir())
-	n, err := database.Count()
+	n, err := database.NumberOfItems()
 	if err != nil {
 		t.Log(err)
 		t.Fail()
@@ -51,7 +51,7 @@ func TestNumberOfItems(t *testing.T) {
 			return
 		}
 	}
-	n, err = database.Count()
+	n, err = database.NumberOfItems()
 	if err != nil {
 		t.Log(err)
 		t.Fail()
@@ -74,7 +74,7 @@ func TestAddMultipleKeys(t *testing.T) {
 			return
 		}
 	}
-	n, err := database.Count()
+	n, err := database.NumberOfItems()
 	if err != nil {
 		t.Log(err)
 		t.Fail()
@@ -220,6 +220,11 @@ func TestClose(t *testing.T) {
 	database.Close()
 }
 
+func TestKeyValueDbIsDatabaser(t *testing.T) {
+	a := new(KeyValueDb)
+	_ = Databaser(a)
+}
+
 // BenchmarkEntriesInDatabase Benchmark the entry of key-value pairs to the db
 func BenchmarkEntriesInDatabase(b *testing.B) {
 	database := setupDatabaseForTest(b.TempDir())
@@ -231,7 +236,7 @@ func BenchmarkEntriesInDatabase(b *testing.B) {
 			return
 		}
 	}
-	n, err := database.Count()
+	n, err := database.NumberOfItems()
 	if err != nil {
 		b.Errorf("Benchmarking fails, error getting the number of items: %s\n", err)
 		b.Fail()


### PR DESCRIPTION
## Changes:
I saw (working on another problem) that `KeyValueDb` is not implementing the `Databaser` interface and I think it should. The reason is that `KeyValueDb` doesn't have the `NumberOfItems` function, but it does have the `Count` function, with the same functionality, so I just rename it.
- Rename the struct method `Count` to `NumberOfItems` to achieve the `Databaser` interface
- Add a new test to check the `KeyValueDb` implements the `Databaser` interface

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Other (please describe): 

## Testing
**Requires testing**

- [x] Yes
- [ ] No

**In case you checked yes, did you write tests??**

- [x] Yes
- [ ] No