### PR TITLE
mdbx implementation

### DIFF
--- a/core/felt/doc.go
+++ b/core/felt/doc.go
@@ -21,30 +21,33 @@
 // The modulus is hardcoded in all the operations.
 //
 // Field elements are represented as an array, and assumed to be in Montgomery form in all methods:
-// 	type Felt [4]uint64
 //
-// Usage
+//	type Felt [4]uint64
+//
+// # Usage
 //
 // Example API signature:
-// 	// Mul z = x * y (mod q)
-// 	func (z *Element) Mul(x, y *Element) *Element
+//
+//	// Mul z = x * y (mod q)
+//	func (z *Element) Mul(x, y *Element) *Element
 //
 // and can be used like so:
-// 	var a, b Element
-// 	a.SetUint64(2)
-// 	b.SetString("984896738")
-// 	a.Mul(a, b)
-// 	a.Sub(a, a)
-// 	 .Add(a, b)
-// 	 .Inv(a)
-// 	b.Exp(b, new(big.Int).SetUint64(42))
+//
+//	var a, b Element
+//	a.SetUint64(2)
+//	b.SetString("984896738")
+//	a.Mul(a, b)
+//	a.Sub(a, a)
+//	 .Add(a, b)
+//	 .Inv(a)
+//	b.Exp(b, new(big.Int).SetUint64(42))
 //
 // Modulus q =
 //
-// 	q[base10] = 3618502788666131213697322783095070105623107215331596699973092056135872020481
-// 	q[base16] = 0x800000000000011000000000000000000000000000000000000000000000001
+//	q[base10] = 3618502788666131213697322783095070105623107215331596699973092056135872020481
+//	q[base16] = 0x800000000000011000000000000000000000000000000000000000000000001
 //
-// Warning
+// # Warning
 //
 // This code has not been audited and is provided as-is. In particular, there is no security guarantees such as constant time implementation or side-channel attack resistance.
 package felt

--- a/core/felt/felt.go
+++ b/core/felt/felt.go
@@ -35,10 +35,10 @@ import (
 //
 // Modulus q =
 //
-// 	q[base10] = 3618502788666131213697322783095070105623107215331596699973092056135872020481
-// 	q[base16] = 0x800000000000011000000000000000000000000000000000000000000000001
+//	q[base10] = 3618502788666131213697322783095070105623107215331596699973092056135872020481
+//	q[base16] = 0x800000000000011000000000000000000000000000000000000000000000001
 //
-// Warning
+// # Warning
 //
 // This code has not been audited and is provided as-is. In particular, there is no security guarantees such as constant time implementation or side-channel attack resistance.
 type Felt [4]uint64
@@ -68,8 +68,8 @@ var _modulus big.Int // q stored as big.Int
 
 // Modulus returns q as a big.Int
 //
-// 	q[base10] = 3618502788666131213697322783095070105623107215331596699973092056135872020481
-// 	q[base16] = 0x800000000000011000000000000000000000000000000000000000000000001
+//	q[base10] = 3618502788666131213697322783095070105623107215331596699973092056135872020481
+//	q[base16] = 0x800000000000011000000000000000000000000000000000000000000000001
 func Modulus() *big.Int {
 	return new(big.Int).Set(&_modulus)
 }
@@ -91,8 +91,9 @@ func init() {
 // NewFelt returns a new Felt from a uint64 value
 //
 // it is equivalent to
-// 		var v Felt
-// 		v.SetUint64(...)
+//
+//	var v Felt
+//	v.SetUint64(...)
 func NewFelt(v uint64) Felt {
 	z := Felt{v}
 	z.Mul(&z, &rSquare)
@@ -132,14 +133,15 @@ func (z *Felt) Set(x *Felt) *Felt {
 // SetInterface converts provided interface into Felt
 // returns an error if provided type is not supported
 // supported types:
-//  Felt
-//  *Felt
-//  uint64
-//  int
-//  string (see SetString for valid formats)
-//  *big.Int
-//  big.Int
-//  []byte
+//
+//	Felt
+//	*Felt
+//	uint64
+//	int
+//	string (see SetString for valid formats)
+//	*big.Int
+//	big.Int
+//	[]byte
 func (z *Felt) SetInterface(i1 interface{}) (*Felt, error) {
 	if i1 == nil {
 		return nil, errors.New("can't set felt.Felt with <nil>")
@@ -269,10 +271,9 @@ func (z *Felt) FitsOnOneWord() bool {
 
 // Cmp compares (lexicographic order) z and x and returns:
 //
-//   -1 if z <  x
-//    0 if z == x
-//   +1 if z >  x
-//
+//	-1 if z <  x
+//	 0 if z == x
+//	+1 if z >  x
 func (z *Felt) Cmp(x *Felt) int {
 	_z := *z
 	_x := *x
@@ -925,14 +926,14 @@ func (z *Felt) setBigInt(v *big.Int) *Felt {
 // SetString creates a big.Int with number and calls SetBigInt on z
 //
 // The number prefix determines the actual base: A prefix of
-// ''0b'' or ''0B'' selects base 2, ''0'', ''0o'' or ''0O'' selects base 8,
-// and ''0x'' or ''0X'' selects base 16. Otherwise, the selected base is 10
+// ”0b” or ”0B” selects base 2, ”0”, ”0o” or ”0O” selects base 8,
+// and ”0x” or ”0X” selects base 16. Otherwise, the selected base is 10
 // and no prefix is accepted.
 //
 // For base 16, lower and upper case letters are considered the same:
 // The letters 'a' to 'f' and 'A' to 'F' represent digit values 10 to 15.
 //
-// An underscore character ''_'' may appear between a base
+// An underscore character ”_” may appear between a base
 // prefix and an adjacent digit, and between successive digits; such
 // underscores do not change the value of the number.
 // Incorrect placement of underscores is reported as a panic if there

--- a/core/felt/felt_ops_amd64.go
+++ b/core/felt/felt_ops_amd64.go
@@ -35,7 +35,9 @@ func fromMont(res *Felt)
 func reduce(res *Felt)
 
 // Butterfly sets
-//  a = a + b (mod q)
-//  b = a - b (mod q)
+//
+//	a = a + b (mod q)
+//	b = a - b (mod q)
+//
 //go:noescape
 func Butterfly(a, b *Felt)

--- a/core/felt/felt_ops_noasm.go
+++ b/core/felt/felt_ops_noasm.go
@@ -43,8 +43,9 @@ func MulBy13(x *Felt) {
 }
 
 // Butterfly sets
-//  a = a + b (mod q)
-//  b = a - b (mod q)
+//
+//	a = a + b (mod q)
+//	b = a - b (mod q)
 func Butterfly(a, b *Felt) {
 	_butterflyGeneric(a, b)
 }

--- a/db/db.go
+++ b/db/db.go
@@ -4,35 +4,51 @@ import (
 	"io"
 )
 
-// TODO: define custom error types
-
 type TxOp func(Transaction) error
 
+// Database represents a complete database environment, including all
+// buckets (or "sub-databases").
 type Database interface {
 	io.Closer
 
+	// Update creates a read+write transaction on the database.
 	Update(TxOp) error
+	// Update creates a read-only transaction on the database.
 	View(TxOp) error
 }
 
+// Transaction represents a batch of reads and writes to a database.
+// The underlying database may batch transactions in-memory before
+// commiting them to disk, though details vary by implementation.
+// Transactions can also add new buckets to the database.
 type Transaction interface {
-	CreateBucketIfNotExists(string) (Bucket, error)
-	Bucket(string) (Bucket, error)
+	CreateBucketIfNotExists(bucketName string) error
+	Cursor(bucketName string) (Cursor, error)
 }
 
-// TODO we can remove this bucket interface
-type Bucket interface {
-	Get([]byte) ([]byte, error)
-	Put([]byte, []byte) error
-	Cursor() (Cursor, error)
-}
-
+// Cursor performs lookups and modifications on a bucket.
 type Cursor interface {
 	io.Closer
 
-	Seek([]byte) ([]byte, []byte, error)
+	// Get retrieves a value for a provided key. Returns nil if the
+	// value does not exist for the key.
+	Get(key []byte) ([]byte, error)
+	// Put inserts a given key-value pair in the bucket,
+	// overwriting previously inserted pairs if necessary.
+	Put(key []byte, value []byte) error
+	// Seek moves the cursor to the first key with the provided
+	// prefix. Returns nil if no key has the provided prefix. If the
+	// prefix is nil or empty, the first key in the bucket is
+	// returned.
+	Seek(key []byte) ([]byte, []byte, error)
+	// First returns the first key-value pair in the bucket.
 	First() ([]byte, []byte, error)
+	// Last returns the last key-value pair in the bucket.
 	Last() ([]byte, []byte, error)
+	// Next returns the next key-value pair in the bucket relative
+	// to the cursor's current position.
 	Next() ([]byte, []byte, error)
+	// Prev returns the previous key-value pair in the bucket
+	// relative to the cursor's current position.
 	Prev() ([]byte, []byte, error)
 }

--- a/db/db.go
+++ b/db/db.go
@@ -1,0 +1,38 @@
+package db
+
+import (
+	"io"
+)
+
+// TODO: define custom error types
+
+type TxOp func(Transaction) error
+
+type Database interface {
+	io.Closer
+
+	Update(TxOp) error
+	View(TxOp) error
+}
+
+type Transaction interface {
+	CreateBucketIfNotExists(string) (Bucket, error)
+	Bucket(string) (Bucket, error)
+}
+
+// TODO we can remove this bucket interface
+type Bucket interface {
+	Get([]byte) ([]byte, error)
+	Put([]byte, []byte) error
+	Cursor() (Cursor, error)
+}
+
+type Cursor interface {
+	io.Closer
+
+	Seek([]byte) ([]byte, []byte, error)
+	First() ([]byte, []byte, error)
+	Last() ([]byte, []byte, error)
+	Next() ([]byte, []byte, error)
+	Prev() ([]byte, []byte, error)
+}

--- a/db/db_test.go
+++ b/db/db_test.go
@@ -1,0 +1,165 @@
+package db
+
+import (
+	"testing"
+)
+
+func testDb(t *testing.T, db Database) {
+	bucketName := "testBucket"
+	kvs := []struct {
+		k, v []byte
+	}{
+		{[]byte("testKey1"), []byte("testValue1")},
+		{[]byte("testKey2"), []byte("testValue2")},
+		{[]byte("testKey31"), []byte("testValue31")}, // Add trailing '1' to test cursor.Seek() later
+	}
+
+	// View
+	err := db.View(func(tx Transaction) error {
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("failed view transaction: %s", err)
+	}
+
+	// View: try to modify the database
+	err = db.View(func(tx Transaction) error {
+		if err := tx.CreateBucketIfNotExists(bucketName); err == nil {
+			t.Fatalf("db permitted view transaction to modify db")
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("unexpected error in db.View: %s", err)
+	}
+
+	// Update
+	err = db.Update(func(_ Transaction) error {
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("failed to update db: %s", err)
+	}
+
+	// Update: try to modify the database
+	err = db.Update(func(tx Transaction) error {
+		// Transaction: create bucket
+		if err := tx.CreateBucketIfNotExists(bucketName); err != nil {
+			t.Fatalf("failed to create bucket: %s", err)
+		}
+
+		// Transaction: retrieve cursor for nonexistant bucket
+		_, err := tx.Cursor("fakeBucket")
+		if err == nil {
+			t.Fatalf("transaction obtained cursor for nonexistant bucket")
+		}
+
+		// Transaction: obtain cursor for existing bucket
+		c, err := tx.Cursor(bucketName)
+		if err != nil {
+			t.Fatalf("transaction failed to retrieve existing bucket \"%s\": %s", bucketName, err)
+		}
+
+		// Cursor: insert values
+		for _, kv := range kvs {
+			if err = c.Put(kv.k, kv.v); err != nil {
+				t.Fatalf("cursor failed to insert (k: \"%s\", v: \"%s\"): %s", kv.k, kv.v, err)
+			}
+		}
+
+		// Cursor: get a value
+		if v, err := c.Get(kvs[0].k); err != nil {
+			t.Fatalf("cursor failed to get value for key \"%s\": %s", kvs[0].k, err)
+		} else if string(v) != string(kvs[0].v) {
+			t.Fatalf("cursor wrong value for key \"%s\": got \"%s\", want \"%s\"", kvs[0].k, v, kvs[0].v)
+		}
+
+		// Cursor: last, first
+		lastKv := kvs[len(kvs)-1]
+		if k, v, err := c.Last(); err != nil {
+			t.Fatalf("cursor.Last() returned unexpected error: %s", err)
+		} else if string(k) != string(lastKv.k) || string(v) != string(lastKv.v) {
+			t.Fatalf("cursor.Last() returned incorrect pair: got (\"%s\", \"%s\"), want (\"%s\", \"%s\")", k, v, lastKv.k, lastKv.v)
+		}
+		if k, v, err := c.First(); err != nil {
+			t.Fatalf("cursor.First() returned unexpected error: \"%s\"", err)
+		} else if string(k) != string(kvs[0].k) || string(v) != string(kvs[0].v) {
+			t.Fatalf("cursor.First() returned incorrect pair: got (\"%s\", \"%s\"), want (\"%s\", \"%s\")", k, v, kvs[0].k, kvs[0].v)
+		}
+
+		// Cursor: next, prev
+		if k, v, err := c.Next(); err != nil {
+			t.Fatalf("cursor.Next() returned unexpected error")
+		} else if string(k) != string(kvs[1].k) || string(v) != string(kvs[1].v) {
+			t.Fatalf("cursor.Next() returned incorrect pair: got (\"%s\", \"%s\"), want (\"%s\", \"%s\")", k, v, kvs[1].k, kvs[1].v)
+		}
+		if k, v, err := c.Prev(); err != nil {
+			t.Fatalf("cursor.Prev() returned unexpected error: %s", err)
+		} else if string(k) != string(kvs[0].k) || string(v) != string(kvs[0].v) {
+			t.Fatalf("cursor.Prev() returned incorrect pair: got (\"%s\", \"%s\"), want (\"%s\", \"%s\")", k, v, kvs[0].k, kvs[0].v)
+		}
+
+		// Cursor: seek
+		target := kvs[2]
+		prefix := target.k[:len(target.k)-1] // All but the last character
+		if k, v, err := c.Seek(prefix); err != nil {
+			t.Fatalf("cursor.Seek(\"%s\") returned unexpected error: %s", prefix, err)
+		} else if string(k) != string(target.k) || string(v) != string(target.v) {
+			t.Fatalf("cursor.Seek(\"%s\") returned incorrect pair: got (\"%s\", \"%s\"), want (\"%s\", \"%s\")", prefix, k, v, target.k, target.v)
+		}
+
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("failed to update db: %s", err)
+	}
+
+	// Run multiple transactions
+
+	// View
+	err = db.View(func(tx Transaction) error {
+		c, err := tx.Cursor(bucketName)
+		if err != nil {
+			t.Fatalf("failed to open cursor on existing bucket %s: %s", bucketName, err)
+		}
+		kv := kvs[0]
+		if k, v, err := c.First(); err != nil {
+			t.Fatalf("unexpected error on cursor.First(): %s", err)
+		} else if string(k) != string(kv.k) || string(v) != string(kv.v) {
+			t.Fatalf("cursor.First() did not return correct key-value pair: got (\"%s\", \"%s\"), want (\"%s\", \"%s\")", k, v, kv.k, kv.v)
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("failed to view db: %s", err)
+	}
+
+	// Update
+	err = db.Update(func(tx Transaction) error {
+		c, err := tx.Cursor(bucketName)
+		if err != nil {
+			t.Fatalf("failed to open cursor on existing bucket %s: %s", bucketName, err)
+		}
+		if err = c.Put([]byte("testKey4"), []byte("testValue4")); err != nil {
+			t.Fatalf("unexpected error on cursor.Put(\"testKey4\", \"testValue4\"): %s", err)
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("failed to update db: %s", err)
+	}
+}
+
+func TestMdbxDb(t *testing.T) {
+	db, err := NewMdbxDb(t.TempDir(), 1 /* maxBuckets */)
+	if err != nil {
+		t.Fatalf("failed to create db: %s", err)
+	}
+	defer func() {
+		if err := db.Close(); err != nil {
+			t.Fatalf("failed to close db: %s", err)
+		}
+	}()
+
+	testDb(t, db)
+}

--- a/db/mdbx.go
+++ b/db/mdbx.go
@@ -1,0 +1,174 @@
+package db
+
+import (
+	"fmt"
+
+	"github.com/torquem-ch/mdbx-go/mdbx"
+)
+
+type MdbxDb struct {
+	env *mdbx.Env
+}
+
+var _ Database = &MdbxDb{}
+
+func NewMdbxDb(path string, maxBuckets uint64) (*MdbxDb, error) {
+	env, err := mdbx.NewEnv()
+	if err != nil {
+		return nil, err
+	}
+
+	// By default, mdbx will only create enough buckets for its
+	// two CORE_DBs [1]. The first core bucket is used to track free
+	// pages and the second is the "main" bucket [2].
+	// [1] mdbx_env_create in mdbx.c
+	// [2] https://blog.separateconcerns.com/2016-04-03-lmdb-format.html
+	env.SetOption(mdbx.OptMaxDB, maxBuckets)
+
+	// TODO more options?
+
+	// TODO which flags and mode?
+	if err := env.Open(path, 0 /* flags */, 0o664 /* FileMode */); err != nil {
+		env.Close()
+		return nil, err
+	}
+
+	return &MdbxDb{
+		env: env,
+	}, nil
+}
+
+func (db *MdbxDb) Update(op TxOp) error {
+	return db.env.Update(func(tx *mdbx.Txn) error {
+		return op(newMdbxTx(tx))
+	})
+}
+
+func (db *MdbxDb) View(op TxOp) error {
+	return db.env.View(func(tx *mdbx.Txn) error {
+		return op(newMdbxTx(tx))
+	})
+}
+
+func (db *MdbxDb) Close() error {
+	db.env.Close()
+	return nil
+}
+
+type mdbxTx struct {
+	tx *mdbx.Txn
+}
+
+var _ Transaction = &mdbxTx{}
+
+func newMdbxTx(tx *mdbx.Txn) *mdbxTx {
+	return &mdbxTx{
+		tx: tx,
+	}
+}
+
+func (tx *mdbxTx) CreateBucketIfNotExists(name string) (Bucket, error) {
+	b, err := tx.tx.CreateDBI(name)
+	if err != nil {
+		return nil, err // TODO wrap error
+	}
+	return newMdbxBucket(tx.tx, b), nil
+}
+
+func (tx *mdbxTx) Bucket(name string) (Bucket, error) {
+	b, err := tx.tx.OpenDBI(name, 0, nil, nil) // TODO params
+	if err != nil {
+		return nil, err // TODO wrap error
+	}
+	return newMdbxBucket(tx.tx, b), nil
+}
+
+type mdbxBucket struct {
+	tx *mdbx.Txn
+	b  mdbx.DBI
+}
+
+var _ Bucket = &mdbxBucket{}
+
+func newMdbxBucket(tx *mdbx.Txn, b mdbx.DBI) *mdbxBucket {
+	return &mdbxBucket{
+		tx: tx,
+		b:  b,
+	}
+}
+
+func (b *mdbxBucket) Get(key []byte) ([]byte, error) {
+	return b.tx.Get(b.b, key)
+}
+
+func (b *mdbxBucket) Put(key []byte, value []byte) error {
+	return b.tx.Put(b.b, key, value, 0 /* flags */) // TODO: flags
+}
+
+func (b *mdbxBucket) Cursor() (Cursor, error) {
+	c, err := b.tx.OpenCursor(b.b)
+	if err != nil {
+		return nil, err
+	}
+	return newMdbxCursor(c), nil
+}
+
+type mdbxCursor struct {
+	c *mdbx.Cursor
+}
+
+var _ Cursor = &mdbxCursor{}
+
+func newMdbxCursor(c *mdbx.Cursor) *mdbxCursor {
+	return &mdbxCursor{
+		c: c,
+	}
+}
+
+func (c *mdbxCursor) Seek(prefix []byte) ([]byte, []byte, error) {
+	// See https://github.com/ledgerwatch/erigon-lib/blob/661ef494cf0035ddb4caa804394f66532d5cb2d3/kv/mdbx/kv_mdbx.go#L1159-L1178
+	var k, v []byte
+	var err error
+	if len(prefix) == 0 {
+		k, v, err = c.get(nil, nil, mdbx.First)
+	} else {
+		k, v, err = c.get(prefix, nil, mdbx.SetRange)
+	}
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed seek on prefix %x: %w", prefix, err)
+	}
+	return k, v, nil
+}
+
+func (c *mdbxCursor) Next() ([]byte, []byte, error) {
+	return c.get(nil, nil, mdbx.Next)
+}
+
+func (c *mdbxCursor) Prev() ([]byte, []byte, error) {
+	return c.get(nil, nil, mdbx.Prev)
+}
+
+func (c *mdbxCursor) First() ([]byte, []byte, error) {
+	return c.get(nil, nil, mdbx.First)
+}
+
+func (c *mdbxCursor) Last() ([]byte, []byte, error) {
+	return c.get(nil, nil, mdbx.Last)
+}
+
+func (c *mdbxCursor) get(prefix []byte, value []byte, op uint) ([]byte, []byte, error) {
+	k, v, err := c.c.Get(prefix, value, op)
+	// See TODO
+	if err != nil {
+		if mdbx.IsNotFound(err) {
+			return nil, nil, nil
+		}
+		return nil, nil, fmt.Errorf("failed cursor.get(): %w", err)
+	}
+	return k, v, nil
+}
+
+func (c *mdbxCursor) Close() error {
+	c.c.Close()
+	return nil
+}

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/spf13/cobra v1.5.0
 	github.com/spf13/viper v1.12.0
 	github.com/stretchr/testify v1.8.0
+	github.com/torquem-ch/mdbx-go v0.26.3
 	golang.org/x/crypto v0.0.0-20220411220226-7b82a4e95df4
 	golang.org/x/sys v0.2.0
 )

--- a/go.sum
+++ b/go.sum
@@ -175,6 +175,8 @@ github.com/stretchr/testify v1.8.0 h1:pSgiaMZlXftHpm5L7V1+rVB+AZJydKsMxsQBIJw4PK
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
 github.com/subosito/gotenv v1.3.0 h1:mjC+YW8QpAdXibNi+vNWgzmgBH4+5l5dCXv8cNysBLI=
 github.com/subosito/gotenv v1.3.0/go.mod h1:YzJjq/33h7nrwdY+iHMhEOEEbW0ovIz0tB6t6PwAXzs=
+github.com/torquem-ch/mdbx-go v0.26.3 h1:Yddu8hVKjCHqyPpOSwYgNS/zBKviKUiufa3t/nCjvPE=
+github.com/torquem-ch/mdbx-go v0.26.3/go.mod h1:T2fsoJDVppxfAPTLd1svUgH1kpPmeXdPESmroSHcL1E=
 github.com/yuin/goldmark v1.1.25/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.32/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=


### PR DESCRIPTION
Closes #455 

## Description

Add the database interfaces and implementation.
- `Database`: contains all of Juno's tables (or "buckets"). This is represented by mdbx's "environment" struct, which manages the on-disk database file. 
- `Transaction`: creates buckets and opens cursors on buckets.
- `Cursor`: modifies the database, moves to keys in the database

We will probably need to add more functionality to the `Cursor` interface (e.g, `ForEach`, `PutMulti`, etc.) in the future, but it may make sense to add those incrementally rather than making this PR larger.

## Types of changes

- New feature (non-breaking change which adds functionality)
- Documentation Update

## Testing

**Requires testing**: Yes

**Did you write tests??**: Yes

## Documentation

**If this requires a documentation update, did you add one?** Yes: comments added where necessary