### PR TITLE
Update test workflow

### DIFF
--- a/.github/workflows/juno-test.yml
+++ b/.github/workflows/juno-test.yml
@@ -29,6 +29,7 @@ jobs:
         run: make benchmarks
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v3
+        if: matrix.os == 'ubuntu-latest'
         with:
           fail_ci_if_error: true
           files: ./coverage/coverage.out


### PR DESCRIPTION
## Description

Codecov upload was failing during the unit test workflow because we were trying to upload two coverage reports, one for the ubuntu runner and the other for the macos one. This PR fix this problem.

## Changes:

- Only upload codecov coverage on the ubuntu runner

## Types of changes

- Build related changes

## Testing

**Requires testing**: No


