### PR TITLE
Fix on nil pointer after connection broken with the Feeder gateway

### DIFF
--- a/internal/sync/sync.go
+++ b/internal/sync/sync.go
@@ -142,18 +142,18 @@ func (s *Synchronizer) sync() error {
 		}
 		prometheus.IncreaseCountStarknetStateSuccess()
 		prometheus.UpdateStarknetSyncTime(time.Since(start).Seconds())
-		s.logger.With(
-			"Number", collectedDiff.stateDiff.BlockNumber,
-			"Pending", int64(s.stateDiffCollector.LatestBlock().BlockNumber)-collectedDiff.stateDiff.BlockNumber,
-			"Time", time.Since(start),
-		).Info("Synchronized block")
+		s.syncManager.StoreStateDiff(collectedDiff.stateDiff)
 		s.syncManager.StoreLatestBlockSync(collectedDiff.stateDiff.BlockNumber)
 		if collectedDiff.stateDiff.OldRoot.Hex() == "" {
 			collectedDiff.stateDiff.OldRoot = new(felt.Felt).SetHex(s.syncManager.GetLatestStateRoot())
 		}
 		s.syncManager.StoreLatestStateRoot(s.state.Root().Hex0x())
-		s.syncManager.StoreStateDiff(collectedDiff.stateDiff)
 		s.latestBlockNumberSynced = collectedDiff.stateDiff.BlockNumber
+		s.logger.With(
+			"Number", collectedDiff.stateDiff.BlockNumber,
+			"Pending", int64(s.stateDiffCollector.LatestBlock().BlockNumber)-collectedDiff.stateDiff.BlockNumber,
+			"Time", time.Since(start),
+		).Info("Synchronized block")
 	}
 	return nil
 }

--- a/pkg/feeder/feeder.go
+++ b/pkg/feeder/feeder.go
@@ -54,13 +54,13 @@ func NewClient(baseURL, baseAPI string, client *HttpClient) *Client {
 	// retry mechanism for do requests
 	retryFuncForDoReq := func(req *http.Request, httpClient HttpClient) (*http.Response, error) {
 		var res *http.Response
-		wait := 5 * time.Second
-		for i := 0; ; i++ {
+		wait := 2 * time.Second
+		for {
 			res, err = httpClient.Do(req)
-			if err != nil || res.StatusCode != http.StatusOK {
+			if err != nil || res != nil || res.StatusCode != http.StatusOK {
+				wait *= 2
 				Logger.With("Waiting:", wait.Seconds(), "Error", err).Info("Waiting to do again a request")
 				time.Sleep(wait)
-				wait = wait * 2
 				continue
 			}
 			if res.StatusCode == http.StatusOK {

--- a/pkg/feeder/feeder.go
+++ b/pkg/feeder/feeder.go
@@ -196,7 +196,7 @@ func (c *Client) do(req *http.Request, v any) (*http.Response, error) {
 // otherwise. de-Marshals response into appropriate ByteCode and ABI structs.
 func (c *Client) doCodeWithABI(req *http.Request, v *CodeInfo) (*http.Response, error) {
 	metr.IncreaseABISent()
-	res, err := (*c.httpClient).Do(req)
+	res, err := c.retryFuncForDoReq(req, *c.httpClient)
 	if err != nil {
 		metr.IncreaseABIFailed()
 		return nil, err

--- a/pkg/feeder/feeder.go
+++ b/pkg/feeder/feeder.go
@@ -57,7 +57,7 @@ func NewClient(baseURL, baseAPI string, client *HttpClient) *Client {
 		wait := 2 * time.Second
 		for {
 			res, err = httpClient.Do(req)
-			if err != nil || res != nil || res.StatusCode != http.StatusOK {
+			if err != nil || res == nil || res.StatusCode != http.StatusOK {
 				wait *= 2
 				Logger.With("Waiting:", wait.Seconds(), "Error", err).Info("Waiting to do again a request")
 				time.Sleep(wait)

--- a/pkg/feeder/feeder.go
+++ b/pkg/feeder/feeder.go
@@ -57,7 +57,8 @@ func NewClient(baseURL, baseAPI string, client *HttpClient) *Client {
 		wait := 5 * time.Second
 		for i := 0; i < 10; i++ {
 			res, err = httpClient.Do(req)
-			if err != nil {
+			if err != nil || res.StatusCode != http.StatusOK {
+				Logger.With("Error", err, "StatusCode", res.StatusCode).Debug("Error connecting to the gateway.")
 				Logger.With("Waiting:", wait.Seconds()).Info("Waiting to do again a request")
 				time.Sleep(wait)
 				wait = wait * 2

--- a/pkg/feeder/feeder.go
+++ b/pkg/feeder/feeder.go
@@ -55,11 +55,10 @@ func NewClient(baseURL, baseAPI string, client *HttpClient) *Client {
 	retryFuncForDoReq := func(req *http.Request, httpClient HttpClient) (*http.Response, error) {
 		var res *http.Response
 		wait := 5 * time.Second
-		for i := 0; i < 10; i++ {
+		for i := 0; ; i++ {
 			res, err = httpClient.Do(req)
 			if err != nil || res.StatusCode != http.StatusOK {
-				Logger.With("Error", err, "StatusCode", res.StatusCode).Debug("Error connecting to the gateway.")
-				Logger.With("Waiting:", wait.Seconds()).Info("Waiting to do again a request")
+				Logger.With("Waiting:", wait.Seconds(), "Error", err).Info("Waiting to do again a request")
 				time.Sleep(wait)
 				wait = wait * 2
 				continue


### PR DESCRIPTION
Resolves #376 

## Description

After a connection was lost, a nil pointer error was thrown. With these changes, the nil pointer cause was deleted, and also changed the waiting iterator.

## Changes:

- Fix nil pointer error on logs after an error fetching from the feeder gateway
- Remove 10 times and check for requests to the feeder gateway, will be forever.

## Types of changes

_Leave only items that describe your changes, remove the rest. Remove this line too._

- Bugfix (non-breaking change which fixes an issue)

## Testing

**Requires testing**: No

**Did you write tests??**: No

## Documentation

**If this requires a documentation update, did you add one?** No

