### PR TITLE
Ci/gh pages

### DIFF
--- a/.github/workflows/docs-prod-deploy.yml
+++ b/.github/workflows/docs-prod-deploy.yml
@@ -44,7 +44,6 @@ jobs:
           USE_SSH: true
           GIT_USER: git
           CURRENT_BRANCH: ${{ secrets.CURRENT_BRANCH }}
-          DEPLOYMENT_BRANCH: ${{ secrets.DEPLOYMENT_BRANCH }}
           TARGET_URL: "http://gojuno.xyz/"
           BASE_URL: "/"
         run: |

--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -18,6 +18,7 @@ const config = {
     // If you aren't using GitHub pages, you don't need these.
     organizationName: 'NethermindEth', // Usually your GitHub org/user name.
     projectName: 'juno', // Usually your repo name.
+    deploymentBranch: 'gh-pages',
 
     // Even if you don't use internalization, you can use this field to set useful
     // metadata like html lang. For example, if your site is Chinese, you may want

--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -19,6 +19,7 @@ const config = {
     organizationName: 'NethermindEth', // Usually your GitHub org/user name.
     projectName: 'juno', // Usually your repo name.
     deploymentBranch: 'gh-pages',
+    trailingslash: false,
 
     // Even if you don't use internalization, you can use this field to set useful
     // metadata like html lang. For example, if your site is Chinese, you may want


### PR DESCRIPTION
## Changes:
- Makes the deployment branch explicit in the docusaurus config and removes the corresponding variable from the gh-pages configuration.
- Configures [trailingSlash](https://docusaurus.io/docs/deployment#docusaurusconfigjs-settings) (probably not directly causing issues at this time, but it is recommended by docusarus for GitHub pages). 

## Types of changes

- [X] Documentation Update
- [X] Build related changes

## Testing
**Requires testing**

- [X] Yes
- [ ] No

**In case you checked yes, did you write tests??**

- [X] Yes ...? I ran `yarn start` on machine and the website seems to build fine.
- [ ] No

What is the best way to test gh-actions (and specifically the documentation site deployment)? I think issue #285 is relevant here. 