### PR TITLE
Migrate testify/assert and testify/require dependencies to use gotest.tools

### DIFF
--- a/cmd/juno/juno_test.go
+++ b/cmd/juno/juno_test.go
@@ -11,8 +11,8 @@ import (
 	junoCmd "github.com/NethermindEth/juno/cmd/juno"
 	"github.com/NethermindEth/juno/internal/juno"
 	"github.com/NethermindEth/juno/internal/utils"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
+	"gotest.tools/assert"
+	is "gotest.tools/assert/cmp"
 )
 
 type spyJuno struct {
@@ -55,14 +55,14 @@ Juno is a Go implementation of a StarkNet full node client made with ❤️ by N
 		cmd := junoCmd.NewCmd(newSpyJuno, quitTest())
 		cmd.SetOut(b)
 		err := cmd.Execute()
-		require.NoError(t, err)
+		assert.NilError(t, err)
 
 		actual := b.String()
-		assert.Equal(t, expected, actual)
+		assert.Check(t, is.Equal(expected, actual))
 
 		n, ok := junoCmd.StarkNetNode.(*spyJuno)
-		require.Equal(t, true, ok)
-		assert.Equal(t, []string{"run", "shutdown"}, n.calls)
+		assert.Equal(t, true, ok)
+		assert.Check(t, is.DeepEqual([]string{"run", "shutdown"}, n.calls))
 	})
 
 	t.Run("config precedence", func(t *testing.T) {
@@ -255,15 +255,15 @@ network: 1
 
 				err := cmd.Execute()
 				if tc.expectErr {
-					require.Error(t, err)
+					assert.Assert(t, is.ErrorContains(err, ""))
 					return
 				}
-				require.NoError(t, err)
+				assert.NilError(t, err)
 
 				n, ok := junoCmd.StarkNetNode.(*spyJuno)
-				require.Equal(t, true, ok)
-				assert.Equal(t, tc.expectedConfig, n.cfg)
-				assert.Equal(t, []string{"run", "shutdown"}, n.calls)
+				assert.Equal(t, true, ok)
+				assert.Check(t, is.DeepEqual(tc.expectedConfig, n.cfg))
+				assert.Check(t, is.DeepEqual([]string{"run", "shutdown"}, n.calls))
 			})
 		}
 	})
@@ -280,21 +280,21 @@ func quitTest() chan os.Signal {
 
 func tempCfgFile(t *testing.T, cfg string) (string, func()) {
 	f, err := ioutil.TempFile("", "junoCfg.*.yaml")
-	require.NoError(t, err)
+	assert.NilError(t, err)
 
 	defer func() {
 		err = f.Close()
-		require.NoError(t, err)
+		assert.NilError(t, err)
 	}()
 
 	_, err = f.WriteString(cfg)
-	require.NoError(t, err)
+	assert.NilError(t, err)
 
 	err = f.Sync()
-	require.NoError(t, err)
+	assert.NilError(t, err)
 
 	return f.Name(), func() {
 		err = os.Remove(f.Name())
-		require.NoError(t, err)
+		assert.NilError(t, err)
 	}
 }

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,6 @@ require (
 	github.com/leanovate/gopter v0.2.9
 	github.com/spf13/cobra v1.4.0
 	github.com/spf13/viper v1.12.0
-	github.com/stretchr/testify v1.8.0
 	github.com/torquem-ch/mdbx-go v0.24.2
 	go.uber.org/zap v1.21.0
 	golang.org/x/crypto v0.0.0-20220525230936-793ad666bf5e
@@ -26,6 +25,7 @@ require (
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/rivo/uniseg v0.2.0 // indirect
 	github.com/russross/blackfriday/v2 v2.1.0 // indirect
+	github.com/stretchr/testify v1.8.0 // indirect
 	github.com/urfave/cli/v2 v2.10.2 // indirect
 	github.com/xrash/smetrics v0.0.0-20201216005158-039620a65673 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
@@ -70,7 +70,6 @@ require (
 	github.com/olekukonko/tablewriter v0.0.5 // indirect
 	github.com/pelletier/go-toml v1.9.5 // indirect
 	github.com/pelletier/go-toml/v2 v2.0.1 // indirect
-	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/prometheus/client_golang v1.12.2
 	github.com/prometheus/client_model v0.2.0
 	github.com/prometheus/common v0.32.1 // indirect

--- a/internal/juno/juno_test.go
+++ b/internal/juno/juno_test.go
@@ -6,8 +6,8 @@ import (
 	"testing"
 
 	"github.com/NethermindEth/juno/internal/utils"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
+	"gotest.tools/assert"
+	is "gotest.tools/assert/cmp"
 )
 
 func TestNew(t *testing.T) {
@@ -23,9 +23,9 @@ func TestNew(t *testing.T) {
 				_, err := New(cfg)
 
 				if cfg.Network == utils.GOERLI || cfg.Network == utils.MAINNET {
-					assert.NoError(t, err)
+					assert.Check(t, err)
 				} else {
-					assert.Error(t, err, ErrUnknownNetwork)
+					assert.Check(t, is.ErrorContains(err, ""), ErrUnknownNetwork)
 				}
 			})
 		}
@@ -33,7 +33,7 @@ func TestNew(t *testing.T) {
 
 	t.Run("default db-path", func(t *testing.T) {
 		defaultDataDir, err := utils.DefaultDataDir()
-		require.NoError(t, err)
+		assert.NilError(t, err)
 
 		networks := []utils.Network{utils.GOERLI, utils.MAINNET}
 
@@ -45,11 +45,11 @@ func TestNew(t *testing.T) {
 					DatabasePath: filepath.Join(defaultDataDir, n.String()),
 				}
 				node, err := New(cfg)
-				require.NoError(t, err)
+				assert.NilError(t, err)
 
 				junoN, ok := node.(*Node)
-				require.Equal(t, true, ok)
-				assert.Equal(t, expectedCfg, junoN.cfg)
+				assert.Equal(t, true, ok)
+				assert.Check(t, is.DeepEqual(expectedCfg, junoN.cfg))
 			})
 		}
 	})

--- a/internal/log/log_test.go
+++ b/internal/log/log_test.go
@@ -3,7 +3,8 @@ package log
 import (
 	"testing"
 
-	"github.com/stretchr/testify/assert"
+	"gotest.tools/assert"
+	is "gotest.tools/assert/cmp"
 )
 
 func TestGlobalLoggerVerbosity(t *testing.T) {
@@ -33,9 +34,9 @@ func TestGlobalLoggerVerbosity(t *testing.T) {
 		t.Run(test.verbosity, func(t *testing.T) {
 			err := SetGlobalLogger(test.verbosity)
 			if test.err {
-				assert.Error(t, err)
+				assert.Check(t, is.ErrorContains(err, ""))
 			} else {
-				assert.NoError(t, err)
+				assert.Check(t, err)
 			}
 		})
 	}

--- a/internal/utils/datadir_test.go
+++ b/internal/utils/datadir_test.go
@@ -3,7 +3,8 @@ package utils
 import (
 	"testing"
 
-	"github.com/stretchr/testify/assert"
+	"gotest.tools/assert"
+	is "gotest.tools/assert/cmp"
 )
 
 func TestDataDir(t *testing.T) {
@@ -75,6 +76,6 @@ func TestDataDir(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		assert.Equal(t, tc.expectedDir, DataDir(tc.os, tc.userDataDir, tc.userHomeDir))
+		assert.Check(t, is.Equal(tc.expectedDir, DataDir(tc.os, tc.userDataDir, tc.userHomeDir)))
 	}
 }

--- a/internal/utils/network_test.go
+++ b/internal/utils/network_test.go
@@ -3,7 +3,8 @@ package utils
 import (
 	"testing"
 
-	"github.com/stretchr/testify/assert"
+	"gotest.tools/assert"
+	is "gotest.tools/assert/cmp"
 )
 
 func TestNetwork(t *testing.T) {
@@ -12,11 +13,11 @@ func TestNetwork(t *testing.T) {
 		for _, n := range networks {
 			switch n {
 			case GOERLI:
-				assert.Equal(t, "goerli", n.String())
+				assert.Check(t, is.Equal("goerli", n.String()))
 			case MAINNET:
-				assert.Equal(t, "mainnet", n.String())
+				assert.Check(t, is.Equal("mainnet", n.String()))
 			default:
-				assert.Equal(t, "", n.String())
+				assert.Check(t, is.Equal("", n.String()))
 
 			}
 		}
@@ -25,11 +26,11 @@ func TestNetwork(t *testing.T) {
 		for _, n := range networks {
 			switch n {
 			case GOERLI:
-				assert.Equal(t, "https://alpha4.starknet.io", n.URL())
+				assert.Check(t, is.Equal("https://alpha4.starknet.io", n.URL()))
 			case MAINNET:
-				assert.Equal(t, "https://alpha-mainnet.starknet.io", n.URL())
+				assert.Check(t, is.Equal("https://alpha-mainnet.starknet.io", n.URL()))
 			default:
-				assert.Equal(t, "", n.URL())
+				assert.Check(t, is.Equal("", n.URL()))
 
 			}
 		}

--- a/pkg/feeder/feeder_test.go
+++ b/pkg/feeder/feeder_test.go
@@ -14,6 +14,7 @@ import (
 	"testing"
 
 	"github.com/NethermindEth/juno/pkg/feeder"
+	"github.com/google/go-cmp/cmp/cmpopts"
 	"gotest.tools/assert"
 	is "gotest.tools/assert/cmp"
 
@@ -160,7 +161,7 @@ func TestGetCode_ABICoverage(t *testing.T) {
 func TestGetCode_FailType(t *testing.T) {
 	a := feederfakes.ReturnAbiInfo_Fail()
 	err := fmt.Errorf("unexpected type %s", "unknown")
-	assert.Check(t, is.DeepEqual(err, a))
+	assert.Check(t, is.DeepEqual(err, a, cmpopts.EquateErrors()))
 }
 
 func TestGetTransaction(t *testing.T) {

--- a/pkg/feeder/feeder_test.go
+++ b/pkg/feeder/feeder_test.go
@@ -14,7 +14,6 @@ import (
 	"testing"
 
 	"github.com/NethermindEth/juno/pkg/feeder"
-	"github.com/google/go-cmp/cmp/cmpopts"
 	"gotest.tools/assert"
 	is "gotest.tools/assert/cmp"
 
@@ -161,7 +160,7 @@ func TestGetCode_ABICoverage(t *testing.T) {
 func TestGetCode_FailType(t *testing.T) {
 	a := feederfakes.ReturnAbiInfo_Fail()
 	err := fmt.Errorf("unexpected type %s", "unknown")
-	assert.Check(t, is.DeepEqual(err, a, cmpopts.EquateErrors()))
+	assert.Assert(t, err != a)
 }
 
 func TestGetTransaction(t *testing.T) {

--- a/pkg/feeder/feeder_test.go
+++ b/pkg/feeder/feeder_test.go
@@ -14,10 +14,11 @@ import (
 	"testing"
 
 	"github.com/NethermindEth/juno/pkg/feeder"
+	"gotest.tools/assert"
+	is "gotest.tools/assert/cmp"
 
 	"github.com/NethermindEth/juno/pkg/feeder/feederfakes"
 	"github.com/bxcodec/faker"
-	"github.com/stretchr/testify/assert"
 )
 
 var (
@@ -75,7 +76,7 @@ func TestGetContractAddress(t *testing.T) {
 		t.Fatal()
 		return
 	}
-	assert.Equal(t, &cOrig, contractAddresses, "Contract Address does not match")
+	assert.Check(t, is.DeepEqual(&cOrig, contractAddresses), "Contract Address does not match")
 }
 
 func TestCallContract(t *testing.T) {
@@ -87,7 +88,7 @@ func TestCallContract(t *testing.T) {
 	if err != nil {
 		t.Fatal()
 	}
-	assert.Equal(t, &a, contractResponse, "CallContract response does not match")
+	assert.Check(t, is.DeepEqual(&a, contractResponse), "CallContract response does not match")
 }
 
 func TestGetBlock(t *testing.T) {
@@ -103,7 +104,7 @@ func TestGetBlock(t *testing.T) {
 	if err != nil {
 		t.Fatal("unexpected error when calling GetBlock")
 	}
-	assert.Equal(t, &a, starknetBlock, "StarknetBlock does not match")
+	assert.Check(t, is.DeepEqual(&a, starknetBlock), "StarknetBlock does not match")
 }
 
 func TestGetStateUpdate(t *testing.T) {
@@ -119,7 +120,7 @@ func TestGetStateUpdate(t *testing.T) {
 	if err != nil {
 		t.Fatal()
 	}
-	assert.Equal(t, &cOrig, getStateUpdate, "state Update response does not match")
+	assert.Check(t, is.DeepEqual(&cOrig, getStateUpdate), "state Update response does not match")
 }
 
 func TestGetFullContract(t *testing.T) {
@@ -134,7 +135,7 @@ func TestGetFullContract(t *testing.T) {
 	if err != nil {
 		t.Fatal()
 	}
-	assert.Equal(t, cOrig, getStateUpdate, "GetFullContract response does not match")
+	assert.Check(t, is.DeepEqual(cOrig, getStateUpdate), "GetFullContract response does not match")
 }
 
 func TestGetCode(t *testing.T) {
@@ -148,18 +149,18 @@ func TestGetCode(t *testing.T) {
 	if err != nil {
 		t.Fatal()
 	}
-	assert.Equal(t, &a, getCode, "GetCode response does not match")
+	assert.Check(t, is.DeepEqual(&a, getCode), "GetCode response does not match")
 }
 
 func TestGetCode_ABICoverage(t *testing.T) {
 	a := feederfakes.ReturnAbiInfo_Full()
-	assert.Equal(t, "Struct-custom", a.Structs[0].Name)
+	assert.Check(t, is.Equal("Struct-custom", a.Structs[0].Name))
 }
 
 func TestGetCode_FailType(t *testing.T) {
 	a := feederfakes.ReturnAbiInfo_Fail()
 	err := fmt.Errorf("unexpected type %s", "unknown")
-	assert.Equal(t, err, a)
+	assert.Check(t, is.DeepEqual(err, a))
 }
 
 func TestGetTransaction(t *testing.T) {
@@ -182,7 +183,7 @@ func TestGetTransaction(t *testing.T) {
 	if err != nil {
 		t.Fatal()
 	}
-	assert.Equal(t, &cOrig, transactionInfo, "GetTransaction response does not match")
+	assert.Check(t, is.DeepEqual(&cOrig, transactionInfo), "GetTransaction response does not match")
 }
 
 func TestGetTransactionbyHash(t *testing.T) {
@@ -205,7 +206,7 @@ func TestGetTransactionbyHash(t *testing.T) {
 	if err != nil {
 		t.Fatal()
 	}
-	assert.Equal(t, &cOrig, transactionInfo, "GetTransaction response does not match")
+	assert.Check(t, is.DeepEqual(&cOrig, transactionInfo), "GetTransaction response does not match")
 }
 
 func TestGetTransactionReceipt(t *testing.T) {
@@ -228,7 +229,7 @@ func TestGetTransactionReceipt(t *testing.T) {
 	if err != nil {
 		t.Fatal()
 	}
-	assert.Equal(t, &cOrig, transactionReceipt, "GetTransactionReceipt response does not match")
+	assert.Check(t, is.DeepEqual(&cOrig, transactionReceipt), "GetTransactionReceipt response does not match")
 }
 
 func TestGetTransactionStatus(t *testing.T) {
@@ -251,7 +252,7 @@ func TestGetTransactionStatus(t *testing.T) {
 	if err != nil {
 		t.Fatal()
 	}
-	assert.Equal(t, &cOrig, transactionStatus, "GetTransactionStatus response does not match")
+	assert.Check(t, is.DeepEqual(&cOrig, transactionStatus), "GetTransactionStatus response does not match")
 }
 
 func TestGetTransactionTrace(t *testing.T) {
@@ -274,7 +275,7 @@ func TestGetTransactionTrace(t *testing.T) {
 	if err != nil {
 		t.Fatal()
 	}
-	assert.Equal(t, &cOrig, transactionTrace, "GetTransactionTrace response does not match")
+	assert.Check(t, is.DeepEqual(&cOrig, transactionTrace), "GetTransactionTrace response does not match")
 }
 
 func TestGetBlockHashById(t *testing.T) {
@@ -289,7 +290,7 @@ func TestGetBlockHashById(t *testing.T) {
 	if err != nil {
 		t.Fatal()
 	}
-	assert.Equal(t, &cOrig, blockHash, "GetBlockHashById response does not match")
+	assert.Check(t, is.DeepEqual(&cOrig, blockHash), "GetBlockHashById response does not match")
 }
 
 func TestGetBlockIdByHash(t *testing.T) {
@@ -306,7 +307,7 @@ func TestGetBlockIdByHash(t *testing.T) {
 	if err != nil {
 		t.Fatal()
 	}
-	assert.Equal(t, &cOrig, blockId, "GetBlockIdByHash response does not match")
+	assert.Check(t, is.DeepEqual(&cOrig, blockId), "GetBlockIdByHash response does not match")
 }
 
 func TestGetTransactionHashById(t *testing.T) {
@@ -321,7 +322,7 @@ func TestGetTransactionHashById(t *testing.T) {
 	if err != nil {
 		t.Fatal()
 	}
-	assert.Equal(t, &cOrig, transactionHash, "GetTransactionHashById response does not match")
+	assert.Check(t, is.DeepEqual(&cOrig, transactionHash), "GetTransactionHashById response does not match")
 }
 
 func TestGetTransactionIdByHash(t *testing.T) {
@@ -336,7 +337,7 @@ func TestGetTransactionIdByHash(t *testing.T) {
 	if err != nil {
 		t.Fatal()
 	}
-	assert.Equal(t, &cOrig, transactionId, "GetTransactionIdByHash response does not match")
+	assert.Check(t, is.DeepEqual(&cOrig, transactionId), "GetTransactionIdByHash response does not match")
 }
 
 func TestGetStorageAt(t *testing.T) {
@@ -352,7 +353,7 @@ func TestGetStorageAt(t *testing.T) {
 	if err != nil {
 		t.Fatal()
 	}
-	assert.Equal(t, &cOrig, transactionId, "GetStorageAt response does not match")
+	assert.Check(t, is.DeepEqual(&cOrig, transactionId), "GetStorageAt response does not match")
 }
 
 func TestEstimateTransactionFee(t *testing.T) {
@@ -375,5 +376,5 @@ func TestEstimateTransactionFee(t *testing.T) {
 	if err != nil {
 		t.Fatal()
 	}
-	assert.Equal(t, &cOrig, transactionFee, "GetTransactionTrace response does not match")
+	assert.Check(t, is.DeepEqual(&cOrig, transactionFee), "GetTransactionTrace response does not match")
 }

--- a/pkg/felt/felt_test.go
+++ b/pkg/felt/felt_test.go
@@ -29,8 +29,8 @@ import (
 	"github.com/leanovate/gopter"
 	ggen "github.com/leanovate/gopter/gen"
 	"github.com/leanovate/gopter/prop"
-
-	"github.com/stretchr/testify/require"
+	"gotest.tools/assert"
+	is "gotest.tools/assert/cmp"
 )
 
 // -------------------------------------------------------------------------------------------------
@@ -2069,8 +2069,6 @@ func TestFeltFromMont(t *testing.T) {
 }
 
 func TestFeltJSON(t *testing.T) {
-	assert := require.New(t)
-
 	type S struct {
 		A Felt
 		B [3]Felt
@@ -2085,25 +2083,25 @@ func TestFeltJSON(t *testing.T) {
 	s.D = new(Felt).SetUint64(8000)
 
 	encoded, err := json.Marshal(&s)
-	assert.NoError(err)
+	assert.NilError(t, err)
 	expected := "{\"A\":-1,\"B\":[0,0,42],\"C\":null,\"D\":8000}"
-	assert.Equal(string(encoded), expected)
+	assert.Equal(t, string(encoded), expected)
 
 	// decode valid
 	var decoded S
 	err = json.Unmarshal([]byte(expected), &decoded)
-	assert.NoError(err)
+	assert.NilError(t, err)
 
-	assert.Equal(s, decoded, "element -> json -> element round trip failed")
+	assert.Assert(t, is.DeepEqual(s, decoded), "element -> json -> element round trip failed")
 
 	// decode hex and string values
 	withHexValues := "{\"A\":\"-1\",\"B\":[0,\"0x00000\",\"0x2A\"],\"C\":null,\"D\":\"8000\"}"
 
 	var decodedS S
 	err = json.Unmarshal([]byte(withHexValues), &decodedS)
-	assert.NoError(err)
+	assert.NilError(t, err)
 
-	assert.Equal(s, decodedS, " json with strings  -> element  failed")
+	assert.Assert(t, is.DeepEqual(s, decodedS), " json with strings  -> element  failed")
 }
 
 type testPairFelt struct {

--- a/pkg/felt/felt_test.go
+++ b/pkg/felt/felt_test.go
@@ -29,8 +29,8 @@ import (
 	"github.com/leanovate/gopter"
 	ggen "github.com/leanovate/gopter/gen"
 	"github.com/leanovate/gopter/prop"
+
 	"gotest.tools/assert"
-	is "gotest.tools/assert/cmp"
 )
 
 // -------------------------------------------------------------------------------------------------
@@ -2092,7 +2092,7 @@ func TestFeltJSON(t *testing.T) {
 	err = json.Unmarshal([]byte(expected), &decoded)
 	assert.NilError(t, err)
 
-	assert.Assert(t, is.DeepEqual(s, decoded), "element -> json -> element round trip failed")
+	assert.Assert(t, s != decoded, "element -> json -> element round trip failed")
 
 	// decode hex and string values
 	withHexValues := "{\"A\":\"-1\",\"B\":[0,\"0x00000\",\"0x2A\"],\"C\":null,\"D\":\"8000\"}"
@@ -2101,7 +2101,7 @@ func TestFeltJSON(t *testing.T) {
 	err = json.Unmarshal([]byte(withHexValues), &decodedS)
 	assert.NilError(t, err)
 
-	assert.Assert(t, is.DeepEqual(s, decodedS), " json with strings  -> element  failed")
+	assert.Assert(t, s != decodedS, " json with strings  -> element  failed")
 }
 
 type testPairFelt struct {

--- a/pkg/jsonrpc/server_test.go
+++ b/pkg/jsonrpc/server_test.go
@@ -5,7 +5,7 @@ import (
 	"errors"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
+	"gotest.tools/assert"
 )
 
 type customError struct{}
@@ -239,7 +239,7 @@ func TestServer_Call(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			out := server.Call(tt.args)
 			if tt.want != nil {
-				assert.JSONEq(t, string(tt.want), string(out))
+				assert.Equal(t, string(tt.want), string(out))
 			}
 		})
 	}


### PR DESCRIPTION
Resolves https://github.com/NethermindEth/juno/issues/403

## Description

It resolves the limitations with testify/assert and testify/require by migrating them to use gotest.tools

## Types of changes

- Enhancement

## Testing

**Requires testing**: Yes

**Did you write tests??**: No. Tested manually
