### PR TITLE
Sync time improve

### DIFF
--- a/cmd/juno/main.go
+++ b/cmd/juno/main.go
@@ -157,6 +157,7 @@ func loadConfig(cmd *cobra.Command, configFile *string) error {
 	v.AddConfigPath(filepath.Dir(*configFile))
 	v.SetConfigType("yaml")
 	v.SetConfigName(filepath.Base(*configFile))
+	fmt.Printf("Loading config from %s\n", *configFile)
 
 	if err := v.ReadInConfig(); err != nil {
 		if _, ok := err.(viper.ConfigFileNotFoundError); !ok {

--- a/internal/sync/sync.go
+++ b/internal/sync/sync.go
@@ -133,6 +133,7 @@ func (s *Synchronizer) sync() error {
 		if err != nil || s.state.Root().Cmp(stateDiff.NewRoot) != 0 {
 			// In case some errors exist or the new root of the trie didn't match with
 			// the root we receive from the StateDiff, we have to revert the trie
+			s.logger.With("Error", err).Error("State update failed, reverting state")
 			prometheus.IncreaseCountStarknetStateFailed()
 			s.setStateToLatestRoot()
 			return err
@@ -200,24 +201,24 @@ func (s *Synchronizer) updateState(stateDiff *types.StateDiff) error {
 
 func (s *Synchronizer) SetCode(stateDiff *types.StateDiff, deployedContract types.DeployedContract) error {
 	// Get Full Contract
-	contractFromApi, err := s.feeder.GetFullContractRaw(deployedContract.Address.Hex0x(), "",
-		strconv.FormatInt(stateDiff.BlockNumber, 10))
-	if err != nil {
-		s.logger.With("Block Number", stateDiff.BlockNumber,
-			"Contract Address", deployedContract.Address.Hex0x()).
-			Error("Error getting full contract")
-		return err
-	}
-
-	contract := new(types.Contract)
-	err = contract.UnmarshalRaw(contractFromApi)
-	if err != nil {
-		s.logger.With("Block Number", stateDiff.BlockNumber,
-			"Contract Address", deployedContract.Address.Hex0x()).
-			Error("Error unmarshalling contract")
-		return err
-	}
-	err = s.state.SetContract(deployedContract.Address, deployedContract.Hash, contract)
+	//contractFromApi, err := s.feeder.GetFullContractRaw(deployedContract.Address.Hex0x(), "",
+	//	strconv.FormatInt(stateDiff.BlockNumber, 10))
+	//if err != nil {
+	//	s.logger.With("Block Number", stateDiff.BlockNumber,
+	//		"Contract Address", deployedContract.Address.Hex0x()).
+	//		Error("Error getting full contract")
+	//	return err
+	//}
+	//
+	//contract := new(types.Contract)
+	//err = contract.UnmarshalRaw(contractFromApi)
+	//if err != nil {
+	//	s.logger.With("Block Number", stateDiff.BlockNumber,
+	//		"Contract Address", deployedContract.Address.Hex0x()).
+	//		Error("Error unmarshalling contract")
+	//	return err
+	//}
+	err := s.state.SetContract(deployedContract.Address, deployedContract.Hash, deployedContract.Code)
 	if err != nil {
 		s.logger.With("Block Number", stateDiff.BlockNumber,
 			"Contract Address", deployedContract.Address).

--- a/internal/sync/sync.go
+++ b/internal/sync/sync.go
@@ -2,6 +2,7 @@ package sync
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"math"
 	"math/big"
@@ -181,7 +182,7 @@ func (s *Synchronizer) Status() *types.SyncStatus {
 
 func (s *Synchronizer) updateState(stateDiff *types.StateDiff) error {
 	for _, deployedContract := range stateDiff.DeployedContracts {
-		err := s.SetCode(stateDiff, deployedContract)
+		err := s.SetCode(stateDiff, &deployedContract)
 		if err != nil {
 			return err
 		}
@@ -199,7 +200,7 @@ func (s *Synchronizer) updateState(stateDiff *types.StateDiff) error {
 	return nil
 }
 
-func (s *Synchronizer) SetCode(stateDiff *types.StateDiff, deployedContract types.DeployedContract) error {
+func (s *Synchronizer) SetCode(stateDiff *types.StateDiff, deployedContract *types.DeployedContract) error {
 	// Get Full Contract
 	//contractFromApi, err := s.feeder.GetFullContractRaw(deployedContract.Address.Hex0x(), "",
 	//	strconv.FormatInt(stateDiff.BlockNumber, 10))
@@ -218,6 +219,10 @@ func (s *Synchronizer) SetCode(stateDiff *types.StateDiff, deployedContract type
 	//		Error("Error unmarshalling contract")
 	//	return err
 	//}
+	if deployedContract == nil {
+		ErrorNotDeployedContract := errors.New("contract not deployed")
+		return ErrorNotDeployedContract
+	}
 	err := s.state.SetContract(deployedContract.Address, deployedContract.Hash, deployedContract.Code)
 	if err != nil {
 		s.logger.With("Block Number", stateDiff.BlockNumber,

--- a/pkg/feeder/feeder.go
+++ b/pkg/feeder/feeder.go
@@ -58,10 +58,9 @@ func NewClient(baseURL, baseAPI string, client *HttpClient) *Client {
 		for i := 0; i < 10; i++ {
 			res, err = httpClient.Do(req)
 			if res.StatusCode == http.StatusOK {
-				Logger.Info("Successful request")
 				return res, err
 			}
-			Logger.With("Waiting:", wait.Seconds()).Info("Waiting to do again a request")
+			Logger.With("Waiting:", wait.Seconds()).Error("Waiting to do again a request")
 			time.Sleep(wait)
 			wait = wait * 2
 		}

--- a/pkg/feeder/feeder.go
+++ b/pkg/feeder/feeder.go
@@ -67,8 +67,7 @@ func NewClient(baseURL, baseAPI string, client *HttpClient) *Client {
 		return res, err
 	}
 
-	available := make(chan bool, 2)
-	available <- true
+	available := make(chan bool, 1)
 	available <- true
 	return &Client{BaseURL: u, BaseAPI: baseAPI, httpClient: client, retryFuncForDoReq: retryFuncForDoReq, available: available}
 }

--- a/pkg/feeder/feeder.go
+++ b/pkg/feeder/feeder.go
@@ -57,7 +57,7 @@ func NewClient(baseURL, baseAPI string, client *HttpClient) *Client {
 		wait := 5 * time.Second
 		for i := 0; err != nil && i < 10; i++ {
 			res, err = httpClient.Do(req)
-			if err == nil {
+			if res.StatusCode == http.StatusOK {
 				return res, nil
 			}
 			fmt.Println("Waiting to do again a request:", wait.Seconds())

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -46,6 +46,7 @@ type DeployedContract struct {
 	Address             *felt.Felt   `json:"address"`
 	Hash                *felt.Felt   `json:"contract_hash"`
 	ConstructorCallData []*felt.Felt `json:"constructor_call_data"`
+	Code                *Contract
 }
 
 type StorageDiff map[string][]MemoryCell


### PR DESCRIPTION
## Description

To perform a sync, we needed to execute one call to the API for each deployed contract. 

After this PR gets merged, this call to the feeder is going to be performed in the collection of the State Diffs.

## Changes:

- Move fetching of Full Contract Definition to collectors
- Improve feeder cadence

## Types of changes

_Leave only items that describe your changes, remove the rest. Remove this line too._

- Refactoring (no functional changes, no api changes)

## Testing

**Requires testing**: No

**Did you write tests??**: No

## Documentation

**If this requires a documentation update, did you add one?** No

