### PR TITLE
Added pedersen benchmark test

### DIFF
--- a/core/crypto/pedersen_hash_test.go
+++ b/core/crypto/pedersen_hash_test.go
@@ -163,3 +163,25 @@ func BenchmarkPedersenArray(b *testing.B) {
 		})
 	}
 }
+
+func BenchmarkPedersen(b *testing.B) {
+	e0, err := new(felt.Felt).SetString("0x3d937c035c878245caf64531a5756109c53068da139362728feb561405371cb")
+	if err != nil {
+		b.Errorf("Error occured %s", err)
+	}
+
+	e1, err := new(felt.Felt).SetString("0x208a0a10250e382e1e4bbe2880906c2791bf6275695e02fbbc6aeff9cd8b31a")
+	if err != nil {
+		b.Errorf("Error occured %s", err)
+	}
+
+	b.Run("Pedersen hash benchmark test", func(b *testing.B) {
+		var f *felt.Felt
+		var err error
+		f, err = Pedersen(e0, e1)
+		if err != nil {
+			b.Errorf("expected no error but got %s", err)
+		}
+		feltBench = f
+	})
+}

--- a/core/crypto/pedersen_hash_test.go
+++ b/core/crypto/pedersen_hash_test.go
@@ -175,15 +175,12 @@ func BenchmarkPedersen(b *testing.B) {
 		b.Errorf("Error occured %s", err)
 	}
 
-	b.Run("Pedersen hash benchmark test", func(b *testing.B) {
-		var f *felt.Felt
-		var err error
-		for n := 0; n < b.N; n++ {
-			f, err = Pedersen(e0, e1)
-			if err != nil {
-				b.Errorf("expected no error but got %s", err)
-			}
+	var f *felt.Felt
+	for n := 0; n < b.N; n++ {
+		f, err = Pedersen(e0, e1)
+		if err != nil {
+			b.Errorf("expected no error but got %s", err)
 		}
-		feltBench = f
-	})
+	}
+	feltBench = f
 }

--- a/core/crypto/pedersen_hash_test.go
+++ b/core/crypto/pedersen_hash_test.go
@@ -178,9 +178,11 @@ func BenchmarkPedersen(b *testing.B) {
 	b.Run("Pedersen hash benchmark test", func(b *testing.B) {
 		var f *felt.Felt
 		var err error
-		f, err = Pedersen(e0, e1)
-		if err != nil {
-			b.Errorf("expected no error but got %s", err)
+		for n := 0; n < b.N; n++ {
+			f, err = Pedersen(e0, e1)
+			if err != nil {
+				b.Errorf("expected no error but got %s", err)
+			}
 		}
 		feltBench = f
 	})


### PR DESCRIPTION
Fixes | Closes | Resolves #

## Description

_To compare the Juno's pedersen hash implementation with Pathfinder's implementation, we needed a bench mark that takes fixed input and give us the result._

## Changes:

- Added pedersen hash benchmark which takes fixed inputs and run the pedersen hash for them

## Types of changes

_New feature (non-breaking change which adds functionality)._

## Testing

**Requires testing**: No

**Did you write tests??**: No

## Documentation

**If this requires a documentation update, did you add one?** Yes

## Results of the benchmarks
### Juno's Implementation
BenchmarkPedersen-8         2948            361187 ns/op            1121 B/op          4 allocs/op
The benchmark ran 2948 times on average the result that we got is 361187 ns.
Specification of the system used for benchmarking as printed by golang :-
"cpu":0,"vendorId":"","family":"0","model":"0","stepping":0,"physicalId":"","coreId":"","cores":8,"modelName":"Apple M1 Pro","mhz":0,"cacheSize":0,"flags":null,"microcode":""

### Pathfinder's Implementation
Benchmarking pedersen_hash: Collecting 100 samples in estimated 5.0596 s (167k i                                                                                pedersen_hash           time:   [30.268 us 30.380 us 30.517 us]
                        change: [-0.2611% +0.3040% +1.0079%] (p = 0.42 > 0.05)
                        No change in performance detected.
Specification of the system used for benchmarking as printed by rust :-
total memory: 17179869184 bytes
used memory : 17090428928 bytes
total swap  : 21474836480 bytes
used swap   : 20259733504 bytes
System name:             Some("Darwin")
System kernel version:   Some("22.1.0")
System OS version:       Some("13.0")
NB CPUs: 8

Both the bench marks took place on same computer.
Result in same unit
Juno - 361.187 us (micro seconds)
Pathfinder - 30.380 us (micro seconds)