### PR TITLE
Add Database Iterations

### DIFF
--- a/core/state_pkg_test.go
+++ b/core/state_pkg_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/NethermindEth/juno/core/felt"
 	"github.com/NethermindEth/juno/core/trie"
+	"github.com/NethermindEth/juno/db"
 	"github.com/NethermindEth/juno/db/pebble"
 	"github.com/bits-and-blooms/bitset"
 	"github.com/stretchr/testify/assert"
@@ -18,7 +19,7 @@ func TestState_PutNewContract(t *testing.T) {
 	classHash, _ := new(felt.Felt).SetRandom()
 
 	_, err := state.GetContractClass(addr)
-	assert.EqualError(t, err, "Key not found")
+	assert.EqualError(t, err, db.ErrKeyNotFound.Error())
 
 	assert.Equal(t, nil, state.putNewContract(addr, classHash))
 	assert.EqualError(t, state.putNewContract(addr, classHash), "existing contract")

--- a/core/transaction_storage_test.go
+++ b/core/transaction_storage_test.go
@@ -70,5 +70,5 @@ func TestTrieTxn(t *testing.T) {
 		tTxn := &TransactionStorage{txn, prefix}
 		_, err := tTxn.Get(key)
 		return err
-	}), "Key not found")
+	}), db.ErrKeyNotFound.Error())
 }

--- a/db/db.go
+++ b/db/db.go
@@ -6,7 +6,7 @@ import (
 )
 
 // ErrKeyNotFound is returned when key isn't found on a txn.Get.
-var ErrKeyNotFound = errors.New("Key not found")
+var ErrKeyNotFound = errors.New("key not found")
 
 // DB is a key-value database
 type DB interface {
@@ -30,6 +30,8 @@ type DB interface {
 
 // Iterator is an iterator over a DB's key/value pairs.
 type Iterator interface {
+	io.Closer
+
 	// Valid returns true if the iterator is positioned at a valid key/value pair.
 	Valid() bool
 
@@ -42,10 +44,7 @@ type Iterator interface {
 	Key() []byte
 
 	// Value returns the value at the current position.
-	Value() []byte
-
-	// Close closes the iterator.
-	Close() error
+	Value() ([]byte, error)
 
 	// Seek would seek to the provided key if present. If absent, it would seek to the next
 	// key in lexicographical order

--- a/db/db.go
+++ b/db/db.go
@@ -28,16 +28,36 @@ type DB interface {
 	Impl() any
 }
 
-// Entry is a database entry consisting of a Key and Value
-type Entry struct {
-	Key   []byte
-	Value []byte
+// Iterator is an iterator over a DB's key/value pairs.
+type Iterator interface {
+	// Valid returns true if the iterator is positioned at a valid key/value pair.
+	Valid() bool
+
+	// Next moves the iterator to the next key/value pair. It returns whether the
+	// iterator is valid after the call. Once invalid, the iterator remains
+	// invalid.
+	Next() bool
+
+	// Key returns the key at the current position.
+	Key() []byte
+
+	// Value returns the value at the current position.
+	Value() []byte
+
+	// Close closes the iterator.
+	Close() error
+
+	// Seek would seek to the provided key if present. If absent, it would seek to the next
+	// key in lexicographical order
+	Seek(key []byte) bool
 }
 
 // Transaction provides an interface to access the database's state at the point the transaction was created
 // Updates done to the database with a transaction should be only visible to other newly created transaction after
 // the transaction is committed.
 type Transaction interface {
+	// NewIterator returns an iterator over the database's key/value pairs.
+	NewIterator() (Iterator, error)
 	// Discard discards all the changes done to the database with this transaction
 	Discard()
 	// Commit flushes all the changes pending on this transaction to the database, making the changes visible to other

--- a/db/pebble/db_test.go
+++ b/db/pebble/db_test.go
@@ -1,6 +1,7 @@
 package pebble_test
 
 import (
+	"encoding/binary"
 	"fmt"
 	"sync"
 	"testing"
@@ -219,5 +220,96 @@ func TestConcurrentUpdate(t *testing.T) {
 			assert.Equal(t, byte(200), bytes[0])
 			return nil
 		})
+	}))
+}
+
+func TestSeek(t *testing.T) {
+	testDb := pebble.NewMemTest()
+	defer testDb.Close()
+
+	err := testDb.Update(func(txn db.Transaction) error {
+		err := txn.Set([]byte{1}, []byte{1})
+		assert.NoError(t, err)
+		err = txn.Set([]byte{3}, []byte{3})
+		assert.NoError(t, err)
+		return nil
+	})
+	assert.NoError(t, err)
+
+	testDb.View(func(txn db.Transaction) error {
+		t.Run("seeks to the next key in lexicographical order", func(t *testing.T) {
+			iter, _ := txn.NewIterator()
+			defer iter.Close()
+
+			iter.Seek([]byte{0})
+			assert.Equal(t, []byte{1}, iter.Key())
+		})
+
+		t.Run("key returns nil when seeking nonexistent data", func(t *testing.T) {
+			iter, _ := txn.NewIterator()
+			defer iter.Close()
+
+			iter.Seek([]byte{4})
+			assert.Nil(t, iter.Key())
+		})
+		return nil
+	})
+}
+
+type Entry struct {
+	Key   uint64
+	Value []byte
+}
+
+func TestPrefixSearch(t *testing.T) {
+	data := []struct {
+		key   uint64
+		value []byte
+	}{
+		{11, []byte("c")},
+		{12, []byte("a")},
+		{13, []byte("e")},
+		{22, []byte("d")},
+		{23, []byte("b")},
+		{123, []byte("f")},
+	}
+
+	testDb := pebble.NewMemTest()
+	defer testDb.Close()
+
+	require.NoError(t, testDb.Update(func(txn db.Transaction) error {
+		for _, d := range data {
+			numBytes := make([]byte, 8)
+			binary.BigEndian.PutUint64(numBytes, d.key)
+			err := txn.Set(numBytes, d.value)
+			assert.NoError(t, err)
+		}
+		return nil
+	}))
+
+	require.NoError(t, testDb.View(func(txn db.Transaction) error {
+		iter, _ := txn.NewIterator()
+		defer iter.Close()
+
+		prefixBytes := make([]byte, 8)
+		binary.BigEndian.PutUint64(prefixBytes, 1)
+		var entries []Entry
+		for iter.Seek(prefixBytes); iter.Valid(); iter.Next() {
+			key := binary.BigEndian.Uint64(iter.Key())
+			if key >= 20 {
+				break
+			}
+			entries = append(entries, Entry{key, iter.Value()})
+		}
+
+		expectedKeys := []uint64{11, 12, 13}
+
+		assert.Equal(t, len(expectedKeys), len(entries))
+
+		for i := 0; i < len(entries); i++ {
+			assert.Contains(t, expectedKeys, entries[i].Key)
+		}
+
+		return nil
 	}))
 }

--- a/db/pebble/db_test.go
+++ b/db/pebble/db_test.go
@@ -227,45 +227,40 @@ func TestSeek(t *testing.T) {
 	testDb := pebble.NewMemTest()
 	defer testDb.Close()
 
-	err := testDb.Update(func(txn db.Transaction) error {
-		err := txn.Set([]byte{1}, []byte{1})
-		assert.NoError(t, err)
-		err = txn.Set([]byte{3}, []byte{3})
-		assert.NoError(t, err)
-		return nil
+	txn := testDb.NewTransaction(true)
+	defer txn.Discard()
+
+	require.NoError(t, txn.Set([]byte{1}, []byte{1}))
+	require.NoError(t, txn.Set([]byte{3}, []byte{3}))
+
+	t.Run("seeks to the next key in lexicographical order", func(t *testing.T) {
+		iter, err := txn.NewIterator()
+		require.NoError(t, err)
+		defer iter.Close()
+
+		iter.Seek([]byte{0})
+		v, err := iter.Value()
+		require.NoError(t, err)
+		assert.Equal(t, []byte{1}, iter.Key())
+		assert.Equal(t, []byte{1}, v)
 	})
-	assert.NoError(t, err)
 
-	testDb.View(func(txn db.Transaction) error {
-		t.Run("seeks to the next key in lexicographical order", func(t *testing.T) {
-			iter, _ := txn.NewIterator()
-			defer iter.Close()
+	t.Run("key returns nil when seeking nonexistent data", func(t *testing.T) {
+		iter, _ := txn.NewIterator()
+		defer iter.Close()
 
-			iter.Seek([]byte{0})
-			assert.Equal(t, []byte{1}, iter.Key())
-		})
-
-		t.Run("key returns nil when seeking nonexistent data", func(t *testing.T) {
-			iter, _ := txn.NewIterator()
-			defer iter.Close()
-
-			iter.Seek([]byte{4})
-			assert.Nil(t, iter.Key())
-		})
-		return nil
+		iter.Seek([]byte{4})
+		assert.Nil(t, iter.Key())
 	})
-}
-
-type Entry struct {
-	Key   uint64
-	Value []byte
 }
 
 func TestPrefixSearch(t *testing.T) {
-	data := []struct {
+	type entry struct {
 		key   uint64
 		value []byte
-	}{
+	}
+
+	data := []entry{
 		{11, []byte("c")},
 		{12, []byte("a")},
 		{13, []byte("e")},
@@ -281,19 +276,20 @@ func TestPrefixSearch(t *testing.T) {
 		for _, d := range data {
 			numBytes := make([]byte, 8)
 			binary.BigEndian.PutUint64(numBytes, d.key)
-			err := txn.Set(numBytes, d.value)
-			assert.NoError(t, err)
+			require.NoError(t, txn.Set(numBytes, d.value))
 		}
 		return nil
 	}))
 
 	require.NoError(t, testDb.View(func(txn db.Transaction) error {
-		iter, _ := txn.NewIterator()
+		iter, err := txn.NewIterator()
+		require.NoError(t, err)
 		defer iter.Close()
 
 		prefixBytes := make([]byte, 8)
 		binary.BigEndian.PutUint64(prefixBytes, 1)
-		var entries []Entry
+
+		var entries []entry
 		for iter.Seek(prefixBytes); iter.Valid(); iter.Next() {
 			key := binary.BigEndian.Uint64(iter.Key())
 			if key >= 20 {
@@ -301,7 +297,7 @@ func TestPrefixSearch(t *testing.T) {
 			}
 			v, err := iter.Value()
 			require.NoError(t, err)
-			entries = append(entries, Entry{key, v})
+			entries = append(entries, entry{key, v})
 		}
 
 		expectedKeys := []uint64{11, 12, 13}
@@ -309,7 +305,7 @@ func TestPrefixSearch(t *testing.T) {
 		assert.Equal(t, len(expectedKeys), len(entries))
 
 		for i := 0; i < len(entries); i++ {
-			assert.Contains(t, expectedKeys, entries[i].Key)
+			assert.Contains(t, expectedKeys, entries[i].key)
 		}
 
 		return nil

--- a/db/pebble/db_test.go
+++ b/db/pebble/db_test.go
@@ -299,7 +299,9 @@ func TestPrefixSearch(t *testing.T) {
 			if key >= 20 {
 				break
 			}
-			entries = append(entries, Entry{key, iter.Value()})
+			v, err := iter.Value()
+			require.NoError(t, err)
+			entries = append(entries, Entry{key, v})
 		}
 
 		expectedKeys := []uint64{11, 12, 13}

--- a/db/pebble/iterator.go
+++ b/db/pebble/iterator.go
@@ -1,0 +1,37 @@
+package pebble
+
+import "github.com/cockroachdb/pebble"
+
+type iterator struct {
+	iter *pebble.Iterator
+}
+
+// Valid : see db.Transaction.Iterator.Valid
+func (i *iterator) Valid() bool {
+	return i.iter.Valid()
+}
+
+// Key : see db.Transaction.Iterator.Key
+func (i *iterator) Key() []byte {
+	return i.iter.Key()
+}
+
+// Value : see db.Transaction.Iterator.Value
+func (i *iterator) Value() ([]byte, error) {
+	return i.iter.ValueAndErr()
+}
+
+// Next : see db.Transaction.Iterator.Next
+func (i *iterator) Next() bool {
+	return i.iter.Next()
+}
+
+// Seek : see db.Transaction.Iterator.Seek
+func (i *iterator) Seek(key []byte) bool {
+	return i.iter.SeekGE(key)
+}
+
+// Close : see db.Transaction.Iterator.Close
+func (i *iterator) Close() error {
+	return i.iter.Close()
+}

--- a/db/pebble/transaction.go
+++ b/db/pebble/transaction.go
@@ -104,7 +104,7 @@ func (t *Transaction) NewIterator() (db.Iterator, error) {
 	} else if t.snapshot != nil {
 		iter = t.snapshot.NewIter(nil)
 	} else {
-		return nil, errors.New("discarded txn")
+		return nil, ErrDiscardedTransaction
 	}
 
 	return &iterator{iter: iter}, nil


### PR DESCRIPTION
## Description

This PR allows us to be able to query the database using prefixes. It will be useful when querying all the`Transactions` and `Receipts` in a `Block`. 

We will now be able to query all `Transactions` using the block number as a prefix.

## Types of changes

- New feature (non-breaking change which adds functionality)

## Testing

**Requires testing**: Yes

**Did you write tests??**: Yes


