### PR TITLE
Add guard for multiple node unmarshal

### DIFF
--- a/core/trie/node.go
+++ b/core/trie/node.go
@@ -100,11 +100,7 @@ func (n *Node) UnmarshalBinary(data []byte) error {
 	data = data[felt.Bytes:]
 
 	stream := bytes.NewReader(data)
-	type Slot struct {
-		leftSlot  bool
-		rightSlot bool
-	}
-	slot := Slot{false, false}
+
 	for stream.Len() > 0 {
 		head, err := stream.ReadByte()
 		if err != nil {
@@ -114,16 +110,14 @@ func (n *Node) UnmarshalBinary(data []byte) error {
 		var pathP **bitset.BitSet
 		switch head {
 		case 'l':
-			if !slot.leftSlot {
+			if n.left == nil {
 				pathP = &(n.left)
-				slot.leftSlot = true
 			} else {
 				return ErrMalformedNode{"multiple left childs are not support"}
 			}
 		case 'r':
-			if !slot.rightSlot {
+			if n.right == nil {
 				pathP = &(n.right)
-				slot.rightSlot = true
 			} else {
 				return ErrMalformedNode{"multiple right childs are not support"}
 			}

--- a/core/trie/node.go
+++ b/core/trie/node.go
@@ -100,6 +100,11 @@ func (n *Node) UnmarshalBinary(data []byte) error {
 	data = data[felt.Bytes:]
 
 	stream := bytes.NewReader(data)
+	type Slot struct {
+		leftSlot  bool
+		rightSlot bool
+	}
+	slot := Slot{false, false}
 	for stream.Len() > 0 {
 		head, err := stream.ReadByte()
 		if err != nil {
@@ -109,9 +114,19 @@ func (n *Node) UnmarshalBinary(data []byte) error {
 		var pathP **bitset.BitSet
 		switch head {
 		case 'l':
-			pathP = &(n.left)
+			if !slot.leftSlot {
+				pathP = &(n.left)
+				slot.leftSlot = true
+			} else {
+				return ErrMalformedNode{"multiple left childs are not support"}
+			}
 		case 'r':
-			pathP = &(n.right)
+			if !slot.rightSlot {
+				pathP = &(n.right)
+				slot.rightSlot = true
+			} else {
+				return ErrMalformedNode{"multiple right childs are not support"}
+			}
 		default:
 			return ErrMalformedNode{"unknown child node prefix"}
 		}

--- a/data_source/data_source.go
+++ b/data_source/data_source.go
@@ -1,4 +1,4 @@
-package dataSource
+package datasource
 
 import (
 	"github.com/NethermindEth/juno/core"

--- a/data_source/gateway.go
+++ b/data_source/gateway.go
@@ -1,4 +1,4 @@
-package dataSource
+package datasource
 
 import (
 	"errors"

--- a/data_source/gateway_test.go
+++ b/data_source/gateway_test.go
@@ -1,4 +1,4 @@
-package dataSource
+package datasource
 
 import (
 	"encoding/json"

--- a/sync/sync.go
+++ b/sync/sync.go
@@ -13,12 +13,12 @@ type SyncLoop struct {
 	running uint64
 
 	Blockchain  *blockchain.Blockchain
-	DataSources []*dataSource.DataSource
+	DataSources []*datasource.DataSource
 
 	ExitChn chan struct{}
 }
 
-func NewSyncLoop(bc *blockchain.Blockchain, sources []*dataSource.DataSource) *SyncLoop {
+func NewSyncLoop(bc *blockchain.Blockchain, sources []*datasource.DataSource) *SyncLoop {
 	return &SyncLoop{
 		running: 0,
 


### PR DESCRIPTION
Fixes unmarshalling a node with multiple left and right children

## Description

Add a check for unmarshalling a node when the input byte array with multiple left or right childs.
[Mentioned in Here](https://github.com/NethermindEth/juno/blob/develop/core/trie/node.go#:~:text=//%20TODO%3A%20Implement%20and,will%20still%20succeed.)

## Changes:

- Add left and right flag to protect there only at most 1 left or right child when marshalling.
- Add unit test for this part

## Types of changes

- Bugfix (non-breaking change which fixes an issue)


## Testing

**Requires testing**: Yes

**Did you write tests??**: Yes

## Documentation

**If this requires a documentation update, did you add one?** No,No

