### PR TITLE
Reduce docker image size on build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ RUN go mod download
 
 RUN make juno
 
-# State 2: Build Python dependencies for Cairo
+# Stage 2: Build Python dependencies for Cairo
 FROM python:3.7.13-alpine as py_builder
 
 WORKDIR /app

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
-FROM golang:1.18-alpine as build
+# Stage 1: Build golang dependencies and binaries
+FROM golang:1.18-alpine as go_builder
 
 WORKDIR /app
 
@@ -12,20 +13,37 @@ RUN go mod download
 
 RUN make juno
 
-FROM python:3.7.13-alpine
+# State 2: Build Python dependencies for Cairo
+FROM python:3.7.13-alpine as py_builder
 
 WORKDIR /app
 
-COPY --from=build /app/build/juno /home/app/juno
-COPY --from=build /app/requirements.txt /req/requirements.txt
+COPY ./requirements.txt /req/requirements.txt
 
-RUN apk update && apk upgrade && apk add --update alpine-sdk && \
-    apk add --no-cache gmp-dev cmake gcc g++ linux-headers && pip install -r /req/requirements.txt
+# Install Python Dependencies
+RUN apk update && apk upgrade && apk add --update alpine-sdk && apk add --no-cache gmp-dev cmake gcc g++ linux-headers
 
-RUN addgroup -S appgroup && adduser -S app -G appgroup
-USER app
+# Install project Dependencies
+RUN pip --disable-pip-version-check install -r /req/requirements.txt
+ENV PY_PATH=/usr/local/lib/python3.7/
+RUN find ${PY_PATH} -type d -a -name test -exec rm -rf '{}' + \
+    && find ${PY_PATH} -type d -a -name tests  -exec rm -rf '{}' + \
+    && find ${PY_PATH} -type f -a -name '*.pyc' -exec rm -rf '{}' + \
+    && find ${PY_PATH} -type f -a -name '*.pyo' -exec rm -rf '{}' +
+
+# Stage 3: Build Docker Image
+FROM python:3.7.13-alpine as runtime
+
+COPY --from=py_builder /usr/local/lib/python3.7/site-packages /usr/local/lib/python3.7/site-packages
+COPY --from=go_builder /app/build/juno /home/app/juno
+
 ENV HOME /home/app
+RUN addgroup -S appgroup && adduser -S app -G appgroup
+RUN apk add --no-cache gmp-dev gcc g++ linux-headers
+USER app
 
-EXPOSE  8080
+EXPOSE 6060
+EXPOSE 9090
 ENTRYPOINT ["/home/app/juno"]
+
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -31,7 +31,7 @@ RUN find ${PY_PATH} -type d -a -name test -exec rm -rf '{}' + \
     && find ${PY_PATH} -type f -a -name '*.pyc' -exec rm -rf '{}' + \
     && find ${PY_PATH} -type f -a -name '*.pyo' -exec rm -rf '{}' +
 
-# Stage 3: Build Docker Image
+# Stage 3: Build Docker image
 FROM python:3.7.13-alpine as runtime
 
 COPY --from=py_builder /usr/local/lib/python3.7/site-packages /usr/local/lib/python3.7/site-packages

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,7 @@ COPY ./requirements.txt /req/requirements.txt
 # Install Python Dependencies
 RUN apk update && apk upgrade && apk add --update alpine-sdk && apk add --no-cache gmp-dev cmake gcc g++ linux-headers
 
-# Install project Dependencies
+# Install project dependencies
 RUN pip --disable-pip-version-check install -r /req/requirements.txt
 ENV PY_PATH=/usr/local/lib/python3.7/
 RUN find ${PY_PATH} -type d -a -name test -exec rm -rf '{}' + \

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,7 @@ WORKDIR /app
 
 COPY ./requirements.txt /req/requirements.txt
 
-# Install Python Dependencies
+# Install Python dependencies
 RUN apk update && apk upgrade && apk add --update alpine-sdk && apk add --no-cache gmp-dev cmake gcc g++ linux-headers
 
 # Install project dependencies


### PR DESCRIPTION
## Description

Currently, the docker image has a size of almost `580MB`

```
juno                                new        3c4310b2103a   5 minutes ago   371MB
juno                                latest          ad813212fccf   4 days ago      586MB
```

## Changes:

- Reduce python dependencies on the image
- Add more stages to build making fewer layers

## Types of changes

_Leave only items that describe your changes, remove the rest. Remove this line too._

- Refactoring (no functional changes, no api changes)
- Build related changes
