### PR TITLE
Update map key types in core.StateUpdate

### DIFF
--- a/core/state_update.go
+++ b/core/state_update.go
@@ -8,12 +8,12 @@ type StateUpdate struct {
 	OldRoot   *felt.Felt
 
 	StateDiff struct {
-		StorageDiffs map[string][]struct {
+		StorageDiffs map[felt.Felt][]struct {
 			Key   *felt.Felt
 			Value *felt.Felt
 		}
 
-		Nonces            map[string]*felt.Felt
+		Nonces            map[felt.Felt]*felt.Felt
 		DeployedContracts []struct {
 			Address   *felt.Felt
 			ClassHash *felt.Felt


### PR DESCRIPTION
Any part of the code that deals with core types should not be bothered with converting these keys from strings to felts. That is the job of the struct that implements `DataSource` interface.