### PR TITLE
upgrade node version for Docusaurus v2.0

### DIFF
--- a/.github/workflows/docs-prod-deploy.yml
+++ b/.github/workflows/docs-prod-deploy.yml
@@ -13,7 +13,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v1
         with:
-          node-version: '14.x'
+          node-version: '16.14'
       - name: Test Build
         run: |
           cd docs
@@ -35,7 +35,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v1
         with:
-          node-version: '14.x'
+          node-version: '16.14'
       - uses: webfactory/ssh-agent@v0.5.0
         with:
           ssh-private-key: ${{ secrets.GH_PAGES_DEPLOY }}


### PR DESCRIPTION
Necessary to upgrade node version in GH actions to fix docusaurus