### PR TITLE
Return error when state root != root from StateDiff

### DIFF
--- a/internal/sync/sync.go
+++ b/internal/sync/sync.go
@@ -150,6 +150,9 @@ func (s *Synchronizer) sync() error {
 			if err != nil || s.state.Root().Cmp(collectedDiff.stateDiff.NewRoot) != 0 {
 				// In case some errors exist or the new root of the trie didn't match with
 				// the root we receive from the StateDiff, we have to revert the trie
+				if err == nil {
+					err = errors.New("incompatible state root")
+				}
 				s.logger.With("Error", err).Error("State update failed, reverting state")
 				prometheus.IncreaseCountStarknetStateFailed()
 				s.setStateToLatestRoot()

--- a/internal/sync/sync.go
+++ b/internal/sync/sync.go
@@ -24,6 +24,8 @@ import (
 	"go.uber.org/zap"
 )
 
+var errIncompatibleStateRoot = errors.New("incompatible state root")
+
 type Synchronizer struct {
 	// feeder is the client that will be used to fetch the data that comes from the Feeder Gateway.
 	feeder *feeder.Client
@@ -122,6 +124,10 @@ func (s *Synchronizer) handleSync() {
 	s.wg.Add(1)
 	for {
 		if err := s.sync(); err != nil {
+			if err == errIncompatibleStateRoot {
+				s.logger.Fatal(err)
+				break
+			}
 			s.logger.With("Error", err).Info("Sync Failed, restarting iterator in 10 seconds")
 			time.Sleep(10 * time.Second)
 			s.stateDiffCollector.Close()
@@ -151,7 +157,7 @@ func (s *Synchronizer) sync() error {
 				// In case some errors exist or the new root of the trie didn't match with
 				// the root we receive from the StateDiff, we have to revert the trie
 				if err == nil {
-					err = errors.New("incompatible state root")
+					err = errIncompatibleStateRoot
 				}
 				s.logger.With("Error", err).Error("State update failed, reverting state")
 				prometheus.IncreaseCountStarknetStateFailed()


### PR DESCRIPTION
## Description

If the user accidentally starts Juno with goerli database with mainnet option. The go-routine for state diff retrieval is stopped however go-routine for retrieving blocks keeps running. This is incorrect behaviour.

## Types of changes

- Bugfix (non-breaking change which fixes an issue)

## Testing

**Requires testing**: Yes

**Did you write tests??**: No
