### PR TITLE
Refactor pebble iterator

### DIFF
--- a/core/state_pkg_test.go
+++ b/core/state_pkg_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/NethermindEth/juno/core/felt"
 	"github.com/NethermindEth/juno/core/trie"
+	"github.com/NethermindEth/juno/db"
 	"github.com/NethermindEth/juno/db/pebble"
 	"github.com/bits-and-blooms/bitset"
 	"github.com/stretchr/testify/assert"
@@ -18,7 +19,7 @@ func TestState_PutNewContract(t *testing.T) {
 	classHash, _ := new(felt.Felt).SetRandom()
 
 	_, err := state.GetContractClass(addr)
-	assert.EqualError(t, err, "Key not found")
+	assert.EqualError(t, err, db.ErrKeyNotFound.Error())
 
 	assert.Equal(t, nil, state.putNewContract(addr, classHash))
 	assert.EqualError(t, state.putNewContract(addr, classHash), "existing contract")

--- a/core/transaction_storage_test.go
+++ b/core/transaction_storage_test.go
@@ -70,5 +70,5 @@ func TestTrieTxn(t *testing.T) {
 		tTxn := &TransactionStorage{txn, prefix}
 		_, err := tTxn.Get(key)
 		return err
-	}), "Key not found")
+	}), db.ErrKeyNotFound.Error())
 }

--- a/db/db.go
+++ b/db/db.go
@@ -6,7 +6,7 @@ import (
 )
 
 // ErrKeyNotFound is returned when key isn't found on a txn.Get.
-var ErrKeyNotFound = errors.New("Key not found")
+var ErrKeyNotFound = errors.New("key not found")
 
 // DB is a key-value database
 type DB interface {
@@ -30,6 +30,8 @@ type DB interface {
 
 // Iterator is an iterator over a DB's key/value pairs.
 type Iterator interface {
+	io.Closer
+
 	// Valid returns true if the iterator is positioned at a valid key/value pair.
 	Valid() bool
 
@@ -42,10 +44,7 @@ type Iterator interface {
 	Key() []byte
 
 	// Value returns the value at the current position.
-	Value() []byte
-
-	// Close closes the iterator.
-	Close() error
+	Value() ([]byte, error)
 
 	// Seek would seek to the provided key if present. If absent, it would seek to the next
 	// key in lexicographical order

--- a/db/pebble/db_test.go
+++ b/db/pebble/db_test.go
@@ -299,7 +299,9 @@ func TestPrefixSearch(t *testing.T) {
 			if key >= 20 {
 				break
 			}
-			entries = append(entries, Entry{key, iter.Value()})
+			v, err := iter.Value()
+			require.NoError(t, err)
+			entries = append(entries, Entry{key, v})
 		}
 
 		expectedKeys := []uint64{11, 12, 13}

--- a/db/pebble/iterator.go
+++ b/db/pebble/iterator.go
@@ -1,0 +1,37 @@
+package pebble
+
+import "github.com/cockroachdb/pebble"
+
+type iterator struct {
+	iter *pebble.Iterator
+}
+
+// Valid : see db.Transaction.Iterator.Valid
+func (i *iterator) Valid() bool {
+	return i.iter.Valid()
+}
+
+// Key : see db.Transaction.Iterator.Key
+func (i *iterator) Key() []byte {
+	return i.iter.Key()
+}
+
+// Value : see db.Transaction.Iterator.Value
+func (i *iterator) Value() ([]byte, error) {
+	return i.iter.ValueAndErr()
+}
+
+// Next : see db.Transaction.Iterator.Next
+func (i *iterator) Next() bool {
+	return i.iter.Next()
+}
+
+// Seek : see db.Transaction.Iterator.Seek
+func (i *iterator) Seek(key []byte) bool {
+	return i.iter.SeekGE(key)
+}
+
+// Close : see db.Transaction.Iterator.Close
+func (i *iterator) Close() error {
+	return i.iter.Close()
+}


### PR DESCRIPTION
Rename pebbleIterator to iterator and move all its related code to iterator.go. Also, use pebble.iterator.ValueAndErr() since pebble .iterator.Value() is deprecated.

Use io.Closer interface instead of Close() function in Iterator interface.