### PR TITLE
fix: use correct value for P in pedersen benchmark (#151)

### DIFF
--- a/pkg/crypto/pedersen/pedersen_test.go
+++ b/pkg/crypto/pedersen/pedersen_test.go
@@ -3,17 +3,11 @@ package pedersen
 import (
 	"fmt"
 	"math/big"
+	"math/rand"
 	"testing"
+
+	"github.com/NethermindEth/juno/pkg/crypto/weierstrass"
 )
-
-// FIXME: See initBenchmarkArrayDigest below.
-/*
-var benchmarkArrayDigestData []*big.Int
-
-func init() {
-	initBenchmarkArrayDigest()
-}
-*/
 
 // BenchmarkDigest runs a benchmark on the Digest function by hashing a
 // *big.Int with a value of 0 N times.
@@ -62,25 +56,19 @@ func TestDigest(t *testing.T) {
 	}
 }
 
-// FIXME: Some values generated here are outside 𝔽ₚ.
-/*
-func initBenchmarkArrayDigest() {
-	// max = 2**252 - 1
-	max := new(big.Int)
-	max.Exp(big.NewInt(2), big.NewInt(252), nil).Sub(max, big.NewInt(1))
-	// Building a batch of 20 random big.Int between 0 and 2**252-1.
-	for i := 0; i < 20; i++ {
-		value := new(big.Int).Rand(rand.New(rand.NewSource(1)), max)
-		benchmarkArrayDigestData = append(benchmarkArrayDigestData, value)
-	}
-}
-
 func BenchmarkArrayDigest(b *testing.B) {
-	for i := 0; i < b.N; i++ {
-		ArrayDigest(benchmarkArrayDigestData...)
+	max := weierstrass.Stark().Params().P
+	data := make([]*big.Int, 20)
+	for i := range data {
+		data[i] = new(big.Int).Rand(rand.New(rand.NewSource(1)), max)
 	}
+
+	b.Run("-", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			ArrayDigest(data...)
+		}
+	})
 }
-*/
 
 func TestArrayDigest(t *testing.T) {
 	var tests = [...]struct {


### PR DESCRIPTION
Fixes #151 

## Changes:
- Fix array digest benchmark to use correct maximum value
- Replaced the global setup with a sub-benchmark

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [X ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Other (please describe): 

## Testing
**Requires testing**

- [ ] Yes
- [X ] No

**In case you checked yes, did you write tests??**

- [ ] Yes
- [ ] No