### PR TITLE
Test for Pedersen hash limit

### DIFF
--- a/pkg/crypto/pedersen/pedersen_test.go
+++ b/pkg/crypto/pedersen/pedersen_test.go
@@ -65,6 +65,25 @@ func TestDigest(t *testing.T) {
 	}
 }
 
+func TestDigestLimit(t *testing.T) {
+	var tests = [...]string{
+		"800000000000011000000000000000000000000000000000000000000000001",
+		"80000000000001100000000000000000000000000000000000000024b8b90c3",
+		"90000000000001100000000000000000000000000000000000000024b8b90c3",
+		"80000000000001100000000000000300000000000000000000000024b8b90c3",
+	}
+	for _, test := range tests {
+		a, ok := new(big.Int).SetString(test, 16)
+		if !ok {
+			t.Error("error decoding hex-string")
+		}
+		_, err := Digest(a)
+		if err != ErrInvalid {
+			t.Errorf("expected error %s for Digest(%s) because is out of the limits", ErrInvalid, a)
+		}
+	}
+}
+
 func initBenchmarkArrayDigest() {
 	// max = 2**252 - 1
 	max := new(big.Int)


### PR DESCRIPTION
## Changes:
- Add a new test case to the Pedersen hash function (`Digest` function in the `pedersen` package) to check the limit of the input values. The limit is `3618502788666131213697322783095070105623107215331596699973092056135872020481` or 2²⁵¹ + 17·2¹⁹² + 1

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] Other (please describe): Add new test case

## Testing
**Requires testing**

- [ ] Yes
- [x] No

**In case you checked yes, did you write tests??**

- [ ] Yes
- [ ] No
