### PR TITLE
Allow printing Felts in a short format

### DIFF
--- a/core/felt/felt.go
+++ b/core/felt/felt.go
@@ -2,6 +2,7 @@ package felt
 
 import (
 	"errors"
+	"fmt"
 	"math/big"
 	"sync"
 
@@ -112,6 +113,16 @@ func (z *Felt) SetRandom() (*Felt, error) {
 // String forwards the call to underlying field element implementation
 func (z *Felt) String() string {
 	return z.val.String()
+}
+
+// ShortString prints the felt to a string in a shortened format
+func (z *Felt) ShortString() string {
+	hex := z.val.Text(16)
+
+	if len(hex) <= 8 {
+		return fmt.Sprintf("0x%s", hex)
+	}
+	return fmt.Sprintf("0x%s...%s", hex[:4], hex[len(hex)-4:])
 }
 
 // Text forwards the call to underlying field element implementation

--- a/core/felt/felt_test.go
+++ b/core/felt/felt_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/NethermindEth/juno/core/felt"
 	"github.com/NethermindEth/juno/encoder"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestUnmarshalJson(t *testing.T) {
@@ -28,4 +29,26 @@ func TestFeltCbor(t *testing.T) {
 	assert.NoError(t, err)
 
 	encoder.TestSymmetry(t, val)
+}
+
+func TestShortString(t *testing.T) {
+	var f felt.Felt
+
+	t.Run("less than 8 digits", func(t *testing.T) {
+		_, err := f.SetString("0x1234567")
+		require.NoError(t, err)
+		assert.Equal(t, "0x1234567", f.ShortString())
+	})
+
+	t.Run("8 digits", func(t *testing.T) {
+		_, err := f.SetString("0x12345678")
+		require.NoError(t, err)
+		assert.Equal(t, "0x12345678", f.ShortString())
+	})
+
+	t.Run("more than 8 digits", func(t *testing.T) {
+		_, err := f.SetString("0x123456789")
+		require.NoError(t, err)
+		assert.Equal(t, "0x1234...6789", f.ShortString())
+	})
 }

--- a/sync/sync.go
+++ b/sync/sync.go
@@ -84,11 +84,11 @@ func (s *Synchronizer) verifierTask(ctx context.Context, block *core.Block, stat
 			if err != nil {
 				if errors.As(err, new(core.ErrCantVerifyTransactionHash)) {
 					for ; err != nil; err = errors.Unwrap(err) {
-						s.log.Debugw("Sanity checks failed", "number", block.Number, "hash", block.Hash.Text(16),
-							"error", err.Error())
+						s.log.Debugw("Sanity checks failed", "number", block.Number, "hash",
+							block.Hash.ShortString(), "error", err.Error())
 					}
 				} else {
-					s.log.Warnw("Sanity checks failed", "number", block.Number, "hash", block.Hash.Text(16))
+					s.log.Warnw("Sanity checks failed", "number", block.Number, "hash", block.Hash.ShortString())
 					select {
 					case <-ctx.Done():
 					case errChan <- ErrSyncFailed{block.Number, err}:
@@ -98,8 +98,8 @@ func (s *Synchronizer) verifierTask(ctx context.Context, block *core.Block, stat
 			}
 			err := s.Blockchain.Store(block, stateUpdate, declaredClasses)
 			if err != nil {
-				s.log.Warnw("Failed storing Block", "number", block.Number, "hash", block.Hash.Text(16),
-					"err", err.Error())
+				s.log.Warnw("Failed storing Block", "number", block.Number,
+					"hash", block.Hash.ShortString(), "err", err.Error())
 				select {
 				case <-ctx.Done():
 				case errChan <- ErrSyncFailed{block.Number, err}:
@@ -107,8 +107,8 @@ func (s *Synchronizer) verifierTask(ctx context.Context, block *core.Block, stat
 				return
 			}
 
-			s.log.Infow("Stored Block", "number", block.Number, "hash", block.Hash.Text(16),
-				"root", block.GlobalStateRoot.Text(16))
+			s.log.Infow("Stored Block", "number", block.Number, "hash",
+				block.Hash.ShortString(), "root", block.GlobalStateRoot.ShortString())
 		}
 	}
 }


### PR DESCRIPTION
Looks like

```
15:26:40.462 03/03/2023 +03:00  INFO    sync/sync.go:110        Stored Block    {"number": 52, "hash": "0x118b..7012", "root": "0x513d..b779"}
15:26:40.555 03/03/2023 +03:00  INFO    sync/sync.go:110        Stored Block    {"number": 53, "hash": "0x407c..6fef", "root": "0x6d60..76d9"}
15:26:40.667 03/03/2023 +03:00  INFO    sync/sync.go:110        Stored Block    {"number": 54, "hash": "0x1ab2..235c", "root": "0x773e..6482"}
15:26:40.761 03/03/2023 +03:00  INFO    sync/sync.go:110        Stored Block    {"number": 55, "hash": "0x1dd8..0605", "root": "0x20f8..b416"}
15:26:40.838 03/03/2023 +03:00  INFO    sync/sync.go:110        Stored Block    {"number": 56, "hash": "0x2e84..a105", "root": "0x13db..ba09"}
15:26:40.964 03/03/2023 +03:00  INFO    sync/sync.go:110        Stored Block    {"number": 57, "hash": "0x454f..700e", "root": "0x720e..2ae3"}
```