### PR TITLE
Fix Assert.Equal() Arguments Order in Tests

### DIFF
--- a/blockchain/blockchain_test.go
+++ b/blockchain/blockchain_test.go
@@ -220,11 +220,11 @@ func TestStore(t *testing.T) {
 
 		got0Block, err := chain.GetBlockByNumber(0)
 		assert.NoError(t, err)
-		assert.Equal(t, got0Block, block0)
+		assert.Equal(t, block0, got0Block)
 
 		got0Update, err := chain.GetStateUpdateByHash(block0.Hash)
 		require.NoError(t, err)
-		assert.Equal(t, got0Update, stateUpdate0)
+		assert.Equal(t, stateUpdate0, got0Update)
 	})
 	t.Run("add block to non-empty blockchain", func(t *testing.T) {
 		block1, err := gw.BlockByNumber(context.Background(), 1)
@@ -247,11 +247,11 @@ func TestStore(t *testing.T) {
 
 		got1Block, err := chain.GetBlockByNumber(1)
 		assert.NoError(t, err)
-		assert.Equal(t, got1Block, block1)
+		assert.Equal(t, block1, got1Block)
 
 		got1Update, err := chain.GetStateUpdateByNumber(1)
 		require.NoError(t, err)
-		assert.Equal(t, got1Update, stateUpdate1)
+		assert.Equal(t, stateUpdate1, got1Update)
 	})
 }
 

--- a/clients/gateway_test.go
+++ b/clients/gateway_test.go
@@ -467,9 +467,9 @@ func TestGetTransaction(t *testing.T) {
 		gatewayClient := testClient(srv.URL)
 		actualStatus, err := gatewayClient.GetTransaction(context.Background(), transaction_hash)
 		assert.Equal(t, nil, err, "Unexpected error")
-		assert.Equal(t, *actualStatus, transactionStatus)
+		assert.Equal(t, transactionStatus, *actualStatus)
 	})
-	t.Run("Test case when transaction_hash not exit", func(t *testing.T) {
+	t.Run("Test case when transaction_hash does not exist", func(t *testing.T) {
 		transaction_hash, _ := new(felt.Felt).SetString("0xffff")
 		gatewayClient := testClient(srv.URL)
 		actualStatus, err := gatewayClient.GetTransaction(context.Background(), transaction_hash)

--- a/core/trie/trie_test.go
+++ b/core/trie/trie_test.go
@@ -434,7 +434,7 @@ func TestPath(t *testing.T) {
 
 	for idx, test := range tests {
 		got := path(test.child, test.parent)
-		assert.Equal(t, got, test.want, "TestPath failing #%d", idx)
+		assert.Equal(t, test.want, got, "TestPath failing #%d", idx)
 	}
 }
 

--- a/rpc/block_test.go
+++ b/rpc/block_test.go
@@ -44,7 +44,7 @@ func TestBlockId(t *testing.T) {
 			t.Parallel()
 			var blockId rpc.BlockId
 			require.NoError(t, blockId.UnmarshalJSON([]byte(test.blockIdJson)))
-			assert.Equal(t, blockId, test.expectedBlockId)
+			assert.Equal(t, test.expectedBlockId, blockId)
 		})
 	}
 

--- a/rpc/handlers_test.go
+++ b/rpc/handlers_test.go
@@ -613,7 +613,7 @@ func TestGetTransactionByBlockIdAndIndex(t *testing.T) {
 		txn2, rpcErr := handler.GetTransactionByHash(latestBlock.Transactions[index].Hash())
 		assert.Nil(t, rpcErr)
 
-		assert.Equal(t, txn2, txn1)
+		assert.Equal(t, txn1, txn2)
 	})
 
 	t.Run("blockId - hash", func(t *testing.T) {
@@ -635,7 +635,7 @@ func TestGetTransactionByBlockIdAndIndex(t *testing.T) {
 		txn2, rpcErr := handler.GetTransactionByHash(latestBlock.Transactions[index].Hash())
 		assert.Nil(t, rpcErr)
 
-		assert.Equal(t, txn2, txn1)
+		assert.Equal(t, txn1, txn2)
 	})
 
 	t.Run("blockId - number", func(t *testing.T) {
@@ -657,7 +657,7 @@ func TestGetTransactionByBlockIdAndIndex(t *testing.T) {
 		txn2, rpcErr := handler.GetTransactionByHash(latestBlock.Transactions[index].Hash())
 		assert.Nil(t, rpcErr)
 
-		assert.Equal(t, txn2, txn1)
+		assert.Equal(t, txn1, txn2)
 	})
 }
 

--- a/starknetdata/gateway/gateway_pkg_test.go
+++ b/starknetdata/gateway/gateway_pkg_test.go
@@ -38,7 +38,7 @@ func TestAdaptBlock(t *testing.T) {
 		assert.True(t, block.ParentHash.Equal(response.ParentHash))
 		assert.Equal(t, response.Number, block.Number)
 		assert.True(t, block.GlobalStateRoot.Equal(response.StateRoot))
-		assert.Equal(t, block.Timestamp, response.Timestamp)
+		assert.Equal(t, response.Timestamp, block.Timestamp)
 		assert.Equal(t, len(response.Transactions), len(block.Transactions))
 		assert.Equal(t, uint64(len(response.Transactions)), block.TransactionCount)
 		assert.Equal(t, len(response.Receipts), len(block.Receipts))
@@ -63,7 +63,7 @@ func TestAdaptBlock(t *testing.T) {
 		assert.True(t, block.ParentHash.Equal(response.ParentHash))
 		assert.Equal(t, response.Number, block.Number)
 		assert.True(t, block.GlobalStateRoot.Equal(response.StateRoot))
-		assert.Equal(t, block.Timestamp, response.Timestamp)
+		assert.Equal(t, response.Timestamp, block.Timestamp)
 		assert.Equal(t, len(response.Transactions), len(block.Transactions))
 		assert.Equal(t, uint64(len(response.Transactions)), block.TransactionCount)
 		assert.Equal(t, len(response.Receipts), len(block.Receipts))
@@ -173,7 +173,7 @@ func TestAdaptStateUpdate(t *testing.T) {
 		for keyStr, diffs := range gatewayStateUpdate.StateDiff.StorageDiffs {
 			key, _ := new(felt.Felt).SetString(keyStr)
 			coreDiffs := coreStateUpdate.StateDiff.StorageDiffs[*key]
-			assert.Equal(t, len(diffs) > 0, true)
+			assert.Equal(t, true, len(diffs) > 0)
 			assert.Equal(t, len(diffs), len(coreDiffs))
 			for idx := range diffs {
 				assert.Equal(t, true, diffs[idx].Key.Equal(coreDiffs[idx].Key))


### PR DESCRIPTION
When using `assert.Equal()`, the expected order for the arguments is the following:

```
func assert.Equal(t assert.TestingT, expected interface{}, actual interface{}, msgAndArgs ...interface{}) bool
```

But we tend to not follow the order in some of our test cases. So, we sometimes do this:

```
func assert.Equal(t assert.TestingT, actual interface{}, expected interface{}, msgAndArgs ...interface{}) bool
```

This PR refactors our tests to follow the correct order.