### PR TITLE
Add a basic GatewayClient

### DIFF
--- a/clients/block_11817.json
+++ b/clients/block_11817.json
@@ -1,0 +1,4829 @@
+{
+  "block_hash": "0x24c692acaed3b486990bd9d2b2fbbee802b37b3bd79c59f295bad3277200a83",
+  "parent_block_hash": "0x3873ccb937f14429b169c654dda28886d2cc2d6ea17b3cff9748fe5cfdb67e0",
+  "block_number": 11817,
+  "state_root": "03df24be7b5fed6b41de08d38686b6142944119ca2a345c38793590d6804bba4",
+  "status": "ACCEPTED_ON_L2",
+  "gas_price": "0x27ad16775",
+  "transactions": [
+    {
+      "transaction_hash": "0xd38080575a9133cecdd5c80a79a513ff49d7dd478d8fd6ffe75fdac532e810",
+      "version": "0x0",
+      "max_fee": "0x135832dacd5000",
+      "signature": [
+        "0x25b889e9c7625eb35b647085ea149445dfaa893f95d0346f49bb80ab9c237b1",
+        "0x8fff8b2a44b5b89ec655492cd7a92fe5ef3986cd8b7d5237da52cc528b2d61"
+      ],
+      "contract_address": "0x1b706b18846667c44fdf2dc302ed90b98c0ae3aa6e041fdbdea1289d0284b03",
+      "entry_point_selector": "0x15d40a3d6ca2ac30f4031e42be28da9b056fef9bb7357ac5e85627ee876e5ad",
+      "calldata": [
+        "0x1",
+        "0x29959a546dda754dc823a7b8aa65862c5825faeaaf7938741d8ca6bfdc69e4e",
+        "0x3e8cfd4725c1e28fa4a6e3e468b4fcf75367166b850ac5f04e33ec843e82c1",
+        "0x0",
+        "0x4",
+        "0x4",
+        "0x1b706b18846667c44fdf2dc302ed90b98c0ae3aa6e041fdbdea1289d0284b02",
+        "0x1b706b18846667c44fdf2dc302ed90b98c0ae3aa6e041fdbdea1289d0284b03",
+        "0x35bdf",
+        "0x0",
+        "0x14"
+      ],
+      "type": "INVOKE_FUNCTION"
+    },
+    {
+      "transaction_hash": "0x27247dec49459069a36ac946ef9833651010067dc53bd7efdf029396acb329",
+      "version": "0x0",
+      "contract_address": "0x3af41d2a853ae4186509eecfab865f6bd01a75007ddc880d79aa83eb546c2f0",
+      "contract_address_salt": "0x4a95aeae8d8add5405e10ddeeaf2ac9174946d7e5edc37605353cd9645dea17",
+      "class_hash": "0x25ec026985a3bf9d0cc1fe17326b245dfdc3ff89b8fde106542a3ea56c5a918",
+      "constructor_calldata": [
+        "0x3e327de1c40540b98d05cbcb13552008e36f0ec8d61d46956d2f9752c294328",
+        "0x79dc0da7c54b95f10aa182ad0a46400db63156920adb65eca2654c0945a463",
+        "0x2",
+        "0x4a95aeae8d8add5405e10ddeeaf2ac9174946d7e5edc37605353cd9645dea17",
+        "0x0"
+      ],
+      "type": "DEPLOY"
+    },
+    {
+      "transaction_hash": "0x27791f280df704ed3b38cb73b3b41ec3d5e5ff5038c142a717e0feff031008a",
+      "version": "0x0",
+      "max_fee": "0xdb78f1d7a5000",
+      "signature": [
+        "0x614ebbb0efe6466dba74d71b2663e8227dde636286fcc1aca22ad2807d78ff3",
+        "0x68e804ecf5db8ab2053c8a2e846c9214b5a567fc22a758c749d777c4c7b7f7b"
+      ],
+      "contract_address": "0x17ef1d618cb84e023e014f586144f192c7f92334e351a4eb4a8c83fbbb31b1f",
+      "entry_point_selector": "0x15d40a3d6ca2ac30f4031e42be28da9b056fef9bb7357ac5e85627ee876e5ad",
+      "calldata": [
+        "0x2",
+        "0x53c91253bc9682c04929ca02ed00b3e423f6710d2ee7e0d5ebb06f3ecf368a8",
+        "0x219209e083275171774dab1df80982e9df2096516f06319c5c6d71ae0a8480c",
+        "0x0",
+        "0x3",
+        "0x7a6f98c03379b9513ca84cca1373ff452a7462a3b61598f0af5bb27ad7f76d1",
+        "0x3a6a860649d92cb2c2e1068e013c8ab63b36c6155658861e544a3f477c9691b",
+        "0x3",
+        "0x9",
+        "0xc",
+        "0x7a6f98c03379b9513ca84cca1373ff452a7462a3b61598f0af5bb27ad7f76d1",
+        "0x6242329",
+        "0x0",
+        "0x5f5e100",
+        "0x0",
+        "0x6242329",
+        "0x0",
+        "0x2",
+        "0x53c91253bc9682c04929ca02ed00b3e423f6710d2ee7e0d5ebb06f3ecf368a8",
+        "0x68f5c6a61780768455de69077e07e89787839bf8166decfbf92b645209c0fb8",
+        "0x17ef1d618cb84e023e014f586144f192c7f92334e351a4eb4a8c83fbbb31b1f",
+        "0x6384a5aa",
+        "0xa"
+      ],
+      "type": "INVOKE_FUNCTION"
+    },
+    {
+      "transaction_hash": "0x5b558a0cbe82da1448633f294a150fa4d367190d7db18299c97c17a40a3695a",
+      "version": "0x1",
+      "max_fee": "0x1d7d4d0b16888",
+      "signature": [
+        "0x4a7c7f8c819cdca14811170a48f9043b5fbbc54f6756d44b479315022972e7d",
+        "0x4d748cbdeb2e981ed52fe93bbd0c444c5e75c167d5085adb825e99f796000ce"
+      ],
+      "nonce": "0x6",
+      "contract_address": "0x24b436c72d3c78a11492e119d9e3d7f09cbcacab96e8bb0a0f66dfa6df8475e",
+      "calldata": [
+        "0x1",
+        "0x7861c4e276294a7e859ff0ae2eec0c68300ad9cbb43219db907da9bad786488",
+        "0x2f0b3c5710379609eb5495f1ecd348cb28167711b73609fe565a72734550354",
+        "0x0",
+        "0x3",
+        "0x3",
+        "0x697066733a2f2f516d6253374e566a6a706e46483576316279357738367033",
+        "0x3570775477574345357a634872677148313144706670",
+        "0x0"
+      ],
+      "type": "INVOKE_FUNCTION"
+    },
+    {
+      "transaction_hash": "0x2c82cad2be3b1897050ad9caebca05f29b0d3b5f23791025d53d59ae1b3d0ef",
+      "version": "0x1",
+      "max_fee": "0x1ff973cafa7fff",
+      "signature": [
+        "0x64698c64696bbd458e94028f8311b4e5ab0d8164e76d3bc094d2af895ad3e59",
+        "0x11d00575493e6baf4186bc7b5d78dfb2418a75e70b85edd291fe9eaa574431"
+      ],
+      "nonce": "0x67b",
+      "contract_address": "0x7b393627bd514d2aa4c83e9f0c468939df15ea3c29980cd8e7be3ec847795f0",
+      "calldata": [
+        "0x1",
+        "0x49d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7",
+        "0x83afd3f4caedc6eebf44246fe54e38c95e3179a5ec9ea81740eca5b482d12e",
+        "0x0",
+        "0x3",
+        "0x3",
+        "0xf7dbffbfdb48e0a71ca7366ab3df23665cce05f8f5d4cc49c3cff4fe3dba7a",
+        "0x49440df2e1680d3",
+        "0x0"
+      ],
+      "type": "INVOKE_FUNCTION"
+    },
+    {
+      "transaction_hash": "0x4862394e9031e9ab040c76462bd9a6f456785b24f64d56c189cf2963fa19454",
+      "version": "0x0",
+      "max_fee": "0xc29250617f4c",
+      "signature": [
+        "0xb5603f8b955c7bb0860401287a2978fd614742da53399e016d5d46df1e677c",
+        "0xa96f4be297de759604f7699864ef446f9692544e7d30d70c77bf00a2c6dd60"
+      ],
+      "contract_address": "0x669562f4aa4137b6f96123b2d2fc94716287458ef39df5d1b185ee7f026a723",
+      "entry_point_selector": "0x15d40a3d6ca2ac30f4031e42be28da9b056fef9bb7357ac5e85627ee876e5ad",
+      "calldata": [
+        "0x1",
+        "0x669562f4aa4137b6f96123b2d2fc94716287458ef39df5d1b185ee7f026a723",
+        "0xf2f7c15cbe06c8d94597cd91fd7f3369eae842359235712def5584f8d270cd",
+        "0x0",
+        "0x1",
+        "0x1",
+        "0x33434ad846cdd5f23eb73ff09fe6fddd568284a0fb7d1be20ee482f044dabe2",
+        "0x0"
+      ],
+      "type": "INVOKE_FUNCTION"
+    },
+    {
+      "transaction_hash": "0x12d4ab0f110a9a389d227c97f8a50ab1696e18bd6ea3c0cb117450bd226ca81",
+      "version": "0x1",
+      "max_fee": "0x94da909d3788",
+      "signature": [
+        "0x521bf1cb1a2b67bc2f3d6a94ec7a973e6d646bb42cd9a1c5dc754a9450a254b",
+        "0x49186edc18f5165c124bcff6aa93f352bdd9ab98675a67bebc5ce2004bab18e"
+      ],
+      "nonce": "0x2",
+      "contract_address": "0x114f1e702f7c05ed986956a8d626d0bd49848560b70e90ed664d4687e8e5fd0",
+      "calldata": [
+        "0x1",
+        "0x1e1f972637ad02e0eed03b69304344c4253804e528e1a5dd5c26bb2f23a8139",
+        "0x2d4c8ea4c8fb9f571d1f6f9b7692fff8e5ceaf73b1df98e7da8c1109b39ae9a",
+        "0x0",
+        "0x2",
+        "0x2",
+        "0x6883c3af369d1b3cdc0135480302a6a037ed5ece95dfdae36731912a49f722e",
+        "0x1"
+      ],
+      "type": "INVOKE_FUNCTION"
+    },
+    {
+      "transaction_hash": "0xa93fcc1af5aecdc114552c4d14409cfed9e9a2938b0d7a5d32a119a111fefc",
+      "version": "0x0",
+      "contract_address": "0x2b5e55b3ab2508626342fe28bb500b57f8a79fdd460f843b820f94d62cd5442",
+      "contract_address_salt": "0x59afdc786bf1cac438d28e6ab4f08985c4a008ff611ab560a4586a3c59b3f1",
+      "class_hash": "0x3131fa018d520a037686ce3efddeab8f28895662f019ca3ca18a626650f7d1e",
+      "constructor_calldata": [
+        "0x69577e6756a99b584b5d1ce8e60650ae33b6e2b13541783458268f07da6b38a",
+        "0x2dd76e7ad84dbed81c314ffe5e7a7cacfb8f4836f01af4e913f275f89a3de1a",
+        "0x1",
+        "0x59afdc786bf1cac438d28e6ab4f08985c4a008ff611ab560a4586a3c59b3f1"
+      ],
+      "type": "DEPLOY"
+    },
+    {
+      "transaction_hash": "0x70c7479c5494ad6c5b479dbc4ffd21a721dcfad99de7474d8d9e151da443567",
+      "version": "0x0",
+      "max_fee": "0xd6a53eda3808",
+      "signature": [
+        "0x40c09a2a0fe7777599e7d1d84a76a021e354a1d8ecf8838f2300dad8fe1c840",
+        "0x67970d5af8fdf68a4d3234afef2d1e1221074c52970739d82a1cf00e00030ae"
+      ],
+      "contract_address": "0x5e88c663366c79fddbfae974bca3a72125220ac183572dfb35ffdb9a9068e86",
+      "entry_point_selector": "0x15d40a3d6ca2ac30f4031e42be28da9b056fef9bb7357ac5e85627ee876e5ad",
+      "calldata": [
+        "0x2",
+        "0x46bfa580e4fa55a38eaa7f51a3469f86b336eed59a6136a07b7adcd095b0eb2",
+        "0x219209e083275171774dab1df80982e9df2096516f06319c5c6d71ae0a8480c",
+        "0x0",
+        "0x5",
+        "0x63a4b3b0122cdaa6ba244739add94aed1d31e3330458cda833a8d119f28cbe8",
+        "0x2ade85e543e31e17c85efcb86504a6afcba9eb5d7281076e9dfbf5f2543dd65",
+        "0x5",
+        "0x3",
+        "0x8",
+        "0x63a4b3b0122cdaa6ba244739add94aed1d31e3330458cda833a8d119f28cbe8",
+        "0x746861486f6d6579",
+        "0x51f01000000000000000000000000",
+        "0x1",
+        "0x0",
+        "0x746861486f6d6579",
+        "0x51f01000000000000000000000000",
+        "0x12795f58d50000",
+        "0x0"
+      ],
+      "type": "INVOKE_FUNCTION"
+    },
+    {
+      "transaction_hash": "0xdfa009e3713b0ac73be6808925462dce34447d974c9e15eec5cf76daa8b055",
+      "version": "0x0",
+      "contract_address": "0x73314940630fd6dcda0d772d4c972c4e0a9946bef9dabf4ef84eda8ef542b82",
+      "entry_point_selector": "0x2d757788a8d8d6f21d1cd40bce38a8222d70654214e96ff95d8086e684fbee5",
+      "nonce": "0x16bac",
+      "calldata": [
+        "0xae0ee0a63a2ce6baeeffe56e7714fb4efe48d419",
+        "0x2af8130d3ef618732766fb8f9a8924459db825a851ca7c204acf78ecb0a7905",
+        "0x16dedf44bdd8000",
+        "0x0"
+      ],
+      "type": "L1_HANDLER"
+    },
+    {
+      "transaction_hash": "0x2de5222193956868bd8acf59bca038e5ef2be22d6a54246711ee9acce35d33b",
+      "version": "0x1",
+      "max_fee": "0x3728b29b4543c",
+      "signature": [
+        "0x6112d0051cf8a28a2011ac748c9f4d909167a53635d02b3ae98030d88984b3b",
+        "0x5cfcd7ac57c91bec465a6505c2cab889333bf7260867f1a39d46dcc866e159c"
+      ],
+      "nonce": "0x10",
+      "contract_address": "0x3bde29ef8f62d3ec0160e9583536521cc2449f369ee713544a5a260743e13bb",
+      "calldata": [
+        "0x2",
+        "0x5900cfa2b50d53b097cb305d54e249e31f24f881885aae5639b0cd6af4ed298",
+        "0x219209e083275171774dab1df80982e9df2096516f06319c5c6d71ae0a8480c",
+        "0x0",
+        "0x3",
+        "0x7a6f98c03379b9513ca84cca1373ff452a7462a3b61598f0af5bb27ad7f76d1",
+        "0x147fd8f7d12de6da66feedc6d64a11bd371e5471ee1018f11f9072ede67a0fa",
+        "0x3",
+        "0xa",
+        "0xd",
+        "0x7a6f98c03379b9513ca84cca1373ff452a7462a3b61598f0af5bb27ad7f76d1",
+        "0x2146ee5404",
+        "0x0",
+        "0x49d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7",
+        "0x68f5c6a61780768455de69077e07e89787839bf8166decfbf92b645209c0fb8",
+        "0x2146ee5404",
+        "0x0",
+        "0xeb6201b1d723e",
+        "0x0",
+        "0x4df24e",
+        "0x0",
+        "0x3bde29ef8f62d3ec0160e9583536521cc2449f369ee713544a5a260743e13bb",
+        "0x6384a5ba"
+      ],
+      "type": "INVOKE_FUNCTION"
+    },
+    {
+      "transaction_hash": "0x3b3452571c2ea38f0681046a1bb2aba4df94cde5c39a436988689a3c26929f1",
+      "version": "0x1",
+      "max_fee": "0x1ed8cd0520e14",
+      "signature": [
+        "0x8faded62ce1f3352ba55cff1995090fc5dc340b9b9d9beae2c2e1be29a8d1",
+        "0x6c2f6fb66b7788d039b8e1244320206baf7ae49bb1aa49b07c5a33685351a54"
+      ],
+      "nonce": "0x5",
+      "contract_address": "0x6f0c776c711bdf73b53925caba6095801cc5037f3784e8f3aa26564973aba7d",
+      "calldata": [
+        "0x2",
+        "0x53c91253bc9682c04929ca02ed00b3e423f6710d2ee7e0d5ebb06f3ecf368a8",
+        "0x219209e083275171774dab1df80982e9df2096516f06319c5c6d71ae0a8480c",
+        "0x0",
+        "0x3",
+        "0x10884171baf1914edc28d7afb619b40a4051cfae78a094a55d230f19e944a28",
+        "0x15543c3708653cda9d418b4ccd3be11368e40636c10c44b18cfe756b6d88b29",
+        "0x3",
+        "0x6",
+        "0x9",
+        "0x10884171baf1914edc28d7afb619b40a4051cfae78a094a55d230f19e944a28",
+        "0x5940ee",
+        "0x0",
+        "0x1",
+        "0x53c91253bc9682c04929ca02ed00b3e423f6710d2ee7e0d5ebb06f3ecf368a8",
+        "0x5940ee",
+        "0x0",
+        "0x10af6aebb31c7f",
+        "0x0"
+      ],
+      "type": "INVOKE_FUNCTION"
+    },
+    {
+      "transaction_hash": "0x5b96978276a0e9005d32ac08683e752ee3b8aa4667c94e3d725915ceed8aef2",
+      "version": "0x0",
+      "max_fee": "0xc29250617f4c",
+      "signature": [
+        "0x2bada0d4e39bc642c86eb775428764112cc291459101aeb493802babb5627b4",
+        "0x54c70625387a00e524408a9c462bf9b98ba62d636ae66ca6213311d86119325"
+      ],
+      "contract_address": "0x435822721c4d7cf88f32a970bccacb40e864a32b327de0bea2518bb2e97bc12",
+      "entry_point_selector": "0x15d40a3d6ca2ac30f4031e42be28da9b056fef9bb7357ac5e85627ee876e5ad",
+      "calldata": [
+        "0x1",
+        "0x435822721c4d7cf88f32a970bccacb40e864a32b327de0bea2518bb2e97bc12",
+        "0xf2f7c15cbe06c8d94597cd91fd7f3369eae842359235712def5584f8d270cd",
+        "0x0",
+        "0x1",
+        "0x1",
+        "0x33434ad846cdd5f23eb73ff09fe6fddd568284a0fb7d1be20ee482f044dabe2",
+        "0x1"
+      ],
+      "type": "INVOKE_FUNCTION"
+    },
+    {
+      "transaction_hash": "0x51fae89e76799957f28bd0567702d1ccbecd06e35196af816766b70e5fc0bf3",
+      "version": "0x0",
+      "max_fee": "0xc29250617f4c",
+      "signature": [
+        "0x78c1325a9e77a61f253bbbfae71a6552735089860c16967a541dc2bb429b088",
+        "0x13e0ca95c7b20661ac3aed45fdfd36c18ddf3d0608d942447f17e4f23ab7fb2"
+      ],
+      "contract_address": "0x17584598729e398d59ec52f1021a5deeb13d439bb140f74faa96d91d241ac65",
+      "entry_point_selector": "0x15d40a3d6ca2ac30f4031e42be28da9b056fef9bb7357ac5e85627ee876e5ad",
+      "calldata": [
+        "0x1",
+        "0x17584598729e398d59ec52f1021a5deeb13d439bb140f74faa96d91d241ac65",
+        "0xf2f7c15cbe06c8d94597cd91fd7f3369eae842359235712def5584f8d270cd",
+        "0x0",
+        "0x1",
+        "0x1",
+        "0x33434ad846cdd5f23eb73ff09fe6fddd568284a0fb7d1be20ee482f044dabe2",
+        "0x7"
+      ],
+      "type": "INVOKE_FUNCTION"
+    },
+    {
+      "transaction_hash": "0x100fb2df5e9828308dcc64cc9f9900ca416b19a736fb41685cc7b9e6c6dd7d4",
+      "version": "0x0",
+      "contract_address": "0x3384e36c3642d0bd51dfbc22639ef24b601a1b11002ed57101bdb81f0851554",
+      "contract_address_salt": "0x2a064492f2bcfed6495b4391d557f8af0b0e61620034be17d952e786c126dd5",
+      "class_hash": "0x3131fa018d520a037686ce3efddeab8f28895662f019ca3ca18a626650f7d1e",
+      "constructor_calldata": [
+        "0x69577e6756a99b584b5d1ce8e60650ae33b6e2b13541783458268f07da6b38a",
+        "0x2dd76e7ad84dbed81c314ffe5e7a7cacfb8f4836f01af4e913f275f89a3de1a",
+        "0x1",
+        "0x2a064492f2bcfed6495b4391d557f8af0b0e61620034be17d952e786c126dd5"
+      ],
+      "type": "DEPLOY"
+    },
+    {
+      "transaction_hash": "0x110c6cbe6cbe9231181023c85220dd06a26185b6fb4b29605e1a1365be0eed6",
+      "version": "0x1",
+      "max_fee": "0x2b70985ecdf9c",
+      "signature": [
+        "0x16c7518d7ee557b5fc7b75c38f5b4c6eba0a4d207e7278f86d964232f0c2bf4",
+        "0x5260101329cf866e2b78839bf39056af0548b6365378c4733ac6444c3a99e68"
+      ],
+      "nonce": "0xb",
+      "contract_address": "0x3ce9a3268eec8ef82765605af341670b737a30ebd74584b21e7b5607e4175cd",
+      "calldata": [
+        "0x2",
+        "0x23c72abdf49dffc85ae3ede714f2168ad384cc67d08524732acea90df325",
+        "0x219209e083275171774dab1df80982e9df2096516f06319c5c6d71ae0a8480c",
+        "0x0",
+        "0x3",
+        "0x7a6f98c03379b9513ca84cca1373ff452a7462a3b61598f0af5bb27ad7f76d1",
+        "0x147fd8f7d12de6da66feedc6d64a11bd371e5471ee1018f11f9072ede67a0fa",
+        "0x3",
+        "0xa",
+        "0xd",
+        "0x7a6f98c03379b9513ca84cca1373ff452a7462a3b61598f0af5bb27ad7f76d1",
+        "0xe3ae4609a",
+        "0x0",
+        "0x49d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7",
+        "0x53c91253bc9682c04929ca02ed00b3e423f6710d2ee7e0d5ebb06f3ecf368a8",
+        "0xe3ae4609a",
+        "0x0",
+        "0x6c37e67ba93de",
+        "0x0",
+        "0x233c20",
+        "0x0",
+        "0x3ce9a3268eec8ef82765605af341670b737a30ebd74584b21e7b5607e4175cd",
+        "0x6384a5cf"
+      ],
+      "type": "INVOKE_FUNCTION"
+    },
+    {
+      "transaction_hash": "0x17a9acfc90327e502aaadbdfa924d7335b7a757196ad69ac00f4cbb3169b092",
+      "version": "0x1",
+      "max_fee": "0xa9651e2430a2",
+      "signature": [
+        "0x2eb02e36e45790eef35198263851b0378775717368bb4bdf6d6a85d4610b4bb",
+        "0x54eda3e3e294f2b6513726738469deabb091b8c017632608f6de864d4f3c22f"
+      ],
+      "nonce": "0x7",
+      "contract_address": "0x510cfec90ca586922ea6d5cf9fd053705876d0a7afbb053520e808fa27de0fd",
+      "calldata": [
+        "0x2",
+        "0x46bfa580e4fa55a38eaa7f51a3469f86b336eed59a6136a07b7adcd095b0eb2",
+        "0x219209e083275171774dab1df80982e9df2096516f06319c5c6d71ae0a8480c",
+        "0x0",
+        "0x5",
+        "0x63a4b3b0122cdaa6ba244739add94aed1d31e3330458cda833a8d119f28cbe8",
+        "0x2ade85e543e31e17c85efcb86504a6afcba9eb5d7281076e9dfbf5f2543dd65",
+        "0x5",
+        "0x3",
+        "0x8",
+        "0x63a4b3b0122cdaa6ba244739add94aed1d31e3330458cda833a8d119f28cbe8",
+        "0x5368656c646f6e",
+        "0xa6b01000000000000000000000000",
+        "0x1",
+        "0x0",
+        "0x5368656c646f6e",
+        "0xa6b01000000000000000000000000",
+        "0x93cafac6a8000"
+      ],
+      "type": "INVOKE_FUNCTION"
+    },
+    {
+      "transaction_hash": "0x77c2c1c330206f4222df159dc52aabd8156a98813df2c3d4f22c1440f23cb4",
+      "version": "0x1",
+      "max_fee": "0x93820e36bb98",
+      "signature": [
+        "0x18e9699bcf1375ad20c5f21d36ffa79121c71a0424358ce1c749507074eb483",
+        "0x34ac1fbbd5b1994232da8991363d1c73e40679d2d15d9c118cf97ddef9727f8"
+      ],
+      "nonce": "0x6",
+      "contract_address": "0x25338da98b11cc09bbf148a7f54c87ac5fa18248d783a08ba224ce382ca64c6",
+      "calldata": [
+        "0x1",
+        "0x7861c4e276294a7e859ff0ae2eec0c68300ad9cbb43219db907da9bad786488",
+        "0x2d4c8ea4c8fb9f571d1f6f9b7692fff8e5ceaf73b1df98e7da8c1109b39ae9a",
+        "0x0",
+        "0x2",
+        "0x2",
+        "0x4767b873669406d25dddbf67356e385a14480979e5358a411955d692576aa30",
+        "0x1"
+      ],
+      "type": "INVOKE_FUNCTION"
+    },
+    {
+      "transaction_hash": "0x7e243b28b61ff7ed082c7d54e12c716d52ba2d2e407fe8767ba09c5e3127cd2",
+      "version": "0x1",
+      "max_fee": "0x93820e36bb98",
+      "signature": [
+        "0x200d1873c64291c9300ddbb6cbff06bb5c7773b97fa6f06e133ad22b6525c52",
+        "0x6a70fca3f4c8789e9e6d1e5d6acaf10b82d8b98259350cfb4bebc61beea626d"
+      ],
+      "nonce": "0x6",
+      "contract_address": "0x49c2a1ec35979e3213232b2c59b0c3d9ac2a8a735958f6e8f917e6f8c9502fd",
+      "calldata": [
+        "0x1",
+        "0x7861c4e276294a7e859ff0ae2eec0c68300ad9cbb43219db907da9bad786488",
+        "0x2d4c8ea4c8fb9f571d1f6f9b7692fff8e5ceaf73b1df98e7da8c1109b39ae9a",
+        "0x0",
+        "0x2",
+        "0x2",
+        "0x4767b873669406d25dddbf67356e385a14480979e5358a411955d692576aa30",
+        "0x1"
+      ],
+      "type": "INVOKE_FUNCTION"
+    },
+    {
+      "transaction_hash": "0x6830b119458e42ec48a293bc0c8567653c406c32df2d4b40a8241ab0ac80ffa",
+      "version": "0x1",
+      "max_fee": "0x93820e36bb98",
+      "signature": [
+        "0x3c1bd7b8b7a7c01567504560e79c88c4f60d91990ebe70ecad95b75bc4cb2d1",
+        "0x4cbda2bb3c2ff62471160141f2cab437f26b8fe1d0c474c6539642185960d38"
+      ],
+      "nonce": "0x6",
+      "contract_address": "0x745fdf1332f23c2efaf7e9b95967fe17c68bdebfb6bb37bf9eb953beab849c",
+      "calldata": [
+        "0x1",
+        "0x7861c4e276294a7e859ff0ae2eec0c68300ad9cbb43219db907da9bad786488",
+        "0x2d4c8ea4c8fb9f571d1f6f9b7692fff8e5ceaf73b1df98e7da8c1109b39ae9a",
+        "0x0",
+        "0x2",
+        "0x2",
+        "0x4767b873669406d25dddbf67356e385a14480979e5358a411955d692576aa30",
+        "0x1"
+      ],
+      "type": "INVOKE_FUNCTION"
+    },
+    {
+      "transaction_hash": "0x2be3cc7d3fe8419086c118044f0d5b56f07d27fd129f6d5fd8fc61ddc191d28",
+      "version": "0x1",
+      "max_fee": "0x650620a2c296",
+      "signature": [
+        "0x5d6609f93a1f826619997b85e91d82fb3334492b325676c969facea0890529e",
+        "0x65c79ed6b915c78170d41a1ff5af1d207333a06b50440e6000b6814a5e419b4"
+      ],
+      "nonce": "0x6",
+      "contract_address": "0x5c7f1abb33a5ed33a36c9733d2702ea3c2ccd8c970f3686ff65ee09fa373ba9",
+      "calldata": [
+        "0x1",
+        "0x46bfa580e4fa55a38eaa7f51a3469f86b336eed59a6136a07b7adcd095b0eb2",
+        "0x19d59d013d4aa1a8b1ce4c8299086f070733b453c02d0dc46e735edc04d6444",
+        "0x0",
+        "0x8",
+        "0x8",
+        "0x5c7f1abb33a5ed33a36c9733d2702ea3c2ccd8c970f3686ff65ee09fa373ba9",
+        "0x7976c66b4439bcf35baaf020f4933726e4e1dbb34958c15542b823b5a07ff88",
+        "0x4d61686469204261",
+        "0x97701000000000000000000000000",
+        "0x1",
+        "0x0",
+        "0x1",
+        "0x0"
+      ],
+      "type": "INVOKE_FUNCTION"
+    },
+    {
+      "transaction_hash": "0x1d513e73e7ac102119e3998058d9b51c3daddfc14c77756f7720a82979a3e8c",
+      "version": "0x1",
+      "max_fee": "0x93820e36bb98",
+      "signature": [
+        "0x2fdae144c3da5ab089385990b2b3295edea4204034b60342b034cde52c62f35",
+        "0x7b9bd84f49bf68b79a2295d0b41ec92b479e1948521635cec869d430f44af96"
+      ],
+      "nonce": "0x6",
+      "contract_address": "0x8cac83ec41b03db54f4cef0adef66983f54236cb8a8781e8d2048fa96e4d15",
+      "calldata": [
+        "0x1",
+        "0x7861c4e276294a7e859ff0ae2eec0c68300ad9cbb43219db907da9bad786488",
+        "0x2d4c8ea4c8fb9f571d1f6f9b7692fff8e5ceaf73b1df98e7da8c1109b39ae9a",
+        "0x0",
+        "0x2",
+        "0x2",
+        "0x4767b873669406d25dddbf67356e385a14480979e5358a411955d692576aa30",
+        "0x1"
+      ],
+      "type": "INVOKE_FUNCTION"
+    },
+    {
+      "transaction_hash": "0x11367fb2aeab68f205256b6ae6e0ca86c6f0a08904f4c2f7b1012c3dd5b8aec",
+      "version": "0x1",
+      "max_fee": "0x93820e36bb98",
+      "signature": [
+        "0xc795cfa9ae3078efe657c5b417ad3cd7623da6b764ee62c8091c3432501ae8",
+        "0x4c1585c8a453c8fa3e71ea914acf52923efbd823f96b6746dc7b54e173bcb4b"
+      ],
+      "nonce": "0x6",
+      "contract_address": "0x5063903ed2b9b3fdf7126152ffee5f7dc6253b56ae4bdba64c39cef33cba572",
+      "calldata": [
+        "0x1",
+        "0x7861c4e276294a7e859ff0ae2eec0c68300ad9cbb43219db907da9bad786488",
+        "0x2d4c8ea4c8fb9f571d1f6f9b7692fff8e5ceaf73b1df98e7da8c1109b39ae9a",
+        "0x0",
+        "0x2",
+        "0x2",
+        "0x4767b873669406d25dddbf67356e385a14480979e5358a411955d692576aa30",
+        "0x1"
+      ],
+      "type": "INVOKE_FUNCTION"
+    },
+    {
+      "transaction_hash": "0x3e5ed5e468ca399a67f410c805ed4ee77384213bd4c308fca44ad88ecf8f277",
+      "version": "0x1",
+      "max_fee": "0x93820e36bb98",
+      "signature": [
+        "0x1183deb53415568a63f301813a88fbff7d0da14e6b1310f7c62a90af7252048",
+        "0x5daabc35010719e96cc6bfe1de6a64d375ad5eccfbd9cd01ebdf8588e214433"
+      ],
+      "nonce": "0x6",
+      "contract_address": "0x6669441ec4dd884e34219fb6eabb41d5f80a537d71352260683c0bb0919ae49",
+      "calldata": [
+        "0x1",
+        "0x7861c4e276294a7e859ff0ae2eec0c68300ad9cbb43219db907da9bad786488",
+        "0x2d4c8ea4c8fb9f571d1f6f9b7692fff8e5ceaf73b1df98e7da8c1109b39ae9a",
+        "0x0",
+        "0x2",
+        "0x2",
+        "0x4767b873669406d25dddbf67356e385a14480979e5358a411955d692576aa30",
+        "0x1"
+      ],
+      "type": "INVOKE_FUNCTION"
+    },
+    {
+      "transaction_hash": "0x5575dd8ebcad9791d3b6e39b379b0ee791f952a7f5e8e09e9eb7b31e49eca9b",
+      "version": "0x0",
+      "max_fee": "0x2054001b43f6c",
+      "signature": [
+        "0x263b487d25238ac695ff201ea1bc8f5441b0a913b2461be4ad87cb14fd9275b",
+        "0x389db6f25431fb66fad47f51cd8789a0855ba794358bd8f927613245e8be82f"
+      ],
+      "contract_address": "0x35c751960896c3c89a500ef4339449331eb73aa9f80336b9d3bd3d5c6ff09d0",
+      "entry_point_selector": "0x15d40a3d6ca2ac30f4031e42be28da9b056fef9bb7357ac5e85627ee876e5ad",
+      "calldata": [
+        "0x1",
+        "0x3090623ea32d932ca1236595076b00702e7d860696faf300ca9eb13bfe0a78c",
+        "0x2f0b3c5710379609eb5495f1ecd348cb28167711b73609fe565a72734550354",
+        "0x0",
+        "0x4",
+        "0x4",
+        "0x35c751960896c3c89a500ef4339449331eb73aa9f80336b9d3bd3d5c6ff09d0",
+        "0x2",
+        "0x697066733a2f2f516d654168485671744e3571473839357862643378427845",
+        "0x506348526e68657138714e4e353753316b64384c3337",
+        "0x8"
+      ],
+      "type": "INVOKE_FUNCTION"
+    },
+    {
+      "transaction_hash": "0x56a54ac65e6aad855a5d0bd5859147addcc48b0a61f86b3b15efe5f854c2932",
+      "version": "0x0",
+      "max_fee": "0x91a201bea2000",
+      "signature": [
+        "0x377c9f8f7e2bd5c23fb5df038d7375b4df164b2c8f740cd644ca1efa9d47fde",
+        "0x47132d0edf05d287428002b540a215bfeb25c09660b98cb64943b985c563542"
+      ],
+      "contract_address": "0x58b62e6584a00c62c3886abd0ee5590121e5cb33324eac10a8eff43a6d60b64",
+      "entry_point_selector": "0x15d40a3d6ca2ac30f4031e42be28da9b056fef9bb7357ac5e85627ee876e5ad",
+      "calldata": [
+        "0x1",
+        "0x3090623ea32d932ca1236595076b00702e7d860696faf300ca9eb13bfe0a78c",
+        "0x2f0b3c5710379609eb5495f1ecd348cb28167711b73609fe565a72734550354",
+        "0x0",
+        "0x4",
+        "0x4",
+        "0x58b62e6584a00c62c3886abd0ee5590121e5cb33324eac10a8eff43a6d60b64",
+        "0x2",
+        "0x697066733a2f2f516d646e665646555837707857634d3233676e6767556152",
+        "0x745852314e464e753862657a56414736674556617947",
+        "0x1"
+      ],
+      "type": "INVOKE_FUNCTION"
+    },
+    {
+      "transaction_hash": "0x7917a17f431c2cfaa7031ca00dc782065d8477299cd0797c4dbe3e5abcc477c",
+      "version": "0x1",
+      "max_fee": "0x2af2fe2970ca4",
+      "signature": [
+        "0x31c4406edb8bf5c4a12bf481739cd090b5bd5e3edde689400545dff99bb190a",
+        "0x587266ad47c83b25f78d90c754253e48c1c1be5aaa59bb502673a61413585af"
+      ],
+      "nonce": "0x2",
+      "contract_address": "0x1148ed7da24228c369d5dd044a5064626d2b623a8edd28a0efa1223c3767355",
+      "calldata": [
+        "0x2",
+        "0x49d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7",
+        "0x219209e083275171774dab1df80982e9df2096516f06319c5c6d71ae0a8480c",
+        "0x0",
+        "0x3",
+        "0x7a6f98c03379b9513ca84cca1373ff452a7462a3b61598f0af5bb27ad7f76d1",
+        "0x2c0f7bf2d6cf5304c29171bf493feb222fef84bdaf17805a6574b0c2e8bcc87",
+        "0x3",
+        "0x9",
+        "0xc",
+        "0x7a6f98c03379b9513ca84cca1373ff452a7462a3b61598f0af5bb27ad7f76d1",
+        "0x16345785d8a0000",
+        "0x0",
+        "0x16345785d8a0000",
+        "0x0",
+        "0x6423de46f0e99be55",
+        "0x0",
+        "0x2",
+        "0x49d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7",
+        "0xda114221cb83fa859dbdb4c44beeaa0bb37c7537ad5ae66fe5e0efd20e6eb3",
+        "0x1148ed7da24228c369d5dd044a5064626d2b623a8edd28a0efa1223c3767355",
+        "0x6384a5e9"
+      ],
+      "type": "INVOKE_FUNCTION"
+    },
+    {
+      "transaction_hash": "0x77feea3cbbfe51a29f11061f285953eb825f808cbb2439e18434c6c0bf6760e",
+      "version": "0x1",
+      "max_fee": "0x1d7d4d0b16888",
+      "signature": [
+        "0x3edbe2f289a5d740527dfcc0d8f31cfc8723ce3e5971163dd91cfda144d255f",
+        "0x4a7b3a1e3aa8566a668fda2360ed403a2520cfc6ce94d176d7d45709f7f4032"
+      ],
+      "nonce": "0x6",
+      "contract_address": "0x1cc5188bf60e31a4825f7e29c608add1f6dadb1cbb237b36842f646f91181a5",
+      "calldata": [
+        "0x1",
+        "0x7861c4e276294a7e859ff0ae2eec0c68300ad9cbb43219db907da9bad786488",
+        "0x2f0b3c5710379609eb5495f1ecd348cb28167711b73609fe565a72734550354",
+        "0x0",
+        "0x3",
+        "0x3",
+        "0x697066733a2f2f516d51614b4b4766654e684c6768696e5157396a664d3871",
+        "0x3166374363343732343646634d426e38675358757236",
+        "0x0"
+      ],
+      "type": "INVOKE_FUNCTION"
+    },
+    {
+      "transaction_hash": "0x3e162983cc807cc57171688d0452b5eb4dd162a51e86d700de4726fb9832d71",
+      "version": "0x0",
+      "contract_address": "0x73314940630fd6dcda0d772d4c972c4e0a9946bef9dabf4ef84eda8ef542b82",
+      "entry_point_selector": "0x2d757788a8d8d6f21d1cd40bce38a8222d70654214e96ff95d8086e684fbee5",
+      "nonce": "0x16bad",
+      "calldata": [
+        "0xae0ee0a63a2ce6baeeffe56e7714fb4efe48d419",
+        "0x5d22b724a6ebe4a7758ba997decf4bfb97cf269e634f3866f5c6f6e23414721",
+        "0x38d7ea4c68000",
+        "0x0"
+      ],
+      "type": "L1_HANDLER"
+    },
+    {
+      "transaction_hash": "0x2db4259ed32d96ab92dc6cb1c36ed5abb6a65734c229160cfc3e692538a1d43",
+      "version": "0x1",
+      "max_fee": "0x1ed8cd0520e14",
+      "signature": [
+        "0x5b08194c3fb3415187d82a83f4e21ebd3f8902362fb6fd24f6d24d594679d38",
+        "0x55964a4be20fd08bd906b25539d23c4d95b3de81c37d8b6e81facdd2a7b6bc8"
+      ],
+      "nonce": "0x10",
+      "contract_address": "0x2736b678f2349dfbd64fe07e5e07a0f9f558b5183c7819031ca020a2d1f08af",
+      "calldata": [
+        "0x2",
+        "0x68f5c6a61780768455de69077e07e89787839bf8166decfbf92b645209c0fb8",
+        "0x219209e083275171774dab1df80982e9df2096516f06319c5c6d71ae0a8480c",
+        "0x0",
+        "0x3",
+        "0x10884171baf1914edc28d7afb619b40a4051cfae78a094a55d230f19e944a28",
+        "0x15543c3708653cda9d418b4ccd3be11368e40636c10c44b18cfe756b6d88b29",
+        "0x3",
+        "0x6",
+        "0x9",
+        "0x10884171baf1914edc28d7afb619b40a4051cfae78a094a55d230f19e944a28",
+        "0xc2f61b",
+        "0x0",
+        "0x4",
+        "0x68f5c6a61780768455de69077e07e89787839bf8166decfbf92b645209c0fb8",
+        "0xc2f61b",
+        "0x0",
+        "0x240c3b0e77d7c3",
+        "0x0"
+      ],
+      "type": "INVOKE_FUNCTION"
+    },
+    {
+      "transaction_hash": "0x515a016b825751838e676da9ad73a728a51555bb8a3358b572d618d5e698830",
+      "version": "0x1",
+      "max_fee": "0x1ed8cd0520e14",
+      "signature": [
+        "0x31f4dfd8b75df5bc30e3a0554a5138fe496ed8d49905d1facc393ff052d5272",
+        "0x13805feeb4a5b3895b91a82e1cb1a33d34999e5a50d63d194c53490806e7070"
+      ],
+      "nonce": "0xd",
+      "contract_address": "0x18e130cd8a0b6bbd5e50701caca13761cd7f2cd7997eedb3a12037d67830957",
+      "calldata": [
+        "0x2",
+        "0x53c91253bc9682c04929ca02ed00b3e423f6710d2ee7e0d5ebb06f3ecf368a8",
+        "0x219209e083275171774dab1df80982e9df2096516f06319c5c6d71ae0a8480c",
+        "0x0",
+        "0x3",
+        "0x10884171baf1914edc28d7afb619b40a4051cfae78a094a55d230f19e944a28",
+        "0x15543c3708653cda9d418b4ccd3be11368e40636c10c44b18cfe756b6d88b29",
+        "0x3",
+        "0x6",
+        "0x9",
+        "0x10884171baf1914edc28d7afb619b40a4051cfae78a094a55d230f19e944a28",
+        "0x6f17d3d",
+        "0x0",
+        "0x1",
+        "0x53c91253bc9682c04929ca02ed00b3e423f6710d2ee7e0d5ebb06f3ecf368a8",
+        "0x6f17d3d",
+        "0x0",
+        "0x14a7a726b72a09e",
+        "0x0"
+      ],
+      "type": "INVOKE_FUNCTION"
+    },
+    {
+      "transaction_hash": "0x4f2f0224a8e80cf2a4427691a3bb3b25d81031ac061bf85ced15a6a3b04929c",
+      "version": "0x1",
+      "max_fee": "0x650620a2c296",
+      "signature": [
+        "0x75a0700011b86ae94ce7441c9c9fc7c23ca09603d242fe92bb8da669566f82b",
+        "0x53fd9da344989eed9025239f9ce04e0a4c07b258de38293e1dcab2990e343fc"
+      ],
+      "nonce": "0x3",
+      "contract_address": "0x59a0e2b44b40e07dcc247e1f86c4f7f268414fe6d2b67845e2bae2f479420dd",
+      "calldata": [
+        "0x1",
+        "0x46bfa580e4fa55a38eaa7f51a3469f86b336eed59a6136a07b7adcd095b0eb2",
+        "0x19d59d013d4aa1a8b1ce4c8299086f070733b453c02d0dc46e735edc04d6444",
+        "0x0",
+        "0x8",
+        "0x8",
+        "0x59a0e2b44b40e07dcc247e1f86c4f7f268414fe6d2b67845e2bae2f479420dd",
+        "0x7976c66b4439bcf35baaf020f4933726e4e1dbb34958c15542b823b5a07ff88",
+        "0x5a75756b6f75204d61797a6965",
+        "0xab201000000000000000000000000",
+        "0x1",
+        "0x0",
+        "0x1",
+        "0x0"
+      ],
+      "type": "INVOKE_FUNCTION"
+    },
+    {
+      "transaction_hash": "0x49e0f644286f05c6e5b7fd762e6e5dca8a1302419fcc799af85463c519bb89",
+      "version": "0x0",
+      "max_fee": "0xc29250617f4c",
+      "signature": [
+        "0x39bf023c0c76da50161dc12d42db288fdafe3013b15e06a24f1083aa604d4bf",
+        "0x5193439806d742a54a89e42a630ddff98dbac6f2c196cf7cc53ea034773807e"
+      ],
+      "contract_address": "0xbc1529814a493420c91f3c7f902c30ee36c1e22b79a9cb304a09c1226d8cf9",
+      "entry_point_selector": "0x15d40a3d6ca2ac30f4031e42be28da9b056fef9bb7357ac5e85627ee876e5ad",
+      "calldata": [
+        "0x1",
+        "0xbc1529814a493420c91f3c7f902c30ee36c1e22b79a9cb304a09c1226d8cf9",
+        "0xf2f7c15cbe06c8d94597cd91fd7f3369eae842359235712def5584f8d270cd",
+        "0x0",
+        "0x1",
+        "0x1",
+        "0x33434ad846cdd5f23eb73ff09fe6fddd568284a0fb7d1be20ee482f044dabe2",
+        "0x2"
+      ],
+      "type": "INVOKE_FUNCTION"
+    },
+    {
+      "transaction_hash": "0x30c51e9cef2136728e93a81605c5508a2e659c528d03c04e4c1ae7d0ec100ea",
+      "version": "0x1",
+      "max_fee": "0x3f95c4db9e9b2",
+      "signature": [
+        "0x6895477a96e44f2fef7ac02f6870f9c19b5a498146da0c8db24f29abd70d81c",
+        "0x3c6e8781474c56dd927f419d6d4565f30cc0aa286ba2be6bf158faaee125eae"
+      ],
+      "nonce": "0xed",
+      "contract_address": "0x7518a3810c8204fb4377de22df74ed80857368795b936a99ca70bb0fda8bdd",
+      "calldata": [
+        "0x2",
+        "0x27fb5a7be4707e2b1fe653e7296ad30114596fafdd3fbc3f9b92a0551ff18ec",
+        "0x8bde087a787e765f84e3045b61265573830a938d83c750c5b44ca3e6c1b3e2",
+        "0x0",
+        "0x1d",
+        "0x27fb5a7be4707e2b1fe653e7296ad30114596fafdd3fbc3f9b92a0551ff18ec",
+        "0x8bde087a787e765f84e3045b61265573830a938d83c750c5b44ca3e6c1b3e2",
+        "0x1d",
+        "0x1d",
+        "0x3a",
+        "0x216ca69e83b0b28acfb22350297f8af85749538ac6974b638ed15a7046a30f",
+        "0x5",
+        "0x0",
+        "0x3",
+        "0x4a65616e4a617373",
+        "0x0",
+        "0x1",
+        "0x0",
+        "0xb91",
+        "0x5a75756b6f75204d61797a6965",
+        "0x0",
+        "0x1",
+        "0x0",
+        "0x9f8",
+        "0x446f756d73",
+        "0x0",
+        "0x1",
+        "0x0",
+        "0x479",
+        "0x3",
+        "0xc6f446dbd982d86cf3fed358c04fa3d5",
+        "0x523e55a9c4394db9ebf2400cf32cbbb4",
+        "0x1220",
+        "0x67e763b1615d8b3b62a68cdc2ef31b47",
+        "0x161644b1d2bafc10b732e061539a67d2",
+        "0x1220",
+        "0xe77cc55ee5a57a9ac2a9c4e3990b4894",
+        "0xe8d1ea0aa69868f666ca5f6216349886",
+        "0x1220",
+        "0x216ca69e83b0b28acfb22350297f8af85749538ac6974b638ed15a7046a30f",
+        "0x5",
+        "0x0",
+        "0x3",
+        "0x537069646572205a6564",
+        "0x0",
+        "0x1",
+        "0x0",
+        "0xafb",
+        "0x536b756e61",
+        "0x0",
+        "0x1",
+        "0x0",
+        "0x7e6",
+        "0x4c652052e8676c656d656e74",
+        "0x0",
+        "0x1",
+        "0x0",
+        "0xb06",
+        "0x3",
+        "0xe692e62404514db51b82de6ef02f0557",
+        "0xae3ac9e10fc12e0230a6fa5171cafa9c",
+        "0x1220",
+        "0x8ed5b65a4b4330cecb41656375e9de5d",
+        "0x4b58126df550345dd1906a24608b131d",
+        "0x1220",
+        "0x7b35414d0a100cad6e256e9100248383",
+        "0x98616dc6fc70ba2eeaa828cb817c5a33",
+        "0x1220"
+      ],
+      "type": "INVOKE_FUNCTION"
+    },
+    {
+      "transaction_hash": "0x5c4ae1561e64e28d6d912d92899b146bc72d365b7e8af5d4303ab9c9d48806d",
+      "version": "0x1",
+      "max_fee": "0xc2cbbb7293f4",
+      "signature": [
+        "0x366d23ca1c9c6c1a4b01297c953513d726f2126ba935aeff929bb19a0fec20d",
+        "0x17de3eb700992e5147aef3d887c4d6916b62c64db121e7894f9bb8ce607e25f"
+      ],
+      "nonce": "0x9",
+      "contract_address": "0x30877eccc7226b595e5744222c37e536774c864b7516226ef6b622416e395b4",
+      "calldata": [
+        "0x1",
+        "0x49d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7",
+        "0x219209e083275171774dab1df80982e9df2096516f06319c5c6d71ae0a8480c",
+        "0x0",
+        "0x3",
+        "0x3",
+        "0x173f81c529191726c6e7287e24626fe24760ac44dae2a1f7e02080230f8458b",
+        "0xffffffffffffffffffffffffffffffff",
+        "0xffffffffffffffffffffffffffffffff"
+      ],
+      "type": "INVOKE_FUNCTION"
+    },
+    {
+      "transaction_hash": "0x16c9e63a7139a3b6f9974cfc76f700c75c41fa102bbddf7ad9da96f2c3ebc55",
+      "version": "0x0",
+      "max_fee": "0x8eca693ad000",
+      "signature": [
+        "0x39869f427a38de78fe5b63a211c29a43729d99115aacc230a38ee03c88893e5",
+        "0x7681c0a7db2adb85e5929fd55967cc54772e11e1435d76590c6333922e18774"
+      ],
+      "contract_address": "0x8162333d66f7e8ed9284b8e5a2e28135fa171db01e355086a259e500d9690b",
+      "entry_point_selector": "0x15d40a3d6ca2ac30f4031e42be28da9b056fef9bb7357ac5e85627ee876e5ad",
+      "calldata": [
+        "0x1",
+        "0x49d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7",
+        "0x219209e083275171774dab1df80982e9df2096516f06319c5c6d71ae0a8480c",
+        "0x0",
+        "0x3",
+        "0x3",
+        "0x173f81c529191726c6e7287e24626fe24760ac44dae2a1f7e02080230f8458b",
+        "0xffffffffffffffffffffffffffffffff",
+        "0xffffffffffffffffffffffffffffffff",
+        "0x0"
+      ],
+      "type": "INVOKE_FUNCTION"
+    },
+    {
+      "transaction_hash": "0x5ac2ad423e116359c205906174b525a6a1b6c3d76fb6ba92c74d631e1ec2f2d",
+      "version": "0x1",
+      "max_fee": "0x650620a2c296",
+      "signature": [
+        "0x53f7da5ec0b0bc0e33804d5f22051f97dd4c3c70c310f30a7327e22a3f14495",
+        "0x5368526706f31c8be0924ad87d67cd07d1a5efc9f7086ecb5702294fe525fa5"
+      ],
+      "nonce": "0x1a",
+      "contract_address": "0x7976c66b4439bcf35baaf020f4933726e4e1dbb34958c15542b823b5a07ff88",
+      "calldata": [
+        "0x1",
+        "0x46bfa580e4fa55a38eaa7f51a3469f86b336eed59a6136a07b7adcd095b0eb2",
+        "0x19d59d013d4aa1a8b1ce4c8299086f070733b453c02d0dc46e735edc04d6444",
+        "0x0",
+        "0x8",
+        "0x8",
+        "0x7976c66b4439bcf35baaf020f4933726e4e1dbb34958c15542b823b5a07ff88",
+        "0x59a0e2b44b40e07dcc247e1f86c4f7f268414fe6d2b67845e2bae2f479420dd",
+        "0x4a776c6573",
+        "0xb7901000000000000000000000000",
+        "0x1",
+        "0x0",
+        "0x1",
+        "0x0"
+      ],
+      "type": "INVOKE_FUNCTION"
+    },
+    {
+      "transaction_hash": "0xae69fed1399566f91dd7a82ea872677a20e240d0ca0684e3326fc80341d57e",
+      "version": "0x0",
+      "max_fee": "0x5051db3115000",
+      "signature": [
+        "0x72b9ab8534d30f91db9306c2b1f6df01fc4a273a6617b7d5c9464b24f6235fb",
+        "0x7c69837a73d371ddc2dcc2c02a7b70f31e42fb81b218a9f57fe84d54adbf384"
+      ],
+      "contract_address": "0x21f7c10f6a8123c1653bac4925bba8aabaac5fc0d9f894a1f48711434ae054d",
+      "entry_point_selector": "0x15d40a3d6ca2ac30f4031e42be28da9b056fef9bb7357ac5e85627ee876e5ad",
+      "calldata": [
+        "0x1",
+        "0x49d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7",
+        "0x219209e083275171774dab1df80982e9df2096516f06319c5c6d71ae0a8480c",
+        "0x0",
+        "0x3",
+        "0x3",
+        "0x173f81c529191726c6e7287e24626fe24760ac44dae2a1f7e02080230f8458b",
+        "0xffffffffffffffffffffffffffffffff",
+        "0xffffffffffffffffffffffffffffffff",
+        "0x0"
+      ],
+      "type": "INVOKE_FUNCTION"
+    },
+    {
+      "transaction_hash": "0x1c0ec9284cd3cbf53d341cffe2caef02a08305813cbda250ceb6acebad6b23a",
+      "version": "0x1",
+      "max_fee": "0x93820e36bb98",
+      "signature": [
+        "0x549cbcb2556eea8d3b0d4b2cb7f537b24928390eff99e9b3bb36c917c92d0ac",
+        "0x1afc4925950dcbd7681a93b46a2293c3320a2acc818c954c7c8b3f93e97d2ff"
+      ],
+      "nonce": "0x5",
+      "contract_address": "0x59402a11cccbc49b8253f74939d5824bf08f3323cd8f41459994bbe677ed518",
+      "calldata": [
+        "0x1",
+        "0x7861c4e276294a7e859ff0ae2eec0c68300ad9cbb43219db907da9bad786488",
+        "0x2d4c8ea4c8fb9f571d1f6f9b7692fff8e5ceaf73b1df98e7da8c1109b39ae9a",
+        "0x0",
+        "0x2",
+        "0x2",
+        "0x2a92f0f860bf7c63fb9ef42cff4137006b309e0e6e1484e42d0b5511959414d",
+        "0x1"
+      ],
+      "type": "INVOKE_FUNCTION"
+    },
+    {
+      "transaction_hash": "0x268e46ee69e91770bed7dda7d47714e2c44b0f28968fb072595a2eac659ea1a",
+      "version": "0x0",
+      "max_fee": "0xd915c3a65b000",
+      "signature": [
+        "0x1ca446f184c248e35290566f12161232d19de1270d5abc1182d094d684937ad",
+        "0x2003239303c14979bd997e45992da873d45fa8bfd8bb7698e6aa7dee9b88e08"
+      ],
+      "contract_address": "0x481ea57ebd208e2487215e6db394a3d41575ffc2ac9136cc40869b4ef3c2db5",
+      "entry_point_selector": "0x15d40a3d6ca2ac30f4031e42be28da9b056fef9bb7357ac5e85627ee876e5ad",
+      "calldata": [
+        "0x3",
+        "0xda114221cb83fa859dbdb4c44beeaa0bb37c7537ad5ae66fe5e0efd20e6eb3",
+        "0x219209e083275171774dab1df80982e9df2096516f06319c5c6d71ae0a8480c",
+        "0x0",
+        "0x3",
+        "0x49d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7",
+        "0x219209e083275171774dab1df80982e9df2096516f06319c5c6d71ae0a8480c",
+        "0x3",
+        "0x3",
+        "0x10884171baf1914edc28d7afb619b40a4051cfae78a094a55d230f19e944a28",
+        "0x2cfb12ff9e08412ec5009c65ea06e727119ad948d25c8a8cc2c86fec4adee70",
+        "0x6",
+        "0xa",
+        "0x10",
+        "0x10884171baf1914edc28d7afb619b40a4051cfae78a094a55d230f19e944a28",
+        "0x32f98fb9f89b50000",
+        "0x0",
+        "0x10884171baf1914edc28d7afb619b40a4051cfae78a094a55d230f19e944a28",
+        "0xb1d2afd1347381",
+        "0x0",
+        "0xda114221cb83fa859dbdb4c44beeaa0bb37c7537ad5ae66fe5e0efd20e6eb3",
+        "0x32f98fb9f89b50000",
+        "0x0",
+        "0x31f491f8cfcb68000",
+        "0x0",
+        "0x49d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7",
+        "0xb1d2afd1347381",
+        "0x0",
+        "0xae443ba92e483b",
+        "0x0",
+        "0x1"
+      ],
+      "type": "INVOKE_FUNCTION"
+    },
+    {
+      "transaction_hash": "0x4f41a71816e95a88bd56cf16570e3b39079026657716817882394a5624a070f",
+      "version": "0x1",
+      "max_fee": "0x94d0fec5096c",
+      "signature": [
+        "0x7ef16a1eeac1856d73811f7a2ced515225fa12451be30943fee564d9e8f6fb9",
+        "0x5593e73c8da139c6abc39f302d10efc8d6e0bca85fc5acd4177f353ce0ae74a"
+      ],
+      "nonce": "0x10",
+      "contract_address": "0x20dcc849b1712cf6e3c1668eee84bab760db54fa658e8529e866820a1b135bb",
+      "calldata": [
+        "0x1",
+        "0x1e1f972637ad02e0eed03b69304344c4253804e528e1a5dd5c26bb2f23a8139",
+        "0x2d4c8ea4c8fb9f571d1f6f9b7692fff8e5ceaf73b1df98e7da8c1109b39ae9a",
+        "0x0",
+        "0x2",
+        "0x2",
+        "0x6883c3af369d1b3cdc0135480302a6a037ed5ece95dfdae36731912a49f722e",
+        "0x1"
+      ],
+      "type": "INVOKE_FUNCTION"
+    },
+    {
+      "transaction_hash": "0x565ab7d1deb082200accc89b0137c68ed9e9cd1504a8b9e6134fb136ab7bd75",
+      "version": "0x0",
+      "max_fee": "0x2054001b43f6c",
+      "signature": [
+        "0x120577d79df084bbcae9e2e91876a3c4e61fb51f66e65edfe9167a6c7ca88ae",
+        "0x7a7a9bb217e6fe7b19b0d6eca9d990c17eb030464df53b45acaef484fbf22c0"
+      ],
+      "contract_address": "0x35c751960896c3c89a500ef4339449331eb73aa9f80336b9d3bd3d5c6ff09d0",
+      "entry_point_selector": "0x15d40a3d6ca2ac30f4031e42be28da9b056fef9bb7357ac5e85627ee876e5ad",
+      "calldata": [
+        "0x1",
+        "0x3090623ea32d932ca1236595076b00702e7d860696faf300ca9eb13bfe0a78c",
+        "0x2f0b3c5710379609eb5495f1ecd348cb28167711b73609fe565a72734550354",
+        "0x0",
+        "0x4",
+        "0x4",
+        "0x35c751960896c3c89a500ef4339449331eb73aa9f80336b9d3bd3d5c6ff09d0",
+        "0x2",
+        "0x697066733a2f2f516d58434c41364a7a6542795678464c6953746531455557",
+        "0x5866573231725377624c4b3161426262384a46715745",
+        "0x9"
+      ],
+      "type": "INVOKE_FUNCTION"
+    },
+    {
+      "transaction_hash": "0xf685badf2a8683a8774c1a642ca1adfed3f7c46e982847a480affa95f7a5d5",
+      "version": "0x0",
+      "max_fee": "0x29f3503d82000",
+      "signature": [
+        "0x3e3f180e3622706641d6194a308457cae87ff7e5453a4d0521f0bf7878780a1",
+        "0x6a08f6a90d6e7d47f28dd6b82e7992d56f60cff243658e7be651aaa780e53d"
+      ],
+      "contract_address": "0xc8386608ef88be2eb1f9af53845883232499547f4f63a8bf29aeca47c153ea",
+      "entry_point_selector": "0x15d40a3d6ca2ac30f4031e42be28da9b056fef9bb7357ac5e85627ee876e5ad",
+      "calldata": [
+        "0x1",
+        "0x49d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7",
+        "0x83afd3f4caedc6eebf44246fe54e38c95e3179a5ec9ea81740eca5b482d12e",
+        "0x0",
+        "0x3",
+        "0x3",
+        "0x70b59cd474b2a8b0f5570a93abfdff5cb107ada7d0ac37743b82fa2ff613f8e",
+        "0x11c37937e08000",
+        "0x0",
+        "0x9"
+      ],
+      "type": "INVOKE_FUNCTION"
+    },
+    {
+      "transaction_hash": "0x47c6cbf67636dff3ae644df0ab8be96423ef53653778b4a97d8176de253a5df",
+      "version": "0x1",
+      "max_fee": "0x1d7d4d0b16888",
+      "signature": [
+        "0x450f25eb233311e8e291167790af920ed902cc97cbd89bd3d2a114fe41b5226",
+        "0x11c4f83395fbab180dbbb7f5cf03d7947ec2bcc7093c3b0768c70e03dd5c0f9"
+      ],
+      "nonce": "0x6",
+      "contract_address": "0x7fa14a93b02b946e1ba6d417a7b19d398b253625f79d6472c309a675a0fe506",
+      "calldata": [
+        "0x1",
+        "0x7861c4e276294a7e859ff0ae2eec0c68300ad9cbb43219db907da9bad786488",
+        "0x2f0b3c5710379609eb5495f1ecd348cb28167711b73609fe565a72734550354",
+        "0x0",
+        "0x3",
+        "0x3",
+        "0x697066733a2f2f516d4e6f383766664d396b5538325674646365746d715a75",
+        "0x46614561593376634b456d675272667a6574424c7164",
+        "0x0"
+      ],
+      "type": "INVOKE_FUNCTION"
+    },
+    {
+      "transaction_hash": "0x4c3f0cebe3ab2d246080b3383e59cc0abe94e9e3ec2ea7eaf9a8d12abae8b60",
+      "version": "0x1",
+      "max_fee": "0x7705f0bd7c40",
+      "signature": [
+        "0x38b32bf3dee39eb74e714bbb59912cc8775227546d9359bb6c23c4e236363f1",
+        "0x6c2367cb5e0250a40ed5d1bbec36c8cf1e540ff59a587461b1ef8341b5ae8c1"
+      ],
+      "nonce": "0x0",
+      "contract_address": "0x59c526eeceff9b8e76cf10e46724144fbc01e491eee0d25b6a54066cee1e389",
+      "contract_address_salt": "0x242ec33479795299cd464ef6e5542a816ca3e865d913a87c434c626e5b98e38",
+      "class_hash": "0x25ec026985a3bf9d0cc1fe17326b245dfdc3ff89b8fde106542a3ea56c5a918",
+      "constructor_calldata": [
+        "0x33434ad846cdd5f23eb73ff09fe6fddd568284a0fb7d1be20ee482f044dabe2",
+        "0x79dc0da7c54b95f10aa182ad0a46400db63156920adb65eca2654c0945a463",
+        "0x2",
+        "0x242ec33479795299cd464ef6e5542a816ca3e865d913a87c434c626e5b98e38",
+        "0x0"
+      ],
+      "type": "DEPLOY_ACCOUNT"
+    },
+    {
+      "transaction_hash": "0x6bc781025d55863d3aaf5c017011cedda0a0a61ff5b1d070864e9a991128c16",
+      "version": "0x1",
+      "max_fee": "0xdf31ec3a3700",
+      "signature": [
+        "0x4eb31a15410ac77b6d1df0a5bef8a6435f7112bf1fe0078d32f0e2434e9458d",
+        "0x53866da19113bd3728ad886facdcee421856575432f1a6f3e0fb456a0ff6cd4"
+      ],
+      "nonce": "0x1",
+      "contract_address": "0x59c526eeceff9b8e76cf10e46724144fbc01e491eee0d25b6a54066cee1e389",
+      "calldata": [
+        "0x2",
+        "0x49d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7",
+        "0x219209e083275171774dab1df80982e9df2096516f06319c5c6d71ae0a8480c",
+        "0x0",
+        "0x3",
+        "0x7a6f98c03379b9513ca84cca1373ff452a7462a3b61598f0af5bb27ad7f76d1",
+        "0x2c0f7bf2d6cf5304c29171bf493feb222fef84bdaf17805a6574b0c2e8bcc87",
+        "0x3",
+        "0x9",
+        "0xc",
+        "0x7a6f98c03379b9513ca84cca1373ff452a7462a3b61598f0af5bb27ad7f76d1",
+        "0x16345785d8a0000",
+        "0x0",
+        "0x16345785d8a0000",
+        "0x0",
+        "0x70c87a3",
+        "0x0",
+        "0x2",
+        "0x49d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7",
+        "0x53c91253bc9682c04929ca02ed00b3e423f6710d2ee7e0d5ebb06f3ecf368a8",
+        "0x59c526eeceff9b8e76cf10e46724144fbc01e491eee0d25b6a54066cee1e389",
+        "0x6384a61c"
+      ],
+      "type": "INVOKE_FUNCTION"
+    },
+    {
+      "transaction_hash": "0x3b37db7bdd39f8d9af2816df0bbec818471dd29da19e466598bfa51ff330b0a",
+      "version": "0x1",
+      "max_fee": "0x20596224dde68",
+      "signature": [
+        "0x62fe88983a8bf1d7a1c77de37c71c7261dd6b864229b6c32287819e9ccc7db4",
+        "0x7f932641f210a1507c483789b62c3005904286aa99320ed38f51bcec31ebc81"
+      ],
+      "nonce": "0xa",
+      "contract_address": "0x79e8337d91274875ce5e44b640a2bcdc7c1f2960fe00e2b09fadca412f0be71",
+      "calldata": [
+        "0x1",
+        "0x7861c4e276294a7e859ff0ae2eec0c68300ad9cbb43219db907da9bad786488",
+        "0x2f0b3c5710379609eb5495f1ecd348cb28167711b73609fe565a72734550354",
+        "0x0",
+        "0x3",
+        "0x3",
+        "0x697066733a2f2f516d63557a48396131476e7745475a6a3658554176675443",
+        "0x547761344d6b7a45454d4a574633763242365761786f",
+        "0x0"
+      ],
+      "type": "INVOKE_FUNCTION"
+    },
+    {
+      "transaction_hash": "0x226e00a507daa5de371a4b0ecb4740907a8c4c6aad998e3708108e4ffced0e4",
+      "version": "0x1",
+      "max_fee": "0x2815b6d4a3a8c",
+      "signature": [
+        "0x2a39a1baa6c9f715eb6195ba31e9a686b77c287323cd6a4aa54cad64cbb3a88",
+        "0x2f1ff6cd836bcc4ebfb4e8ce36aeebd740b2153fd41304622aa62d833dcd246"
+      ],
+      "nonce": "0xe",
+      "contract_address": "0x5442d381b14ae0484cb1178d8ebd5ffb99152ceb41fc254b8749469af69732e",
+      "calldata": [
+        "0x3",
+        "0x49d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7",
+        "0x219209e083275171774dab1df80982e9df2096516f06319c5c6d71ae0a8480c",
+        "0x0",
+        "0x3",
+        "0x68f5c6a61780768455de69077e07e89787839bf8166decfbf92b645209c0fb8",
+        "0x219209e083275171774dab1df80982e9df2096516f06319c5c6d71ae0a8480c",
+        "0x3",
+        "0x3",
+        "0x10884171baf1914edc28d7afb619b40a4051cfae78a094a55d230f19e944a28",
+        "0x2cfb12ff9e08412ec5009c65ea06e727119ad948d25c8a8cc2c86fec4adee70",
+        "0x6",
+        "0xa",
+        "0x10",
+        "0x10884171baf1914edc28d7afb619b40a4051cfae78a094a55d230f19e944a28",
+        "0x273ed3375ffd95",
+        "0x0",
+        "0x10884171baf1914edc28d7afb619b40a4051cfae78a094a55d230f19e944a28",
+        "0xcf0ed5",
+        "0x0",
+        "0x49d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7",
+        "0x273ed3375ffd95",
+        "0x0",
+        "0x2675e378d3d4ab",
+        "0x0",
+        "0x68f5c6a61780768455de69077e07e89787839bf8166decfbf92b645209c0fb8",
+        "0xcf0ed5",
+        "0x0",
+        "0xcaeab2",
+        "0x0"
+      ],
+      "type": "INVOKE_FUNCTION"
+    },
+    {
+      "transaction_hash": "0x70d0030cc3668f8ceb4a28f2d1e7d90faf41687eb3703c2345a7411e81af947",
+      "version": "0x1",
+      "max_fee": "0x93820e36bb98",
+      "signature": [
+        "0x2245fcffb37723bd35f00e48cf5b5266d90b8a60b4c9ad64be0d9d65c2d9e03",
+        "0x7fd177f98808a1b238ae09acde342c4abe10c34e5c4ac5329aaf37079575e4f"
+      ],
+      "nonce": "0x7",
+      "contract_address": "0x584909a41b0d7db4b9e21362281745930555c2616f7871b300330fefd85afe",
+      "calldata": [
+        "0x1",
+        "0x7861c4e276294a7e859ff0ae2eec0c68300ad9cbb43219db907da9bad786488",
+        "0x2d4c8ea4c8fb9f571d1f6f9b7692fff8e5ceaf73b1df98e7da8c1109b39ae9a",
+        "0x0",
+        "0x2",
+        "0x2",
+        "0x4767b873669406d25dddbf67356e385a14480979e5358a411955d692576aa30",
+        "0x1"
+      ],
+      "type": "INVOKE_FUNCTION"
+    },
+    {
+      "transaction_hash": "0x6c9081e8a441b8468399952b4c3720fc87d0e51eb48041cc43ffac0f3ed40e5",
+      "version": "0x1",
+      "max_fee": "0x125ab9a06fb40",
+      "signature": [
+        "0x446520b7e39673071e54460c0faf2cd9de632517f8dfba7f7899486ef99691a",
+        "0x38a17ceebf2531786f940410cacf63972e0d0b3975f88d33ef846545c5404c8"
+      ],
+      "nonce": "0x3",
+      "contract_address": "0x19e5b8e6b5afcb92fba17eecc7e9bf1755381f757b565e130147e3d04ef5fc7",
+      "calldata": [
+        "0x2",
+        "0x49d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7",
+        "0x16cc063b8338363cf388ce7fe1df408bf10f16cd51635d392e21d852fafb683",
+        "0x0",
+        "0x3",
+        "0x63a4b3b0122cdaa6ba244739add94aed1d31e3330458cda833a8d119f28cbe8",
+        "0x1ea54af605527300833a86aa671ae663e947b79e1928a757fd295e56ad3fc6",
+        "0x3",
+        "0x2",
+        "0x5",
+        "0x63a4b3b0122cdaa6ba244739add94aed1d31e3330458cda833a8d119f28cbe8",
+        "0xa4d88ddd94000",
+        "0x0",
+        "0x596f757620446565",
+        "0x1e101020000000000000000000000"
+      ],
+      "type": "INVOKE_FUNCTION"
+    },
+    {
+      "transaction_hash": "0x687751818ebcbe3b72711d50d242ee7e5310e0c168f22c2541df7522ded56d7",
+      "version": "0x1",
+      "max_fee": "0x125ab9a06fb40",
+      "signature": [
+        "0x3dac5c5135b07181318cf6ab6f77ebfd74070857f893a4e8b8142e5cb82fa7b",
+        "0x6ac4328dce7b63c6d35775ad3aa8d3fba5bf653c398d0608184ebbefda7e263"
+      ],
+      "nonce": "0x1e",
+      "contract_address": "0x336106b46408dd1a9bafe7028427e4632320ba4f93ce5c80a046a1592df6e10",
+      "calldata": [
+        "0x2",
+        "0x49d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7",
+        "0x16cc063b8338363cf388ce7fe1df408bf10f16cd51635d392e21d852fafb683",
+        "0x0",
+        "0x3",
+        "0x63a4b3b0122cdaa6ba244739add94aed1d31e3330458cda833a8d119f28cbe8",
+        "0x1ea54af605527300833a86aa671ae663e947b79e1928a757fd295e56ad3fc6",
+        "0x3",
+        "0x2",
+        "0x5",
+        "0x63a4b3b0122cdaa6ba244739add94aed1d31e3330458cda833a8d119f28cbe8",
+        "0x38d7ea4c68000",
+        "0x0",
+        "0x417a7572",
+        "0x7dd01000000000000000000000000"
+      ],
+      "type": "INVOKE_FUNCTION"
+    },
+    {
+      "transaction_hash": "0x73c0fa81a2fd84518ebd0b2ba36cfb13c67fda0cb24e698d236c296d4240d7e",
+      "version": "0x1",
+      "max_fee": "0x5de8980e39f46",
+      "signature": [
+        "0x30f0eb3d2b2efcf8149d990f47c6e2ec4397a0d370863dba4d1e6072d219b4c",
+        "0x4adf87bf2a99c959ba230b32f2236230147e2b18b800caad26fd03881a3993f"
+      ],
+      "nonce": "0xe3",
+      "contract_address": "0xd90fd6aa27edd344c5cbe1fe999611416b268658e866a54265aaf50d9cf28d",
+      "calldata": [
+        "0x3",
+        "0x27fb5a7be4707e2b1fe653e7296ad30114596fafdd3fbc3f9b92a0551ff18ec",
+        "0x8bde087a787e765f84e3045b61265573830a938d83c750c5b44ca3e6c1b3e2",
+        "0x0",
+        "0x1d",
+        "0x27fb5a7be4707e2b1fe653e7296ad30114596fafdd3fbc3f9b92a0551ff18ec",
+        "0x8bde087a787e765f84e3045b61265573830a938d83c750c5b44ca3e6c1b3e2",
+        "0x1d",
+        "0x1d",
+        "0x27fb5a7be4707e2b1fe653e7296ad30114596fafdd3fbc3f9b92a0551ff18ec",
+        "0x8bde087a787e765f84e3045b61265573830a938d83c750c5b44ca3e6c1b3e2",
+        "0x3a",
+        "0x1d",
+        "0x57",
+        "0x3d0b2d9c96e7e540b688b4f835460d5f2c30506826c71e5b14bf336eaa7248b",
+        "0x5",
+        "0x0",
+        "0x3",
+        "0x4c79636f73",
+        "0x0",
+        "0x1",
+        "0x0",
+        "0x7c2",
+        "0x4465656e204275726269676f",
+        "0x0",
+        "0x1",
+        "0x0",
+        "0xa91",
+        "0x5a696ee965",
+        "0x0",
+        "0x1",
+        "0x0",
+        "0x792",
+        "0x3",
+        "0x182b2ed0cfa6a8fd1d65dc86fe78481",
+        "0xc3930080bb153c11b377f7b5a6244391",
+        "0x1220",
+        "0x213ce6b1cb1fb1c30dc2b39f3cd51c31",
+        "0xfb79bee179175567203e2e7b077fe391",
+        "0x1220",
+        "0xe40ddf72147bea3ad3f38c76ba0c9c22",
+        "0x875d0348ff5c69f9af7cce7053524d3c",
+        "0x1220",
+        "0x216ca69e83b0b28acfb22350297f8af85749538ac6974b638ed15a7046a30f",
+        "0x5",
+        "0x0",
+        "0x3",
+        "0x4a65616e4a617373",
+        "0x0",
+        "0x1",
+        "0x0",
+        "0xa98",
+        "0x4b65726368616b",
+        "0x0",
+        "0x1",
+        "0x0",
+        "0x55a",
+        "0x746861486f6d6579",
+        "0x0",
+        "0x1",
+        "0x1",
+        "0x8",
+        "0x3",
+        "0x5448e35961a92daf12182952143918f7",
+        "0xa986fdbf442c79978768328618d85f19",
+        "0x1220",
+        "0x8b06441b7ed3c83dd44b32fd54e9a30a",
+        "0xab2487234ff21bb843c1e32c2a4d3517",
+        "0x1220",
+        "0x34989cfe697e7aea65b08bc914b2e58d",
+        "0x403142d4900d77fb5361d41994d24f37",
+        "0x1220",
+        "0x430064ab11c47a34f075134c3bdc0da185c91b51f0d6065719af0c0e4d021",
+        "0x5",
+        "0x0",
+        "0x3",
+        "0x536f204c61204c756e65",
+        "0x0",
+        "0x1",
+        "0x0",
+        "0xa83",
+        "0x426967666c6f",
+        "0x0",
+        "0x1",
+        "0x0",
+        "0x35a",
+        "0x446f756d73",
+        "0x0",
+        "0x1",
+        "0x0",
+        "0x514",
+        "0x3",
+        "0x76872b7ae24709ff13f96a819eda4e41",
+        "0x5bd6fd237bf21f91fca55a4af362fe9c",
+        "0x1220",
+        "0xe6e15ab9da62d05114c42110c0ed4b58",
+        "0x55e2b8b30a86d26215a283a2f6ff3648",
+        "0x1220",
+        "0x313ef8448150dcd92e3a94d62d8723ca",
+        "0x5d0e591f1a9f4d96800ef56e14a5dcfb",
+        "0x1220"
+      ],
+      "type": "INVOKE_FUNCTION"
+    }
+  ],
+  "timestamp": 1669465009,
+  "sequencer_address": "0x5dcd266a80b8a5f29f04d779c6b166b80150c24f2180a75e82427242dab20a9",
+  "transaction_receipts": [
+    {
+      "transaction_index": 0,
+      "transaction_hash": "0xd38080575a9133cecdd5c80a79a513ff49d7dd478d8fd6ffe75fdac532e810",
+      "l2_to_l1_messages": [],
+      "events": [
+        {
+          "from_address": "0x6af9a313434c0987f5952277f1ac8c61dc4d50b8b009539891ed8aaee5d041d",
+          "keys": [
+            "0x99cd8bde557814842a3121e8ddfd433a539b8c9f14bf31ebf108d12e6196e9"
+          ],
+          "data": [
+            "0x0",
+            "0x2974a8f02653b0ef2d612a9098f0fbb02e69f7f33e70f14f65a282301bf9019",
+            "0x9",
+            "0x0"
+          ]
+        },
+        {
+          "from_address": "0x6af9a313434c0987f5952277f1ac8c61dc4d50b8b009539891ed8aaee5d041d",
+          "keys": [
+            "0x34e55c1cd55f1338241b50d352f0e91c7e4ffad0e4271d64eb347589ebdfd16"
+          ],
+          "data": [
+            "0x2974a8f02653b0ef2d612a9098f0fbb02e69f7f33e70f14f65a282301bf9019",
+            "0x9",
+            "0x0"
+          ]
+        },
+        {
+          "from_address": "0x29959a546dda754dc823a7b8aa65862c5825faeaaf7938741d8ca6bfdc69e4e",
+          "keys": [
+            "0x99cd8bde557814842a3121e8ddfd433a539b8c9f14bf31ebf108d12e6196e9"
+          ],
+          "data": [
+            "0x1b706b18846667c44fdf2dc302ed90b98c0ae3aa6e041fdbdea1289d0284b02",
+            "0x0",
+            "0x35bde",
+            "0x0"
+          ]
+        },
+        {
+          "from_address": "0x29959a546dda754dc823a7b8aa65862c5825faeaaf7938741d8ca6bfdc69e4e",
+          "keys": [
+            "0x243e1de00e8a6bc1dfa3e950e6ade24c52e4a25de4dee7fb5affe918ad1e744"
+          ],
+          "data": [
+            "0x1b706b18846667c44fdf2dc302ed90b98c0ae3aa6e041fdbdea1289d0284b02",
+            "0x35bde",
+            "0x0"
+          ]
+        },
+        {
+          "from_address": "0x53c91253bc9682c04929ca02ed00b3e423f6710d2ee7e0d5ebb06f3ecf368a8",
+          "keys": [
+            "0x99cd8bde557814842a3121e8ddfd433a539b8c9f14bf31ebf108d12e6196e9"
+          ],
+          "data": [
+            "0x3d39f7248fb2bfb960275746470f7fb470317350ad8656249ec66067559e892",
+            "0x1b706b18846667c44fdf2dc302ed90b98c0ae3aa6e041fdbdea1289d0284b03",
+            "0x35bdf",
+            "0x0"
+          ]
+        },
+        {
+          "from_address": "0x3d39f7248fb2bfb960275746470f7fb470317350ad8656249ec66067559e892",
+          "keys": [
+            "0x33db1d611576200c90997bde1f948502469d333e65e87045c250e6efd2e42c7"
+          ],
+          "data": [
+            "0x3b6058a9f6029b519bc72b2cc31bcb93ca704d0ab79fec2ae5d43f79ac07f7a",
+            "0x2b603b6443144",
+            "0x0",
+            "0x15cf0de0f119b7",
+            "0x0",
+            "0xde0bb8f9de77999",
+            "0x0",
+            "0xde0dffc7294500c",
+            "0x0"
+          ]
+        },
+        {
+          "from_address": "0x49d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7",
+          "keys": [
+            "0x99cd8bde557814842a3121e8ddfd433a539b8c9f14bf31ebf108d12e6196e9"
+          ],
+          "data": [
+            "0x1b706b18846667c44fdf2dc302ed90b98c0ae3aa6e041fdbdea1289d0284b03",
+            "0x5dcd266a80b8a5f29f04d779c6b166b80150c24f2180a75e82427242dab20a9",
+            "0x11d15c01cebe3",
+            "0x0"
+          ]
+        }
+      ],
+      "execution_resources": {
+        "n_steps": 71638,
+        "builtin_instance_counter": {
+          "pedersen_builtin": 313,
+          "range_check_builtin": 5282,
+          "ecdsa_builtin": 1,
+          "bitwise_builtin": 2
+        },
+        "n_memory_holes": 5397
+      },
+      "actual_fee": "0x11d15c01cebe3"
+    },
+    {
+      "transaction_index": 1,
+      "transaction_hash": "0x27247dec49459069a36ac946ef9833651010067dc53bd7efdf029396acb329",
+      "l2_to_l1_messages": [],
+      "events": [
+        {
+          "from_address": "0x3af41d2a853ae4186509eecfab865f6bd01a75007ddc880d79aa83eb546c2f0",
+          "keys": [
+            "0x10c19bef19acd19b2c9f4caa40fd47c9fbe1d9f91324d44dcd36be2dae96784"
+          ],
+          "data": [
+            "0x3af41d2a853ae4186509eecfab865f6bd01a75007ddc880d79aa83eb546c2f0",
+            "0x4a95aeae8d8add5405e10ddeeaf2ac9174946d7e5edc37605353cd9645dea17",
+            "0x0"
+          ]
+        }
+      ],
+      "execution_resources": {
+        "n_steps": 219,
+        "builtin_instance_counter": {
+          "range_check_builtin": 1
+        },
+        "n_memory_holes": 0
+      },
+      "actual_fee": "0x0"
+    },
+    {
+      "transaction_index": 2,
+      "transaction_hash": "0x27791f280df704ed3b38cb73b3b41ec3d5e5ff5038c142a717e0feff031008a",
+      "l2_to_l1_messages": [],
+      "events": [
+        {
+          "from_address": "0x53c91253bc9682c04929ca02ed00b3e423f6710d2ee7e0d5ebb06f3ecf368a8",
+          "keys": [
+            "0x134692b230b9e1ffa39098904722134159652b09c5bc41d88d6698779d228ff"
+          ],
+          "data": [
+            "0x17ef1d618cb84e023e014f586144f192c7f92334e351a4eb4a8c83fbbb31b1f",
+            "0x7a6f98c03379b9513ca84cca1373ff452a7462a3b61598f0af5bb27ad7f76d1",
+            "0x6242329",
+            "0x0"
+          ]
+        },
+        {
+          "from_address": "0x53c91253bc9682c04929ca02ed00b3e423f6710d2ee7e0d5ebb06f3ecf368a8",
+          "keys": [
+            "0x99cd8bde557814842a3121e8ddfd433a539b8c9f14bf31ebf108d12e6196e9"
+          ],
+          "data": [
+            "0x17ef1d618cb84e023e014f586144f192c7f92334e351a4eb4a8c83fbbb31b1f",
+            "0x41a708cf109737a50baa6cbeb9adf0bf8d97112dc6cc80c7a458cbad35328b0",
+            "0x612752a",
+            "0x0"
+          ]
+        },
+        {
+          "from_address": "0x68f5c6a61780768455de69077e07e89787839bf8166decfbf92b645209c0fb8",
+          "keys": [
+            "0x99cd8bde557814842a3121e8ddfd433a539b8c9f14bf31ebf108d12e6196e9"
+          ],
+          "data": [
+            "0x41a708cf109737a50baa6cbeb9adf0bf8d97112dc6cc80c7a458cbad35328b0",
+            "0x17ef1d618cb84e023e014f586144f192c7f92334e351a4eb4a8c83fbbb31b1f",
+            "0x5f5e100",
+            "0x0"
+          ]
+        },
+        {
+          "from_address": "0x41a708cf109737a50baa6cbeb9adf0bf8d97112dc6cc80c7a458cbad35328b0",
+          "keys": [
+            "0xe14a408baf7f453312eec68e9b7d728ec5337fbdf671f917ee8c80f3255232"
+          ],
+          "data": [
+            "0x27306aba6",
+            "0x2635f2f2b"
+          ]
+        },
+        {
+          "from_address": "0x41a708cf109737a50baa6cbeb9adf0bf8d97112dc6cc80c7a458cbad35328b0",
+          "keys": [
+            "0xe316f0d9d2a3affa97de1d99bb2aac0538e2666d0d8545545ead241ef0ccab"
+          ],
+          "data": [
+            "0x7a6f98c03379b9513ca84cca1373ff452a7462a3b61598f0af5bb27ad7f76d1",
+            "0x612752a",
+            "0x0",
+            "0x0",
+            "0x0",
+            "0x0",
+            "0x0",
+            "0x5f5e100",
+            "0x0",
+            "0x17ef1d618cb84e023e014f586144f192c7f92334e351a4eb4a8c83fbbb31b1f"
+          ]
+        },
+        {
+          "from_address": "0x49d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7",
+          "keys": [
+            "0x99cd8bde557814842a3121e8ddfd433a539b8c9f14bf31ebf108d12e6196e9"
+          ],
+          "data": [
+            "0x17ef1d618cb84e023e014f586144f192c7f92334e351a4eb4a8c83fbbb31b1f",
+            "0x5dcd266a80b8a5f29f04d779c6b166b80150c24f2180a75e82427242dab20a9",
+            "0xca1239fb8921",
+            "0x0"
+          ]
+        }
+      ],
+      "execution_resources": {
+        "n_steps": 11713,
+        "builtin_instance_counter": {
+          "pedersen_builtin": 40,
+          "range_check_builtin": 864,
+          "ecdsa_builtin": 1,
+          "bitwise_builtin": 3
+        },
+        "n_memory_holes": 286
+      },
+      "actual_fee": "0xca1239fb8921"
+    },
+    {
+      "transaction_index": 3,
+      "transaction_hash": "0x5b558a0cbe82da1448633f294a150fa4d367190d7db18299c97c17a40a3695a",
+      "l2_to_l1_messages": [],
+      "events": [
+        {
+          "from_address": "0x7861c4e276294a7e859ff0ae2eec0c68300ad9cbb43219db907da9bad786488",
+          "keys": [
+            "0x99cd8bde557814842a3121e8ddfd433a539b8c9f14bf31ebf108d12e6196e9"
+          ],
+          "data": [
+            "0x0",
+            "0x24b436c72d3c78a11492e119d9e3d7f09cbcacab96e8bb0a0f66dfa6df8475e",
+            "0xa0b2",
+            "0x0"
+          ]
+        },
+        {
+          "from_address": "0x24b436c72d3c78a11492e119d9e3d7f09cbcacab96e8bb0a0f66dfa6df8475e",
+          "keys": [
+            "0x5ad857f66a5b55f1301ff1ed7e098ac6d4433148f0b72ebc4a2945ab85ad53"
+          ],
+          "data": [
+            "0x5b558a0cbe82da1448633f294a150fa4d367190d7db18299c97c17a40a3695a",
+            "0x0"
+          ]
+        },
+        {
+          "from_address": "0x49d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7",
+          "keys": [
+            "0x99cd8bde557814842a3121e8ddfd433a539b8c9f14bf31ebf108d12e6196e9"
+          ],
+          "data": [
+            "0x24b436c72d3c78a11492e119d9e3d7f09cbcacab96e8bb0a0f66dfa6df8475e",
+            "0x5dcd266a80b8a5f29f04d779c6b166b80150c24f2180a75e82427242dab20a9",
+            "0x7a43809aeaa6",
+            "0x0"
+          ]
+        }
+      ],
+      "execution_resources": {
+        "n_steps": 1377,
+        "builtin_instance_counter": {
+          "pedersen_builtin": 18,
+          "range_check_builtin": 45
+        },
+        "n_memory_holes": 111
+      },
+      "actual_fee": "0x7a43809aeaa6"
+    },
+    {
+      "transaction_index": 4,
+      "transaction_hash": "0x2c82cad2be3b1897050ad9caebca05f29b0d3b5f23791025d53d59ae1b3d0ef",
+      "l2_to_l1_messages": [],
+      "events": [
+        {
+          "from_address": "0x49d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7",
+          "keys": [
+            "0x99cd8bde557814842a3121e8ddfd433a539b8c9f14bf31ebf108d12e6196e9"
+          ],
+          "data": [
+            "0x7b393627bd514d2aa4c83e9f0c468939df15ea3c29980cd8e7be3ec847795f0",
+            "0xf7dbffbfdb48e0a71ca7366ab3df23665cce05f8f5d4cc49c3cff4fe3dba7a",
+            "0x49440df2e1680d3",
+            "0x0"
+          ]
+        },
+        {
+          "from_address": "0x7b393627bd514d2aa4c83e9f0c468939df15ea3c29980cd8e7be3ec847795f0",
+          "keys": [
+            "0x5ad857f66a5b55f1301ff1ed7e098ac6d4433148f0b72ebc4a2945ab85ad53"
+          ],
+          "data": [
+            "0x2c82cad2be3b1897050ad9caebca05f29b0d3b5f23791025d53d59ae1b3d0ef",
+            "0x1",
+            "0x1"
+          ]
+        },
+        {
+          "from_address": "0x49d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7",
+          "keys": [
+            "0x99cd8bde557814842a3121e8ddfd433a539b8c9f14bf31ebf108d12e6196e9"
+          ],
+          "data": [
+            "0x7b393627bd514d2aa4c83e9f0c468939df15ea3c29980cd8e7be3ec847795f0",
+            "0x5dcd266a80b8a5f29f04d779c6b166b80150c24f2180a75e82427242dab20a9",
+            "0x32c6e3e071c2",
+            "0x0"
+          ]
+        }
+      ],
+      "execution_resources": {
+        "n_steps": 865,
+        "builtin_instance_counter": {
+          "pedersen_builtin": 4,
+          "range_check_builtin": 24
+        },
+        "n_memory_holes": 45
+      },
+      "actual_fee": "0x32c6e3e071c2"
+    },
+    {
+      "transaction_index": 5,
+      "transaction_hash": "0x4862394e9031e9ab040c76462bd9a6f456785b24f64d56c189cf2963fa19454",
+      "l2_to_l1_messages": [],
+      "events": [
+        {
+          "from_address": "0x669562f4aa4137b6f96123b2d2fc94716287458ef39df5d1b185ee7f026a723",
+          "keys": [
+            "0x112d26124b60e4d99e8c4387c732086fd96b159bf3d72e6d8f5f60c944533f1"
+          ],
+          "data": [
+            "0x33434ad846cdd5f23eb73ff09fe6fddd568284a0fb7d1be20ee482f044dabe2"
+          ]
+        },
+        {
+          "from_address": "0x669562f4aa4137b6f96123b2d2fc94716287458ef39df5d1b185ee7f026a723",
+          "keys": [
+            "0x5ad857f66a5b55f1301ff1ed7e098ac6d4433148f0b72ebc4a2945ab85ad53"
+          ],
+          "data": [
+            "0x4862394e9031e9ab040c76462bd9a6f456785b24f64d56c189cf2963fa19454",
+            "0x0"
+          ]
+        },
+        {
+          "from_address": "0x49d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7",
+          "keys": [
+            "0x99cd8bde557814842a3121e8ddfd433a539b8c9f14bf31ebf108d12e6196e9"
+          ],
+          "data": [
+            "0x669562f4aa4137b6f96123b2d2fc94716287458ef39df5d1b185ee7f026a723",
+            "0x5dcd266a80b8a5f29f04d779c6b166b80150c24f2180a75e82427242dab20a9",
+            "0x326b239c7dd9",
+            "0x0"
+          ]
+        }
+      ],
+      "execution_resources": {
+        "n_steps": 694,
+        "builtin_instance_counter": {
+          "range_check_builtin": 4,
+          "ecdsa_builtin": 1
+        },
+        "n_memory_holes": 3
+      },
+      "actual_fee": "0x326b239c7dd9"
+    },
+    {
+      "transaction_index": 6,
+      "transaction_hash": "0x12d4ab0f110a9a389d227c97f8a50ab1696e18bd6ea3c0cb117450bd226ca81",
+      "l2_to_l1_messages": [],
+      "events": [
+        {
+          "from_address": "0x1e1f972637ad02e0eed03b69304344c4253804e528e1a5dd5c26bb2f23a8139",
+          "keys": [
+            "0x6ad9ed7b6318f1bcffefe19df9aeb40d22c36bed567e1925a5ccde0536edd"
+          ],
+          "data": [
+            "0x114f1e702f7c05ed986956a8d626d0bd49848560b70e90ed664d4687e8e5fd0",
+            "0x6883c3af369d1b3cdc0135480302a6a037ed5ece95dfdae36731912a49f722e",
+            "0x1"
+          ]
+        },
+        {
+          "from_address": "0x114f1e702f7c05ed986956a8d626d0bd49848560b70e90ed664d4687e8e5fd0",
+          "keys": [
+            "0x5ad857f66a5b55f1301ff1ed7e098ac6d4433148f0b72ebc4a2945ab85ad53"
+          ],
+          "data": [
+            "0x12d4ab0f110a9a389d227c97f8a50ab1696e18bd6ea3c0cb117450bd226ca81",
+            "0x0"
+          ]
+        },
+        {
+          "from_address": "0x49d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7",
+          "keys": [
+            "0x99cd8bde557814842a3121e8ddfd433a539b8c9f14bf31ebf108d12e6196e9"
+          ],
+          "data": [
+            "0x114f1e702f7c05ed986956a8d626d0bd49848560b70e90ed664d4687e8e5fd0",
+            "0x5dcd266a80b8a5f29f04d779c6b166b80150c24f2180a75e82427242dab20a9",
+            "0x269265373de6",
+            "0x0"
+          ]
+        }
+      ],
+      "execution_resources": {
+        "n_steps": 493,
+        "builtin_instance_counter": {
+          "pedersen_builtin": 2,
+          "range_check_builtin": 6
+        },
+        "n_memory_holes": 13
+      },
+      "actual_fee": "0x269265373de6"
+    },
+    {
+      "transaction_index": 7,
+      "transaction_hash": "0xa93fcc1af5aecdc114552c4d14409cfed9e9a2938b0d7a5d32a119a111fefc",
+      "l2_to_l1_messages": [],
+      "events": [
+        {
+          "from_address": "0x2b5e55b3ab2508626342fe28bb500b57f8a79fdd460f843b820f94d62cd5442",
+          "keys": [
+            "0x2db340e6c609371026731f47050d3976552c89b4fbb012941663841c59d1af3"
+          ],
+          "data": [
+            "0x69577e6756a99b584b5d1ce8e60650ae33b6e2b13541783458268f07da6b38a"
+          ]
+        },
+        {
+          "from_address": "0x2b5e55b3ab2508626342fe28bb500b57f8a79fdd460f843b820f94d62cd5442",
+          "keys": [
+            "0x17edf1120040be1bbc6931f143df1cc1cf80bb7f7fdadb251a3668ba3755049"
+          ],
+          "data": [
+            "0x59afdc786bf1cac438d28e6ab4f08985c4a008ff611ab560a4586a3c59b3f1"
+          ]
+        }
+      ],
+      "execution_resources": {
+        "n_steps": 370,
+        "builtin_instance_counter": {
+          "pedersen_builtin": 1,
+          "range_check_builtin": 4
+        },
+        "n_memory_holes": 11
+      },
+      "actual_fee": "0x0"
+    },
+    {
+      "transaction_index": 8,
+      "transaction_hash": "0x70c7479c5494ad6c5b479dbc4ffd21a721dcfad99de7474d8d9e151da443567",
+      "l2_to_l1_messages": [],
+      "events": [
+        {
+          "from_address": "0x46bfa580e4fa55a38eaa7f51a3469f86b336eed59a6136a07b7adcd095b0eb2",
+          "keys": [
+            "0x134692b230b9e1ffa39098904722134159652b09c5bc41d88d6698779d228ff"
+          ],
+          "data": [
+            "0x5e88c663366c79fddbfae974bca3a72125220ac183572dfb35ffdb9a9068e86",
+            "0x63a4b3b0122cdaa6ba244739add94aed1d31e3330458cda833a8d119f28cbe8",
+            "0x746861486f6d6579",
+            "0x51f01000000000000000000000000",
+            "0x1",
+            "0x0"
+          ]
+        },
+        {
+          "from_address": "0x63a4b3b0122cdaa6ba244739add94aed1d31e3330458cda833a8d119f28cbe8",
+          "keys": [
+            "0x3dfc158c05b32ed2ffabe664bf6edb241c38aa671d19165307582cde75743b6"
+          ],
+          "data": [
+            "0x746861486f6d6579",
+            "0x51f01000000000000000000000000",
+            "0x5e88c663366c79fddbfae974bca3a72125220ac183572dfb35ffdb9a9068e86",
+            "0x12795f58d50000"
+          ]
+        },
+        {
+          "from_address": "0x5e88c663366c79fddbfae974bca3a72125220ac183572dfb35ffdb9a9068e86",
+          "keys": [
+            "0x1dcde06aabdbca2f80aa51392b345d7549d7757aa855f7e37f5d335ac8243b1"
+          ],
+          "data": [
+            "0x70c7479c5494ad6c5b479dbc4ffd21a721dcfad99de7474d8d9e151da443567",
+            "0x0"
+          ]
+        },
+        {
+          "from_address": "0x49d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7",
+          "keys": [
+            "0x99cd8bde557814842a3121e8ddfd433a539b8c9f14bf31ebf108d12e6196e9"
+          ],
+          "data": [
+            "0x5e88c663366c79fddbfae974bca3a72125220ac183572dfb35ffdb9a9068e86",
+            "0x5dcd266a80b8a5f29f04d779c6b166b80150c24f2180a75e82427242dab20a9",
+            "0x6f3d89bd048c",
+            "0x0"
+          ]
+        }
+      ],
+      "execution_resources": {
+        "n_steps": 1657,
+        "builtin_instance_counter": {
+          "pedersen_builtin": 19,
+          "range_check_builtin": 32,
+          "ecdsa_builtin": 1
+        },
+        "n_memory_holes": 78
+      },
+      "actual_fee": "0x6f3d89bd048c"
+    },
+    {
+      "transaction_index": 9,
+      "transaction_hash": "0xdfa009e3713b0ac73be6808925462dce34447d974c9e15eec5cf76daa8b055",
+      "l1_to_l2_consumed_message": {
+        "from_address": "0xae0Ee0A63A2cE6BaeEFFE56e7714FB4EFE48D419",
+        "to_address": "0x73314940630fd6dcda0d772d4c972c4e0a9946bef9dabf4ef84eda8ef542b82",
+        "selector": "0x2d757788a8d8d6f21d1cd40bce38a8222d70654214e96ff95d8086e684fbee5",
+        "payload": [
+          "0x2af8130d3ef618732766fb8f9a8924459db825a851ca7c204acf78ecb0a7905",
+          "0x16dedf44bdd8000",
+          "0x0"
+        ],
+        "nonce": "0x16bac"
+      },
+      "l2_to_l1_messages": [],
+      "events": [
+        {
+          "from_address": "0x49d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7",
+          "keys": [
+            "0x99cd8bde557814842a3121e8ddfd433a539b8c9f14bf31ebf108d12e6196e9"
+          ],
+          "data": [
+            "0x0",
+            "0x2af8130d3ef618732766fb8f9a8924459db825a851ca7c204acf78ecb0a7905",
+            "0x16dedf44bdd8000",
+            "0x0"
+          ]
+        },
+        {
+          "from_address": "0x73314940630fd6dcda0d772d4c972c4e0a9946bef9dabf4ef84eda8ef542b82",
+          "keys": [
+            "0x221e5a5008f7a28564f0eaa32cdeb0848d10657c449aed3e15d12150a7c2db3"
+          ],
+          "data": [
+            "0x2af8130d3ef618732766fb8f9a8924459db825a851ca7c204acf78ecb0a7905",
+            "0x16dedf44bdd8000",
+            "0x0"
+          ]
+        }
+      ],
+      "execution_resources": {
+        "n_steps": 677,
+        "builtin_instance_counter": {
+          "pedersen_builtin": 2,
+          "range_check_builtin": 12
+        },
+        "n_memory_holes": 20
+      },
+      "actual_fee": "0x0"
+    },
+    {
+      "transaction_index": 10,
+      "transaction_hash": "0x2de5222193956868bd8acf59bca038e5ef2be22d6a54246711ee9acce35d33b",
+      "l2_to_l1_messages": [],
+      "events": [
+        {
+          "from_address": "0x5900cfa2b50d53b097cb305d54e249e31f24f881885aae5639b0cd6af4ed298",
+          "keys": [
+            "0x134692b230b9e1ffa39098904722134159652b09c5bc41d88d6698779d228ff"
+          ],
+          "data": [
+            "0x3bde29ef8f62d3ec0160e9583536521cc2449f369ee713544a5a260743e13bb",
+            "0x7a6f98c03379b9513ca84cca1373ff452a7462a3b61598f0af5bb27ad7f76d1",
+            "0x2146ee5404",
+            "0x0"
+          ]
+        },
+        {
+          "from_address": "0x5900cfa2b50d53b097cb305d54e249e31f24f881885aae5639b0cd6af4ed298",
+          "keys": [
+            "0x134692b230b9e1ffa39098904722134159652b09c5bc41d88d6698779d228ff"
+          ],
+          "data": [
+            "0x3bde29ef8f62d3ec0160e9583536521cc2449f369ee713544a5a260743e13bb",
+            "0x7a6f98c03379b9513ca84cca1373ff452a7462a3b61598f0af5bb27ad7f76d1",
+            "0x0",
+            "0x0"
+          ]
+        },
+        {
+          "from_address": "0x5900cfa2b50d53b097cb305d54e249e31f24f881885aae5639b0cd6af4ed298",
+          "keys": [
+            "0x99cd8bde557814842a3121e8ddfd433a539b8c9f14bf31ebf108d12e6196e9"
+          ],
+          "data": [
+            "0x3bde29ef8f62d3ec0160e9583536521cc2449f369ee713544a5a260743e13bb",
+            "0x5900cfa2b50d53b097cb305d54e249e31f24f881885aae5639b0cd6af4ed298",
+            "0x2146ee5404",
+            "0x0"
+          ]
+        },
+        {
+          "from_address": "0x5900cfa2b50d53b097cb305d54e249e31f24f881885aae5639b0cd6af4ed298",
+          "keys": [
+            "0x99cd8bde557814842a3121e8ddfd433a539b8c9f14bf31ebf108d12e6196e9"
+          ],
+          "data": [
+            "0x0",
+            "0x98707809b39a3b14d9f5004bc1fe77721baa2d8b67fd54ed5794f60671de0",
+            "0x22569fa7",
+            "0x0"
+          ]
+        },
+        {
+          "from_address": "0x5900cfa2b50d53b097cb305d54e249e31f24f881885aae5639b0cd6af4ed298",
+          "keys": [
+            "0x99cd8bde557814842a3121e8ddfd433a539b8c9f14bf31ebf108d12e6196e9"
+          ],
+          "data": [
+            "0x5900cfa2b50d53b097cb305d54e249e31f24f881885aae5639b0cd6af4ed298",
+            "0x0",
+            "0x2146ee5404",
+            "0x0"
+          ]
+        },
+        {
+          "from_address": "0x49d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7",
+          "keys": [
+            "0x99cd8bde557814842a3121e8ddfd433a539b8c9f14bf31ebf108d12e6196e9"
+          ],
+          "data": [
+            "0x5900cfa2b50d53b097cb305d54e249e31f24f881885aae5639b0cd6af4ed298",
+            "0x3bde29ef8f62d3ec0160e9583536521cc2449f369ee713544a5a260743e13bb",
+            "0xf02faac940591",
+            "0x0"
+          ]
+        },
+        {
+          "from_address": "0x68f5c6a61780768455de69077e07e89787839bf8166decfbf92b645209c0fb8",
+          "keys": [
+            "0x99cd8bde557814842a3121e8ddfd433a539b8c9f14bf31ebf108d12e6196e9"
+          ],
+          "data": [
+            "0x5900cfa2b50d53b097cb305d54e249e31f24f881885aae5639b0cd6af4ed298",
+            "0x3bde29ef8f62d3ec0160e9583536521cc2449f369ee713544a5a260743e13bb",
+            "0x4f8982",
+            "0x0"
+          ]
+        },
+        {
+          "from_address": "0x5900cfa2b50d53b097cb305d54e249e31f24f881885aae5639b0cd6af4ed298",
+          "keys": [
+            "0xe14a408baf7f453312eec68e9b7d728ec5337fbdf671f917ee8c80f3255232"
+          ],
+          "data": [
+            "0x995f4e2f75e58dbc",
+            "0x32c9f5ba3"
+          ]
+        },
+        {
+          "from_address": "0x5900cfa2b50d53b097cb305d54e249e31f24f881885aae5639b0cd6af4ed298",
+          "keys": [
+            "0x243e1de00e8a6bc1dfa3e950e6ade24c52e4a25de4dee7fb5affe918ad1e744"
+          ],
+          "data": [
+            "0x7a6f98c03379b9513ca84cca1373ff452a7462a3b61598f0af5bb27ad7f76d1",
+            "0xf02faac940591",
+            "0x0",
+            "0x4f8982",
+            "0x0",
+            "0x3bde29ef8f62d3ec0160e9583536521cc2449f369ee713544a5a260743e13bb"
+          ]
+        },
+        {
+          "from_address": "0x3bde29ef8f62d3ec0160e9583536521cc2449f369ee713544a5a260743e13bb",
+          "keys": [
+            "0x5ad857f66a5b55f1301ff1ed7e098ac6d4433148f0b72ebc4a2945ab85ad53"
+          ],
+          "data": [
+            "0x2de5222193956868bd8acf59bca038e5ef2be22d6a54246711ee9acce35d33b",
+            "0x5",
+            "0x1",
+            "0xf02faac940591",
+            "0x0",
+            "0x4f8982",
+            "0x0"
+          ]
+        },
+        {
+          "from_address": "0x49d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7",
+          "keys": [
+            "0x99cd8bde557814842a3121e8ddfd433a539b8c9f14bf31ebf108d12e6196e9"
+          ],
+          "data": [
+            "0x3bde29ef8f62d3ec0160e9583536521cc2449f369ee713544a5a260743e13bb",
+            "0x5dcd266a80b8a5f29f04d779c6b166b80150c24f2180a75e82427242dab20a9",
+            "0xe4b099ce150d",
+            "0x0"
+          ]
+        }
+      ],
+      "execution_resources": {
+        "n_steps": 12901,
+        "builtin_instance_counter": {
+          "pedersen_builtin": 35,
+          "range_check_builtin": 979,
+          "bitwise_builtin": 3
+        },
+        "n_memory_holes": 316
+      },
+      "actual_fee": "0xe4b099ce150d"
+    },
+    {
+      "transaction_index": 11,
+      "transaction_hash": "0x3b3452571c2ea38f0681046a1bb2aba4df94cde5c39a436988689a3c26929f1",
+      "l2_to_l1_messages": [],
+      "events": [
+        {
+          "from_address": "0x53c91253bc9682c04929ca02ed00b3e423f6710d2ee7e0d5ebb06f3ecf368a8",
+          "keys": [
+            "0x134692b230b9e1ffa39098904722134159652b09c5bc41d88d6698779d228ff"
+          ],
+          "data": [
+            "0x6f0c776c711bdf73b53925caba6095801cc5037f3784e8f3aa26564973aba7d",
+            "0x10884171baf1914edc28d7afb619b40a4051cfae78a094a55d230f19e944a28",
+            "0x5940ee",
+            "0x0"
+          ]
+        },
+        {
+          "from_address": "0x53c91253bc9682c04929ca02ed00b3e423f6710d2ee7e0d5ebb06f3ecf368a8",
+          "keys": [
+            "0x99cd8bde557814842a3121e8ddfd433a539b8c9f14bf31ebf108d12e6196e9"
+          ],
+          "data": [
+            "0x6f0c776c711bdf73b53925caba6095801cc5037f3784e8f3aa26564973aba7d",
+            "0x10884171baf1914edc28d7afb619b40a4051cfae78a094a55d230f19e944a28",
+            "0x5940ee",
+            "0x0"
+          ]
+        },
+        {
+          "from_address": "0x49d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7",
+          "keys": [
+            "0x99cd8bde557814842a3121e8ddfd433a539b8c9f14bf31ebf108d12e6196e9"
+          ],
+          "data": [
+            "0x10884171baf1914edc28d7afb619b40a4051cfae78a094a55d230f19e944a28",
+            "0x6f0c776c711bdf73b53925caba6095801cc5037f3784e8f3aa26564973aba7d",
+            "0x110696e60f953e",
+            "0x0"
+          ]
+        },
+        {
+          "from_address": "0x6f0c776c711bdf73b53925caba6095801cc5037f3784e8f3aa26564973aba7d",
+          "keys": [
+            "0x5ad857f66a5b55f1301ff1ed7e098ac6d4433148f0b72ebc4a2945ab85ad53"
+          ],
+          "data": [
+            "0x3b3452571c2ea38f0681046a1bb2aba4df94cde5c39a436988689a3c26929f1",
+            "0x3",
+            "0x1",
+            "0x110696e60f953e",
+            "0x0"
+          ]
+        },
+        {
+          "from_address": "0x49d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7",
+          "keys": [
+            "0x99cd8bde557814842a3121e8ddfd433a539b8c9f14bf31ebf108d12e6196e9"
+          ],
+          "data": [
+            "0x6f0c776c711bdf73b53925caba6095801cc5037f3784e8f3aa26564973aba7d",
+            "0x5dcd266a80b8a5f29f04d779c6b166b80150c24f2180a75e82427242dab20a9",
+            "0x7fe43ddab72f",
+            "0x0"
+          ]
+        }
+      ],
+      "execution_resources": {
+        "n_steps": 5118,
+        "builtin_instance_counter": {
+          "pedersen_builtin": 21,
+          "range_check_builtin": 249
+        },
+        "n_memory_holes": 194
+      },
+      "actual_fee": "0x7fe43ddab72f"
+    },
+    {
+      "transaction_index": 12,
+      "transaction_hash": "0x5b96978276a0e9005d32ac08683e752ee3b8aa4667c94e3d725915ceed8aef2",
+      "l2_to_l1_messages": [],
+      "events": [
+        {
+          "from_address": "0x435822721c4d7cf88f32a970bccacb40e864a32b327de0bea2518bb2e97bc12",
+          "keys": [
+            "0x112d26124b60e4d99e8c4387c732086fd96b159bf3d72e6d8f5f60c944533f1"
+          ],
+          "data": [
+            "0x33434ad846cdd5f23eb73ff09fe6fddd568284a0fb7d1be20ee482f044dabe2"
+          ]
+        },
+        {
+          "from_address": "0x435822721c4d7cf88f32a970bccacb40e864a32b327de0bea2518bb2e97bc12",
+          "keys": [
+            "0x5ad857f66a5b55f1301ff1ed7e098ac6d4433148f0b72ebc4a2945ab85ad53"
+          ],
+          "data": [
+            "0x5b96978276a0e9005d32ac08683e752ee3b8aa4667c94e3d725915ceed8aef2",
+            "0x0"
+          ]
+        },
+        {
+          "from_address": "0x49d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7",
+          "keys": [
+            "0x99cd8bde557814842a3121e8ddfd433a539b8c9f14bf31ebf108d12e6196e9"
+          ],
+          "data": [
+            "0x435822721c4d7cf88f32a970bccacb40e864a32b327de0bea2518bb2e97bc12",
+            "0x5dcd266a80b8a5f29f04d779c6b166b80150c24f2180a75e82427242dab20a9",
+            "0x326b239c7dd9",
+            "0x0"
+          ]
+        }
+      ],
+      "execution_resources": {
+        "n_steps": 694,
+        "builtin_instance_counter": {
+          "range_check_builtin": 4,
+          "ecdsa_builtin": 1
+        },
+        "n_memory_holes": 3
+      },
+      "actual_fee": "0x326b239c7dd9"
+    },
+    {
+      "transaction_index": 13,
+      "transaction_hash": "0x51fae89e76799957f28bd0567702d1ccbecd06e35196af816766b70e5fc0bf3",
+      "l2_to_l1_messages": [],
+      "events": [
+        {
+          "from_address": "0x17584598729e398d59ec52f1021a5deeb13d439bb140f74faa96d91d241ac65",
+          "keys": [
+            "0x112d26124b60e4d99e8c4387c732086fd96b159bf3d72e6d8f5f60c944533f1"
+          ],
+          "data": [
+            "0x33434ad846cdd5f23eb73ff09fe6fddd568284a0fb7d1be20ee482f044dabe2"
+          ]
+        },
+        {
+          "from_address": "0x17584598729e398d59ec52f1021a5deeb13d439bb140f74faa96d91d241ac65",
+          "keys": [
+            "0x5ad857f66a5b55f1301ff1ed7e098ac6d4433148f0b72ebc4a2945ab85ad53"
+          ],
+          "data": [
+            "0x51fae89e76799957f28bd0567702d1ccbecd06e35196af816766b70e5fc0bf3",
+            "0x0"
+          ]
+        },
+        {
+          "from_address": "0x49d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7",
+          "keys": [
+            "0x99cd8bde557814842a3121e8ddfd433a539b8c9f14bf31ebf108d12e6196e9"
+          ],
+          "data": [
+            "0x17584598729e398d59ec52f1021a5deeb13d439bb140f74faa96d91d241ac65",
+            "0x5dcd266a80b8a5f29f04d779c6b166b80150c24f2180a75e82427242dab20a9",
+            "0x326b239c7dd9",
+            "0x0"
+          ]
+        }
+      ],
+      "execution_resources": {
+        "n_steps": 694,
+        "builtin_instance_counter": {
+          "range_check_builtin": 4,
+          "ecdsa_builtin": 1
+        },
+        "n_memory_holes": 3
+      },
+      "actual_fee": "0x326b239c7dd9"
+    },
+    {
+      "transaction_index": 14,
+      "transaction_hash": "0x100fb2df5e9828308dcc64cc9f9900ca416b19a736fb41685cc7b9e6c6dd7d4",
+      "l2_to_l1_messages": [],
+      "events": [
+        {
+          "from_address": "0x3384e36c3642d0bd51dfbc22639ef24b601a1b11002ed57101bdb81f0851554",
+          "keys": [
+            "0x2db340e6c609371026731f47050d3976552c89b4fbb012941663841c59d1af3"
+          ],
+          "data": [
+            "0x69577e6756a99b584b5d1ce8e60650ae33b6e2b13541783458268f07da6b38a"
+          ]
+        },
+        {
+          "from_address": "0x3384e36c3642d0bd51dfbc22639ef24b601a1b11002ed57101bdb81f0851554",
+          "keys": [
+            "0x17edf1120040be1bbc6931f143df1cc1cf80bb7f7fdadb251a3668ba3755049"
+          ],
+          "data": [
+            "0x2a064492f2bcfed6495b4391d557f8af0b0e61620034be17d952e786c126dd5"
+          ]
+        }
+      ],
+      "execution_resources": {
+        "n_steps": 370,
+        "builtin_instance_counter": {
+          "pedersen_builtin": 1,
+          "range_check_builtin": 4
+        },
+        "n_memory_holes": 11
+      },
+      "actual_fee": "0x0"
+    },
+    {
+      "transaction_index": 15,
+      "transaction_hash": "0x110c6cbe6cbe9231181023c85220dd06a26185b6fb4b29605e1a1365be0eed6",
+      "l2_to_l1_messages": [],
+      "events": [
+        {
+          "from_address": "0x23c72abdf49dffc85ae3ede714f2168ad384cc67d08524732acea90df325",
+          "keys": [
+            "0x134692b230b9e1ffa39098904722134159652b09c5bc41d88d6698779d228ff"
+          ],
+          "data": [
+            "0x3ce9a3268eec8ef82765605af341670b737a30ebd74584b21e7b5607e4175cd",
+            "0x7a6f98c03379b9513ca84cca1373ff452a7462a3b61598f0af5bb27ad7f76d1",
+            "0xe3ae4609a",
+            "0x0"
+          ]
+        },
+        {
+          "from_address": "0x23c72abdf49dffc85ae3ede714f2168ad384cc67d08524732acea90df325",
+          "keys": [
+            "0x134692b230b9e1ffa39098904722134159652b09c5bc41d88d6698779d228ff"
+          ],
+          "data": [
+            "0x3ce9a3268eec8ef82765605af341670b737a30ebd74584b21e7b5607e4175cd",
+            "0x7a6f98c03379b9513ca84cca1373ff452a7462a3b61598f0af5bb27ad7f76d1",
+            "0x0",
+            "0x0"
+          ]
+        },
+        {
+          "from_address": "0x23c72abdf49dffc85ae3ede714f2168ad384cc67d08524732acea90df325",
+          "keys": [
+            "0x99cd8bde557814842a3121e8ddfd433a539b8c9f14bf31ebf108d12e6196e9"
+          ],
+          "data": [
+            "0x3ce9a3268eec8ef82765605af341670b737a30ebd74584b21e7b5607e4175cd",
+            "0x23c72abdf49dffc85ae3ede714f2168ad384cc67d08524732acea90df325",
+            "0xe3ae4609a",
+            "0x0"
+          ]
+        },
+        {
+          "from_address": "0x23c72abdf49dffc85ae3ede714f2168ad384cc67d08524732acea90df325",
+          "keys": [
+            "0x99cd8bde557814842a3121e8ddfd433a539b8c9f14bf31ebf108d12e6196e9"
+          ],
+          "data": [
+            "0x0",
+            "0x98707809b39a3b14d9f5004bc1fe77721baa2d8b67fd54ed5794f60671de0",
+            "0x73ae795b",
+            "0x0"
+          ]
+        },
+        {
+          "from_address": "0x23c72abdf49dffc85ae3ede714f2168ad384cc67d08524732acea90df325",
+          "keys": [
+            "0x99cd8bde557814842a3121e8ddfd433a539b8c9f14bf31ebf108d12e6196e9"
+          ],
+          "data": [
+            "0x23c72abdf49dffc85ae3ede714f2168ad384cc67d08524732acea90df325",
+            "0x0",
+            "0xe3ae4609a",
+            "0x0"
+          ]
+        },
+        {
+          "from_address": "0x49d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7",
+          "keys": [
+            "0x99cd8bde557814842a3121e8ddfd433a539b8c9f14bf31ebf108d12e6196e9"
+          ],
+          "data": [
+            "0x23c72abdf49dffc85ae3ede714f2168ad384cc67d08524732acea90df325",
+            "0x3ce9a3268eec8ef82765605af341670b737a30ebd74584b21e7b5607e4175cd",
+            "0x6e7330c664115",
+            "0x0"
+          ]
+        },
+        {
+          "from_address": "0x53c91253bc9682c04929ca02ed00b3e423f6710d2ee7e0d5ebb06f3ecf368a8",
+          "keys": [
+            "0x99cd8bde557814842a3121e8ddfd433a539b8c9f14bf31ebf108d12e6196e9"
+          ],
+          "data": [
+            "0x23c72abdf49dffc85ae3ede714f2168ad384cc67d08524732acea90df325",
+            "0x3ce9a3268eec8ef82765605af341670b737a30ebd74584b21e7b5607e4175cd",
+            "0x23f24f",
+            "0x0"
+          ]
+        },
+        {
+          "from_address": "0x23c72abdf49dffc85ae3ede714f2168ad384cc67d08524732acea90df325",
+          "keys": [
+            "0xe14a408baf7f453312eec68e9b7d728ec5337fbdf671f917ee8c80f3255232"
+          ],
+          "data": [
+            "0x2992b4022067ea62c",
+            "0xd87b943c6"
+          ]
+        },
+        {
+          "from_address": "0x23c72abdf49dffc85ae3ede714f2168ad384cc67d08524732acea90df325",
+          "keys": [
+            "0x243e1de00e8a6bc1dfa3e950e6ade24c52e4a25de4dee7fb5affe918ad1e744"
+          ],
+          "data": [
+            "0x7a6f98c03379b9513ca84cca1373ff452a7462a3b61598f0af5bb27ad7f76d1",
+            "0x6e7330c664115",
+            "0x0",
+            "0x23f24f",
+            "0x0",
+            "0x3ce9a3268eec8ef82765605af341670b737a30ebd74584b21e7b5607e4175cd"
+          ]
+        },
+        {
+          "from_address": "0x3ce9a3268eec8ef82765605af341670b737a30ebd74584b21e7b5607e4175cd",
+          "keys": [
+            "0x5ad857f66a5b55f1301ff1ed7e098ac6d4433148f0b72ebc4a2945ab85ad53"
+          ],
+          "data": [
+            "0x110c6cbe6cbe9231181023c85220dd06a26185b6fb4b29605e1a1365be0eed6",
+            "0x5",
+            "0x1",
+            "0x6e7330c664115",
+            "0x0",
+            "0x23f24f",
+            "0x0"
+          ]
+        },
+        {
+          "from_address": "0x49d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7",
+          "keys": [
+            "0x99cd8bde557814842a3121e8ddfd433a539b8c9f14bf31ebf108d12e6196e9"
+          ],
+          "data": [
+            "0x3ce9a3268eec8ef82765605af341670b737a30ebd74584b21e7b5607e4175cd",
+            "0x5dcd266a80b8a5f29f04d779c6b166b80150c24f2180a75e82427242dab20a9",
+            "0xe4ae1efcad98",
+            "0x0"
+          ]
+        }
+      ],
+      "execution_resources": {
+        "n_steps": 12889,
+        "builtin_instance_counter": {
+          "pedersen_builtin": 35,
+          "range_check_builtin": 979,
+          "bitwise_builtin": 3
+        },
+        "n_memory_holes": 322
+      },
+      "actual_fee": "0xe4ae1efcad98"
+    },
+    {
+      "transaction_index": 16,
+      "transaction_hash": "0x17a9acfc90327e502aaadbdfa924d7335b7a757196ad69ac00f4cbb3169b092",
+      "l2_to_l1_messages": [],
+      "events": [
+        {
+          "from_address": "0x46bfa580e4fa55a38eaa7f51a3469f86b336eed59a6136a07b7adcd095b0eb2",
+          "keys": [
+            "0x134692b230b9e1ffa39098904722134159652b09c5bc41d88d6698779d228ff"
+          ],
+          "data": [
+            "0x510cfec90ca586922ea6d5cf9fd053705876d0a7afbb053520e808fa27de0fd",
+            "0x63a4b3b0122cdaa6ba244739add94aed1d31e3330458cda833a8d119f28cbe8",
+            "0x5368656c646f6e",
+            "0xa6b01000000000000000000000000",
+            "0x1",
+            "0x0"
+          ]
+        },
+        {
+          "from_address": "0x63a4b3b0122cdaa6ba244739add94aed1d31e3330458cda833a8d119f28cbe8",
+          "keys": [
+            "0x3dfc158c05b32ed2ffabe664bf6edb241c38aa671d19165307582cde75743b6"
+          ],
+          "data": [
+            "0x5368656c646f6e",
+            "0xa6b01000000000000000000000000",
+            "0x510cfec90ca586922ea6d5cf9fd053705876d0a7afbb053520e808fa27de0fd",
+            "0x93cafac6a8000"
+          ]
+        },
+        {
+          "from_address": "0x510cfec90ca586922ea6d5cf9fd053705876d0a7afbb053520e808fa27de0fd",
+          "keys": [
+            "0x1dcde06aabdbca2f80aa51392b345d7549d7757aa855f7e37f5d335ac8243b1"
+          ],
+          "data": [
+            "0x17a9acfc90327e502aaadbdfa924d7335b7a757196ad69ac00f4cbb3169b092",
+            "0x0"
+          ]
+        },
+        {
+          "from_address": "0x49d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7",
+          "keys": [
+            "0x99cd8bde557814842a3121e8ddfd433a539b8c9f14bf31ebf108d12e6196e9"
+          ],
+          "data": [
+            "0x510cfec90ca586922ea6d5cf9fd053705876d0a7afbb053520e808fa27de0fd",
+            "0x5dcd266a80b8a5f29f04d779c6b166b80150c24f2180a75e82427242dab20a9",
+            "0x57ca0b659f13",
+            "0x0"
+          ]
+        }
+      ],
+      "execution_resources": {
+        "n_steps": 1449,
+        "builtin_instance_counter": {
+          "pedersen_builtin": 19,
+          "range_check_builtin": 30
+        },
+        "n_memory_holes": 79
+      },
+      "actual_fee": "0x57ca0b659f13"
+    },
+    {
+      "transaction_index": 17,
+      "transaction_hash": "0x77c2c1c330206f4222df159dc52aabd8156a98813df2c3d4f22c1440f23cb4",
+      "l2_to_l1_messages": [],
+      "events": [
+        {
+          "from_address": "0x25338da98b11cc09bbf148a7f54c87ac5fa18248d783a08ba224ce382ca64c6",
+          "keys": [
+            "0x5ad857f66a5b55f1301ff1ed7e098ac6d4433148f0b72ebc4a2945ab85ad53"
+          ],
+          "data": [
+            "0x77c2c1c330206f4222df159dc52aabd8156a98813df2c3d4f22c1440f23cb4",
+            "0x0"
+          ]
+        },
+        {
+          "from_address": "0x49d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7",
+          "keys": [
+            "0x99cd8bde557814842a3121e8ddfd433a539b8c9f14bf31ebf108d12e6196e9"
+          ],
+          "data": [
+            "0x25338da98b11cc09bbf148a7f54c87ac5fa18248d783a08ba224ce382ca64c6",
+            "0x5dcd266a80b8a5f29f04d779c6b166b80150c24f2180a75e82427242dab20a9",
+            "0x26391fc4b172",
+            "0x0"
+          ]
+        }
+      ],
+      "execution_resources": {
+        "n_steps": 375,
+        "builtin_instance_counter": {
+          "pedersen_builtin": 2,
+          "range_check_builtin": 6
+        },
+        "n_memory_holes": 14
+      },
+      "actual_fee": "0x26391fc4b172"
+    },
+    {
+      "transaction_index": 18,
+      "transaction_hash": "0x7e243b28b61ff7ed082c7d54e12c716d52ba2d2e407fe8767ba09c5e3127cd2",
+      "l2_to_l1_messages": [],
+      "events": [
+        {
+          "from_address": "0x49c2a1ec35979e3213232b2c59b0c3d9ac2a8a735958f6e8f917e6f8c9502fd",
+          "keys": [
+            "0x5ad857f66a5b55f1301ff1ed7e098ac6d4433148f0b72ebc4a2945ab85ad53"
+          ],
+          "data": [
+            "0x7e243b28b61ff7ed082c7d54e12c716d52ba2d2e407fe8767ba09c5e3127cd2",
+            "0x0"
+          ]
+        },
+        {
+          "from_address": "0x49d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7",
+          "keys": [
+            "0x99cd8bde557814842a3121e8ddfd433a539b8c9f14bf31ebf108d12e6196e9"
+          ],
+          "data": [
+            "0x49c2a1ec35979e3213232b2c59b0c3d9ac2a8a735958f6e8f917e6f8c9502fd",
+            "0x5dcd266a80b8a5f29f04d779c6b166b80150c24f2180a75e82427242dab20a9",
+            "0x26391fc4b172",
+            "0x0"
+          ]
+        }
+      ],
+      "execution_resources": {
+        "n_steps": 375,
+        "builtin_instance_counter": {
+          "pedersen_builtin": 2,
+          "range_check_builtin": 6
+        },
+        "n_memory_holes": 14
+      },
+      "actual_fee": "0x26391fc4b172"
+    },
+    {
+      "transaction_index": 19,
+      "transaction_hash": "0x6830b119458e42ec48a293bc0c8567653c406c32df2d4b40a8241ab0ac80ffa",
+      "l2_to_l1_messages": [],
+      "events": [
+        {
+          "from_address": "0x745fdf1332f23c2efaf7e9b95967fe17c68bdebfb6bb37bf9eb953beab849c",
+          "keys": [
+            "0x5ad857f66a5b55f1301ff1ed7e098ac6d4433148f0b72ebc4a2945ab85ad53"
+          ],
+          "data": [
+            "0x6830b119458e42ec48a293bc0c8567653c406c32df2d4b40a8241ab0ac80ffa",
+            "0x0"
+          ]
+        },
+        {
+          "from_address": "0x49d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7",
+          "keys": [
+            "0x99cd8bde557814842a3121e8ddfd433a539b8c9f14bf31ebf108d12e6196e9"
+          ],
+          "data": [
+            "0x745fdf1332f23c2efaf7e9b95967fe17c68bdebfb6bb37bf9eb953beab849c",
+            "0x5dcd266a80b8a5f29f04d779c6b166b80150c24f2180a75e82427242dab20a9",
+            "0x26391fc4b172",
+            "0x0"
+          ]
+        }
+      ],
+      "execution_resources": {
+        "n_steps": 377,
+        "builtin_instance_counter": {
+          "pedersen_builtin": 2,
+          "range_check_builtin": 6
+        },
+        "n_memory_holes": 13
+      },
+      "actual_fee": "0x26391fc4b172"
+    },
+    {
+      "transaction_index": 20,
+      "transaction_hash": "0x2be3cc7d3fe8419086c118044f0d5b56f07d27fd129f6d5fd8fc61ddc191d28",
+      "l2_to_l1_messages": [],
+      "events": [
+        {
+          "from_address": "0x46bfa580e4fa55a38eaa7f51a3469f86b336eed59a6136a07b7adcd095b0eb2",
+          "keys": [
+            "0x182d859c0807ba9db63baf8b9d9fdbfeb885d820be6e206b9dab626d995c433"
+          ],
+          "data": [
+            "0x5c7f1abb33a5ed33a36c9733d2702ea3c2ccd8c970f3686ff65ee09fa373ba9",
+            "0x5c7f1abb33a5ed33a36c9733d2702ea3c2ccd8c970f3686ff65ee09fa373ba9",
+            "0x7976c66b4439bcf35baaf020f4933726e4e1dbb34958c15542b823b5a07ff88",
+            "0x4d61686469204261",
+            "0x97701000000000000000000000000",
+            "0x1",
+            "0x0"
+          ]
+        },
+        {
+          "from_address": "0x5c7f1abb33a5ed33a36c9733d2702ea3c2ccd8c970f3686ff65ee09fa373ba9",
+          "keys": [
+            "0x1dcde06aabdbca2f80aa51392b345d7549d7757aa855f7e37f5d335ac8243b1"
+          ],
+          "data": [
+            "0x2be3cc7d3fe8419086c118044f0d5b56f07d27fd129f6d5fd8fc61ddc191d28",
+            "0x0"
+          ]
+        },
+        {
+          "from_address": "0x49d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7",
+          "keys": [
+            "0x99cd8bde557814842a3121e8ddfd433a539b8c9f14bf31ebf108d12e6196e9"
+          ],
+          "data": [
+            "0x5c7f1abb33a5ed33a36c9733d2702ea3c2ccd8c970f3686ff65ee09fa373ba9",
+            "0x5dcd266a80b8a5f29f04d779c6b166b80150c24f2180a75e82427242dab20a9",
+            "0x345b17355141",
+            "0x0"
+          ]
+        }
+      ],
+      "execution_resources": {
+        "n_steps": 1696,
+        "builtin_instance_counter": {
+          "pedersen_builtin": 21,
+          "range_check_builtin": 45
+        },
+        "n_memory_holes": 78
+      },
+      "actual_fee": "0x345b17355141"
+    },
+    {
+      "transaction_index": 21,
+      "transaction_hash": "0x1d513e73e7ac102119e3998058d9b51c3daddfc14c77756f7720a82979a3e8c",
+      "l2_to_l1_messages": [],
+      "events": [
+        {
+          "from_address": "0x8cac83ec41b03db54f4cef0adef66983f54236cb8a8781e8d2048fa96e4d15",
+          "keys": [
+            "0x5ad857f66a5b55f1301ff1ed7e098ac6d4433148f0b72ebc4a2945ab85ad53"
+          ],
+          "data": [
+            "0x1d513e73e7ac102119e3998058d9b51c3daddfc14c77756f7720a82979a3e8c",
+            "0x0"
+          ]
+        },
+        {
+          "from_address": "0x49d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7",
+          "keys": [
+            "0x99cd8bde557814842a3121e8ddfd433a539b8c9f14bf31ebf108d12e6196e9"
+          ],
+          "data": [
+            "0x8cac83ec41b03db54f4cef0adef66983f54236cb8a8781e8d2048fa96e4d15",
+            "0x5dcd266a80b8a5f29f04d779c6b166b80150c24f2180a75e82427242dab20a9",
+            "0x26391fc4b172",
+            "0x0"
+          ]
+        }
+      ],
+      "execution_resources": {
+        "n_steps": 377,
+        "builtin_instance_counter": {
+          "pedersen_builtin": 2,
+          "range_check_builtin": 6
+        },
+        "n_memory_holes": 13
+      },
+      "actual_fee": "0x26391fc4b172"
+    },
+    {
+      "transaction_index": 22,
+      "transaction_hash": "0x11367fb2aeab68f205256b6ae6e0ca86c6f0a08904f4c2f7b1012c3dd5b8aec",
+      "l2_to_l1_messages": [],
+      "events": [
+        {
+          "from_address": "0x5063903ed2b9b3fdf7126152ffee5f7dc6253b56ae4bdba64c39cef33cba572",
+          "keys": [
+            "0x5ad857f66a5b55f1301ff1ed7e098ac6d4433148f0b72ebc4a2945ab85ad53"
+          ],
+          "data": [
+            "0x11367fb2aeab68f205256b6ae6e0ca86c6f0a08904f4c2f7b1012c3dd5b8aec",
+            "0x0"
+          ]
+        },
+        {
+          "from_address": "0x49d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7",
+          "keys": [
+            "0x99cd8bde557814842a3121e8ddfd433a539b8c9f14bf31ebf108d12e6196e9"
+          ],
+          "data": [
+            "0x5063903ed2b9b3fdf7126152ffee5f7dc6253b56ae4bdba64c39cef33cba572",
+            "0x5dcd266a80b8a5f29f04d779c6b166b80150c24f2180a75e82427242dab20a9",
+            "0x26391fc4b172",
+            "0x0"
+          ]
+        }
+      ],
+      "execution_resources": {
+        "n_steps": 377,
+        "builtin_instance_counter": {
+          "pedersen_builtin": 2,
+          "range_check_builtin": 6
+        },
+        "n_memory_holes": 13
+      },
+      "actual_fee": "0x26391fc4b172"
+    },
+    {
+      "transaction_index": 23,
+      "transaction_hash": "0x3e5ed5e468ca399a67f410c805ed4ee77384213bd4c308fca44ad88ecf8f277",
+      "l2_to_l1_messages": [],
+      "events": [
+        {
+          "from_address": "0x6669441ec4dd884e34219fb6eabb41d5f80a537d71352260683c0bb0919ae49",
+          "keys": [
+            "0x5ad857f66a5b55f1301ff1ed7e098ac6d4433148f0b72ebc4a2945ab85ad53"
+          ],
+          "data": [
+            "0x3e5ed5e468ca399a67f410c805ed4ee77384213bd4c308fca44ad88ecf8f277",
+            "0x0"
+          ]
+        },
+        {
+          "from_address": "0x49d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7",
+          "keys": [
+            "0x99cd8bde557814842a3121e8ddfd433a539b8c9f14bf31ebf108d12e6196e9"
+          ],
+          "data": [
+            "0x6669441ec4dd884e34219fb6eabb41d5f80a537d71352260683c0bb0919ae49",
+            "0x5dcd266a80b8a5f29f04d779c6b166b80150c24f2180a75e82427242dab20a9",
+            "0x26391fc4b172",
+            "0x0"
+          ]
+        }
+      ],
+      "execution_resources": {
+        "n_steps": 375,
+        "builtin_instance_counter": {
+          "pedersen_builtin": 2,
+          "range_check_builtin": 6
+        },
+        "n_memory_holes": 14
+      },
+      "actual_fee": "0x26391fc4b172"
+    },
+    {
+      "transaction_index": 24,
+      "transaction_hash": "0x5575dd8ebcad9791d3b6e39b379b0ee791f952a7f5e8e09e9eb7b31e49eca9b",
+      "l2_to_l1_messages": [],
+      "events": [
+        {
+          "from_address": "0x3090623ea32d932ca1236595076b00702e7d860696faf300ca9eb13bfe0a78c",
+          "keys": [
+            "0x99cd8bde557814842a3121e8ddfd433a539b8c9f14bf31ebf108d12e6196e9"
+          ],
+          "data": [
+            "0x0",
+            "0x35c751960896c3c89a500ef4339449331eb73aa9f80336b9d3bd3d5c6ff09d0",
+            "0x623b",
+            "0x0"
+          ]
+        },
+        {
+          "from_address": "0x35c751960896c3c89a500ef4339449331eb73aa9f80336b9d3bd3d5c6ff09d0",
+          "keys": [
+            "0x5ad857f66a5b55f1301ff1ed7e098ac6d4433148f0b72ebc4a2945ab85ad53"
+          ],
+          "data": [
+            "0x5575dd8ebcad9791d3b6e39b379b0ee791f952a7f5e8e09e9eb7b31e49eca9b",
+            "0x0"
+          ]
+        },
+        {
+          "from_address": "0x49d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7",
+          "keys": [
+            "0x99cd8bde557814842a3121e8ddfd433a539b8c9f14bf31ebf108d12e6196e9"
+          ],
+          "data": [
+            "0x35c751960896c3c89a500ef4339449331eb73aa9f80336b9d3bd3d5c6ff09d0",
+            "0x5dcd266a80b8a5f29f04d779c6b166b80150c24f2180a75e82427242dab20a9",
+            "0x86086874eef1",
+            "0x0"
+          ]
+        }
+      ],
+      "execution_resources": {
+        "n_steps": 1600,
+        "builtin_instance_counter": {
+          "pedersen_builtin": 10,
+          "range_check_builtin": 51,
+          "ecdsa_builtin": 1
+        },
+        "n_memory_holes": 66
+      },
+      "actual_fee": "0x86086874eef1"
+    },
+    {
+      "transaction_index": 25,
+      "transaction_hash": "0x56a54ac65e6aad855a5d0bd5859147addcc48b0a61f86b3b15efe5f854c2932",
+      "l2_to_l1_messages": [],
+      "events": [
+        {
+          "from_address": "0x3090623ea32d932ca1236595076b00702e7d860696faf300ca9eb13bfe0a78c",
+          "keys": [
+            "0x99cd8bde557814842a3121e8ddfd433a539b8c9f14bf31ebf108d12e6196e9"
+          ],
+          "data": [
+            "0x0",
+            "0x58b62e6584a00c62c3886abd0ee5590121e5cb33324eac10a8eff43a6d60b64",
+            "0x623c",
+            "0x0"
+          ]
+        },
+        {
+          "from_address": "0x49d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7",
+          "keys": [
+            "0x99cd8bde557814842a3121e8ddfd433a539b8c9f14bf31ebf108d12e6196e9"
+          ],
+          "data": [
+            "0x58b62e6584a00c62c3886abd0ee5590121e5cb33324eac10a8eff43a6d60b64",
+            "0x5dcd266a80b8a5f29f04d779c6b166b80150c24f2180a75e82427242dab20a9",
+            "0x8605eda3877c",
+            "0x0"
+          ]
+        }
+      ],
+      "execution_resources": {
+        "n_steps": 1566,
+        "builtin_instance_counter": {
+          "pedersen_builtin": 10,
+          "range_check_builtin": 50,
+          "ecdsa_builtin": 1
+        },
+        "n_memory_holes": 63
+      },
+      "actual_fee": "0x8605eda3877c"
+    },
+    {
+      "transaction_index": 26,
+      "transaction_hash": "0x7917a17f431c2cfaa7031ca00dc782065d8477299cd0797c4dbe3e5abcc477c",
+      "l2_to_l1_messages": [],
+      "events": [
+        {
+          "from_address": "0x49d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7",
+          "keys": [
+            "0x134692b230b9e1ffa39098904722134159652b09c5bc41d88d6698779d228ff"
+          ],
+          "data": [
+            "0x1148ed7da24228c369d5dd044a5064626d2b623a8edd28a0efa1223c3767355",
+            "0x7a6f98c03379b9513ca84cca1373ff452a7462a3b61598f0af5bb27ad7f76d1",
+            "0x16345785d8a0000",
+            "0x0"
+          ]
+        },
+        {
+          "from_address": "0x49d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7",
+          "keys": [
+            "0x99cd8bde557814842a3121e8ddfd433a539b8c9f14bf31ebf108d12e6196e9"
+          ],
+          "data": [
+            "0x1148ed7da24228c369d5dd044a5064626d2b623a8edd28a0efa1223c3767355",
+            "0x17e9e62c04b50800d7c59454754fe31a2193c9c3c6c92c093f2ab0faadf8c87",
+            "0x16345785d8a0000",
+            "0x0"
+          ]
+        },
+        {
+          "from_address": "0xda114221cb83fa859dbdb4c44beeaa0bb37c7537ad5ae66fe5e0efd20e6eb3",
+          "keys": [
+            "0x99cd8bde557814842a3121e8ddfd433a539b8c9f14bf31ebf108d12e6196e9"
+          ],
+          "data": [
+            "0x17e9e62c04b50800d7c59454754fe31a2193c9c3c6c92c093f2ab0faadf8c87",
+            "0x1148ed7da24228c369d5dd044a5064626d2b623a8edd28a0efa1223c3767355",
+            "0x6600c93dcacbe58bf",
+            "0x0"
+          ]
+        },
+        {
+          "from_address": "0x17e9e62c04b50800d7c59454754fe31a2193c9c3c6c92c093f2ab0faadf8c87",
+          "keys": [
+            "0xe14a408baf7f453312eec68e9b7d728ec5337fbdf671f917ee8c80f3255232"
+          ],
+          "data": [
+            "0x3fe72f846692f400806",
+            "0xdf4a86a1078a56d6"
+          ]
+        },
+        {
+          "from_address": "0x17e9e62c04b50800d7c59454754fe31a2193c9c3c6c92c093f2ab0faadf8c87",
+          "keys": [
+            "0xe316f0d9d2a3affa97de1d99bb2aac0538e2666d0d8545545ead241ef0ccab"
+          ],
+          "data": [
+            "0x7a6f98c03379b9513ca84cca1373ff452a7462a3b61598f0af5bb27ad7f76d1",
+            "0x0",
+            "0x0",
+            "0x16345785d8a0000",
+            "0x0",
+            "0x6600c93dcacbe58bf",
+            "0x0",
+            "0x0",
+            "0x0",
+            "0x1148ed7da24228c369d5dd044a5064626d2b623a8edd28a0efa1223c3767355"
+          ]
+        },
+        {
+          "from_address": "0x1148ed7da24228c369d5dd044a5064626d2b623a8edd28a0efa1223c3767355",
+          "keys": [
+            "0x5ad857f66a5b55f1301ff1ed7e098ac6d4433148f0b72ebc4a2945ab85ad53"
+          ],
+          "data": [
+            "0x7917a17f431c2cfaa7031ca00dc782065d8477299cd0797c4dbe3e5abcc477c",
+            "0x6",
+            "0x1",
+            "0x2",
+            "0x16345785d8a0000",
+            "0x0",
+            "0x6600c93dcacbe58bf",
+            "0x0"
+          ]
+        },
+        {
+          "from_address": "0x49d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7",
+          "keys": [
+            "0x99cd8bde557814842a3121e8ddfd433a539b8c9f14bf31ebf108d12e6196e9"
+          ],
+          "data": [
+            "0x1148ed7da24228c369d5dd044a5064626d2b623a8edd28a0efa1223c3767355",
+            "0x5dcd266a80b8a5f29f04d779c6b166b80150c24f2180a75e82427242dab20a9",
+            "0xb21163041a9b",
+            "0x0"
+          ]
+        }
+      ],
+      "execution_resources": {
+        "n_steps": 11339,
+        "builtin_instance_counter": {
+          "pedersen_builtin": 40,
+          "range_check_builtin": 855,
+          "bitwise_builtin": 3
+        },
+        "n_memory_holes": 281
+      },
+      "actual_fee": "0xb21163041a9b"
+    },
+    {
+      "transaction_index": 27,
+      "transaction_hash": "0x77feea3cbbfe51a29f11061f285953eb825f808cbb2439e18434c6c0bf6760e",
+      "l2_to_l1_messages": [],
+      "events": [
+        {
+          "from_address": "0x7861c4e276294a7e859ff0ae2eec0c68300ad9cbb43219db907da9bad786488",
+          "keys": [
+            "0x99cd8bde557814842a3121e8ddfd433a539b8c9f14bf31ebf108d12e6196e9"
+          ],
+          "data": [
+            "0x0",
+            "0x1cc5188bf60e31a4825f7e29c608add1f6dadb1cbb237b36842f646f91181a5",
+            "0xa0b3",
+            "0x0"
+          ]
+        },
+        {
+          "from_address": "0x1cc5188bf60e31a4825f7e29c608add1f6dadb1cbb237b36842f646f91181a5",
+          "keys": [
+            "0x5ad857f66a5b55f1301ff1ed7e098ac6d4433148f0b72ebc4a2945ab85ad53"
+          ],
+          "data": [
+            "0x77feea3cbbfe51a29f11061f285953eb825f808cbb2439e18434c6c0bf6760e",
+            "0x0"
+          ]
+        },
+        {
+          "from_address": "0x49d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7",
+          "keys": [
+            "0x99cd8bde557814842a3121e8ddfd433a539b8c9f14bf31ebf108d12e6196e9"
+          ],
+          "data": [
+            "0x1cc5188bf60e31a4825f7e29c608add1f6dadb1cbb237b36842f646f91181a5",
+            "0x5dcd266a80b8a5f29f04d779c6b166b80150c24f2180a75e82427242dab20a9",
+            "0x7a43809aeaa6",
+            "0x0"
+          ]
+        }
+      ],
+      "execution_resources": {
+        "n_steps": 1387,
+        "builtin_instance_counter": {
+          "pedersen_builtin": 18,
+          "range_check_builtin": 45
+        },
+        "n_memory_holes": 106
+      },
+      "actual_fee": "0x7a43809aeaa6"
+    },
+    {
+      "transaction_index": 28,
+      "transaction_hash": "0x3e162983cc807cc57171688d0452b5eb4dd162a51e86d700de4726fb9832d71",
+      "l1_to_l2_consumed_message": {
+        "from_address": "0xae0Ee0A63A2cE6BaeEFFE56e7714FB4EFE48D419",
+        "to_address": "0x73314940630fd6dcda0d772d4c972c4e0a9946bef9dabf4ef84eda8ef542b82",
+        "selector": "0x2d757788a8d8d6f21d1cd40bce38a8222d70654214e96ff95d8086e684fbee5",
+        "payload": [
+          "0x5d22b724a6ebe4a7758ba997decf4bfb97cf269e634f3866f5c6f6e23414721",
+          "0x38d7ea4c68000",
+          "0x0"
+        ],
+        "nonce": "0x16bad"
+      },
+      "l2_to_l1_messages": [],
+      "events": [
+        {
+          "from_address": "0x49d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7",
+          "keys": [
+            "0x99cd8bde557814842a3121e8ddfd433a539b8c9f14bf31ebf108d12e6196e9"
+          ],
+          "data": [
+            "0x0",
+            "0x5d22b724a6ebe4a7758ba997decf4bfb97cf269e634f3866f5c6f6e23414721",
+            "0x38d7ea4c68000",
+            "0x0"
+          ]
+        },
+        {
+          "from_address": "0x73314940630fd6dcda0d772d4c972c4e0a9946bef9dabf4ef84eda8ef542b82",
+          "keys": [
+            "0x221e5a5008f7a28564f0eaa32cdeb0848d10657c449aed3e15d12150a7c2db3"
+          ],
+          "data": [
+            "0x5d22b724a6ebe4a7758ba997decf4bfb97cf269e634f3866f5c6f6e23414721",
+            "0x38d7ea4c68000",
+            "0x0"
+          ]
+        }
+      ],
+      "execution_resources": {
+        "n_steps": 677,
+        "builtin_instance_counter": {
+          "pedersen_builtin": 2,
+          "range_check_builtin": 12
+        },
+        "n_memory_holes": 20
+      },
+      "actual_fee": "0x0"
+    },
+    {
+      "transaction_index": 29,
+      "transaction_hash": "0x2db4259ed32d96ab92dc6cb1c36ed5abb6a65734c229160cfc3e692538a1d43",
+      "l2_to_l1_messages": [],
+      "events": [
+        {
+          "from_address": "0x68f5c6a61780768455de69077e07e89787839bf8166decfbf92b645209c0fb8",
+          "keys": [
+            "0x134692b230b9e1ffa39098904722134159652b09c5bc41d88d6698779d228ff"
+          ],
+          "data": [
+            "0x2736b678f2349dfbd64fe07e5e07a0f9f558b5183c7819031ca020a2d1f08af",
+            "0x10884171baf1914edc28d7afb619b40a4051cfae78a094a55d230f19e944a28",
+            "0xc2f61b",
+            "0x0"
+          ]
+        },
+        {
+          "from_address": "0x68f5c6a61780768455de69077e07e89787839bf8166decfbf92b645209c0fb8",
+          "keys": [
+            "0x99cd8bde557814842a3121e8ddfd433a539b8c9f14bf31ebf108d12e6196e9"
+          ],
+          "data": [
+            "0x2736b678f2349dfbd64fe07e5e07a0f9f558b5183c7819031ca020a2d1f08af",
+            "0x10884171baf1914edc28d7afb619b40a4051cfae78a094a55d230f19e944a28",
+            "0xc2f61b",
+            "0x0"
+          ]
+        },
+        {
+          "from_address": "0x49d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7",
+          "keys": [
+            "0x99cd8bde557814842a3121e8ddfd433a539b8c9f14bf31ebf108d12e6196e9"
+          ],
+          "data": [
+            "0x10884171baf1914edc28d7afb619b40a4051cfae78a094a55d230f19e944a28",
+            "0x2736b678f2349dfbd64fe07e5e07a0f9f558b5183c7819031ca020a2d1f08af",
+            "0x24aac43d76cd5d",
+            "0x0"
+          ]
+        },
+        {
+          "from_address": "0x2736b678f2349dfbd64fe07e5e07a0f9f558b5183c7819031ca020a2d1f08af",
+          "keys": [
+            "0x5ad857f66a5b55f1301ff1ed7e098ac6d4433148f0b72ebc4a2945ab85ad53"
+          ],
+          "data": [
+            "0x2db4259ed32d96ab92dc6cb1c36ed5abb6a65734c229160cfc3e692538a1d43",
+            "0x3",
+            "0x1",
+            "0x24aac43d76cd5d",
+            "0x0"
+          ]
+        },
+        {
+          "from_address": "0x49d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7",
+          "keys": [
+            "0x99cd8bde557814842a3121e8ddfd433a539b8c9f14bf31ebf108d12e6196e9"
+          ],
+          "data": [
+            "0x2736b678f2349dfbd64fe07e5e07a0f9f558b5183c7819031ca020a2d1f08af",
+            "0x5dcd266a80b8a5f29f04d779c6b166b80150c24f2180a75e82427242dab20a9",
+            "0x7fe43ddab72f",
+            "0x0"
+          ]
+        }
+      ],
+      "execution_resources": {
+        "n_steps": 5140,
+        "builtin_instance_counter": {
+          "pedersen_builtin": 21,
+          "range_check_builtin": 249
+        },
+        "n_memory_holes": 183
+      },
+      "actual_fee": "0x7fe43ddab72f"
+    },
+    {
+      "transaction_index": 30,
+      "transaction_hash": "0x515a016b825751838e676da9ad73a728a51555bb8a3358b572d618d5e698830",
+      "l2_to_l1_messages": [],
+      "events": [
+        {
+          "from_address": "0x53c91253bc9682c04929ca02ed00b3e423f6710d2ee7e0d5ebb06f3ecf368a8",
+          "keys": [
+            "0x134692b230b9e1ffa39098904722134159652b09c5bc41d88d6698779d228ff"
+          ],
+          "data": [
+            "0x18e130cd8a0b6bbd5e50701caca13761cd7f2cd7997eedb3a12037d67830957",
+            "0x10884171baf1914edc28d7afb619b40a4051cfae78a094a55d230f19e944a28",
+            "0x6f17d3d",
+            "0x0"
+          ]
+        },
+        {
+          "from_address": "0x53c91253bc9682c04929ca02ed00b3e423f6710d2ee7e0d5ebb06f3ecf368a8",
+          "keys": [
+            "0x99cd8bde557814842a3121e8ddfd433a539b8c9f14bf31ebf108d12e6196e9"
+          ],
+          "data": [
+            "0x18e130cd8a0b6bbd5e50701caca13761cd7f2cd7997eedb3a12037d67830957",
+            "0x10884171baf1914edc28d7afb619b40a4051cfae78a094a55d230f19e944a28",
+            "0x6f17d3d",
+            "0x0"
+          ]
+        },
+        {
+          "from_address": "0x49d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7",
+          "keys": [
+            "0x99cd8bde557814842a3121e8ddfd433a539b8c9f14bf31ebf108d12e6196e9"
+          ],
+          "data": [
+            "0x10884171baf1914edc28d7afb619b40a4051cfae78a094a55d230f19e944a28",
+            "0x18e130cd8a0b6bbd5e50701caca13761cd7f2cd7997eedb3a12037d67830957",
+            "0x1526e2858b1c51a",
+            "0x0"
+          ]
+        },
+        {
+          "from_address": "0x18e130cd8a0b6bbd5e50701caca13761cd7f2cd7997eedb3a12037d67830957",
+          "keys": [
+            "0x5ad857f66a5b55f1301ff1ed7e098ac6d4433148f0b72ebc4a2945ab85ad53"
+          ],
+          "data": [
+            "0x515a016b825751838e676da9ad73a728a51555bb8a3358b572d618d5e698830",
+            "0x3",
+            "0x1",
+            "0x1526e2858b1c51a",
+            "0x0"
+          ]
+        },
+        {
+          "from_address": "0x49d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7",
+          "keys": [
+            "0x99cd8bde557814842a3121e8ddfd433a539b8c9f14bf31ebf108d12e6196e9"
+          ],
+          "data": [
+            "0x18e130cd8a0b6bbd5e50701caca13761cd7f2cd7997eedb3a12037d67830957",
+            "0x5dcd266a80b8a5f29f04d779c6b166b80150c24f2180a75e82427242dab20a9",
+            "0x7fe43ddab72f",
+            "0x0"
+          ]
+        }
+      ],
+      "execution_resources": {
+        "n_steps": 5128,
+        "builtin_instance_counter": {
+          "pedersen_builtin": 21,
+          "range_check_builtin": 249
+        },
+        "n_memory_holes": 189
+      },
+      "actual_fee": "0x7fe43ddab72f"
+    },
+    {
+      "transaction_index": 31,
+      "transaction_hash": "0x4f2f0224a8e80cf2a4427691a3bb3b25d81031ac061bf85ced15a6a3b04929c",
+      "l2_to_l1_messages": [],
+      "events": [
+        {
+          "from_address": "0x46bfa580e4fa55a38eaa7f51a3469f86b336eed59a6136a07b7adcd095b0eb2",
+          "keys": [
+            "0x182d859c0807ba9db63baf8b9d9fdbfeb885d820be6e206b9dab626d995c433"
+          ],
+          "data": [
+            "0x59a0e2b44b40e07dcc247e1f86c4f7f268414fe6d2b67845e2bae2f479420dd",
+            "0x59a0e2b44b40e07dcc247e1f86c4f7f268414fe6d2b67845e2bae2f479420dd",
+            "0x7976c66b4439bcf35baaf020f4933726e4e1dbb34958c15542b823b5a07ff88",
+            "0x5a75756b6f75204d61797a6965",
+            "0xab201000000000000000000000000",
+            "0x1",
+            "0x0"
+          ]
+        },
+        {
+          "from_address": "0x59a0e2b44b40e07dcc247e1f86c4f7f268414fe6d2b67845e2bae2f479420dd",
+          "keys": [
+            "0x1dcde06aabdbca2f80aa51392b345d7549d7757aa855f7e37f5d335ac8243b1"
+          ],
+          "data": [
+            "0x4f2f0224a8e80cf2a4427691a3bb3b25d81031ac061bf85ced15a6a3b04929c",
+            "0x0"
+          ]
+        },
+        {
+          "from_address": "0x49d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7",
+          "keys": [
+            "0x99cd8bde557814842a3121e8ddfd433a539b8c9f14bf31ebf108d12e6196e9"
+          ],
+          "data": [
+            "0x59a0e2b44b40e07dcc247e1f86c4f7f268414fe6d2b67845e2bae2f479420dd",
+            "0x5dcd266a80b8a5f29f04d779c6b166b80150c24f2180a75e82427242dab20a9",
+            "0x345b17355141",
+            "0x0"
+          ]
+        }
+      ],
+      "execution_resources": {
+        "n_steps": 1698,
+        "builtin_instance_counter": {
+          "pedersen_builtin": 21,
+          "range_check_builtin": 45
+        },
+        "n_memory_holes": 77
+      },
+      "actual_fee": "0x345b17355141"
+    },
+    {
+      "transaction_index": 32,
+      "transaction_hash": "0x49e0f644286f05c6e5b7fd762e6e5dca8a1302419fcc799af85463c519bb89",
+      "l2_to_l1_messages": [],
+      "events": [
+        {
+          "from_address": "0xbc1529814a493420c91f3c7f902c30ee36c1e22b79a9cb304a09c1226d8cf9",
+          "keys": [
+            "0x112d26124b60e4d99e8c4387c732086fd96b159bf3d72e6d8f5f60c944533f1"
+          ],
+          "data": [
+            "0x33434ad846cdd5f23eb73ff09fe6fddd568284a0fb7d1be20ee482f044dabe2"
+          ]
+        },
+        {
+          "from_address": "0xbc1529814a493420c91f3c7f902c30ee36c1e22b79a9cb304a09c1226d8cf9",
+          "keys": [
+            "0x5ad857f66a5b55f1301ff1ed7e098ac6d4433148f0b72ebc4a2945ab85ad53"
+          ],
+          "data": [
+            "0x49e0f644286f05c6e5b7fd762e6e5dca8a1302419fcc799af85463c519bb89",
+            "0x0"
+          ]
+        },
+        {
+          "from_address": "0x49d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7",
+          "keys": [
+            "0x99cd8bde557814842a3121e8ddfd433a539b8c9f14bf31ebf108d12e6196e9"
+          ],
+          "data": [
+            "0xbc1529814a493420c91f3c7f902c30ee36c1e22b79a9cb304a09c1226d8cf9",
+            "0x5dcd266a80b8a5f29f04d779c6b166b80150c24f2180a75e82427242dab20a9",
+            "0x326b239c7dd9",
+            "0x0"
+          ]
+        }
+      ],
+      "execution_resources": {
+        "n_steps": 694,
+        "builtin_instance_counter": {
+          "range_check_builtin": 4,
+          "ecdsa_builtin": 1
+        },
+        "n_memory_holes": 3
+      },
+      "actual_fee": "0x326b239c7dd9"
+    },
+    {
+      "transaction_index": 33,
+      "transaction_hash": "0x30c51e9cef2136728e93a81605c5508a2e659c528d03c04e4c1ae7d0ec100ea",
+      "l2_to_l1_messages": [],
+      "events": [
+        {
+          "from_address": "0x46bfa580e4fa55a38eaa7f51a3469f86b336eed59a6136a07b7adcd095b0eb2",
+          "keys": [
+            "0x2563683c757f3abe19c4b7237e2285d8993417ddffe0b54a19eb212ea574b08"
+          ],
+          "data": [
+            "0x27fb5a7be4707e2b1fe653e7296ad30114596fafdd3fbc3f9b92a0551ff18ec",
+            "0x0",
+            "0x216ca69e83b0b28acfb22350297f8af85749538ac6974b638ed15a7046a30f",
+            "0x3",
+            "0x4a65616e4a617373",
+            "0xb9101000000000000000000000000",
+            "0x5a75756b6f75204d61797a6965",
+            "0x9f801000000000000000000000000",
+            "0x446f756d73",
+            "0x47901000000000000000000000000",
+            "0x3",
+            "0x1",
+            "0x0",
+            "0x1",
+            "0x0",
+            "0x1",
+            "0x0"
+          ]
+        },
+        {
+          "from_address": "0x46bfa580e4fa55a38eaa7f51a3469f86b336eed59a6136a07b7adcd095b0eb2",
+          "keys": [
+            "0x182d859c0807ba9db63baf8b9d9fdbfeb885d820be6e206b9dab626d995c433"
+          ],
+          "data": [
+            "0x27fb5a7be4707e2b1fe653e7296ad30114596fafdd3fbc3f9b92a0551ff18ec",
+            "0x27fb5a7be4707e2b1fe653e7296ad30114596fafdd3fbc3f9b92a0551ff18ec",
+            "0x0",
+            "0x5",
+            "0x0",
+            "0x1",
+            "0x0"
+          ]
+        },
+        {
+          "from_address": "0x46bfa580e4fa55a38eaa7f51a3469f86b336eed59a6136a07b7adcd095b0eb2",
+          "keys": [
+            "0x2563683c757f3abe19c4b7237e2285d8993417ddffe0b54a19eb212ea574b08"
+          ],
+          "data": [
+            "0x27fb5a7be4707e2b1fe653e7296ad30114596fafdd3fbc3f9b92a0551ff18ec",
+            "0x0",
+            "0x216ca69e83b0b28acfb22350297f8af85749538ac6974b638ed15a7046a30f",
+            "0x3",
+            "0x537069646572205a6564",
+            "0xafb01000000000000000000000000",
+            "0x536b756e61",
+            "0x7e601000000000000000000000000",
+            "0x4c652052e8676c656d656e74",
+            "0xb0601000000000000000000000000",
+            "0x3",
+            "0x1",
+            "0x0",
+            "0x1",
+            "0x0",
+            "0x1",
+            "0x0"
+          ]
+        },
+        {
+          "from_address": "0x46bfa580e4fa55a38eaa7f51a3469f86b336eed59a6136a07b7adcd095b0eb2",
+          "keys": [
+            "0x182d859c0807ba9db63baf8b9d9fdbfeb885d820be6e206b9dab626d995c433"
+          ],
+          "data": [
+            "0x27fb5a7be4707e2b1fe653e7296ad30114596fafdd3fbc3f9b92a0551ff18ec",
+            "0x27fb5a7be4707e2b1fe653e7296ad30114596fafdd3fbc3f9b92a0551ff18ec",
+            "0x0",
+            "0x5",
+            "0x0",
+            "0x1",
+            "0x0"
+          ]
+        },
+        {
+          "from_address": "0x7518a3810c8204fb4377de22df74ed80857368795b936a99ca70bb0fda8bdd",
+          "keys": [
+            "0x1dcde06aabdbca2f80aa51392b345d7549d7757aa855f7e37f5d335ac8243b1"
+          ],
+          "data": [
+            "0x30c51e9cef2136728e93a81605c5508a2e659c528d03c04e4c1ae7d0ec100ea",
+            "0x0"
+          ]
+        },
+        {
+          "from_address": "0x49d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7",
+          "keys": [
+            "0x99cd8bde557814842a3121e8ddfd433a539b8c9f14bf31ebf108d12e6196e9"
+          ],
+          "data": [
+            "0x7518a3810c8204fb4377de22df74ed80857368795b936a99ca70bb0fda8bdd",
+            "0x5dcd266a80b8a5f29f04d779c6b166b80150c24f2180a75e82427242dab20a9",
+            "0x20f3fb1bc25ab",
+            "0x0"
+          ]
+        }
+      ],
+      "execution_resources": {
+        "n_steps": 16253,
+        "builtin_instance_counter": {
+          "pedersen_builtin": 240,
+          "range_check_builtin": 442
+        },
+        "n_memory_holes": 1056
+      },
+      "actual_fee": "0x20f3fb1bc25ab"
+    },
+    {
+      "transaction_index": 34,
+      "transaction_hash": "0x5c4ae1561e64e28d6d912d92899b146bc72d365b7e8af5d4303ab9c9d48806d",
+      "l2_to_l1_messages": [],
+      "events": [
+        {
+          "from_address": "0x49d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7",
+          "keys": [
+            "0x134692b230b9e1ffa39098904722134159652b09c5bc41d88d6698779d228ff"
+          ],
+          "data": [
+            "0x30877eccc7226b595e5744222c37e536774c864b7516226ef6b622416e395b4",
+            "0x173f81c529191726c6e7287e24626fe24760ac44dae2a1f7e02080230f8458b",
+            "0xffffffffffffffffffffffffffffffff",
+            "0xffffffffffffffffffffffffffffffff"
+          ]
+        },
+        {
+          "from_address": "0x30877eccc7226b595e5744222c37e536774c864b7516226ef6b622416e395b4",
+          "keys": [
+            "0x5ad857f66a5b55f1301ff1ed7e098ac6d4433148f0b72ebc4a2945ab85ad53"
+          ],
+          "data": [
+            "0x5c4ae1561e64e28d6d912d92899b146bc72d365b7e8af5d4303ab9c9d48806d",
+            "0x1",
+            "0x1"
+          ]
+        },
+        {
+          "from_address": "0x49d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7",
+          "keys": [
+            "0x99cd8bde557814842a3121e8ddfd433a539b8c9f14bf31ebf108d12e6196e9"
+          ],
+          "data": [
+            "0x30877eccc7226b595e5744222c37e536774c864b7516226ef6b622416e395b4",
+            "0x5dcd266a80b8a5f29f04d779c6b166b80150c24f2180a75e82427242dab20a9",
+            "0x327a0484ea97",
+            "0x0"
+          ]
+        }
+      ],
+      "execution_resources": {
+        "n_steps": 517,
+        "builtin_instance_counter": {
+          "pedersen_builtin": 2,
+          "range_check_builtin": 8
+        },
+        "n_memory_holes": 14
+      },
+      "actual_fee": "0x327a0484ea97"
+    },
+    {
+      "transaction_index": 35,
+      "transaction_hash": "0x16c9e63a7139a3b6f9974cfc76f700c75c41fa102bbddf7ad9da96f2c3ebc55",
+      "l2_to_l1_messages": [],
+      "events": [
+        {
+          "from_address": "0x49d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7",
+          "keys": [
+            "0x134692b230b9e1ffa39098904722134159652b09c5bc41d88d6698779d228ff"
+          ],
+          "data": [
+            "0x8162333d66f7e8ed9284b8e5a2e28135fa171db01e355086a259e500d9690b",
+            "0x173f81c529191726c6e7287e24626fe24760ac44dae2a1f7e02080230f8458b",
+            "0xffffffffffffffffffffffffffffffff",
+            "0xffffffffffffffffffffffffffffffff"
+          ]
+        },
+        {
+          "from_address": "0x49d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7",
+          "keys": [
+            "0x99cd8bde557814842a3121e8ddfd433a539b8c9f14bf31ebf108d12e6196e9"
+          ],
+          "data": [
+            "0x8162333d66f7e8ed9284b8e5a2e28135fa171db01e355086a259e500d9690b",
+            "0x5dcd266a80b8a5f29f04d779c6b166b80150c24f2180a75e82427242dab20a9",
+            "0x49e39796b23c",
+            "0x0"
+          ]
+        }
+      ],
+      "execution_resources": {
+        "n_steps": 668,
+        "builtin_instance_counter": {
+          "pedersen_builtin": 2,
+          "range_check_builtin": 8,
+          "ecdsa_builtin": 1
+        },
+        "n_memory_holes": 13
+      },
+      "actual_fee": "0x49e39796b23c"
+    },
+    {
+      "transaction_index": 36,
+      "transaction_hash": "0x5ac2ad423e116359c205906174b525a6a1b6c3d76fb6ba92c74d631e1ec2f2d",
+      "l2_to_l1_messages": [],
+      "events": [
+        {
+          "from_address": "0x46bfa580e4fa55a38eaa7f51a3469f86b336eed59a6136a07b7adcd095b0eb2",
+          "keys": [
+            "0x182d859c0807ba9db63baf8b9d9fdbfeb885d820be6e206b9dab626d995c433"
+          ],
+          "data": [
+            "0x7976c66b4439bcf35baaf020f4933726e4e1dbb34958c15542b823b5a07ff88",
+            "0x7976c66b4439bcf35baaf020f4933726e4e1dbb34958c15542b823b5a07ff88",
+            "0x59a0e2b44b40e07dcc247e1f86c4f7f268414fe6d2b67845e2bae2f479420dd",
+            "0x4a776c6573",
+            "0xb7901000000000000000000000000",
+            "0x1",
+            "0x0"
+          ]
+        },
+        {
+          "from_address": "0x7976c66b4439bcf35baaf020f4933726e4e1dbb34958c15542b823b5a07ff88",
+          "keys": [
+            "0x1dcde06aabdbca2f80aa51392b345d7549d7757aa855f7e37f5d335ac8243b1"
+          ],
+          "data": [
+            "0x5ac2ad423e116359c205906174b525a6a1b6c3d76fb6ba92c74d631e1ec2f2d",
+            "0x0"
+          ]
+        },
+        {
+          "from_address": "0x49d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7",
+          "keys": [
+            "0x99cd8bde557814842a3121e8ddfd433a539b8c9f14bf31ebf108d12e6196e9"
+          ],
+          "data": [
+            "0x7976c66b4439bcf35baaf020f4933726e4e1dbb34958c15542b823b5a07ff88",
+            "0x5dcd266a80b8a5f29f04d779c6b166b80150c24f2180a75e82427242dab20a9",
+            "0x345b17355141",
+            "0x0"
+          ]
+        }
+      ],
+      "execution_resources": {
+        "n_steps": 1696,
+        "builtin_instance_counter": {
+          "pedersen_builtin": 21,
+          "range_check_builtin": 45
+        },
+        "n_memory_holes": 78
+      },
+      "actual_fee": "0x345b17355141"
+    },
+    {
+      "transaction_index": 37,
+      "transaction_hash": "0xae69fed1399566f91dd7a82ea872677a20e240d0ca0684e3326fc80341d57e",
+      "l2_to_l1_messages": [],
+      "events": [
+        {
+          "from_address": "0x49d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7",
+          "keys": [
+            "0x134692b230b9e1ffa39098904722134159652b09c5bc41d88d6698779d228ff"
+          ],
+          "data": [
+            "0x21f7c10f6a8123c1653bac4925bba8aabaac5fc0d9f894a1f48711434ae054d",
+            "0x173f81c529191726c6e7287e24626fe24760ac44dae2a1f7e02080230f8458b",
+            "0xffffffffffffffffffffffffffffffff",
+            "0xffffffffffffffffffffffffffffffff"
+          ]
+        },
+        {
+          "from_address": "0x49d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7",
+          "keys": [
+            "0x99cd8bde557814842a3121e8ddfd433a539b8c9f14bf31ebf108d12e6196e9"
+          ],
+          "data": [
+            "0x21f7c10f6a8123c1653bac4925bba8aabaac5fc0d9f894a1f48711434ae054d",
+            "0x5dcd266a80b8a5f29f04d779c6b166b80150c24f2180a75e82427242dab20a9",
+            "0x49e39796b23c",
+            "0x0"
+          ]
+        }
+      ],
+      "execution_resources": {
+        "n_steps": 666,
+        "builtin_instance_counter": {
+          "pedersen_builtin": 2,
+          "range_check_builtin": 8,
+          "ecdsa_builtin": 1
+        },
+        "n_memory_holes": 14
+      },
+      "actual_fee": "0x49e39796b23c"
+    },
+    {
+      "transaction_index": 38,
+      "transaction_hash": "0x1c0ec9284cd3cbf53d341cffe2caef02a08305813cbda250ceb6acebad6b23a",
+      "l2_to_l1_messages": [],
+      "events": [
+        {
+          "from_address": "0x59402a11cccbc49b8253f74939d5824bf08f3323cd8f41459994bbe677ed518",
+          "keys": [
+            "0x5ad857f66a5b55f1301ff1ed7e098ac6d4433148f0b72ebc4a2945ab85ad53"
+          ],
+          "data": [
+            "0x1c0ec9284cd3cbf53d341cffe2caef02a08305813cbda250ceb6acebad6b23a",
+            "0x0"
+          ]
+        },
+        {
+          "from_address": "0x49d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7",
+          "keys": [
+            "0x99cd8bde557814842a3121e8ddfd433a539b8c9f14bf31ebf108d12e6196e9"
+          ],
+          "data": [
+            "0x59402a11cccbc49b8253f74939d5824bf08f3323cd8f41459994bbe677ed518",
+            "0x5dcd266a80b8a5f29f04d779c6b166b80150c24f2180a75e82427242dab20a9",
+            "0x26391fc4b172",
+            "0x0"
+          ]
+        }
+      ],
+      "execution_resources": {
+        "n_steps": 375,
+        "builtin_instance_counter": {
+          "pedersen_builtin": 2,
+          "range_check_builtin": 6
+        },
+        "n_memory_holes": 14
+      },
+      "actual_fee": "0x26391fc4b172"
+    },
+    {
+      "transaction_index": 39,
+      "transaction_hash": "0x268e46ee69e91770bed7dda7d47714e2c44b0f28968fb072595a2eac659ea1a",
+      "l2_to_l1_messages": [],
+      "events": [
+        {
+          "from_address": "0xda114221cb83fa859dbdb4c44beeaa0bb37c7537ad5ae66fe5e0efd20e6eb3",
+          "keys": [
+            "0x134692b230b9e1ffa39098904722134159652b09c5bc41d88d6698779d228ff"
+          ],
+          "data": [
+            "0x481ea57ebd208e2487215e6db394a3d41575ffc2ac9136cc40869b4ef3c2db5",
+            "0x10884171baf1914edc28d7afb619b40a4051cfae78a094a55d230f19e944a28",
+            "0x32f98fb9f89b50000",
+            "0x0"
+          ]
+        },
+        {
+          "from_address": "0x49d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7",
+          "keys": [
+            "0x134692b230b9e1ffa39098904722134159652b09c5bc41d88d6698779d228ff"
+          ],
+          "data": [
+            "0x481ea57ebd208e2487215e6db394a3d41575ffc2ac9136cc40869b4ef3c2db5",
+            "0x10884171baf1914edc28d7afb619b40a4051cfae78a094a55d230f19e944a28",
+            "0xb1d2afd1347381",
+            "0x0"
+          ]
+        },
+        {
+          "from_address": "0xda114221cb83fa859dbdb4c44beeaa0bb37c7537ad5ae66fe5e0efd20e6eb3",
+          "keys": [
+            "0x99cd8bde557814842a3121e8ddfd433a539b8c9f14bf31ebf108d12e6196e9"
+          ],
+          "data": [
+            "0x481ea57ebd208e2487215e6db394a3d41575ffc2ac9136cc40869b4ef3c2db5",
+            "0x10884171baf1914edc28d7afb619b40a4051cfae78a094a55d230f19e944a28",
+            "0x32f98fb9f89b4ff6f",
+            "0x0"
+          ]
+        },
+        {
+          "from_address": "0x49d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7",
+          "keys": [
+            "0x99cd8bde557814842a3121e8ddfd433a539b8c9f14bf31ebf108d12e6196e9"
+          ],
+          "data": [
+            "0x481ea57ebd208e2487215e6db394a3d41575ffc2ac9136cc40869b4ef3c2db5",
+            "0x10884171baf1914edc28d7afb619b40a4051cfae78a094a55d230f19e944a28",
+            "0xb1d2afd1347381",
+            "0x0"
+          ]
+        },
+        {
+          "from_address": "0x7c662b10f409d7a0a69c8da79b397fd91187ca5f6230ed30effef2dceddc5b3",
+          "keys": [
+            "0x99cd8bde557814842a3121e8ddfd433a539b8c9f14bf31ebf108d12e6196e9"
+          ],
+          "data": [
+            "0x0",
+            "0x481ea57ebd208e2487215e6db394a3d41575ffc2ac9136cc40869b4ef3c2db5",
+            "0x16babbaaffcb1ca5",
+            "0x0"
+          ]
+        },
+        {
+          "from_address": "0x49d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7",
+          "keys": [
+            "0x99cd8bde557814842a3121e8ddfd433a539b8c9f14bf31ebf108d12e6196e9"
+          ],
+          "data": [
+            "0x481ea57ebd208e2487215e6db394a3d41575ffc2ac9136cc40869b4ef3c2db5",
+            "0x5dcd266a80b8a5f29f04d779c6b166b80150c24f2180a75e82427242dab20a9",
+            "0xc7fd141da5de",
+            "0x0"
+          ]
+        }
+      ],
+      "execution_resources": {
+        "n_steps": 7955,
+        "builtin_instance_counter": {
+          "pedersen_builtin": 28,
+          "range_check_builtin": 494,
+          "ecdsa_builtin": 1
+        },
+        "n_memory_holes": 227
+      },
+      "actual_fee": "0xc7fd141da5de"
+    },
+    {
+      "transaction_index": 40,
+      "transaction_hash": "0x4f41a71816e95a88bd56cf16570e3b39079026657716817882394a5624a070f",
+      "l2_to_l1_messages": [],
+      "events": [
+        {
+          "from_address": "0x1e1f972637ad02e0eed03b69304344c4253804e528e1a5dd5c26bb2f23a8139",
+          "keys": [
+            "0x6ad9ed7b6318f1bcffefe19df9aeb40d22c36bed567e1925a5ccde0536edd"
+          ],
+          "data": [
+            "0x20dcc849b1712cf6e3c1668eee84bab760db54fa658e8529e866820a1b135bb",
+            "0x6883c3af369d1b3cdc0135480302a6a037ed5ece95dfdae36731912a49f722e",
+            "0x1"
+          ]
+        },
+        {
+          "from_address": "0x20dcc849b1712cf6e3c1668eee84bab760db54fa658e8529e866820a1b135bb",
+          "keys": [
+            "0x5ad857f66a5b55f1301ff1ed7e098ac6d4433148f0b72ebc4a2945ab85ad53"
+          ],
+          "data": [
+            "0x4f41a71816e95a88bd56cf16570e3b39079026657716817882394a5624a070f",
+            "0x0"
+          ]
+        },
+        {
+          "from_address": "0x49d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7",
+          "keys": [
+            "0x99cd8bde557814842a3121e8ddfd433a539b8c9f14bf31ebf108d12e6196e9"
+          ],
+          "data": [
+            "0x20dcc849b1712cf6e3c1668eee84bab760db54fa658e8529e866820a1b135bb",
+            "0x5dcd266a80b8a5f29f04d779c6b166b80150c24f2180a75e82427242dab20a9",
+            "0x268fea65d671",
+            "0x0"
+          ]
+        }
+      ],
+      "execution_resources": {
+        "n_steps": 491,
+        "builtin_instance_counter": {
+          "pedersen_builtin": 2,
+          "range_check_builtin": 6
+        },
+        "n_memory_holes": 14
+      },
+      "actual_fee": "0x268fea65d671"
+    },
+    {
+      "transaction_index": 41,
+      "transaction_hash": "0x565ab7d1deb082200accc89b0137c68ed9e9cd1504a8b9e6134fb136ab7bd75",
+      "l2_to_l1_messages": [],
+      "events": [
+        {
+          "from_address": "0x3090623ea32d932ca1236595076b00702e7d860696faf300ca9eb13bfe0a78c",
+          "keys": [
+            "0x99cd8bde557814842a3121e8ddfd433a539b8c9f14bf31ebf108d12e6196e9"
+          ],
+          "data": [
+            "0x0",
+            "0x35c751960896c3c89a500ef4339449331eb73aa9f80336b9d3bd3d5c6ff09d0",
+            "0x623d",
+            "0x0"
+          ]
+        },
+        {
+          "from_address": "0x35c751960896c3c89a500ef4339449331eb73aa9f80336b9d3bd3d5c6ff09d0",
+          "keys": [
+            "0x5ad857f66a5b55f1301ff1ed7e098ac6d4433148f0b72ebc4a2945ab85ad53"
+          ],
+          "data": [
+            "0x565ab7d1deb082200accc89b0137c68ed9e9cd1504a8b9e6134fb136ab7bd75",
+            "0x0"
+          ]
+        },
+        {
+          "from_address": "0x49d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7",
+          "keys": [
+            "0x99cd8bde557814842a3121e8ddfd433a539b8c9f14bf31ebf108d12e6196e9"
+          ],
+          "data": [
+            "0x35c751960896c3c89a500ef4339449331eb73aa9f80336b9d3bd3d5c6ff09d0",
+            "0x5dcd266a80b8a5f29f04d779c6b166b80150c24f2180a75e82427242dab20a9",
+            "0x86086874eef1",
+            "0x0"
+          ]
+        }
+      ],
+      "execution_resources": {
+        "n_steps": 1594,
+        "builtin_instance_counter": {
+          "pedersen_builtin": 10,
+          "range_check_builtin": 51,
+          "ecdsa_builtin": 1
+        },
+        "n_memory_holes": 69
+      },
+      "actual_fee": "0x86086874eef1"
+    },
+    {
+      "transaction_index": 42,
+      "transaction_hash": "0xf685badf2a8683a8774c1a642ca1adfed3f7c46e982847a480affa95f7a5d5",
+      "l2_to_l1_messages": [],
+      "events": [
+        {
+          "from_address": "0x49d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7",
+          "keys": [
+            "0x99cd8bde557814842a3121e8ddfd433a539b8c9f14bf31ebf108d12e6196e9"
+          ],
+          "data": [
+            "0xc8386608ef88be2eb1f9af53845883232499547f4f63a8bf29aeca47c153ea",
+            "0x70b59cd474b2a8b0f5570a93abfdff5cb107ada7d0ac37743b82fa2ff613f8e",
+            "0x11c37937e08000",
+            "0x0"
+          ]
+        },
+        {
+          "from_address": "0x49d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7",
+          "keys": [
+            "0x99cd8bde557814842a3121e8ddfd433a539b8c9f14bf31ebf108d12e6196e9"
+          ],
+          "data": [
+            "0xc8386608ef88be2eb1f9af53845883232499547f4f63a8bf29aeca47c153ea",
+            "0x5dcd266a80b8a5f29f04d779c6b166b80150c24f2180a75e82427242dab20a9",
+            "0x4a32f1c3a0dc",
+            "0x0"
+          ]
+        }
+      ],
+      "execution_resources": {
+        "n_steps": 1018,
+        "builtin_instance_counter": {
+          "pedersen_builtin": 4,
+          "range_check_builtin": 24,
+          "ecdsa_builtin": 1
+        },
+        "n_memory_holes": 43
+      },
+      "actual_fee": "0x4a32f1c3a0dc"
+    },
+    {
+      "transaction_index": 43,
+      "transaction_hash": "0x47c6cbf67636dff3ae644df0ab8be96423ef53653778b4a97d8176de253a5df",
+      "l2_to_l1_messages": [],
+      "events": [
+        {
+          "from_address": "0x7861c4e276294a7e859ff0ae2eec0c68300ad9cbb43219db907da9bad786488",
+          "keys": [
+            "0x99cd8bde557814842a3121e8ddfd433a539b8c9f14bf31ebf108d12e6196e9"
+          ],
+          "data": [
+            "0x0",
+            "0x7fa14a93b02b946e1ba6d417a7b19d398b253625f79d6472c309a675a0fe506",
+            "0xa0b4",
+            "0x0"
+          ]
+        },
+        {
+          "from_address": "0x7fa14a93b02b946e1ba6d417a7b19d398b253625f79d6472c309a675a0fe506",
+          "keys": [
+            "0x5ad857f66a5b55f1301ff1ed7e098ac6d4433148f0b72ebc4a2945ab85ad53"
+          ],
+          "data": [
+            "0x47c6cbf67636dff3ae644df0ab8be96423ef53653778b4a97d8176de253a5df",
+            "0x0"
+          ]
+        },
+        {
+          "from_address": "0x49d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7",
+          "keys": [
+            "0x99cd8bde557814842a3121e8ddfd433a539b8c9f14bf31ebf108d12e6196e9"
+          ],
+          "data": [
+            "0x7fa14a93b02b946e1ba6d417a7b19d398b253625f79d6472c309a675a0fe506",
+            "0x5dcd266a80b8a5f29f04d779c6b166b80150c24f2180a75e82427242dab20a9",
+            "0x7a43809aeaa6",
+            "0x0"
+          ]
+        }
+      ],
+      "execution_resources": {
+        "n_steps": 1377,
+        "builtin_instance_counter": {
+          "pedersen_builtin": 18,
+          "range_check_builtin": 45
+        },
+        "n_memory_holes": 111
+      },
+      "actual_fee": "0x7a43809aeaa6"
+    },
+    {
+      "transaction_index": 44,
+      "transaction_hash": "0x4c3f0cebe3ab2d246080b3383e59cc0abe94e9e3ec2ea7eaf9a8d12abae8b60",
+      "l2_to_l1_messages": [],
+      "events": [
+        {
+          "from_address": "0x59c526eeceff9b8e76cf10e46724144fbc01e491eee0d25b6a54066cee1e389",
+          "keys": [
+            "0x10c19bef19acd19b2c9f4caa40fd47c9fbe1d9f91324d44dcd36be2dae96784"
+          ],
+          "data": [
+            "0x59c526eeceff9b8e76cf10e46724144fbc01e491eee0d25b6a54066cee1e389",
+            "0x242ec33479795299cd464ef6e5542a816ca3e865d913a87c434c626e5b98e38",
+            "0x0"
+          ]
+        },
+        {
+          "from_address": "0x49d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7",
+          "keys": [
+            "0x99cd8bde557814842a3121e8ddfd433a539b8c9f14bf31ebf108d12e6196e9"
+          ],
+          "data": [
+            "0x59c526eeceff9b8e76cf10e46724144fbc01e491eee0d25b6a54066cee1e389",
+            "0x5dcd266a80b8a5f29f04d779c6b166b80150c24f2180a75e82427242dab20a9",
+            "0x3daf18ed7e60",
+            "0x0"
+          ]
+        }
+      ],
+      "execution_resources": {
+        "n_steps": 226,
+        "builtin_instance_counter": {
+          "range_check_builtin": 1
+        },
+        "n_memory_holes": 0
+      },
+      "actual_fee": "0x3daf18ed7e60"
+    },
+    {
+      "transaction_index": 45,
+      "transaction_hash": "0x6bc781025d55863d3aaf5c017011cedda0a0a61ff5b1d070864e9a991128c16",
+      "l2_to_l1_messages": [],
+      "events": [
+        {
+          "from_address": "0x49d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7",
+          "keys": [
+            "0x134692b230b9e1ffa39098904722134159652b09c5bc41d88d6698779d228ff"
+          ],
+          "data": [
+            "0x59c526eeceff9b8e76cf10e46724144fbc01e491eee0d25b6a54066cee1e389",
+            "0x7a6f98c03379b9513ca84cca1373ff452a7462a3b61598f0af5bb27ad7f76d1",
+            "0x16345785d8a0000",
+            "0x0"
+          ]
+        },
+        {
+          "from_address": "0x49d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7",
+          "keys": [
+            "0x99cd8bde557814842a3121e8ddfd433a539b8c9f14bf31ebf108d12e6196e9"
+          ],
+          "data": [
+            "0x59c526eeceff9b8e76cf10e46724144fbc01e491eee0d25b6a54066cee1e389",
+            "0x23c72abdf49dffc85ae3ede714f2168ad384cc67d08524732acea90df325",
+            "0x16345785d8a0000",
+            "0x0"
+          ]
+        },
+        {
+          "from_address": "0x53c91253bc9682c04929ca02ed00b3e423f6710d2ee7e0d5ebb06f3ecf368a8",
+          "keys": [
+            "0x99cd8bde557814842a3121e8ddfd433a539b8c9f14bf31ebf108d12e6196e9"
+          ],
+          "data": [
+            "0x23c72abdf49dffc85ae3ede714f2168ad384cc67d08524732acea90df325",
+            "0x59c526eeceff9b8e76cf10e46724144fbc01e491eee0d25b6a54066cee1e389",
+            "0x7309eca",
+            "0x0"
+          ]
+        },
+        {
+          "from_address": "0x23c72abdf49dffc85ae3ede714f2168ad384cc67d08524732acea90df325",
+          "keys": [
+            "0xe14a408baf7f453312eec68e9b7d728ec5337fbdf671f917ee8c80f3255232"
+          ],
+          "data": [
+            "0x29a8e859a6408a62c",
+            "0xd8088a4fc"
+          ]
+        },
+        {
+          "from_address": "0x23c72abdf49dffc85ae3ede714f2168ad384cc67d08524732acea90df325",
+          "keys": [
+            "0xe316f0d9d2a3affa97de1d99bb2aac0538e2666d0d8545545ead241ef0ccab"
+          ],
+          "data": [
+            "0x7a6f98c03379b9513ca84cca1373ff452a7462a3b61598f0af5bb27ad7f76d1",
+            "0x16345785d8a0000",
+            "0x0",
+            "0x0",
+            "0x0",
+            "0x0",
+            "0x0",
+            "0x7309eca",
+            "0x0",
+            "0x59c526eeceff9b8e76cf10e46724144fbc01e491eee0d25b6a54066cee1e389"
+          ]
+        },
+        {
+          "from_address": "0x59c526eeceff9b8e76cf10e46724144fbc01e491eee0d25b6a54066cee1e389",
+          "keys": [
+            "0x5ad857f66a5b55f1301ff1ed7e098ac6d4433148f0b72ebc4a2945ab85ad53"
+          ],
+          "data": [
+            "0x6bc781025d55863d3aaf5c017011cedda0a0a61ff5b1d070864e9a991128c16",
+            "0x6",
+            "0x1",
+            "0x2",
+            "0x16345785d8a0000",
+            "0x0",
+            "0x7309eca",
+            "0x0"
+          ]
+        },
+        {
+          "from_address": "0x49d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7",
+          "keys": [
+            "0x99cd8bde557814842a3121e8ddfd433a539b8c9f14bf31ebf108d12e6196e9"
+          ],
+          "data": [
+            "0x59c526eeceff9b8e76cf10e46724144fbc01e491eee0d25b6a54066cee1e389",
+            "0x5dcd266a80b8a5f29f04d779c6b166b80150c24f2180a75e82427242dab20a9",
+            "0x820fb5153d8f",
+            "0x0"
+          ]
+        }
+      ],
+      "execution_resources": {
+        "n_steps": 9248,
+        "builtin_instance_counter": {
+          "pedersen_builtin": 40,
+          "range_check_builtin": 605,
+          "bitwise_builtin": 3
+        },
+        "n_memory_holes": 247
+      },
+      "actual_fee": "0x820fb5153d8f"
+    },
+    {
+      "transaction_index": 46,
+      "transaction_hash": "0x3b37db7bdd39f8d9af2816df0bbec818471dd29da19e466598bfa51ff330b0a",
+      "l2_to_l1_messages": [],
+      "events": [
+        {
+          "from_address": "0x7861c4e276294a7e859ff0ae2eec0c68300ad9cbb43219db907da9bad786488",
+          "keys": [
+            "0x99cd8bde557814842a3121e8ddfd433a539b8c9f14bf31ebf108d12e6196e9"
+          ],
+          "data": [
+            "0x0",
+            "0x79e8337d91274875ce5e44b640a2bcdc7c1f2960fe00e2b09fadca412f0be71",
+            "0xa0b5",
+            "0x0"
+          ]
+        },
+        {
+          "from_address": "0x79e8337d91274875ce5e44b640a2bcdc7c1f2960fe00e2b09fadca412f0be71",
+          "keys": [
+            "0x5ad857f66a5b55f1301ff1ed7e098ac6d4433148f0b72ebc4a2945ab85ad53"
+          ],
+          "data": [
+            "0x3b37db7bdd39f8d9af2816df0bbec818471dd29da19e466598bfa51ff330b0a",
+            "0x0"
+          ]
+        },
+        {
+          "from_address": "0x49d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7",
+          "keys": [
+            "0x99cd8bde557814842a3121e8ddfd433a539b8c9f14bf31ebf108d12e6196e9"
+          ],
+          "data": [
+            "0x79e8337d91274875ce5e44b640a2bcdc7c1f2960fe00e2b09fadca412f0be71",
+            "0x5dcd266a80b8a5f29f04d779c6b166b80150c24f2180a75e82427242dab20a9",
+            "0x861eb9d1920e",
+            "0x0"
+          ]
+        }
+      ],
+      "execution_resources": {
+        "n_steps": 1389,
+        "builtin_instance_counter": {
+          "pedersen_builtin": 18,
+          "range_check_builtin": 45
+        },
+        "n_memory_holes": 105
+      },
+      "actual_fee": "0x861eb9d1920e"
+    },
+    {
+      "transaction_index": 47,
+      "transaction_hash": "0x226e00a507daa5de371a4b0ecb4740907a8c4c6aad998e3708108e4ffced0e4",
+      "l2_to_l1_messages": [],
+      "events": [
+        {
+          "from_address": "0x49d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7",
+          "keys": [
+            "0x134692b230b9e1ffa39098904722134159652b09c5bc41d88d6698779d228ff"
+          ],
+          "data": [
+            "0x5442d381b14ae0484cb1178d8ebd5ffb99152ceb41fc254b8749469af69732e",
+            "0x10884171baf1914edc28d7afb619b40a4051cfae78a094a55d230f19e944a28",
+            "0x273ed3375ffd95",
+            "0x0"
+          ]
+        },
+        {
+          "from_address": "0x68f5c6a61780768455de69077e07e89787839bf8166decfbf92b645209c0fb8",
+          "keys": [
+            "0x134692b230b9e1ffa39098904722134159652b09c5bc41d88d6698779d228ff"
+          ],
+          "data": [
+            "0x5442d381b14ae0484cb1178d8ebd5ffb99152ceb41fc254b8749469af69732e",
+            "0x10884171baf1914edc28d7afb619b40a4051cfae78a094a55d230f19e944a28",
+            "0xcf0ed5",
+            "0x0"
+          ]
+        },
+        {
+          "from_address": "0x49d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7",
+          "keys": [
+            "0x99cd8bde557814842a3121e8ddfd433a539b8c9f14bf31ebf108d12e6196e9"
+          ],
+          "data": [
+            "0x5442d381b14ae0484cb1178d8ebd5ffb99152ceb41fc254b8749469af69732e",
+            "0x10884171baf1914edc28d7afb619b40a4051cfae78a094a55d230f19e944a28",
+            "0x26ff4bca7e4a4f",
+            "0x0"
+          ]
+        },
+        {
+          "from_address": "0x68f5c6a61780768455de69077e07e89787839bf8166decfbf92b645209c0fb8",
+          "keys": [
+            "0x99cd8bde557814842a3121e8ddfd433a539b8c9f14bf31ebf108d12e6196e9"
+          ],
+          "data": [
+            "0x5442d381b14ae0484cb1178d8ebd5ffb99152ceb41fc254b8749469af69732e",
+            "0x10884171baf1914edc28d7afb619b40a4051cfae78a094a55d230f19e944a28",
+            "0xcf0ed5",
+            "0x0"
+          ]
+        },
+        {
+          "from_address": "0x41f9a1e9a4d924273f5a5c0c138d52d66d2e6a8bee17412c6b0f48fe059ae04",
+          "keys": [
+            "0x99cd8bde557814842a3121e8ddfd433a539b8c9f14bf31ebf108d12e6196e9"
+          ],
+          "data": [
+            "0x0",
+            "0x5442d381b14ae0484cb1178d8ebd5ffb99152ceb41fc254b8749469af69732e",
+            "0x553a3003df",
+            "0x0"
+          ]
+        },
+        {
+          "from_address": "0x5442d381b14ae0484cb1178d8ebd5ffb99152ceb41fc254b8749469af69732e",
+          "keys": [
+            "0x5ad857f66a5b55f1301ff1ed7e098ac6d4433148f0b72ebc4a2945ab85ad53"
+          ],
+          "data": [
+            "0x226e00a507daa5de371a4b0ecb4740907a8c4c6aad998e3708108e4ffced0e4",
+            "0x6",
+            "0x1",
+            "0x1",
+            "0x26ff4bca7e4a4f",
+            "0x0",
+            "0xcf0ed5",
+            "0x0"
+          ]
+        },
+        {
+          "from_address": "0x49d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7",
+          "keys": [
+            "0x99cd8bde557814842a3121e8ddfd433a539b8c9f14bf31ebf108d12e6196e9"
+          ],
+          "data": [
+            "0x5442d381b14ae0484cb1178d8ebd5ffb99152ceb41fc254b8749469af69732e",
+            "0x5dcd266a80b8a5f29f04d779c6b166b80150c24f2180a75e82427242dab20a9",
+            "0xb20c6d614bb1",
+            "0x0"
+          ]
+        }
+      ],
+      "execution_resources": {
+        "n_steps": 9701,
+        "builtin_instance_counter": {
+          "pedersen_builtin": 28,
+          "range_check_builtin": 713
+        },
+        "n_memory_holes": 219
+      },
+      "actual_fee": "0xb20c6d614bb1"
+    },
+    {
+      "transaction_index": 48,
+      "transaction_hash": "0x70d0030cc3668f8ceb4a28f2d1e7d90faf41687eb3703c2345a7411e81af947",
+      "l2_to_l1_messages": [],
+      "events": [
+        {
+          "from_address": "0x584909a41b0d7db4b9e21362281745930555c2616f7871b300330fefd85afe",
+          "keys": [
+            "0x5ad857f66a5b55f1301ff1ed7e098ac6d4433148f0b72ebc4a2945ab85ad53"
+          ],
+          "data": [
+            "0x70d0030cc3668f8ceb4a28f2d1e7d90faf41687eb3703c2345a7411e81af947",
+            "0x0"
+          ]
+        },
+        {
+          "from_address": "0x49d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7",
+          "keys": [
+            "0x99cd8bde557814842a3121e8ddfd433a539b8c9f14bf31ebf108d12e6196e9"
+          ],
+          "data": [
+            "0x584909a41b0d7db4b9e21362281745930555c2616f7871b300330fefd85afe",
+            "0x5dcd266a80b8a5f29f04d779c6b166b80150c24f2180a75e82427242dab20a9",
+            "0x26391fc4b172",
+            "0x0"
+          ]
+        }
+      ],
+      "execution_resources": {
+        "n_steps": 377,
+        "builtin_instance_counter": {
+          "pedersen_builtin": 2,
+          "range_check_builtin": 6
+        },
+        "n_memory_holes": 13
+      },
+      "actual_fee": "0x26391fc4b172"
+    },
+    {
+      "transaction_index": 49,
+      "transaction_hash": "0x6c9081e8a441b8468399952b4c3720fc87d0e51eb48041cc43ffac0f3ed40e5",
+      "l2_to_l1_messages": [],
+      "events": [
+        {
+          "from_address": "0x49d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7",
+          "keys": [
+            "0x134692b230b9e1ffa39098904722134159652b09c5bc41d88d6698779d228ff"
+          ],
+          "data": [
+            "0x19e5b8e6b5afcb92fba17eecc7e9bf1755381f757b565e130147e3d04ef5fc7",
+            "0x63a4b3b0122cdaa6ba244739add94aed1d31e3330458cda833a8d119f28cbe8",
+            "0xa4d88ddd94000",
+            "0x0"
+          ]
+        },
+        {
+          "from_address": "0x49d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7",
+          "keys": [
+            "0x99cd8bde557814842a3121e8ddfd433a539b8c9f14bf31ebf108d12e6196e9"
+          ],
+          "data": [
+            "0x19e5b8e6b5afcb92fba17eecc7e9bf1755381f757b565e130147e3d04ef5fc7",
+            "0x790f75c2306c8b54ed497b32c864861af5505f0d5978b0dde51144b0592cd40",
+            "0x9c9a86c5b3000",
+            "0x0"
+          ]
+        },
+        {
+          "from_address": "0x49d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7",
+          "keys": [
+            "0x99cd8bde557814842a3121e8ddfd433a539b8c9f14bf31ebf108d12e6196e9"
+          ],
+          "data": [
+            "0x19e5b8e6b5afcb92fba17eecc7e9bf1755381f757b565e130147e3d04ef5fc7",
+            "0x5abca3aa491806315a8cadebee93a8a167a4c0ac1a56b924429a891970e0b8d",
+            "0x83e0717e1000",
+            "0x0"
+          ]
+        },
+        {
+          "from_address": "0x46bfa580e4fa55a38eaa7f51a3469f86b336eed59a6136a07b7adcd095b0eb2",
+          "keys": [
+            "0x182d859c0807ba9db63baf8b9d9fdbfeb885d820be6e206b9dab626d995c433"
+          ],
+          "data": [
+            "0x63a4b3b0122cdaa6ba244739add94aed1d31e3330458cda833a8d119f28cbe8",
+            "0x790f75c2306c8b54ed497b32c864861af5505f0d5978b0dde51144b0592cd40",
+            "0x19e5b8e6b5afcb92fba17eecc7e9bf1755381f757b565e130147e3d04ef5fc7",
+            "0x596f757620446565",
+            "0x1e101020000000000000000000000",
+            "0x1",
+            "0x0"
+          ]
+        },
+        {
+          "from_address": "0x46bfa580e4fa55a38eaa7f51a3469f86b336eed59a6136a07b7adcd095b0eb2",
+          "keys": [
+            "0x134692b230b9e1ffa39098904722134159652b09c5bc41d88d6698779d228ff"
+          ],
+          "data": [
+            "0x790f75c2306c8b54ed497b32c864861af5505f0d5978b0dde51144b0592cd40",
+            "0x63a4b3b0122cdaa6ba244739add94aed1d31e3330458cda833a8d119f28cbe8",
+            "0x596f757620446565",
+            "0x1e101020000000000000000000000",
+            "0x0",
+            "0x0"
+          ]
+        },
+        {
+          "from_address": "0x63a4b3b0122cdaa6ba244739add94aed1d31e3330458cda833a8d119f28cbe8",
+          "keys": [
+            "0x309058ad25cd782e894bb5ed51758424e0fcfaf9b0e2996dec721837242fd4d"
+          ],
+          "data": [
+            "0x596f757620446565",
+            "0x1e101020000000000000000000000",
+            "0x19e5b8e6b5afcb92fba17eecc7e9bf1755381f757b565e130147e3d04ef5fc7"
+          ]
+        },
+        {
+          "from_address": "0x19e5b8e6b5afcb92fba17eecc7e9bf1755381f757b565e130147e3d04ef5fc7",
+          "keys": [
+            "0x1dcde06aabdbca2f80aa51392b345d7549d7757aa855f7e37f5d335ac8243b1"
+          ],
+          "data": [
+            "0x6c9081e8a441b8468399952b4c3720fc87d0e51eb48041cc43ffac0f3ed40e5",
+            "0x1",
+            "0x1"
+          ]
+        },
+        {
+          "from_address": "0x49d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7",
+          "keys": [
+            "0x99cd8bde557814842a3121e8ddfd433a539b8c9f14bf31ebf108d12e6196e9"
+          ],
+          "data": [
+            "0x19e5b8e6b5afcb92fba17eecc7e9bf1755381f757b565e130147e3d04ef5fc7",
+            "0x5dcd266a80b8a5f29f04d779c6b166b80150c24f2180a75e82427242dab20a9",
+            "0x9831f42dace0",
+            "0x0"
+          ]
+        }
+      ],
+      "execution_resources": {
+        "n_steps": 5127,
+        "builtin_instance_counter": {
+          "pedersen_builtin": 63,
+          "range_check_builtin": 161
+        },
+        "n_memory_holes": 331
+      },
+      "actual_fee": "0x9831f42dace0"
+    },
+    {
+      "transaction_index": 50,
+      "transaction_hash": "0x687751818ebcbe3b72711d50d242ee7e5310e0c168f22c2541df7522ded56d7",
+      "l2_to_l1_messages": [],
+      "events": [
+        {
+          "from_address": "0x49d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7",
+          "keys": [
+            "0x134692b230b9e1ffa39098904722134159652b09c5bc41d88d6698779d228ff"
+          ],
+          "data": [
+            "0x336106b46408dd1a9bafe7028427e4632320ba4f93ce5c80a046a1592df6e10",
+            "0x63a4b3b0122cdaa6ba244739add94aed1d31e3330458cda833a8d119f28cbe8",
+            "0x38d7ea4c68000",
+            "0x0"
+          ]
+        },
+        {
+          "from_address": "0x49d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7",
+          "keys": [
+            "0x99cd8bde557814842a3121e8ddfd433a539b8c9f14bf31ebf108d12e6196e9"
+          ],
+          "data": [
+            "0x336106b46408dd1a9bafe7028427e4632320ba4f93ce5c80a046a1592df6e10",
+            "0xa210072cff0429abd16e66bc22cf861a004527786cff24c05d63717148031f",
+            "0x360051c896000",
+            "0x0"
+          ]
+        },
+        {
+          "from_address": "0x49d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7",
+          "keys": [
+            "0x99cd8bde557814842a3121e8ddfd433a539b8c9f14bf31ebf108d12e6196e9"
+          ],
+          "data": [
+            "0x336106b46408dd1a9bafe7028427e4632320ba4f93ce5c80a046a1592df6e10",
+            "0x5abca3aa491806315a8cadebee93a8a167a4c0ac1a56b924429a891970e0b8d",
+            "0x2d79883d2000",
+            "0x0"
+          ]
+        },
+        {
+          "from_address": "0x46bfa580e4fa55a38eaa7f51a3469f86b336eed59a6136a07b7adcd095b0eb2",
+          "keys": [
+            "0x182d859c0807ba9db63baf8b9d9fdbfeb885d820be6e206b9dab626d995c433"
+          ],
+          "data": [
+            "0x63a4b3b0122cdaa6ba244739add94aed1d31e3330458cda833a8d119f28cbe8",
+            "0xa210072cff0429abd16e66bc22cf861a004527786cff24c05d63717148031f",
+            "0x336106b46408dd1a9bafe7028427e4632320ba4f93ce5c80a046a1592df6e10",
+            "0x417a7572",
+            "0x7dd01000000000000000000000000",
+            "0x1",
+            "0x0"
+          ]
+        },
+        {
+          "from_address": "0x46bfa580e4fa55a38eaa7f51a3469f86b336eed59a6136a07b7adcd095b0eb2",
+          "keys": [
+            "0x134692b230b9e1ffa39098904722134159652b09c5bc41d88d6698779d228ff"
+          ],
+          "data": [
+            "0xa210072cff0429abd16e66bc22cf861a004527786cff24c05d63717148031f",
+            "0x63a4b3b0122cdaa6ba244739add94aed1d31e3330458cda833a8d119f28cbe8",
+            "0x417a7572",
+            "0x7dd01000000000000000000000000",
+            "0x0",
+            "0x0"
+          ]
+        },
+        {
+          "from_address": "0x63a4b3b0122cdaa6ba244739add94aed1d31e3330458cda833a8d119f28cbe8",
+          "keys": [
+            "0x309058ad25cd782e894bb5ed51758424e0fcfaf9b0e2996dec721837242fd4d"
+          ],
+          "data": [
+            "0x417a7572",
+            "0x7dd01000000000000000000000000",
+            "0x336106b46408dd1a9bafe7028427e4632320ba4f93ce5c80a046a1592df6e10"
+          ]
+        },
+        {
+          "from_address": "0x336106b46408dd1a9bafe7028427e4632320ba4f93ce5c80a046a1592df6e10",
+          "keys": [
+            "0x1dcde06aabdbca2f80aa51392b345d7549d7757aa855f7e37f5d335ac8243b1"
+          ],
+          "data": [
+            "0x687751818ebcbe3b72711d50d242ee7e5310e0c168f22c2541df7522ded56d7",
+            "0x1",
+            "0x1"
+          ]
+        },
+        {
+          "from_address": "0x49d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7",
+          "keys": [
+            "0x99cd8bde557814842a3121e8ddfd433a539b8c9f14bf31ebf108d12e6196e9"
+          ],
+          "data": [
+            "0x336106b46408dd1a9bafe7028427e4632320ba4f93ce5c80a046a1592df6e10",
+            "0x5dcd266a80b8a5f29f04d779c6b166b80150c24f2180a75e82427242dab20a9",
+            "0x9831f42dace0",
+            "0x0"
+          ]
+        }
+      ],
+      "execution_resources": {
+        "n_steps": 5137,
+        "builtin_instance_counter": {
+          "pedersen_builtin": 63,
+          "range_check_builtin": 161
+        },
+        "n_memory_holes": 326
+      },
+      "actual_fee": "0x9831f42dace0"
+    },
+    {
+      "transaction_index": 51,
+      "transaction_hash": "0x73c0fa81a2fd84518ebd0b2ba36cfb13c67fda0cb24e698d236c296d4240d7e",
+      "l2_to_l1_messages": [],
+      "events": [
+        {
+          "from_address": "0x46bfa580e4fa55a38eaa7f51a3469f86b336eed59a6136a07b7adcd095b0eb2",
+          "keys": [
+            "0x2563683c757f3abe19c4b7237e2285d8993417ddffe0b54a19eb212ea574b08"
+          ],
+          "data": [
+            "0x27fb5a7be4707e2b1fe653e7296ad30114596fafdd3fbc3f9b92a0551ff18ec",
+            "0x0",
+            "0x3d0b2d9c96e7e540b688b4f835460d5f2c30506826c71e5b14bf336eaa7248b",
+            "0x3",
+            "0x4c79636f73",
+            "0x7c201000000000000000000000000",
+            "0x4465656e204275726269676f",
+            "0xa9101000000000000000000000000",
+            "0x5a696ee965",
+            "0x79201000000000000000000000000",
+            "0x3",
+            "0x1",
+            "0x0",
+            "0x1",
+            "0x0",
+            "0x1",
+            "0x0"
+          ]
+        },
+        {
+          "from_address": "0x46bfa580e4fa55a38eaa7f51a3469f86b336eed59a6136a07b7adcd095b0eb2",
+          "keys": [
+            "0x182d859c0807ba9db63baf8b9d9fdbfeb885d820be6e206b9dab626d995c433"
+          ],
+          "data": [
+            "0x27fb5a7be4707e2b1fe653e7296ad30114596fafdd3fbc3f9b92a0551ff18ec",
+            "0x27fb5a7be4707e2b1fe653e7296ad30114596fafdd3fbc3f9b92a0551ff18ec",
+            "0x0",
+            "0x5",
+            "0x0",
+            "0x1",
+            "0x0"
+          ]
+        },
+        {
+          "from_address": "0x46bfa580e4fa55a38eaa7f51a3469f86b336eed59a6136a07b7adcd095b0eb2",
+          "keys": [
+            "0x2563683c757f3abe19c4b7237e2285d8993417ddffe0b54a19eb212ea574b08"
+          ],
+          "data": [
+            "0x27fb5a7be4707e2b1fe653e7296ad30114596fafdd3fbc3f9b92a0551ff18ec",
+            "0x0",
+            "0x216ca69e83b0b28acfb22350297f8af85749538ac6974b638ed15a7046a30f",
+            "0x3",
+            "0x4a65616e4a617373",
+            "0xa9801000000000000000000000000",
+            "0x4b65726368616b",
+            "0x55a01000000000000000000000000",
+            "0x746861486f6d6579",
+            "0x801010000000000000000000000",
+            "0x3",
+            "0x1",
+            "0x0",
+            "0x1",
+            "0x0",
+            "0x1",
+            "0x0"
+          ]
+        },
+        {
+          "from_address": "0x46bfa580e4fa55a38eaa7f51a3469f86b336eed59a6136a07b7adcd095b0eb2",
+          "keys": [
+            "0x182d859c0807ba9db63baf8b9d9fdbfeb885d820be6e206b9dab626d995c433"
+          ],
+          "data": [
+            "0x27fb5a7be4707e2b1fe653e7296ad30114596fafdd3fbc3f9b92a0551ff18ec",
+            "0x27fb5a7be4707e2b1fe653e7296ad30114596fafdd3fbc3f9b92a0551ff18ec",
+            "0x0",
+            "0x5",
+            "0x0",
+            "0x1",
+            "0x0"
+          ]
+        },
+        {
+          "from_address": "0x46bfa580e4fa55a38eaa7f51a3469f86b336eed59a6136a07b7adcd095b0eb2",
+          "keys": [
+            "0x2563683c757f3abe19c4b7237e2285d8993417ddffe0b54a19eb212ea574b08"
+          ],
+          "data": [
+            "0x27fb5a7be4707e2b1fe653e7296ad30114596fafdd3fbc3f9b92a0551ff18ec",
+            "0x0",
+            "0x430064ab11c47a34f075134c3bdc0da185c91b51f0d6065719af0c0e4d021",
+            "0x3",
+            "0x536f204c61204c756e65",
+            "0xa8301000000000000000000000000",
+            "0x426967666c6f",
+            "0x35a01000000000000000000000000",
+            "0x446f756d73",
+            "0x51401000000000000000000000000",
+            "0x3",
+            "0x1",
+            "0x0",
+            "0x1",
+            "0x0",
+            "0x1",
+            "0x0"
+          ]
+        },
+        {
+          "from_address": "0x46bfa580e4fa55a38eaa7f51a3469f86b336eed59a6136a07b7adcd095b0eb2",
+          "keys": [
+            "0x182d859c0807ba9db63baf8b9d9fdbfeb885d820be6e206b9dab626d995c433"
+          ],
+          "data": [
+            "0x27fb5a7be4707e2b1fe653e7296ad30114596fafdd3fbc3f9b92a0551ff18ec",
+            "0x27fb5a7be4707e2b1fe653e7296ad30114596fafdd3fbc3f9b92a0551ff18ec",
+            "0x0",
+            "0x5",
+            "0x0",
+            "0x1",
+            "0x0"
+          ]
+        },
+        {
+          "from_address": "0xd90fd6aa27edd344c5cbe1fe999611416b268658e866a54265aaf50d9cf28d",
+          "keys": [
+            "0x1dcde06aabdbca2f80aa51392b345d7549d7757aa855f7e37f5d335ac8243b1"
+          ],
+          "data": [
+            "0x73c0fa81a2fd84518ebd0b2ba36cfb13c67fda0cb24e698d236c296d4240d7e",
+            "0x0"
+          ]
+        },
+        {
+          "from_address": "0x49d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7",
+          "keys": [
+            "0x99cd8bde557814842a3121e8ddfd433a539b8c9f14bf31ebf108d12e6196e9"
+          ],
+          "data": [
+            "0xd90fd6aa27edd344c5cbe1fe999611416b268658e866a54265aaf50d9cf28d",
+            "0x5dcd266a80b8a5f29f04d779c6b166b80150c24f2180a75e82427242dab20a9",
+            "0x30ab13efc8749",
+            "0x0"
+          ]
+        }
+      ],
+      "execution_resources": {
+        "n_steps": 25215,
+        "builtin_instance_counter": {
+          "pedersen_builtin": 384,
+          "range_check_builtin": 700
+        },
+        "n_memory_holes": 1720
+      },
+      "actual_fee": "0x30ab13efc8749"
+    }
+  ],
+  "starknet_version": "0.10.1"
+}

--- a/clients/class_01efa8f8.json
+++ b/clients/class_01efa8f8.json
@@ -1,0 +1,6020 @@
+{
+  "program": {
+    "prime": "0x800000000000011000000000000000000000000000000000000000000000001",
+    "main_scope": "__main__",
+    "data": [
+      "0x40780017fff7fff",
+      "0x1",
+      "0x208b7fff7fff7ffe",
+      "0x20780017fff7ffd",
+      "0x4",
+      "0x400780017fff7ffd",
+      "0x1",
+      "0x208b7fff7fff7ffe",
+      "0x480680017fff8000",
+      "0x4c69627261727943616c6c",
+      "0x400280007ff97fff",
+      "0x400380017ff97ffa",
+      "0x400380027ff97ffb",
+      "0x400380037ff97ffc",
+      "0x400380047ff97ffd",
+      "0x482680017ff98000",
+      "0x7",
+      "0x480280057ff98000",
+      "0x480280067ff98000",
+      "0x208b7fff7fff7ffe",
+      "0x480680017fff8000",
+      "0x4c69627261727943616c6c4c3148616e646c6572",
+      "0x400280007ff97fff",
+      "0x400380017ff97ffa",
+      "0x400380027ff97ffb",
+      "0x400380037ff97ffc",
+      "0x400380047ff97ffd",
+      "0x482680017ff98000",
+      "0x7",
+      "0x480280057ff98000",
+      "0x480280067ff98000",
+      "0x208b7fff7fff7ffe",
+      "0x480680017fff8000",
+      "0x53746f7261676552656164",
+      "0x400280007ffc7fff",
+      "0x400380017ffc7ffd",
+      "0x482680017ffc8000",
+      "0x3",
+      "0x480280027ffc8000",
+      "0x208b7fff7fff7ffe",
+      "0x480680017fff8000",
+      "0x53746f726167655772697465",
+      "0x400280007ffb7fff",
+      "0x400380017ffb7ffc",
+      "0x400380027ffb7ffd",
+      "0x482680017ffb8000",
+      "0x3",
+      "0x208b7fff7fff7ffe",
+      "0x480680017fff8000",
+      "0x456d69744576656e74",
+      "0x400280007ff97fff",
+      "0x400380017ff97ffa",
+      "0x400380027ff97ffb",
+      "0x400380037ff97ffc",
+      "0x400380047ff97ffd",
+      "0x482680017ff98000",
+      "0x5",
+      "0x208b7fff7fff7ffe",
+      "0x40780017fff7fff",
+      "0x2",
+      "0x1104800180018000",
+      "0x800000000000010ffffffffffffffffffffffffffffffffffffffffffffffc5",
+      "0x40137fff7fff8000",
+      "0x480680017fff8000",
+      "0x2db340e6c609371026731f47050d3976552c89b4fbb012941663841c59d1af3",
+      "0x4002800080007fff",
+      "0x1104800180018000",
+      "0x800000000000010ffffffffffffffffffffffffffffffffffffffffffffffbf",
+      "0x40137fff7fff8001",
+      "0x4003800080017ffd",
+      "0x4826800180018000",
+      "0x1",
+      "0x480a7ffb7fff8000",
+      "0x480680017fff8000",
+      "0x1",
+      "0x480a80007fff8000",
+      "0x4828800180007ffc",
+      "0x480a80017fff8000",
+      "0x1104800180018000",
+      "0x800000000000010ffffffffffffffffffffffffffffffffffffffffffffffe3",
+      "0x480a7ffc7fff8000",
+      "0x208b7fff7fff7ffe",
+      "0x480a7ffc7fff8000",
+      "0x480a7ffd7fff8000",
+      "0x480680017fff8000",
+      "0x3f1abe37754ee6ca6d8dfa1036089f78a07ebe8f3b1e336cdbf3274d25becd0",
+      "0x208b7fff7fff7ffe",
+      "0x480a7ffc7fff8000",
+      "0x480a7ffd7fff8000",
+      "0x1104800180018000",
+      "0x800000000000010fffffffffffffffffffffffffffffffffffffffffffffffa",
+      "0x480a7ffb7fff8000",
+      "0x48127ffe7fff8000",
+      "0x1104800180018000",
+      "0x800000000000010ffffffffffffffffffffffffffffffffffffffffffffffc4",
+      "0x48127ffe7fff8000",
+      "0x48127ff57fff8000",
+      "0x48127ff57fff8000",
+      "0x48127ffc7fff8000",
+      "0x208b7fff7fff7ffe",
+      "0x480a7ffb7fff8000",
+      "0x480a7ffc7fff8000",
+      "0x1104800180018000",
+      "0x800000000000010ffffffffffffffffffffffffffffffffffffffffffffffed",
+      "0x480a7ffa7fff8000",
+      "0x48127ffe7fff8000",
+      "0x480a7ffd7fff8000",
+      "0x1104800180018000",
+      "0x800000000000010ffffffffffffffffffffffffffffffffffffffffffffffbe",
+      "0x48127ff67fff8000",
+      "0x48127ff67fff8000",
+      "0x208b7fff7fff7ffe",
+      "0x480a7ffb7fff8000",
+      "0x480a7ffc7fff8000",
+      "0x480a7ffd7fff8000",
+      "0x1104800180018000",
+      "0x800000000000010ffffffffffffffffffffffffffffffffffffffffffffffe5",
+      "0x208b7fff7fff7ffe",
+      "0x480a7ffd7fff8000",
+      "0x1104800180018000",
+      "0x800000000000010ffffffffffffffffffffffffffffffffffffffffffffff8d",
+      "0x480a7ffa7fff8000",
+      "0x480a7ffb7fff8000",
+      "0x480a7ffc7fff8000",
+      "0x480a7ffd7fff8000",
+      "0x1104800180018000",
+      "0x800000000000010ffffffffffffffffffffffffffffffffffffffffffffffe8",
+      "0x48127ffd7fff8000",
+      "0x48127ffe7fff8000",
+      "0x480a7ffd7fff8000",
+      "0x1104800180018000",
+      "0x800000000000010ffffffffffffffffffffffffffffffffffffffffffffffb9",
+      "0x48127ffe7fff8000",
+      "0x48127fe47fff8000",
+      "0x48127ffd7fff8000",
+      "0x208b7fff7fff7ffe",
+      "0x40780017fff7fff",
+      "0x2",
+      "0x480a7ff77fff8000",
+      "0x480a7ff87fff8000",
+      "0x480a7ff97fff8000",
+      "0x480a7ffa7fff8000",
+      "0x1104800180018000",
+      "0x800000000000010ffffffffffffffffffffffffffffffffffffffffffffffe9",
+      "0x40137ffe7fff8000",
+      "0x40137fff7fff8001",
+      "0x20780017fff7ffb",
+      "0x4",
+      "0x10780017fff7fff",
+      "0x9",
+      "0x48127ffd7fff8000",
+      "0x480a7ffa7fff8000",
+      "0x480a7ffb7fff8000",
+      "0x480a7ffc7fff8000",
+      "0x480a7ffd7fff8000",
+      "0x1104800180018000",
+      "0x800000000000010ffffffffffffffffffffffffffffffffffffffffffffff6e",
+      "0x48127ffd7fff8000",
+      "0x480a80007fff8000",
+      "0x480a80017fff8000",
+      "0x208b7fff7fff7ffe",
+      "0x480280027ffb8000",
+      "0x480280027ffd8000",
+      "0x400080007ffe7fff",
+      "0x482680017ffd8000",
+      "0x3",
+      "0x480280027ffd8000",
+      "0x48307fff7ffe8000",
+      "0x402a7ffd7ffc7fff",
+      "0x480280027ffb8000",
+      "0x480280007ffb8000",
+      "0x480280017ffb8000",
+      "0x482480017ffd8000",
+      "0x1",
+      "0x480280007ffd8000",
+      "0x480280017ffd8000",
+      "0x480280027ffd8000",
+      "0x482680017ffd8000",
+      "0x3",
+      "0x1104800180018000",
+      "0x800000000000010ffffffffffffffffffffffffffffffffffffffffffffffd6",
+      "0x40780017fff7fff",
+      "0x1",
+      "0x48127ffc7fff8000",
+      "0x48127ffc7fff8000",
+      "0x48127ffc7fff8000",
+      "0x480680017fff8000",
+      "0x0",
+      "0x48127ffb7fff8000",
+      "0x208b7fff7fff7ffe",
+      "0x480a7ff87fff8000",
+      "0x480a7ff97fff8000",
+      "0x480a7ffa7fff8000",
+      "0x1104800180018000",
+      "0x800000000000010ffffffffffffffffffffffffffffffffffffffffffffffb0",
+      "0x48127ffc7fff8000",
+      "0x48127ffe7fff8000",
+      "0x480a7ffb7fff8000",
+      "0x480a7ffc7fff8000",
+      "0x480a7ffd7fff8000",
+      "0x1104800180018000",
+      "0x800000000000010ffffffffffffffffffffffffffffffffffffffffffffff41",
+      "0x48127ffd7fff8000",
+      "0x48127ff17fff8000",
+      "0x48127ff17fff8000",
+      "0x48127ffb7fff8000",
+      "0x48127ffb7fff8000",
+      "0x208b7fff7fff7ffe",
+      "0x480280007ffb8000",
+      "0x480280017ffb8000",
+      "0x480280027ffb8000",
+      "0x480a7ffa7fff8000",
+      "0x480a7ffc7fff8000",
+      "0x480a7ffd7fff8000",
+      "0x1104800180018000",
+      "0x800000000000010ffffffffffffffffffffffffffffffffffffffffffffffe9",
+      "0x208b7fff7fff7ffe",
+      "0x480a7ff87fff8000",
+      "0x480a7ff97fff8000",
+      "0x480a7ffa7fff8000",
+      "0x1104800180018000",
+      "0x800000000000010ffffffffffffffffffffffffffffffffffffffffffffff95",
+      "0x48127ffc7fff8000",
+      "0x48127ffe7fff8000",
+      "0x480a7ffb7fff8000",
+      "0x480a7ffc7fff8000",
+      "0x480a7ffd7fff8000",
+      "0x1104800180018000",
+      "0x800000000000010ffffffffffffffffffffffffffffffffffffffffffffff32",
+      "0x48127ffd7fff8000",
+      "0x48127ff17fff8000",
+      "0x48127ff17fff8000",
+      "0x208b7fff7fff7ffe",
+      "0x480280007ffb8000",
+      "0x480280017ffb8000",
+      "0x480280027ffb8000",
+      "0x480a7ffa7fff8000",
+      "0x480a7ffc7fff8000",
+      "0x480a7ffd7fff8000",
+      "0x1104800180018000",
+      "0x800000000000010ffffffffffffffffffffffffffffffffffffffffffffffeb",
+      "0x40780017fff7fff",
+      "0x1",
+      "0x48127ffc7fff8000",
+      "0x48127ffc7fff8000",
+      "0x48127ffc7fff8000",
+      "0x480680017fff8000",
+      "0x0",
+      "0x48127ffb7fff8000",
+      "0x208b7fff7fff7ffe"
+    ],
+    "attributes": [
+      {
+        "end_pc": 121,
+        "name": "error_message",
+        "flow_tracking_data": {
+          "reference_ids": {
+            "cairo_contracts.src.openzeppelin.upgrades.library.Proxy._set_implementation_hash.new_implementation": 78,
+            "cairo_contracts.src.openzeppelin.upgrades.library.Proxy._set_implementation_hash.pedersen_ptr": 80,
+            "cairo_contracts.src.openzeppelin.upgrades.library.Proxy._set_implementation_hash.range_check_ptr": 81,
+            "cairo_contracts.src.openzeppelin.upgrades.library.Proxy._set_implementation_hash.syscall_ptr": 79
+          },
+          "ap_tracking": {
+            "offset": 0,
+            "group": 12
+          }
+        },
+        "value": "Proxy: implementation hash cannot be zero",
+        "accessible_scopes": [
+          "cairo_contracts.src.openzeppelin.upgrades.library",
+          "cairo_contracts.src.openzeppelin.upgrades.library.Proxy",
+          "cairo_contracts.src.openzeppelin.upgrades.library.Proxy._set_implementation_hash"
+        ],
+        "start_pc": 118
+      }
+    ],
+    "compiler_version": "0.10.1",
+    "debug_info": null,
+    "reference_manager": {
+      "references": [
+        {
+          "ap_tracking_data": {
+            "offset": 0,
+            "group": 1
+          },
+          "pc": 3,
+          "value": "[cast(fp + (-3), felt*)]"
+        },
+        {
+          "ap_tracking_data": {
+            "offset": 0,
+            "group": 2
+          },
+          "pc": 8,
+          "value": "[cast(fp + (-6), felt*)]"
+        },
+        {
+          "ap_tracking_data": {
+            "offset": 0,
+            "group": 2
+          },
+          "pc": 8,
+          "value": "[cast(fp + (-5), felt*)]"
+        },
+        {
+          "ap_tracking_data": {
+            "offset": 0,
+            "group": 2
+          },
+          "pc": 8,
+          "value": "[cast(fp + (-4), felt*)]"
+        },
+        {
+          "ap_tracking_data": {
+            "offset": 0,
+            "group": 2
+          },
+          "pc": 8,
+          "value": "[cast(fp + (-3), felt**)]"
+        },
+        {
+          "ap_tracking_data": {
+            "offset": 0,
+            "group": 2
+          },
+          "pc": 8,
+          "value": "[cast(fp + (-7), felt**)]"
+        },
+        {
+          "ap_tracking_data": {
+            "offset": 0,
+            "group": 2
+          },
+          "pc": 8,
+          "value": "[cast([fp + (-7)], starkware.starknet.common.syscalls.LibraryCall*)]"
+        },
+        {
+          "ap_tracking_data": {
+            "offset": 1,
+            "group": 2
+          },
+          "pc": 10,
+          "value": "[cast(ap + (-1), felt*)]"
+        },
+        {
+          "ap_tracking_data": {
+            "offset": 1,
+            "group": 2
+          },
+          "pc": 15,
+          "value": "[cast([fp + (-7)] + 5, starkware.starknet.common.syscalls.CallContractResponse*)]"
+        },
+        {
+          "ap_tracking_data": {
+            "offset": 1,
+            "group": 2
+          },
+          "pc": 15,
+          "value": "cast([fp + (-7)] + 7, felt*)"
+        },
+        {
+          "ap_tracking_data": {
+            "offset": 0,
+            "group": 3
+          },
+          "pc": 20,
+          "value": "[cast(fp + (-6), felt*)]"
+        },
+        {
+          "ap_tracking_data": {
+            "offset": 0,
+            "group": 3
+          },
+          "pc": 20,
+          "value": "[cast(fp + (-5), felt*)]"
+        },
+        {
+          "ap_tracking_data": {
+            "offset": 0,
+            "group": 3
+          },
+          "pc": 20,
+          "value": "[cast(fp + (-4), felt*)]"
+        },
+        {
+          "ap_tracking_data": {
+            "offset": 0,
+            "group": 3
+          },
+          "pc": 20,
+          "value": "[cast(fp + (-3), felt**)]"
+        },
+        {
+          "ap_tracking_data": {
+            "offset": 0,
+            "group": 3
+          },
+          "pc": 20,
+          "value": "[cast(fp + (-7), felt**)]"
+        },
+        {
+          "ap_tracking_data": {
+            "offset": 0,
+            "group": 3
+          },
+          "pc": 20,
+          "value": "[cast([fp + (-7)], starkware.starknet.common.syscalls.LibraryCall*)]"
+        },
+        {
+          "ap_tracking_data": {
+            "offset": 1,
+            "group": 3
+          },
+          "pc": 22,
+          "value": "[cast(ap + (-1), felt*)]"
+        },
+        {
+          "ap_tracking_data": {
+            "offset": 1,
+            "group": 3
+          },
+          "pc": 27,
+          "value": "[cast([fp + (-7)] + 5, starkware.starknet.common.syscalls.CallContractResponse*)]"
+        },
+        {
+          "ap_tracking_data": {
+            "offset": 1,
+            "group": 3
+          },
+          "pc": 27,
+          "value": "cast([fp + (-7)] + 7, felt*)"
+        },
+        {
+          "ap_tracking_data": {
+            "offset": 0,
+            "group": 4
+          },
+          "pc": 32,
+          "value": "[cast(fp + (-3), felt*)]"
+        },
+        {
+          "ap_tracking_data": {
+            "offset": 0,
+            "group": 4
+          },
+          "pc": 32,
+          "value": "[cast(fp + (-4), felt**)]"
+        },
+        {
+          "ap_tracking_data": {
+            "offset": 0,
+            "group": 4
+          },
+          "pc": 32,
+          "value": "[cast([fp + (-4)], starkware.starknet.common.syscalls.StorageRead*)]"
+        },
+        {
+          "ap_tracking_data": {
+            "offset": 1,
+            "group": 4
+          },
+          "pc": 34,
+          "value": "[cast(ap + (-1), felt*)]"
+        },
+        {
+          "ap_tracking_data": {
+            "offset": 1,
+            "group": 4
+          },
+          "pc": 36,
+          "value": "[cast([fp + (-4)] + 2, starkware.starknet.common.syscalls.StorageReadResponse*)]"
+        },
+        {
+          "ap_tracking_data": {
+            "offset": 1,
+            "group": 4
+          },
+          "pc": 36,
+          "value": "cast([fp + (-4)] + 3, felt*)"
+        },
+        {
+          "ap_tracking_data": {
+            "offset": 0,
+            "group": 5
+          },
+          "pc": 40,
+          "value": "[cast(fp + (-4), felt*)]"
+        },
+        {
+          "ap_tracking_data": {
+            "offset": 0,
+            "group": 5
+          },
+          "pc": 40,
+          "value": "[cast(fp + (-3), felt*)]"
+        },
+        {
+          "ap_tracking_data": {
+            "offset": 0,
+            "group": 5
+          },
+          "pc": 40,
+          "value": "[cast(fp + (-5), felt**)]"
+        },
+        {
+          "ap_tracking_data": {
+            "offset": 1,
+            "group": 5
+          },
+          "pc": 42,
+          "value": "[cast(ap + (-1), felt*)]"
+        },
+        {
+          "ap_tracking_data": {
+            "offset": 1,
+            "group": 5
+          },
+          "pc": 45,
+          "value": "cast([fp + (-5)] + 3, felt*)"
+        },
+        {
+          "ap_tracking_data": {
+            "offset": 0,
+            "group": 6
+          },
+          "pc": 48,
+          "value": "[cast(fp + (-6), felt*)]"
+        },
+        {
+          "ap_tracking_data": {
+            "offset": 0,
+            "group": 6
+          },
+          "pc": 48,
+          "value": "[cast(fp + (-5), felt**)]"
+        },
+        {
+          "ap_tracking_data": {
+            "offset": 0,
+            "group": 6
+          },
+          "pc": 48,
+          "value": "[cast(fp + (-4), felt*)]"
+        },
+        {
+          "ap_tracking_data": {
+            "offset": 0,
+            "group": 6
+          },
+          "pc": 48,
+          "value": "[cast(fp + (-3), felt**)]"
+        },
+        {
+          "ap_tracking_data": {
+            "offset": 0,
+            "group": 6
+          },
+          "pc": 48,
+          "value": "[cast(fp + (-7), felt**)]"
+        },
+        {
+          "ap_tracking_data": {
+            "offset": 1,
+            "group": 6
+          },
+          "pc": 50,
+          "value": "[cast(ap + (-1), felt*)]"
+        },
+        {
+          "ap_tracking_data": {
+            "offset": 1,
+            "group": 6
+          },
+          "pc": 55,
+          "value": "cast([fp + (-7)] + 5, felt*)"
+        },
+        {
+          "ap_tracking_data": {
+            "offset": 0,
+            "group": 7
+          },
+          "pc": 58,
+          "value": "[cast(fp + (-3), felt*)]"
+        },
+        {
+          "ap_tracking_data": {
+            "offset": 0,
+            "group": 7
+          },
+          "pc": 58,
+          "value": "[cast(fp + (-5), felt**)]"
+        },
+        {
+          "ap_tracking_data": {
+            "offset": 0,
+            "group": 7
+          },
+          "pc": 58,
+          "value": "[cast(fp + (-4), felt*)]"
+        },
+        {
+          "ap_tracking_data": {
+            "offset": 5,
+            "group": 7
+          },
+          "pc": 62,
+          "value": "[cast(ap + (-1), felt**)]"
+        },
+        {
+          "ap_tracking_data": {
+            "offset": 5,
+            "group": 7
+          },
+          "pc": 63,
+          "value": "[cast(fp, felt**)]"
+        },
+        {
+          "ap_tracking_data": {
+            "offset": 6,
+            "group": 7
+          },
+          "pc": 65,
+          "value": "[cast(ap + (-1), felt*)]"
+        },
+        {
+          "ap_tracking_data": {
+            "offset": 9,
+            "group": 7
+          },
+          "pc": 68,
+          "value": "[cast(ap + (-1), felt**)]"
+        },
+        {
+          "ap_tracking_data": {
+            "offset": 9,
+            "group": 7
+          },
+          "pc": 69,
+          "value": "[cast(fp + 1, felt**)]"
+        },
+        {
+          "ap_tracking_data": {
+            "offset": 9,
+            "group": 7
+          },
+          "pc": 69,
+          "value": "[cast(fp + 1, felt**)]"
+        },
+        {
+          "ap_tracking_data": {
+            "offset": 9,
+            "group": 7
+          },
+          "pc": 70,
+          "value": "cast([fp + 1] + 1, felt*)"
+        },
+        {
+          "ap_tracking_data": {
+            "offset": 10,
+            "group": 7
+          },
+          "pc": 72,
+          "value": "[cast(ap + (-1), felt*)]"
+        },
+        {
+          "ap_tracking_data": {
+            "offset": 19,
+            "group": 7
+          },
+          "pc": 80,
+          "value": "[cast(ap + (-1), felt**)]"
+        },
+        {
+          "ap_tracking_data": {
+            "offset": 0,
+            "group": 8
+          },
+          "pc": 82,
+          "value": "[cast(fp + (-4), starkware.cairo.common.cairo_builtins.HashBuiltin**)]"
+        },
+        {
+          "ap_tracking_data": {
+            "offset": 0,
+            "group": 8
+          },
+          "pc": 82,
+          "value": "[cast(fp + (-3), felt*)]"
+        },
+        {
+          "ap_tracking_data": {
+            "offset": 0,
+            "group": 8
+          },
+          "pc": 82,
+          "value": "cast(1783935019461685855687084032167085762428877981963606680389089912112530844880, felt)"
+        },
+        {
+          "ap_tracking_data": {
+            "offset": 0,
+            "group": 9
+          },
+          "pc": 87,
+          "value": "[cast(fp + (-5), felt**)]"
+        },
+        {
+          "ap_tracking_data": {
+            "offset": 0,
+            "group": 9
+          },
+          "pc": 87,
+          "value": "[cast(fp + (-4), starkware.cairo.common.cairo_builtins.HashBuiltin**)]"
+        },
+        {
+          "ap_tracking_data": {
+            "offset": 0,
+            "group": 9
+          },
+          "pc": 87,
+          "value": "[cast(fp + (-3), felt*)]"
+        },
+        {
+          "ap_tracking_data": {
+            "offset": 7,
+            "group": 9
+          },
+          "pc": 91,
+          "value": "[cast(ap + (-3), starkware.cairo.common.cairo_builtins.HashBuiltin**)]"
+        },
+        {
+          "ap_tracking_data": {
+            "offset": 7,
+            "group": 9
+          },
+          "pc": 91,
+          "value": "[cast(ap + (-2), felt*)]"
+        },
+        {
+          "ap_tracking_data": {
+            "offset": 7,
+            "group": 9
+          },
+          "pc": 91,
+          "value": "[cast(ap + (-1), felt*)]"
+        },
+        {
+          "ap_tracking_data": {
+            "offset": 14,
+            "group": 9
+          },
+          "pc": 95,
+          "value": "[cast(ap + (-2), felt**)]"
+        },
+        {
+          "ap_tracking_data": {
+            "offset": 14,
+            "group": 9
+          },
+          "pc": 95,
+          "value": "[cast(ap + (-1), felt*)]"
+        },
+        {
+          "ap_tracking_data": {
+            "offset": 15,
+            "group": 9
+          },
+          "pc": 96,
+          "value": "[cast(ap + (-1), felt**)]"
+        },
+        {
+          "ap_tracking_data": {
+            "offset": 16,
+            "group": 9
+          },
+          "pc": 97,
+          "value": "[cast(ap + (-1), starkware.cairo.common.cairo_builtins.HashBuiltin**)]"
+        },
+        {
+          "ap_tracking_data": {
+            "offset": 17,
+            "group": 9
+          },
+          "pc": 98,
+          "value": "[cast(ap + (-1), felt*)]"
+        },
+        {
+          "ap_tracking_data": {
+            "offset": 18,
+            "group": 9
+          },
+          "pc": 99,
+          "value": "[cast(ap + (-1), felt*)]"
+        },
+        {
+          "ap_tracking_data": {
+            "offset": 0,
+            "group": 10
+          },
+          "pc": 100,
+          "value": "[cast(fp + (-3), felt*)]"
+        },
+        {
+          "ap_tracking_data": {
+            "offset": 0,
+            "group": 10
+          },
+          "pc": 100,
+          "value": "[cast(fp + (-6), felt**)]"
+        },
+        {
+          "ap_tracking_data": {
+            "offset": 0,
+            "group": 10
+          },
+          "pc": 100,
+          "value": "[cast(fp + (-5), starkware.cairo.common.cairo_builtins.HashBuiltin**)]"
+        },
+        {
+          "ap_tracking_data": {
+            "offset": 0,
+            "group": 10
+          },
+          "pc": 100,
+          "value": "[cast(fp + (-4), felt*)]"
+        },
+        {
+          "ap_tracking_data": {
+            "offset": 7,
+            "group": 10
+          },
+          "pc": 104,
+          "value": "[cast(ap + (-3), starkware.cairo.common.cairo_builtins.HashBuiltin**)]"
+        },
+        {
+          "ap_tracking_data": {
+            "offset": 7,
+            "group": 10
+          },
+          "pc": 104,
+          "value": "[cast(ap + (-2), felt*)]"
+        },
+        {
+          "ap_tracking_data": {
+            "offset": 7,
+            "group": 10
+          },
+          "pc": 104,
+          "value": "[cast(ap + (-1), felt*)]"
+        },
+        {
+          "ap_tracking_data": {
+            "offset": 14,
+            "group": 10
+          },
+          "pc": 109,
+          "value": "[cast(ap + (-1), felt**)]"
+        },
+        {
+          "ap_tracking_data": {
+            "offset": 0,
+            "group": 11
+          },
+          "pc": 112,
+          "value": "[cast(fp + (-5), felt**)]"
+        },
+        {
+          "ap_tracking_data": {
+            "offset": 0,
+            "group": 11
+          },
+          "pc": 112,
+          "value": "[cast(fp + (-4), starkware.cairo.common.cairo_builtins.HashBuiltin**)]"
+        },
+        {
+          "ap_tracking_data": {
+            "offset": 0,
+            "group": 11
+          },
+          "pc": 112,
+          "value": "[cast(fp + (-3), felt*)]"
+        },
+        {
+          "ap_tracking_data": {
+            "offset": 23,
+            "group": 11
+          },
+          "pc": 117,
+          "value": "[cast(ap + (-4), felt**)]"
+        },
+        {
+          "ap_tracking_data": {
+            "offset": 23,
+            "group": 11
+          },
+          "pc": 117,
+          "value": "[cast(ap + (-3), starkware.cairo.common.cairo_builtins.HashBuiltin**)]"
+        },
+        {
+          "ap_tracking_data": {
+            "offset": 23,
+            "group": 11
+          },
+          "pc": 117,
+          "value": "[cast(ap + (-2), felt*)]"
+        },
+        {
+          "ap_tracking_data": {
+            "offset": 0,
+            "group": 12
+          },
+          "pc": 118,
+          "value": "[cast(fp + (-3), felt*)]"
+        },
+        {
+          "ap_tracking_data": {
+            "offset": 0,
+            "group": 12
+          },
+          "pc": 118,
+          "value": "[cast(fp + (-6), felt**)]"
+        },
+        {
+          "ap_tracking_data": {
+            "offset": 0,
+            "group": 12
+          },
+          "pc": 118,
+          "value": "[cast(fp + (-5), starkware.cairo.common.cairo_builtins.HashBuiltin**)]"
+        },
+        {
+          "ap_tracking_data": {
+            "offset": 0,
+            "group": 12
+          },
+          "pc": 118,
+          "value": "[cast(fp + (-4), felt*)]"
+        },
+        {
+          "ap_tracking_data": {
+            "offset": 25,
+            "group": 12
+          },
+          "pc": 127,
+          "value": "[cast(ap + (-3), felt**)]"
+        },
+        {
+          "ap_tracking_data": {
+            "offset": 25,
+            "group": 12
+          },
+          "pc": 127,
+          "value": "[cast(ap + (-2), starkware.cairo.common.cairo_builtins.HashBuiltin**)]"
+        },
+        {
+          "ap_tracking_data": {
+            "offset": 25,
+            "group": 12
+          },
+          "pc": 127,
+          "value": "[cast(ap + (-1), felt*)]"
+        },
+        {
+          "ap_tracking_data": {
+            "offset": 50,
+            "group": 12
+          },
+          "pc": 132,
+          "value": "[cast(ap + (-2), felt**)]"
+        },
+        {
+          "ap_tracking_data": {
+            "offset": 50,
+            "group": 12
+          },
+          "pc": 132,
+          "value": "[cast(ap + (-1), felt*)]"
+        },
+        {
+          "ap_tracking_data": {
+            "offset": 0,
+            "group": 13
+          },
+          "pc": 136,
+          "value": "[cast(fp + (-6), felt*)]"
+        },
+        {
+          "ap_tracking_data": {
+            "offset": 0,
+            "group": 13
+          },
+          "pc": 136,
+          "value": "[cast(fp + (-5), felt*)]"
+        },
+        {
+          "ap_tracking_data": {
+            "offset": 0,
+            "group": 13
+          },
+          "pc": 136,
+          "value": "[cast(fp + (-4), felt*)]"
+        },
+        {
+          "ap_tracking_data": {
+            "offset": 0,
+            "group": 13
+          },
+          "pc": 136,
+          "value": "[cast(fp + (-3), felt**)]"
+        },
+        {
+          "ap_tracking_data": {
+            "offset": 0,
+            "group": 13
+          },
+          "pc": 136,
+          "value": "[cast(fp + (-9), felt**)]"
+        },
+        {
+          "ap_tracking_data": {
+            "offset": 0,
+            "group": 13
+          },
+          "pc": 136,
+          "value": "[cast(fp + (-8), starkware.cairo.common.cairo_builtins.HashBuiltin**)]"
+        },
+        {
+          "ap_tracking_data": {
+            "offset": 0,
+            "group": 13
+          },
+          "pc": 136,
+          "value": "[cast(fp + (-7), felt*)]"
+        },
+        {
+          "ap_tracking_data": {
+            "offset": 61,
+            "group": 13
+          },
+          "pc": 144,
+          "value": "[cast(ap + (-3), felt**)]"
+        },
+        {
+          "ap_tracking_data": {
+            "offset": 61,
+            "group": 13
+          },
+          "pc": 144,
+          "value": "[cast(ap + (-2), starkware.cairo.common.cairo_builtins.HashBuiltin**)]"
+        },
+        {
+          "ap_tracking_data": {
+            "offset": 61,
+            "group": 13
+          },
+          "pc": 144,
+          "value": "[cast(ap + (-1), felt*)]"
+        },
+        {
+          "ap_tracking_data": {
+            "offset": 61,
+            "group": 13
+          },
+          "pc": 145,
+          "value": "[cast(fp, starkware.cairo.common.cairo_builtins.HashBuiltin**)]"
+        },
+        {
+          "ap_tracking_data": {
+            "offset": 61,
+            "group": 13
+          },
+          "pc": 146,
+          "value": "[cast(fp + 1, felt*)]"
+        },
+        {
+          "ap_tracking_data": {
+            "offset": 72,
+            "group": 13
+          },
+          "pc": 157,
+          "value": "[cast(ap + (-3), felt**)]"
+        },
+        {
+          "ap_tracking_data": {
+            "offset": 0,
+            "group": 14
+          },
+          "pc": 157,
+          "value": "[cast(ap - 0 + (-3), felt**)]"
+        },
+        {
+          "ap_tracking_data": {
+            "offset": 0,
+            "group": 15
+          },
+          "pc": 161,
+          "value": "[cast([fp + (-5)], felt**)]"
+        },
+        {
+          "ap_tracking_data": {
+            "offset": 0,
+            "group": 15
+          },
+          "pc": 161,
+          "value": "[cast([fp + (-5)] + 1, starkware.cairo.common.cairo_builtins.HashBuiltin**)]"
+        },
+        {
+          "ap_tracking_data": {
+            "offset": 0,
+            "group": 15
+          },
+          "pc": 161,
+          "value": "[cast([fp + (-5)] + 2, felt*)]"
+        },
+        {
+          "ap_tracking_data": {
+            "offset": 0,
+            "group": 15
+          },
+          "pc": 161,
+          "value": "[cast(fp + (-3), felt**)]"
+        },
+        {
+          "ap_tracking_data": {
+            "offset": 0,
+            "group": 15
+          },
+          "pc": 161,
+          "value": "[cast([fp + (-3)], felt*)]"
+        },
+        {
+          "ap_tracking_data": {
+            "offset": 0,
+            "group": 15
+          },
+          "pc": 161,
+          "value": "cast([fp + (-3)] + 1, felt*)"
+        },
+        {
+          "ap_tracking_data": {
+            "offset": 0,
+            "group": 15
+          },
+          "pc": 161,
+          "value": "[cast([fp + (-3)] + 1, felt*)]"
+        },
+        {
+          "ap_tracking_data": {
+            "offset": 0,
+            "group": 15
+          },
+          "pc": 161,
+          "value": "cast([fp + (-3)] + 2, felt*)"
+        },
+        {
+          "ap_tracking_data": {
+            "offset": 0,
+            "group": 15
+          },
+          "pc": 161,
+          "value": "[cast([fp + (-3)] + 2, felt*)]"
+        },
+        {
+          "ap_tracking_data": {
+            "offset": 0,
+            "group": 15
+          },
+          "pc": 161,
+          "value": "cast([fp + (-3)] + 3, felt*)"
+        },
+        {
+          "ap_tracking_data": {
+            "offset": 1,
+            "group": 15
+          },
+          "pc": 162,
+          "value": "[cast(ap + (-1), felt*)]"
+        },
+        {
+          "ap_tracking_data": {
+            "offset": 2,
+            "group": 15
+          },
+          "pc": 163,
+          "value": "[cast(ap + (-1), felt*)]"
+        },
+        {
+          "ap_tracking_data": {
+            "offset": 2,
+            "group": 15
+          },
+          "pc": 164,
+          "value": "cast([[fp + (-5)] + 2] + 1, felt)"
+        },
+        {
+          "ap_tracking_data": {
+            "offset": 2,
+            "group": 15
+          },
+          "pc": 164,
+          "value": "cast([fp + (-3)] + 3, felt*)"
+        },
+        {
+          "ap_tracking_data": {
+            "offset": 3,
+            "group": 15
+          },
+          "pc": 166,
+          "value": "[cast(ap + (-1), felt*)]"
+        },
+        {
+          "ap_tracking_data": {
+            "offset": 4,
+            "group": 15
+          },
+          "pc": 167,
+          "value": "[cast(ap + (-1), felt*)]"
+        },
+        {
+          "ap_tracking_data": {
+            "offset": 5,
+            "group": 15
+          },
+          "pc": 168,
+          "value": "[cast(ap + (-1), felt**)]"
+        },
+        {
+          "ap_tracking_data": {
+            "offset": 5,
+            "group": 15
+          },
+          "pc": 168,
+          "value": "cast([ap + (-1)] - [fp + (-3)], felt)"
+        },
+        {
+          "ap_tracking_data": {
+            "offset": 6,
+            "group": 15
+          },
+          "pc": 170,
+          "value": "[cast(ap + (-1), felt*)]"
+        },
+        {
+          "ap_tracking_data": {
+            "offset": 0,
+            "group": 16
+          },
+          "pc": 181,
+          "value": "[cast(ap + (-3), felt**)]"
+        },
+        {
+          "ap_tracking_data": {
+            "offset": 0,
+            "group": 16
+          },
+          "pc": 181,
+          "value": "[cast(ap + (-2), starkware.cairo.common.cairo_builtins.HashBuiltin**)]"
+        },
+        {
+          "ap_tracking_data": {
+            "offset": 0,
+            "group": 16
+          },
+          "pc": 181,
+          "value": "[cast(ap + (-1), felt*)]"
+        },
+        {
+          "ap_tracking_data": {
+            "offset": 0,
+            "group": 16
+          },
+          "pc": 181,
+          "value": "[cast(ap + 0, ()*)]"
+        },
+        {
+          "ap_tracking_data": {
+            "offset": 1,
+            "group": 16
+          },
+          "pc": 183,
+          "value": "[cast(ap + (-1), felt**)]"
+        },
+        {
+          "ap_tracking_data": {
+            "offset": 1,
+            "group": 16
+          },
+          "pc": 183,
+          "value": "cast(0, felt)"
+        },
+        {
+          "ap_tracking_data": {
+            "offset": 0,
+            "group": 17
+          },
+          "pc": 190,
+          "value": "[cast(fp + (-5), felt*)]"
+        },
+        {
+          "ap_tracking_data": {
+            "offset": 0,
+            "group": 17
+          },
+          "pc": 190,
+          "value": "[cast(fp + (-4), felt*)]"
+        },
+        {
+          "ap_tracking_data": {
+            "offset": 0,
+            "group": 17
+          },
+          "pc": 190,
+          "value": "[cast(fp + (-3), felt**)]"
+        },
+        {
+          "ap_tracking_data": {
+            "offset": 0,
+            "group": 17
+          },
+          "pc": 190,
+          "value": "[cast(fp + (-8), felt**)]"
+        },
+        {
+          "ap_tracking_data": {
+            "offset": 0,
+            "group": 17
+          },
+          "pc": 190,
+          "value": "[cast(fp + (-7), starkware.cairo.common.cairo_builtins.HashBuiltin**)]"
+        },
+        {
+          "ap_tracking_data": {
+            "offset": 0,
+            "group": 17
+          },
+          "pc": 190,
+          "value": "[cast(fp + (-6), felt*)]"
+        },
+        {
+          "ap_tracking_data": {
+            "offset": 28,
+            "group": 17
+          },
+          "pc": 195,
+          "value": "[cast(ap + (-4), felt**)]"
+        },
+        {
+          "ap_tracking_data": {
+            "offset": 28,
+            "group": 17
+          },
+          "pc": 195,
+          "value": "[cast(ap + (-3), starkware.cairo.common.cairo_builtins.HashBuiltin**)]"
+        },
+        {
+          "ap_tracking_data": {
+            "offset": 28,
+            "group": 17
+          },
+          "pc": 195,
+          "value": "[cast(ap + (-2), felt*)]"
+        },
+        {
+          "ap_tracking_data": {
+            "offset": 28,
+            "group": 17
+          },
+          "pc": 195,
+          "value": "[cast(ap + (-1), felt*)]"
+        },
+        {
+          "ap_tracking_data": {
+            "offset": 39,
+            "group": 17
+          },
+          "pc": 202,
+          "value": "[cast(ap + (-3), felt**)]"
+        },
+        {
+          "ap_tracking_data": {
+            "offset": 39,
+            "group": 17
+          },
+          "pc": 202,
+          "value": "[cast(ap + (-2), felt*)]"
+        },
+        {
+          "ap_tracking_data": {
+            "offset": 39,
+            "group": 17
+          },
+          "pc": 202,
+          "value": "[cast(ap + (-1), felt**)]"
+        },
+        {
+          "ap_tracking_data": {
+            "offset": 0,
+            "group": 18
+          },
+          "pc": 208,
+          "value": "[cast([fp + (-5)], felt**)]"
+        },
+        {
+          "ap_tracking_data": {
+            "offset": 0,
+            "group": 18
+          },
+          "pc": 208,
+          "value": "[cast([fp + (-5)] + 1, starkware.cairo.common.cairo_builtins.HashBuiltin**)]"
+        },
+        {
+          "ap_tracking_data": {
+            "offset": 0,
+            "group": 18
+          },
+          "pc": 208,
+          "value": "[cast([fp + (-5)] + 2, felt*)]"
+        },
+        {
+          "ap_tracking_data": {
+            "offset": 52,
+            "group": 18
+          },
+          "pc": 216,
+          "value": "[cast(ap + (-5), felt**)]"
+        },
+        {
+          "ap_tracking_data": {
+            "offset": 52,
+            "group": 18
+          },
+          "pc": 216,
+          "value": "[cast(ap + (-4), starkware.cairo.common.cairo_builtins.HashBuiltin**)]"
+        },
+        {
+          "ap_tracking_data": {
+            "offset": 52,
+            "group": 18
+          },
+          "pc": 216,
+          "value": "[cast(ap + (-3), felt*)]"
+        },
+        {
+          "ap_tracking_data": {
+            "offset": 52,
+            "group": 18
+          },
+          "pc": 216,
+          "value": "[cast(ap + (-2), (retdata_size: felt, retdata: felt*)*)]"
+        },
+        {
+          "ap_tracking_data": {
+            "offset": 52,
+            "group": 18
+          },
+          "pc": 216,
+          "value": "[cast(ap + (-2), felt*)]"
+        },
+        {
+          "ap_tracking_data": {
+            "offset": 52,
+            "group": 18
+          },
+          "pc": 216,
+          "value": "[cast(ap + (-1), felt**)]"
+        },
+        {
+          "ap_tracking_data": {
+            "offset": 0,
+            "group": 19
+          },
+          "pc": 217,
+          "value": "[cast(fp + (-5), felt*)]"
+        },
+        {
+          "ap_tracking_data": {
+            "offset": 0,
+            "group": 19
+          },
+          "pc": 217,
+          "value": "[cast(fp + (-4), felt*)]"
+        },
+        {
+          "ap_tracking_data": {
+            "offset": 0,
+            "group": 19
+          },
+          "pc": 217,
+          "value": "[cast(fp + (-3), felt**)]"
+        },
+        {
+          "ap_tracking_data": {
+            "offset": 0,
+            "group": 19
+          },
+          "pc": 217,
+          "value": "[cast(fp + (-8), felt**)]"
+        },
+        {
+          "ap_tracking_data": {
+            "offset": 0,
+            "group": 19
+          },
+          "pc": 217,
+          "value": "[cast(fp + (-7), starkware.cairo.common.cairo_builtins.HashBuiltin**)]"
+        },
+        {
+          "ap_tracking_data": {
+            "offset": 0,
+            "group": 19
+          },
+          "pc": 217,
+          "value": "[cast(fp + (-6), felt*)]"
+        },
+        {
+          "ap_tracking_data": {
+            "offset": 28,
+            "group": 19
+          },
+          "pc": 222,
+          "value": "[cast(ap + (-4), felt**)]"
+        },
+        {
+          "ap_tracking_data": {
+            "offset": 28,
+            "group": 19
+          },
+          "pc": 222,
+          "value": "[cast(ap + (-3), starkware.cairo.common.cairo_builtins.HashBuiltin**)]"
+        },
+        {
+          "ap_tracking_data": {
+            "offset": 28,
+            "group": 19
+          },
+          "pc": 222,
+          "value": "[cast(ap + (-2), felt*)]"
+        },
+        {
+          "ap_tracking_data": {
+            "offset": 28,
+            "group": 19
+          },
+          "pc": 222,
+          "value": "[cast(ap + (-1), felt*)]"
+        },
+        {
+          "ap_tracking_data": {
+            "offset": 39,
+            "group": 19
+          },
+          "pc": 229,
+          "value": "[cast(ap + (-3), felt**)]"
+        },
+        {
+          "ap_tracking_data": {
+            "offset": 0,
+            "group": 20
+          },
+          "pc": 233,
+          "value": "[cast([fp + (-5)], felt**)]"
+        },
+        {
+          "ap_tracking_data": {
+            "offset": 0,
+            "group": 20
+          },
+          "pc": 233,
+          "value": "[cast([fp + (-5)] + 1, starkware.cairo.common.cairo_builtins.HashBuiltin**)]"
+        },
+        {
+          "ap_tracking_data": {
+            "offset": 0,
+            "group": 20
+          },
+          "pc": 233,
+          "value": "[cast([fp + (-5)] + 2, felt*)]"
+        },
+        {
+          "ap_tracking_data": {
+            "offset": 50,
+            "group": 20
+          },
+          "pc": 241,
+          "value": "[cast(ap + (-3), felt**)]"
+        },
+        {
+          "ap_tracking_data": {
+            "offset": 50,
+            "group": 20
+          },
+          "pc": 241,
+          "value": "[cast(ap + (-2), starkware.cairo.common.cairo_builtins.HashBuiltin**)]"
+        },
+        {
+          "ap_tracking_data": {
+            "offset": 50,
+            "group": 20
+          },
+          "pc": 241,
+          "value": "[cast(ap + (-1), felt*)]"
+        },
+        {
+          "ap_tracking_data": {
+            "offset": 50,
+            "group": 20
+          },
+          "pc": 241,
+          "value": "[cast(ap + 0, ()*)]"
+        },
+        {
+          "ap_tracking_data": {
+            "offset": 51,
+            "group": 20
+          },
+          "pc": 243,
+          "value": "[cast(ap + (-1), felt**)]"
+        },
+        {
+          "ap_tracking_data": {
+            "offset": 51,
+            "group": 20
+          },
+          "pc": 243,
+          "value": "cast(0, felt)"
+        }
+      ]
+    },
+    "identifiers": {
+      "__main__.HashBuiltin": {
+        "destination": "starkware.cairo.common.cairo_builtins.HashBuiltin",
+        "type": "alias"
+      },
+      "__main__.Proxy": {
+        "destination": "cairo_contracts.src.openzeppelin.upgrades.library.Proxy",
+        "type": "alias"
+      },
+      "__main__.__default__": {
+        "pc": 190,
+        "decorators": [
+          "external",
+          "raw_input",
+          "raw_output"
+        ],
+        "type": "function"
+      },
+      "__main__.__default__.Args": {
+        "full_name": "__main__.__default__.Args",
+        "members": {
+          "selector": {
+            "cairo_type": "felt",
+            "offset": 0
+          },
+          "calldata_size": {
+            "cairo_type": "felt",
+            "offset": 1
+          },
+          "calldata": {
+            "cairo_type": "felt*",
+            "offset": 2
+          }
+        },
+        "size": 3,
+        "type": "struct"
+      },
+      "__main__.__default__.ImplicitArgs": {
+        "full_name": "__main__.__default__.ImplicitArgs",
+        "members": {
+          "syscall_ptr": {
+            "cairo_type": "felt*",
+            "offset": 0
+          },
+          "pedersen_ptr": {
+            "cairo_type": "starkware.cairo.common.cairo_builtins.HashBuiltin*",
+            "offset": 1
+          },
+          "range_check_ptr": {
+            "cairo_type": "felt",
+            "offset": 2
+          }
+        },
+        "size": 3,
+        "type": "struct"
+      },
+      "__main__.__default__.Return": {
+        "cairo_type": "(retdata_size: felt, retdata: felt*)",
+        "type": "type_definition"
+      },
+      "__main__.__default__.SIZEOF_LOCALS": {
+        "value": 0,
+        "type": "const"
+      },
+      "__main__.__default__.calldata": {
+        "full_name": "__main__.__default__.calldata",
+        "cairo_type": "felt*",
+        "references": [
+          {
+            "ap_tracking_data": {
+              "offset": 0,
+              "group": 17
+            },
+            "pc": 190,
+            "value": "[cast(fp + (-3), felt**)]"
+          }
+        ],
+        "type": "reference"
+      },
+      "__main__.__default__.calldata_size": {
+        "full_name": "__main__.__default__.calldata_size",
+        "cairo_type": "felt",
+        "references": [
+          {
+            "ap_tracking_data": {
+              "offset": 0,
+              "group": 17
+            },
+            "pc": 190,
+            "value": "[cast(fp + (-4), felt*)]"
+          }
+        ],
+        "type": "reference"
+      },
+      "__main__.__default__.class_hash": {
+        "full_name": "__main__.__default__.class_hash",
+        "cairo_type": "felt",
+        "references": [
+          {
+            "ap_tracking_data": {
+              "offset": 28,
+              "group": 17
+            },
+            "pc": 195,
+            "value": "[cast(ap + (-1), felt*)]"
+          }
+        ],
+        "type": "reference"
+      },
+      "__main__.__default__.pedersen_ptr": {
+        "full_name": "__main__.__default__.pedersen_ptr",
+        "cairo_type": "starkware.cairo.common.cairo_builtins.HashBuiltin*",
+        "references": [
+          {
+            "ap_tracking_data": {
+              "offset": 0,
+              "group": 17
+            },
+            "pc": 190,
+            "value": "[cast(fp + (-7), starkware.cairo.common.cairo_builtins.HashBuiltin**)]"
+          },
+          {
+            "ap_tracking_data": {
+              "offset": 28,
+              "group": 17
+            },
+            "pc": 195,
+            "value": "[cast(ap + (-3), starkware.cairo.common.cairo_builtins.HashBuiltin**)]"
+          }
+        ],
+        "type": "reference"
+      },
+      "__main__.__default__.range_check_ptr": {
+        "full_name": "__main__.__default__.range_check_ptr",
+        "cairo_type": "felt",
+        "references": [
+          {
+            "ap_tracking_data": {
+              "offset": 0,
+              "group": 17
+            },
+            "pc": 190,
+            "value": "[cast(fp + (-6), felt*)]"
+          },
+          {
+            "ap_tracking_data": {
+              "offset": 28,
+              "group": 17
+            },
+            "pc": 195,
+            "value": "[cast(ap + (-2), felt*)]"
+          }
+        ],
+        "type": "reference"
+      },
+      "__main__.__default__.retdata": {
+        "full_name": "__main__.__default__.retdata",
+        "cairo_type": "felt*",
+        "references": [
+          {
+            "ap_tracking_data": {
+              "offset": 39,
+              "group": 17
+            },
+            "pc": 202,
+            "value": "[cast(ap + (-1), felt**)]"
+          }
+        ],
+        "type": "reference"
+      },
+      "__main__.__default__.retdata_size": {
+        "full_name": "__main__.__default__.retdata_size",
+        "cairo_type": "felt",
+        "references": [
+          {
+            "ap_tracking_data": {
+              "offset": 39,
+              "group": 17
+            },
+            "pc": 202,
+            "value": "[cast(ap + (-2), felt*)]"
+          }
+        ],
+        "type": "reference"
+      },
+      "__main__.__default__.selector": {
+        "full_name": "__main__.__default__.selector",
+        "cairo_type": "felt",
+        "references": [
+          {
+            "ap_tracking_data": {
+              "offset": 0,
+              "group": 17
+            },
+            "pc": 190,
+            "value": "[cast(fp + (-5), felt*)]"
+          }
+        ],
+        "type": "reference"
+      },
+      "__main__.__default__.syscall_ptr": {
+        "full_name": "__main__.__default__.syscall_ptr",
+        "cairo_type": "felt*",
+        "references": [
+          {
+            "ap_tracking_data": {
+              "offset": 0,
+              "group": 17
+            },
+            "pc": 190,
+            "value": "[cast(fp + (-8), felt**)]"
+          },
+          {
+            "ap_tracking_data": {
+              "offset": 28,
+              "group": 17
+            },
+            "pc": 195,
+            "value": "[cast(ap + (-4), felt**)]"
+          },
+          {
+            "ap_tracking_data": {
+              "offset": 39,
+              "group": 17
+            },
+            "pc": 202,
+            "value": "[cast(ap + (-3), felt**)]"
+          }
+        ],
+        "type": "reference"
+      },
+      "__main__.__l1_default__": {
+        "pc": 217,
+        "decorators": [
+          "l1_handler",
+          "raw_input"
+        ],
+        "type": "function"
+      },
+      "__main__.__l1_default__.Args": {
+        "full_name": "__main__.__l1_default__.Args",
+        "members": {
+          "selector": {
+            "cairo_type": "felt",
+            "offset": 0
+          },
+          "calldata_size": {
+            "cairo_type": "felt",
+            "offset": 1
+          },
+          "calldata": {
+            "cairo_type": "felt*",
+            "offset": 2
+          }
+        },
+        "size": 3,
+        "type": "struct"
+      },
+      "__main__.__l1_default__.ImplicitArgs": {
+        "full_name": "__main__.__l1_default__.ImplicitArgs",
+        "members": {
+          "syscall_ptr": {
+            "cairo_type": "felt*",
+            "offset": 0
+          },
+          "pedersen_ptr": {
+            "cairo_type": "starkware.cairo.common.cairo_builtins.HashBuiltin*",
+            "offset": 1
+          },
+          "range_check_ptr": {
+            "cairo_type": "felt",
+            "offset": 2
+          }
+        },
+        "size": 3,
+        "type": "struct"
+      },
+      "__main__.__l1_default__.Return": {
+        "cairo_type": "()",
+        "type": "type_definition"
+      },
+      "__main__.__l1_default__.SIZEOF_LOCALS": {
+        "value": 0,
+        "type": "const"
+      },
+      "__main__.__l1_default__.calldata": {
+        "full_name": "__main__.__l1_default__.calldata",
+        "cairo_type": "felt*",
+        "references": [
+          {
+            "ap_tracking_data": {
+              "offset": 0,
+              "group": 19
+            },
+            "pc": 217,
+            "value": "[cast(fp + (-3), felt**)]"
+          }
+        ],
+        "type": "reference"
+      },
+      "__main__.__l1_default__.calldata_size": {
+        "full_name": "__main__.__l1_default__.calldata_size",
+        "cairo_type": "felt",
+        "references": [
+          {
+            "ap_tracking_data": {
+              "offset": 0,
+              "group": 19
+            },
+            "pc": 217,
+            "value": "[cast(fp + (-4), felt*)]"
+          }
+        ],
+        "type": "reference"
+      },
+      "__main__.__l1_default__.class_hash": {
+        "full_name": "__main__.__l1_default__.class_hash",
+        "cairo_type": "felt",
+        "references": [
+          {
+            "ap_tracking_data": {
+              "offset": 28,
+              "group": 19
+            },
+            "pc": 222,
+            "value": "[cast(ap + (-1), felt*)]"
+          }
+        ],
+        "type": "reference"
+      },
+      "__main__.__l1_default__.pedersen_ptr": {
+        "full_name": "__main__.__l1_default__.pedersen_ptr",
+        "cairo_type": "starkware.cairo.common.cairo_builtins.HashBuiltin*",
+        "references": [
+          {
+            "ap_tracking_data": {
+              "offset": 0,
+              "group": 19
+            },
+            "pc": 217,
+            "value": "[cast(fp + (-7), starkware.cairo.common.cairo_builtins.HashBuiltin**)]"
+          },
+          {
+            "ap_tracking_data": {
+              "offset": 28,
+              "group": 19
+            },
+            "pc": 222,
+            "value": "[cast(ap + (-3), starkware.cairo.common.cairo_builtins.HashBuiltin**)]"
+          }
+        ],
+        "type": "reference"
+      },
+      "__main__.__l1_default__.range_check_ptr": {
+        "full_name": "__main__.__l1_default__.range_check_ptr",
+        "cairo_type": "felt",
+        "references": [
+          {
+            "ap_tracking_data": {
+              "offset": 0,
+              "group": 19
+            },
+            "pc": 217,
+            "value": "[cast(fp + (-6), felt*)]"
+          },
+          {
+            "ap_tracking_data": {
+              "offset": 28,
+              "group": 19
+            },
+            "pc": 222,
+            "value": "[cast(ap + (-2), felt*)]"
+          }
+        ],
+        "type": "reference"
+      },
+      "__main__.__l1_default__.selector": {
+        "full_name": "__main__.__l1_default__.selector",
+        "cairo_type": "felt",
+        "references": [
+          {
+            "ap_tracking_data": {
+              "offset": 0,
+              "group": 19
+            },
+            "pc": 217,
+            "value": "[cast(fp + (-5), felt*)]"
+          }
+        ],
+        "type": "reference"
+      },
+      "__main__.__l1_default__.syscall_ptr": {
+        "full_name": "__main__.__l1_default__.syscall_ptr",
+        "cairo_type": "felt*",
+        "references": [
+          {
+            "ap_tracking_data": {
+              "offset": 0,
+              "group": 19
+            },
+            "pc": 217,
+            "value": "[cast(fp + (-8), felt**)]"
+          },
+          {
+            "ap_tracking_data": {
+              "offset": 28,
+              "group": 19
+            },
+            "pc": 222,
+            "value": "[cast(ap + (-4), felt**)]"
+          },
+          {
+            "ap_tracking_data": {
+              "offset": 39,
+              "group": 19
+            },
+            "pc": 229,
+            "value": "[cast(ap + (-3), felt**)]"
+          }
+        ],
+        "type": "reference"
+      },
+      "__main__.constructor": {
+        "pc": 136,
+        "decorators": [
+          "constructor"
+        ],
+        "type": "function"
+      },
+      "__main__.constructor.Args": {
+        "full_name": "__main__.constructor.Args",
+        "members": {
+          "implementation_hash": {
+            "cairo_type": "felt",
+            "offset": 0
+          },
+          "selector": {
+            "cairo_type": "felt",
+            "offset": 1
+          },
+          "calldata_len": {
+            "cairo_type": "felt",
+            "offset": 2
+          },
+          "calldata": {
+            "cairo_type": "felt*",
+            "offset": 3
+          }
+        },
+        "size": 4,
+        "type": "struct"
+      },
+      "__main__.constructor.ImplicitArgs": {
+        "full_name": "__main__.constructor.ImplicitArgs",
+        "members": {
+          "syscall_ptr": {
+            "cairo_type": "felt*",
+            "offset": 0
+          },
+          "pedersen_ptr": {
+            "cairo_type": "starkware.cairo.common.cairo_builtins.HashBuiltin*",
+            "offset": 1
+          },
+          "range_check_ptr": {
+            "cairo_type": "felt",
+            "offset": 2
+          }
+        },
+        "size": 3,
+        "type": "struct"
+      },
+      "__main__.constructor.Return": {
+        "cairo_type": "()",
+        "type": "type_definition"
+      },
+      "__main__.constructor.SIZEOF_LOCALS": {
+        "value": 2,
+        "type": "const"
+      },
+      "__main__.constructor.calldata": {
+        "full_name": "__main__.constructor.calldata",
+        "cairo_type": "felt*",
+        "references": [
+          {
+            "ap_tracking_data": {
+              "offset": 0,
+              "group": 13
+            },
+            "pc": 136,
+            "value": "[cast(fp + (-3), felt**)]"
+          }
+        ],
+        "type": "reference"
+      },
+      "__main__.constructor.calldata_len": {
+        "full_name": "__main__.constructor.calldata_len",
+        "cairo_type": "felt",
+        "references": [
+          {
+            "ap_tracking_data": {
+              "offset": 0,
+              "group": 13
+            },
+            "pc": 136,
+            "value": "[cast(fp + (-4), felt*)]"
+          }
+        ],
+        "type": "reference"
+      },
+      "__main__.constructor.implementation_hash": {
+        "full_name": "__main__.constructor.implementation_hash",
+        "cairo_type": "felt",
+        "references": [
+          {
+            "ap_tracking_data": {
+              "offset": 0,
+              "group": 13
+            },
+            "pc": 136,
+            "value": "[cast(fp + (-6), felt*)]"
+          }
+        ],
+        "type": "reference"
+      },
+      "__main__.constructor.pedersen_ptr": {
+        "full_name": "__main__.constructor.pedersen_ptr",
+        "cairo_type": "starkware.cairo.common.cairo_builtins.HashBuiltin*",
+        "references": [
+          {
+            "ap_tracking_data": {
+              "offset": 0,
+              "group": 13
+            },
+            "pc": 136,
+            "value": "[cast(fp + (-8), starkware.cairo.common.cairo_builtins.HashBuiltin**)]"
+          },
+          {
+            "ap_tracking_data": {
+              "offset": 59,
+              "group": 13
+            },
+            "pc": 144,
+            "value": "[cast(ap + (-2), starkware.cairo.common.cairo_builtins.HashBuiltin**)]"
+          },
+          {
+            "ap_tracking_data": {
+              "offset": 61,
+              "group": 13
+            },
+            "pc": 144,
+            "value": "[cast(ap + (-2), starkware.cairo.common.cairo_builtins.HashBuiltin**)]"
+          },
+          {
+            "ap_tracking_data": {
+              "offset": 61,
+              "group": 13
+            },
+            "pc": 145,
+            "value": "[cast(fp, starkware.cairo.common.cairo_builtins.HashBuiltin**)]"
+          }
+        ],
+        "type": "reference"
+      },
+      "__main__.constructor.range_check_ptr": {
+        "full_name": "__main__.constructor.range_check_ptr",
+        "cairo_type": "felt",
+        "references": [
+          {
+            "ap_tracking_data": {
+              "offset": 0,
+              "group": 13
+            },
+            "pc": 136,
+            "value": "[cast(fp + (-7), felt*)]"
+          },
+          {
+            "ap_tracking_data": {
+              "offset": 59,
+              "group": 13
+            },
+            "pc": 144,
+            "value": "[cast(ap + (-1), felt*)]"
+          },
+          {
+            "ap_tracking_data": {
+              "offset": 61,
+              "group": 13
+            },
+            "pc": 144,
+            "value": "[cast(ap + (-1), felt*)]"
+          },
+          {
+            "ap_tracking_data": {
+              "offset": 61,
+              "group": 13
+            },
+            "pc": 146,
+            "value": "[cast(fp + 1, felt*)]"
+          }
+        ],
+        "type": "reference"
+      },
+      "__main__.constructor.selector": {
+        "full_name": "__main__.constructor.selector",
+        "cairo_type": "felt",
+        "references": [
+          {
+            "ap_tracking_data": {
+              "offset": 0,
+              "group": 13
+            },
+            "pc": 136,
+            "value": "[cast(fp + (-5), felt*)]"
+          }
+        ],
+        "type": "reference"
+      },
+      "__main__.constructor.syscall_ptr": {
+        "full_name": "__main__.constructor.syscall_ptr",
+        "cairo_type": "felt*",
+        "references": [
+          {
+            "ap_tracking_data": {
+              "offset": 0,
+              "group": 13
+            },
+            "pc": 136,
+            "value": "[cast(fp + (-9), felt**)]"
+          },
+          {
+            "ap_tracking_data": {
+              "offset": 59,
+              "group": 13
+            },
+            "pc": 144,
+            "value": "[cast(ap + (-3), felt**)]"
+          },
+          {
+            "ap_tracking_data": {
+              "offset": 70,
+              "group": 13
+            },
+            "pc": 155,
+            "value": "[cast(ap + (-3), felt**)]"
+          },
+          {
+            "ap_tracking_data": {
+              "offset": 61,
+              "group": 13
+            },
+            "pc": 144,
+            "value": "[cast(ap + (-3), felt**)]"
+          },
+          {
+            "ap_tracking_data": {
+              "offset": 72,
+              "group": 13
+            },
+            "pc": 157,
+            "value": "[cast(ap + (-3), felt**)]"
+          }
+        ],
+        "type": "reference"
+      },
+      "__main__.library_call": {
+        "destination": "starkware.starknet.common.syscalls.library_call",
+        "type": "alias"
+      },
+      "__main__.library_call_l1_handler": {
+        "destination": "starkware.starknet.common.syscalls.library_call_l1_handler",
+        "type": "alias"
+      },
+      "__wrappers__.__default__": {
+        "pc": 208,
+        "decorators": [
+          "external",
+          "raw_input",
+          "raw_output"
+        ],
+        "type": "function"
+      },
+      "__wrappers__.__default__.Args": {
+        "full_name": "__wrappers__.__default__.Args",
+        "members": {},
+        "size": 0,
+        "type": "struct"
+      },
+      "__wrappers__.__default__.ImplicitArgs": {
+        "full_name": "__wrappers__.__default__.ImplicitArgs",
+        "members": {},
+        "size": 0,
+        "type": "struct"
+      },
+      "__wrappers__.__default__.Return": {
+        "cairo_type": "(syscall_ptr: felt*, pedersen_ptr: starkware.cairo.common.cairo_builtins.HashBuiltin*, range_check_ptr: felt, size: felt, retdata: felt*)",
+        "type": "type_definition"
+      },
+      "__wrappers__.__default__.SIZEOF_LOCALS": {
+        "value": 0,
+        "type": "const"
+      },
+      "__wrappers__.__default__.__wrapped_func": {
+        "destination": "__main__.__default__",
+        "type": "alias"
+      },
+      "__wrappers__.__default__.pedersen_ptr": {
+        "full_name": "__wrappers__.__default__.pedersen_ptr",
+        "cairo_type": "starkware.cairo.common.cairo_builtins.HashBuiltin*",
+        "references": [
+          {
+            "ap_tracking_data": {
+              "offset": 0,
+              "group": 18
+            },
+            "pc": 208,
+            "value": "[cast([fp + (-5)] + 1, starkware.cairo.common.cairo_builtins.HashBuiltin**)]"
+          },
+          {
+            "ap_tracking_data": {
+              "offset": 52,
+              "group": 18
+            },
+            "pc": 216,
+            "value": "[cast(ap + (-4), starkware.cairo.common.cairo_builtins.HashBuiltin**)]"
+          }
+        ],
+        "type": "reference"
+      },
+      "__wrappers__.__default__.range_check_ptr": {
+        "full_name": "__wrappers__.__default__.range_check_ptr",
+        "cairo_type": "felt",
+        "references": [
+          {
+            "ap_tracking_data": {
+              "offset": 0,
+              "group": 18
+            },
+            "pc": 208,
+            "value": "[cast([fp + (-5)] + 2, felt*)]"
+          },
+          {
+            "ap_tracking_data": {
+              "offset": 52,
+              "group": 18
+            },
+            "pc": 216,
+            "value": "[cast(ap + (-3), felt*)]"
+          }
+        ],
+        "type": "reference"
+      },
+      "__wrappers__.__default__.ret_value": {
+        "full_name": "__wrappers__.__default__.ret_value",
+        "cairo_type": "(retdata_size: felt, retdata: felt*)",
+        "references": [
+          {
+            "ap_tracking_data": {
+              "offset": 52,
+              "group": 18
+            },
+            "pc": 216,
+            "value": "[cast(ap + (-2), (retdata_size: felt, retdata: felt*)*)]"
+          }
+        ],
+        "type": "reference"
+      },
+      "__wrappers__.__default__.retdata": {
+        "full_name": "__wrappers__.__default__.retdata",
+        "cairo_type": "felt*",
+        "references": [
+          {
+            "ap_tracking_data": {
+              "offset": 52,
+              "group": 18
+            },
+            "pc": 216,
+            "value": "[cast(ap + (-1), felt**)]"
+          }
+        ],
+        "type": "reference"
+      },
+      "__wrappers__.__default__.retdata_size": {
+        "full_name": "__wrappers__.__default__.retdata_size",
+        "cairo_type": "felt",
+        "references": [
+          {
+            "ap_tracking_data": {
+              "offset": 52,
+              "group": 18
+            },
+            "pc": 216,
+            "value": "[cast(ap + (-2), felt*)]"
+          }
+        ],
+        "type": "reference"
+      },
+      "__wrappers__.__default__.syscall_ptr": {
+        "full_name": "__wrappers__.__default__.syscall_ptr",
+        "cairo_type": "felt*",
+        "references": [
+          {
+            "ap_tracking_data": {
+              "offset": 0,
+              "group": 18
+            },
+            "pc": 208,
+            "value": "[cast([fp + (-5)], felt**)]"
+          },
+          {
+            "ap_tracking_data": {
+              "offset": 52,
+              "group": 18
+            },
+            "pc": 216,
+            "value": "[cast(ap + (-5), felt**)]"
+          }
+        ],
+        "type": "reference"
+      },
+      "__wrappers__.__default___encode_return.memcpy": {
+        "destination": "starkware.cairo.common.memcpy.memcpy",
+        "type": "alias"
+      },
+      "__wrappers__.__l1_default__": {
+        "pc": 233,
+        "decorators": [
+          "l1_handler",
+          "raw_input"
+        ],
+        "type": "function"
+      },
+      "__wrappers__.__l1_default__.Args": {
+        "full_name": "__wrappers__.__l1_default__.Args",
+        "members": {},
+        "size": 0,
+        "type": "struct"
+      },
+      "__wrappers__.__l1_default__.ImplicitArgs": {
+        "full_name": "__wrappers__.__l1_default__.ImplicitArgs",
+        "members": {},
+        "size": 0,
+        "type": "struct"
+      },
+      "__wrappers__.__l1_default__.Return": {
+        "cairo_type": "(syscall_ptr: felt*, pedersen_ptr: starkware.cairo.common.cairo_builtins.HashBuiltin*, range_check_ptr: felt, size: felt, retdata: felt*)",
+        "type": "type_definition"
+      },
+      "__wrappers__.__l1_default__.SIZEOF_LOCALS": {
+        "value": 0,
+        "type": "const"
+      },
+      "__wrappers__.__l1_default__.__wrapped_func": {
+        "destination": "__main__.__l1_default__",
+        "type": "alias"
+      },
+      "__wrappers__.__l1_default__.pedersen_ptr": {
+        "full_name": "__wrappers__.__l1_default__.pedersen_ptr",
+        "cairo_type": "starkware.cairo.common.cairo_builtins.HashBuiltin*",
+        "references": [
+          {
+            "ap_tracking_data": {
+              "offset": 0,
+              "group": 20
+            },
+            "pc": 233,
+            "value": "[cast([fp + (-5)] + 1, starkware.cairo.common.cairo_builtins.HashBuiltin**)]"
+          },
+          {
+            "ap_tracking_data": {
+              "offset": 50,
+              "group": 20
+            },
+            "pc": 241,
+            "value": "[cast(ap + (-2), starkware.cairo.common.cairo_builtins.HashBuiltin**)]"
+          }
+        ],
+        "type": "reference"
+      },
+      "__wrappers__.__l1_default__.range_check_ptr": {
+        "full_name": "__wrappers__.__l1_default__.range_check_ptr",
+        "cairo_type": "felt",
+        "references": [
+          {
+            "ap_tracking_data": {
+              "offset": 0,
+              "group": 20
+            },
+            "pc": 233,
+            "value": "[cast([fp + (-5)] + 2, felt*)]"
+          },
+          {
+            "ap_tracking_data": {
+              "offset": 50,
+              "group": 20
+            },
+            "pc": 241,
+            "value": "[cast(ap + (-1), felt*)]"
+          }
+        ],
+        "type": "reference"
+      },
+      "__wrappers__.__l1_default__.ret_value": {
+        "full_name": "__wrappers__.__l1_default__.ret_value",
+        "cairo_type": "()",
+        "references": [
+          {
+            "ap_tracking_data": {
+              "offset": 50,
+              "group": 20
+            },
+            "pc": 241,
+            "value": "[cast(ap + 0, ()*)]"
+          }
+        ],
+        "type": "reference"
+      },
+      "__wrappers__.__l1_default__.retdata": {
+        "full_name": "__wrappers__.__l1_default__.retdata",
+        "cairo_type": "felt*",
+        "references": [
+          {
+            "ap_tracking_data": {
+              "offset": 51,
+              "group": 20
+            },
+            "pc": 243,
+            "value": "[cast(ap + (-1), felt**)]"
+          }
+        ],
+        "type": "reference"
+      },
+      "__wrappers__.__l1_default__.retdata_size": {
+        "full_name": "__wrappers__.__l1_default__.retdata_size",
+        "cairo_type": "felt",
+        "references": [
+          {
+            "ap_tracking_data": {
+              "offset": 51,
+              "group": 20
+            },
+            "pc": 243,
+            "value": "cast(0, felt)"
+          }
+        ],
+        "type": "reference"
+      },
+      "__wrappers__.__l1_default__.syscall_ptr": {
+        "full_name": "__wrappers__.__l1_default__.syscall_ptr",
+        "cairo_type": "felt*",
+        "references": [
+          {
+            "ap_tracking_data": {
+              "offset": 0,
+              "group": 20
+            },
+            "pc": 233,
+            "value": "[cast([fp + (-5)], felt**)]"
+          },
+          {
+            "ap_tracking_data": {
+              "offset": 50,
+              "group": 20
+            },
+            "pc": 241,
+            "value": "[cast(ap + (-3), felt**)]"
+          }
+        ],
+        "type": "reference"
+      },
+      "__wrappers__.__l1_default___encode_return.memcpy": {
+        "destination": "starkware.cairo.common.memcpy.memcpy",
+        "type": "alias"
+      },
+      "__wrappers__.constructor": {
+        "pc": 161,
+        "decorators": [
+          "constructor"
+        ],
+        "type": "function"
+      },
+      "__wrappers__.constructor.Args": {
+        "full_name": "__wrappers__.constructor.Args",
+        "members": {},
+        "size": 0,
+        "type": "struct"
+      },
+      "__wrappers__.constructor.ImplicitArgs": {
+        "full_name": "__wrappers__.constructor.ImplicitArgs",
+        "members": {},
+        "size": 0,
+        "type": "struct"
+      },
+      "__wrappers__.constructor.Return": {
+        "cairo_type": "(syscall_ptr: felt*, pedersen_ptr: starkware.cairo.common.cairo_builtins.HashBuiltin*, range_check_ptr: felt, size: felt, retdata: felt*)",
+        "type": "type_definition"
+      },
+      "__wrappers__.constructor.SIZEOF_LOCALS": {
+        "value": 0,
+        "type": "const"
+      },
+      "__wrappers__.constructor.__calldata_actual_size": {
+        "full_name": "__wrappers__.constructor.__calldata_actual_size",
+        "cairo_type": "felt",
+        "references": [
+          {
+            "ap_tracking_data": {
+              "offset": 5,
+              "group": 15
+            },
+            "pc": 168,
+            "value": "cast([ap + (-1)] - [fp + (-3)], felt)"
+          }
+        ],
+        "type": "reference"
+      },
+      "__wrappers__.constructor.__calldata_arg_calldata": {
+        "full_name": "__wrappers__.constructor.__calldata_arg_calldata",
+        "cairo_type": "felt*",
+        "references": [
+          {
+            "ap_tracking_data": {
+              "offset": 2,
+              "group": 15
+            },
+            "pc": 164,
+            "value": "cast([fp + (-3)] + 3, felt*)"
+          }
+        ],
+        "type": "reference"
+      },
+      "__wrappers__.constructor.__calldata_arg_calldata_len": {
+        "full_name": "__wrappers__.constructor.__calldata_arg_calldata_len",
+        "cairo_type": "felt",
+        "references": [
+          {
+            "ap_tracking_data": {
+              "offset": 0,
+              "group": 15
+            },
+            "pc": 161,
+            "value": "[cast([fp + (-3)] + 2, felt*)]"
+          }
+        ],
+        "type": "reference"
+      },
+      "__wrappers__.constructor.__calldata_arg_implementation_hash": {
+        "full_name": "__wrappers__.constructor.__calldata_arg_implementation_hash",
+        "cairo_type": "felt",
+        "references": [
+          {
+            "ap_tracking_data": {
+              "offset": 0,
+              "group": 15
+            },
+            "pc": 161,
+            "value": "[cast([fp + (-3)], felt*)]"
+          }
+        ],
+        "type": "reference"
+      },
+      "__wrappers__.constructor.__calldata_arg_selector": {
+        "full_name": "__wrappers__.constructor.__calldata_arg_selector",
+        "cairo_type": "felt",
+        "references": [
+          {
+            "ap_tracking_data": {
+              "offset": 0,
+              "group": 15
+            },
+            "pc": 161,
+            "value": "[cast([fp + (-3)] + 1, felt*)]"
+          }
+        ],
+        "type": "reference"
+      },
+      "__wrappers__.constructor.__calldata_ptr": {
+        "full_name": "__wrappers__.constructor.__calldata_ptr",
+        "cairo_type": "felt*",
+        "references": [
+          {
+            "ap_tracking_data": {
+              "offset": 0,
+              "group": 15
+            },
+            "pc": 161,
+            "value": "[cast(fp + (-3), felt**)]"
+          },
+          {
+            "ap_tracking_data": {
+              "offset": 0,
+              "group": 15
+            },
+            "pc": 161,
+            "value": "cast([fp + (-3)] + 1, felt*)"
+          },
+          {
+            "ap_tracking_data": {
+              "offset": 0,
+              "group": 15
+            },
+            "pc": 161,
+            "value": "cast([fp + (-3)] + 2, felt*)"
+          },
+          {
+            "ap_tracking_data": {
+              "offset": 0,
+              "group": 15
+            },
+            "pc": 161,
+            "value": "cast([fp + (-3)] + 3, felt*)"
+          },
+          {
+            "ap_tracking_data": {
+              "offset": 5,
+              "group": 15
+            },
+            "pc": 168,
+            "value": "[cast(ap + (-1), felt**)]"
+          }
+        ],
+        "type": "reference"
+      },
+      "__wrappers__.constructor.__temp10": {
+        "full_name": "__wrappers__.constructor.__temp10",
+        "cairo_type": "felt",
+        "references": [
+          {
+            "ap_tracking_data": {
+              "offset": 4,
+              "group": 15
+            },
+            "pc": 167,
+            "value": "[cast(ap + (-1), felt*)]"
+          }
+        ],
+        "type": "reference"
+      },
+      "__wrappers__.constructor.__temp11": {
+        "full_name": "__wrappers__.constructor.__temp11",
+        "cairo_type": "felt",
+        "references": [
+          {
+            "ap_tracking_data": {
+              "offset": 6,
+              "group": 15
+            },
+            "pc": 170,
+            "value": "[cast(ap + (-1), felt*)]"
+          }
+        ],
+        "type": "reference"
+      },
+      "__wrappers__.constructor.__temp7": {
+        "full_name": "__wrappers__.constructor.__temp7",
+        "cairo_type": "felt",
+        "references": [
+          {
+            "ap_tracking_data": {
+              "offset": 1,
+              "group": 15
+            },
+            "pc": 162,
+            "value": "[cast(ap + (-1), felt*)]"
+          }
+        ],
+        "type": "reference"
+      },
+      "__wrappers__.constructor.__temp8": {
+        "full_name": "__wrappers__.constructor.__temp8",
+        "cairo_type": "felt",
+        "references": [
+          {
+            "ap_tracking_data": {
+              "offset": 2,
+              "group": 15
+            },
+            "pc": 163,
+            "value": "[cast(ap + (-1), felt*)]"
+          }
+        ],
+        "type": "reference"
+      },
+      "__wrappers__.constructor.__temp9": {
+        "full_name": "__wrappers__.constructor.__temp9",
+        "cairo_type": "felt",
+        "references": [
+          {
+            "ap_tracking_data": {
+              "offset": 3,
+              "group": 15
+            },
+            "pc": 166,
+            "value": "[cast(ap + (-1), felt*)]"
+          }
+        ],
+        "type": "reference"
+      },
+      "__wrappers__.constructor.__wrapped_func": {
+        "destination": "__main__.constructor",
+        "type": "alias"
+      },
+      "__wrappers__.constructor.pedersen_ptr": {
+        "full_name": "__wrappers__.constructor.pedersen_ptr",
+        "cairo_type": "starkware.cairo.common.cairo_builtins.HashBuiltin*",
+        "references": [
+          {
+            "ap_tracking_data": {
+              "offset": 0,
+              "group": 15
+            },
+            "pc": 161,
+            "value": "[cast([fp + (-5)] + 1, starkware.cairo.common.cairo_builtins.HashBuiltin**)]"
+          },
+          {
+            "ap_tracking_data": {
+              "offset": 0,
+              "group": 16
+            },
+            "pc": 181,
+            "value": "[cast(ap + (-2), starkware.cairo.common.cairo_builtins.HashBuiltin**)]"
+          }
+        ],
+        "type": "reference"
+      },
+      "__wrappers__.constructor.range_check_ptr": {
+        "full_name": "__wrappers__.constructor.range_check_ptr",
+        "cairo_type": "felt",
+        "references": [
+          {
+            "ap_tracking_data": {
+              "offset": 0,
+              "group": 15
+            },
+            "pc": 161,
+            "value": "[cast([fp + (-5)] + 2, felt*)]"
+          },
+          {
+            "ap_tracking_data": {
+              "offset": 2,
+              "group": 15
+            },
+            "pc": 164,
+            "value": "cast([[fp + (-5)] + 2] + 1, felt)"
+          },
+          {
+            "ap_tracking_data": {
+              "offset": 0,
+              "group": 16
+            },
+            "pc": 181,
+            "value": "[cast(ap + (-1), felt*)]"
+          }
+        ],
+        "type": "reference"
+      },
+      "__wrappers__.constructor.ret_value": {
+        "full_name": "__wrappers__.constructor.ret_value",
+        "cairo_type": "()",
+        "references": [
+          {
+            "ap_tracking_data": {
+              "offset": 0,
+              "group": 16
+            },
+            "pc": 181,
+            "value": "[cast(ap + 0, ()*)]"
+          }
+        ],
+        "type": "reference"
+      },
+      "__wrappers__.constructor.retdata": {
+        "full_name": "__wrappers__.constructor.retdata",
+        "cairo_type": "felt*",
+        "references": [
+          {
+            "ap_tracking_data": {
+              "offset": 1,
+              "group": 16
+            },
+            "pc": 183,
+            "value": "[cast(ap + (-1), felt**)]"
+          }
+        ],
+        "type": "reference"
+      },
+      "__wrappers__.constructor.retdata_size": {
+        "full_name": "__wrappers__.constructor.retdata_size",
+        "cairo_type": "felt",
+        "references": [
+          {
+            "ap_tracking_data": {
+              "offset": 1,
+              "group": 16
+            },
+            "pc": 183,
+            "value": "cast(0, felt)"
+          }
+        ],
+        "type": "reference"
+      },
+      "__wrappers__.constructor.syscall_ptr": {
+        "full_name": "__wrappers__.constructor.syscall_ptr",
+        "cairo_type": "felt*",
+        "references": [
+          {
+            "ap_tracking_data": {
+              "offset": 0,
+              "group": 15
+            },
+            "pc": 161,
+            "value": "[cast([fp + (-5)], felt**)]"
+          },
+          {
+            "ap_tracking_data": {
+              "offset": 0,
+              "group": 16
+            },
+            "pc": 181,
+            "value": "[cast(ap + (-3), felt**)]"
+          }
+        ],
+        "type": "reference"
+      },
+      "__wrappers__.constructor_encode_return.memcpy": {
+        "destination": "starkware.cairo.common.memcpy.memcpy",
+        "type": "alias"
+      },
+      "cairo_contracts.src.openzeppelin.upgrades.library.AdminChanged": {
+        "type": "namespace"
+      },
+      "cairo_contracts.src.openzeppelin.upgrades.library.AdminChanged.Args": {
+        "full_name": "cairo_contracts.src.openzeppelin.upgrades.library.AdminChanged.Args",
+        "members": {},
+        "size": 0,
+        "type": "struct"
+      },
+      "cairo_contracts.src.openzeppelin.upgrades.library.AdminChanged.ImplicitArgs": {
+        "full_name": "cairo_contracts.src.openzeppelin.upgrades.library.AdminChanged.ImplicitArgs",
+        "members": {},
+        "size": 0,
+        "type": "struct"
+      },
+      "cairo_contracts.src.openzeppelin.upgrades.library.AdminChanged.Return": {
+        "cairo_type": "()",
+        "type": "type_definition"
+      },
+      "cairo_contracts.src.openzeppelin.upgrades.library.AdminChanged.SELECTOR": {
+        "value": 5.095494176482239e+74,
+        "type": "const"
+      },
+      "cairo_contracts.src.openzeppelin.upgrades.library.AdminChanged.SIZEOF_LOCALS": {
+        "value": 0,
+        "type": "const"
+      },
+      "cairo_contracts.src.openzeppelin.upgrades.library.AdminChanged.alloc": {
+        "destination": "starkware.cairo.common.alloc.alloc",
+        "type": "alias"
+      },
+      "cairo_contracts.src.openzeppelin.upgrades.library.AdminChanged.emit_event": {
+        "destination": "starkware.starknet.common.syscalls.emit_event",
+        "type": "alias"
+      },
+      "cairo_contracts.src.openzeppelin.upgrades.library.AdminChanged.memcpy": {
+        "destination": "starkware.cairo.common.memcpy.memcpy",
+        "type": "alias"
+      },
+      "cairo_contracts.src.openzeppelin.upgrades.library.FALSE": {
+        "destination": "starkware.cairo.common.bool.FALSE",
+        "type": "alias"
+      },
+      "cairo_contracts.src.openzeppelin.upgrades.library.HashBuiltin": {
+        "destination": "starkware.cairo.common.cairo_builtins.HashBuiltin",
+        "type": "alias"
+      },
+      "cairo_contracts.src.openzeppelin.upgrades.library.Proxy": {
+        "type": "namespace"
+      },
+      "cairo_contracts.src.openzeppelin.upgrades.library.Proxy.Args": {
+        "full_name": "cairo_contracts.src.openzeppelin.upgrades.library.Proxy.Args",
+        "members": {},
+        "size": 0,
+        "type": "struct"
+      },
+      "cairo_contracts.src.openzeppelin.upgrades.library.Proxy.ImplicitArgs": {
+        "full_name": "cairo_contracts.src.openzeppelin.upgrades.library.Proxy.ImplicitArgs",
+        "members": {},
+        "size": 0,
+        "type": "struct"
+      },
+      "cairo_contracts.src.openzeppelin.upgrades.library.Proxy.Return": {
+        "cairo_type": "()",
+        "type": "type_definition"
+      },
+      "cairo_contracts.src.openzeppelin.upgrades.library.Proxy.SIZEOF_LOCALS": {
+        "value": 0,
+        "type": "const"
+      },
+      "cairo_contracts.src.openzeppelin.upgrades.library.Proxy._set_implementation_hash": {
+        "pc": 118,
+        "decorators": [],
+        "type": "function"
+      },
+      "cairo_contracts.src.openzeppelin.upgrades.library.Proxy._set_implementation_hash.Args": {
+        "full_name": "cairo_contracts.src.openzeppelin.upgrades.library.Proxy._set_implementation_hash.Args",
+        "members": {
+          "new_implementation": {
+            "cairo_type": "felt",
+            "offset": 0
+          }
+        },
+        "size": 1,
+        "type": "struct"
+      },
+      "cairo_contracts.src.openzeppelin.upgrades.library.Proxy._set_implementation_hash.ImplicitArgs": {
+        "full_name": "cairo_contracts.src.openzeppelin.upgrades.library.Proxy._set_implementation_hash.ImplicitArgs",
+        "members": {
+          "syscall_ptr": {
+            "cairo_type": "felt*",
+            "offset": 0
+          },
+          "pedersen_ptr": {
+            "cairo_type": "starkware.cairo.common.cairo_builtins.HashBuiltin*",
+            "offset": 1
+          },
+          "range_check_ptr": {
+            "cairo_type": "felt",
+            "offset": 2
+          }
+        },
+        "size": 3,
+        "type": "struct"
+      },
+      "cairo_contracts.src.openzeppelin.upgrades.library.Proxy._set_implementation_hash.Return": {
+        "cairo_type": "()",
+        "type": "type_definition"
+      },
+      "cairo_contracts.src.openzeppelin.upgrades.library.Proxy._set_implementation_hash.SIZEOF_LOCALS": {
+        "value": 0,
+        "type": "const"
+      },
+      "cairo_contracts.src.openzeppelin.upgrades.library.Proxy._set_implementation_hash.new_implementation": {
+        "full_name": "cairo_contracts.src.openzeppelin.upgrades.library.Proxy._set_implementation_hash.new_implementation",
+        "cairo_type": "felt",
+        "references": [
+          {
+            "ap_tracking_data": {
+              "offset": 0,
+              "group": 12
+            },
+            "pc": 118,
+            "value": "[cast(fp + (-3), felt*)]"
+          }
+        ],
+        "type": "reference"
+      },
+      "cairo_contracts.src.openzeppelin.upgrades.library.Proxy._set_implementation_hash.pedersen_ptr": {
+        "full_name": "cairo_contracts.src.openzeppelin.upgrades.library.Proxy._set_implementation_hash.pedersen_ptr",
+        "cairo_type": "starkware.cairo.common.cairo_builtins.HashBuiltin*",
+        "references": [
+          {
+            "ap_tracking_data": {
+              "offset": 0,
+              "group": 12
+            },
+            "pc": 118,
+            "value": "[cast(fp + (-5), starkware.cairo.common.cairo_builtins.HashBuiltin**)]"
+          },
+          {
+            "ap_tracking_data": {
+              "offset": 25,
+              "group": 12
+            },
+            "pc": 127,
+            "value": "[cast(ap + (-2), starkware.cairo.common.cairo_builtins.HashBuiltin**)]"
+          }
+        ],
+        "type": "reference"
+      },
+      "cairo_contracts.src.openzeppelin.upgrades.library.Proxy._set_implementation_hash.range_check_ptr": {
+        "full_name": "cairo_contracts.src.openzeppelin.upgrades.library.Proxy._set_implementation_hash.range_check_ptr",
+        "cairo_type": "felt",
+        "references": [
+          {
+            "ap_tracking_data": {
+              "offset": 0,
+              "group": 12
+            },
+            "pc": 118,
+            "value": "[cast(fp + (-4), felt*)]"
+          },
+          {
+            "ap_tracking_data": {
+              "offset": 25,
+              "group": 12
+            },
+            "pc": 127,
+            "value": "[cast(ap + (-1), felt*)]"
+          },
+          {
+            "ap_tracking_data": {
+              "offset": 50,
+              "group": 12
+            },
+            "pc": 132,
+            "value": "[cast(ap + (-1), felt*)]"
+          }
+        ],
+        "type": "reference"
+      },
+      "cairo_contracts.src.openzeppelin.upgrades.library.Proxy._set_implementation_hash.syscall_ptr": {
+        "full_name": "cairo_contracts.src.openzeppelin.upgrades.library.Proxy._set_implementation_hash.syscall_ptr",
+        "cairo_type": "felt*",
+        "references": [
+          {
+            "ap_tracking_data": {
+              "offset": 0,
+              "group": 12
+            },
+            "pc": 118,
+            "value": "[cast(fp + (-6), felt**)]"
+          },
+          {
+            "ap_tracking_data": {
+              "offset": 25,
+              "group": 12
+            },
+            "pc": 127,
+            "value": "[cast(ap + (-3), felt**)]"
+          },
+          {
+            "ap_tracking_data": {
+              "offset": 50,
+              "group": 12
+            },
+            "pc": 132,
+            "value": "[cast(ap + (-2), felt**)]"
+          }
+        ],
+        "type": "reference"
+      },
+      "cairo_contracts.src.openzeppelin.upgrades.library.Proxy.get_implementation_hash": {
+        "pc": 112,
+        "decorators": [],
+        "type": "function"
+      },
+      "cairo_contracts.src.openzeppelin.upgrades.library.Proxy.get_implementation_hash.Args": {
+        "full_name": "cairo_contracts.src.openzeppelin.upgrades.library.Proxy.get_implementation_hash.Args",
+        "members": {},
+        "size": 0,
+        "type": "struct"
+      },
+      "cairo_contracts.src.openzeppelin.upgrades.library.Proxy.get_implementation_hash.ImplicitArgs": {
+        "full_name": "cairo_contracts.src.openzeppelin.upgrades.library.Proxy.get_implementation_hash.ImplicitArgs",
+        "members": {
+          "syscall_ptr": {
+            "cairo_type": "felt*",
+            "offset": 0
+          },
+          "pedersen_ptr": {
+            "cairo_type": "starkware.cairo.common.cairo_builtins.HashBuiltin*",
+            "offset": 1
+          },
+          "range_check_ptr": {
+            "cairo_type": "felt",
+            "offset": 2
+          }
+        },
+        "size": 3,
+        "type": "struct"
+      },
+      "cairo_contracts.src.openzeppelin.upgrades.library.Proxy.get_implementation_hash.Return": {
+        "cairo_type": "(implementation: felt)",
+        "type": "type_definition"
+      },
+      "cairo_contracts.src.openzeppelin.upgrades.library.Proxy.get_implementation_hash.SIZEOF_LOCALS": {
+        "value": 0,
+        "type": "const"
+      },
+      "cairo_contracts.src.openzeppelin.upgrades.library.Proxy.get_implementation_hash.pedersen_ptr": {
+        "full_name": "cairo_contracts.src.openzeppelin.upgrades.library.Proxy.get_implementation_hash.pedersen_ptr",
+        "cairo_type": "starkware.cairo.common.cairo_builtins.HashBuiltin*",
+        "references": [
+          {
+            "ap_tracking_data": {
+              "offset": 0,
+              "group": 11
+            },
+            "pc": 112,
+            "value": "[cast(fp + (-4), starkware.cairo.common.cairo_builtins.HashBuiltin**)]"
+          },
+          {
+            "ap_tracking_data": {
+              "offset": 23,
+              "group": 11
+            },
+            "pc": 117,
+            "value": "[cast(ap + (-3), starkware.cairo.common.cairo_builtins.HashBuiltin**)]"
+          }
+        ],
+        "type": "reference"
+      },
+      "cairo_contracts.src.openzeppelin.upgrades.library.Proxy.get_implementation_hash.range_check_ptr": {
+        "full_name": "cairo_contracts.src.openzeppelin.upgrades.library.Proxy.get_implementation_hash.range_check_ptr",
+        "cairo_type": "felt",
+        "references": [
+          {
+            "ap_tracking_data": {
+              "offset": 0,
+              "group": 11
+            },
+            "pc": 112,
+            "value": "[cast(fp + (-3), felt*)]"
+          },
+          {
+            "ap_tracking_data": {
+              "offset": 23,
+              "group": 11
+            },
+            "pc": 117,
+            "value": "[cast(ap + (-2), felt*)]"
+          }
+        ],
+        "type": "reference"
+      },
+      "cairo_contracts.src.openzeppelin.upgrades.library.Proxy.get_implementation_hash.syscall_ptr": {
+        "full_name": "cairo_contracts.src.openzeppelin.upgrades.library.Proxy.get_implementation_hash.syscall_ptr",
+        "cairo_type": "felt*",
+        "references": [
+          {
+            "ap_tracking_data": {
+              "offset": 0,
+              "group": 11
+            },
+            "pc": 112,
+            "value": "[cast(fp + (-5), felt**)]"
+          },
+          {
+            "ap_tracking_data": {
+              "offset": 23,
+              "group": 11
+            },
+            "pc": 117,
+            "value": "[cast(ap + (-4), felt**)]"
+          }
+        ],
+        "type": "reference"
+      },
+      "cairo_contracts.src.openzeppelin.upgrades.library.Proxy_admin": {
+        "type": "namespace"
+      },
+      "cairo_contracts.src.openzeppelin.upgrades.library.Proxy_admin.Args": {
+        "full_name": "cairo_contracts.src.openzeppelin.upgrades.library.Proxy_admin.Args",
+        "members": {},
+        "size": 0,
+        "type": "struct"
+      },
+      "cairo_contracts.src.openzeppelin.upgrades.library.Proxy_admin.HashBuiltin": {
+        "destination": "starkware.cairo.common.cairo_builtins.HashBuiltin",
+        "type": "alias"
+      },
+      "cairo_contracts.src.openzeppelin.upgrades.library.Proxy_admin.ImplicitArgs": {
+        "full_name": "cairo_contracts.src.openzeppelin.upgrades.library.Proxy_admin.ImplicitArgs",
+        "members": {},
+        "size": 0,
+        "type": "struct"
+      },
+      "cairo_contracts.src.openzeppelin.upgrades.library.Proxy_admin.Return": {
+        "cairo_type": "()",
+        "type": "type_definition"
+      },
+      "cairo_contracts.src.openzeppelin.upgrades.library.Proxy_admin.SIZEOF_LOCALS": {
+        "value": 0,
+        "type": "const"
+      },
+      "cairo_contracts.src.openzeppelin.upgrades.library.Proxy_admin.hash2": {
+        "destination": "starkware.cairo.common.hash.hash2",
+        "type": "alias"
+      },
+      "cairo_contracts.src.openzeppelin.upgrades.library.Proxy_admin.normalize_address": {
+        "destination": "starkware.starknet.common.storage.normalize_address",
+        "type": "alias"
+      },
+      "cairo_contracts.src.openzeppelin.upgrades.library.Proxy_admin.storage_read": {
+        "destination": "starkware.starknet.common.syscalls.storage_read",
+        "type": "alias"
+      },
+      "cairo_contracts.src.openzeppelin.upgrades.library.Proxy_admin.storage_write": {
+        "destination": "starkware.starknet.common.syscalls.storage_write",
+        "type": "alias"
+      },
+      "cairo_contracts.src.openzeppelin.upgrades.library.Proxy_implementation_hash": {
+        "type": "namespace"
+      },
+      "cairo_contracts.src.openzeppelin.upgrades.library.Proxy_implementation_hash.Args": {
+        "full_name": "cairo_contracts.src.openzeppelin.upgrades.library.Proxy_implementation_hash.Args",
+        "members": {},
+        "size": 0,
+        "type": "struct"
+      },
+      "cairo_contracts.src.openzeppelin.upgrades.library.Proxy_implementation_hash.HashBuiltin": {
+        "destination": "starkware.cairo.common.cairo_builtins.HashBuiltin",
+        "type": "alias"
+      },
+      "cairo_contracts.src.openzeppelin.upgrades.library.Proxy_implementation_hash.ImplicitArgs": {
+        "full_name": "cairo_contracts.src.openzeppelin.upgrades.library.Proxy_implementation_hash.ImplicitArgs",
+        "members": {},
+        "size": 0,
+        "type": "struct"
+      },
+      "cairo_contracts.src.openzeppelin.upgrades.library.Proxy_implementation_hash.Return": {
+        "cairo_type": "()",
+        "type": "type_definition"
+      },
+      "cairo_contracts.src.openzeppelin.upgrades.library.Proxy_implementation_hash.SIZEOF_LOCALS": {
+        "value": 0,
+        "type": "const"
+      },
+      "cairo_contracts.src.openzeppelin.upgrades.library.Proxy_implementation_hash.addr": {
+        "pc": 82,
+        "decorators": [],
+        "type": "function"
+      },
+      "cairo_contracts.src.openzeppelin.upgrades.library.Proxy_implementation_hash.addr.Args": {
+        "full_name": "cairo_contracts.src.openzeppelin.upgrades.library.Proxy_implementation_hash.addr.Args",
+        "members": {},
+        "size": 0,
+        "type": "struct"
+      },
+      "cairo_contracts.src.openzeppelin.upgrades.library.Proxy_implementation_hash.addr.ImplicitArgs": {
+        "full_name": "cairo_contracts.src.openzeppelin.upgrades.library.Proxy_implementation_hash.addr.ImplicitArgs",
+        "members": {
+          "pedersen_ptr": {
+            "cairo_type": "starkware.cairo.common.cairo_builtins.HashBuiltin*",
+            "offset": 0
+          },
+          "range_check_ptr": {
+            "cairo_type": "felt",
+            "offset": 1
+          }
+        },
+        "size": 2,
+        "type": "struct"
+      },
+      "cairo_contracts.src.openzeppelin.upgrades.library.Proxy_implementation_hash.addr.Return": {
+        "cairo_type": "(res: felt)",
+        "type": "type_definition"
+      },
+      "cairo_contracts.src.openzeppelin.upgrades.library.Proxy_implementation_hash.addr.SIZEOF_LOCALS": {
+        "value": 0,
+        "type": "const"
+      },
+      "cairo_contracts.src.openzeppelin.upgrades.library.Proxy_implementation_hash.addr.pedersen_ptr": {
+        "full_name": "cairo_contracts.src.openzeppelin.upgrades.library.Proxy_implementation_hash.addr.pedersen_ptr",
+        "cairo_type": "starkware.cairo.common.cairo_builtins.HashBuiltin*",
+        "references": [
+          {
+            "ap_tracking_data": {
+              "offset": 0,
+              "group": 8
+            },
+            "pc": 82,
+            "value": "[cast(fp + (-4), starkware.cairo.common.cairo_builtins.HashBuiltin**)]"
+          }
+        ],
+        "type": "reference"
+      },
+      "cairo_contracts.src.openzeppelin.upgrades.library.Proxy_implementation_hash.addr.range_check_ptr": {
+        "full_name": "cairo_contracts.src.openzeppelin.upgrades.library.Proxy_implementation_hash.addr.range_check_ptr",
+        "cairo_type": "felt",
+        "references": [
+          {
+            "ap_tracking_data": {
+              "offset": 0,
+              "group": 8
+            },
+            "pc": 82,
+            "value": "[cast(fp + (-3), felt*)]"
+          }
+        ],
+        "type": "reference"
+      },
+      "cairo_contracts.src.openzeppelin.upgrades.library.Proxy_implementation_hash.addr.res": {
+        "full_name": "cairo_contracts.src.openzeppelin.upgrades.library.Proxy_implementation_hash.addr.res",
+        "cairo_type": "felt",
+        "references": [
+          {
+            "ap_tracking_data": {
+              "offset": 0,
+              "group": 8
+            },
+            "pc": 82,
+            "value": "cast(1783935019461685855687084032167085762428877981963606680389089912112530844880, felt)"
+          }
+        ],
+        "type": "reference"
+      },
+      "cairo_contracts.src.openzeppelin.upgrades.library.Proxy_implementation_hash.hash2": {
+        "destination": "starkware.cairo.common.hash.hash2",
+        "type": "alias"
+      },
+      "cairo_contracts.src.openzeppelin.upgrades.library.Proxy_implementation_hash.normalize_address": {
+        "destination": "starkware.starknet.common.storage.normalize_address",
+        "type": "alias"
+      },
+      "cairo_contracts.src.openzeppelin.upgrades.library.Proxy_implementation_hash.read": {
+        "pc": 87,
+        "decorators": [],
+        "type": "function"
+      },
+      "cairo_contracts.src.openzeppelin.upgrades.library.Proxy_implementation_hash.read.Args": {
+        "full_name": "cairo_contracts.src.openzeppelin.upgrades.library.Proxy_implementation_hash.read.Args",
+        "members": {},
+        "size": 0,
+        "type": "struct"
+      },
+      "cairo_contracts.src.openzeppelin.upgrades.library.Proxy_implementation_hash.read.ImplicitArgs": {
+        "full_name": "cairo_contracts.src.openzeppelin.upgrades.library.Proxy_implementation_hash.read.ImplicitArgs",
+        "members": {
+          "syscall_ptr": {
+            "cairo_type": "felt*",
+            "offset": 0
+          },
+          "pedersen_ptr": {
+            "cairo_type": "starkware.cairo.common.cairo_builtins.HashBuiltin*",
+            "offset": 1
+          },
+          "range_check_ptr": {
+            "cairo_type": "felt",
+            "offset": 2
+          }
+        },
+        "size": 3,
+        "type": "struct"
+      },
+      "cairo_contracts.src.openzeppelin.upgrades.library.Proxy_implementation_hash.read.Return": {
+        "cairo_type": "(implementation: felt)",
+        "type": "type_definition"
+      },
+      "cairo_contracts.src.openzeppelin.upgrades.library.Proxy_implementation_hash.read.SIZEOF_LOCALS": {
+        "value": 0,
+        "type": "const"
+      },
+      "cairo_contracts.src.openzeppelin.upgrades.library.Proxy_implementation_hash.read.__storage_var_temp0": {
+        "full_name": "cairo_contracts.src.openzeppelin.upgrades.library.Proxy_implementation_hash.read.__storage_var_temp0",
+        "cairo_type": "felt",
+        "references": [
+          {
+            "ap_tracking_data": {
+              "offset": 14,
+              "group": 9
+            },
+            "pc": 95,
+            "value": "[cast(ap + (-1), felt*)]"
+          },
+          {
+            "ap_tracking_data": {
+              "offset": 18,
+              "group": 9
+            },
+            "pc": 99,
+            "value": "[cast(ap + (-1), felt*)]"
+          }
+        ],
+        "type": "reference"
+      },
+      "cairo_contracts.src.openzeppelin.upgrades.library.Proxy_implementation_hash.read.pedersen_ptr": {
+        "full_name": "cairo_contracts.src.openzeppelin.upgrades.library.Proxy_implementation_hash.read.pedersen_ptr",
+        "cairo_type": "starkware.cairo.common.cairo_builtins.HashBuiltin*",
+        "references": [
+          {
+            "ap_tracking_data": {
+              "offset": 0,
+              "group": 9
+            },
+            "pc": 87,
+            "value": "[cast(fp + (-4), starkware.cairo.common.cairo_builtins.HashBuiltin**)]"
+          },
+          {
+            "ap_tracking_data": {
+              "offset": 7,
+              "group": 9
+            },
+            "pc": 91,
+            "value": "[cast(ap + (-3), starkware.cairo.common.cairo_builtins.HashBuiltin**)]"
+          },
+          {
+            "ap_tracking_data": {
+              "offset": 16,
+              "group": 9
+            },
+            "pc": 97,
+            "value": "[cast(ap + (-1), starkware.cairo.common.cairo_builtins.HashBuiltin**)]"
+          }
+        ],
+        "type": "reference"
+      },
+      "cairo_contracts.src.openzeppelin.upgrades.library.Proxy_implementation_hash.read.range_check_ptr": {
+        "full_name": "cairo_contracts.src.openzeppelin.upgrades.library.Proxy_implementation_hash.read.range_check_ptr",
+        "cairo_type": "felt",
+        "references": [
+          {
+            "ap_tracking_data": {
+              "offset": 0,
+              "group": 9
+            },
+            "pc": 87,
+            "value": "[cast(fp + (-3), felt*)]"
+          },
+          {
+            "ap_tracking_data": {
+              "offset": 7,
+              "group": 9
+            },
+            "pc": 91,
+            "value": "[cast(ap + (-2), felt*)]"
+          },
+          {
+            "ap_tracking_data": {
+              "offset": 17,
+              "group": 9
+            },
+            "pc": 98,
+            "value": "[cast(ap + (-1), felt*)]"
+          }
+        ],
+        "type": "reference"
+      },
+      "cairo_contracts.src.openzeppelin.upgrades.library.Proxy_implementation_hash.read.storage_addr": {
+        "full_name": "cairo_contracts.src.openzeppelin.upgrades.library.Proxy_implementation_hash.read.storage_addr",
+        "cairo_type": "felt",
+        "references": [
+          {
+            "ap_tracking_data": {
+              "offset": 7,
+              "group": 9
+            },
+            "pc": 91,
+            "value": "[cast(ap + (-1), felt*)]"
+          }
+        ],
+        "type": "reference"
+      },
+      "cairo_contracts.src.openzeppelin.upgrades.library.Proxy_implementation_hash.read.syscall_ptr": {
+        "full_name": "cairo_contracts.src.openzeppelin.upgrades.library.Proxy_implementation_hash.read.syscall_ptr",
+        "cairo_type": "felt*",
+        "references": [
+          {
+            "ap_tracking_data": {
+              "offset": 0,
+              "group": 9
+            },
+            "pc": 87,
+            "value": "[cast(fp + (-5), felt**)]"
+          },
+          {
+            "ap_tracking_data": {
+              "offset": 14,
+              "group": 9
+            },
+            "pc": 95,
+            "value": "[cast(ap + (-2), felt**)]"
+          },
+          {
+            "ap_tracking_data": {
+              "offset": 15,
+              "group": 9
+            },
+            "pc": 96,
+            "value": "[cast(ap + (-1), felt**)]"
+          }
+        ],
+        "type": "reference"
+      },
+      "cairo_contracts.src.openzeppelin.upgrades.library.Proxy_implementation_hash.storage_read": {
+        "destination": "starkware.starknet.common.syscalls.storage_read",
+        "type": "alias"
+      },
+      "cairo_contracts.src.openzeppelin.upgrades.library.Proxy_implementation_hash.storage_write": {
+        "destination": "starkware.starknet.common.syscalls.storage_write",
+        "type": "alias"
+      },
+      "cairo_contracts.src.openzeppelin.upgrades.library.Proxy_implementation_hash.write": {
+        "pc": 100,
+        "decorators": [],
+        "type": "function"
+      },
+      "cairo_contracts.src.openzeppelin.upgrades.library.Proxy_implementation_hash.write.Args": {
+        "full_name": "cairo_contracts.src.openzeppelin.upgrades.library.Proxy_implementation_hash.write.Args",
+        "members": {
+          "value": {
+            "cairo_type": "felt",
+            "offset": 0
+          }
+        },
+        "size": 1,
+        "type": "struct"
+      },
+      "cairo_contracts.src.openzeppelin.upgrades.library.Proxy_implementation_hash.write.ImplicitArgs": {
+        "full_name": "cairo_contracts.src.openzeppelin.upgrades.library.Proxy_implementation_hash.write.ImplicitArgs",
+        "members": {
+          "syscall_ptr": {
+            "cairo_type": "felt*",
+            "offset": 0
+          },
+          "pedersen_ptr": {
+            "cairo_type": "starkware.cairo.common.cairo_builtins.HashBuiltin*",
+            "offset": 1
+          },
+          "range_check_ptr": {
+            "cairo_type": "felt",
+            "offset": 2
+          }
+        },
+        "size": 3,
+        "type": "struct"
+      },
+      "cairo_contracts.src.openzeppelin.upgrades.library.Proxy_implementation_hash.write.Return": {
+        "cairo_type": "()",
+        "type": "type_definition"
+      },
+      "cairo_contracts.src.openzeppelin.upgrades.library.Proxy_implementation_hash.write.SIZEOF_LOCALS": {
+        "value": 0,
+        "type": "const"
+      },
+      "cairo_contracts.src.openzeppelin.upgrades.library.Proxy_implementation_hash.write.pedersen_ptr": {
+        "full_name": "cairo_contracts.src.openzeppelin.upgrades.library.Proxy_implementation_hash.write.pedersen_ptr",
+        "cairo_type": "starkware.cairo.common.cairo_builtins.HashBuiltin*",
+        "references": [
+          {
+            "ap_tracking_data": {
+              "offset": 0,
+              "group": 10
+            },
+            "pc": 100,
+            "value": "[cast(fp + (-5), starkware.cairo.common.cairo_builtins.HashBuiltin**)]"
+          },
+          {
+            "ap_tracking_data": {
+              "offset": 7,
+              "group": 10
+            },
+            "pc": 104,
+            "value": "[cast(ap + (-3), starkware.cairo.common.cairo_builtins.HashBuiltin**)]"
+          }
+        ],
+        "type": "reference"
+      },
+      "cairo_contracts.src.openzeppelin.upgrades.library.Proxy_implementation_hash.write.range_check_ptr": {
+        "full_name": "cairo_contracts.src.openzeppelin.upgrades.library.Proxy_implementation_hash.write.range_check_ptr",
+        "cairo_type": "felt",
+        "references": [
+          {
+            "ap_tracking_data": {
+              "offset": 0,
+              "group": 10
+            },
+            "pc": 100,
+            "value": "[cast(fp + (-4), felt*)]"
+          },
+          {
+            "ap_tracking_data": {
+              "offset": 7,
+              "group": 10
+            },
+            "pc": 104,
+            "value": "[cast(ap + (-2), felt*)]"
+          }
+        ],
+        "type": "reference"
+      },
+      "cairo_contracts.src.openzeppelin.upgrades.library.Proxy_implementation_hash.write.storage_addr": {
+        "full_name": "cairo_contracts.src.openzeppelin.upgrades.library.Proxy_implementation_hash.write.storage_addr",
+        "cairo_type": "felt",
+        "references": [
+          {
+            "ap_tracking_data": {
+              "offset": 7,
+              "group": 10
+            },
+            "pc": 104,
+            "value": "[cast(ap + (-1), felt*)]"
+          }
+        ],
+        "type": "reference"
+      },
+      "cairo_contracts.src.openzeppelin.upgrades.library.Proxy_implementation_hash.write.syscall_ptr": {
+        "full_name": "cairo_contracts.src.openzeppelin.upgrades.library.Proxy_implementation_hash.write.syscall_ptr",
+        "cairo_type": "felt*",
+        "references": [
+          {
+            "ap_tracking_data": {
+              "offset": 0,
+              "group": 10
+            },
+            "pc": 100,
+            "value": "[cast(fp + (-6), felt**)]"
+          },
+          {
+            "ap_tracking_data": {
+              "offset": 14,
+              "group": 10
+            },
+            "pc": 109,
+            "value": "[cast(ap + (-1), felt**)]"
+          }
+        ],
+        "type": "reference"
+      },
+      "cairo_contracts.src.openzeppelin.upgrades.library.Proxy_implementation_hash.write.value": {
+        "full_name": "cairo_contracts.src.openzeppelin.upgrades.library.Proxy_implementation_hash.write.value",
+        "cairo_type": "felt",
+        "references": [
+          {
+            "ap_tracking_data": {
+              "offset": 0,
+              "group": 10
+            },
+            "pc": 100,
+            "value": "[cast(fp + (-3), felt*)]"
+          }
+        ],
+        "type": "reference"
+      },
+      "cairo_contracts.src.openzeppelin.upgrades.library.Proxy_initialized": {
+        "type": "namespace"
+      },
+      "cairo_contracts.src.openzeppelin.upgrades.library.Proxy_initialized.Args": {
+        "full_name": "cairo_contracts.src.openzeppelin.upgrades.library.Proxy_initialized.Args",
+        "members": {},
+        "size": 0,
+        "type": "struct"
+      },
+      "cairo_contracts.src.openzeppelin.upgrades.library.Proxy_initialized.HashBuiltin": {
+        "destination": "starkware.cairo.common.cairo_builtins.HashBuiltin",
+        "type": "alias"
+      },
+      "cairo_contracts.src.openzeppelin.upgrades.library.Proxy_initialized.ImplicitArgs": {
+        "full_name": "cairo_contracts.src.openzeppelin.upgrades.library.Proxy_initialized.ImplicitArgs",
+        "members": {},
+        "size": 0,
+        "type": "struct"
+      },
+      "cairo_contracts.src.openzeppelin.upgrades.library.Proxy_initialized.Return": {
+        "cairo_type": "()",
+        "type": "type_definition"
+      },
+      "cairo_contracts.src.openzeppelin.upgrades.library.Proxy_initialized.SIZEOF_LOCALS": {
+        "value": 0,
+        "type": "const"
+      },
+      "cairo_contracts.src.openzeppelin.upgrades.library.Proxy_initialized.hash2": {
+        "destination": "starkware.cairo.common.hash.hash2",
+        "type": "alias"
+      },
+      "cairo_contracts.src.openzeppelin.upgrades.library.Proxy_initialized.normalize_address": {
+        "destination": "starkware.starknet.common.storage.normalize_address",
+        "type": "alias"
+      },
+      "cairo_contracts.src.openzeppelin.upgrades.library.Proxy_initialized.storage_read": {
+        "destination": "starkware.starknet.common.syscalls.storage_read",
+        "type": "alias"
+      },
+      "cairo_contracts.src.openzeppelin.upgrades.library.Proxy_initialized.storage_write": {
+        "destination": "starkware.starknet.common.syscalls.storage_write",
+        "type": "alias"
+      },
+      "cairo_contracts.src.openzeppelin.upgrades.library.TRUE": {
+        "destination": "starkware.cairo.common.bool.TRUE",
+        "type": "alias"
+      },
+      "cairo_contracts.src.openzeppelin.upgrades.library.Upgraded": {
+        "type": "namespace"
+      },
+      "cairo_contracts.src.openzeppelin.upgrades.library.Upgraded.Args": {
+        "full_name": "cairo_contracts.src.openzeppelin.upgrades.library.Upgraded.Args",
+        "members": {},
+        "size": 0,
+        "type": "struct"
+      },
+      "cairo_contracts.src.openzeppelin.upgrades.library.Upgraded.ImplicitArgs": {
+        "full_name": "cairo_contracts.src.openzeppelin.upgrades.library.Upgraded.ImplicitArgs",
+        "members": {},
+        "size": 0,
+        "type": "struct"
+      },
+      "cairo_contracts.src.openzeppelin.upgrades.library.Upgraded.Return": {
+        "cairo_type": "()",
+        "type": "type_definition"
+      },
+      "cairo_contracts.src.openzeppelin.upgrades.library.Upgraded.SELECTOR": {
+        "value": 1.291924484015742e+75,
+        "type": "const"
+      },
+      "cairo_contracts.src.openzeppelin.upgrades.library.Upgraded.SIZEOF_LOCALS": {
+        "value": 0,
+        "type": "const"
+      },
+      "cairo_contracts.src.openzeppelin.upgrades.library.Upgraded.alloc": {
+        "destination": "starkware.cairo.common.alloc.alloc",
+        "type": "alias"
+      },
+      "cairo_contracts.src.openzeppelin.upgrades.library.Upgraded.emit": {
+        "pc": 58,
+        "decorators": [],
+        "type": "function"
+      },
+      "cairo_contracts.src.openzeppelin.upgrades.library.Upgraded.emit.Args": {
+        "full_name": "cairo_contracts.src.openzeppelin.upgrades.library.Upgraded.emit.Args",
+        "members": {
+          "implementation": {
+            "cairo_type": "felt",
+            "offset": 0
+          }
+        },
+        "size": 1,
+        "type": "struct"
+      },
+      "cairo_contracts.src.openzeppelin.upgrades.library.Upgraded.emit.ImplicitArgs": {
+        "full_name": "cairo_contracts.src.openzeppelin.upgrades.library.Upgraded.emit.ImplicitArgs",
+        "members": {
+          "syscall_ptr": {
+            "cairo_type": "felt*",
+            "offset": 0
+          },
+          "range_check_ptr": {
+            "cairo_type": "felt",
+            "offset": 1
+          }
+        },
+        "size": 2,
+        "type": "struct"
+      },
+      "cairo_contracts.src.openzeppelin.upgrades.library.Upgraded.emit.Return": {
+        "cairo_type": "()",
+        "type": "type_definition"
+      },
+      "cairo_contracts.src.openzeppelin.upgrades.library.Upgraded.emit.SIZEOF_LOCALS": {
+        "value": 2,
+        "type": "const"
+      },
+      "cairo_contracts.src.openzeppelin.upgrades.library.Upgraded.emit.__calldata_ptr": {
+        "full_name": "cairo_contracts.src.openzeppelin.upgrades.library.Upgraded.emit.__calldata_ptr",
+        "cairo_type": "felt*",
+        "references": [
+          {
+            "ap_tracking_data": {
+              "offset": 9,
+              "group": 7
+            },
+            "pc": 69,
+            "value": "[cast(fp + 1, felt**)]"
+          },
+          {
+            "ap_tracking_data": {
+              "offset": 9,
+              "group": 7
+            },
+            "pc": 70,
+            "value": "cast([fp + 1] + 1, felt*)"
+          }
+        ],
+        "type": "reference"
+      },
+      "cairo_contracts.src.openzeppelin.upgrades.library.Upgraded.emit.__data_ptr": {
+        "full_name": "cairo_contracts.src.openzeppelin.upgrades.library.Upgraded.emit.__data_ptr",
+        "cairo_type": "felt*",
+        "references": [
+          {
+            "ap_tracking_data": {
+              "offset": 9,
+              "group": 7
+            },
+            "pc": 68,
+            "value": "[cast(ap + (-1), felt**)]"
+          },
+          {
+            "ap_tracking_data": {
+              "offset": 9,
+              "group": 7
+            },
+            "pc": 69,
+            "value": "[cast(fp + 1, felt**)]"
+          }
+        ],
+        "type": "reference"
+      },
+      "cairo_contracts.src.openzeppelin.upgrades.library.Upgraded.emit.__keys_ptr": {
+        "full_name": "cairo_contracts.src.openzeppelin.upgrades.library.Upgraded.emit.__keys_ptr",
+        "cairo_type": "felt*",
+        "references": [
+          {
+            "ap_tracking_data": {
+              "offset": 5,
+              "group": 7
+            },
+            "pc": 62,
+            "value": "[cast(ap + (-1), felt**)]"
+          },
+          {
+            "ap_tracking_data": {
+              "offset": 5,
+              "group": 7
+            },
+            "pc": 63,
+            "value": "[cast(fp, felt**)]"
+          }
+        ],
+        "type": "reference"
+      },
+      "cairo_contracts.src.openzeppelin.upgrades.library.Upgraded.emit.__temp5": {
+        "full_name": "cairo_contracts.src.openzeppelin.upgrades.library.Upgraded.emit.__temp5",
+        "cairo_type": "felt",
+        "references": [
+          {
+            "ap_tracking_data": {
+              "offset": 6,
+              "group": 7
+            },
+            "pc": 65,
+            "value": "[cast(ap + (-1), felt*)]"
+          }
+        ],
+        "type": "reference"
+      },
+      "cairo_contracts.src.openzeppelin.upgrades.library.Upgraded.emit.__temp6": {
+        "full_name": "cairo_contracts.src.openzeppelin.upgrades.library.Upgraded.emit.__temp6",
+        "cairo_type": "felt",
+        "references": [
+          {
+            "ap_tracking_data": {
+              "offset": 10,
+              "group": 7
+            },
+            "pc": 72,
+            "value": "[cast(ap + (-1), felt*)]"
+          }
+        ],
+        "type": "reference"
+      },
+      "cairo_contracts.src.openzeppelin.upgrades.library.Upgraded.emit.implementation": {
+        "full_name": "cairo_contracts.src.openzeppelin.upgrades.library.Upgraded.emit.implementation",
+        "cairo_type": "felt",
+        "references": [
+          {
+            "ap_tracking_data": {
+              "offset": 0,
+              "group": 7
+            },
+            "pc": 58,
+            "value": "[cast(fp + (-3), felt*)]"
+          }
+        ],
+        "type": "reference"
+      },
+      "cairo_contracts.src.openzeppelin.upgrades.library.Upgraded.emit.range_check_ptr": {
+        "full_name": "cairo_contracts.src.openzeppelin.upgrades.library.Upgraded.emit.range_check_ptr",
+        "cairo_type": "felt",
+        "references": [
+          {
+            "ap_tracking_data": {
+              "offset": 0,
+              "group": 7
+            },
+            "pc": 58,
+            "value": "[cast(fp + (-4), felt*)]"
+          }
+        ],
+        "type": "reference"
+      },
+      "cairo_contracts.src.openzeppelin.upgrades.library.Upgraded.emit.syscall_ptr": {
+        "full_name": "cairo_contracts.src.openzeppelin.upgrades.library.Upgraded.emit.syscall_ptr",
+        "cairo_type": "felt*",
+        "references": [
+          {
+            "ap_tracking_data": {
+              "offset": 0,
+              "group": 7
+            },
+            "pc": 58,
+            "value": "[cast(fp + (-5), felt**)]"
+          },
+          {
+            "ap_tracking_data": {
+              "offset": 19,
+              "group": 7
+            },
+            "pc": 80,
+            "value": "[cast(ap + (-1), felt**)]"
+          }
+        ],
+        "type": "reference"
+      },
+      "cairo_contracts.src.openzeppelin.upgrades.library.Upgraded.emit_event": {
+        "destination": "starkware.starknet.common.syscalls.emit_event",
+        "type": "alias"
+      },
+      "cairo_contracts.src.openzeppelin.upgrades.library.Upgraded.memcpy": {
+        "destination": "starkware.cairo.common.memcpy.memcpy",
+        "type": "alias"
+      },
+      "cairo_contracts.src.openzeppelin.upgrades.library.assert_not_zero": {
+        "destination": "starkware.cairo.common.math.assert_not_zero",
+        "type": "alias"
+      },
+      "cairo_contracts.src.openzeppelin.upgrades.library.get_caller_address": {
+        "destination": "starkware.starknet.common.syscalls.get_caller_address",
+        "type": "alias"
+      },
+      "starkware.cairo.common.alloc.alloc": {
+        "pc": 0,
+        "decorators": [],
+        "type": "function"
+      },
+      "starkware.cairo.common.alloc.alloc.Args": {
+        "full_name": "starkware.cairo.common.alloc.alloc.Args",
+        "members": {},
+        "size": 0,
+        "type": "struct"
+      },
+      "starkware.cairo.common.alloc.alloc.ImplicitArgs": {
+        "full_name": "starkware.cairo.common.alloc.alloc.ImplicitArgs",
+        "members": {},
+        "size": 0,
+        "type": "struct"
+      },
+      "starkware.cairo.common.alloc.alloc.Return": {
+        "cairo_type": "(ptr: felt*)",
+        "type": "type_definition"
+      },
+      "starkware.cairo.common.alloc.alloc.SIZEOF_LOCALS": {
+        "value": 0,
+        "type": "const"
+      },
+      "starkware.cairo.common.bool.FALSE": {
+        "value": 0,
+        "type": "const"
+      },
+      "starkware.cairo.common.bool.TRUE": {
+        "value": 1,
+        "type": "const"
+      },
+      "starkware.cairo.common.cairo_builtins.BitwiseBuiltin": {
+        "full_name": "starkware.cairo.common.cairo_builtins.BitwiseBuiltin",
+        "members": {
+          "x": {
+            "cairo_type": "felt",
+            "offset": 0
+          },
+          "y": {
+            "cairo_type": "felt",
+            "offset": 1
+          },
+          "x_and_y": {
+            "cairo_type": "felt",
+            "offset": 2
+          },
+          "x_xor_y": {
+            "cairo_type": "felt",
+            "offset": 3
+          },
+          "x_or_y": {
+            "cairo_type": "felt",
+            "offset": 4
+          }
+        },
+        "size": 5,
+        "type": "struct"
+      },
+      "starkware.cairo.common.cairo_builtins.EcOpBuiltin": {
+        "full_name": "starkware.cairo.common.cairo_builtins.EcOpBuiltin",
+        "members": {
+          "p": {
+            "cairo_type": "starkware.cairo.common.ec_point.EcPoint",
+            "offset": 0
+          },
+          "q": {
+            "cairo_type": "starkware.cairo.common.ec_point.EcPoint",
+            "offset": 2
+          },
+          "m": {
+            "cairo_type": "felt",
+            "offset": 4
+          },
+          "r": {
+            "cairo_type": "starkware.cairo.common.ec_point.EcPoint",
+            "offset": 5
+          }
+        },
+        "size": 7,
+        "type": "struct"
+      },
+      "starkware.cairo.common.cairo_builtins.EcPoint": {
+        "destination": "starkware.cairo.common.ec_point.EcPoint",
+        "type": "alias"
+      },
+      "starkware.cairo.common.cairo_builtins.HashBuiltin": {
+        "full_name": "starkware.cairo.common.cairo_builtins.HashBuiltin",
+        "members": {
+          "x": {
+            "cairo_type": "felt",
+            "offset": 0
+          },
+          "y": {
+            "cairo_type": "felt",
+            "offset": 1
+          },
+          "result": {
+            "cairo_type": "felt",
+            "offset": 2
+          }
+        },
+        "size": 3,
+        "type": "struct"
+      },
+      "starkware.cairo.common.cairo_builtins.KeccakBuiltin": {
+        "full_name": "starkware.cairo.common.cairo_builtins.KeccakBuiltin",
+        "members": {
+          "input": {
+            "cairo_type": "starkware.cairo.common.keccak_state.KeccakBuiltinState",
+            "offset": 0
+          },
+          "output": {
+            "cairo_type": "starkware.cairo.common.keccak_state.KeccakBuiltinState",
+            "offset": 8
+          }
+        },
+        "size": 16,
+        "type": "struct"
+      },
+      "starkware.cairo.common.cairo_builtins.KeccakBuiltinState": {
+        "destination": "starkware.cairo.common.keccak_state.KeccakBuiltinState",
+        "type": "alias"
+      },
+      "starkware.cairo.common.cairo_builtins.SignatureBuiltin": {
+        "full_name": "starkware.cairo.common.cairo_builtins.SignatureBuiltin",
+        "members": {
+          "pub_key": {
+            "cairo_type": "felt",
+            "offset": 0
+          },
+          "message": {
+            "cairo_type": "felt",
+            "offset": 1
+          }
+        },
+        "size": 2,
+        "type": "struct"
+      },
+      "starkware.cairo.common.dict_access.DictAccess": {
+        "full_name": "starkware.cairo.common.dict_access.DictAccess",
+        "members": {
+          "key": {
+            "cairo_type": "felt",
+            "offset": 0
+          },
+          "prev_value": {
+            "cairo_type": "felt",
+            "offset": 1
+          },
+          "new_value": {
+            "cairo_type": "felt",
+            "offset": 2
+          }
+        },
+        "size": 3,
+        "type": "struct"
+      },
+      "starkware.cairo.common.ec_point.EcPoint": {
+        "full_name": "starkware.cairo.common.ec_point.EcPoint",
+        "members": {
+          "x": {
+            "cairo_type": "felt",
+            "offset": 0
+          },
+          "y": {
+            "cairo_type": "felt",
+            "offset": 1
+          }
+        },
+        "size": 2,
+        "type": "struct"
+      },
+      "starkware.cairo.common.hash.HashBuiltin": {
+        "destination": "starkware.cairo.common.cairo_builtins.HashBuiltin",
+        "type": "alias"
+      },
+      "starkware.cairo.common.keccak_state.KeccakBuiltinState": {
+        "full_name": "starkware.cairo.common.keccak_state.KeccakBuiltinState",
+        "members": {
+          "s0": {
+            "cairo_type": "felt",
+            "offset": 0
+          },
+          "s1": {
+            "cairo_type": "felt",
+            "offset": 1
+          },
+          "s2": {
+            "cairo_type": "felt",
+            "offset": 2
+          },
+          "s3": {
+            "cairo_type": "felt",
+            "offset": 3
+          },
+          "s4": {
+            "cairo_type": "felt",
+            "offset": 4
+          },
+          "s5": {
+            "cairo_type": "felt",
+            "offset": 5
+          },
+          "s6": {
+            "cairo_type": "felt",
+            "offset": 6
+          },
+          "s7": {
+            "cairo_type": "felt",
+            "offset": 7
+          }
+        },
+        "size": 8,
+        "type": "struct"
+      },
+      "starkware.cairo.common.math.FALSE": {
+        "destination": "starkware.cairo.common.bool.FALSE",
+        "type": "alias"
+      },
+      "starkware.cairo.common.math.TRUE": {
+        "destination": "starkware.cairo.common.bool.TRUE",
+        "type": "alias"
+      },
+      "starkware.cairo.common.math.assert_not_zero": {
+        "pc": 3,
+        "decorators": [],
+        "type": "function"
+      },
+      "starkware.cairo.common.math.assert_not_zero.Args": {
+        "full_name": "starkware.cairo.common.math.assert_not_zero.Args",
+        "members": {
+          "value": {
+            "cairo_type": "felt",
+            "offset": 0
+          }
+        },
+        "size": 1,
+        "type": "struct"
+      },
+      "starkware.cairo.common.math.assert_not_zero.ImplicitArgs": {
+        "full_name": "starkware.cairo.common.math.assert_not_zero.ImplicitArgs",
+        "members": {},
+        "size": 0,
+        "type": "struct"
+      },
+      "starkware.cairo.common.math.assert_not_zero.Return": {
+        "cairo_type": "()",
+        "type": "type_definition"
+      },
+      "starkware.cairo.common.math.assert_not_zero.SIZEOF_LOCALS": {
+        "value": 0,
+        "type": "const"
+      },
+      "starkware.cairo.common.math.assert_not_zero.value": {
+        "full_name": "starkware.cairo.common.math.assert_not_zero.value",
+        "cairo_type": "felt",
+        "references": [
+          {
+            "ap_tracking_data": {
+              "offset": 0,
+              "group": 1
+            },
+            "pc": 3,
+            "value": "[cast(fp + (-3), felt*)]"
+          }
+        ],
+        "type": "reference"
+      },
+      "starkware.starknet.common.storage.ADDR_BOUND": {
+        "value": -1.0671072950157357e+59,
+        "type": "const"
+      },
+      "starkware.starknet.common.storage.MAX_STORAGE_ITEM_SIZE": {
+        "value": 256,
+        "type": "const"
+      },
+      "starkware.starknet.common.storage.assert_250_bit": {
+        "destination": "starkware.cairo.common.math.assert_250_bit",
+        "type": "alias"
+      },
+      "starkware.starknet.common.syscalls.CALL_CONTRACT_SELECTOR": {
+        "value": 2.0853273475220474e+28,
+        "type": "const"
+      },
+      "starkware.starknet.common.syscalls.CallContract": {
+        "full_name": "starkware.starknet.common.syscalls.CallContract",
+        "members": {
+          "request": {
+            "cairo_type": "starkware.starknet.common.syscalls.CallContractRequest",
+            "offset": 0
+          },
+          "response": {
+            "cairo_type": "starkware.starknet.common.syscalls.CallContractResponse",
+            "offset": 5
+          }
+        },
+        "size": 7,
+        "type": "struct"
+      },
+      "starkware.starknet.common.syscalls.CallContractRequest": {
+        "full_name": "starkware.starknet.common.syscalls.CallContractRequest",
+        "members": {
+          "selector": {
+            "cairo_type": "felt",
+            "offset": 0
+          },
+          "contract_address": {
+            "cairo_type": "felt",
+            "offset": 1
+          },
+          "function_selector": {
+            "cairo_type": "felt",
+            "offset": 2
+          },
+          "calldata_size": {
+            "cairo_type": "felt",
+            "offset": 3
+          },
+          "calldata": {
+            "cairo_type": "felt*",
+            "offset": 4
+          }
+        },
+        "size": 5,
+        "type": "struct"
+      },
+      "starkware.starknet.common.syscalls.CallContractResponse": {
+        "full_name": "starkware.starknet.common.syscalls.CallContractResponse",
+        "members": {
+          "retdata_size": {
+            "cairo_type": "felt",
+            "offset": 0
+          },
+          "retdata": {
+            "cairo_type": "felt*",
+            "offset": 1
+          }
+        },
+        "size": 2,
+        "type": "struct"
+      },
+      "starkware.starknet.common.syscalls.DELEGATE_CALL_SELECTOR": {
+        "value": 2.1167594061783206e+28,
+        "type": "const"
+      },
+      "starkware.starknet.common.syscalls.DELEGATE_L1_HANDLER_SELECTOR": {
+        "value": 2.3274015802972845e+40,
+        "type": "const"
+      },
+      "starkware.starknet.common.syscalls.DEPLOY_SELECTOR": {
+        "value": 75202468540281,
+        "type": "const"
+      },
+      "starkware.starknet.common.syscalls.Deploy": {
+        "full_name": "starkware.starknet.common.syscalls.Deploy",
+        "members": {
+          "request": {
+            "cairo_type": "starkware.starknet.common.syscalls.DeployRequest",
+            "offset": 0
+          },
+          "response": {
+            "cairo_type": "starkware.starknet.common.syscalls.DeployResponse",
+            "offset": 6
+          }
+        },
+        "size": 9,
+        "type": "struct"
+      },
+      "starkware.starknet.common.syscalls.DeployRequest": {
+        "full_name": "starkware.starknet.common.syscalls.DeployRequest",
+        "members": {
+          "selector": {
+            "cairo_type": "felt",
+            "offset": 0
+          },
+          "class_hash": {
+            "cairo_type": "felt",
+            "offset": 1
+          },
+          "contract_address_salt": {
+            "cairo_type": "felt",
+            "offset": 2
+          },
+          "constructor_calldata_size": {
+            "cairo_type": "felt",
+            "offset": 3
+          },
+          "constructor_calldata": {
+            "cairo_type": "felt*",
+            "offset": 4
+          },
+          "deploy_from_zero": {
+            "cairo_type": "felt",
+            "offset": 5
+          }
+        },
+        "size": 6,
+        "type": "struct"
+      },
+      "starkware.starknet.common.syscalls.DeployResponse": {
+        "full_name": "starkware.starknet.common.syscalls.DeployResponse",
+        "members": {
+          "contract_address": {
+            "cairo_type": "felt",
+            "offset": 0
+          },
+          "constructor_retdata_size": {
+            "cairo_type": "felt",
+            "offset": 1
+          },
+          "constructor_retdata": {
+            "cairo_type": "felt*",
+            "offset": 2
+          }
+        },
+        "size": 3,
+        "type": "struct"
+      },
+      "starkware.starknet.common.syscalls.DictAccess": {
+        "destination": "starkware.cairo.common.dict_access.DictAccess",
+        "type": "alias"
+      },
+      "starkware.starknet.common.syscalls.EMIT_EVENT_SELECTOR": {
+        "value": 1.2807093015503357e+21,
+        "type": "const"
+      },
+      "starkware.starknet.common.syscalls.EmitEvent": {
+        "full_name": "starkware.starknet.common.syscalls.EmitEvent",
+        "members": {
+          "selector": {
+            "cairo_type": "felt",
+            "offset": 0
+          },
+          "keys_len": {
+            "cairo_type": "felt",
+            "offset": 1
+          },
+          "keys": {
+            "cairo_type": "felt*",
+            "offset": 2
+          },
+          "data_len": {
+            "cairo_type": "felt",
+            "offset": 3
+          },
+          "data": {
+            "cairo_type": "felt*",
+            "offset": 4
+          }
+        },
+        "size": 5,
+        "type": "struct"
+      },
+      "starkware.starknet.common.syscalls.GET_BLOCK_NUMBER_SELECTOR": {
+        "value": 1.448089106835523e+33,
+        "type": "const"
+      },
+      "starkware.starknet.common.syscalls.GET_BLOCK_TIMESTAMP_SELECTOR": {
+        "value": 2.4294903732626647e+40,
+        "type": "const"
+      },
+      "starkware.starknet.common.syscalls.GET_CALLER_ADDRESS_SELECTOR": {
+        "value": 9.490196778139308e+37,
+        "type": "const"
+      },
+      "starkware.starknet.common.syscalls.GET_CONTRACT_ADDRESS_SELECTOR": {
+        "value": 6.219495360805491e+42,
+        "type": "const"
+      },
+      "starkware.starknet.common.syscalls.GET_SEQUENCER_ADDRESS_SELECTOR": {
+        "value": 1.5921908335819916e+45,
+        "type": "const"
+      },
+      "starkware.starknet.common.syscalls.GET_TX_INFO_SELECTOR": {
+        "value": 1.3170293902041122e+21,
+        "type": "const"
+      },
+      "starkware.starknet.common.syscalls.GET_TX_SIGNATURE_SELECTOR": {
+        "value": 1.44808912865234e+33,
+        "type": "const"
+      },
+      "starkware.starknet.common.syscalls.GetBlockNumber": {
+        "full_name": "starkware.starknet.common.syscalls.GetBlockNumber",
+        "members": {
+          "request": {
+            "cairo_type": "starkware.starknet.common.syscalls.GetBlockNumberRequest",
+            "offset": 0
+          },
+          "response": {
+            "cairo_type": "starkware.starknet.common.syscalls.GetBlockNumberResponse",
+            "offset": 1
+          }
+        },
+        "size": 2,
+        "type": "struct"
+      },
+      "starkware.starknet.common.syscalls.GetBlockNumberRequest": {
+        "full_name": "starkware.starknet.common.syscalls.GetBlockNumberRequest",
+        "members": {
+          "selector": {
+            "cairo_type": "felt",
+            "offset": 0
+          }
+        },
+        "size": 1,
+        "type": "struct"
+      },
+      "starkware.starknet.common.syscalls.GetBlockNumberResponse": {
+        "full_name": "starkware.starknet.common.syscalls.GetBlockNumberResponse",
+        "members": {
+          "block_number": {
+            "cairo_type": "felt",
+            "offset": 0
+          }
+        },
+        "size": 1,
+        "type": "struct"
+      },
+      "starkware.starknet.common.syscalls.GetBlockTimestamp": {
+        "full_name": "starkware.starknet.common.syscalls.GetBlockTimestamp",
+        "members": {
+          "request": {
+            "cairo_type": "starkware.starknet.common.syscalls.GetBlockTimestampRequest",
+            "offset": 0
+          },
+          "response": {
+            "cairo_type": "starkware.starknet.common.syscalls.GetBlockTimestampResponse",
+            "offset": 1
+          }
+        },
+        "size": 2,
+        "type": "struct"
+      },
+      "starkware.starknet.common.syscalls.GetBlockTimestampRequest": {
+        "full_name": "starkware.starknet.common.syscalls.GetBlockTimestampRequest",
+        "members": {
+          "selector": {
+            "cairo_type": "felt",
+            "offset": 0
+          }
+        },
+        "size": 1,
+        "type": "struct"
+      },
+      "starkware.starknet.common.syscalls.GetBlockTimestampResponse": {
+        "full_name": "starkware.starknet.common.syscalls.GetBlockTimestampResponse",
+        "members": {
+          "block_timestamp": {
+            "cairo_type": "felt",
+            "offset": 0
+          }
+        },
+        "size": 1,
+        "type": "struct"
+      },
+      "starkware.starknet.common.syscalls.GetCallerAddress": {
+        "full_name": "starkware.starknet.common.syscalls.GetCallerAddress",
+        "members": {
+          "request": {
+            "cairo_type": "starkware.starknet.common.syscalls.GetCallerAddressRequest",
+            "offset": 0
+          },
+          "response": {
+            "cairo_type": "starkware.starknet.common.syscalls.GetCallerAddressResponse",
+            "offset": 1
+          }
+        },
+        "size": 2,
+        "type": "struct"
+      },
+      "starkware.starknet.common.syscalls.GetCallerAddressRequest": {
+        "full_name": "starkware.starknet.common.syscalls.GetCallerAddressRequest",
+        "members": {
+          "selector": {
+            "cairo_type": "felt",
+            "offset": 0
+          }
+        },
+        "size": 1,
+        "type": "struct"
+      },
+      "starkware.starknet.common.syscalls.GetCallerAddressResponse": {
+        "full_name": "starkware.starknet.common.syscalls.GetCallerAddressResponse",
+        "members": {
+          "caller_address": {
+            "cairo_type": "felt",
+            "offset": 0
+          }
+        },
+        "size": 1,
+        "type": "struct"
+      },
+      "starkware.starknet.common.syscalls.GetContractAddress": {
+        "full_name": "starkware.starknet.common.syscalls.GetContractAddress",
+        "members": {
+          "request": {
+            "cairo_type": "starkware.starknet.common.syscalls.GetContractAddressRequest",
+            "offset": 0
+          },
+          "response": {
+            "cairo_type": "starkware.starknet.common.syscalls.GetContractAddressResponse",
+            "offset": 1
+          }
+        },
+        "size": 2,
+        "type": "struct"
+      },
+      "starkware.starknet.common.syscalls.GetContractAddressRequest": {
+        "full_name": "starkware.starknet.common.syscalls.GetContractAddressRequest",
+        "members": {
+          "selector": {
+            "cairo_type": "felt",
+            "offset": 0
+          }
+        },
+        "size": 1,
+        "type": "struct"
+      },
+      "starkware.starknet.common.syscalls.GetContractAddressResponse": {
+        "full_name": "starkware.starknet.common.syscalls.GetContractAddressResponse",
+        "members": {
+          "contract_address": {
+            "cairo_type": "felt",
+            "offset": 0
+          }
+        },
+        "size": 1,
+        "type": "struct"
+      },
+      "starkware.starknet.common.syscalls.GetSequencerAddress": {
+        "full_name": "starkware.starknet.common.syscalls.GetSequencerAddress",
+        "members": {
+          "request": {
+            "cairo_type": "starkware.starknet.common.syscalls.GetSequencerAddressRequest",
+            "offset": 0
+          },
+          "response": {
+            "cairo_type": "starkware.starknet.common.syscalls.GetSequencerAddressResponse",
+            "offset": 1
+          }
+        },
+        "size": 2,
+        "type": "struct"
+      },
+      "starkware.starknet.common.syscalls.GetSequencerAddressRequest": {
+        "full_name": "starkware.starknet.common.syscalls.GetSequencerAddressRequest",
+        "members": {
+          "selector": {
+            "cairo_type": "felt",
+            "offset": 0
+          }
+        },
+        "size": 1,
+        "type": "struct"
+      },
+      "starkware.starknet.common.syscalls.GetSequencerAddressResponse": {
+        "full_name": "starkware.starknet.common.syscalls.GetSequencerAddressResponse",
+        "members": {
+          "sequencer_address": {
+            "cairo_type": "felt",
+            "offset": 0
+          }
+        },
+        "size": 1,
+        "type": "struct"
+      },
+      "starkware.starknet.common.syscalls.GetTxInfo": {
+        "full_name": "starkware.starknet.common.syscalls.GetTxInfo",
+        "members": {
+          "request": {
+            "cairo_type": "starkware.starknet.common.syscalls.GetTxInfoRequest",
+            "offset": 0
+          },
+          "response": {
+            "cairo_type": "starkware.starknet.common.syscalls.GetTxInfoResponse",
+            "offset": 1
+          }
+        },
+        "size": 2,
+        "type": "struct"
+      },
+      "starkware.starknet.common.syscalls.GetTxInfoRequest": {
+        "full_name": "starkware.starknet.common.syscalls.GetTxInfoRequest",
+        "members": {
+          "selector": {
+            "cairo_type": "felt",
+            "offset": 0
+          }
+        },
+        "size": 1,
+        "type": "struct"
+      },
+      "starkware.starknet.common.syscalls.GetTxInfoResponse": {
+        "full_name": "starkware.starknet.common.syscalls.GetTxInfoResponse",
+        "members": {
+          "tx_info": {
+            "cairo_type": "starkware.starknet.common.syscalls.TxInfo*",
+            "offset": 0
+          }
+        },
+        "size": 1,
+        "type": "struct"
+      },
+      "starkware.starknet.common.syscalls.GetTxSignature": {
+        "full_name": "starkware.starknet.common.syscalls.GetTxSignature",
+        "members": {
+          "request": {
+            "cairo_type": "starkware.starknet.common.syscalls.GetTxSignatureRequest",
+            "offset": 0
+          },
+          "response": {
+            "cairo_type": "starkware.starknet.common.syscalls.GetTxSignatureResponse",
+            "offset": 1
+          }
+        },
+        "size": 3,
+        "type": "struct"
+      },
+      "starkware.starknet.common.syscalls.GetTxSignatureRequest": {
+        "full_name": "starkware.starknet.common.syscalls.GetTxSignatureRequest",
+        "members": {
+          "selector": {
+            "cairo_type": "felt",
+            "offset": 0
+          }
+        },
+        "size": 1,
+        "type": "struct"
+      },
+      "starkware.starknet.common.syscalls.GetTxSignatureResponse": {
+        "full_name": "starkware.starknet.common.syscalls.GetTxSignatureResponse",
+        "members": {
+          "signature_len": {
+            "cairo_type": "felt",
+            "offset": 0
+          },
+          "signature": {
+            "cairo_type": "felt*",
+            "offset": 1
+          }
+        },
+        "size": 2,
+        "type": "struct"
+      },
+      "starkware.starknet.common.syscalls.LIBRARY_CALL_L1_HANDLER_SELECTOR": {
+        "value": 4.362334527541981e+47,
+        "type": "const"
+      },
+      "starkware.starknet.common.syscalls.LIBRARY_CALL_SELECTOR": {
+        "value": 9.2376026794327e+25,
+        "type": "const"
+      },
+      "starkware.starknet.common.syscalls.LibraryCall": {
+        "full_name": "starkware.starknet.common.syscalls.LibraryCall",
+        "members": {
+          "request": {
+            "cairo_type": "starkware.starknet.common.syscalls.LibraryCallRequest",
+            "offset": 0
+          },
+          "response": {
+            "cairo_type": "starkware.starknet.common.syscalls.CallContractResponse",
+            "offset": 5
+          }
+        },
+        "size": 7,
+        "type": "struct"
+      },
+      "starkware.starknet.common.syscalls.LibraryCallRequest": {
+        "full_name": "starkware.starknet.common.syscalls.LibraryCallRequest",
+        "members": {
+          "selector": {
+            "cairo_type": "felt",
+            "offset": 0
+          },
+          "class_hash": {
+            "cairo_type": "felt",
+            "offset": 1
+          },
+          "function_selector": {
+            "cairo_type": "felt",
+            "offset": 2
+          },
+          "calldata_size": {
+            "cairo_type": "felt",
+            "offset": 3
+          },
+          "calldata": {
+            "cairo_type": "felt*",
+            "offset": 4
+          }
+        },
+        "size": 5,
+        "type": "struct"
+      },
+      "starkware.starknet.common.syscalls.SEND_MESSAGE_TO_L1_SELECTOR": {
+        "value": 4.3301790876830345e+35,
+        "type": "const"
+      },
+      "starkware.starknet.common.syscalls.STORAGE_READ_SELECTOR": {
+        "value": 1.0089069337060175e+26,
+        "type": "const"
+      },
+      "starkware.starknet.common.syscalls.STORAGE_WRITE_SELECTOR": {
+        "value": 2.582801750287405e+28,
+        "type": "const"
+      },
+      "starkware.starknet.common.syscalls.SendMessageToL1SysCall": {
+        "full_name": "starkware.starknet.common.syscalls.SendMessageToL1SysCall",
+        "members": {
+          "selector": {
+            "cairo_type": "felt",
+            "offset": 0
+          },
+          "to_address": {
+            "cairo_type": "felt",
+            "offset": 1
+          },
+          "payload_size": {
+            "cairo_type": "felt",
+            "offset": 2
+          },
+          "payload_ptr": {
+            "cairo_type": "felt*",
+            "offset": 3
+          }
+        },
+        "size": 4,
+        "type": "struct"
+      },
+      "starkware.starknet.common.syscalls.StorageRead": {
+        "full_name": "starkware.starknet.common.syscalls.StorageRead",
+        "members": {
+          "request": {
+            "cairo_type": "starkware.starknet.common.syscalls.StorageReadRequest",
+            "offset": 0
+          },
+          "response": {
+            "cairo_type": "starkware.starknet.common.syscalls.StorageReadResponse",
+            "offset": 2
+          }
+        },
+        "size": 3,
+        "type": "struct"
+      },
+      "starkware.starknet.common.syscalls.StorageReadRequest": {
+        "full_name": "starkware.starknet.common.syscalls.StorageReadRequest",
+        "members": {
+          "selector": {
+            "cairo_type": "felt",
+            "offset": 0
+          },
+          "address": {
+            "cairo_type": "felt",
+            "offset": 1
+          }
+        },
+        "size": 2,
+        "type": "struct"
+      },
+      "starkware.starknet.common.syscalls.StorageReadResponse": {
+        "full_name": "starkware.starknet.common.syscalls.StorageReadResponse",
+        "members": {
+          "value": {
+            "cairo_type": "felt",
+            "offset": 0
+          }
+        },
+        "size": 1,
+        "type": "struct"
+      },
+      "starkware.starknet.common.syscalls.StorageWrite": {
+        "full_name": "starkware.starknet.common.syscalls.StorageWrite",
+        "members": {
+          "selector": {
+            "cairo_type": "felt",
+            "offset": 0
+          },
+          "address": {
+            "cairo_type": "felt",
+            "offset": 1
+          },
+          "value": {
+            "cairo_type": "felt",
+            "offset": 2
+          }
+        },
+        "size": 3,
+        "type": "struct"
+      },
+      "starkware.starknet.common.syscalls.TxInfo": {
+        "full_name": "starkware.starknet.common.syscalls.TxInfo",
+        "members": {
+          "version": {
+            "cairo_type": "felt",
+            "offset": 0
+          },
+          "account_contract_address": {
+            "cairo_type": "felt",
+            "offset": 1
+          },
+          "max_fee": {
+            "cairo_type": "felt",
+            "offset": 2
+          },
+          "signature_len": {
+            "cairo_type": "felt",
+            "offset": 3
+          },
+          "signature": {
+            "cairo_type": "felt*",
+            "offset": 4
+          },
+          "transaction_hash": {
+            "cairo_type": "felt",
+            "offset": 5
+          },
+          "chain_id": {
+            "cairo_type": "felt",
+            "offset": 6
+          },
+          "nonce": {
+            "cairo_type": "felt",
+            "offset": 7
+          }
+        },
+        "size": 8,
+        "type": "struct"
+      },
+      "starkware.starknet.common.syscalls.emit_event": {
+        "pc": 48,
+        "decorators": [],
+        "type": "function"
+      },
+      "starkware.starknet.common.syscalls.emit_event.Args": {
+        "full_name": "starkware.starknet.common.syscalls.emit_event.Args",
+        "members": {
+          "keys_len": {
+            "cairo_type": "felt",
+            "offset": 0
+          },
+          "keys": {
+            "cairo_type": "felt*",
+            "offset": 1
+          },
+          "data_len": {
+            "cairo_type": "felt",
+            "offset": 2
+          },
+          "data": {
+            "cairo_type": "felt*",
+            "offset": 3
+          }
+        },
+        "size": 4,
+        "type": "struct"
+      },
+      "starkware.starknet.common.syscalls.emit_event.ImplicitArgs": {
+        "full_name": "starkware.starknet.common.syscalls.emit_event.ImplicitArgs",
+        "members": {
+          "syscall_ptr": {
+            "cairo_type": "felt*",
+            "offset": 0
+          }
+        },
+        "size": 1,
+        "type": "struct"
+      },
+      "starkware.starknet.common.syscalls.emit_event.Return": {
+        "cairo_type": "()",
+        "type": "type_definition"
+      },
+      "starkware.starknet.common.syscalls.emit_event.SIZEOF_LOCALS": {
+        "value": 0,
+        "type": "const"
+      },
+      "starkware.starknet.common.syscalls.emit_event.__temp4": {
+        "full_name": "starkware.starknet.common.syscalls.emit_event.__temp4",
+        "cairo_type": "felt",
+        "references": [
+          {
+            "ap_tracking_data": {
+              "offset": 1,
+              "group": 6
+            },
+            "pc": 50,
+            "value": "[cast(ap + (-1), felt*)]"
+          }
+        ],
+        "type": "reference"
+      },
+      "starkware.starknet.common.syscalls.emit_event.data": {
+        "full_name": "starkware.starknet.common.syscalls.emit_event.data",
+        "cairo_type": "felt*",
+        "references": [
+          {
+            "ap_tracking_data": {
+              "offset": 0,
+              "group": 6
+            },
+            "pc": 48,
+            "value": "[cast(fp + (-3), felt**)]"
+          }
+        ],
+        "type": "reference"
+      },
+      "starkware.starknet.common.syscalls.emit_event.data_len": {
+        "full_name": "starkware.starknet.common.syscalls.emit_event.data_len",
+        "cairo_type": "felt",
+        "references": [
+          {
+            "ap_tracking_data": {
+              "offset": 0,
+              "group": 6
+            },
+            "pc": 48,
+            "value": "[cast(fp + (-4), felt*)]"
+          }
+        ],
+        "type": "reference"
+      },
+      "starkware.starknet.common.syscalls.emit_event.keys": {
+        "full_name": "starkware.starknet.common.syscalls.emit_event.keys",
+        "cairo_type": "felt*",
+        "references": [
+          {
+            "ap_tracking_data": {
+              "offset": 0,
+              "group": 6
+            },
+            "pc": 48,
+            "value": "[cast(fp + (-5), felt**)]"
+          }
+        ],
+        "type": "reference"
+      },
+      "starkware.starknet.common.syscalls.emit_event.keys_len": {
+        "full_name": "starkware.starknet.common.syscalls.emit_event.keys_len",
+        "cairo_type": "felt",
+        "references": [
+          {
+            "ap_tracking_data": {
+              "offset": 0,
+              "group": 6
+            },
+            "pc": 48,
+            "value": "[cast(fp + (-6), felt*)]"
+          }
+        ],
+        "type": "reference"
+      },
+      "starkware.starknet.common.syscalls.emit_event.syscall_ptr": {
+        "full_name": "starkware.starknet.common.syscalls.emit_event.syscall_ptr",
+        "cairo_type": "felt*",
+        "references": [
+          {
+            "ap_tracking_data": {
+              "offset": 0,
+              "group": 6
+            },
+            "pc": 48,
+            "value": "[cast(fp + (-7), felt**)]"
+          },
+          {
+            "ap_tracking_data": {
+              "offset": 1,
+              "group": 6
+            },
+            "pc": 55,
+            "value": "cast([fp + (-7)] + 5, felt*)"
+          }
+        ],
+        "type": "reference"
+      },
+      "starkware.starknet.common.syscalls.library_call": {
+        "pc": 8,
+        "decorators": [],
+        "type": "function"
+      },
+      "starkware.starknet.common.syscalls.library_call.Args": {
+        "full_name": "starkware.starknet.common.syscalls.library_call.Args",
+        "members": {
+          "class_hash": {
+            "cairo_type": "felt",
+            "offset": 0
+          },
+          "function_selector": {
+            "cairo_type": "felt",
+            "offset": 1
+          },
+          "calldata_size": {
+            "cairo_type": "felt",
+            "offset": 2
+          },
+          "calldata": {
+            "cairo_type": "felt*",
+            "offset": 3
+          }
+        },
+        "size": 4,
+        "type": "struct"
+      },
+      "starkware.starknet.common.syscalls.library_call.ImplicitArgs": {
+        "full_name": "starkware.starknet.common.syscalls.library_call.ImplicitArgs",
+        "members": {
+          "syscall_ptr": {
+            "cairo_type": "felt*",
+            "offset": 0
+          }
+        },
+        "size": 1,
+        "type": "struct"
+      },
+      "starkware.starknet.common.syscalls.library_call.Return": {
+        "cairo_type": "(retdata_size: felt, retdata: felt*)",
+        "type": "type_definition"
+      },
+      "starkware.starknet.common.syscalls.library_call.SIZEOF_LOCALS": {
+        "value": 0,
+        "type": "const"
+      },
+      "starkware.starknet.common.syscalls.library_call.__temp0": {
+        "full_name": "starkware.starknet.common.syscalls.library_call.__temp0",
+        "cairo_type": "felt",
+        "references": [
+          {
+            "ap_tracking_data": {
+              "offset": 1,
+              "group": 2
+            },
+            "pc": 10,
+            "value": "[cast(ap + (-1), felt*)]"
+          }
+        ],
+        "type": "reference"
+      },
+      "starkware.starknet.common.syscalls.library_call.calldata": {
+        "full_name": "starkware.starknet.common.syscalls.library_call.calldata",
+        "cairo_type": "felt*",
+        "references": [
+          {
+            "ap_tracking_data": {
+              "offset": 0,
+              "group": 2
+            },
+            "pc": 8,
+            "value": "[cast(fp + (-3), felt**)]"
+          }
+        ],
+        "type": "reference"
+      },
+      "starkware.starknet.common.syscalls.library_call.calldata_size": {
+        "full_name": "starkware.starknet.common.syscalls.library_call.calldata_size",
+        "cairo_type": "felt",
+        "references": [
+          {
+            "ap_tracking_data": {
+              "offset": 0,
+              "group": 2
+            },
+            "pc": 8,
+            "value": "[cast(fp + (-4), felt*)]"
+          }
+        ],
+        "type": "reference"
+      },
+      "starkware.starknet.common.syscalls.library_call.class_hash": {
+        "full_name": "starkware.starknet.common.syscalls.library_call.class_hash",
+        "cairo_type": "felt",
+        "references": [
+          {
+            "ap_tracking_data": {
+              "offset": 0,
+              "group": 2
+            },
+            "pc": 8,
+            "value": "[cast(fp + (-6), felt*)]"
+          }
+        ],
+        "type": "reference"
+      },
+      "starkware.starknet.common.syscalls.library_call.function_selector": {
+        "full_name": "starkware.starknet.common.syscalls.library_call.function_selector",
+        "cairo_type": "felt",
+        "references": [
+          {
+            "ap_tracking_data": {
+              "offset": 0,
+              "group": 2
+            },
+            "pc": 8,
+            "value": "[cast(fp + (-5), felt*)]"
+          }
+        ],
+        "type": "reference"
+      },
+      "starkware.starknet.common.syscalls.library_call.response": {
+        "full_name": "starkware.starknet.common.syscalls.library_call.response",
+        "cairo_type": "starkware.starknet.common.syscalls.CallContractResponse",
+        "references": [
+          {
+            "ap_tracking_data": {
+              "offset": 1,
+              "group": 2
+            },
+            "pc": 15,
+            "value": "[cast([fp + (-7)] + 5, starkware.starknet.common.syscalls.CallContractResponse*)]"
+          }
+        ],
+        "type": "reference"
+      },
+      "starkware.starknet.common.syscalls.library_call.syscall": {
+        "full_name": "starkware.starknet.common.syscalls.library_call.syscall",
+        "cairo_type": "starkware.starknet.common.syscalls.LibraryCall",
+        "references": [
+          {
+            "ap_tracking_data": {
+              "offset": 0,
+              "group": 2
+            },
+            "pc": 8,
+            "value": "[cast([fp + (-7)], starkware.starknet.common.syscalls.LibraryCall*)]"
+          }
+        ],
+        "type": "reference"
+      },
+      "starkware.starknet.common.syscalls.library_call.syscall_ptr": {
+        "full_name": "starkware.starknet.common.syscalls.library_call.syscall_ptr",
+        "cairo_type": "felt*",
+        "references": [
+          {
+            "ap_tracking_data": {
+              "offset": 0,
+              "group": 2
+            },
+            "pc": 8,
+            "value": "[cast(fp + (-7), felt**)]"
+          },
+          {
+            "ap_tracking_data": {
+              "offset": 1,
+              "group": 2
+            },
+            "pc": 15,
+            "value": "cast([fp + (-7)] + 7, felt*)"
+          }
+        ],
+        "type": "reference"
+      },
+      "starkware.starknet.common.syscalls.library_call_l1_handler": {
+        "pc": 20,
+        "decorators": [],
+        "type": "function"
+      },
+      "starkware.starknet.common.syscalls.library_call_l1_handler.Args": {
+        "full_name": "starkware.starknet.common.syscalls.library_call_l1_handler.Args",
+        "members": {
+          "class_hash": {
+            "cairo_type": "felt",
+            "offset": 0
+          },
+          "function_selector": {
+            "cairo_type": "felt",
+            "offset": 1
+          },
+          "calldata_size": {
+            "cairo_type": "felt",
+            "offset": 2
+          },
+          "calldata": {
+            "cairo_type": "felt*",
+            "offset": 3
+          }
+        },
+        "size": 4,
+        "type": "struct"
+      },
+      "starkware.starknet.common.syscalls.library_call_l1_handler.ImplicitArgs": {
+        "full_name": "starkware.starknet.common.syscalls.library_call_l1_handler.ImplicitArgs",
+        "members": {
+          "syscall_ptr": {
+            "cairo_type": "felt*",
+            "offset": 0
+          }
+        },
+        "size": 1,
+        "type": "struct"
+      },
+      "starkware.starknet.common.syscalls.library_call_l1_handler.Return": {
+        "cairo_type": "(retdata_size: felt, retdata: felt*)",
+        "type": "type_definition"
+      },
+      "starkware.starknet.common.syscalls.library_call_l1_handler.SIZEOF_LOCALS": {
+        "value": 0,
+        "type": "const"
+      },
+      "starkware.starknet.common.syscalls.library_call_l1_handler.__temp1": {
+        "full_name": "starkware.starknet.common.syscalls.library_call_l1_handler.__temp1",
+        "cairo_type": "felt",
+        "references": [
+          {
+            "ap_tracking_data": {
+              "offset": 1,
+              "group": 3
+            },
+            "pc": 22,
+            "value": "[cast(ap + (-1), felt*)]"
+          }
+        ],
+        "type": "reference"
+      },
+      "starkware.starknet.common.syscalls.library_call_l1_handler.calldata": {
+        "full_name": "starkware.starknet.common.syscalls.library_call_l1_handler.calldata",
+        "cairo_type": "felt*",
+        "references": [
+          {
+            "ap_tracking_data": {
+              "offset": 0,
+              "group": 3
+            },
+            "pc": 20,
+            "value": "[cast(fp + (-3), felt**)]"
+          }
+        ],
+        "type": "reference"
+      },
+      "starkware.starknet.common.syscalls.library_call_l1_handler.calldata_size": {
+        "full_name": "starkware.starknet.common.syscalls.library_call_l1_handler.calldata_size",
+        "cairo_type": "felt",
+        "references": [
+          {
+            "ap_tracking_data": {
+              "offset": 0,
+              "group": 3
+            },
+            "pc": 20,
+            "value": "[cast(fp + (-4), felt*)]"
+          }
+        ],
+        "type": "reference"
+      },
+      "starkware.starknet.common.syscalls.library_call_l1_handler.class_hash": {
+        "full_name": "starkware.starknet.common.syscalls.library_call_l1_handler.class_hash",
+        "cairo_type": "felt",
+        "references": [
+          {
+            "ap_tracking_data": {
+              "offset": 0,
+              "group": 3
+            },
+            "pc": 20,
+            "value": "[cast(fp + (-6), felt*)]"
+          }
+        ],
+        "type": "reference"
+      },
+      "starkware.starknet.common.syscalls.library_call_l1_handler.function_selector": {
+        "full_name": "starkware.starknet.common.syscalls.library_call_l1_handler.function_selector",
+        "cairo_type": "felt",
+        "references": [
+          {
+            "ap_tracking_data": {
+              "offset": 0,
+              "group": 3
+            },
+            "pc": 20,
+            "value": "[cast(fp + (-5), felt*)]"
+          }
+        ],
+        "type": "reference"
+      },
+      "starkware.starknet.common.syscalls.library_call_l1_handler.response": {
+        "full_name": "starkware.starknet.common.syscalls.library_call_l1_handler.response",
+        "cairo_type": "starkware.starknet.common.syscalls.CallContractResponse",
+        "references": [
+          {
+            "ap_tracking_data": {
+              "offset": 1,
+              "group": 3
+            },
+            "pc": 27,
+            "value": "[cast([fp + (-7)] + 5, starkware.starknet.common.syscalls.CallContractResponse*)]"
+          }
+        ],
+        "type": "reference"
+      },
+      "starkware.starknet.common.syscalls.library_call_l1_handler.syscall": {
+        "full_name": "starkware.starknet.common.syscalls.library_call_l1_handler.syscall",
+        "cairo_type": "starkware.starknet.common.syscalls.LibraryCall",
+        "references": [
+          {
+            "ap_tracking_data": {
+              "offset": 0,
+              "group": 3
+            },
+            "pc": 20,
+            "value": "[cast([fp + (-7)], starkware.starknet.common.syscalls.LibraryCall*)]"
+          }
+        ],
+        "type": "reference"
+      },
+      "starkware.starknet.common.syscalls.library_call_l1_handler.syscall_ptr": {
+        "full_name": "starkware.starknet.common.syscalls.library_call_l1_handler.syscall_ptr",
+        "cairo_type": "felt*",
+        "references": [
+          {
+            "ap_tracking_data": {
+              "offset": 0,
+              "group": 3
+            },
+            "pc": 20,
+            "value": "[cast(fp + (-7), felt**)]"
+          },
+          {
+            "ap_tracking_data": {
+              "offset": 1,
+              "group": 3
+            },
+            "pc": 27,
+            "value": "cast([fp + (-7)] + 7, felt*)"
+          }
+        ],
+        "type": "reference"
+      },
+      "starkware.starknet.common.syscalls.storage_read": {
+        "pc": 32,
+        "decorators": [],
+        "type": "function"
+      },
+      "starkware.starknet.common.syscalls.storage_read.Args": {
+        "full_name": "starkware.starknet.common.syscalls.storage_read.Args",
+        "members": {
+          "address": {
+            "cairo_type": "felt",
+            "offset": 0
+          }
+        },
+        "size": 1,
+        "type": "struct"
+      },
+      "starkware.starknet.common.syscalls.storage_read.ImplicitArgs": {
+        "full_name": "starkware.starknet.common.syscalls.storage_read.ImplicitArgs",
+        "members": {
+          "syscall_ptr": {
+            "cairo_type": "felt*",
+            "offset": 0
+          }
+        },
+        "size": 1,
+        "type": "struct"
+      },
+      "starkware.starknet.common.syscalls.storage_read.Return": {
+        "cairo_type": "(value: felt)",
+        "type": "type_definition"
+      },
+      "starkware.starknet.common.syscalls.storage_read.SIZEOF_LOCALS": {
+        "value": 0,
+        "type": "const"
+      },
+      "starkware.starknet.common.syscalls.storage_read.__temp2": {
+        "full_name": "starkware.starknet.common.syscalls.storage_read.__temp2",
+        "cairo_type": "felt",
+        "references": [
+          {
+            "ap_tracking_data": {
+              "offset": 1,
+              "group": 4
+            },
+            "pc": 34,
+            "value": "[cast(ap + (-1), felt*)]"
+          }
+        ],
+        "type": "reference"
+      },
+      "starkware.starknet.common.syscalls.storage_read.address": {
+        "full_name": "starkware.starknet.common.syscalls.storage_read.address",
+        "cairo_type": "felt",
+        "references": [
+          {
+            "ap_tracking_data": {
+              "offset": 0,
+              "group": 4
+            },
+            "pc": 32,
+            "value": "[cast(fp + (-3), felt*)]"
+          }
+        ],
+        "type": "reference"
+      },
+      "starkware.starknet.common.syscalls.storage_read.response": {
+        "full_name": "starkware.starknet.common.syscalls.storage_read.response",
+        "cairo_type": "starkware.starknet.common.syscalls.StorageReadResponse",
+        "references": [
+          {
+            "ap_tracking_data": {
+              "offset": 1,
+              "group": 4
+            },
+            "pc": 36,
+            "value": "[cast([fp + (-4)] + 2, starkware.starknet.common.syscalls.StorageReadResponse*)]"
+          }
+        ],
+        "type": "reference"
+      },
+      "starkware.starknet.common.syscalls.storage_read.syscall": {
+        "full_name": "starkware.starknet.common.syscalls.storage_read.syscall",
+        "cairo_type": "starkware.starknet.common.syscalls.StorageRead",
+        "references": [
+          {
+            "ap_tracking_data": {
+              "offset": 0,
+              "group": 4
+            },
+            "pc": 32,
+            "value": "[cast([fp + (-4)], starkware.starknet.common.syscalls.StorageRead*)]"
+          }
+        ],
+        "type": "reference"
+      },
+      "starkware.starknet.common.syscalls.storage_read.syscall_ptr": {
+        "full_name": "starkware.starknet.common.syscalls.storage_read.syscall_ptr",
+        "cairo_type": "felt*",
+        "references": [
+          {
+            "ap_tracking_data": {
+              "offset": 0,
+              "group": 4
+            },
+            "pc": 32,
+            "value": "[cast(fp + (-4), felt**)]"
+          },
+          {
+            "ap_tracking_data": {
+              "offset": 1,
+              "group": 4
+            },
+            "pc": 36,
+            "value": "cast([fp + (-4)] + 3, felt*)"
+          }
+        ],
+        "type": "reference"
+      },
+      "starkware.starknet.common.syscalls.storage_write": {
+        "pc": 40,
+        "decorators": [],
+        "type": "function"
+      },
+      "starkware.starknet.common.syscalls.storage_write.Args": {
+        "full_name": "starkware.starknet.common.syscalls.storage_write.Args",
+        "members": {
+          "address": {
+            "cairo_type": "felt",
+            "offset": 0
+          },
+          "value": {
+            "cairo_type": "felt",
+            "offset": 1
+          }
+        },
+        "size": 2,
+        "type": "struct"
+      },
+      "starkware.starknet.common.syscalls.storage_write.ImplicitArgs": {
+        "full_name": "starkware.starknet.common.syscalls.storage_write.ImplicitArgs",
+        "members": {
+          "syscall_ptr": {
+            "cairo_type": "felt*",
+            "offset": 0
+          }
+        },
+        "size": 1,
+        "type": "struct"
+      },
+      "starkware.starknet.common.syscalls.storage_write.Return": {
+        "cairo_type": "()",
+        "type": "type_definition"
+      },
+      "starkware.starknet.common.syscalls.storage_write.SIZEOF_LOCALS": {
+        "value": 0,
+        "type": "const"
+      },
+      "starkware.starknet.common.syscalls.storage_write.__temp3": {
+        "full_name": "starkware.starknet.common.syscalls.storage_write.__temp3",
+        "cairo_type": "felt",
+        "references": [
+          {
+            "ap_tracking_data": {
+              "offset": 1,
+              "group": 5
+            },
+            "pc": 42,
+            "value": "[cast(ap + (-1), felt*)]"
+          }
+        ],
+        "type": "reference"
+      },
+      "starkware.starknet.common.syscalls.storage_write.address": {
+        "full_name": "starkware.starknet.common.syscalls.storage_write.address",
+        "cairo_type": "felt",
+        "references": [
+          {
+            "ap_tracking_data": {
+              "offset": 0,
+              "group": 5
+            },
+            "pc": 40,
+            "value": "[cast(fp + (-4), felt*)]"
+          }
+        ],
+        "type": "reference"
+      },
+      "starkware.starknet.common.syscalls.storage_write.syscall_ptr": {
+        "full_name": "starkware.starknet.common.syscalls.storage_write.syscall_ptr",
+        "cairo_type": "felt*",
+        "references": [
+          {
+            "ap_tracking_data": {
+              "offset": 0,
+              "group": 5
+            },
+            "pc": 40,
+            "value": "[cast(fp + (-5), felt**)]"
+          },
+          {
+            "ap_tracking_data": {
+              "offset": 1,
+              "group": 5
+            },
+            "pc": 45,
+            "value": "cast([fp + (-5)] + 3, felt*)"
+          }
+        ],
+        "type": "reference"
+      },
+      "starkware.starknet.common.syscalls.storage_write.value": {
+        "full_name": "starkware.starknet.common.syscalls.storage_write.value",
+        "cairo_type": "felt",
+        "references": [
+          {
+            "ap_tracking_data": {
+              "offset": 0,
+              "group": 5
+            },
+            "pc": 40,
+            "value": "[cast(fp + (-3), felt*)]"
+          }
+        ],
+        "type": "reference"
+      }
+    },
+    "hints": {
+      "0": [
+        {
+          "flow_tracking_data": {
+            "reference_ids": {},
+            "ap_tracking": {
+              "offset": 0,
+              "group": 0
+            }
+          },
+          "accessible_scopes": [
+            "starkware.cairo.common.alloc",
+            "starkware.cairo.common.alloc.alloc"
+          ],
+          "code": "memory[ap] = segments.add()"
+        }
+      ],
+      "3": [
+        {
+          "flow_tracking_data": {
+            "reference_ids": {
+              "starkware.cairo.common.math.assert_not_zero.value": 0
+            },
+            "ap_tracking": {
+              "offset": 0,
+              "group": 1
+            }
+          },
+          "accessible_scopes": [
+            "starkware.cairo.common.math",
+            "starkware.cairo.common.math.assert_not_zero"
+          ],
+          "code": "from starkware.cairo.common.math_utils import assert_integer\nassert_integer(ids.value)\nassert ids.value % PRIME != 0, f'assert_not_zero failed: {ids.value} = 0.'"
+        }
+      ],
+      "15": [
+        {
+          "flow_tracking_data": {
+            "reference_ids": {
+              "starkware.starknet.common.syscalls.library_call.__temp0": 7,
+              "starkware.starknet.common.syscalls.library_call.calldata": 4,
+              "starkware.starknet.common.syscalls.library_call.calldata_size": 3,
+              "starkware.starknet.common.syscalls.library_call.class_hash": 1,
+              "starkware.starknet.common.syscalls.library_call.function_selector": 2,
+              "starkware.starknet.common.syscalls.library_call.syscall": 6,
+              "starkware.starknet.common.syscalls.library_call.syscall_ptr": 5
+            },
+            "ap_tracking": {
+              "offset": 1,
+              "group": 2
+            }
+          },
+          "accessible_scopes": [
+            "starkware.starknet.common.syscalls",
+            "starkware.starknet.common.syscalls.library_call"
+          ],
+          "code": "syscall_handler.library_call(segments=segments, syscall_ptr=ids.syscall_ptr)"
+        }
+      ],
+      "27": [
+        {
+          "flow_tracking_data": {
+            "reference_ids": {
+              "starkware.starknet.common.syscalls.library_call_l1_handler.__temp1": 16,
+              "starkware.starknet.common.syscalls.library_call_l1_handler.calldata": 13,
+              "starkware.starknet.common.syscalls.library_call_l1_handler.calldata_size": 12,
+              "starkware.starknet.common.syscalls.library_call_l1_handler.class_hash": 10,
+              "starkware.starknet.common.syscalls.library_call_l1_handler.function_selector": 11,
+              "starkware.starknet.common.syscalls.library_call_l1_handler.syscall": 15,
+              "starkware.starknet.common.syscalls.library_call_l1_handler.syscall_ptr": 14
+            },
+            "ap_tracking": {
+              "offset": 1,
+              "group": 3
+            }
+          },
+          "accessible_scopes": [
+            "starkware.starknet.common.syscalls",
+            "starkware.starknet.common.syscalls.library_call_l1_handler"
+          ],
+          "code": "syscall_handler.library_call_l1_handler(segments=segments, syscall_ptr=ids.syscall_ptr)"
+        }
+      ],
+      "36": [
+        {
+          "flow_tracking_data": {
+            "reference_ids": {
+              "starkware.starknet.common.syscalls.storage_read.__temp2": 22,
+              "starkware.starknet.common.syscalls.storage_read.address": 19,
+              "starkware.starknet.common.syscalls.storage_read.syscall": 21,
+              "starkware.starknet.common.syscalls.storage_read.syscall_ptr": 20
+            },
+            "ap_tracking": {
+              "offset": 1,
+              "group": 4
+            }
+          },
+          "accessible_scopes": [
+            "starkware.starknet.common.syscalls",
+            "starkware.starknet.common.syscalls.storage_read"
+          ],
+          "code": "syscall_handler.storage_read(segments=segments, syscall_ptr=ids.syscall_ptr)"
+        }
+      ],
+      "45": [
+        {
+          "flow_tracking_data": {
+            "reference_ids": {
+              "starkware.starknet.common.syscalls.storage_write.__temp3": 28,
+              "starkware.starknet.common.syscalls.storage_write.address": 25,
+              "starkware.starknet.common.syscalls.storage_write.syscall_ptr": 27,
+              "starkware.starknet.common.syscalls.storage_write.value": 26
+            },
+            "ap_tracking": {
+              "offset": 1,
+              "group": 5
+            }
+          },
+          "accessible_scopes": [
+            "starkware.starknet.common.syscalls",
+            "starkware.starknet.common.syscalls.storage_write"
+          ],
+          "code": "syscall_handler.storage_write(segments=segments, syscall_ptr=ids.syscall_ptr)"
+        }
+      ],
+      "55": [
+        {
+          "flow_tracking_data": {
+            "reference_ids": {
+              "starkware.starknet.common.syscalls.emit_event.__temp4": 35,
+              "starkware.starknet.common.syscalls.emit_event.data": 33,
+              "starkware.starknet.common.syscalls.emit_event.data_len": 32,
+              "starkware.starknet.common.syscalls.emit_event.keys": 31,
+              "starkware.starknet.common.syscalls.emit_event.keys_len": 30,
+              "starkware.starknet.common.syscalls.emit_event.syscall_ptr": 34
+            },
+            "ap_tracking": {
+              "offset": 1,
+              "group": 6
+            }
+          },
+          "accessible_scopes": [
+            "starkware.starknet.common.syscalls",
+            "starkware.starknet.common.syscalls.emit_event"
+          ],
+          "code": "syscall_handler.emit_event(segments=segments, syscall_ptr=ids.syscall_ptr)"
+        }
+      ],
+      "181": [
+        {
+          "flow_tracking_data": {
+            "reference_ids": {
+              "__wrappers__.constructor.__calldata_actual_size": 118,
+              "__wrappers__.constructor.__calldata_arg_calldata": 114,
+              "__wrappers__.constructor.__calldata_arg_calldata_len": 109,
+              "__wrappers__.constructor.__calldata_arg_implementation_hash": 105,
+              "__wrappers__.constructor.__calldata_arg_selector": 107,
+              "__wrappers__.constructor.__calldata_ptr": 117,
+              "__wrappers__.constructor.__temp10": 116,
+              "__wrappers__.constructor.__temp11": 119,
+              "__wrappers__.constructor.__temp7": 111,
+              "__wrappers__.constructor.__temp8": 112,
+              "__wrappers__.constructor.__temp9": 115,
+              "__wrappers__.constructor.pedersen_ptr": 121,
+              "__wrappers__.constructor.range_check_ptr": 122,
+              "__wrappers__.constructor.ret_value": 123,
+              "__wrappers__.constructor.syscall_ptr": 120
+            },
+            "ap_tracking": {
+              "offset": 0,
+              "group": 16
+            }
+          },
+          "accessible_scopes": [
+            "__main__",
+            "__main__",
+            "__wrappers__",
+            "__wrappers__.constructor"
+          ],
+          "code": "memory[ap] = segments.add()"
+        }
+      ],
+      "241": [
+        {
+          "flow_tracking_data": {
+            "reference_ids": {
+              "__wrappers__.__l1_default__.pedersen_ptr": 163,
+              "__wrappers__.__l1_default__.range_check_ptr": 164,
+              "__wrappers__.__l1_default__.ret_value": 165,
+              "__wrappers__.__l1_default__.syscall_ptr": 162
+            },
+            "ap_tracking": {
+              "offset": 50,
+              "group": 20
+            }
+          },
+          "accessible_scopes": [
+            "__main__",
+            "__main__",
+            "__wrappers__",
+            "__wrappers__.__l1_default__"
+          ],
+          "code": "memory[ap] = segments.add()"
+        }
+      ]
+    },
+    "builtins": [
+      "pedersen",
+      "range_check"
+    ]
+  },
+  "abi": [
+    {
+      "data": [
+        {
+          "name": "implementation",
+          "type": "felt"
+        }
+      ],
+      "keys": [],
+      "name": "Upgraded",
+      "type": "event"
+    },
+    {
+      "data": [
+        {
+          "name": "previousAdmin",
+          "type": "felt"
+        },
+        {
+          "name": "newAdmin",
+          "type": "felt"
+        }
+      ],
+      "keys": [],
+      "name": "AdminChanged",
+      "type": "event"
+    },
+    {
+      "inputs": [
+        {
+          "name": "implementation_hash",
+          "type": "felt"
+        },
+        {
+          "name": "selector",
+          "type": "felt"
+        },
+        {
+          "name": "calldata_len",
+          "type": "felt"
+        },
+        {
+          "name": "calldata",
+          "type": "felt*"
+        }
+      ],
+      "name": "constructor",
+      "outputs": [],
+      "type": "constructor"
+    },
+    {
+      "inputs": [
+        {
+          "name": "selector",
+          "type": "felt"
+        },
+        {
+          "name": "calldata_size",
+          "type": "felt"
+        },
+        {
+          "name": "calldata",
+          "type": "felt*"
+        }
+      ],
+      "name": "__default__",
+      "outputs": [
+        {
+          "name": "retdata_size",
+          "type": "felt"
+        },
+        {
+          "name": "retdata",
+          "type": "felt*"
+        }
+      ],
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "name": "selector",
+          "type": "felt"
+        },
+        {
+          "name": "calldata_size",
+          "type": "felt"
+        },
+        {
+          "name": "calldata",
+          "type": "felt*"
+        }
+      ],
+      "name": "__l1_default__",
+      "outputs": [],
+      "type": "l1_handler"
+    }
+  ],
+  "entry_points_by_type": {
+    "CONSTRUCTOR": [
+      {
+        "offset": "0xa1",
+        "selector": "0x28ffe4ff0f226a9107253e17a904099aa4f63a02a5621de0576e5aa71bc5194"
+      }
+    ],
+    "EXTERNAL": [
+      {
+        "offset": "0xd0",
+        "selector": "0x0"
+      }
+    ],
+    "L1_HANDLER": [
+      {
+        "offset": "0xe9",
+        "selector": "0x0"
+      }
+    ]
+  }
+}

--- a/clients/gateway.go
+++ b/clients/gateway.go
@@ -38,6 +38,17 @@ func (c *GatewayClient) buildQueryString(endpoint string, args map[string]string
 	return base.String()
 }
 
+// get performs a "GET" http request with the given URL and returns the response body
+func (c *GatewayClient) get(queryUrl string) ([]byte, error) {
+	res, err := http.Get(queryUrl)
+	if err != nil {
+		return nil, err
+	}
+
+	body, err := ioutil.ReadAll(res.Body)
+	return body, err
+}
+
 // StateUpdate object returned by the gateway in JSON format for "get_state_update" endpoint
 type StateUpdate struct {
 	BlockHash *felt.Felt `json:"block_hash"`
@@ -64,16 +75,7 @@ func (c *GatewayClient) GetStateUpdate(blockNumber uint64) (*StateUpdate, error)
 		"blockNumber": strconv.FormatUint(blockNumber, 10),
 	})
 
-	res, err := http.Get(queryUrl)
-	if err != nil {
-		return nil, err
-	}
-
-	body, err := ioutil.ReadAll(res.Body)
-	if err != nil {
-		return nil, err
-	}
-
+	body, err := c.get(queryUrl)
 	update := new(StateUpdate)
 	if err = json.Unmarshal(body, update); err != nil {
 		return nil, err

--- a/clients/gateway.go
+++ b/clients/gateway.go
@@ -1,0 +1,83 @@
+package clients
+
+import (
+	"encoding/json"
+	"io/ioutil"
+	"net/http"
+	"net/url"
+	"strconv"
+
+	"github.com/NethermindEth/juno/core/felt"
+)
+
+type GatewayClient struct {
+	baseUrl string
+}
+
+func NewGatewayClient(baseUrl string) *GatewayClient {
+	return &GatewayClient{
+		baseUrl: baseUrl,
+	}
+}
+
+// `buildQueryString` builds the query url with encoded parameters
+func (c *GatewayClient) buildQueryString(endpoint string, args map[string]string) string {
+	base, err := url.Parse(c.baseUrl)
+	if err != nil {
+		panic("Malformed feeder gateway base URL")
+	}
+
+	base.Path += endpoint
+
+	params := url.Values{}
+	for k, v := range args {
+		params.Add(k, v)
+	}
+	base.RawQuery = params.Encode()
+
+	return base.String()
+}
+
+// StateUpdate object returned by the gateway in JSON format for "get_state_update" endpoint
+type StateUpdate struct {
+	BlockHash *felt.Felt `json:"block_hash"`
+	NewRoot   *felt.Felt `json:"new_root"`
+	OldRoot   *felt.Felt `json:"old_root"`
+
+	StateDiff struct {
+		StorageDiffs map[string][]struct {
+			Key   *felt.Felt `json:"key"`
+			Value *felt.Felt `json:"value"`
+		} `json:"storage_diffs"`
+
+		Nonces            interface{} `json:"nonces"` // todo: define
+		DeployedContracts []struct {
+			Address   *felt.Felt `json:"address"`
+			ClassHash *felt.Felt `json:"class_hash"`
+		} `json:"deployed_contracts"`
+		DeclaredContracts interface{} `json:"declared_contracts"` // todo: define
+	} `json:"state_diff"`
+}
+
+func (c *GatewayClient) GetStateUpdate(blockNumber uint64) (*StateUpdate, error) {
+	queryUrl := c.buildQueryString("get_state_update", map[string]string{
+		"blockNumber": strconv.FormatUint(blockNumber, 10),
+	})
+
+	res, err := http.Get(queryUrl)
+	if err != nil {
+		return nil, err
+	}
+
+	body, err := ioutil.ReadAll(res.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	update := new(StateUpdate)
+	if err = json.Unmarshal(body, update); err != nil {
+		return nil, err
+	}
+
+	return update, nil
+}

--- a/clients/gateway.go
+++ b/clients/gateway.go
@@ -197,3 +197,53 @@ func (c *GatewayClient) GetBlock(blockNumber uint64) (*Block, error) {
 
 	return block, nil
 }
+
+type EntryPoint struct {
+	Selector *felt.Felt `json:"selector"`
+	Offset   *felt.Felt `json:"offset"`
+}
+
+type Abi []struct {
+	Name   string `json:"name"`
+	Type   string `json:"type"`
+	Inputs []struct {
+		Name string `json:"name"`
+		Type string `json:"type"`
+	} `json:"inputs"`
+	Outputs []interface{} `json:"outputs"`
+}
+
+type ClassDefinition struct {
+	Abi         Abi `json:"abi"`
+	EntryPoints struct {
+		Constructor []EntryPoint `json:"CONSTRUCTOR"`
+		External    []EntryPoint `json:"EXTERNAL"`
+		L1Handler   []EntryPoint `json:"L1_HANDLER"`
+	} `json:"entry_points_by_type"`
+	Program struct {
+		Builtins         []string     `json:"builtins"`
+		Prime            string       `json:"prime"`
+		ReferenceManager interface{}  `json:"reference_manager"`
+		Identifiers      interface{}  `json:"identifiers"`
+		Attributes       interface{}  `json:"attributes"`
+		Data             []*felt.Felt `json:"data"`
+		DebugInfo        interface{}  `json:"debug_info"`
+		MainScope        interface{}  `json:"main_scope"`
+		Hints            interface{}  `json:"hints"`
+		CompilerVersion  string       `json:"compiler_version"`
+	} `json:"program"`
+}
+
+func (c *GatewayClient) GetClassDefinition(classHash *felt.Felt) (*ClassDefinition, error) {
+	queryUrl := c.buildQueryString("get_class_by_hash", map[string]string{
+		"classHash": "0x" + classHash.Text(16),
+	})
+
+	body, err := c.get(queryUrl)
+	class := new(ClassDefinition)
+	if err = json.Unmarshal(body, class); err != nil {
+		return nil, err
+	}
+
+	return class, nil
+}

--- a/clients/gateway_test.go
+++ b/clients/gateway_test.go
@@ -1,0 +1,61 @@
+package clients
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/NethermindEth/juno/core/felt"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestStateUpdateUnmarshal(t *testing.T) {
+	jsonData := []byte(`{
+  "block_hash": "0x47c3637b57c2b079b93c61539950c17e868a28f46cdef28f88521067f21e943",
+  "new_root": "021870ba80540e7831fb21c591ee93481f5ae1bb71ff85a86ddd465be4eddee6",
+  "old_root": "0000000000000000000000000000000000000000000000000000000000000000",
+  "state_diff": {
+    "storage_diffs": {
+      "0x20cfa74ee3564b4cd5435cdace0f9c4d43b939620e4a0bb5076105df0a626c6": [
+        {
+          "key": "0x5",
+          "value": "0x22b"
+        }
+      ]
+    },
+    "nonces": {},
+    "deployed_contracts": [
+      {
+        "address": "0x20cfa74ee3564b4cd5435cdace0f9c4d43b939620e4a0bb5076105df0a626c6",
+        "class_hash": "0x10455c752b86932ce552f2b0fe81a880746649b9aee7e0d842bf3f52378f9f8"
+      }
+	],
+    "declared_contracts": []
+  }
+}`)
+
+	var update StateUpdate
+	err := json.Unmarshal(jsonData, &update)
+	assert.Equal(t, nil, err, "Unexpected error")
+	expected, _ := new(felt.Felt).SetString("0x47c3637b57c2b079b93c61539950c17e868a28f46cdef28f88521067f21e943")
+	assert.Equal(t, true, update.BlockHash.Equal(expected))
+	expected, _ = new(felt.Felt).SetString("0x021870ba80540e7831fb21c591ee93481f5ae1bb71ff85a86ddd465be4eddee6")
+	assert.Equal(t, true, update.NewRoot.Equal(expected))
+	expected, _ = new(felt.Felt).SetString("0x0000000000000000000000000000000000000000000000000000000000000000")
+	assert.Equal(t, true, update.OldRoot.Equal(expected))
+	assert.Equal(t, 1, len(update.StateDiff.StorageDiffs))
+
+	diffs, found := update.StateDiff.StorageDiffs["0x20cfa74ee3564b4cd5435cdace0f9c4d43b939620e4a0bb5076105df0a626c6"]
+	assert.Equal(t, true, found)
+	assert.Equal(t, 1, len(diffs))
+
+	expected, _ = new(felt.Felt).SetString("0x5")
+	assert.Equal(t, true, diffs[0].Key.Equal(expected))
+	expected, _ = new(felt.Felt).SetString("0x22b")
+	assert.Equal(t, true, diffs[0].Value.Equal(expected))
+
+	assert.Equal(t, 1, len(update.StateDiff.DeployedContracts))
+	expected, _ = new(felt.Felt).SetString("0x20cfa74ee3564b4cd5435cdace0f9c4d43b939620e4a0bb5076105df0a626c6")
+	assert.Equal(t, true, update.StateDiff.DeployedContracts[0].Address.Equal(expected))
+	expected, _ = new(felt.Felt).SetString("0x10455c752b86932ce552f2b0fe81a880746649b9aee7e0d842bf3f52378f9f8")
+	assert.Equal(t, true, update.StateDiff.DeployedContracts[0].ClassHash.Equal(expected))
+}

--- a/clients/gateway_test.go
+++ b/clients/gateway_test.go
@@ -2,6 +2,7 @@ package clients
 
 import (
 	"encoding/json"
+	"os"
 	"testing"
 
 	"github.com/NethermindEth/juno/core/felt"
@@ -239,4 +240,28 @@ func TestL1HandlerTransactionUnmarshal(t *testing.T) {
 	assert.Equal(t, "2386f26fc10000", handlerTx.Calldata[2].Text(16))
 	assert.Equal(t, "0", handlerTx.Calldata[3].Text(16))
 	assert.Equal(t, "L1_HANDLER", handlerTx.Type)
+}
+
+func TestBlockUnmarshal(t *testing.T) {
+	blockJson, err := os.ReadFile("block_11817.json")
+	if err != nil {
+		t.Error(err)
+	}
+
+	var block Block
+	err = json.Unmarshal(blockJson, &block)
+	if err != nil {
+		t.Error(err)
+	}
+
+	assert.Equal(t, "24c692acaed3b486990bd9d2b2fbbee802b37b3bd79c59f295bad3277200a83", block.Hash.Text(16))
+	assert.Equal(t, "3873ccb937f14429b169c654dda28886d2cc2d6ea17b3cff9748fe5cfdb67e0", block.ParentHash.Text(16))
+	assert.Equal(t, uint64(11817), block.Number)
+	assert.Equal(t, "3df24be7b5fed6b41de08d38686b6142944119ca2a345c38793590d6804bba4", block.StateRoot.Text(16))
+	assert.Equal(t, "ACCEPTED_ON_L2", block.Status)
+	assert.Equal(t, "27ad16775", block.GasPrice.Text(16))
+	assert.Equal(t, 52, len(block.Transactions))
+	assert.Equal(t, 52, len(block.Receipts))
+	assert.Equal(t, uint64(1669465009), block.Timestamp)
+	assert.Equal(t, "0.10.1", block.Version)
 }

--- a/clients/gateway_test.go
+++ b/clients/gateway_test.go
@@ -265,3 +265,25 @@ func TestBlockUnmarshal(t *testing.T) {
 	assert.Equal(t, uint64(1669465009), block.Timestamp)
 	assert.Equal(t, "0.10.1", block.Version)
 }
+
+func TestClassUnmarshal(t *testing.T) {
+	classJson, err := os.ReadFile("class_01efa8f8.json")
+	if err != nil {
+		t.Error(err)
+	}
+
+	var class ClassDefinition
+	err = json.Unmarshal(classJson, &class)
+	if err != nil {
+		t.Error(err)
+	}
+
+	assert.Equal(t, 1, len(class.EntryPoints.Constructor))
+	assert.Equal(t, "a1", class.EntryPoints.Constructor[0].Offset.Text(16))
+	assert.Equal(t, "28ffe4ff0f226a9107253e17a904099aa4f63a02a5621de0576e5aa71bc5194", class.EntryPoints.Constructor[0].Selector.Text(16))
+	assert.Equal(t, 1, len(class.EntryPoints.L1Handler))
+	assert.Equal(t, 1, len(class.EntryPoints.External))
+	assert.Equal(t, 250, len(class.Program.Data))
+	assert.Equal(t, []string{"pedersen", "range_check"}, class.Program.Builtins)
+	assert.Equal(t, "0.10.1", class.Program.CompilerVersion)
+}

--- a/clients/gateway_test.go
+++ b/clients/gateway_test.go
@@ -59,3 +59,184 @@ func TestStateUpdateUnmarshal(t *testing.T) {
 	expected, _ = new(felt.Felt).SetString("0x10455c752b86932ce552f2b0fe81a880746649b9aee7e0d842bf3f52378f9f8")
 	assert.Equal(t, true, update.StateDiff.DeployedContracts[0].ClassHash.Equal(expected))
 }
+
+func TestDeclareTransactionUnmarshal(t *testing.T) {
+	declareJson := []byte(`{
+      "transaction_hash":"0x93f542728e403f1edcea4a41f1509a39be35ebcad7d4b5aa77623e5e6480d",
+      "version":"0x1",
+      "max_fee":"0x5af3107a4000",
+      "signature":[
+         "0x516b5999b47509105675dd4c6ed9c373448038cfd00549fe868695916eee0ff",
+         "0x6c0189aaa56bfcb2a3e97198d04bd7a9750a4354b88f4e5edf57cf4d966ddda"
+      ],
+      "nonce":"0x1d",
+      "class_hash":"0x2ed6bb4d57ad27a22972b81feb9d09798ff8c273684376ec72c154d90343453",
+      "sender_address":"0xb8a60857ed233885155f1d839086ca7ad03e6d4237cc10b085a4652a61a23",
+      "type":"DECLARE"
+   }`)
+	var declareTx Transaction
+	err := json.Unmarshal(declareJson, &declareTx)
+	if err != nil {
+		t.Error(err)
+	}
+	assert.Equal(t, "93f542728e403f1edcea4a41f1509a39be35ebcad7d4b5aa77623e5e6480d", declareTx.Hash.Text(16))
+	assert.Equal(t, "1", declareTx.Version.Text(16))
+	assert.Equal(t, "5af3107a4000", declareTx.MaxFee.Text(16))
+	assert.Equal(t, "1d", declareTx.Nonce.Text(16))
+	assert.Equal(t, "2ed6bb4d57ad27a22972b81feb9d09798ff8c273684376ec72c154d90343453", declareTx.ClassHash.Text(16))
+	assert.Equal(t, "b8a60857ed233885155f1d839086ca7ad03e6d4237cc10b085a4652a61a23", declareTx.SenderAddress.Text(16))
+	assert.Equal(t, "DECLARE", declareTx.Type)
+	assert.Equal(t, 2, len(declareTx.Signature))
+	assert.Equal(t, "516b5999b47509105675dd4c6ed9c373448038cfd00549fe868695916eee0ff", declareTx.Signature[0].Text(16))
+	assert.Equal(t, "6c0189aaa56bfcb2a3e97198d04bd7a9750a4354b88f4e5edf57cf4d966ddda", declareTx.Signature[1].Text(16))
+}
+
+func TestInvokeTransactionUnmarshal(t *testing.T) {
+	invokeJson := []byte(`{
+      "transaction_hash":"0x631333277e88053336d8c302630b4420dc3ff24018a1c464da37d5e36ea19df",
+      "version":"0x44",
+      "max_fee":"0x37",
+      "signature":[
+
+      ],
+      "contract_address":"0x17daeb497b6fe0f7adaa32b44677c3a9712b6856b792ad993fcef20aed21ac8",
+      "entry_point_selector":"0x218f305395474a84a39307fa5297be118fe17bf65e27ac5e2de6617baa44c64",
+      "calldata":[
+         "0x346f2b6376b4b57f714ba187716fce9edff1361628cc54783ed0351538faa5e",
+         "0x2"
+      ],
+      "type":"INVOKE_FUNCTION"
+   }`)
+	var invokeTx Transaction
+	err := json.Unmarshal(invokeJson, &invokeTx)
+	if err != nil {
+		t.Error(err)
+	}
+
+	assert.Equal(t, "631333277e88053336d8c302630b4420dc3ff24018a1c464da37d5e36ea19df", invokeTx.Hash.Text(16))
+	assert.Equal(t, "44", invokeTx.Version.Text(16))
+	assert.Equal(t, "37", invokeTx.MaxFee.Text(16))
+	assert.Equal(t, 0, len(invokeTx.Signature))
+	assert.Equal(t, "17daeb497b6fe0f7adaa32b44677c3a9712b6856b792ad993fcef20aed21ac8", invokeTx.ContractAddress.Text(16))
+	assert.Equal(t, "218f305395474a84a39307fa5297be118fe17bf65e27ac5e2de6617baa44c64", invokeTx.EntryPointSelector.Text(16))
+	assert.Equal(t, 2, len(invokeTx.Calldata))
+	assert.Equal(t, "346f2b6376b4b57f714ba187716fce9edff1361628cc54783ed0351538faa5e", invokeTx.Calldata[0].Text(16))
+	assert.Equal(t, "2", invokeTx.Calldata[1].Text(16))
+	assert.Equal(t, "INVOKE_FUNCTION", invokeTx.Type)
+}
+
+func TestDeployTransactionUnmarshal(t *testing.T) {
+	deployJson := []byte(`{
+      "transaction_hash":"0x6d3e06989ee2245139cd677f59b4da7f360a27b2b614a4eb088fdf5862d23ee",
+      "version":"0x0",
+      "contract_address":"0x7cc55b21de4b7d6d7389df3b27de950924ac976d263ac8d71022d0b18155fc",
+      "contract_address_salt":"0x614b9e0c3cb7a8f4ed73b673eba239c41a172859bf129c4b269c4b8057e21d8",
+      "class_hash":"0x3131fa018d520a037686ce3efddeab8f28895662f019ca3ca18a626650f7d1e",
+      "constructor_calldata":[
+         "0x69577e6756a99b584b5d1ce8e60650ae33b6e2b13541783458268f07da6b38a",
+         "0x2dd76e7ad84dbed81c314ffe5e7a7cacfb8f4836f01af4e913f275f89a3de1a",
+         "0x1",
+         "0x614b9e0c3cb7a8f4ed73b673eba239c41a172859bf129c4b269c4b8057e21d8"
+      ],
+      "type":"DEPLOY"
+   }`)
+	var deployTx Transaction
+	err := json.Unmarshal(deployJson, &deployTx)
+	if err != nil {
+		t.Error(err)
+	}
+
+	assert.Equal(t, "6d3e06989ee2245139cd677f59b4da7f360a27b2b614a4eb088fdf5862d23ee", deployTx.Hash.Text(16))
+	assert.Equal(t, "0", deployTx.Version.Text(16))
+	assert.Equal(t, "7cc55b21de4b7d6d7389df3b27de950924ac976d263ac8d71022d0b18155fc", deployTx.ContractAddress.Text(16))
+	assert.Equal(t, "614b9e0c3cb7a8f4ed73b673eba239c41a172859bf129c4b269c4b8057e21d8", deployTx.ContractAddressSalt.Text(16))
+	assert.Equal(t, "3131fa018d520a037686ce3efddeab8f28895662f019ca3ca18a626650f7d1e", deployTx.ClassHash.Text(16))
+	assert.Equal(t, 4, len(deployTx.ConstructorCalldata))
+	assert.Equal(t, "69577e6756a99b584b5d1ce8e60650ae33b6e2b13541783458268f07da6b38a", deployTx.ConstructorCalldata[0].Text(16))
+	assert.Equal(t, "2dd76e7ad84dbed81c314ffe5e7a7cacfb8f4836f01af4e913f275f89a3de1a", deployTx.ConstructorCalldata[1].Text(16))
+	assert.Equal(t, "1", deployTx.ConstructorCalldata[2].Text(16))
+	assert.Equal(t, "614b9e0c3cb7a8f4ed73b673eba239c41a172859bf129c4b269c4b8057e21d8", deployTx.ConstructorCalldata[3].Text(16))
+	assert.Equal(t, "DEPLOY", deployTx.Type)
+}
+
+func TestDeployAccountTransactionUnmarshal(t *testing.T) {
+	deployJson := []byte(`{
+      "transaction_hash":"0x32b272b6d0d584305a460197aa849b5c7a9a85903b66e9d3e1afa2427ef093e",
+      "version":"0x1",
+      "max_fee":"0x59f5f9f474b0",
+      "signature":[
+         "0x467ae89bbbbaa0139e8f8a02ddc614bd80252998f3c033239f59f9f2ab973c5",
+         "0x92938929b5afcd596d651a6d28ed38baf90b000192897617d98de19d475331"
+      ],
+      "nonce":"0x0",
+      "contract_address":"0x104714313388bd0ab569ac247fed6cf0b7a2c737105c00d64c23e24bd8dea40",
+      "contract_address_salt":"0x25b9dbdab19b190a556aa42cdfbc07ad6ffe415031e42a8caffd4a2438d5cc3",
+      "class_hash":"0x25ec026985a3bf9d0cc1fe17326b245dfdc3ff89b8fde106542a3ea56c5a918",
+      "constructor_calldata":[
+         "0x33434ad846cdd5f23eb73ff09fe6fddd568284a0fb7d1be20ee482f044dabe2",
+         "0x79dc0da7c54b95f10aa182ad0a46400db63156920adb65eca2654c0945a463",
+         "0x2",
+         "0x25b9dbdab19b190a556aa42cdfbc07ad6ffe415031e42a8caffd4a2438d5cc3",
+         "0x0"
+      ],
+      "type":"DEPLOY_ACCOUNT"
+   }`)
+	var deployTx Transaction
+	err := json.Unmarshal(deployJson, &deployTx)
+	if err != nil {
+		t.Error(err)
+	}
+
+	assert.Equal(t, "32b272b6d0d584305a460197aa849b5c7a9a85903b66e9d3e1afa2427ef093e", deployTx.Hash.Text(16))
+	assert.Equal(t, "1", deployTx.Version.Text(16))
+	assert.Equal(t, "59f5f9f474b0", deployTx.MaxFee.Text(16))
+	assert.Equal(t, 2, len(deployTx.Signature))
+	assert.Equal(t, "467ae89bbbbaa0139e8f8a02ddc614bd80252998f3c033239f59f9f2ab973c5", deployTx.Signature[0].Text(16))
+	assert.Equal(t, "92938929b5afcd596d651a6d28ed38baf90b000192897617d98de19d475331", deployTx.Signature[1].Text(16))
+	assert.Equal(t, "0", deployTx.Nonce.Text(16))
+	assert.Equal(t, "104714313388bd0ab569ac247fed6cf0b7a2c737105c00d64c23e24bd8dea40", deployTx.ContractAddress.Text(16))
+	assert.Equal(t, "25b9dbdab19b190a556aa42cdfbc07ad6ffe415031e42a8caffd4a2438d5cc3", deployTx.ContractAddressSalt.Text(16))
+	assert.Equal(t, "25ec026985a3bf9d0cc1fe17326b245dfdc3ff89b8fde106542a3ea56c5a918", deployTx.ClassHash.Text(16))
+
+	assert.Equal(t, 5, len(deployTx.ConstructorCalldata))
+	assert.Equal(t, "33434ad846cdd5f23eb73ff09fe6fddd568284a0fb7d1be20ee482f044dabe2", deployTx.ConstructorCalldata[0].Text(16))
+	assert.Equal(t, "79dc0da7c54b95f10aa182ad0a46400db63156920adb65eca2654c0945a463", deployTx.ConstructorCalldata[1].Text(16))
+	assert.Equal(t, "2", deployTx.ConstructorCalldata[2].Text(16))
+	assert.Equal(t, "25b9dbdab19b190a556aa42cdfbc07ad6ffe415031e42a8caffd4a2438d5cc3", deployTx.ConstructorCalldata[3].Text(16))
+	assert.Equal(t, "0", deployTx.ConstructorCalldata[4].Text(16))
+	assert.Equal(t, "DEPLOY_ACCOUNT", deployTx.Type)
+}
+
+func TestL1HandlerTransactionUnmarshal(t *testing.T) {
+	handlerJson := []byte(`{
+      "transaction_hash":"0x218adbb5aea7985d67fe49b45d44a991380b63db41622f9f4adc36274d02190",
+      "version":"0x0",
+      "contract_address":"0x73314940630fd6dcda0d772d4c972c4e0a9946bef9dabf4ef84eda8ef542b82",
+      "entry_point_selector":"0x2d757788a8d8d6f21d1cd40bce38a8222d70654214e96ff95d8086e684fbee5",
+      "nonce":"0x1654d",
+      "calldata":[
+         "0xae0ee0a63a2ce6baeeffe56e7714fb4efe48d419",
+         "0x218559e75713ca564d6eaf043b73388e9ac7c2f459ef8905988052051d3ef5e",
+         "0x2386f26fc10000",
+         "0x0"
+      ],
+      "type":"L1_HANDLER"
+   }`)
+	var handlerTx Transaction
+	err := json.Unmarshal(handlerJson, &handlerTx)
+	if err != nil {
+		t.Error(err)
+	}
+
+	assert.Equal(t, "218adbb5aea7985d67fe49b45d44a991380b63db41622f9f4adc36274d02190", handlerTx.Hash.Text(16))
+	assert.Equal(t, "0", handlerTx.Version.Text(16))
+	assert.Equal(t, "73314940630fd6dcda0d772d4c972c4e0a9946bef9dabf4ef84eda8ef542b82", handlerTx.ContractAddress.Text(16))
+	assert.Equal(t, "2d757788a8d8d6f21d1cd40bce38a8222d70654214e96ff95d8086e684fbee5", handlerTx.EntryPointSelector.Text(16))
+	assert.Equal(t, "1654d", handlerTx.Nonce.Text(16))
+	assert.Equal(t, 4, len(handlerTx.Calldata))
+	assert.Equal(t, "ae0ee0a63a2ce6baeeffe56e7714fb4efe48d419", handlerTx.Calldata[0].Text(16))
+	assert.Equal(t, "218559e75713ca564d6eaf043b73388e9ac7c2f459ef8905988052051d3ef5e", handlerTx.Calldata[1].Text(16))
+	assert.Equal(t, "2386f26fc10000", handlerTx.Calldata[2].Text(16))
+	assert.Equal(t, "0", handlerTx.Calldata[3].Text(16))
+	assert.Equal(t, "L1_HANDLER", handlerTx.Type)
+}

--- a/core/felt/felt.go
+++ b/core/felt/felt.go
@@ -993,7 +993,11 @@ func (z *Felt) UnmarshalJSON(data []byte) error {
 	vv := bigIntPool.Get().(*big.Int)
 
 	if _, ok := vv.SetString(s, 0); !ok {
-		return errors.New("can't parse into a big.Int: " + s)
+		// feeder gateway sometimes omits the "0x" prefix
+		// if failed, try with forced base 16
+		if _, ok = vv.SetString(s, 16); !ok {
+			return errors.New("can't parse into a big.Int: " + s)
+		}
 	}
 
 	z.SetBigInt(vv)


### PR DESCRIPTION
Currently only supports "get_state_update" endpoint because this was started to be able to query the gateway for Trie test data.

Could be used a template for future endpoints

The change in felt.go is warranted because gateway inconsistently omits "0x" prefix for some hex values. So if we fail to parse a hex value as field element, we try again hoping that it is a hexadecimal with a missing prefix

Towards #440 