### PR TITLE
Disable logging on in-memory databases

### DIFF
--- a/db/badger.go
+++ b/db/badger.go
@@ -96,6 +96,7 @@ func NewDb(path string) (DB, error) {
 // NewInMemoryDb opens a new in-memory database
 func NewInMemoryDb() (DB, error) {
 	opt := badger.DefaultOptions("").WithInMemory(true)
+	opt.Logger = nil
 	db, err := badger.Open(opt)
 	return &badgerDb{db}, err
 }


### PR DESCRIPTION
## Description

Badger logs stuff on Open() and we call it quite alot for temp databases. Reduces the log spam that we mostly don't care about.

## Changes:

Disable logging on in-memory databases

## Types of changes

- Bugfix (non-breaking change which fixes an issue)

## Testing

**Requires testing**: No

**Did you write tests??**: No

