### PR TITLE
refactor: export `trie.Node`

### DIFF
--- a/pkg/trie/node.go
+++ b/pkg/trie/node.go
@@ -7,28 +7,28 @@ import (
 	"github.com/NethermindEth/juno/pkg/crypto/pedersen"
 )
 
-// encoding represents the encoding of a node in a binary tree
+// Encoding represents the Encoding of a node in a binary tree
 // represented by the triplet (length, path, bottom).
-type encoding struct {
+type Encoding struct {
 	Length uint8    `json:"length"`
 	Path   *big.Int `json:"path"`
 	Bottom *big.Int `json:"bottom"`
 }
 
-// node represents a node in a binary tree.
-type node struct {
-	encoding
+// Node represents a Node in a binary tree.
+type Node struct {
+	Encoding
 	Hash *big.Int `json:"hash"`
 }
 
 // bytes returns a JSON byte representation of a node.
-func (n *node) bytes() []byte {
+func (n *Node) bytes() []byte {
 	b, _ := json.Marshal(n)
 	return b
 }
 
 // hash updates the node hash.
-func (n *node) hash() {
+func (n *Node) hash() {
 	if n.Length == 0 {
 		n.Hash = new(big.Int).Set(n.Bottom)
 		return

--- a/pkg/trie/trie.go
+++ b/pkg/trie/trie.go
@@ -88,18 +88,18 @@ func (t *Trie) remove(key []byte) {
 
 // retrieve gets a node from storage and returns true if the node was
 // found.
-func (t *Trie) retrieve(key []byte) (node, bool) {
+func (t *Trie) retrieve(key []byte) (Node, bool) {
 	if len(key) == 0 {
 		key = []byte("root")
 	}
 	b, ok := t.store.Get(key)
 	if !ok {
-		return node{}, false
+		return Node{}, false
 	}
-	var n node
+	var n Node
 	if err := json.Unmarshal(b, &n); err != nil {
 		// notest
-		return node{}, false
+		return Node{}, false
 	}
 	return n, true
 }
@@ -119,16 +119,16 @@ func (t *Trie) diff(key *big.Int) {
 			t.remove(parent)
 		} else {
 			// Overwrite the parent node.
-			n := new(node)
+			n := new(Node)
 
 			// Compute its encoding.
 			switch {
 			case !rightChildIsNotEmpty:
-				n.encoding = encoding{
+				n.Encoding = Encoding{
 					leftChild.Length + 1, leftChild.Path, new(big.Int).Set(leftChild.Bottom),
 				}
 			case !leftChildIsNotEmpty:
-				n.encoding = encoding{
+				n.Encoding = Encoding{
 					rightChild.Length + 1,
 					rightChild.Path.Add(
 						rightChild.Path,
@@ -138,7 +138,7 @@ func (t *Trie) diff(key *big.Int) {
 					new(big.Int).Set(rightChild.Bottom),
 				}
 			default:
-				n.encoding = encoding{
+				n.Encoding = Encoding{
 					0, new(big.Int), pedersen.Digest(leftChild.Hash, rightChild.Hash),
 				}
 			}
@@ -187,8 +187,7 @@ func (t *Trie) Put(key, val *big.Int) {
 	// copy with the bits reversed is used instead.
 	rev := Reversed(key, t.keyLen)
 
-	leaf := node{encoding: encoding{0, new(big.Int), val}}
-	leaf.hash()
+	leaf := Node{Encoding{0, new(big.Int), val}, val}
 	t.commit(Prefix(rev, t.keyLen), leaf.bytes())
 	t.diff(rev)
 }

--- a/pkg/trie/trie_test.go
+++ b/pkg/trie/trie_test.go
@@ -194,7 +194,7 @@ func TestPut(t *testing.T) {
 				}
 				t.Fatalf("failed to retrieve value with key %s from database", pre)
 			}
-			var n node
+			var n Node
 			if err := json.Unmarshal(got, &n); err != nil {
 				t.Fatal("failed to unmarshal value from database")
 			}


### PR DESCRIPTION
## Changes:

- Exports the `trie.Node` type so that it can be used outside the trie package.

## Types of changes

- [x] Refactoring (no functional changes, no api changes)

## Testing
**Requires testing**

- [x] Yes
- [ ] No

**In case you checked yes, did you write tests??**

- [x] Yes
- [ ] No
