### PR TITLE
update networks

### DIFF
--- a/utils/network.go
+++ b/utils/network.go
@@ -5,6 +5,8 @@ type Network uint8
 const (
 	GOERLI Network = iota
 	MAINNET
+	GOERLI2
+	INTEGRATION
 )
 
 func (n Network) String() string {
@@ -13,6 +15,10 @@ func (n Network) String() string {
 		return "goerli"
 	case MAINNET:
 		return "mainnet"
+	case GOERLI2:
+		return "goerli2"
+	case INTEGRATION:
+		return "integration"
 	default:
 		return ""
 	}
@@ -24,6 +30,34 @@ func (n Network) URL() string {
 		return "https://alpha4.starknet.io"
 	case MAINNET:
 		return "https://alpha-mainnet.starknet.io"
+	case GOERLI2:
+		return "https://alpha4.starknet.io"
+	case INTEGRATION:
+		return "https://external.integration.starknet.io"
+	default:
+		return ""
+	}
+}
+
+type Chain string
+
+const (
+	Goerli      Chain = "SN_GOERLI"
+	Mainnet     Chain = "SN_MAINNET"
+	Goerli2     Chain = "SN_GOERLI2"
+	Integration Chain = "SN_INTEGRATION"
+)
+
+func (n Network) ChainId() Chain {
+	switch n {
+	case GOERLI:
+		return Goerli
+	case MAINNET:
+		return Mainnet
+	case GOERLI2:
+		return Goerli2
+	case INTEGRATION:
+		return Integration
 	default:
 		return ""
 	}

--- a/utils/network.go
+++ b/utils/network.go
@@ -39,25 +39,16 @@ func (n Network) URL() string {
 	}
 }
 
-type Chain string
-
-const (
-	Goerli      Chain = "SN_GOERLI"
-	Mainnet     Chain = "SN_MAINNET"
-	Goerli2     Chain = "SN_GOERLI2"
-	Integration Chain = "SN_INTEGRATION"
-)
-
-func (n Network) ChainId() Chain {
+func (n Network) ChainId() string {
 	switch n {
 	case GOERLI:
-		return Goerli
+		return "SN_GOERLI"
 	case MAINNET:
-		return Mainnet
+		return "SN_MAINNET"
 	case GOERLI2:
-		return Goerli2
+		return "SN_GOERLI2"
 	case INTEGRATION:
-		return Integration
+		return "SN_INTEGRATION"
 	default:
 		return ""
 	}

--- a/utils/network.go
+++ b/utils/network.go
@@ -1,5 +1,7 @@
 package utils
 
+import "github.com/NethermindEth/juno/core/felt"
+
 type Network uint8
 
 const (
@@ -39,17 +41,17 @@ func (n Network) URL() string {
 	}
 }
 
-func (n Network) ChainId() string {
+func (n Network) ChainId() *felt.Felt {
 	switch n {
 	case GOERLI:
-		return "SN_GOERLI"
+		return new(felt.Felt).SetBytes([]byte("SN_GOERLI"))
 	case MAINNET:
-		return "SN_MAINNET"
+		return new(felt.Felt).SetBytes([]byte("SN_MAINNET"))
 	case GOERLI2:
-		return "SN_GOERLI2"
+		return new(felt.Felt).SetBytes([]byte("SN_GOERLI2"))
 	case INTEGRATION:
-		return "SN_INTEGRATION"
+		return new(felt.Felt).SetBytes([]byte("SN_INTEGRATION"))
 	default:
-		return ""
+		return nil
 	}
 }

--- a/utils/network_test.go
+++ b/utils/network_test.go
@@ -45,15 +45,15 @@ func TestNetwork(t *testing.T) {
 		for _, n := range networks {
 			switch n {
 			case GOERLI:
-				assert.Equal(t, Goerli, n.ChainId())
+				assert.Equal(t, "SN_GOERLI", n.ChainId())
 			case MAINNET:
-				assert.Equal(t, Mainnet, n.ChainId())
+				assert.Equal(t, "SN_MAINNET", n.ChainId())
 			case GOERLI2:
-				assert.Equal(t, Goerli2, n.ChainId())
+				assert.Equal(t, "SN_GOERLI2", n.ChainId())
 			case INTEGRATION:
-				assert.Equal(t, Integration, n.ChainId())
+				assert.Equal(t, "SN_INTEGRATION", n.ChainId())
 			default:
-				assert.Equal(t, Chain(""), n.ChainId())
+				assert.Equal(t, "", n.ChainId())
 
 			}
 		}

--- a/utils/network_test.go
+++ b/utils/network_test.go
@@ -15,9 +15,12 @@ func TestNetwork(t *testing.T) {
 				assert.Equal(t, "goerli", n.String())
 			case MAINNET:
 				assert.Equal(t, "mainnet", n.String())
+			case GOERLI2:
+				assert.Equal(t, "goerli2", n.String())
+			case INTEGRATION:
+				assert.Equal(t, "integration", n.String())
 			default:
 				assert.Equal(t, "", n.String())
-
 			}
 		}
 	})
@@ -28,8 +31,29 @@ func TestNetwork(t *testing.T) {
 				assert.Equal(t, "https://alpha4.starknet.io", n.URL())
 			case MAINNET:
 				assert.Equal(t, "https://alpha-mainnet.starknet.io", n.URL())
+			case GOERLI2:
+				assert.Equal(t, "https://alpha4.starknet.io", n.URL())
+			case INTEGRATION:
+				assert.Equal(t, "https://external.integration.starknet.io", n.URL())
 			default:
 				assert.Equal(t, "", n.URL())
+
+			}
+		}
+	})
+	t.Run("chainId", func(t *testing.T) {
+		for _, n := range networks {
+			switch n {
+			case GOERLI:
+				assert.Equal(t, Goerli, n.ChainId())
+			case MAINNET:
+				assert.Equal(t, Mainnet, n.ChainId())
+			case GOERLI2:
+				assert.Equal(t, Goerli2, n.ChainId())
+			case INTEGRATION:
+				assert.Equal(t, Integration, n.ChainId())
+			default:
+				assert.Equal(t, Chain(""), n.ChainId())
 
 			}
 		}

--- a/utils/network_test.go
+++ b/utils/network_test.go
@@ -3,6 +3,7 @@ package utils
 import (
 	"testing"
 
+	"github.com/NethermindEth/juno/core/felt"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -45,16 +46,15 @@ func TestNetwork(t *testing.T) {
 		for _, n := range networks {
 			switch n {
 			case GOERLI:
-				assert.Equal(t, "SN_GOERLI", n.ChainId())
+				assert.Equal(t, new(felt.Felt).SetBytes([]byte("SN_GOERLI")), n.ChainId())
 			case MAINNET:
-				assert.Equal(t, "SN_MAINNET", n.ChainId())
+				assert.Equal(t, new(felt.Felt).SetBytes([]byte("SN_MAINNET")), n.ChainId())
 			case GOERLI2:
-				assert.Equal(t, "SN_GOERLI2", n.ChainId())
+				assert.Equal(t, new(felt.Felt).SetBytes([]byte("SN_GOERLI2")), n.ChainId())
 			case INTEGRATION:
-				assert.Equal(t, "SN_INTEGRATION", n.ChainId())
+				assert.Equal(t, new(felt.Felt).SetBytes([]byte("SN_INTEGRATION")), n.ChainId())
 			default:
-				assert.Equal(t, "", n.ChainId())
-
+				assert.Equal(t, (*felt.Felt)(nil), n.ChainId())
 			}
 		}
 	})


### PR DESCRIPTION
## Description

Starknet has 2 other networks that Juno doesn't support at the moment. Supporting these networks is required for us to correctly compute all block hashes

## Changes:

- Added support for the `GOERLI2` and `INTEGRATION` networks
- Added Chain id

## Types of changes

- New feature (non-breaking change which adds functionality)

## Testing

**Requires testing**: Yes

**Did you write tests??**: Yes

