### PR TITLE
Add Block Transaction Count Endpoint

### DIFF
--- a/node/node.go
+++ b/node/node.go
@@ -98,6 +98,7 @@ func makeHttp(port uint16, rpcHandler *rpc.Handler, log utils.Logger) *jsonrpc.H
 		{"starknet_getBlockWithTxHashes", []jsonrpc.Parameter{{Name: "block_id"}}, rpcHandler.GetBlockWithTxHashes},
 		{"starknet_getBlockWithTxs", []jsonrpc.Parameter{{Name: "block_id"}}, rpcHandler.GetBlockWithTxs},
 		{"starknet_getTransactionByHash", []jsonrpc.Parameter{{Name: "transaction_hash"}}, rpcHandler.GetTransactionByHash},
+		{"starknet_getBlockTransactionCount", []jsonrpc.Parameter{{Name: "block_id"}}, rpcHandler.GetBlockTransactionCount},
 	}, log)
 }
 

--- a/rpc/handlers.go
+++ b/rpc/handlers.go
@@ -215,3 +215,12 @@ func (h *Handler) GetTransactionByHash(hash *felt.Felt) (*Transaction, *jsonrpc.
 	}
 	return adaptTransaction(txn), nil
 }
+
+// https://github.com/starkware-libs/starknet-specs/blob/a789ccc3432c57777beceaa53a34a7ae2f25fda0/api/starknet_api_openrpc.json#L373
+func (h *Handler) GetBlockTransactionCount(id *BlockId) (int, *jsonrpc.Error) {
+	block, err := h.getBlockById(id)
+	if err != nil {
+		return 0, ErrBlockNotFound
+	}
+	return len(block.Transactions), nil
+}

--- a/rpc/handlers_test.go
+++ b/rpc/handlers_test.go
@@ -111,6 +111,16 @@ func TestHandler(t *testing.T) {
 		}
 	})
 
+	t.Run("starknet_getBlockTransactionCount", func(t *testing.T) {
+		blockTxnCount, err := handler.GetBlockTransactionCount(&rpc.BlockId{Number: 2})
+		assert.Nil(t, err)
+
+		gwBlock, gwErr := gw.BlockByNumber(ctx, 2)
+		assert.NoError(t, gwErr)
+
+		assert.Equal(t, len(gwBlock.Transactions), blockTxnCount)
+	})
+
 	canceler()
 	<-syncNodeChan
 }


### PR DESCRIPTION
## Description

Adds `starknet_getBlockTransactionCount` rpc endpoint

## Types of changes

- New feature (non-breaking change which adds functionality)

## Testing

**Requires testing**: Yes

**Did you write tests??**: Yes


