### PR TITLE
Shutdown multiple sync go-routines gracefully

### DIFF
--- a/internal/juno/juno.go
+++ b/internal/juno/juno.go
@@ -181,12 +181,14 @@ func (n *Node) Run() error {
 }
 
 func (n *Node) Shutdown() error {
+	log.Logger.Info("Shutting down Juno...")
+	n.virtualMachine.Close()
+	n.synchronizer.Close()
+
 	n.stateManager.Close()
 	n.transactionManager.Close()
 	n.blockManager.Close()
-	n.stateManager.Close()
-	n.synchronizer.Close()
-	n.virtualMachine.Close()
+	n.syncManager.Close()
 
 	if err := n.rpcServer.Close(shutdownTimeout); err != nil {
 		return err


### PR DESCRIPTION
## Description

In the sync package, multiple go routines are started, however, they were not closed properly. Hence, when `synchroniser.Close()` was called those go-routines continued to run, which led to panic in the database as they would try to store/retrieve information.

A quit channel and select statement are used to ensure the go-routine exit when `synchroniser.Close()` is called.

## Types of changes

- Bugfix (non-breaking change which fixes an issue)

## Testing

**Requires testing**: Yes

**Did you write tests??**: No (manual tested)