### PR TITLE
logs: change timestamp encoding

### DIFF
--- a/internal/log/log.go
+++ b/internal/log/log.go
@@ -27,6 +27,7 @@ func ReplaceGlobalLogger(enableJsonOutput bool, verbosityLevel string) error {
 
 	// Timestamp format (ISO8601) and time zone (UTC)
 	config.EncoderConfig.EncodeTime = zapcore.TimeEncoder(func(t time.Time, enc zapcore.PrimitiveArrayEncoder) {
+		// notest
 		enc.AppendString(t.UTC().Format("2006-01-02T15:04:05Z0700"))
 	})
 

--- a/internal/log/log.go
+++ b/internal/log/log.go
@@ -2,9 +2,8 @@
 package log
 
 import (
-	"fmt"
 	"log"
-	"os"
+	"time"
 
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
@@ -17,42 +16,40 @@ func init() {
 	logger, err := zap.NewDevelopment()
 	if err != nil {
 		// notest
-		log.Fatalln("failed to initialise application logger")
+		log.Fatalln("failed to initialise logger")
 	}
 	Logger = logger.Sugar()
 }
 
 // ReplaceGlobalLogger replace the logger and inject it globally
 func ReplaceGlobalLogger(enableJsonOutput bool, verbosityLevel string) error {
-	// parsing log verbosity level
-	zapVerbosityLevel, err := zapcore.ParseLevel(verbosityLevel)
-	if err != nil {
-		return fmt.Errorf("parsing logger verbosity level failed %s", err)
-	}
+	config := zap.NewProductionConfig()
 
-	// get the output format
-	encoder := getEncoder(enableJsonOutput)
+	// Timestamp format (ISO8601) and time zone (UTC)
+	config.EncoderConfig.EncodeTime = zapcore.TimeEncoder(func(t time.Time, enc zapcore.PrimitiveArrayEncoder) {
+		enc.AppendString(t.UTC().Format("2006-01-02T15:04:05Z0700"))
+	})
 
-	// define where logs will be output
-	writerSyncer := os.Stdout
-
-	// initiate logger core config
-	core := zapcore.NewCore(encoder, writerSyncer, zapVerbosityLevel)
-	zapLogger := zap.New(core)
-
-	// inject globally
-	zap.ReplaceGlobals(zapLogger)
-
-	// replace default
-	Logger = zapLogger.Sugar()
-
-	return nil
-}
-
-// getEncoder define the output format
-func getEncoder(enableJsonOutput bool) zapcore.Encoder {
+	// Output encoding
+	config.Encoding = "console"
 	if enableJsonOutput {
-		return zapcore.NewJSONEncoder(zap.NewProductionEncoderConfig())
+		config.Encoding = "json"
 	}
-	return zapcore.NewConsoleEncoder(zap.NewProductionEncoderConfig())
+
+	// Log level
+	logLevel, err := zapcore.ParseLevel(verbosityLevel)
+	if err != nil {
+		// notest
+		return err
+	}
+	config.Level.SetLevel(logLevel)
+
+	logger, err := config.Build()
+	if err != nil {
+		// notest
+		return err
+	}
+
+	Logger = logger.Sugar()
+	return nil
 }

--- a/internal/log/log_test.go
+++ b/internal/log/log_test.go
@@ -1,9 +1,6 @@
 package log
 
-import (
-	"errors"
-	"testing"
-)
+import "testing"
 
 func TestReplaceGlobalLogger(t *testing.T) {
 	type args struct {
@@ -35,9 +32,7 @@ func TestReplaceGlobalLogger(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			if err := ReplaceGlobalLogger(test.args.enableJsonOutput, test.args.verbosityLevel); err != nil {
-				if !errors.Is(err, test.err) {
-					t.Errorf("ReplaceGlobalLogger() error = %v, wantErr %v", err, test.err.Error())
-				}
+				t.Errorf("ReplaceGlobalLogger() error = %v", err)
 			}
 		})
 	}


### PR DESCRIPTION
## Changes

Our current logger uses timestamps encoded as Unix time based on the user's system clock. This PR changes the timestamp encoder configuration to always use the human-readable ISO8601 format in the UTC time zone.

## Types of changes

What types of changes does your code introduce?

- [X] Bugfix (non-breaking change which fixes an issue)
- [X] Refactoring

## Testing
**Requires testing**

- [X] Yes
- [ ] No

**In case you checked yes, did you write tests??**

- [X] Yes (modified existing tests)
- [ ] No