### PR TITLE
Remove notest from files on test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,6 +33,7 @@ codecov-test:
 	mkdir -p coverage
 	@cd internal/db && $(MAKE) add-notest
 	courtney/courtney -v -o coverage/coverage.out ./...
+	@cd internal/db && $(MAKE) rm-notest
 
 gomod_tidy: ## add missing and remove unused modules
 	 go mod tidy

--- a/internal/db/Makefile
+++ b/internal/db/Makefile
@@ -11,3 +11,6 @@ generate:
 
 add-notest:
 	find . -name '*.pb.go' -exec sh -c "awk '/func/ { print \"// notest\"; }; 1;' {} > tmp_file && mv tmp_file {}" \;
+
+rm-notest:
+	find . -name '*.pb.go' -exec sh -c "awk '!/\/\/ notest/' {} > tmp_file && mv tmp_file {}" \;


### PR DESCRIPTION
After the execution of `make codecov-test` we remove all the `\\ notest` lines on the autogenerated files