### PR TITLE
Implement contract address

### DIFF
--- a/core/contract.go
+++ b/core/contract.go
@@ -66,12 +66,9 @@ type Contract struct {
 }
 
 // ContractAddress computes the address of a StarkNet contract.
-func ContractAddress(callerAddress, classHash, salt *felt.Felt, constructorCalldata []*felt.Felt) (*felt.Felt, error) {
+func ContractAddress(callerAddress, classHash, salt *felt.Felt, constructorCalldata []*felt.Felt) *felt.Felt {
 	prefix := new(felt.Felt).SetBytes([]byte("STARKNET_CONTRACT_ADDRESS"))
-	calldataHash, err := crypto.PedersenArray(constructorCalldata...)
-	if err != nil {
-		return nil, err
-	}
+	calldataHash := crypto.PedersenArray(constructorCalldata...)
 
 	// https://docs.starknet.io/documentation/architecture_and_concepts/Contracts/contract-address
 	return crypto.PedersenArray(

--- a/core/contract.go
+++ b/core/contract.go
@@ -64,3 +64,21 @@ type Contract struct {
 	// Root of the contract's storage trie.
 	StorageRoot *felt.Felt // TODO: is this field necessary?
 }
+
+// ContractAddress computes the address of a StarkNet contract.
+func ContractAddress(callerAddress, classHash, salt *felt.Felt, constructorCalldata []*felt.Felt) (*felt.Felt, error) {
+	prefix := new(felt.Felt).SetBytes([]byte("STARKNET_CONTRACT_ADDRESS"))
+	calldataHash, err := crypto.PedersenArray(constructorCalldata...)
+	if err != nil {
+		return nil, err
+	}
+
+	// https://docs.starknet.io/documentation/architecture_and_concepts/Contracts/contract-address
+	return crypto.PedersenArray(
+		prefix,
+		callerAddress,
+		salt,
+		classHash,
+		calldataHash,
+	)
+}

--- a/core/contract.go
+++ b/core/contract.go
@@ -66,9 +66,25 @@ type Contract struct {
 }
 
 // ContractAddress computes the address of a StarkNet contract.
-func ContractAddress(callerAddress, classHash, salt *felt.Felt, constructorCalldata []*felt.Felt) *felt.Felt {
+// Todo: [Contract] should have all the information it needs to calculate its address therefore we
+// should add callerAddress, salt and constructorCallData to [Contract]'s fields.
+// Then we have two options to the address of the contract:
+//
+//  1. Keep the following function and at [Contract] instantiation time calculate the address and
+//     store it as a field of [Class].
+//
+//  2. Add ContractAddress as a method on the Contract object. The ContractAddress would calculate
+//     the address as follows (when contract.Address() is called):
+//
+//     func (c *Contract) Address(...) *felt.Felt{
+//     if c.Address != nil {
+//     return c.Address
+//     } else {
+//     // Calculate the Address and Store it in c.Address
+//     }
+func ContractAddress(callerAddress, classHash, salt *felt.Felt, constructorCallData []*felt.Felt) *felt.Felt {
 	prefix := new(felt.Felt).SetBytes([]byte("STARKNET_CONTRACT_ADDRESS"))
-	calldataHash := crypto.PedersenArray(constructorCalldata...)
+	callDataHash := crypto.PedersenArray(constructorCallData...)
 
 	// https://docs.starknet.io/documentation/architecture_and_concepts/Contracts/contract-address
 	return crypto.PedersenArray(
@@ -76,6 +92,6 @@ func ContractAddress(callerAddress, classHash, salt *felt.Felt, constructorCalld
 		callerAddress,
 		salt,
 		classHash,
-		calldataHash,
+		callDataHash,
 	)
 }

--- a/core/contract_test.go
+++ b/core/contract_test.go
@@ -238,7 +238,7 @@ func TestClassHash(t *testing.T) {
 	}
 }
 
-func TestAddresses(t *testing.T) {
+func TestContractAddress(t *testing.T) {
 	tests := []struct {
 		callerAddress       *felt.Felt
 		classHash           *felt.Felt
@@ -264,10 +264,7 @@ func TestAddresses(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run("Address", func(t *testing.T) {
-			address, err := ContractAddress(tt.callerAddress, tt.classHash, tt.salt, tt.constructorCalldata)
-			if err != nil {
-				t.Fatalf("unexpected error while computing address: %s", err)
-			}
+			address := ContractAddress(tt.callerAddress, tt.classHash, tt.salt, tt.constructorCalldata)
 			if !address.Equal(tt.want) {
 				t.Errorf("wrong address: got %s, want %s", address.Text(16), tt.want.Text(16))
 			}

--- a/core/contract_test.go
+++ b/core/contract_test.go
@@ -258,7 +258,7 @@ func TestAddresses(t *testing.T) {
 				hexToFelt("0x6658165b4984816ab189568637bedec5aa0a18305909c7f5726e4a16e3afef6"),
 				hexToFelt("0x6b648b36b074a91eee55730f5f5e075ec19c0a8f9ffb0903cefeee93b6ff328"),
 			},
-			want: hexToFelt("0x6486c6303dba2f364c684a2e9609211c5b8e417e767f37b527cda51e776e6f0"),
+			want: hexToFelt("0x3ec215c6c9028ff671b46a2a9814970ea23ed3c4bcc3838c6d1dcbf395263c3"),
 		},
 	}
 

--- a/core/contract_test.go
+++ b/core/contract_test.go
@@ -17,6 +17,12 @@ var (
 	bytecodeCairo10Bytes []byte
 )
 
+func hexToFelt(hex string) *felt.Felt {
+	// We know our test hex values are valid, so we'll ignore the potential error
+	f, _ := new(felt.Felt).SetString(hex)
+	return f
+}
+
 func TestClassHash(t *testing.T) {
 	var bytecodeGenesis []*felt.Felt
 	if err := json.Unmarshal(bytecodeGenesisBytes, &bytecodeGenesis); err != nil {
@@ -29,12 +35,6 @@ func TestClassHash(t *testing.T) {
 	var bytecodeCairo10 []*felt.Felt
 	if err := json.Unmarshal(bytecodeCairo10Bytes, &bytecodeCairo10); err != nil {
 		t.Fatalf("unexpected error while unmarshalling bytecodeBytes: %s", err)
-	}
-
-	// We know our test hex values are valid, so we'll ignore the potential error
-	hexToFelt := func(hex string) *felt.Felt {
-		f, _ := new(felt.Felt).SetString(hex)
-		return f
 	}
 
 	tests := []struct {
@@ -233,6 +233,43 @@ func TestClassHash(t *testing.T) {
 			classHash := tt.class.Hash()
 			if !classHash.Equal(tt.want) {
 				t.Errorf("wrong hash: got %s, want %s", classHash.Text(16), tt.want.Text(16))
+			}
+		})
+	}
+}
+
+func TestAddresses(t *testing.T) {
+	tests := []struct {
+		callerAddress       *felt.Felt
+		classHash           *felt.Felt
+		salt                *felt.Felt
+		constructorCalldata []*felt.Felt
+		want                *felt.Felt
+	}{
+		{
+			// https://alpha-mainnet.starknet.io/feeder_gateway/get_transaction?transactionHash=0x6486c6303dba2f364c684a2e9609211c5b8e417e767f37b527cda51e776e6f0
+			callerAddress: hexToFelt("0x0000000000000000000000000000000000000000"),
+			classHash:     hexToFelt("0x46f844ea1a3b3668f81d38b5c1bd55e816e0373802aefe732138628f0133486"),
+			salt:          hexToFelt("0x74dc2fe193daf1abd8241b63329c1123214842b96ad7fd003d25512598a956b"),
+			constructorCalldata: []*felt.Felt{
+				hexToFelt("0x6d706cfbac9b8262d601c38251c5fbe0497c3a96cc91a92b08d91b61d9e70c4"),
+				hexToFelt("0x79dc0da7c54b95f10aa182ad0a46400db63156920adb65eca2654c0945a463"),
+				hexToFelt("0x2"),
+				hexToFelt("0x6658165b4984816ab189568637bedec5aa0a18305909c7f5726e4a16e3afef6"),
+				hexToFelt("0x6b648b36b074a91eee55730f5f5e075ec19c0a8f9ffb0903cefeee93b6ff328"),
+			},
+			want: hexToFelt("0x6486c6303dba2f364c684a2e9609211c5b8e417e767f37b527cda51e776e6f0"),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run("Address", func(t *testing.T) {
+			address, err := ContractAddress(tt.callerAddress, tt.classHash, tt.salt, tt.constructorCalldata)
+			if err != nil {
+				t.Fatalf("unexpected error while computing address: %s", err)
+			}
+			if !address.Equal(tt.want) {
+				t.Errorf("wrong address: got %s, want %s", address.Text(16), tt.want.Text(16))
 			}
 		})
 	}


### PR DESCRIPTION
## Description

Contract address computation is required to compute the `deploy transaction` hash. Hence, the implementation.

## Types of changes

- New feature (non-breaking change which adds functionality)

## Testing

**Requires testing**: Yes

**Did you write tests??**: Yes
