### PR TITLE
Update RPC Felt regexp

### DIFF
--- a/internal/rpc/starknet/utils.go
+++ b/internal/rpc/starknet/utils.go
@@ -10,7 +10,7 @@ import (
 )
 
 var (
-	feltRegexp = regexp.MustCompile(`^0x[a-fA-F0-9]{1,63}$`)
+	feltRegexp = regexp.MustCompile(`^0x0[a-fA-F0-9]{1,63}$`)
 	blockTags  = map[string]any{
 		"latest":  nil,
 		"pending": nil,


### PR DESCRIPTION
## Changes:
- Update the RPC Felt regexp to `^0x0[a-fA-F0-9]{1,63}$`, matching with the Starkware spec

## Testing
**Requires testing**

- [x] No