### PR TITLE
```NewTrie``` checks max height 251

### DIFF
--- a/core/trie/trie.go
+++ b/core/trie/trie.go
@@ -43,7 +43,13 @@ type Trie struct {
 }
 
 func NewTrie(storage Storage, height uint, rootKey *bitset.BitSet) *Trie {
-	// Todo: set max height to 251 and set max key value accordingly
+	if height > 251 {
+		fmt.Println("Height is over 251. Select a height under 251 to create a new trie.")
+		return
+	}
+	
+	// Todo: Set max key value for height 251	
+	
 	return &Trie{
 		storage: storage,
 		height:  height,


### PR DESCRIPTION
## Description

Checks for max new trie height to be 251. 
Prints message requesting the height to be 251 or lower, and returns no new trie.

## Changes:

- Branch if statement to check for max height

## Types of changes

- Bugfix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)

## Testing

**Requires testing**: 

Yes

**Did you write tests??**: 

I tested different uint values for the branch statement.
I can help with formal tests as well if needed.

## Documentation

**If this requires a documentation update, did you add one?** 

No, but this new check will follow the:

```
maxHeight = 251 
```

specification stated here: 

https://docs.starknet.io/documentation/architecture_and_concepts/State/starknet-state/#state_commitment

