### PR TITLE
shutdown on error

### DIFF
--- a/cmd/juno/main.go
+++ b/cmd/juno/main.go
@@ -221,7 +221,7 @@ func juno(cfg *config.Juno) {
 	}
 
 	// Wait until error
-	checkErrChs(errChs)
+	checkErrChs(errChs, cfg)
 }
 
 func setupVirtualMachine() {
@@ -390,11 +390,11 @@ func shutdown(cfg *config.Juno) {
 	}
 }
 
-func checkErrChs(errChs []chan error) {
+func checkErrChs(errChs []chan error, cfg *config.Juno) {
 	for _, errCh := range errChs {
 		for {
 			if err := <-errCh; err != nil {
-				Logger.Fatal(err)
+				shutdown(cfg)
 			}
 		}
 	}


### PR DESCRIPTION
Resolves https://github.com/NethermindEth/juno/issues/336

## Description

If an error is caught in [checkErrChs](https://github.com/NethermindEth/juno/blob/7735bff86b9e243266dbe6070a329a949409bda0/cmd/juno/main.go#L397), we immediately exit with a log message. This PR is meant to allow it to exit cleanly without a trace

## Types of changes

- Bugfix (non-breaking change which fixes an issue)


