### PR TITLE
update pedersen

### DIFF
--- a/core/crypto/pedersen_hash.go
+++ b/core/crypto/pedersen_hash.go
@@ -43,3 +43,15 @@ func Pedersen(a *felt.Felt, b *felt.Felt) (*felt.Felt, error) {
 	}
 	return new(felt.Felt).SetBytes(out[:starkware.FeltSize]), nil
 }
+
+func PedersenHash(elems ...*felt.Felt) (*felt.Felt, error) {
+	if len(elems) < 2 {
+		return nil, errors.New("number of elems must be 2 and above")
+	}
+
+	if len(elems) < 3 {
+		return Pedersen(elems[0], elems[1])
+	} else {
+		return PedersenArray(elems...)
+	}
+}

--- a/core/crypto/pedersen_hash.go
+++ b/core/crypto/pedersen_hash.go
@@ -45,13 +45,14 @@ func Pedersen(a *felt.Felt, b *felt.Felt) (*felt.Felt, error) {
 }
 
 func PedersenHash(elems ...*felt.Felt) (*felt.Felt, error) {
-	if len(elems) < 2 {
-		return nil, errors.New("number of elems must be 2 and above")
-	}
-
-	if len(elems) < 3 {
+	switch len(elems) {
+	case 0:
+		return nil, errors.New("number of elems must be more than 0")
+	case 1:
+		return Pedersen(new(felt.Felt).SetZero(), elems[0])
+	case 2:
 		return Pedersen(elems[0], elems[1])
-	} else {
+	default:
 		return PedersenArray(elems...)
 	}
 }

--- a/core/crypto/pedersen_hash_test.go
+++ b/core/crypto/pedersen_hash_test.go
@@ -131,6 +131,43 @@ func TestPedersenArray(t *testing.T) {
 	}
 }
 
+func TestPedersenHash(t *testing.T) {
+	tests := []struct {
+		elems   []*felt.Felt
+		wantErr bool
+	}{
+
+		{
+			elems:   []*felt.Felt{},
+			wantErr: true,
+		},
+		{
+			elems:   []*felt.Felt{new(felt.Felt).SetOne()},
+			wantErr: true,
+		},
+		{
+			elems:   []*felt.Felt{new(felt.Felt).SetOne(), new(felt.Felt).SetZero()},
+			wantErr: false,
+		},
+		{
+			elems:   []*felt.Felt{new(felt.Felt).SetOne(), new(felt.Felt).SetZero(), new(felt.Felt).SetZero()},
+			wantErr: false,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(fmt.Sprintf("Num of input %d", len(test.elems)), func(t *testing.T) {
+			_, err := PedersenHash(test.elems...)
+			if err != nil && !test.wantErr {
+				t.Errorf("PedersenHash(%x) = %v, want no error", test.elems, err)
+			}
+			if err == nil && test.wantErr {
+				t.Error("expected to get an error but got none")
+			}
+		})
+	}
+}
+
 var feltBench *felt.Felt
 
 // go test -bench=. -run=^# -cpu=1,2,4,8,16

--- a/core/crypto/pedersen_hash_test.go
+++ b/core/crypto/pedersen_hash_test.go
@@ -143,7 +143,7 @@ func TestPedersenHash(t *testing.T) {
 		},
 		{
 			elems:   []*felt.Felt{new(felt.Felt).SetOne()},
-			wantErr: true,
+			wantErr: false,
 		},
 		{
 			elems:   []*felt.Felt{new(felt.Felt).SetOne(), new(felt.Felt).SetZero()},


### PR DESCRIPTION
## Description

Pedersen Hash is used a lot in the hash calculations and sometimes, we can't predict the input number (whether the elements are > 2 or less than 2). For example, [this](https://github.com/NethermindEth/juno/blob/jelilat/implement_class_hash/core/contract/contract.go#L165-L178) in the class hash computation.

The current solution is checking this before computing the Pedersen hash. But given the fact that we may have to do this multiple times, it's neater to check in the Pedersen Hash function

## Changes:

- Change 1
- Change 2

## Types of changes

- Improve existing functionality

## Testing

**Requires testing**: Yes

**Did you write tests??**: Yes


