### PR TITLE
Cover all packages

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ benchmarks: ## benchmarking
 
 test-cover: ## tests with coverage
 	mkdir -p coverage
-	go test -coverprofile=coverage/coverage.out -covermode=atomic ./...
+	go test -coverpkg=./... -coverprofile=coverage/coverage.out -covermode=atomic ./...
 	go tool cover -html=coverage/coverage.out -o coverage/coverage.html
 
 install-deps: | install-gofumpt ## install some project dependencies


### PR DESCRIPTION
## Description

default options do not cover lines from other packages than the one being tested at that point. We should include coverage for indirectly executed lines as well.

## Changes:

- adds coverpkg swtich to go test

## Types of changes

- Build related changes

## Testing

**Requires testing**: No

**Did you write tests??**: No