### PR TITLE
Fix sync loop not being able to roll itself back to a known good height

### DIFF
--- a/sync/sync_test.go
+++ b/sync/sync_test.go
@@ -22,6 +22,7 @@ func TestSyncBlocks(t *testing.T) {
 			require.NoError(t, err)
 
 			height := int(headBlock.Number)
+			assert.Equal(t, 2, height)
 			for height >= 0 {
 				b, err := gw.BlockByNumber(context.Background(), uint64(height))
 				if err != nil {


### PR DESCRIPTION
Assume all our streams are full, and `SyncBlocks` is blocked on `fetchers.Go`.

If the next `verifierTask` callback encounters an error and tries to write it to the `errChan` it will block indefinitely because our main loop is blocked on `fetchers.Go`. This is a deadlock that mostly happens after we restart sync loop a couple of times.

By making `errChan` a buffered channel with capacity 1, we make sure that we get to write at least 1 error to the channel without blocking and immediately free up a slot in our streams. That makes sure `fetchers.Go` will never block indefinitely.

Other verifiers in the `stream` may end up being blocked trying to write to the `errChan`, but `SyncBlocks` loop will immediately acknowledge the first error in the channel and cancel the stream context. So all verifiers and fetchers will eventually terminate.