### PR TITLE
Prepare Trie and DB for historical state storage

### DIFF
--- a/core/block.go
+++ b/core/block.go
@@ -163,7 +163,7 @@ func TransactionCommitment(receipts []*TransactionReceipt) (*felt.Felt, error) {
 				signaturesHash = crypto.PedersenArray(receipt.Signatures...)
 			}
 			transactionAndSignatureHash := crypto.Pedersen(receipt.TransactionHash, signaturesHash)
-			if err := trie.Put(new(felt.Felt).SetUint64(uint64(i)), transactionAndSignatureHash); err != nil {
+			if _, err := trie.Put(new(felt.Felt).SetUint64(uint64(i)), transactionAndSignatureHash); err != nil {
 				return err
 			}
 		}
@@ -189,7 +189,7 @@ func EventData(receipts []*TransactionReceipt) (*felt.Felt, uint64, error) {
 					crypto.PedersenArray(event.Data...),
 				)
 
-				if err := trie.Put(new(felt.Felt).SetUint64(eventCount), eventHash); err != nil {
+				if _, err := trie.Put(new(felt.Felt).SetUint64(eventCount), eventHash); err != nil {
 					return err
 				}
 				eventCount++

--- a/core/contract.go
+++ b/core/contract.go
@@ -160,7 +160,7 @@ func (c *Contract) UpdateStorage(diff []StorageDiff) error {
 
 	// apply the diff
 	for _, pair := range diff {
-		if err = storage.Put(pair.Key, pair.Value); err != nil {
+		if _, err = storage.Put(pair.Key, pair.Value); err != nil {
 			return err
 		}
 	}

--- a/core/contract_test.go
+++ b/core/contract_test.go
@@ -296,7 +296,8 @@ func TestContract(t *testing.T) {
 
 	storage, err := contract.Storage()
 
-	assert.NoError(t, storage.Put(addr, class))
+	_, err = storage.Put(addr, class)
+	assert.NoError(t, err)
 	root, err := storage.Root()
 	assert.NoError(t, err)
 

--- a/core/state/state.go
+++ b/core/state/state.go
@@ -214,7 +214,7 @@ func (s *State) updateContractCommitment(contract *core.Contract) error {
 			return err
 		}
 
-		if err = state.Put(contract.Address, commitment); err != nil {
+		if _, err = state.Put(contract.Address, commitment); err != nil {
 			return err
 		}
 

--- a/core/state/state_test.go
+++ b/core/state/state_test.go
@@ -44,7 +44,8 @@ func TestState_Root(t *testing.T) {
 	// add a value and update db
 	storage, err := state.getStateStorage()
 	assert.Equal(t, nil, err)
-	assert.Equal(t, nil, storage.Put(key, value))
+	_, err = storage.Put(key, value)
+	assert.Equal(t, nil, err)
 
 	err = state.putStateStorage(storage)
 	assert.Equal(t, nil, err)

--- a/db/badger.go
+++ b/db/badger.go
@@ -81,6 +81,26 @@ func (t *badgerTxn) Get(key []byte) ([]byte, error) {
 	})
 }
 
+// Seek : see db.Transaction.Seek
+func (t *badgerTxn) Seek(key []byte) (*Entry, error) {
+	it := t.badger.NewIterator(badger.DefaultIteratorOptions)
+	defer it.Close()
+
+	it.Seek(key)
+	if it.Valid() {
+		item := it.Item()
+		next := &Entry{
+			Key: item.Key(),
+		}
+		return next, item.Value(func(val []byte) error {
+			next.Value = append([]byte{}, val...)
+			return nil
+		})
+	}
+
+	return nil, nil
+}
+
 // Impl : see db.Transaction.Impl
 func (t *badgerTxn) Impl() any {
 	return t.badger

--- a/db/db.go
+++ b/db/db.go
@@ -27,6 +27,12 @@ type DB interface {
 	Impl() any
 }
 
+// Entry is a database entry consisting of a Key and Value
+type Entry struct {
+	Key   []byte
+	Value []byte
+}
+
 // Transaction provides an interface to access the database's state at the point the transaction was created
 // Updates done to the database with a transaction should be only visible to other newly created transaction after
 // the transaction is committed.
@@ -43,6 +49,9 @@ type Transaction interface {
 	Delete(key []byte) error
 	// Get fetches the value for the given key, should return ErrKeyNotFound if key is not present
 	Get(key []byte) ([]byte, error)
+	// Seek would seek to the provided key if present. If absent, it would seek to the next
+	// key in lexicographic order
+	Seek(key []byte) (*Entry, error)
 
 	// Impl returns the underlying transaction object
 	Impl() any

--- a/db/db_test.go
+++ b/db/db_test.go
@@ -175,3 +175,39 @@ func TestNilValue(t *testing.T) {
 	})
 	assert.Nil(t, err)
 }
+
+func TestSeek(t *testing.T) {
+	db := NewTestDb()
+	defer db.Close()
+
+	err := db.Update(func(txn Transaction) error {
+		err := txn.Set([]byte{1}, []byte{1})
+		assert.NoError(t, err)
+		err = txn.Set([]byte{3}, []byte{3})
+		assert.NoError(t, err)
+		return nil
+	})
+	assert.NoError(t, err)
+
+	db.View(func(txn Transaction) error {
+		next, err := txn.Seek([]byte{0})
+		assert.NoError(t, err)
+		assert.Equal(t, []byte{1}, next.Key)
+		assert.Equal(t, []byte{1}, next.Value)
+
+		next, err = txn.Seek([]byte{2})
+		assert.NoError(t, err)
+		assert.Equal(t, []byte{3}, next.Key)
+		assert.Equal(t, []byte{3}, next.Value)
+
+		next, err = txn.Seek([]byte{3})
+		assert.NoError(t, err)
+		assert.Equal(t, []byte{3}, next.Key)
+		assert.Equal(t, []byte{3}, next.Value)
+
+		next, err = txn.Seek([]byte{4})
+		assert.NoError(t, err)
+		assert.Nil(t, next)
+		return nil
+	})
+}


### PR DESCRIPTION
## Description

To be able to query historical storage data. This is required to be able to implement `getStorageAt` RPC endpoint.

## Changes:

See each commit message

## Types of changes

- New feature (non-breaking change which adds functionality)

## Testing

**Requires testing**: Yes

**Did you write tests??**: Yes
