### PR TITLE
Introduce Transaction type constraint

### DIFF
--- a/core/transaction.go
+++ b/core/transaction.go
@@ -71,8 +71,7 @@ type TransactionReceipt struct {
 }
 
 type Transaction interface {
-	// Todo: Add Hash as a field to all the Transaction Objects
-	Hash(utils.Network) *felt.Felt
+	DeployTransaction | InvokeTransaction | DeclareTransaction
 }
 
 type DeployTransaction struct {

--- a/starknetdata/gateway/gateway.go
+++ b/starknetdata/gateway/gateway.go
@@ -158,7 +158,7 @@ func adaptL2ToL1Message(response *clients.L2ToL1Message) *core.L2ToL1Message {
 
 // Transaction gets the transaction for a given transaction hash from the feeder gateway,
 // then adapts it to the appropriate core.Transaction types.
-func (g *Gateway) Transaction(transactionHash *felt.Felt) (*core.Transaction, error) {
+func (g *Gateway) Transaction(transactionHash *felt.Felt) (any, error) {
 	return nil, errors.New("not implemented")
 }
 

--- a/starknetdata/starknetdata.go
+++ b/starknetdata/starknetdata.go
@@ -8,7 +8,7 @@ import (
 // StarkNetData defines the function which are required to retrieve StarkNet's state
 type StarkNetData interface {
 	BlockByNumber(blockNumber uint64) (*core.Block, error)
-	Transaction(transactionHash *felt.Felt) (*core.Transaction, error)
+	Transaction(transactionHash *felt.Felt) (any, error)
 	Class(classHash *felt.Felt) (*core.Class, error)
 	StateUpdate(blockNumber uint64) (*core.StateUpdate, error)
 }

--- a/sync/sync_test.go
+++ b/sync/sync_test.go
@@ -157,7 +157,7 @@ func (f *fakeStarkNetData) StateUpdate(blockNumber uint64) (*core.StateUpdate, e
 	return u, nil
 }
 
-func (f *fakeStarkNetData) Transaction(_ *felt.Felt) (*core.Transaction, error) {
+func (f *fakeStarkNetData) Transaction(_ *felt.Felt) (any, error) {
 	return nil, nil
 }
 


### PR DESCRIPTION
## Description

Introduce Transaction type constraints to represent different types of Transactions for our core package. Unfortunately, we cannot pass type parameters to interface functions or struct methods. This is why the `StarkNetData` interface's Transaction function's return type needed to be changed from `*core.Transaction` -> `any`.

## Types of changes

- New feature (non-breaking change which adds functionality)

## Testing

**Requires testing**: No
