### PR TITLE
Block Hash Bug Fix

### DIFF
--- a/core/block_test.go
+++ b/core/block_test.go
@@ -169,6 +169,27 @@ func TestBlockHash(t *testing.T) {
 			"0x6902dad2e7ad976c59e032825b43474097396ad4a323d3782ede467540085f5",
 			false,
 		},
+		{
+			// block 0: main
+			// https://alpha-mainnet.starknet.io/feeder_gateway/get_block?blockNumber=0
+			&Block{
+				hexToFelt("0x0"),
+				0,
+				hexToFelt("0x021870ba80540e7831fb21c591ee93481f5ae1bb71ff85a86ddd465be4eddee6"),
+				nil,
+				uintToFelt(1637069048),
+				uintToFelt(18),
+				hexToFelt("0x27821704010baa1479045e0063dcebca597d3a0d4fe5fe44a6edbbe68225bf2"),
+				uintToFelt(0),
+				hexToFelt("0x0"),
+				uintToFelt(0),
+				hexToFelt(""),
+			},
+			1,
+			"mainnet (pre 0.7.0 without sequencer address)",
+			"0x47c3637b57c2b079b93c61539950c17e868a28f46cdef28f88521067f21e943",
+			false,
+		},
 	}
 
 	for _, tt := range tests {

--- a/utils/network.go
+++ b/utils/network.go
@@ -46,7 +46,7 @@ func (n Network) ChainId() *felt.Felt {
 	case GOERLI:
 		return new(felt.Felt).SetBytes([]byte("SN_GOERLI"))
 	case MAINNET:
-		return new(felt.Felt).SetBytes([]byte("SN_MAINNET"))
+		return new(felt.Felt).SetBytes([]byte("SN_MAIN"))
 	case GOERLI2:
 		return new(felt.Felt).SetBytes([]byte("SN_GOERLI2"))
 	case INTEGRATION:


### PR DESCRIPTION
## Description

There was a bug in the `ChainId` function causing us to get a wrong block hash calculation on mainnet (pre 0.7.0). This PR fixes it.

## Changes:

- Fixed ChainId bug
- Added test for pre 0.7.0 hash on mainnet

## Types of changes

- Bugfix (non-breaking change which fixes an issue)

## Testing

**Requires testing**: Yes

**Did you write tests??**: Yes

