### PR TITLE
Add guard for multiple node unmarshal

### DIFF
--- a/core/trie/node.go
+++ b/core/trie/node.go
@@ -88,11 +88,6 @@ func (n *Node) MarshalBinary() ([]byte, error) {
 
 // UnmarshalBinary deserializes a [Node] from a byte array
 func (n *Node) UnmarshalBinary(data []byte) error {
-	// TODO: Implement and test the following edge cases:
-	//	- Unmarshalling a node with multiple left and right children.
-	//		Currently the assumption is that the node will only have at max 1 left and/or right
-	//		child. However if the UnmarshalBinary is called with multiple left and/or right child
-	//		in any order then UnmarshalBinary will still succeed.
 	if len(data) < felt.Bytes {
 		return ErrMalformedNode{"size of input data is less than felt size"}
 	}
@@ -114,6 +109,9 @@ func (n *Node) UnmarshalBinary(data []byte) error {
 			pathP = &(n.right)
 		default:
 			return ErrMalformedNode{"unknown child node prefix"}
+		}
+		if *pathP != nil {
+			return ErrMalformedNode{"multiple children are not supported"}
 		}
 
 		*pathP = new(bitset.BitSet)

--- a/core/trie/node_test.go
+++ b/core/trie/node_test.go
@@ -2,6 +2,7 @@ package trie
 
 import (
 	"encoding/hex"
+	"errors"
 	"testing"
 
 	"github.com/NethermindEth/juno/core/felt"
@@ -84,6 +85,61 @@ func TestNodeMarshalAndUnmarshalBinary(t *testing.T) {
 				}
 				if !test.node.Equal(unmarshalled) {
 					t.Errorf("expected node: %v but got %v", test.node, unmarshalled)
+				}
+			})
+		}
+	})
+	t.Run("Test edge case of malformed node", func(t *testing.T) {
+		value, err := new(felt.Felt).SetRandom()
+		if err != nil {
+			t.Fatalf("expected no error but got %s", err)
+		}
+		path1 := bitset.FromWithLength(44, []uint64{11})
+		path2 := bitset.FromWithLength(22, []uint64{22})
+		path3 := bitset.FromWithLength(22, []uint64{33})
+		path4 := bitset.FromWithLength(22, []uint64{44})
+		flexibleMarshal := func(val *felt.Felt, left []bitset.BitSet, right []bitset.BitSet) []byte {
+			var ret []byte
+			valueB := val.Bytes()
+			ret = append(ret, valueB[:]...)
+			for _, ele := range left {
+				ret = append(ret, 'l')
+				leftB, _ := ele.MarshalBinary()
+				ret = append(ret, leftB...)
+			}
+
+			for _, ele := range right {
+				ret = append(ret, 'r')
+				rightB, _ := ele.MarshalBinary()
+				ret = append(ret, rightB...)
+			}
+			return ret
+		}
+
+		tests := [...]struct {
+			name       string
+			marshalBin []byte
+			errStr     string
+		}{
+			{
+				name:       "node with only 2 left children",
+				marshalBin: flexibleMarshal(value, []bitset.BitSet{*path1, *path2}, []bitset.BitSet{}),
+			},
+			{
+				name:       "node with only 2 right children",
+				marshalBin: flexibleMarshal(value, []bitset.BitSet{}, []bitset.BitSet{*path3, *path4}),
+			},
+			{
+				name:       "node with 2 left and 2 right children",
+				marshalBin: flexibleMarshal(value, []bitset.BitSet{*path1, *path2}, []bitset.BitSet{*path3, *path4}),
+			},
+		}
+		unmarshalled := new(Node)
+		for _, test := range tests {
+			t.Run(test.name, func(t *testing.T) {
+				err = unmarshalled.UnmarshalBinary(test.marshalBin)
+				if errors.Is(err, ErrMalformedNode{}) {
+					t.Errorf("expected error not right: got %s, wanted ErrMalformedNode", err)
 				}
 			})
 		}


### PR DESCRIPTION
Fixes unmarshalling a node with multiple left and right children

## Description

Add a check for unmarshalling a node when the input byte array with multiple left or right childs.
[Mentioned in Here](https://github.com/NethermindEth/juno/blob/develop/core/trie/node.go#:~:text=//%20TODO%3A%20Implement%20and,will%20still%20succeed.)

## Changes:

- Add left and right flag to protect there only at most 1 left or right child when marshalling.
- Add unit test for this part.

## Types of changes

_Leave only items that describe your changes, remove the rest. Remove this line too._

- Bugfix (non-breaking change which fixes an issue)


## Testing

**Requires testing**: Yes

**Did you write tests??**: Yes

## Documentation

**If this requires a documentation update, did you add one?** No

