### PR TITLE
Fix type cast bug

### DIFF
--- a/pkg/rpc/types.go
+++ b/pkg/rpc/types.go
@@ -96,11 +96,11 @@ func (x *BlockNumberOrTag) UnmarshalJSON(data []byte) error {
 	}
 	switch t := token.(type) {
 	case float64:
-		blockNumber := uint64(t)
-		if blockNumber < 0 {
+		if t < 0 {
 			// notest
 			return errors.New("invalid block number")
 		}
+		blockNumber := uint64(t)
 		*x = BlockNumberOrTag{Number: &blockNumber}
 	case string:
 		// notest


### PR DESCRIPTION
Fixes #243

If we expect the complete rpc refactoring to be complete in the near future, this can be closed.

## Changes:
- Properly cast `float64` to `uint64`

## Types of changes

What types of changes does your code introduce?

- [X] Bugfix (non-breaking change which fixes an issue)

## Testing
**Requires testing**

- [ ] Yes
- [X] No
