### PR TITLE
change Path and FindCommonKey as private

### DIFF
--- a/core/state_pkg_test.go
+++ b/core/state_pkg_test.go
@@ -37,8 +37,6 @@ func TestState_Root(t *testing.T) {
 	key, _ := new(felt.Felt).SetRandom()
 	value, _ := new(felt.Felt).SetRandom()
 
-	var newRootPath *bitset.BitSet
-
 	// add a value and update db
 	storage, err := state.getStateStorage()
 	assert.Equal(t, nil, err)
@@ -47,12 +45,13 @@ func TestState_Root(t *testing.T) {
 
 	err = state.putStateStorage(storage)
 	assert.Equal(t, nil, err)
-	newRootPath = storage.FeltToBitSet(key)
 
 	expectedRootNode := new(trie.Node)
 	expectedRootNode.Value = value
 
-	expectedRoot := expectedRootNode.Hash(trie.Path(newRootPath, nil))
+	kBits := key.Bits()
+	newRootPath := bitset.FromWithLength(stateTrieHeight, kBits[:])
+	expectedRoot := expectedRootNode.Hash(newRootPath)
 
 	actualRoot, err := state.Root()
 	assert.Equal(t, nil, err)

--- a/core/trie/trie_test.go
+++ b/core/trie/trie_test.go
@@ -18,7 +18,7 @@ import (
 //   - [*] Table test are being used incorrectly: they should be separated into subsets, see node_test.go
 //   - [*] Functions such as Path and findCommonKey don't need to be public. Thus,
 //     they don't need to be tested explicitly.
-//   - [ ] There are warning which ignore returned errors, returned errors should not be ignored.
+//   - [*] There are warning which ignore returned errors, returned errors should not be ignored.
 //   - [ ] Add more test cases with different heights
 //   - [*] Add more complicated Put and Delete scenarios
 func TestTriePut(t *testing.T) {
@@ -28,9 +28,9 @@ func TestTriePut(t *testing.T) {
 			zeroVal := new(felt.Felt).SetUint64(0)
 
 			oldVal, err := trie.Put(key, zeroVal)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 
-			require.Nil(t, oldVal)
+			assert.Nil(t, oldVal)
 
 			return nil
 		})
@@ -44,7 +44,7 @@ func TestTriePut(t *testing.T) {
 			val := new(felt.Felt).SetUint64(11)
 
 			_, err = trie.Put(key, val)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 
 			value, err := trie.Get(key)
 			require.NoError(t, err)
@@ -69,8 +69,8 @@ func TestTriePut(t *testing.T) {
 
 			value, err := trie.Get(key)
 			// should return an error when try to access a non-exist key
-			require.Error(t, err)
-
+			assert.Error(t, err)
+			// after empty, the return value and Trie's root should be nil
 			assert.Nil(t, value)
 			assert.Nil(t, trie.rootKey)
 
@@ -94,7 +94,8 @@ func TestTriePut(t *testing.T) {
 			require.NoError(t, err, "update a new value at an exist key")
 
 			value, err := trie.Get(key)
-			assert.NoError(t, err)
+			require.NoError(t, err)
+
 			assert.Equal(t, newVal, value)
 
 			return nil
@@ -128,6 +129,7 @@ func TestTriePut(t *testing.T) {
 
 			// Common key should be 0b100, length 251-2;
 			expectKey := bitset.New(251 - 2).Set(2)
+
 			assert.Equal(t, expectKey, commonKey)
 
 			// Current rootKey should be the common key
@@ -168,6 +170,7 @@ func TestTriePut(t *testing.T) {
 			require.False(t, isSame)
 
 			expectKey := bitset.New(251 - 2).Set(2)
+
 			assert.Equal(t, expectKey, commonKey)
 
 			parentNode, err := trie.storage.Get(commonKey)
@@ -254,6 +257,7 @@ func TestTriePut(t *testing.T) {
 				assert.Equal(t, trie.feltToBitSet(newKey), parentNode.Left)
 
 				expectRightKey := bitset.New(251 - 2).Set(0)
+
 				assert.Equal(t, expectRightKey, parentNode.Right)
 			})
 			return nil
@@ -316,9 +320,11 @@ func TestTrieDeleteBasic(t *testing.T) {
 					require.NoError(t, err)
 
 					val, err := trie.Get(key)
+
 					assert.Error(t, err, "should return an error when access a deleted key")
-					assert.Nil(t, val)
+					assert.Nil(t, val, "should return an nil value when access a deleted key")
 				}
+
 				// Check the final rootKey
 				assert.Equal(t, trie.feltToBitSet(test.expectRootKey), trie.rootKey)
 
@@ -388,6 +394,7 @@ func TestTrieDeleteSubtree(t *testing.T) {
 				require.NoError(t, err)
 
 				newRootKey := bitset.New(251 - 2).Set(0)
+
 				assert.Equal(t, newRootKey, trie.rootKey)
 
 				rootNode, err := trie.storage.Get(newRootKey)
@@ -426,9 +433,8 @@ func TestPath(t *testing.T) {
 	}
 
 	for idx, test := range tests {
-		if got := path(test.child, test.parent); !got.Equal(test.want) {
-			t.Error("TestPath failing #", idx)
-		}
+		got := path(test.child, test.parent)
+		assert.Equal(t, got, test.want, "TestPath failing #%d", idx)
 	}
 }
 
@@ -441,104 +447,108 @@ func TestState(t *testing.T) {
 		diffs map[string][]diff
 	)
 
-	var (
-		addresses = diffs{
-			"0x735596016a37ee972c42adef6a3cf628c19bb3794369c65d2c82ba034aecf2c": {
-				{"0x5", "0x64"},
-				{
-					"0x2f50710449a06a9fa789b3c029a63bd0b1f722f46505828a9f815cf91b31d8",
-					"0x2a222e62eabe91abdb6838fa8b267ffe81a6eb575f61e96ec9aa4460c0925a2",
-				},
+	addresses := diffs{
+		"0x735596016a37ee972c42adef6a3cf628c19bb3794369c65d2c82ba034aecf2c": {
+			{"0x5", "0x64"},
+			{
+				"0x2f50710449a06a9fa789b3c029a63bd0b1f722f46505828a9f815cf91b31d8",
+				"0x2a222e62eabe91abdb6838fa8b267ffe81a6eb575f61e96ec9aa4460c0925a2",
 			},
-			"0x20cfa74ee3564b4cd5435cdace0f9c4d43b939620e4a0bb5076105df0a626c6": {
-				{"0x5", "0x22b"},
-				{
-					"0x5aee31408163292105d875070f98cb48275b8c87e80380b78d30647e05854d5",
-					"0x7e5",
-				},
-				{
-					"0x313ad57fdf765addc71329abf8d74ac2bce6d46da8c2b9b82255a5076620300",
-					"0x4e7e989d58a17cd279eca440c5eaa829efb6f9967aaad89022acbe644c39b36",
-				},
-				{
-					"0x313ad57fdf765addc71329abf8d74ac2bce6d46da8c2b9b82255a5076620301",
-					"0x453ae0c9610197b18b13645c44d3d0a407083d96562e8752aab3fab616cecb0",
-				},
-				{
-					"0x6cf6c2f36d36b08e591e4489e92ca882bb67b9c39a3afccf011972a8de467f0",
-					"0x7ab344d88124307c07b56f6c59c12f4543e9c96398727854a322dea82c73240",
-				},
+		},
+		"0x20cfa74ee3564b4cd5435cdace0f9c4d43b939620e4a0bb5076105df0a626c6": {
+			{"0x5", "0x22b"},
+			{
+				"0x5aee31408163292105d875070f98cb48275b8c87e80380b78d30647e05854d5",
+				"0x7e5",
 			},
-			"0x6ee3440b08a9c805305449ec7f7003f27e9f7e287b83610952ec36bdc5a6bae": {
-				{
-					"0x1e2cd4b3588e8f6f9c4e89fb0e293bf92018c96d7a93ee367d29a284223b6ff",
-					"0x71d1e9d188c784a0bde95c1d508877a0d93e9102b37213d1e13f3ebc54a7751",
-				},
-				{
-					"0x5f750dc13ed239fa6fc43ff6e10ae9125a33bd05ec034fc3bb4dd168df3505f",
-					"0x7e5",
-				},
-				{
-					"0x48cba68d4e86764105adcdcf641ab67b581a55a4f367203647549c8bf1feea2",
-					"0x362d24a3b030998ac75e838955dfee19ec5b6eceb235b9bfbeccf51b6304d0b",
-				},
-				{
-					"0x449908c349e90f81ab13042b1e49dc251eb6e3e51092d9a40f86859f7f415b0",
-					"0x6cb6104279e754967a721b52bcf5be525fdc11fa6db6ef5c3a4db832acf7804",
-				},
-				{
-					"0x5bdaf1d47b176bfcd1114809af85a46b9c4376e87e361d86536f0288a284b65",
-					"0x28dff6722aa73281b2cf84cac09950b71fa90512db294d2042119abdd9f4b87",
-				},
-				{
-					"0x5bdaf1d47b176bfcd1114809af85a46b9c4376e87e361d86536f0288a284b66",
-					"0x57a8f8a019ccab5bfc6ff86c96b1392257abb8d5d110c01d326b94247af161c",
-				},
+			{
+				"0x313ad57fdf765addc71329abf8d74ac2bce6d46da8c2b9b82255a5076620300",
+				"0x4e7e989d58a17cd279eca440c5eaa829efb6f9967aaad89022acbe644c39b36",
 			},
-			"0x31c887d82502ceb218c06ebb46198da3f7b92864a8223746bc836dda3e34b52": {
-				{
-					"0x5f750dc13ed239fa6fc43ff6e10ae9125a33bd05ec034fc3bb4dd168df3505f",
-					"0x7c7",
-				},
-				{
-					"0xdf28e613c065616a2e79ca72f9c1908e17b8c913972a9993da77588dc9cae9",
-					"0x1432126ac23c7028200e443169c2286f99cdb5a7bf22e607bcd724efa059040",
-				},
+			{
+				"0x313ad57fdf765addc71329abf8d74ac2bce6d46da8c2b9b82255a5076620301",
+				"0x453ae0c9610197b18b13645c44d3d0a407083d96562e8752aab3fab616cecb0",
 			},
-			"0x31c9cdb9b00cb35cf31c05855c0ec3ecf6f7952a1ce6e3c53c3455fcd75a280": {
-				{"0x5", "0x65"},
-				{
-					"0x5aee31408163292105d875070f98cb48275b8c87e80380b78d30647e05854d5",
-					"0x7c7",
-				},
-				{
-					"0xcfc2e2866fd08bfb4ac73b70e0c136e326ae18fc797a2c090c8811c695577e",
-					"0x5f1dd5a5aef88e0498eeca4e7b2ea0fa7110608c11531278742f0b5499af4b3",
-				},
-				{
-					"0x5fac6815fddf6af1ca5e592359862ede14f171e1544fd9e792288164097c35d",
-					"0x299e2f4b5a873e95e65eb03d31e532ea2cde43b498b50cd3161145db5542a5",
-				},
-				{
-					"0x5fac6815fddf6af1ca5e592359862ede14f171e1544fd9e792288164097c35e",
-					"0x3d6897cf23da3bf4fd35cc7a43ccaf7c5eaf8f7c5b9031ac9b09a929204175f",
-				},
+			{
+				"0x6cf6c2f36d36b08e591e4489e92ca882bb67b9c39a3afccf011972a8de467f0",
+				"0x7ab344d88124307c07b56f6c59c12f4543e9c96398727854a322dea82c73240",
 			},
-		}
+		},
+		"0x6ee3440b08a9c805305449ec7f7003f27e9f7e287b83610952ec36bdc5a6bae": {
+			{
+				"0x1e2cd4b3588e8f6f9c4e89fb0e293bf92018c96d7a93ee367d29a284223b6ff",
+				"0x71d1e9d188c784a0bde95c1d508877a0d93e9102b37213d1e13f3ebc54a7751",
+			},
+			{
+				"0x5f750dc13ed239fa6fc43ff6e10ae9125a33bd05ec034fc3bb4dd168df3505f",
+				"0x7e5",
+			},
+			{
+				"0x48cba68d4e86764105adcdcf641ab67b581a55a4f367203647549c8bf1feea2",
+				"0x362d24a3b030998ac75e838955dfee19ec5b6eceb235b9bfbeccf51b6304d0b",
+			},
+			{
+				"0x449908c349e90f81ab13042b1e49dc251eb6e3e51092d9a40f86859f7f415b0",
+				"0x6cb6104279e754967a721b52bcf5be525fdc11fa6db6ef5c3a4db832acf7804",
+			},
+			{
+				"0x5bdaf1d47b176bfcd1114809af85a46b9c4376e87e361d86536f0288a284b65",
+				"0x28dff6722aa73281b2cf84cac09950b71fa90512db294d2042119abdd9f4b87",
+			},
+			{
+				"0x5bdaf1d47b176bfcd1114809af85a46b9c4376e87e361d86536f0288a284b66",
+				"0x57a8f8a019ccab5bfc6ff86c96b1392257abb8d5d110c01d326b94247af161c",
+			},
+		},
+		"0x31c887d82502ceb218c06ebb46198da3f7b92864a8223746bc836dda3e34b52": {
+			{
+				"0x5f750dc13ed239fa6fc43ff6e10ae9125a33bd05ec034fc3bb4dd168df3505f",
+				"0x7c7",
+			},
+			{
+				"0xdf28e613c065616a2e79ca72f9c1908e17b8c913972a9993da77588dc9cae9",
+				"0x1432126ac23c7028200e443169c2286f99cdb5a7bf22e607bcd724efa059040",
+			},
+		},
+		"0x31c9cdb9b00cb35cf31c05855c0ec3ecf6f7952a1ce6e3c53c3455fcd75a280": {
+			{"0x5", "0x65"},
+			{
+				"0x5aee31408163292105d875070f98cb48275b8c87e80380b78d30647e05854d5",
+				"0x7c7",
+			},
+			{
+				"0xcfc2e2866fd08bfb4ac73b70e0c136e326ae18fc797a2c090c8811c695577e",
+				"0x5f1dd5a5aef88e0498eeca4e7b2ea0fa7110608c11531278742f0b5499af4b3",
+			},
+			{
+				"0x5fac6815fddf6af1ca5e592359862ede14f171e1544fd9e792288164097c35d",
+				"0x299e2f4b5a873e95e65eb03d31e532ea2cde43b498b50cd3161145db5542a5",
+			},
+			{
+				"0x5fac6815fddf6af1ca5e592359862ede14f171e1544fd9e792288164097c35e",
+				"0x3d6897cf23da3bf4fd35cc7a43ccaf7c5eaf8f7c5b9031ac9b09a929204175f",
+			},
+		},
+	}
 
-		want, _         = new(felt.Felt).SetString("0x021870ba80540e7831fb21c591ee93481f5ae1bb71ff85a86ddd465be4eddee6")
-		contractHash, _ = new(felt.Felt).SetString("0x10455c752b86932ce552f2b0fe81a880746649b9aee7e0d842bf3f52378f9f8")
-	)
+	want, err := new(felt.Felt).SetString("0x021870ba80540e7831fb21c591ee93481f5ae1bb71ff85a86ddd465be4eddee6")
+	require.NoError(t, err)
+
+	contractHash, err := new(felt.Felt).SetString("0x10455c752b86932ce552f2b0fe81a880746649b9aee7e0d842bf3f52378f9f8")
+	require.NoError(t, err)
 
 	RunOnTempTrie(251, func(state *Trie) error {
 		for addr, dif := range addresses {
 			RunOnTempTrie(251, func(contractState *Trie) error {
 				for _, slot := range dif {
-					key, _ := new(felt.Felt).SetString(slot.key)
-					val, _ := new(felt.Felt).SetString(slot.val)
-					if _, err := contractState.Put(key, val); err != nil {
-						t.Fatal(err)
-					}
+					key, err := new(felt.Felt).SetString(slot.key)
+					require.NoError(t, err)
+
+					val, err := new(felt.Felt).SetString(slot.val)
+					require.NoError(t, err)
+
+					_, err = contractState.Put(key, val)
+					require.NoError(t, err)
 				}
 				/*
 				   735596016a37ee972c42adef6a3cf628c19bb3794369c65d2c82ba034aecf2c  :  15c52969f4ae2ad48bf324e21b8c06ce8abcbc492263072a8de9c7f0bfa3c81
@@ -548,26 +558,29 @@ func TestState(t *testing.T) {
 				   31c9cdb9b00cb35cf31c05855c0ec3ecf6f7952a1ce6e3c53c3455fcd75a280  :  6fe0662f4be66647b4508a53a08e13e7d1ffb2b19e93fa9dc991153f3a447d
 				*/
 
-				key, _ := new(felt.Felt).SetString(addr)
-				contractRoot, _ := contractState.Root()
+				key, err := new(felt.Felt).SetString(addr)
+				require.NoError(t, err)
+
+				contractRoot, err := contractState.Root()
+				require.NoError(t, err)
+
 				fmt.Println(addr, " : ", contractRoot.Text(16))
 
 				val := crypto.Pedersen(contractHash, contractRoot)
 				val = crypto.Pedersen(val, new(felt.Felt))
 				val = crypto.Pedersen(val, new(felt.Felt))
 
-				if _, err := state.Put(key, val); err != nil {
-					t.Fatal(err)
-				}
+				_, err = state.Put(key, val)
+				require.NoError(t, err)
 
 				return nil
 			})
 		}
 
-		got, _ := state.Root()
-		if !want.Equal(got) {
-			t.Errorf("state.RootHash() = %s, want = %s", got.Text(16), want.Text(16))
-		}
+		got, err := state.Root()
+		require.NoError(t, err)
+
+		assert.Equal(t, want, got)
 
 		return nil
 	})
@@ -577,57 +590,47 @@ func TestPutZero(t *testing.T) {
 	storage := newMemStorage()
 	trie := NewTrie(storage, 251, nil)
 	emptyRoot, err := trie.Root()
-	if err != nil {
-		t.Error(err)
-	}
+	require.NoError(t, err)
 
 	var roots []*felt.Felt
 	var keys []*felt.Felt
 	// put random 64 keys and record roots
 	for i := 0; i < 64; i++ {
 		key, err := new(felt.Felt).SetRandom()
-		if err != nil {
-			t.Error(err)
-		}
-		value, err := new(felt.Felt).SetRandom()
-		if err != nil {
-			t.Error(err)
-		}
+		require.NoError(t, err)
 
-		if _, err = trie.Put(key, value); err != nil {
-			t.Error(err)
-		}
+		value, err := new(felt.Felt).SetRandom()
+		require.NoError(t, err)
+
+		_, err = trie.Put(key, value)
+		require.NoError(t, err)
 
 		keys = append(keys, key)
 		root, err := trie.Root()
-		if err != nil {
-			t.Error(err)
-		}
+		require.NoError(t, err)
 
 		roots = append(roots, root)
 	}
 
 	key, err := new(felt.Felt).SetRandom()
-	if err != nil {
-		t.Error(err)
-	}
+	require.NoError(t, err)
+
 	// adding a zero value should not change Trie
-	if _, err = trie.Put(key, new(felt.Felt)); err != nil {
-		t.Error(err)
-	}
+	_, err = trie.Put(key, new(felt.Felt))
+	require.NoError(t, err)
+
 	root, err := trie.Root()
-	if err != nil {
-		t.Error(err)
-	}
+	require.NoError(t, err)
+
 	assert.Equal(t, true, root.Equal(roots[len(roots)-1]))
 
 	// put zero in reverse order and check roots still match
 	for i := 0; i < 64; i++ {
 		root := roots[len(roots)-1-i]
+
 		actual, err := trie.Root()
-		if err != nil {
-			t.Error(err)
-		}
+		require.NoError(t, err)
+
 		assert.Equal(t, true, actual.Equal(root))
 
 		key := keys[len(keys)-1-i]
@@ -635,12 +638,10 @@ func TestPutZero(t *testing.T) {
 	}
 
 	actualEmptyRoot, err := trie.Root()
-	if err != nil {
-		t.Error(err)
-	}
-	assert.Equal(t, true, actualEmptyRoot.Equal(emptyRoot))
+	require.NoError(t, err)
 
-	assert.Equal(t, 0, len(storage.storage)) // storage should be empty
+	assert.Equal(t, true, actualEmptyRoot.Equal(emptyRoot))
+	assert.Zero(t, len(storage.storage)) // storage should be empty
 }
 
 func TestOldData(t *testing.T) {
@@ -649,28 +650,36 @@ func TestOldData(t *testing.T) {
 		old := new(felt.Felt)
 
 		was, err := trie.Put(key, old)
-		assert.NoError(t, err)
+		require.NoError(t, err)
+
 		assert.Nil(t, was) // no change
 
 		was, err = trie.Put(key, new(felt.Felt).SetUint64(1))
-		assert.NoError(t, err)
+		require.NoError(t, err)
+
 		assert.Equal(t, old, was)
 
 		old.SetUint64(1)
 
 		was, err = trie.Put(key, new(felt.Felt).SetUint64(2))
-		assert.NoError(t, err)
+		require.NoError(t, err)
+
 		assert.Equal(t, old, was)
 
 		old.SetUint64(2)
 
+		// put zero value to delete current key
 		was, err = trie.Put(key, new(felt.Felt))
-		assert.NoError(t, err)
+		require.NoError(t, err)
+
 		assert.Equal(t, old, was)
 
+		// put zero again to check old data
 		was, err = trie.Put(key, new(felt.Felt))
-		assert.NoError(t, err)
-		assert.Nil(t, was) // no change
+		require.NoError(t, err)
+
+		// there should no old data to return
+		assert.Nil(t, was)
 
 		return nil
 	})


### PR DESCRIPTION
Complete the TODO list for trie's test in #528

## Description

Complete the TODO list for trie's test.

## Changes:

- change Path and FindCommonKey to private,
- add more test to trie.Put and trie.FeltToBitSet,
- handle the ignored return error,
- replace all the t.Error with require.NoError,
- replace some improper assert by require,

## Types of changes

- Code style update (formatting, renaming)

## Testing

**Requires testing**: Yes

**Did you write tests??**: Yes

## Documentation

**If this requires a documentation update, did you add one?** No

