### PR TITLE
Get block by number

### DIFF
--- a/internal/db/block/block_test.go
+++ b/internal/db/block/block_test.go
@@ -36,14 +36,24 @@ func TestManager_PutBlock(t *testing.T) {
 	for _, block := range blocks {
 		key := block.Hash
 		manager.PutBlock(key, block)
-		returnedBlock := manager.GetBlock(key)
+		// Get block by hash
+		returnedBlock := manager.GetBlockByHash(key)
 		if returnedBlock == nil {
 			t.Errorf("unexpected nil after search for block with hash %s", hex.EncodeToString(block.Hash))
 		}
 		if !equalData(t, block, returnedBlock) {
 			t.Errorf("block")
 		}
+		// Get block by number
+		returnedBlock = manager.GetBlockByNumber(block.BlockNumber)
+		if returnedBlock == nil {
+			t.Errorf("unexpected nil after search for block with number %d", block.BlockNumber)
+		}
+		if !equalData(t, block, returnedBlock) {
+			t.Errorf("block")
+		}
 	}
+	manager.Close()
 }
 
 func equalData(t *testing.T, a, b *Block) bool {

--- a/internal/db/block/manager.go
+++ b/internal/db/block/manager.go
@@ -1,6 +1,7 @@
 package block
 
 import (
+	"encoding/binary"
 	"github.com/NethermindEth/juno/internal/db"
 	"google.golang.org/protobuf/proto"
 )
@@ -15,13 +16,41 @@ func NewManager(database db.Databaser) *Manager {
 	return &Manager{database: database}
 }
 
-// GetBlock search the block with the given block hash. If the block does not
-// exist then returns nil. If any error happens, then panic.
-func (manager *Manager) GetBlock(blockHash []byte) *Block {
-	rawResult, err := manager.database.Get(blockHash)
+// GetBlockByHash search the block with the given block hash. If the block does
+// not exist then returns nil. If any error happens, then panic.
+func (manager *Manager) GetBlockByHash(blockHash []byte) *Block {
+	// Build the hash key
+	hashKey := buildHashKey(blockHash)
+	// Search on the database
+	rawResult, err := manager.database.Get(hashKey)
 	if err != nil {
 		panic(any(err))
 	}
+	// Unmarshal the data
+	block := &Block{}
+	err = proto.Unmarshal(rawResult, block)
+	if err != nil {
+		panic(any(err))
+	}
+	return block
+}
+
+// GetBlockByNumber search the block with the given block number. If the block
+// does not exist then returns nil. If any error happens, then panic.
+func (manager *Manager) GetBlockByNumber(blockNumber uint64) *Block {
+	// Build the number key
+	numberKey := buildNumberKey(blockNumber)
+	// Search for the hash key
+	hashKey, err := manager.database.Get(numberKey)
+	if err != nil {
+		panic(any(err))
+	}
+	// Search for the block
+	rawResult, err := manager.database.Get(hashKey)
+	if err != nil {
+		panic(any(err))
+	}
+	// Unmarshal the data
 	block := &Block{}
 	err = proto.Unmarshal(rawResult, block)
 	if err != nil {
@@ -33,11 +62,22 @@ func (manager *Manager) GetBlock(blockHash []byte) *Block {
 // PutBlock saves the given block with the given hash as key. If any error happens
 // then panic.
 func (manager *Manager) PutBlock(blockHash []byte, block *Block) {
+	// Build the keys
+	hashKey := buildHashKey(blockHash)
+	numberKey := buildNumberKey(block.BlockNumber)
+	// Encode the block as []byte
 	rawValue, err := proto.Marshal(block)
 	if err != nil {
 		panic(any(err))
 	}
-	err = manager.database.Put(blockHash, rawValue)
+	// TODO: Use transaction?
+	// Save (hashKey, block)
+	err = manager.database.Put(hashKey, rawValue)
+	if err != nil {
+		panic(any(err))
+	}
+	// Save (hashNumber, hashKey)
+	err = manager.database.Put(numberKey, hashKey)
 	if err != nil {
 		panic(any(err))
 	}
@@ -45,4 +85,14 @@ func (manager *Manager) PutBlock(blockHash []byte, block *Block) {
 
 func (manager *Manager) Close() {
 	manager.database.Close()
+}
+
+func buildHashKey(blockHash []byte) []byte {
+	return append([]byte("blockHash:"), blockHash...)
+}
+
+func buildNumberKey(blockNumber uint64) []byte {
+	numberB := make([]byte, 8)
+	binary.BigEndian.PutUint64(numberB, blockNumber)
+	return append([]byte("block_number:"), numberB...)
 }

--- a/internal/services/block.go
+++ b/internal/services/block.go
@@ -60,17 +60,30 @@ func (s *blockService) Close(ctx context.Context) {
 	s.manager.Close()
 }
 
-// GetBlock searches for the block associated with the given block hash. If the
-// block does not exist on the database, then returns nil.
-func (s *blockService) GetBlock(blockHash []byte) *block.Block {
+// GetBlockByHash searches for the block associated with the given block hash.
+// If the block does not exist on the database, then returns nil.
+func (s *blockService) GetBlockByHash(blockHash []byte) *block.Block {
 	s.AddProcess()
 	defer s.DoneProcess()
 
 	s.logger.
 		With("blockHash", blockHash).
-		Debug("GetBlock")
+		Debug("GetBlockByHash")
 
-	return s.manager.GetBlock(blockHash)
+	return s.manager.GetBlockByHash(blockHash)
+}
+
+// GetBlockByNumber searches for the block associated with the given block
+// number. If the block does not exist on the database, then returns nil.
+func (s *blockService) GetBlockByNumber(blockNumber uint64) *block.Block {
+	s.AddProcess()
+	defer s.DoneProcess()
+
+	s.logger.
+		With("blockNumber", blockNumber).
+		Debug("GetBlockByNumber")
+
+	return s.manager.GetBlockByNumber(blockNumber)
 }
 
 // StoreBlock stores the given block into the database. The key used to map the

--- a/internal/services/block_test.go
+++ b/internal/services/block_test.go
@@ -42,9 +42,18 @@ func TestService(t *testing.T) {
 	for _, b := range blocks {
 		key := b.Hash
 		BlockService.StoreBlock(key, b)
-		returnedBlock := BlockService.GetBlock(key)
+		// Get block by hash
+		returnedBlock := BlockService.GetBlockByHash(key)
 		if returnedBlock == nil {
 			t.Errorf("unexpected nil after search for block with hash %s", hex.EncodeToString(b.Hash))
+		}
+		if !equalData(t, b, returnedBlock) {
+			t.Errorf("b")
+		}
+		// Get block by number
+		returnedBlock = BlockService.GetBlockByNumber(b.BlockNumber)
+		if returnedBlock == nil {
+			t.Errorf("unexpected nil after search for block with number %d", b.BlockNumber)
 		}
 		if !equalData(t, b, returnedBlock) {
 			t.Errorf("b")


### PR DESCRIPTION
Resolves #179

## Changes:
- Rename the `GetBlock` function to `GetBlockByHash`.
- Implement the `GetBlockByNumber` function on the blocks' manager and service.
- The database has two types of keys:
  - `hashKey`, with the form: `blockHash:<hashBytes>`, where `<hashBytes>` is the binary representation of the block hash `Felt`. This key has a block as the associated value.
  - `numberKey`, with the form: `blockNumber:<numberBytes>`, where `<numberBytes>` is the binary representation, in big-endian notation, of the block number. This key has the `hashKey` of the block as the associated value.

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Testing
**Requires testing**

- [x] Yes

**In case you checked yes, did you write tests??**

- [x] Yes