### PR TITLE
Log local time using ANSIC format

### DIFF
--- a/internal/log/log.go
+++ b/internal/log/log.go
@@ -23,7 +23,7 @@ func SetGlobalLogger(verbosityLevel string) error {
 
 	// Timestamp format (ISO8601) and time zone (UTC)
 	config.EncoderConfig.EncodeTime = func(t time.Time, enc zapcore.PrimitiveArrayEncoder) {
-		enc.AppendString(t.UTC().Format("2006-01-02T15:04:05Z0700"))
+		enc.AppendString(t.Local().Format(time.ANSIC))
 	}
 
 	logLevel, err := zapcore.ParseLevel(verbosityLevel)

--- a/internal/log/log.go
+++ b/internal/log/log.go
@@ -21,7 +21,7 @@ func SetGlobalLogger(verbosityLevel string) error {
 	config.EncoderConfig.EncodeLevel = zapcore.CapitalColorLevelEncoder
 	config.Encoding = "console"
 
-	// Timestamp format (ISO8601) and time zone (UTC)
+	// Timestamp format (ANSIC) and time zone (local)
 	config.EncoderConfig.EncodeTime = func(t time.Time, enc zapcore.PrimitiveArrayEncoder) {
 		enc.AppendString(t.Local().Format(time.ANSIC))
 	}


### PR DESCRIPTION
## Description

The logger uses the local time using the ANSIC time format. Now the logs look like the following:

```
       _                    
      | |                   
      | |_   _ _ __   ___   
  _   | | | | | '_ \ / _ \  
 | |__| | |_| | | | | (_) |  
  \____/ \__,_|_| |_|\___/  

Juno is a Go implementation of a StarkNet full node client made with ❤️ by Nethermind.

Wed Aug 31 21:19:14 2022        INFO    juno/juno.go:87 Running Juno with config: {Verbosity:info RpcPort:6060 Metrics:false DatabasePath:config/localdb/goerli Network:goerli EthNode:}
Wed Aug 31 21:19:14 2022        INFO    Sync Service    sync/sync.go:76 Defaulting to syncing from gateway
Wed Aug 31 21:19:14 2022        INFO    rpc/http.go:35  Listening for JSON-RPC connections...
Wed Aug 31 21:19:14 2022        INFO    VM      cairovm/vm.go:139       gRPC server listening at 127.0.0.1:49678
Wed Aug 31 21:19:14 2022        INFO    apiCollector    sync/apiCollection.go:50        Collector Started
Wed Aug 31 21:19:16 2022        INFO    Sync Service    sync/sync.go:396        Updated block info      {"Block Number": 477}
Wed Aug 31 21:19:17 2022      INFO    rpc/http.go:49  Shutting down JSON-RPC server...

```

## Types of changes

- Other (please describe): UI change

## Testing

**Requires testing**: No