### PR TITLE
bug fix: update goerli2 network url

### DIFF
--- a/utils/network.go
+++ b/utils/network.go
@@ -33,7 +33,7 @@ func (n Network) URL() string {
 	case MAINNET:
 		return "https://alpha-mainnet.starknet.io"
 	case GOERLI2:
-		return "https://alpha4.starknet.io"
+		return "https://alpha4-2.starknet.io"
 	case INTEGRATION:
 		return "https://external.integration.starknet.io"
 	default:

--- a/utils/network_test.go
+++ b/utils/network_test.go
@@ -33,7 +33,7 @@ func TestNetwork(t *testing.T) {
 			case MAINNET:
 				assert.Equal(t, "https://alpha-mainnet.starknet.io", n.URL())
 			case GOERLI2:
-				assert.Equal(t, "https://alpha4.starknet.io", n.URL())
+				assert.Equal(t, "https://alpha4-2.starknet.io", n.URL())
 			case INTEGRATION:
 				assert.Equal(t, "https://external.integration.starknet.io", n.URL())
 			default:


### PR DESCRIPTION
## Description

The network url for `GOERLI2` is wrong. This PR updates it with the correct URL.

## Changes:

- Change `GOERLI2` network url

## Types of changes

- Bugfix (non-breaking change which fixes an issue)

## Testing

**Requires testing**: Yes

**Did you write tests??**: Yes
