### PR TITLE
Fix quit race condition for cmd package tests

### DIFF
--- a/cmd/juno/juno_test.go
+++ b/cmd/juno/juno_test.go
@@ -271,8 +271,10 @@ network: 1
 
 func quitTest() chan os.Signal {
 	exit := make(chan os.Signal, 1)
-	time.Sleep(15 * time.Millisecond)
-	exit <- syscall.SIGINT
+	go func() {
+		time.Sleep(1 * time.Millisecond)
+		exit <- syscall.SIGINT
+	}()
 	return exit
 }
 


### PR DESCRIPTION
## Description

The tests in cmd package need to send a quit signal through an `exit` channel
which simulates the user's behaviour to interrupt the juno. However, the test
also predicates that `Run()` of StarkNetNode must be called before 
`Shutdown()`.

If the test doesn't wait long enough before sending the quit signal, then the
order in which the functions are called changes. This then leads to some tests
failing. Therefore, tests become dependent on the performance of the computer
they are run on.

Also, in `quitTest()` the `time.Sleep()` should have been called in a separate 
go-routine. This lead to the `exit` channel containing the interrupt signal before 
`NewCmd()` is called. Leading to a race condition between `Run()` and `Shutdown()`. 

Increasing the quitting time and sleeping in a separate go-routine should fix 
the problem. We also don't want to unnecessarily increase the test time, since 
we want to have quick feedback.

- Bugfix (non-breaking change which fixes an issue)

## Testing

**Requires testing**: Yes

**Did you write tests??**: Yes

## Documentation

**If this requires a documentation update, did you add one?** No

