### PR TITLE
Handle errors from various Close()

### DIFF
--- a/blockchain/blockchain_test.go
+++ b/blockchain/blockchain_test.go
@@ -220,7 +220,9 @@ func TestStore(t *testing.T) {
 		assert.Equal(t, block0, headBlock)
 
 		txn := chain.database.NewTransaction(false)
-		defer txn.Discard()
+		defer func() {
+			require.NoError(t, txn.Discard())
+		}()
 
 		root, err := core.NewState(txn).Root()
 		assert.NoError(t, err)
@@ -246,7 +248,9 @@ func TestStore(t *testing.T) {
 		assert.Equal(t, block1, headBlock)
 
 		txn := chain.database.NewTransaction(false)
-		defer txn.Discard()
+		defer func() {
+			require.NoError(t, txn.Discard())
+		}()
 
 		root, err := core.NewState(txn).Root()
 		assert.NoError(t, err)

--- a/blockchain/blockchain_test.go
+++ b/blockchain/blockchain_test.go
@@ -16,8 +16,8 @@ import (
 )
 
 func TestNewBlockchain(t *testing.T) {
-	gw, closer := testsource.NewTestGateway(utils.MAINNET)
-	defer closer.Close()
+	gw, closeFn := testsource.NewTestGateway(utils.MAINNET)
+	defer closeFn()
 	t.Run("empty blockchain's head is nil", func(t *testing.T) {
 		chain := NewBlockchain(pebble.NewMemTest(), utils.MAINNET)
 		assert.Equal(t, utils.MAINNET, chain.network)
@@ -44,8 +44,8 @@ func TestNewBlockchain(t *testing.T) {
 }
 
 func TestHeight(t *testing.T) {
-	gw, closer := testsource.NewTestGateway(utils.MAINNET)
-	defer closer.Close()
+	gw, closeFn := testsource.NewTestGateway(utils.MAINNET)
+	defer closeFn()
 	t.Run("return nil if blockchain is empty", func(t *testing.T) {
 		chain := NewBlockchain(pebble.NewMemTest(), utils.GOERLI)
 		_, err := chain.Height()
@@ -72,8 +72,8 @@ func TestHeight(t *testing.T) {
 func TestGetBlockByNumberAndHash(t *testing.T) {
 	chain := NewBlockchain(pebble.NewMemTest(), utils.GOERLI)
 	t.Run("same block is returned for both by GetBlockByNumber and GetBlockByHash", func(t *testing.T) {
-		gw, closer := testsource.NewTestGateway(utils.MAINNET)
-		defer closer.Close()
+		gw, closeFn := testsource.NewTestGateway(utils.MAINNET)
+		defer closeFn()
 
 		block, err := gw.BlockByNumber(context.Background(), 0)
 		require.NoError(t, err)
@@ -120,8 +120,8 @@ func TestVerifyBlock(t *testing.T) {
 		assert.EqualError(t, chain.VerifyBlock(block), expectedErr.Error())
 	})
 
-	gw, closer := testsource.NewTestGateway(utils.MAINNET)
-	defer closer.Close()
+	gw, closeFn := testsource.NewTestGateway(utils.MAINNET)
+	defer closeFn()
 
 	mainnetBlock0, err := gw.BlockByNumber(context.Background(), 0)
 	require.NoError(t, err)
@@ -157,8 +157,8 @@ func TestSanityCheckNewHeight(t *testing.T) {
 
 	chain := NewBlockchain(pebble.NewMemTest(), utils.MAINNET)
 
-	gw, closer := testsource.NewTestGateway(utils.MAINNET)
-	defer closer.Close()
+	gw, closeFn := testsource.NewTestGateway(utils.MAINNET)
+	defer closeFn()
 
 	mainnetBlock0, err := gw.BlockByNumber(context.Background(), 0)
 	require.NoError(t, err)
@@ -202,8 +202,8 @@ func TestSanityCheckNewHeight(t *testing.T) {
 }
 
 func TestStore(t *testing.T) {
-	gw, closer := testsource.NewTestGateway(utils.MAINNET)
-	defer closer.Close()
+	gw, closeFn := testsource.NewTestGateway(utils.MAINNET)
+	defer closeFn()
 
 	block0, err := gw.BlockByNumber(context.Background(), 0)
 	require.NoError(t, err)
@@ -261,8 +261,8 @@ func TestStore(t *testing.T) {
 func TestGetTransactionAndReceipt(t *testing.T) {
 	chain := NewBlockchain(pebble.NewMemTest(), utils.MAINNET)
 
-	gw, closer := testsource.NewTestGateway(utils.MAINNET)
-	defer closer.Close()
+	gw, closeFn := testsource.NewTestGateway(utils.MAINNET)
+	defer closeFn()
 
 	for i := uint64(0); i < 3; i++ {
 		b, err := gw.BlockByNumber(context.Background(), i)

--- a/clients/gateway_test.go
+++ b/clients/gateway_test.go
@@ -270,8 +270,8 @@ func TestL1HandlerTransactionUnmarshal(t *testing.T) {
 }
 
 func TestBlockWithoutSequencerAddressUnmarshal(t *testing.T) {
-	client, closer := testsource.NewTestClient(utils.MAINNET)
-	defer closer.Close()
+	client, closeFn := testsource.NewTestClient(utils.MAINNET)
+	defer closeFn()
 
 	block, err := client.GetBlock(context.Background(), 11817)
 	if err != nil {
@@ -291,8 +291,8 @@ func TestBlockWithoutSequencerAddressUnmarshal(t *testing.T) {
 }
 
 func TestBlockWithSequencerAddressUnmarshal(t *testing.T) {
-	client, closer := testsource.NewTestClient(utils.MAINNET)
-	defer closer.Close()
+	client, closeFn := testsource.NewTestClient(utils.MAINNET)
+	defer closeFn()
 
 	block, err := client.GetBlock(context.Background(), 19199)
 	if err != nil {
@@ -313,8 +313,8 @@ func TestBlockWithSequencerAddressUnmarshal(t *testing.T) {
 }
 
 func TestClassUnmarshal(t *testing.T) {
-	gatewayClient, closer := testsource.NewTestClient(utils.MAINNET)
-	defer closer.Close()
+	gatewayClient, closeFn := testsource.NewTestClient(utils.MAINNET)
+	defer closeFn()
 
 	hash, _ := new(felt.Felt).SetString("0x01efa8f84fd4dff9e2902ec88717cf0dafc8c188f80c3450615944a469428f7f")
 	class, err := gatewayClient.GetClassDefinition(context.Background(), hash)
@@ -479,8 +479,8 @@ func TestGetTransaction(t *testing.T) {
 }
 
 func TestGetBlock(t *testing.T) {
-	gatewayClient, closer := testsource.NewTestClient(utils.MAINNET)
-	defer closer.Close()
+	gatewayClient, closeFn := testsource.NewTestClient(utils.MAINNET)
+	defer closeFn()
 
 	t.Run("Test normal case", func(t *testing.T) {
 		blcokNumber := uint64(11817)
@@ -498,8 +498,8 @@ func TestGetBlock(t *testing.T) {
 }
 
 func TestGetClassDefinition(t *testing.T) {
-	gatewayClient, closer := testsource.NewTestClient(utils.MAINNET)
-	defer closer.Close()
+	gatewayClient, closeFn := testsource.NewTestClient(utils.MAINNET)
+	defer closeFn()
 
 	t.Run("Test normal case", func(t *testing.T) {
 		classHash, _ := new(felt.Felt).SetString("0x01efa8f84fd4dff9e2902ec88717cf0dafc8c188f80c3450615944a469428f7f")

--- a/clients/programhash_test.go
+++ b/clients/programhash_test.go
@@ -12,8 +12,8 @@ import (
 )
 
 func TestProgramHash(t *testing.T) {
-	client, closer := testsource.NewTestClient(utils.GOERLI)
-	defer closer.Close()
+	client, closeFn := testsource.NewTestClient(utils.GOERLI)
+	defer closeFn()
 	hexToFelt := func(t *testing.T, hex string) *felt.Felt {
 		f, err := new(felt.Felt).SetString(hex)
 		require.NoError(t, err)

--- a/clients/programhash_test.go
+++ b/clients/programhash_test.go
@@ -4,18 +4,19 @@ import (
 	"context"
 	"testing"
 
-	"github.com/NethermindEth/juno/testsource"
-	"github.com/NethermindEth/juno/utils"
-
 	"github.com/NethermindEth/juno/clients"
 	"github.com/NethermindEth/juno/core/felt"
+	"github.com/NethermindEth/juno/testsource"
+	"github.com/NethermindEth/juno/utils"
+	"github.com/stretchr/testify/require"
 )
 
 func TestProgramHash(t *testing.T) {
 	client, closer := testsource.NewTestClient(utils.GOERLI)
 	defer closer.Close()
-	hexToFelt := func(hex string) *felt.Felt {
-		f, _ := new(felt.Felt).SetString(hex)
+	hexToFelt := func(t *testing.T, hex string) *felt.Felt {
+		f, err := new(felt.Felt).SetString(hex)
+		require.NoError(t, err)
 		return f
 	}
 	tests := []struct {
@@ -26,23 +27,27 @@ func TestProgramHash(t *testing.T) {
 		{ // https://alpha4.starknet.io/feeder_gateway/get_class_by_hash?classHash=0x010455c752b86932ce552f2b0fe81a880746649b9aee7e0d842bf3f52378f9f8
 			classHash: "0x010455c752b86932ce552f2b0fe81a880746649b9aee7e0d842bf3f52378f9f8",
 			name:      "Genesis contract",
-			want:      hexToFelt("0x1e87d79be8c8146494b5c54318f7d194481c3959752659a1e1bce158649a670"),
+			want: hexToFelt(
+				t, "0x1e87d79be8c8146494b5c54318f7d194481c3959752659a1e1bce158649a670"),
 		},
 		{ // https://alpha4.starknet.io/feeder_gateway/get_class_by_hash?classHash=0x056b96c1d1bbfa01af44b465763d1b71150fa00c6c9d54c3947f57e979ff68c3
 			classHash: "0x056b96c1d1bbfa01af44b465763d1b71150fa00c6c9d54c3947f57e979ff68c3",
 			name:      "Cairo 0.8 contract",
-			want:      hexToFelt("0x359145fc6207854bfbbeadae4c6e289024400a5af87090ed18073200fef6213"),
+			want: hexToFelt(
+				t, "0x359145fc6207854bfbbeadae4c6e289024400a5af87090ed18073200fef6213"),
 		},
 		{ // https://alpha4.starknet.io/feeder_gateway/get_class_by_hash?classHash=0x0079e2d211e70594e687f9f788f71302e6eecb61d98efce48fbe8514948c8118
 			classHash: "0x0079e2d211e70594e687f9f788f71302e6eecb61d98efce48fbe8514948c8118",
 			name:      "Cairo 0.10 contract",
-			want:      hexToFelt("0x88562ac88adfc7760ff452d048d39d72978bcc0f8d7b0fcfb34f33970b3df3"),
+			want: hexToFelt(
+				t, "0x88562ac88adfc7760ff452d048d39d72978bcc0f8d7b0fcfb34f33970b3df3"),
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			classDefinition, err := client.GetClassDefinition(context.Background(), hexToFelt(tt.classHash))
+			classDefinition, err := client.GetClassDefinition(context.Background(),
+				hexToFelt(t, tt.classHash))
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/core/block_test.go
+++ b/core/block_test.go
@@ -85,8 +85,8 @@ func TestBlockHash(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			client, closer := testsource.NewTestGateway(tt.chain)
-			defer closer.Close()
+			client, closeFn := testsource.NewTestGateway(tt.chain)
+			defer closeFn()
 
 			block, err := client.BlockByNumber(context.Background(), tt.blockNumber)
 			require.NoError(t, err)
@@ -95,8 +95,8 @@ func TestBlockHash(t *testing.T) {
 	}
 
 	t.Run("no error if block is unverifiable", func(t *testing.T) {
-		goerliGW, closer := testsource.NewTestGateway(utils.GOERLI)
-		defer closer.Close()
+		goerliGW, closeFn := testsource.NewTestGateway(utils.GOERLI)
+		defer closeFn()
 		block119802, err := goerliGW.BlockByNumber(context.Background(), 119802)
 		require.NoError(t, err)
 

--- a/core/contract_test.go
+++ b/core/contract_test.go
@@ -20,8 +20,8 @@ func hexToFelt(t *testing.T, hex string) *felt.Felt {
 }
 
 func TestClassHash(t *testing.T) {
-	gw, closer := testsource.NewTestGateway(utils.GOERLI)
-	defer closer.Close()
+	gw, closeFn := testsource.NewTestGateway(utils.GOERLI)
+	defer closeFn()
 
 	tests := []struct {
 		classHash string

--- a/core/contract_test.go
+++ b/core/contract_test.go
@@ -10,11 +10,12 @@ import (
 	"github.com/NethermindEth/juno/testsource"
 	"github.com/NethermindEth/juno/utils"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
-func hexToFelt(hex string) *felt.Felt {
-	// We know our test hex values are valid, so we'll ignore the potential error
-	f, _ := new(felt.Felt).SetString(hex)
+func hexToFelt(t *testing.T, hex string) *felt.Felt {
+	f, err := new(felt.Felt).SetString(hex)
+	require.NoError(t, err)
 	return f
 }
 
@@ -41,7 +42,7 @@ func TestClassHash(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run("ClassHash", func(t *testing.T) {
-			hash := hexToFelt(tt.classHash)
+			hash := hexToFelt(t, tt.classHash)
 			class, err := gw.Class(context.Background(), hash)
 			assert.NoError(t, err)
 			got := class.Hash()
@@ -62,17 +63,19 @@ func TestContractAddress(t *testing.T) {
 	}{
 		{
 			// https://alpha-mainnet.starknet.io/feeder_gateway/get_transaction?transactionHash=0x6486c6303dba2f364c684a2e9609211c5b8e417e767f37b527cda51e776e6f0
-			callerAddress: hexToFelt("0x0000000000000000000000000000000000000000"),
-			classHash:     hexToFelt("0x46f844ea1a3b3668f81d38b5c1bd55e816e0373802aefe732138628f0133486"),
-			salt:          hexToFelt("0x74dc2fe193daf1abd8241b63329c1123214842b96ad7fd003d25512598a956b"),
+			callerAddress: hexToFelt(t, "0x0000000000000000000000000000000000000000"),
+			classHash: hexToFelt(
+				t, "0x46f844ea1a3b3668f81d38b5c1bd55e816e0373802aefe732138628f0133486"),
+			salt: hexToFelt(
+				t, "0x74dc2fe193daf1abd8241b63329c1123214842b96ad7fd003d25512598a956b"),
 			constructorCalldata: []*felt.Felt{
-				hexToFelt("0x6d706cfbac9b8262d601c38251c5fbe0497c3a96cc91a92b08d91b61d9e70c4"),
-				hexToFelt("0x79dc0da7c54b95f10aa182ad0a46400db63156920adb65eca2654c0945a463"),
-				hexToFelt("0x2"),
-				hexToFelt("0x6658165b4984816ab189568637bedec5aa0a18305909c7f5726e4a16e3afef6"),
-				hexToFelt("0x6b648b36b074a91eee55730f5f5e075ec19c0a8f9ffb0903cefeee93b6ff328"),
+				hexToFelt(t, "0x6d706cfbac9b8262d601c38251c5fbe0497c3a96cc91a92b08d91b61d9e70c4"),
+				hexToFelt(t, "0x79dc0da7c54b95f10aa182ad0a46400db63156920adb65eca2654c0945a463"),
+				hexToFelt(t, "0x2"),
+				hexToFelt(t, "0x6658165b4984816ab189568637bedec5aa0a18305909c7f5726e4a16e3afef6"),
+				hexToFelt(t, "0x6b648b36b074a91eee55730f5f5e075ec19c0a8f9ffb0903cefeee93b6ff328"),
 			},
-			want: hexToFelt("0x3ec215c6c9028ff671b46a2a9814970ea23ed3c4bcc3838c6d1dcbf395263c3"),
+			want: hexToFelt(t, "0x3ec215c6c9028ff671b46a2a9814970ea23ed3c4bcc3838c6d1dcbf395263c3"),
 		},
 	}
 

--- a/core/contract_test.go
+++ b/core/contract_test.go
@@ -91,7 +91,9 @@ func TestContractAddress(t *testing.T) {
 
 func TestContract(t *testing.T) {
 	testDb := pebble.NewMemTest()
-	defer testDb.Close()
+	defer func() {
+		require.NoError(t, testDb.Close())
+	}()
 
 	txn := testDb.NewTransaction(true)
 	addr := new(felt.Felt).SetUint64(44)

--- a/core/transaction_test.go
+++ b/core/transaction_test.go
@@ -51,8 +51,8 @@ func TestTransactionHash(t *testing.T) {
 
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
-			gw, closer := testsource.NewTestGateway(test.network)
-			defer closer.Close()
+			gw, closerFn := testsource.NewTestGateway(test.network)
+			defer closerFn()
 
 			hash := hexToFelt(t, test.txnHash)
 			txn, err := gw.Transaction(context.Background(), hash)

--- a/core/transaction_test.go
+++ b/core/transaction_test.go
@@ -54,7 +54,7 @@ func TestTransactionHash(t *testing.T) {
 			gw, closer := testsource.NewTestGateway(test.network)
 			defer closer.Close()
 
-			hash := hexToFelt(test.txnHash)
+			hash := hexToFelt(t, test.txnHash)
 			txn, err := gw.Transaction(context.Background(), hash)
 			require.NoError(t, err)
 			require.NotNil(t, txn)

--- a/db/db.go
+++ b/db/db.go
@@ -58,7 +58,7 @@ type Transaction interface {
 	// NewIterator returns an iterator over the database's key/value pairs.
 	NewIterator() (Iterator, error)
 	// Discard discards all the changes done to the database with this transaction
-	Discard()
+	Discard() error
 	// Commit flushes all the changes pending on this transaction to the database, making the changes visible to other
 	// transaction
 	Commit() error

--- a/node/node.go
+++ b/node/node.go
@@ -85,9 +85,14 @@ func New(cfg *Config) (StarknetNode, error) {
 	}, nil
 }
 
-func (n *Node) Run(ctx context.Context) error {
+func (n *Node) Run(ctx context.Context) (err error) {
 	n.log.Infow("Starting Juno...", "config", fmt.Sprintf("%+v", *n.cfg))
-	defer n.db.Close()
+	defer func() {
+		// Prioritise closing error over other errors
+		if closeErr := n.db.Close(); closeErr != nil {
+			err = closeErr
+		}
+	}()
 	go func() {
 		<-ctx.Done()
 		n.log.Infow("Shutting down Juno...")

--- a/sync/sync_test.go
+++ b/sync/sync_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/NethermindEth/juno/testsource"
 	"github.com/NethermindEth/juno/utils"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestSyncBlocks(t *testing.T) {
@@ -18,7 +19,7 @@ func TestSyncBlocks(t *testing.T) {
 	testBlockchain := func(t *testing.T, bc *blockchain.Blockchain) bool {
 		return assert.NoError(t, func() error {
 			headBlock, err := bc.Head()
-			assert.NoError(t, err)
+			require.NoError(t, err)
 
 			height := int(headBlock.Number)
 			for height >= 0 {
@@ -28,7 +29,7 @@ func TestSyncBlocks(t *testing.T) {
 				}
 
 				block, err := bc.GetBlockByNumber(uint64(height))
-				assert.NoError(t, err)
+				require.NoError(t, err)
 
 				assert.Equal(t, b, block)
 				height--
@@ -46,7 +47,7 @@ func TestSyncBlocks(t *testing.T) {
 			time.Sleep(time.Second)
 			cancel()
 		}()
-		assert.NoError(t, synchronizer.Run(ctx))
+		require.NoError(t, synchronizer.Run(ctx))
 
 		testBlockchain(t, bc)
 	})
@@ -54,10 +55,10 @@ func TestSyncBlocks(t *testing.T) {
 		testDB := pebble.NewMemTest()
 		bc := blockchain.NewBlockchain(testDB, utils.MAINNET)
 		b0, err := gw.BlockByNumber(context.Background(), 0)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		s0, err := gw.StateUpdate(context.Background(), 0)
-		assert.NoError(t, err)
-		assert.NoError(t, bc.Store(b0, s0))
+		require.NoError(t, err)
+		require.NoError(t, bc.Store(b0, s0))
 
 		synchronizer := NewSynchronizer(bc, gw, log)
 		ctx, cancel := context.WithCancel(context.Background())
@@ -65,7 +66,7 @@ func TestSyncBlocks(t *testing.T) {
 			time.Sleep(time.Second)
 			cancel()
 		}()
-		assert.NoError(t, synchronizer.Run(ctx))
+		require.NoError(t, synchronizer.Run(ctx))
 
 		testBlockchain(t, bc)
 	})

--- a/sync/sync_test.go
+++ b/sync/sync_test.go
@@ -13,8 +13,8 @@ import (
 )
 
 func TestSyncBlocks(t *testing.T) {
-	gw, closer := testsource.NewTestGateway(utils.MAINNET)
-	defer closer.Close()
+	gw, closeFn := testsource.NewTestGateway(utils.MAINNET)
+	defer closeFn()
 	testBlockchain := func(t *testing.T, bc *blockchain.Blockchain) bool {
 		return assert.NoError(t, func() error {
 			headBlock, err := bc.Head()

--- a/testsource/client.go
+++ b/testsource/client.go
@@ -1,31 +1,21 @@
 package testsource
 
 import (
-	"io"
-	"net/http/httptest"
-
 	"github.com/NethermindEth/juno/clients"
 	"github.com/NethermindEth/juno/starknetdata/gateway"
 	"github.com/NethermindEth/juno/utils"
 )
 
-type srvCloser struct {
-	srv *httptest.Server
-}
+type TestClientCloseFn func()
 
-func (c *srvCloser) Close() error {
-	c.srv.Close()
-	return nil
-}
-
-func NewTestClient(network utils.Network) (*clients.GatewayClient, io.Closer) {
+func NewTestClient(network utils.Network) (*clients.GatewayClient, TestClientCloseFn) {
 	srv := newTestGatewayServer(network)
 	client := clients.NewGatewayClient(srv.URL).WithBackoff(clients.NopBackoff).WithMaxRetries(0)
 
-	return client, &srvCloser{srv}
+	return client, srv.Close
 }
 
-func NewTestGateway(network utils.Network) (*gateway.Gateway, io.Closer) {
+func NewTestGateway(network utils.Network) (*gateway.Gateway, TestClientCloseFn) {
 	client, closer := NewTestClient(network)
 	gw := gateway.NewGatewayWithClient(client)
 


### PR DESCRIPTION
## Description

Most of our calls to close DB, Transaction and Iterators were being called by `defer` statements this meant that if there is an error while closing it would be ignored. This could lead to the corruption of our database.

In order to ensure all errors are handled, the `Transaction` interface's `Discard` function was updated to return an error. 
## Changes:

see commit history

## Types of changes

_Leave only items that describe your changes, remove the rest. Remove this line too._

- Bugfix (non-breaking change which fixes an issue)

## Testing

**Requires testing**: No

