### PR TITLE
Update Transaction Chain Id

### DIFF
--- a/core/transaction.go
+++ b/core/transaction.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/NethermindEth/juno/core/crypto"
 	"github.com/NethermindEth/juno/core/felt"
+	"github.com/NethermindEth/juno/utils"
 	"github.com/ethereum/go-ethereum/common"
 )
 
@@ -71,7 +72,7 @@ type TransactionReceipt struct {
 
 type Transaction interface {
 	// Todo: Add Hash as a field to all the Transaction Objects
-	Hash() *felt.Felt
+	Hash(utils.Network) *felt.Felt
 }
 
 type DeployTransaction struct {
@@ -94,7 +95,7 @@ type DeployTransaction struct {
 	Version *felt.Felt
 }
 
-func (d *DeployTransaction) Hash(chainId []byte) (*felt.Felt, error) {
+func (d *DeployTransaction) Hash(network utils.Network) (*felt.Felt, error) {
 	snKeccakConstructor, err := crypto.StarkNetKeccak([]byte("constructor"))
 	if err != nil {
 		return nil, err
@@ -106,7 +107,7 @@ func (d *DeployTransaction) Hash(chainId []byte) (*felt.Felt, error) {
 		snKeccakConstructor,
 		crypto.PedersenArray(d.ConstructorCallData...),
 		new(felt.Felt),
-		new(felt.Felt).SetBytes(chainId),
+		network.ChainId(),
 	), nil
 }
 
@@ -134,7 +135,7 @@ type InvokeTransaction struct {
 	Version *felt.Felt
 }
 
-func (i *InvokeTransaction) Hash(chainId []byte) (*felt.Felt, error) {
+func (i *InvokeTransaction) Hash(network utils.Network) (*felt.Felt, error) {
 	invokeFelt := new(felt.Felt).SetBytes([]byte("invoke"))
 	if i.Version.IsZero() {
 		return crypto.PedersenArray(
@@ -142,7 +143,7 @@ func (i *InvokeTransaction) Hash(chainId []byte) (*felt.Felt, error) {
 			i.ContractAddress,
 			i.EntryPointSelector,
 			crypto.PedersenArray(i.CallData...),
-			new(felt.Felt).SetBytes(chainId),
+			network.ChainId(),
 		), nil
 	} else if i.Version.IsOne() {
 		return crypto.PedersenArray(
@@ -152,7 +153,7 @@ func (i *InvokeTransaction) Hash(chainId []byte) (*felt.Felt, error) {
 			new(felt.Felt),
 			crypto.PedersenArray(i.CallData...),
 			i.MaxFee,
-			new(felt.Felt).SetBytes(chainId),
+			network.ChainId(),
 			i.Nonce,
 		), nil
 	}
@@ -178,7 +179,7 @@ type DeclareTransaction struct {
 	Version *felt.Felt
 }
 
-func (d *DeclareTransaction) Hash(chainId []byte) (*felt.Felt, error) {
+func (d *DeclareTransaction) Hash(network utils.Network) (*felt.Felt, error) {
 	declareFelt := new(felt.Felt).SetBytes([]byte("declare"))
 	if d.Version.IsZero() {
 		return crypto.PedersenArray(
@@ -188,7 +189,7 @@ func (d *DeclareTransaction) Hash(chainId []byte) (*felt.Felt, error) {
 			new(felt.Felt),
 			crypto.PedersenArray(make([]*felt.Felt, 0)...),
 			d.MaxFee,
-			new(felt.Felt).SetBytes(chainId),
+			network.ChainId(),
 			d.Class.Hash(),
 		), nil
 	} else if d.Version.IsOne() {
@@ -199,7 +200,7 @@ func (d *DeclareTransaction) Hash(chainId []byte) (*felt.Felt, error) {
 			new(felt.Felt),
 			crypto.PedersenArray(d.Class.Hash()),
 			d.MaxFee,
-			new(felt.Felt).SetBytes(chainId),
+			network.ChainId(),
 			d.Nonce,
 		), nil
 	}

--- a/core/transaction_test.go
+++ b/core/transaction_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/NethermindEth/juno/core/felt"
+	"github.com/NethermindEth/juno/utils"
 )
 
 var (
@@ -17,29 +18,34 @@ var (
 
 func TestDeployTransactions(t *testing.T) {
 	tests := map[string]struct {
-		input DeployTransaction
-		want  *felt.Felt
+		input   DeployTransaction
+		network utils.Network
+		want    *felt.Felt
 	}{
 		// https://alpha-mainnet.starknet.io/feeder_gateway/get_transaction?transactionHash=0x6486c6303dba2f364c684a2e9609211c5b8e417e767f37b527cda51e776e6f0
-		"Deploy transaction": {input: DeployTransaction{
-			ContractAddress:     hexToFelt("0x3ec215c6c9028ff671b46a2a9814970ea23ed3c4bcc3838c6d1dcbf395263c3"),
-			ContractAddressSalt: hexToFelt("0x74dc2fe193daf1abd8241b63329c1123214842b96ad7fd003d25512598a956b"),
-			Class:               Class{},
-			ConstructorCallData: [](*felt.Felt){
-				hexToFelt("0x6d706cfbac9b8262d601c38251c5fbe0497c3a96cc91a92b08d91b61d9e70c4"),
-				hexToFelt("0x79dc0da7c54b95f10aa182ad0a46400db63156920adb65eca2654c0945a463"),
-				hexToFelt("0x2"),
-				hexToFelt("0x6658165b4984816ab189568637bedec5aa0a18305909c7f5726e4a16e3afef6"),
-				hexToFelt("0x6b648b36b074a91eee55730f5f5e075ec19c0a8f9ffb0903cefeee93b6ff328"),
+		"Deploy transaction": {
+			input: DeployTransaction{
+				ContractAddress:     hexToFelt("0x3ec215c6c9028ff671b46a2a9814970ea23ed3c4bcc3838c6d1dcbf395263c3"),
+				ContractAddressSalt: hexToFelt("0x74dc2fe193daf1abd8241b63329c1123214842b96ad7fd003d25512598a956b"),
+				Class:               Class{},
+				ConstructorCallData: [](*felt.Felt){
+					hexToFelt("0x6d706cfbac9b8262d601c38251c5fbe0497c3a96cc91a92b08d91b61d9e70c4"),
+					hexToFelt("0x79dc0da7c54b95f10aa182ad0a46400db63156920adb65eca2654c0945a463"),
+					hexToFelt("0x2"),
+					hexToFelt("0x6658165b4984816ab189568637bedec5aa0a18305909c7f5726e4a16e3afef6"),
+					hexToFelt("0x6b648b36b074a91eee55730f5f5e075ec19c0a8f9ffb0903cefeee93b6ff328"),
+				},
+				CallerAddress: new(felt.Felt).SetUint64(0),
+				Version:       new(felt.Felt).SetUint64(0),
 			},
-			CallerAddress: new(felt.Felt).SetUint64(0),
-			Version:       new(felt.Felt).SetUint64(0),
-		}, want: hexToFelt("0x6486c6303dba2f364c684a2e9609211c5b8e417e767f37b527cda51e776e6f0")},
+			network: utils.MAINNET,
+			want:    hexToFelt("0x6486c6303dba2f364c684a2e9609211c5b8e417e767f37b527cda51e776e6f0"),
+		},
 	}
 
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
-			transactionHash, err := test.input.Hash([]byte("SN_MAIN"))
+			transactionHash, err := test.input.Hash(test.network)
 			if err != nil {
 				t.Errorf("no error expected but got %v", err)
 			}
@@ -52,8 +58,9 @@ func TestDeployTransactions(t *testing.T) {
 
 func TestInvokeTransactions(t *testing.T) {
 	tests := map[string]struct {
-		input InvokeTransaction
-		want  *felt.Felt
+		input   InvokeTransaction
+		network utils.Network
+		want    *felt.Felt
 	}{
 		// https://alpha-mainnet.starknet.io/feeder_gateway/get_transaction?transactionHash=0xf1d99fb97509e0dfc425ddc2a8c5398b74231658ca58b6f8da92f39cb739e
 		"Invoke transaction version 0": {
@@ -69,7 +76,8 @@ func TestInvokeTransactions(t *testing.T) {
 				MaxFee:  hexToFelt("0x0"),
 				Version: new(felt.Felt).SetUint64(0),
 			},
-			want: hexToFelt("0xf1d99fb97509e0dfc425ddc2a8c5398b74231658ca58b6f8da92f39cb739e"),
+			network: utils.MAINNET,
+			want:    hexToFelt("0xf1d99fb97509e0dfc425ddc2a8c5398b74231658ca58b6f8da92f39cb739e"),
 		},
 		// https://alpha-mainnet.starknet.io/feeder_gateway/get_transaction?transactionHash=0x2897e3cec3e24e4d341df26b8cf1ab84ea1c01a051021836b36c6639145b497
 		"Invoke transaction version 1": {
@@ -103,13 +111,14 @@ func TestInvokeTransactions(t *testing.T) {
 				MaxFee:        hexToFelt("0x17f0de82f4be6"),
 				Version:       new(felt.Felt).SetUint64(1),
 			},
-			want: hexToFelt("0x2897e3cec3e24e4d341df26b8cf1ab84ea1c01a051021836b36c6639145b497"),
+			network: utils.MAINNET,
+			want:    hexToFelt("0x2897e3cec3e24e4d341df26b8cf1ab84ea1c01a051021836b36c6639145b497"),
 		},
 	}
 
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
-			transactionHash, err := test.input.Hash([]byte("SN_MAIN"))
+			transactionHash, err := test.input.Hash(test.network)
 			if err != nil {
 				t.Errorf("no error expected but got %v", err)
 			}
@@ -132,13 +141,14 @@ func TestDeclareTransaction(t *testing.T) {
 	}
 
 	tests := map[string]struct {
-		input DeclareTransaction
-		want  *felt.Felt
+		input   DeclareTransaction
+		network utils.Network
+		want    *felt.Felt
 	}{
 		// https://alpha-mainnet.starknet.io/feeder_gateway/get_transaction?transactionHash=0x222f8902d1eeea76fa2642a90e2411bfd71cffb299b3a299029e1937fab3fe4
 		"Declare transaction version 0": {
 			input: DeclareTransaction{
-				// https://alpha4.starknet.io/feeder_gateway/get_class_by_hash?classHash=0x2760f25d5a4fb2bdde5f561fd0b44a3dee78c28903577d37d669939d97036a0
+				// https://alpha-mainnet.starknet.io/feeder_gateway/get_class_by_hash?classHash=0x2760f25d5a4fb2bdde5f561fd0b44a3dee78c28903577d37d669939d97036a0
 				Class: Class{
 					APIVersion: new(felt.Felt),
 					Externals: []EntryPoint{
@@ -175,12 +185,13 @@ func TestDeclareTransaction(t *testing.T) {
 				MaxFee:        hexToFelt("0x0"),
 				Version:       new(felt.Felt).SetUint64(0),
 			},
-			want: hexToFelt("0x222f8902d1eeea76fa2642a90e2411bfd71cffb299b3a299029e1937fab3fe4"),
+			network: utils.MAINNET,
+			want:    hexToFelt("0x222f8902d1eeea76fa2642a90e2411bfd71cffb299b3a299029e1937fab3fe4"),
 		},
 		// https://alpha-mainnet.starknet.io/feeder_gateway/get_transaction?transactionHash=0x1b4d9f09276629d496af1af8ff00173c11ff146affacb1b5c858d7aa89001ae
 		"Declare transaction version 1": {
 			input: DeclareTransaction{
-				// https://alpha4.starknet.io/feeder_gateway/get_class_by_hash?classHash=0x7aed6898458c4ed1d720d43e342381b25668ec7c3e8837f761051bf4d655e54
+				// https://alpha-mainnet.starknet.io/feeder_gateway/get_class_by_hash?classHash=0x7aed6898458c4ed1d720d43e342381b25668ec7c3e8837f761051bf4d655e54
 				Class: Class{
 					APIVersion: new(felt.Felt),
 					Externals: []EntryPoint{
@@ -226,13 +237,14 @@ func TestDeclareTransaction(t *testing.T) {
 				MaxFee:        hexToFelt("0xf6dbd653833"),
 				Version:       new(felt.Felt).SetUint64(1),
 			},
-			want: hexToFelt("0x1b4d9f09276629d496af1af8ff00173c11ff146affacb1b5c858d7aa89001ae"),
+			network: utils.MAINNET,
+			want:    hexToFelt("0x1b4d9f09276629d496af1af8ff00173c11ff146affacb1b5c858d7aa89001ae"),
 		},
 	}
 
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
-			transactionHash, err := test.input.Hash([]byte("SN_MAIN"))
+			transactionHash, err := test.input.Hash(test.network)
 			if err != nil {
 				t.Errorf("no error expected but got %v", err)
 			}


### PR DESCRIPTION
## Description

Our transaction hash implementation uses hard-coded chain ids. I updated that to use our standard `utils.Network` type.

## Changes:

- Updated transaction chain id

## Types of changes

- Refactoring (no functional changes, no api changes)

## Testing

**Requires testing**: Yes

**Did you write tests??**: No. Updated existing tests.

