### PR TITLE
fix: build mdbx properly (#152)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,4 @@
+export CC = clang
 .DEFAULT_GOAL 	:= help
 
 compile: ## compile:


### PR DESCRIPTION
Fixes #152 

## Changes:
- Add `export CC = clang` to the Makefile.

## Types of changes

- [X] Build related changes

## Testing

- [ ] Yes
- [X] No

## Further comments (optional)

See the [mdbx-go README](https://github.com/torquem-ch/mdbx-go/tree/96f31f483af593377e52358a079e834256d5af55#build) for more details.