### PR TITLE
Fix Pedersen array hash

### DIFF
--- a/core/crypto/pedersen_hash.go
+++ b/core/crypto/pedersen_hash.go
@@ -1,8 +1,6 @@
 package crypto
 
 import (
-	"errors"
-
 	"github.com/NethermindEth/juno/core/crypto/starkware"
 	"github.com/NethermindEth/juno/core/felt"
 )
@@ -11,13 +9,8 @@ import (
 //
 // [Pedersen array hashing]: https://docs.starknet.io/documentation/develop/Hashing/hash-functions/#pedersen_hash
 func PedersenArray(elems ...*felt.Felt) (*felt.Felt, error) {
-	if len(elems) < 3 {
-		return nil, errors.New("number of elems must be more than 2")
-	}
-
 	var err error
-	d := new(felt.Felt).SetZero()
-
+	d := new(felt.Felt)
 	for _, e := range elems {
 		d, err = Pedersen(d, e)
 		if err != nil {

--- a/core/crypto/pedersen_hash_test.go
+++ b/core/crypto/pedersen_hash_test.go
@@ -47,30 +47,6 @@ func TestPedersen(t *testing.T) {
 	}
 }
 
-func TestPedersenArrayLessThanThree(t *testing.T) {
-	tests := [...]struct {
-		elems []*felt.Felt
-	}{
-		{
-			elems: []*felt.Felt{},
-		},
-		{
-			elems: []*felt.Felt{new(felt.Felt).SetOne()},
-		},
-		{
-			elems: []*felt.Felt{new(felt.Felt).SetOne(), new(felt.Felt).SetZero()},
-		},
-	}
-	for _, test := range tests {
-		t.Run(fmt.Sprintf("Num of input %d", len(test.elems)), func(t *testing.T) {
-			_, err := PedersenArray(test.elems...)
-			if err == nil {
-				t.Error("expected to get an error but got none")
-			}
-		})
-	}
-}
-
 func TestPedersenArray(t *testing.T) {
 	tests := [...]struct {
 		input []string

--- a/core/crypto/pedersen_hash_test.go
+++ b/core/crypto/pedersen_hash_test.go
@@ -92,6 +92,13 @@ func TestPedersenArray(t *testing.T) {
 			},
 			want: "0xe0a2e45a80bb827967e096bcf58874f6c01c191e0a0530624cba66a508ae75",
 		},
+		// Hash of an empty array is defined to be h(0, 0).
+		{
+			input: make([]string, 0),
+			// The value below was found using the reference implementation. See:
+			// https://github.com/starkware-libs/cairo-lang/blob/de741b92657f245a50caab99cfaef093152fd8be/src/starkware/crypto/signature/fast_pedersen_hash.py#L34
+			want: "0x49ee3eba8c1600700ee1b87eb599f16716b0b1022947733551fde4050ca6804",
+		},
 	}
 	for _, test := range tests {
 		var data []*felt.Felt


### PR DESCRIPTION
## Description

We need to hash small arrays (length less than 3), which the current implementation of the Pedersen array hash does not permit.
 
## Changes:

- Remove the check that returns error if provided an array of length < 3 (also remove the associated test)
- Add test for array hash of empty array

## Types of changes

- Bugfix (non-breaking change which fixes an issue)

## Testing

**Requires testing**: Yes

**Did you write tests?**: Yes

