### PR TITLE
Fix missing class_hash field

### DIFF
--- a/internal/sync/sync.go
+++ b/internal/sync/sync.go
@@ -526,6 +526,7 @@ func feederTransactionToDBTransaction(info *feeder.TransactionInfo) types.IsTran
 		return &types.TransactionDeploy{
 			Hash:                new(felt.Felt).SetHex(info.Transaction.TransactionHash),
 			ContractAddress:     new(felt.Felt).SetHex(info.Transaction.ContractAddress),
+			ClassHash:           new(felt.Felt).SetHex(info.Transaction.ClassHash),
 			ConstructorCallData: calldata,
 		}
 	}


### PR DESCRIPTION
The sync process doesn't set the class_hash field to deploy transactions

## Changes:
- Set the `ClassHash` value on the feeder gateway type initialization 

## Types of changes

What types of changes does your code introduce?

- Bugfix (non-breaking change which fixes an issue)

## Testing
**Requires testing**: No
