### PR TITLE
Specify cairo-lang==0.9.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 grpcio
 grpcio-tools
-cairo-lang
+cairo-lang==0.9.1


### PR DESCRIPTION
## Description

For `starknet_call`, we need to specify which cairo-lang version we are using since the new `v0.10.0` introduces breaking changes.