### PR TITLE
RPC CORS

### DIFF
--- a/cmd/juno/juno.go
+++ b/cmd/juno/juno.go
@@ -23,27 +23,34 @@ Juno is a Go implementation of a StarkNet full node client made with ❤️ by N
 `
 
 const (
-	configF    = "config"
-	verbosityF = "verbosity"
-	rpcPortF   = "rpc-port"
-	metricsF   = "metrics"
-	dbPathF    = "db-path"
-	networkF   = "network"
-	ethNodeF   = "eth-node"
+	configF         = "config"
+	verbosityF      = "verbosity"
+	rpcPortF        = "rpc-port"
+	rpcCorsF        = "rpc-cors"
+	rpcCorsOriginsF = "rpc-cors-origins"
+	metricsF        = "metrics"
+	dbPathF         = "db-path"
+	networkF        = "network"
+	ethNodeF        = "eth-node"
 
-	defaultConfig    = ""
-	defaultVerbosity = "info"
-	defaultRpcPort   = uint16(6060)
-	defaultMetrics   = false
-	defaultDbPath    = ""
-	defaultNetwork   = utils.GOERLI
-	defaultEthNode   = ""
+	defaultConfig         = ""
+	defaultVerbosity      = "info"
+	defaultRpcPort        = uint16(6060)
+	defaultRpcCors        = false
+	defaultRpcCorsOrigins = "*"
+	defaultMetrics        = false
+	defaultDbPath         = ""
+	defaultNetwork        = utils.GOERLI
+	defaultEthNode        = ""
 
 	configFlagUsage    = "The yaml configuration file."
 	verbosityFlagUsage = "Verbosity of the logs. Options: debug, info, warn, error, dpanic, " +
 		"panic, fatal."
 	rpcPortUsage = "The port on which the RPC server will listen for requests. " +
 		"Warning: this exposes the node to external requests and potentially DoS attacks."
+	rpcCorsUsage        = "Whether to allow cross-origin requests to the RPC server."
+	rpcCorsOriginsUsage = "Comma-separated list of origins to allow cross-origin requests to the RPC server. " +
+		"If rpc-cors flag is not set to true, this flag is ignored."
 	metricsUsage = "Enables the metrics server and listens on port 9090."
 	dbPathUsage  = "Location of the database files."
 	networkUsage = "Available StarkNet networks. Options: 0 = goerli and 1 = mainnet"
@@ -65,6 +72,8 @@ func NewCmd(newNodeFn juno.NewStarkNetNodeFn, quit <-chan os.Signal) *cobra.Comm
 	junoCmd.Flags().StringVar(&cfgFile, configF, defaultConfig, configFlagUsage)
 	junoCmd.Flags().String(verbosityF, defaultVerbosity, verbosityFlagUsage)
 	junoCmd.Flags().Uint16(rpcPortF, defaultRpcPort, rpcPortUsage)
+	junoCmd.Flags().Bool(rpcCorsF, defaultRpcCors, rpcCorsUsage)
+	junoCmd.Flags().String(rpcCorsOriginsF, defaultRpcCorsOrigins, rpcCorsOriginsUsage)
 	junoCmd.Flags().Bool(metricsF, defaultMetrics, metricsUsage)
 	junoCmd.Flags().String(dbPathF, defaultDbPath, dbPathUsage)
 	junoCmd.Flags().Uint8(networkF, uint8(defaultNetwork), networkUsage)

--- a/cmd/juno/juno.go
+++ b/cmd/juno/juno.go
@@ -23,34 +23,30 @@ Juno is a Go implementation of a StarkNet full node client made with ❤️ by N
 `
 
 const (
-	configF         = "config"
-	verbosityF      = "verbosity"
-	rpcPortF        = "rpc-port"
-	rpcCorsF        = "rpc-cors"
-	rpcCorsOriginsF = "rpc-cors-origins"
-	metricsF        = "metrics"
-	dbPathF         = "db-path"
-	networkF        = "network"
-	ethNodeF        = "eth-node"
+	configF    = "config"
+	verbosityF = "verbosity"
+	rpcPortF   = "rpc-port"
+	rpcCorsF   = "rpc-cors"
+	metricsF   = "metrics"
+	dbPathF    = "db-path"
+	networkF   = "network"
+	ethNodeF   = "eth-node"
 
-	defaultConfig         = ""
-	defaultVerbosity      = "info"
-	defaultRpcPort        = uint16(6060)
-	defaultRpcCors        = false
-	defaultRpcCorsOrigins = "*"
-	defaultMetrics        = false
-	defaultDbPath         = ""
-	defaultNetwork        = utils.GOERLI
-	defaultEthNode        = ""
+	defaultConfig    = ""
+	defaultVerbosity = "info"
+	defaultRpcPort   = uint16(6060)
+	defaultRpcCors   = ""
+	defaultMetrics   = false
+	defaultDbPath    = ""
+	defaultNetwork   = utils.GOERLI
+	defaultEthNode   = ""
 
 	configFlagUsage    = "The yaml configuration file."
 	verbosityFlagUsage = "Verbosity of the logs. Options: debug, info, warn, error, dpanic, " +
 		"panic, fatal."
 	rpcPortUsage = "The port on which the RPC server will listen for requests. " +
 		"Warning: this exposes the node to external requests and potentially DoS attacks."
-	rpcCorsUsage        = "Allow cross-origin requests to the RPC server."
-	rpcCorsOriginsUsage = "Comma-separated list of origins to allow cross-origin requests to the RPC server. " +
-		"If rpc-cors flag is not set to true, this flag is ignored."
+	rpcCorsUsage = "Comma-separated list of origins to allow cross-origin requests to the RPC server."
 	metricsUsage = "Enables the metrics server and listens on port 9090."
 	dbPathUsage  = "Location of the database files."
 	networkUsage = "Available StarkNet networks. Options: 0 = goerli and 1 = mainnet"
@@ -72,8 +68,7 @@ func NewCmd(newNodeFn juno.NewStarkNetNodeFn, quit <-chan os.Signal) *cobra.Comm
 	junoCmd.Flags().StringVar(&cfgFile, configF, defaultConfig, configFlagUsage)
 	junoCmd.Flags().String(verbosityF, defaultVerbosity, verbosityFlagUsage)
 	junoCmd.Flags().Uint16(rpcPortF, defaultRpcPort, rpcPortUsage)
-	junoCmd.Flags().Bool(rpcCorsF, defaultRpcCors, rpcCorsUsage)
-	junoCmd.Flags().String(rpcCorsOriginsF, defaultRpcCorsOrigins, rpcCorsOriginsUsage)
+	junoCmd.Flags().String(rpcCorsF, defaultRpcCors, rpcCorsUsage)
 	junoCmd.Flags().Bool(metricsF, defaultMetrics, metricsUsage)
 	junoCmd.Flags().String(dbPathF, defaultDbPath, dbPathUsage)
 	junoCmd.Flags().Uint8(networkF, uint8(defaultNetwork), networkUsage)

--- a/cmd/juno/juno.go
+++ b/cmd/juno/juno.go
@@ -48,7 +48,7 @@ const (
 		"panic, fatal."
 	rpcPortUsage = "The port on which the RPC server will listen for requests. " +
 		"Warning: this exposes the node to external requests and potentially DoS attacks."
-	rpcCorsUsage        = "Whether to allow cross-origin requests to the RPC server."
+	rpcCorsUsage        = "Allow cross-origin requests to the RPC server."
 	rpcCorsOriginsUsage = "Comma-separated list of origins to allow cross-origin requests to the RPC server. " +
 		"If rpc-cors flag is not set to true, this flag is ignored."
 	metricsUsage = "Enables the metrics server and listens on port 9090."

--- a/cmd/juno/juno_test.go
+++ b/cmd/juno/juno_test.go
@@ -74,6 +74,8 @@ Juno is a Go implementation of a StarkNet full node client made with ❤️ by N
 		// implementation.
 		defaultVerbosity := "info"
 		defaultRpcPort := uint16(6060)
+		defaultRpcCors := false
+		defaultRpcCorsOrigins := "*"
 		defaultMetrics := false
 		defaultDbPath := ""
 		defaultNetwork := utils.GOERLI
@@ -89,21 +91,27 @@ Juno is a Go implementation of a StarkNet full node client made with ❤️ by N
 			"default config with no flags": {
 				inputArgs: []string{""},
 				expectedConfig: &juno.Config{
-					Verbosity:    defaultVerbosity,
-					RpcPort:      defaultRpcPort,
-					Metrics:      defaultMetrics,
-					DatabasePath: defaultDbPath,
-					Network:      defaultNetwork, EthNode: defaultEthNode,
+					Verbosity:      defaultVerbosity,
+					RpcPort:        defaultRpcPort,
+					RpcCors:        defaultRpcCors,
+					RpcCorsOrigins: defaultRpcCorsOrigins,
+					Metrics:        defaultMetrics,
+					DatabasePath:   defaultDbPath,
+					Network:        defaultNetwork,
+					EthNode:        defaultEthNode,
 				},
 			},
 			"config file path is empty string": {
 				inputArgs: []string{"--config", ""},
 				expectedConfig: &juno.Config{
-					Verbosity:    defaultVerbosity,
-					RpcPort:      defaultRpcPort,
-					Metrics:      defaultMetrics,
-					DatabasePath: defaultDbPath,
-					Network:      defaultNetwork, EthNode: defaultEthNode,
+					Verbosity:      defaultVerbosity,
+					RpcPort:        defaultRpcPort,
+					RpcCors:        defaultRpcCors,
+					RpcCorsOrigins: defaultRpcCorsOrigins,
+					Metrics:        defaultMetrics,
+					DatabasePath:   defaultDbPath,
+					Network:        defaultNetwork,
+					EthNode:        defaultEthNode,
 				},
 			},
 			"config file doesn't exist": {
@@ -114,28 +122,35 @@ Juno is a Go implementation of a StarkNet full node client made with ❤️ by N
 				cfgFile:         tempCfgFile,
 				cfgFileContents: "\n",
 				expectedConfig: &juno.Config{
-					Verbosity: defaultVerbosity,
-					RpcPort:   defaultRpcPort,
-					Metrics:   defaultMetrics,
-					Network:   defaultNetwork, EthNode: defaultEthNode,
+					Verbosity:      defaultVerbosity,
+					RpcPort:        defaultRpcPort,
+					RpcCors:        defaultRpcCors,
+					RpcCorsOrigins: defaultRpcCorsOrigins,
+					Metrics:        defaultMetrics,
+					Network:        defaultNetwork,
+					EthNode:        defaultEthNode,
 				},
 			},
 			"config file with all settings but without any other flags": {
 				cfgFile: tempCfgFile,
 				cfgFileContents: `verbosity: "debug"
 rpc-port: 4576
+rpc-cors: true
+rpc-cors-origins: http://127.0.0.1
 metrics: true
 db-path: /home/.juno
 network: 1
 eth-node: "https://some-ethnode:5673"
 `,
 				expectedConfig: &juno.Config{
-					Verbosity:    "debug",
-					RpcPort:      4576,
-					Metrics:      true,
-					DatabasePath: "/home/.juno",
-					Network:      utils.MAINNET,
-					EthNode:      "https://some-ethnode:5673",
+					Verbosity:      "debug",
+					RpcPort:        4576,
+					RpcCors:        true,
+					RpcCorsOrigins: "http://127.0.0.1",
+					Metrics:        true,
+					DatabasePath:   "/home/.juno",
+					Network:        utils.MAINNET,
+					EthNode:        "https://some-ethnode:5673",
 				},
 			},
 			"config file with some settings but without any other flags": {
@@ -145,47 +160,56 @@ rpc-port: 4576
 metrics: true
 `,
 				expectedConfig: &juno.Config{
-					Verbosity:    "debug",
-					RpcPort:      4576,
-					Metrics:      true,
-					DatabasePath: defaultDbPath,
-					Network:      defaultNetwork,
-					EthNode:      defaultEthNode,
+					Verbosity:      "debug",
+					RpcPort:        4576,
+					RpcCors:        defaultRpcCors,
+					RpcCorsOrigins: defaultRpcCorsOrigins,
+					Metrics:        true,
+					DatabasePath:   defaultDbPath,
+					Network:        defaultNetwork,
+					EthNode:        defaultEthNode,
 				},
 			},
 			"all flags without config file": {
 				inputArgs: []string{
 					"--verbosity", "debug", "--rpc-port", "4576",
 					"--metrics", "--db-path", "/home/.juno", "--network", "1",
-					"--eth-node", "https://some-ethnode:5673",
+					"--eth-node", "https://some-ethnode:5673", "--rpc-cors", "--rpc-cors-origins",
+					"http://127.0.0.1",
 				},
 				expectedConfig: &juno.Config{
-					Verbosity:    "debug",
-					RpcPort:      4576,
-					Metrics:      true,
-					DatabasePath: "/home/.juno",
-					Network:      utils.MAINNET,
-					EthNode:      "https://some-ethnode:5673",
+					Verbosity:      "debug",
+					RpcPort:        4576,
+					RpcCors:        true,
+					RpcCorsOrigins: "http://127.0.0.1",
+					Metrics:        true,
+					DatabasePath:   "/home/.juno",
+					Network:        utils.MAINNET,
+					EthNode:        "https://some-ethnode:5673",
 				},
 			},
 			"some flags without config file": {
 				inputArgs: []string{
 					"--verbosity", "debug", "--rpc-port", "4576", "--db-path", "/home/.juno",
-					"--network", "1",
+					"--network", "1", "--rpc-cors",
 				},
 				expectedConfig: &juno.Config{
-					Verbosity:    "debug",
-					RpcPort:      4576,
-					Metrics:      defaultMetrics,
-					DatabasePath: "/home/.juno",
-					Network:      utils.MAINNET,
-					EthNode:      defaultEthNode,
+					Verbosity:      "debug",
+					RpcPort:        4576,
+					RpcCors:        true,
+					RpcCorsOrigins: defaultRpcCorsOrigins,
+					Metrics:        defaultMetrics,
+					DatabasePath:   "/home/.juno",
+					Network:        utils.MAINNET,
+					EthNode:        defaultEthNode,
 				},
 			},
 			"all setting set in both config file and flags": {
 				cfgFile: tempCfgFile,
 				cfgFileContents: `verbosity: "debug"
 rpc-port: 4576
+rpc-cors: false
+rpc-cors-origins: http://127.0.0.1
 metrics: true
 db-path: /home/config-file/.juno
 network: 0
@@ -194,34 +218,40 @@ eth-node: "https://some-ethnode:5673"
 				inputArgs: []string{
 					"--verbosity", "error", "--rpc-port", "4577",
 					"--metrics", "--db-path", "/home/flag/.juno", "--network", "1",
-					"--eth-node", "https://some-ethnode:5674",
+					"--eth-node", "https://some-ethnode:5674", "--rpc-cors", "--rpc-cors-origins",
+					"http://example.com",
 				},
 				expectedConfig: &juno.Config{
-					Verbosity:    "error",
-					RpcPort:      4577,
-					Metrics:      true,
-					DatabasePath: "/home/flag/.juno",
-					Network:      utils.MAINNET,
-					EthNode:      "https://some-ethnode:5674",
+					Verbosity:      "error",
+					RpcPort:        4577,
+					RpcCors:        true,
+					RpcCorsOrigins: "http://example.com",
+					Metrics:        true,
+					DatabasePath:   "/home/flag/.juno",
+					Network:        utils.MAINNET,
+					EthNode:        "https://some-ethnode:5674",
 				},
 			},
 			"some setting set in both config file and flags": {
 				cfgFile: tempCfgFile,
 				cfgFileContents: `verbosity: "panic"
 rpc-port: 4576
+rpc-cors-origins: http://127.0.0.1
 network: 1
 `,
 				inputArgs: []string{
 					"--metrics", "--db-path", "/home/flag/.juno", "--eth-node",
-					"https://some-ethnode:5674",
+					"https://some-ethnode:5674", "--rpc-cors",
 				},
 				expectedConfig: &juno.Config{
-					Verbosity:    "panic",
-					RpcPort:      4576,
-					Metrics:      true,
-					DatabasePath: "/home/flag/.juno",
-					Network:      utils.MAINNET,
-					EthNode:      "https://some-ethnode:5674",
+					Verbosity:      "panic",
+					RpcPort:        4576,
+					RpcCors:        true,
+					RpcCorsOrigins: "http://127.0.0.1",
+					Metrics:        true,
+					DatabasePath:   "/home/flag/.juno",
+					Network:        utils.MAINNET,
+					EthNode:        "https://some-ethnode:5674",
 				},
 			},
 			"some setting set in default, config file and flags": {
@@ -232,12 +262,14 @@ network: 1
 					"https://some-ethnode:5674",
 				},
 				expectedConfig: &juno.Config{
-					Verbosity:    defaultVerbosity,
-					RpcPort:      defaultRpcPort,
-					Metrics:      true,
-					DatabasePath: "/home/flag/.juno",
-					Network:      utils.MAINNET,
-					EthNode:      "https://some-ethnode:5674",
+					Verbosity:      defaultVerbosity,
+					RpcPort:        defaultRpcPort,
+					RpcCors:        defaultRpcCors,
+					RpcCorsOrigins: defaultRpcCorsOrigins,
+					Metrics:        true,
+					DatabasePath:   "/home/flag/.juno",
+					Network:        utils.MAINNET,
+					EthNode:        "https://some-ethnode:5674",
 				},
 			},
 		}

--- a/cmd/juno/juno_test.go
+++ b/cmd/juno/juno_test.go
@@ -74,8 +74,7 @@ Juno is a Go implementation of a StarkNet full node client made with ❤️ by N
 		// implementation.
 		defaultVerbosity := "info"
 		defaultRpcPort := uint16(6060)
-		defaultRpcCors := false
-		defaultRpcCorsOrigins := "*"
+		defaultRpcCors := ""
 		defaultMetrics := false
 		defaultDbPath := ""
 		defaultNetwork := utils.GOERLI
@@ -91,27 +90,25 @@ Juno is a Go implementation of a StarkNet full node client made with ❤️ by N
 			"default config with no flags": {
 				inputArgs: []string{""},
 				expectedConfig: &juno.Config{
-					Verbosity:      defaultVerbosity,
-					RpcPort:        defaultRpcPort,
-					RpcCors:        defaultRpcCors,
-					RpcCorsOrigins: defaultRpcCorsOrigins,
-					Metrics:        defaultMetrics,
-					DatabasePath:   defaultDbPath,
-					Network:        defaultNetwork,
-					EthNode:        defaultEthNode,
+					Verbosity:    defaultVerbosity,
+					RpcPort:      defaultRpcPort,
+					RpcCors:      defaultRpcCors,
+					Metrics:      defaultMetrics,
+					DatabasePath: defaultDbPath,
+					Network:      defaultNetwork,
+					EthNode:      defaultEthNode,
 				},
 			},
 			"config file path is empty string": {
 				inputArgs: []string{"--config", ""},
 				expectedConfig: &juno.Config{
-					Verbosity:      defaultVerbosity,
-					RpcPort:        defaultRpcPort,
-					RpcCors:        defaultRpcCors,
-					RpcCorsOrigins: defaultRpcCorsOrigins,
-					Metrics:        defaultMetrics,
-					DatabasePath:   defaultDbPath,
-					Network:        defaultNetwork,
-					EthNode:        defaultEthNode,
+					Verbosity:    defaultVerbosity,
+					RpcPort:      defaultRpcPort,
+					RpcCors:      defaultRpcCors,
+					Metrics:      defaultMetrics,
+					DatabasePath: defaultDbPath,
+					Network:      defaultNetwork,
+					EthNode:      defaultEthNode,
 				},
 			},
 			"config file doesn't exist": {
@@ -122,35 +119,32 @@ Juno is a Go implementation of a StarkNet full node client made with ❤️ by N
 				cfgFile:         tempCfgFile,
 				cfgFileContents: "\n",
 				expectedConfig: &juno.Config{
-					Verbosity:      defaultVerbosity,
-					RpcPort:        defaultRpcPort,
-					RpcCors:        defaultRpcCors,
-					RpcCorsOrigins: defaultRpcCorsOrigins,
-					Metrics:        defaultMetrics,
-					Network:        defaultNetwork,
-					EthNode:        defaultEthNode,
+					Verbosity: defaultVerbosity,
+					RpcPort:   defaultRpcPort,
+					RpcCors:   defaultRpcCors,
+					Metrics:   defaultMetrics,
+					Network:   defaultNetwork,
+					EthNode:   defaultEthNode,
 				},
 			},
 			"config file with all settings but without any other flags": {
 				cfgFile: tempCfgFile,
 				cfgFileContents: `verbosity: "debug"
 rpc-port: 4576
-rpc-cors: true
-rpc-cors-origins: http://127.0.0.1
+rpc-cors: http://127.0.0.1
 metrics: true
 db-path: /home/.juno
 network: 1
 eth-node: "https://some-ethnode:5673"
 `,
 				expectedConfig: &juno.Config{
-					Verbosity:      "debug",
-					RpcPort:        4576,
-					RpcCors:        true,
-					RpcCorsOrigins: "http://127.0.0.1",
-					Metrics:        true,
-					DatabasePath:   "/home/.juno",
-					Network:        utils.MAINNET,
-					EthNode:        "https://some-ethnode:5673",
+					Verbosity:    "debug",
+					RpcPort:      4576,
+					RpcCors:      "http://127.0.0.1",
+					Metrics:      true,
+					DatabasePath: "/home/.juno",
+					Network:      utils.MAINNET,
+					EthNode:      "https://some-ethnode:5673",
 				},
 			},
 			"config file with some settings but without any other flags": {
@@ -160,56 +154,52 @@ rpc-port: 4576
 metrics: true
 `,
 				expectedConfig: &juno.Config{
-					Verbosity:      "debug",
-					RpcPort:        4576,
-					RpcCors:        defaultRpcCors,
-					RpcCorsOrigins: defaultRpcCorsOrigins,
-					Metrics:        true,
-					DatabasePath:   defaultDbPath,
-					Network:        defaultNetwork,
-					EthNode:        defaultEthNode,
+					Verbosity:    "debug",
+					RpcPort:      4576,
+					RpcCors:      defaultRpcCors,
+					Metrics:      true,
+					DatabasePath: defaultDbPath,
+					Network:      defaultNetwork,
+					EthNode:      defaultEthNode,
 				},
 			},
 			"all flags without config file": {
 				inputArgs: []string{
 					"--verbosity", "debug", "--rpc-port", "4576",
 					"--metrics", "--db-path", "/home/.juno", "--network", "1",
-					"--eth-node", "https://some-ethnode:5673", "--rpc-cors", "--rpc-cors-origins",
+					"--eth-node", "https://some-ethnode:5673", "--rpc-cors",
 					"http://127.0.0.1",
 				},
 				expectedConfig: &juno.Config{
-					Verbosity:      "debug",
-					RpcPort:        4576,
-					RpcCors:        true,
-					RpcCorsOrigins: "http://127.0.0.1",
-					Metrics:        true,
-					DatabasePath:   "/home/.juno",
-					Network:        utils.MAINNET,
-					EthNode:        "https://some-ethnode:5673",
+					Verbosity:    "debug",
+					RpcPort:      4576,
+					RpcCors:      "http://127.0.0.1",
+					Metrics:      true,
+					DatabasePath: "/home/.juno",
+					Network:      utils.MAINNET,
+					EthNode:      "https://some-ethnode:5673",
 				},
 			},
 			"some flags without config file": {
 				inputArgs: []string{
 					"--verbosity", "debug", "--rpc-port", "4576", "--db-path", "/home/.juno",
-					"--network", "1", "--rpc-cors",
+					"--network", "1",
 				},
 				expectedConfig: &juno.Config{
-					Verbosity:      "debug",
-					RpcPort:        4576,
-					RpcCors:        true,
-					RpcCorsOrigins: defaultRpcCorsOrigins,
-					Metrics:        defaultMetrics,
-					DatabasePath:   "/home/.juno",
-					Network:        utils.MAINNET,
-					EthNode:        defaultEthNode,
+					Verbosity:    "debug",
+					RpcPort:      4576,
+					RpcCors:      defaultRpcCors,
+					Metrics:      defaultMetrics,
+					DatabasePath: "/home/.juno",
+					Network:      utils.MAINNET,
+					EthNode:      defaultEthNode,
 				},
 			},
 			"all setting set in both config file and flags": {
 				cfgFile: tempCfgFile,
 				cfgFileContents: `verbosity: "debug"
 rpc-port: 4576
-rpc-cors: false
-rpc-cors-origins: http://127.0.0.1
+rpc-cors: http://127.0.0.1
 metrics: true
 db-path: /home/config-file/.juno
 network: 0
@@ -218,40 +208,38 @@ eth-node: "https://some-ethnode:5673"
 				inputArgs: []string{
 					"--verbosity", "error", "--rpc-port", "4577",
 					"--metrics", "--db-path", "/home/flag/.juno", "--network", "1",
-					"--eth-node", "https://some-ethnode:5674", "--rpc-cors", "--rpc-cors-origins",
+					"--eth-node", "https://some-ethnode:5674", "--rpc-cors",
 					"http://example.com",
 				},
 				expectedConfig: &juno.Config{
-					Verbosity:      "error",
-					RpcPort:        4577,
-					RpcCors:        true,
-					RpcCorsOrigins: "http://example.com",
-					Metrics:        true,
-					DatabasePath:   "/home/flag/.juno",
-					Network:        utils.MAINNET,
-					EthNode:        "https://some-ethnode:5674",
+					Verbosity:    "error",
+					RpcPort:      4577,
+					RpcCors:      "http://example.com",
+					Metrics:      true,
+					DatabasePath: "/home/flag/.juno",
+					Network:      utils.MAINNET,
+					EthNode:      "https://some-ethnode:5674",
 				},
 			},
 			"some setting set in both config file and flags": {
 				cfgFile: tempCfgFile,
 				cfgFileContents: `verbosity: "panic"
 rpc-port: 4576
-rpc-cors-origins: http://127.0.0.1
+rpc-cors: http://127.0.0.1
 network: 1
 `,
 				inputArgs: []string{
 					"--metrics", "--db-path", "/home/flag/.juno", "--eth-node",
-					"https://some-ethnode:5674", "--rpc-cors",
+					"https://some-ethnode:5674",
 				},
 				expectedConfig: &juno.Config{
-					Verbosity:      "panic",
-					RpcPort:        4576,
-					RpcCors:        true,
-					RpcCorsOrigins: "http://127.0.0.1",
-					Metrics:        true,
-					DatabasePath:   "/home/flag/.juno",
-					Network:        utils.MAINNET,
-					EthNode:        "https://some-ethnode:5674",
+					Verbosity:    "panic",
+					RpcPort:      4576,
+					RpcCors:      "http://127.0.0.1",
+					Metrics:      true,
+					DatabasePath: "/home/flag/.juno",
+					Network:      utils.MAINNET,
+					EthNode:      "https://some-ethnode:5674",
 				},
 			},
 			"some setting set in default, config file and flags": {
@@ -262,14 +250,13 @@ network: 1
 					"https://some-ethnode:5674",
 				},
 				expectedConfig: &juno.Config{
-					Verbosity:      defaultVerbosity,
-					RpcPort:        defaultRpcPort,
-					RpcCors:        defaultRpcCors,
-					RpcCorsOrigins: defaultRpcCorsOrigins,
-					Metrics:        true,
-					DatabasePath:   "/home/flag/.juno",
-					Network:        utils.MAINNET,
-					EthNode:        "https://some-ethnode:5674",
+					Verbosity:    defaultVerbosity,
+					RpcPort:      defaultRpcPort,
+					RpcCors:      defaultRpcCors,
+					Metrics:      true,
+					DatabasePath: "/home/flag/.juno",
+					Network:      utils.MAINNET,
+					EthNode:      "https://some-ethnode:5674",
 				},
 			},
 		}

--- a/docs/docs/running/config.mdx
+++ b/docs/docs/running/config.mdx
@@ -14,6 +14,8 @@ Example `juno.yaml`:
 ```yaml
 verbosity: "debug"
 rpc-port: 4576
+rpc-cors: true
+rpc-cors-origins: "http://cors-origin.com,http://127.0.0.1"
 metrics: true
 db-path: "/home/.juno"
 network: 1
@@ -34,14 +36,16 @@ Usage:
   juno [flags]
 
 Flags:
-      --config string      The yaml configuration file.
-      --db-path string     Location of the database files.
-      --eth-node string    The Ethereum endpoint to synchronise with. If unset feeder gateway will be used.
-  -h, --help               help for juno
-      --metrics            Enables the metrics server and listens on port 9090.
-      --network uint8      Available StarkNet networks. Options: 0 = goerli and 1 = mainnet
-      --rpc-port uint16    The port on which the RPC server will listen for requests. Warning: this exposes the node to external requests and potentially DoS attacks. (default 6060)
-      --verbosity string   Verbosity of the logs. Options: debug, info, warn, error, dpanic, panic, fatal. (default "info")
+      --config string             The yaml configuration file.
+      --db-path string            Location of the database files.
+      --eth-node string           The Ethereum endpoint to synchronise with. If unset feeder gateway will be used.
+  -h, --help                      help for juno
+      --metrics                   Enables the metrics server and listens on port 9090.
+      --network uint8             Available StarkNet networks. Options: 0 = goerli and 1 = mainnet
+      --rpc-cors                  Allow cross-origin requests to the RPC server.
+      --rpc-cors-origins string   Comma-separated list of origins to allow cross-origin requests to the RPC server. If rpc-cors flag is not set to true, this flag is ignored. (default "*")
+      --rpc-port uint16           The port on which the RPC server will listen for requests. Warning: this exposes the node to external requests and potentially DoS attacks. (default 6060)
+      --verbosity string          Verbosity of the logs. Options: debug, info, warn, error, dpanic, panic, fatal. (default "info")
 ```
 
 ## Default Configuration
@@ -50,6 +54,8 @@ The default values for the configuration are the following:
 ```yaml
 verbosity: "info"
 rpc-port: 6060
+rpc-cors: false
+rpc-cors-origins: "*"
 metrics: true
 db-path: "~/.local/share/juno/"
 network: 0

--- a/docs/docs/running/config.mdx
+++ b/docs/docs/running/config.mdx
@@ -14,8 +14,7 @@ Example `juno.yaml`:
 ```yaml
 verbosity: "debug"
 rpc-port: 4576
-rpc-cors: true
-rpc-cors-origins: "http://cors-origin.com,http://127.0.0.1"
+rpc-cors: "http://cors-origin.com,http://127.0.0.1"
 metrics: true
 db-path: "/home/.juno"
 network: 1
@@ -36,16 +35,15 @@ Usage:
   juno [flags]
 
 Flags:
-      --config string             The yaml configuration file.
-      --db-path string            Location of the database files.
-      --eth-node string           The Ethereum endpoint to synchronise with. If unset feeder gateway will be used.
-  -h, --help                      help for juno
-      --metrics                   Enables the metrics server and listens on port 9090.
-      --network uint8             Available StarkNet networks. Options: 0 = goerli and 1 = mainnet
-      --rpc-cors                  Allow cross-origin requests to the RPC server.
-      --rpc-cors-origins string   Comma-separated list of origins to allow cross-origin requests to the RPC server. If rpc-cors flag is not set to true, this flag is ignored. (default "*")
-      --rpc-port uint16           The port on which the RPC server will listen for requests. Warning: this exposes the node to external requests and potentially DoS attacks. (default 6060)
-      --verbosity string          Verbosity of the logs. Options: debug, info, warn, error, dpanic, panic, fatal. (default "info")
+      --config string      The yaml configuration file.
+      --db-path string     Location of the database files.
+      --eth-node string    The Ethereum endpoint to synchronise with. If unset feeder gateway will be used.
+  -h, --help               help for juno
+      --metrics            Enables the metrics server and listens on port 9090.
+      --network uint8      Available StarkNet networks. Options: 0 = goerli and 1 = mainnet
+      --rpc-cors string    Comma-separated list of origins to allow cross-origin requests to the RPC server.
+      --rpc-port uint16    The port on which the RPC server will listen for requests. Warning: this exposes the node to external requests and potentially DoS attacks. (default 6060)
+      --verbosity string   Verbosity of the logs. Options: debug, info, warn, error, dpanic, panic, fatal. (default "info")
 ```
 
 ## Default Configuration
@@ -54,8 +52,7 @@ The default values for the configuration are the following:
 ```yaml
 verbosity: "info"
 rpc-port: 6060
-rpc-cors: false
-rpc-cors-origins: "*"
+rpc-cors: ""
 metrics: true
 db-path: "~/.local/share/juno/"
 network: 0

--- a/internal/juno/juno.go
+++ b/internal/juno/juno.go
@@ -44,12 +44,14 @@ var ErrUnknownNetwork = errors.New("unknown network")
 
 // Config is the top-level juno configuration.
 type Config struct {
-	Verbosity    string        `mapstructure:"verbosity"`
-	RpcPort      uint16        `mapstructure:"rpc-port"`
-	Metrics      bool          `mapstructure:"metrics"`
-	DatabasePath string        `mapstructure:"db-path"`
-	Network      utils.Network `mapstructure:"network"`
-	EthNode      string        `mapstructure:"eth-node"`
+	Verbosity      string        `mapstructure:"verbosity"`
+	RpcPort        uint16        `mapstructure:"rpc-port"`
+	RpcCors        bool          `mapstructure:"rpc-cors"`
+	RpcCorsOrigins string        `mapstructure:"rpc-cors-origins"`
+	Metrics        bool          `mapstructure:"metrics"`
+	DatabasePath   string        `mapstructure:"db-path"`
+	Network        utils.Network `mapstructure:"network"`
+	EthNode        string        `mapstructure:"eth-node"`
 }
 
 type Node struct {

--- a/internal/juno/juno.go
+++ b/internal/juno/juno.go
@@ -150,6 +150,9 @@ func (n *Node) Run() error {
 	if err != nil {
 		return err
 	}
+	if n.cfg.RpcCors {
+		n.rpcServer.Provider().EnableCors(n.cfg.RpcCorsOrigins)
+	}
 
 	if n.cfg.Metrics {
 		n.metricsServer = prometheus.SetupMetric(defaultMetricsPort)

--- a/internal/juno/juno.go
+++ b/internal/juno/juno.go
@@ -44,14 +44,13 @@ var ErrUnknownNetwork = errors.New("unknown network")
 
 // Config is the top-level juno configuration.
 type Config struct {
-	Verbosity      string        `mapstructure:"verbosity"`
-	RpcPort        uint16        `mapstructure:"rpc-port"`
-	RpcCors        bool          `mapstructure:"rpc-cors"`
-	RpcCorsOrigins string        `mapstructure:"rpc-cors-origins"`
-	Metrics        bool          `mapstructure:"metrics"`
-	DatabasePath   string        `mapstructure:"db-path"`
-	Network        utils.Network `mapstructure:"network"`
-	EthNode        string        `mapstructure:"eth-node"`
+	Verbosity    string        `mapstructure:"verbosity"`
+	RpcPort      uint16        `mapstructure:"rpc-port"`
+	RpcCors      string        `mapstructure:"rpc-cors"`
+	Metrics      bool          `mapstructure:"metrics"`
+	DatabasePath string        `mapstructure:"db-path"`
+	Network      utils.Network `mapstructure:"network"`
+	EthNode      string        `mapstructure:"eth-node"`
 }
 
 type Node struct {
@@ -150,8 +149,8 @@ func (n *Node) Run() error {
 	if err != nil {
 		return err
 	}
-	if n.cfg.RpcCors {
-		n.rpcServer.Provider().EnableCors(n.cfg.RpcCorsOrigins)
+	if n.cfg.RpcCors != "" {
+		n.rpcServer.Provider().EnableCors(n.cfg.RpcCors)
 	}
 
 	if n.cfg.Metrics {

--- a/internal/rpc/http.go
+++ b/internal/rpc/http.go
@@ -50,3 +50,7 @@ func (h *HttpRpc) Close(timeout time.Duration) error {
 	ctx, _ := context.WithTimeout(context.Background(), timeout)
 	return h.server.Shutdown(ctx)
 }
+
+func (h *HttpRpc) Provider() *HttpProvider {
+	return h.provider
+}

--- a/pkg/jsonrpc/providers/http/provider.go
+++ b/pkg/jsonrpc/providers/http/provider.go
@@ -10,6 +10,8 @@ import (
 type HttpProvider struct {
 	http.Handler
 	jsonrpcServer *jsonrpc.JsonRpc
+	cors          bool
+	corsOrigins   string
 }
 
 func NewHttpProvider(jsonrpcServer *jsonrpc.JsonRpc) *HttpProvider {
@@ -19,6 +21,15 @@ func NewHttpProvider(jsonrpcServer *jsonrpc.JsonRpc) *HttpProvider {
 }
 
 func (p *HttpProvider) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	if p.cors {
+		w.Header().Set("Access-Control-Allow-Origin", p.corsOrigins)
+		if r.Method == http.MethodOptions {
+			w.Header().Set("Access-Control-Allow-Methods", "POST")
+			w.Header().Set("Access-Control-Allow-Headers", "Content-Type")
+			w.WriteHeader(http.StatusNoContent)
+			return
+		}
+	}
 	// Check request method
 	if r.Method != http.MethodPost {
 		// All the requests should be POST
@@ -45,4 +56,9 @@ func (p *HttpProvider) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusInternalServerError)
 		return
 	}
+}
+
+func (p *HttpProvider) EnableCors(origins string) {
+	p.cors = true
+	p.corsOrigins = origins
 }


### PR DESCRIPTION
## Description

Currently, the HTTP RPC fails requests from browsers because of CORS. With these changes is possible to configure CORS.

## Changes:

- Two flags/options are added:
  - `rpc-cors` is a string of a comma-separated list of all authorized CORS origins

## Types of changes

- New feature (non-breaking change which adds functionality)

## Testing

**Requires testing**: Yes

**Did you write tests??**: Yes, tests of the configuration file are updated.

## Documentation

**If this requires a documentation update, did you add one?** Yes

