### PR TITLE
Run benchmarks with memory stats and stop running other tests while benchmarking

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ test: ## tests
 	go test ./...
 
 benchmarks: ## benchmarking
-	go test ./... -bench=.
+	go test ./... -bench=. -benchmem
 
 test-cover: ## tests with coverage
 	mkdir -p coverage

--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ test: ## tests
 	go test ./...
 
 benchmarks: ## benchmarking
-	go test ./... -bench=. -benchmem
+	go test ./... -run=^# -bench=. -benchmem
 
 test-cover: ## tests with coverage
 	mkdir -p coverage


### PR DESCRIPTION
## Description

Run benchmarks with memory stats and stop running other tests while benchmarking.

## Types of changes

- Other (please describe): `Makefile` update

## Testing

**Requires testing**: No

