### PR TITLE
Configure cbor to allow unmarshaling specified types to interfaces they implement

### DIFF
--- a/blockchain/blockchain.go
+++ b/blockchain/blockchain.go
@@ -9,8 +9,8 @@ import (
 	"github.com/NethermindEth/juno/core/felt"
 	"github.com/NethermindEth/juno/core/state"
 	"github.com/NethermindEth/juno/db"
+	"github.com/NethermindEth/juno/encoder"
 	"github.com/NethermindEth/juno/utils"
-	"github.com/fxamacker/cbor/v2"
 )
 
 type ErrIncompatibleBlockAndStateUpdate struct {
@@ -94,7 +94,7 @@ func (b *Blockchain) head(txn db.Transaction) (*core.Block, error) {
 	}
 
 	headBlock := new(core.Block)
-	if err = cbor.Unmarshal(headBlockBin, headBlock); err != nil {
+	if err = encoder.Unmarshal(headBlockBin, headBlock); err != nil {
 		return nil, err
 	}
 	return headBlock, nil
@@ -112,7 +112,7 @@ func (b *Blockchain) Store(block *core.Block, stateUpdate *core.StateUpdate) err
 			return err
 		}
 
-		blockBinary, err := cbor.Marshal(block)
+		blockBinary, err := encoder.Marshal(block)
 		if err != nil {
 			return err
 		}

--- a/blockchain/blockchain_test.go
+++ b/blockchain/blockchain_test.go
@@ -11,9 +11,9 @@ import (
 	"github.com/NethermindEth/juno/core/felt"
 	"github.com/NethermindEth/juno/core/state"
 	"github.com/NethermindEth/juno/db"
+	"github.com/NethermindEth/juno/encoder"
 	"github.com/NethermindEth/juno/starknetdata/gateway"
 	"github.com/NethermindEth/juno/utils"
-	"github.com/fxamacker/cbor/v2"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -158,7 +158,7 @@ func TestVerifyBlock(t *testing.T) {
 			incomingBlock := &core.Block{Number: 10, ParentHash: h2}
 
 			assert.NoError(t, chain.database.Update(func(txn db.Transaction) error {
-				blockBinary, err := cbor.Marshal(headBlock)
+				blockBinary, err := encoder.Marshal(headBlock)
 				if err != nil {
 					return err
 				}
@@ -174,7 +174,7 @@ func TestVerifyBlock(t *testing.T) {
 		headBlock := &core.Block{Hash: h1, Number: 1}
 		incomingBlock := &core.Block{ParentHash: h2, Number: 2}
 		assert.NoError(t, chain.database.Update(func(txn db.Transaction) error {
-			blockBinary, err := cbor.Marshal(headBlock)
+			blockBinary, err := encoder.Marshal(headBlock)
 			if err != nil {
 				return err
 			}
@@ -191,7 +191,7 @@ func TestVerifyBlock(t *testing.T) {
 		block := &core.Block{Number: 1, ParentHash: h1, Hash: h2}
 		stateUpdate := &core.StateUpdate{BlockHash: h3}
 		assert.NoError(t, chain.database.Update(func(txn db.Transaction) error {
-			blockBinary, err := cbor.Marshal(headBlock)
+			blockBinary, err := encoder.Marshal(headBlock)
 			if err != nil {
 				return err
 			}
@@ -207,7 +207,7 @@ func TestVerifyBlock(t *testing.T) {
 			block := &core.Block{Number: 1, ParentHash: h1, Hash: h2, GlobalStateRoot: sr1}
 			stateUpdate := &core.StateUpdate{BlockHash: h2, NewRoot: sr2}
 			assert.NoError(t, chain.database.Update(func(txn db.Transaction) error {
-				blockBinary, err := cbor.Marshal(headBlock)
+				blockBinary, err := encoder.Marshal(headBlock)
 				if err != nil {
 					return err
 				}
@@ -223,7 +223,7 @@ func TestVerifyBlock(t *testing.T) {
 		block := &core.Block{Number: 119802, ParentHash: h1, Hash: h2, GlobalStateRoot: sr1}
 		stateUpdate := &core.StateUpdate{BlockHash: h2, NewRoot: sr1}
 		assert.NoError(t, chain.database.Update(func(txn db.Transaction) error {
-			blockBinary, err := cbor.Marshal(headBlock)
+			blockBinary, err := encoder.Marshal(headBlock)
 			if err != nil {
 				return err
 			}
@@ -243,7 +243,7 @@ func TestVerifyBlock(t *testing.T) {
 		}
 		stateUpdate := &core.StateUpdate{BlockHash: h2, NewRoot: sr1}
 		assert.NoError(t, chain.database.Update(func(txn db.Transaction) error {
-			blockBinary, err := cbor.Marshal(headBlock)
+			blockBinary, err := encoder.Marshal(headBlock)
 			if err != nil {
 				return err
 			}
@@ -296,7 +296,7 @@ func TestStore(t *testing.T) {
 			}
 
 			headBlock := new(core.Block)
-			if err = cbor.Unmarshal(databaseHeadBlock, headBlock); err != nil {
+			if err = encoder.Unmarshal(databaseHeadBlock, headBlock); err != nil {
 				return err
 			}
 			assert.Equal(t, headBlock, block0)
@@ -313,7 +313,7 @@ func TestStore(t *testing.T) {
 			}
 
 			block := new(core.Block)
-			if err = cbor.Unmarshal(databaseBlock0, block); err != nil {
+			if err = encoder.Unmarshal(databaseBlock0, block); err != nil {
 				return err
 			}
 			assert.Equal(t, block, block0)
@@ -358,7 +358,7 @@ func TestStore(t *testing.T) {
 			}
 
 			headBlock := new(core.Block)
-			if err = cbor.Unmarshal(databaseHeadBlock, headBlock); err != nil {
+			if err = encoder.Unmarshal(databaseHeadBlock, headBlock); err != nil {
 				return err
 			}
 			assert.Equal(t, headBlock, block1)
@@ -375,7 +375,7 @@ func TestStore(t *testing.T) {
 			}
 
 			block := new(core.Block)
-			if err = cbor.Unmarshal(databaseBlock0, block); err != nil {
+			if err = encoder.Unmarshal(databaseBlock0, block); err != nil {
 				return err
 			}
 			assert.Equal(t, block, block1)

--- a/core/felt/felt_test.go
+++ b/core/felt/felt_test.go
@@ -3,8 +3,7 @@ package felt
 import (
 	"testing"
 
-	"github.com/fxamacker/cbor/v2"
-
+	"github.com/NethermindEth/juno/encoder"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -22,10 +21,5 @@ func TestFeltCbor(t *testing.T) {
 	_, err := val.SetRandom()
 	assert.NoError(t, err)
 
-	bytes, err := cbor.Marshal(val)
-	assert.NoError(t, err)
-
-	var unmarshaledFelt Felt
-	assert.NoError(t, cbor.Unmarshal(bytes, &unmarshaledFelt))
-	assert.Equal(t, val, unmarshaledFelt)
+	encoder.TestSymmetry(t, val)
 }

--- a/core/state/state_test.go
+++ b/core/state/state_test.go
@@ -52,11 +52,8 @@ func TestState_Root(t *testing.T) {
 	newRootPath = storage.FeltToBitSet(key)
 
 	expectedRootNode := new(trie.Node)
-	if err := expectedRootNode.UnmarshalBinary(value.Marshal()); err != nil {
-		t.Error(err)
-	}
+	expectedRootNode.Value = value
 
-	expectedRootNode.UnmarshalBinary(value.Marshal())
 	expectedRoot := expectedRootNode.Hash(trie.Path(newRootPath, nil))
 
 	actualRoot, err := state.Root()

--- a/core/transaction.go
+++ b/core/transaction.go
@@ -3,9 +3,11 @@ package core
 import (
 	"errors"
 	"math/big"
+	"reflect"
 
 	"github.com/NethermindEth/juno/core/crypto"
 	"github.com/NethermindEth/juno/core/felt"
+	"github.com/NethermindEth/juno/encoder"
 	"github.com/NethermindEth/juno/utils"
 	"github.com/ethereum/go-ethereum/common"
 )
@@ -56,6 +58,21 @@ const (
 	Invoke
 	L1Handler
 )
+
+func init() {
+	err := encoder.RegisterType(reflect.TypeOf(DeclareTransaction{}))
+	if err != nil {
+		panic(err)
+	}
+	err = encoder.RegisterType(reflect.TypeOf(DeployTransaction{}))
+	if err != nil {
+		panic(err)
+	}
+	err = encoder.RegisterType(reflect.TypeOf(InvokeTransaction{}))
+	if err != nil {
+		panic(err)
+	}
+}
 
 type TransactionReceipt struct {
 	ActualFee          *felt.Felt

--- a/core/transaction_test.go
+++ b/core/transaction_test.go
@@ -6,7 +6,9 @@ import (
 	"testing"
 
 	"github.com/NethermindEth/juno/core/felt"
+	"github.com/NethermindEth/juno/encoder"
 	"github.com/NethermindEth/juno/utils"
+	"github.com/stretchr/testify/assert"
 )
 
 var (
@@ -52,6 +54,8 @@ func TestDeployTransactions(t *testing.T) {
 			if !transactionHash.Equal(test.want) {
 				t.Errorf("wrong hash: got %s, want %s", transactionHash.Text(16), test.want.Text(16))
 			}
+
+			checkTransactionSymmetry(t, &test.input)
 		})
 	}
 }
@@ -125,6 +129,8 @@ func TestInvokeTransactions(t *testing.T) {
 			if !transactionHash.Equal(test.want) {
 				t.Errorf("wrong hash: got %s, want %s", transactionHash.Text(16), test.want.Text(16))
 			}
+
+			checkTransactionSymmetry(t, &test.input)
 		})
 	}
 }
@@ -185,6 +191,27 @@ func TestDeclareTransaction(t *testing.T) {
 			if !transactionHash.Equal(test.want) {
 				t.Errorf("wrong hash: got %s, want %s", transactionHash.Text(16), test.want.Text(16))
 			}
+
+			checkTransactionSymmetry(t, &test.input)
 		})
+	}
+}
+
+func checkTransactionSymmetry(t *testing.T, input Transaction) {
+	data, err := encoder.Marshal(input)
+	assert.NoError(t, err)
+
+	var txn Transaction
+	assert.NoError(t, encoder.Unmarshal(data, &txn))
+
+	switch v := txn.(type) {
+	case *DeclareTransaction:
+		assert.Equal(t, input, v)
+	case *DeployTransaction:
+		assert.Equal(t, input, v)
+	case *InvokeTransaction:
+		assert.Equal(t, input, v)
+	default:
+		t.Error("not a transaction")
 	}
 }

--- a/core/trie/node.go
+++ b/core/trie/node.go
@@ -1,7 +1,6 @@
 package trie
 
 import (
-	"bytes"
 	"encoding/binary"
 	"fmt"
 
@@ -20,15 +19,15 @@ func (e ErrMalformedNode) Error() string {
 
 // A Node represents a node in the [Trie]
 type Node struct {
-	value *felt.Felt
-	left  *bitset.BitSet
-	right *bitset.BitSet
+	Value *felt.Felt
+	Left  *bitset.BitSet
+	Right *bitset.BitSet
 }
 
 // Hash calculates the hash of a [Node]
 func (n *Node) Hash(path *bitset.BitSet) *felt.Felt {
 	if path.Len() == 0 {
-		return n.value
+		return n.Value
 	}
 
 	pathWords := path.Bytes()
@@ -45,7 +44,7 @@ func (n *Node) Hash(path *bitset.BitSet) *felt.Felt {
 	pathFelt := new(felt.Felt).SetBytes(pathBytes[:])
 
 	// https://docs.starknet.io/documentation/develop/State/starknet-state/
-	hash := crypto.Pedersen(n.value, pathFelt)
+	hash := crypto.Pedersen(n.Value, pathFelt)
 
 	pathFelt.SetUint64(uint64(path.Len()))
 	return hash.Add(hash, pathFelt)
@@ -53,73 +52,5 @@ func (n *Node) Hash(path *bitset.BitSet) *felt.Felt {
 
 // Equal checks for equality of two [Node]s
 func (n *Node) Equal(other *Node) bool {
-	return n.value.Equal(other.value) && n.left.Equal(other.left) && n.right.Equal(n.right)
-}
-
-// MarshalBinary serializes a [Node] into a byte array
-func (n *Node) MarshalBinary() ([]byte, error) {
-	if n.value == nil {
-		return nil, ErrMalformedNode{"cannot marshal node with nil value"}
-	}
-
-	var ret []byte
-	valueB := n.value.Bytes()
-	ret = append(ret, valueB[:]...)
-
-	if n.left != nil {
-		ret = append(ret, 'l')
-		leftB, err := n.left.MarshalBinary()
-		if err != nil {
-			return nil, err
-		}
-		ret = append(ret, leftB...)
-	}
-
-	if n.right != nil {
-		ret = append(ret, 'r')
-		rightB, err := n.right.MarshalBinary()
-		if err != nil {
-			return nil, err
-		}
-		ret = append(ret, rightB...)
-	}
-	return ret, nil
-}
-
-// UnmarshalBinary deserializes a [Node] from a byte array
-func (n *Node) UnmarshalBinary(data []byte) error {
-	if len(data) < felt.Bytes {
-		return ErrMalformedNode{"size of input data is less than felt size"}
-	}
-	n.value = new(felt.Felt).SetBytes(data[:felt.Bytes])
-	data = data[felt.Bytes:]
-
-	stream := bytes.NewReader(data)
-	for stream.Len() > 0 {
-		head, err := stream.ReadByte()
-		if err != nil {
-			return err
-		}
-
-		var pathP **bitset.BitSet
-		switch head {
-		case 'l':
-			pathP = &(n.left)
-		case 'r':
-			pathP = &(n.right)
-		default:
-			return ErrMalformedNode{"unknown child node prefix"}
-		}
-		if *pathP != nil {
-			return ErrMalformedNode{"multiple children are not supported"}
-		}
-
-		*pathP = new(bitset.BitSet)
-		_, err = (*pathP).ReadFrom(stream)
-		if err != nil {
-			return err
-		}
-	}
-
-	return nil
+	return n.Value.Equal(other.Value) && n.Left.Equal(other.Left) && n.Right.Equal(n.Right)
 }

--- a/core/trie/node_test.go
+++ b/core/trie/node_test.go
@@ -6,19 +6,12 @@ import (
 	"testing"
 
 	"github.com/NethermindEth/juno/core/felt"
+	"github.com/NethermindEth/juno/encoder"
 	"github.com/bits-and-blooms/bitset"
 	"github.com/stretchr/testify/assert"
 )
 
 func TestNodeMarshalAndUnmarshalBinary(t *testing.T) {
-	t.Run("error when marshalling node with nil value", func(t *testing.T) {
-		n := new(Node)
-		_, err := n.MarshalBinary()
-
-		if err == nil {
-			t.Fatal("expected error but got no error")
-		}
-	})
 	t.Run("node with non nil value", func(t *testing.T) {
 		value, err := new(felt.Felt).SetRandom()
 		if err != nil {
@@ -34,52 +27,52 @@ func TestNodeMarshalAndUnmarshalBinary(t *testing.T) {
 			{
 				name: "node with both children nil",
 				node: Node{
-					value: value,
-					left:  nil,
-					right: nil,
+					Value: value,
+					Left:  nil,
+					Right: nil,
 				},
 			},
 			{
 				name: "node with left child",
 				node: Node{
-					value: value,
-					left:  path1,
-					right: nil,
+					Value: value,
+					Left:  path1,
+					Right: nil,
 				},
 			},
 			{
 				name: "node with right child",
 				node: Node{
-					value: value,
-					left:  nil,
-					right: path2,
+					Value: value,
+					Left:  nil,
+					Right: path2,
 				},
 			},
 			{
 				name: "node with both children (l: path1, r: path2)",
 				node: Node{
-					value: value,
-					left:  path1,
-					right: path2,
+					Value: value,
+					Left:  path1,
+					Right: path2,
 				},
 			},
 			{
 				name: "node with both children (l: path2, r: path1)",
 				node: Node{
-					value: value,
-					left:  path2,
-					right: path1,
+					Value: value,
+					Left:  path2,
+					Right: path1,
 				},
 			},
 		}
 		for _, test := range tests {
 			t.Run(test.name, func(t *testing.T) {
-				data, err := test.node.MarshalBinary()
+				data, err := encoder.Marshal(test.node)
 				if err != nil {
 					t.Fatalf("expected no error but got %s", err)
 				}
 				unmarshalled := new(Node)
-				err = unmarshalled.UnmarshalBinary(data)
+				err = encoder.Unmarshal(data, unmarshalled)
 				if err != nil {
 					t.Fatalf("expected no error but got %s", err)
 				}
@@ -137,7 +130,7 @@ func TestNodeMarshalAndUnmarshalBinary(t *testing.T) {
 		unmarshalled := new(Node)
 		for _, test := range tests {
 			t.Run(test.name, func(t *testing.T) {
-				err = unmarshalled.UnmarshalBinary(test.marshalBin)
+				err = encoder.Unmarshal(test.marshalBin, unmarshalled)
 				if errors.Is(err, ErrMalformedNode{}) {
 					t.Errorf("expected error not right: got %s, wanted ErrMalformedNode", err)
 				}
@@ -159,7 +152,7 @@ func TestNodeMarshalAndUnmarshalBinary(t *testing.T) {
 		}
 		for _, test := range tests {
 			t.Run(test.name, func(t *testing.T) {
-				if err := new(Node).UnmarshalBinary(test.node); err == nil {
+				if err := encoder.Unmarshal(test.node, new(Node)); err == nil {
 					t.Errorf("expected error but got no error")
 				}
 			})
@@ -173,7 +166,7 @@ func TestNodeHash(t *testing.T) {
 	expected, _ := new(felt.Felt).SetString("0x1d937094c09b5f8e26a662d21911871e3cbc6858d55cc49af9848ea6fed4e9")
 
 	node := Node{
-		value: new(felt.Felt).SetBytes(valueBytes),
+		Value: new(felt.Felt).SetBytes(valueBytes),
 	}
 	path := bitset.FromWithLength(6, []uint64{42})
 

--- a/core/trie/trie_test.go
+++ b/core/trie/trie_test.go
@@ -187,12 +187,12 @@ func TestPathOnTrie(t *testing.T) {
 			t.Error()
 		}
 
-		assert.Equal(t, true, rootNode.left != nil && rootNode.right != nil)
+		assert.Equal(t, true, rootNode.Left != nil && rootNode.Right != nil)
 
 		expectedLeftPath := bitset.New(2).Set(1)
 		expectedRightPath := bitset.New(2).Set(0)
-		assert.Equal(t, true, Path(rootNode.left, trie.rootKey).Equal(expectedLeftPath))
-		assert.Equal(t, true, Path(rootNode.right, trie.rootKey).Equal(expectedRightPath))
+		assert.Equal(t, true, Path(rootNode.Left, trie.rootKey).Equal(expectedLeftPath))
+		assert.Equal(t, true, Path(rootNode.Right, trie.rootKey).Equal(expectedRightPath))
 		return nil
 	})
 }

--- a/core/trie/trietxn.go
+++ b/core/trie/trietxn.go
@@ -2,6 +2,7 @@ package trie
 
 import (
 	"github.com/NethermindEth/juno/db"
+	"github.com/NethermindEth/juno/encoder"
 	"github.com/bits-and-blooms/bitset"
 )
 
@@ -35,7 +36,7 @@ func (t *TrieTxn) Put(key *bitset.BitSet, value *Node) error {
 		return err
 	}
 
-	valueBytes, err := value.MarshalBinary()
+	valueBytes, err := encoder.Marshal(value)
 	if err != nil {
 		return err
 	}
@@ -53,7 +54,7 @@ func (t *TrieTxn) Get(key *bitset.BitSet) (*Node, error) {
 		return nil, err
 	} else {
 		node := new(Node)
-		return node, node.UnmarshalBinary(val)
+		return node, encoder.Unmarshal(val, node)
 	}
 }
 

--- a/core/trie/trietxn_test.go
+++ b/core/trie/trietxn_test.go
@@ -16,8 +16,7 @@ func TestTrieTxn(t *testing.T) {
 
 	key := bitset.New(44)
 	node := new(Node)
-	value, _ := new(felt.Felt).SetRandom()
-	assert.NoError(t, node.UnmarshalBinary(value.Marshal()))
+	node.Value, _ = new(felt.Felt).SetRandom()
 
 	// put a node
 	assert.NoError(t, testDb.Update(func(txn db.Transaction) error {

--- a/encoder/encoder.go
+++ b/encoder/encoder.go
@@ -8,14 +8,53 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+var (
+	ts = cbor.NewTagSet()
+	// https://www.iana.org/assignments/cbor-tags/cbor-tags.xhtml
+	// 65536-15309735 	Unassigned
+	tagNum  = uint64(65536)
+	encMode cbor.EncMode
+	decMode cbor.DecMode
+)
+
+func initEncModes() {
+	var err error
+	encMode, err = cbor.CanonicalEncOptions().EncModeWithTags(ts)
+	if err != nil {
+		panic(err)
+	}
+
+	decMode, err = cbor.DecOptions{}.DecModeWithTags(ts)
+	if err != nil {
+		panic(err)
+	}
+}
+
+func RegisterType(rType reflect.Type) error {
+	if err := ts.Add(
+		cbor.TagOptions{EncTag: cbor.EncTagRequired, DecTag: cbor.DecTagRequired},
+		rType,
+		tagNum,
+	); err != nil {
+		return err
+	}
+	initEncModes()
+	tagNum++
+	return nil
+}
+
+func init() {
+	initEncModes()
+}
+
 // Marshal returns encoding of param v
 func Marshal(v any) ([]byte, error) {
-	return cbor.Marshal(v)
+	return encMode.Marshal(v)
 }
 
 // Unmarshal decodes param v from []byte b
 func Unmarshal(b []byte, v any) error {
-	return cbor.Unmarshal(b, v)
+	return decMode.Unmarshal(b, v)
 }
 
 // TestSymmetry checks if a type can be marshaled and unmarshalled with no issues

--- a/encoder/encoder.go
+++ b/encoder/encoder.go
@@ -1,0 +1,30 @@
+package encoder
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/fxamacker/cbor/v2"
+	"github.com/stretchr/testify/assert"
+)
+
+// Marshal returns encoding of param v
+func Marshal(v any) ([]byte, error) {
+	return cbor.Marshal(v)
+}
+
+// Unmarshal decodes param v from []byte b
+func Unmarshal(b []byte, v any) error {
+	return cbor.Unmarshal(b, v)
+}
+
+// TestSymmetry checks if a type can be marshaled and unmarshalled with no issues
+func TestSymmetry(t *testing.T, value any) {
+	cborBytes, err := cbor.Marshal(value)
+	assert.NoError(t, err)
+
+	unmarshaled := reflect.New(reflect.TypeOf(value))
+	err = cbor.Unmarshal(cborBytes, unmarshaled.Interface())
+	assert.NoError(t, err)
+	assert.Equal(t, value, unmarshaled.Elem().Interface())
+}

--- a/sync/sync_test.go
+++ b/sync/sync_test.go
@@ -11,9 +11,9 @@ import (
 	"github.com/NethermindEth/juno/core"
 	"github.com/NethermindEth/juno/core/felt"
 	"github.com/NethermindEth/juno/db"
+	"github.com/NethermindEth/juno/encoder"
 	"github.com/NethermindEth/juno/starknetdata/gateway"
 	"github.com/NethermindEth/juno/utils"
-	"github.com/fxamacker/cbor/v2"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -26,7 +26,7 @@ func TestSyncBlocks(t *testing.T) {
 			}
 
 			headBlock := new(core.Block)
-			if err = cbor.Unmarshal(headBlockBinary, headBlock); err != nil {
+			if err = encoder.Unmarshal(headBlockBinary, headBlock); err != nil {
 				return err
 			}
 
@@ -49,7 +49,7 @@ func TestSyncBlocks(t *testing.T) {
 				}
 
 				block := new(core.Block)
-				if err = cbor.Unmarshal(blockBinary, block); err != nil {
+				if err = encoder.Unmarshal(blockBinary, block); err != nil {
 					return err
 				}
 


### PR DESCRIPTION
For example;

``` golang

type A struct {
	B string
	C uint
}

func TestA(t *testing.T) {
	inst := A{"hello", 42}

//	encoder.RegisterType(reflect.TypeOf(inst))

	data, _ := encoder.Marshal(inst)
	var recovered any
	encoder.Unmarshal(data, &recovered)

	switch v := recovered.(type) {
	case A:
		t.Error("success:", v)
	default:
		panic(v)
	}
}
```

if `RegisterType` is not called, test will panic at the type switch. If type `A` is registered, we will be able to cast `recovered` to `A` in runtime.

This helps us to have a `[]Transaction` in our block body and allows us to cast them to our individual transaction types in runtime.