### PR TITLE
Cleanup misusages of the term "path" in state

### DIFF
--- a/core/state/state.go
+++ b/core/state/state.go
@@ -17,7 +17,7 @@ const (
 	stateTrieHeight           = 251
 	contractStorageTrieHeight = 251
 	// fields of state metadata table
-	stateRootKey = "rootPath"
+	stateRootKey = "rootKey"
 )
 
 type ErrMismatchedRoot struct {
@@ -262,7 +262,7 @@ func (s *State) getContractStorage(addr *felt.Felt, txn *badger.Txn) (*trie.Trie
 	addrBytes := addr.Marshal()
 	var contractRootKey *bitset.BitSet
 
-	if item, err := txn.Get(db.ContractRootPath.Key(addrBytes)); err == nil {
+	if item, err := txn.Get(db.ContractRootKey.Key(addrBytes)); err == nil {
 		if err = item.Value(func(val []byte) error {
 			contractRootKey = new(bitset.BitSet)
 			return contractRootKey.UnmarshalBinary(val)
@@ -304,7 +304,7 @@ func (s *State) updateContractStorage(addr *felt.Felt, diff []core.StorageDiff, 
 	}
 
 	// update contract storage root in the database
-	rootKeyDbKey := db.ContractRootPath.Key(addr.Marshal())
+	rootKeyDbKey := db.ContractRootKey.Key(addr.Marshal())
 	if rootKey := storage.RootKey(); rootKey != nil {
 		if rootKeyBytes, err := storage.RootKey().MarshalBinary(); err != nil {
 			return err

--- a/db/buckets.go
+++ b/db/buckets.go
@@ -10,7 +10,7 @@ type Bucket byte
 const (
 	State Bucket = iota // state metadata (e.g., the state root)
 	StateTrie
-	ContractRootPath  // contract storage roots
+	ContractRootKey   // contract storage roots
 	ContractClassHash // maps contract addresses and class hashes
 	ContractStorage   // contract storages
 	ContractNonce     // contract nonce


### PR DESCRIPTION
## Description

These were changed to be called "keys" in most parts of the code, apperantly some were missed

## Types of changes

- Code style update (formatting, renaming)

## Testing

**Requires testing**: No

**Did you write tests??**: No

