### PR TITLE
[sync] solve error around starting block Number

### DIFF
--- a/internal/db/sync/manager.go
+++ b/internal/db/sync/manager.go
@@ -168,20 +168,13 @@ func (m *Manager) GetBlockOfProcessedEvent(starknetFact int64) int64 {
 }
 
 // StoreStateDiff stores the state diff for the given block.
-func (m *Manager) StoreStateDiff(stateDiff *types.StateDiff, blockHash string) {
+func (m *Manager) StoreStateDiff(stateDiff *types.StateDiff) {
 	// Get the key we will use to store the state diff
 	key := []byte(strconv.FormatInt(stateDiff.BlockNumber, 10))
 	// Marshal the state diff
 	value, err := json.Marshal(stateDiff)
 	if err != nil {
 		panic(any(fmt.Errorf("%w: %s", UnmarshalError, err.Error())))
-	}
-
-	// Store the stateDiff key using a blockHash
-	key2 := append(stateDiffPrefix, []byte(blockHash)...)
-	err = m.database.Put(key2, key)
-	if err != nil {
-		panic(any(fmt.Errorf("%w: %s", DbError, err.Error())))
 	}
 
 	// Store the state diff

--- a/internal/db/sync/manager.go
+++ b/internal/db/sync/manager.go
@@ -206,26 +206,6 @@ func (m *Manager) GetStateDiff(blockNumber int64) *types.StateDiff {
 	return stateDiff
 }
 
-func (m *Manager) GetStateDiffFromHash(blockHash string) *types.StateDiff {
-	// Query to database
-	key := append(stateDiffPrefix, []byte(blockHash)...)
-	data, err := m.database.Get(key)
-	if err != nil {
-		// notest
-		if errors.Is(err, db.ErrNotFound) {
-			return nil
-		}
-		panic(any(fmt.Errorf("%w: %s", DbError, err)))
-	}
-	// Unmarshal the data from database
-	blockNumber := new(int64)
-	if err := json.Unmarshal(data, blockNumber); err != nil {
-		// notest
-		panic(any(fmt.Errorf("%w: %s", UnmarshalError, err.Error())))
-	}
-	return m.GetStateDiff(*blockNumber)
-}
-
 // Close closes the Manager.
 func (m *Manager) Close() {
 	m.database.Close()

--- a/internal/db/sync/manager_test.go
+++ b/internal/db/sync/manager_test.go
@@ -136,5 +136,13 @@ func TestStateDiff(t *testing.T) {
 		t.Errorf("State diff was not stored correctly.")
 	}
 
+	// Check that the state diff is stored correctly.
+	retrievedStateDiff = manager.GetStateDiff(stateDiff.BlockNumber)
+
+	// Check that the state diff is stored correctly.
+	if !reflect.DeepEqual(retrievedStateDiff, stateDiff) {
+		t.Errorf("State diff was not stored correctly.")
+	}
+
 	manager.Close()
 }

--- a/internal/db/sync/manager_test.go
+++ b/internal/db/sync/manager_test.go
@@ -126,7 +126,7 @@ func TestStateDiff(t *testing.T) {
 	}
 
 	// Store the state diff.
-	manager.StoreStateDiff(stateDiff, "0x123")
+	manager.StoreStateDiff(stateDiff)
 
 	// Check that the state diff is stored correctly.
 	retrievedStateDiff := manager.GetStateDiff(1)
@@ -136,9 +136,5 @@ func TestStateDiff(t *testing.T) {
 		t.Errorf("State diff was not stored correctly.")
 	}
 
-	retrievedStateDiffByHash := manager.GetStateDiffFromHash("0x123")
-	if !reflect.DeepEqual(retrievedStateDiffByHash, stateDiff) {
-		t.Errorf("State diff was not stored correctly.")
-	}
 	manager.Close()
 }

--- a/internal/rpc/starknet/starknet.go
+++ b/internal/rpc/starknet/starknet.go
@@ -60,7 +60,7 @@ func (s *StarkNetRpc) GetStateUpdate(blockId *BlockId) (any, error) {
 	switch blockId.idType {
 	case blockIdHash:
 		hash, _ := blockId.hash()
-		return s.synchronizer.GetStateDiffFromFelt(hash), nil
+		return s.synchronizer.GetStateDiffFromHash(hash), nil
 	case blockIdNumber:
 		number, _ := blockId.number()
 		return s.synchronizer.GetStateDiff(int64(number)), nil

--- a/internal/rpc/starknet/starknet.go
+++ b/internal/rpc/starknet/starknet.go
@@ -60,7 +60,7 @@ func (s *StarkNetRpc) GetStateUpdate(blockId *BlockId) (any, error) {
 	switch blockId.idType {
 	case blockIdHash:
 		hash, _ := blockId.hash()
-		return s.synchronizer.GetStateDiffFromHash(hash.Hex()), nil
+		return s.synchronizer.GetStateDiffFromFelt(hash), nil
 	case blockIdNumber:
 		number, _ := blockId.number()
 		return s.synchronizer.GetStateDiff(int64(number)), nil

--- a/internal/sync/sync.go
+++ b/internal/sync/sync.go
@@ -245,7 +245,6 @@ func (s *Synchronizer) GetStateDiff(blockNumber int64) *types.StateDiff {
 }
 
 func (s *Synchronizer) GetStateDiffFromFelt(blockHash *felt.Felt) *types.StateDiff {
-
 	block, err := s.blockManager.GetBlockByHash(blockHash)
 	if err != nil {
 		return nil

--- a/internal/sync/sync.go
+++ b/internal/sync/sync.go
@@ -244,8 +244,13 @@ func (s *Synchronizer) GetStateDiff(blockNumber int64) *types.StateDiff {
 	return s.syncManager.GetStateDiff(blockNumber)
 }
 
-func (s *Synchronizer) GetStateDiffFromHash(blockHash string) *types.StateDiff {
-	return s.syncManager.GetStateDiffFromHash(blockHash)
+func (s *Synchronizer) GetStateDiffFromFelt(blockHash *felt.Felt) *types.StateDiff {
+
+	block, err := s.blockManager.GetBlockByHash(blockHash)
+	if err != nil {
+		return nil
+	}
+	return s.syncManager.GetStateDiff(int64(block.BlockNumber))
 }
 
 func (s *Synchronizer) LatestBlockSynced() (blockNumber int64, blockHash *felt.Felt) {

--- a/internal/sync/sync.go
+++ b/internal/sync/sync.go
@@ -152,16 +152,8 @@ func (s *Synchronizer) sync() error {
 			collectedDiff.stateDiff.OldRoot = new(felt.Felt).SetHex(s.syncManager.GetLatestStateRoot())
 		}
 		s.syncManager.StoreLatestStateRoot(s.state.Root().Hex0x())
-		s.syncManager.StoreStateDiff(collectedDiff.stateDiff, s.latestBlockHashSynced.Hex0x())
+		s.syncManager.StoreStateDiff(collectedDiff.stateDiff)
 		s.latestBlockNumberSynced = collectedDiff.stateDiff.BlockNumber
-
-		// Used to keep a track of where the sync started
-		if s.startingBlockHash == "" {
-			s.startingBlockNumber = collectedDiff.stateDiff.BlockNumber
-			s.startingBlockHash = s.latestBlockHashSynced.Hex0x()
-		}
-		s.syncManager.StoreStateDiff(stateDiff)
-		s.latestBlockNumberSynced = stateDiff.BlockNumber
 	}
 	return nil
 }

--- a/internal/sync/sync.go
+++ b/internal/sync/sync.go
@@ -236,7 +236,7 @@ func (s *Synchronizer) GetStateDiff(blockNumber int64) *types.StateDiff {
 	return s.syncManager.GetStateDiff(blockNumber)
 }
 
-func (s *Synchronizer) GetStateDiffFromFelt(blockHash *felt.Felt) *types.StateDiff {
+func (s *Synchronizer) GetStateDiffFromHash(blockHash *felt.Felt) *types.StateDiff {
 	block, err := s.blockManager.GetBlockByHash(blockHash)
 	if err != nil {
 		return nil

--- a/internal/sync/sync_test.go
+++ b/internal/sync/sync_test.go
@@ -56,6 +56,7 @@ func TestStatus(t *testing.T) {
 		blockManager:            blockdb.NewManager(blockDb),
 		latestBlockNumberSynced: blockNumber,
 		stateDiffCollector:      m,
+		startingBlockNumber:     blockNumber,
 	}
 	s.syncManager.StoreLatestBlockSaved(blockNumber)
 	block := &types.Block{
@@ -70,7 +71,7 @@ func TestStatus(t *testing.T) {
 	}
 
 	want := &types.SyncStatus{
-		StartingBlockHash:   s.startingBlockHash,
+		StartingBlockHash:   "0x0000000000000000000000000000000000000000000000000000000000000000",
 		StartingBlockNumber: fmt.Sprintf("%x", s.startingBlockNumber),
 		CurrentBlockHash:    block.BlockHash.Hex0x(),
 		CurrentBlockNumber:  fmt.Sprintf("%x", block.BlockNumber),

--- a/internal/sync/utils.go
+++ b/internal/sync/utils.go
@@ -64,7 +64,7 @@ func loadAbiOfContract(abiVal string) (abi.ABI, error) {
 func fetchContractCode(stateDiff *types.StateDiff, client *feeder.Client, logger *zap.SugaredLogger) *CollectorDiff {
 	collectedDiff := &CollectorDiff{
 		stateDiff: stateDiff,
-		Code:      map[string]*types.Contract{},
+		Code:      make(map[string]*types.Contract, 0),
 	}
 	for _, deployedContract := range stateDiff.DeployedContracts {
 		contractFromApi, err := client.GetFullContractRaw(deployedContract.Address.Hex0x(), "",

--- a/internal/sync/utils.go
+++ b/internal/sync/utils.go
@@ -64,6 +64,7 @@ func loadAbiOfContract(abiVal string) (abi.ABI, error) {
 func fetchContractCode(stateDiff *types.StateDiff, client *feeder.Client, logger *zap.SugaredLogger) *CollectorDiff {
 	collectedDiff := &CollectorDiff{
 		stateDiff: stateDiff,
+		Code:      map[string]*types.Contract{},
 	}
 	for _, deployedContract := range stateDiff.DeployedContracts {
 		contractFromApi, err := client.GetFullContractRaw(deployedContract.Address.Hex0x(), "",

--- a/internal/sync/utils.go
+++ b/internal/sync/utils.go
@@ -64,7 +64,7 @@ func loadAbiOfContract(abiVal string) (abi.ABI, error) {
 func fetchContractCode(stateDiff *types.StateDiff, client *feeder.Client, logger *zap.SugaredLogger) *CollectorDiff {
 	collectedDiff := &CollectorDiff{
 		stateDiff: stateDiff,
-		Code:      make(map[string]*types.Contract, 0),
+		Code:      make(map[string]*types.Contract, len(stateDiff.DeployedContracts)),
 	}
 	for _, deployedContract := range stateDiff.DeployedContracts {
 		contractFromApi, err := client.GetFullContractRaw(deployedContract.Address.Hex0x(), "",


### PR DESCRIPTION
Resolves #361 

## Description

Solve the problem that exists around the initial block fetched.

## Changes:

- Set as default that the minimum block synced and the current block synced, both are the minimum between the block and the state processed.
- Fix Syncing response on Sync

## Types of changes

- Bugfix (non-breaking change which fixes an issue)

## Testing

**Requires testing**: No

**Did you write tests??**: No


