### PR TITLE
Remove Duplicate State Update Data Storage

### DIFF
--- a/blockchain/blockchain_test.go
+++ b/blockchain/blockchain_test.go
@@ -213,6 +213,26 @@ func TestStore(t *testing.T) {
 	stateUpdate0, err := gw.StateUpdate(context.Background(), 0)
 	require.NoError(t, err)
 
+	checkStateUpdate := func(expected *core.StateUpdate, got *core.StateUpdate) {
+		assert.Equal(t, expected.BlockHash, got.BlockHash)
+		assert.Equal(t, expected.NewRoot, got.NewRoot)
+		assert.Equal(t, expected.OldRoot, got.OldRoot)
+		assert.Equal(t, expected.StateDiff.StorageDiffs, got.StateDiff.StorageDiffs)
+		assert.Equal(t, expected.StateDiff.Nonces, got.StateDiff.Nonces)
+		assert.Equal(t, expected.StateDiff.DeclaredClasses, got.StateDiff.DeclaredClasses)
+		assert.Equal(t, len(expected.StateDiff.DeployedContracts), len(got.StateDiff.DeployedContracts))
+		for _, contract := range expected.StateDiff.DeployedContracts {
+			var contains bool
+			for _, gotContract := range got.StateDiff.DeployedContracts {
+				if contract.Address.Equal(gotContract.Address) && contract.ClassHash.Equal(gotContract.ClassHash) {
+					contains = true
+					break
+				}
+			}
+			assert.True(t, contains)
+		}
+	}
+
 	t.Run("add block to empty blockchain", func(t *testing.T) {
 		chain := blockchain.New(pebble.NewMemTest(), utils.MAINNET)
 		require.NoError(t, chain.Store(block0, stateUpdate0, nil))
@@ -231,7 +251,8 @@ func TestStore(t *testing.T) {
 
 		got0Update, err := chain.StateUpdateByHash(block0.Hash)
 		require.NoError(t, err)
-		assert.Equal(t, stateUpdate0, got0Update)
+
+		checkStateUpdate(stateUpdate0, got0Update)
 	})
 	t.Run("add block to non-empty blockchain", func(t *testing.T) {
 		block1, err := gw.BlockByNumber(context.Background(), 1)
@@ -258,7 +279,7 @@ func TestStore(t *testing.T) {
 
 		got1Update, err := chain.StateUpdateByNumber(1)
 		require.NoError(t, err)
-		assert.Equal(t, stateUpdate1, got1Update)
+		checkStateUpdate(stateUpdate1, got1Update)
 	})
 }
 

--- a/core/contract.go
+++ b/core/contract.go
@@ -1,6 +1,8 @@
 package core
 
 import (
+	"bytes"
+	"encoding/binary"
 	"errors"
 
 	"github.com/NethermindEth/juno/core/crypto"
@@ -60,10 +62,46 @@ func (c *Contract) Nonce() (nonce *felt.Felt, err error) {
 	return
 }
 
+// NonceAt returns the nonce value at a given block number.
+func (c *Contract) NonceAt(bNumber uint64) (nonce *felt.Felt, err error) {
+	iterator, err := c.txn.NewIterator()
+	if err != nil {
+		return nil, err
+	}
+	defer db.CloseAndWrapOnError(iterator.Close, &err)
+
+	bnBytes := binary.BigEndian.AppendUint64([]byte{}, bNumber)
+	prefix := db.HistoricalContractNonce.Key(bnBytes)
+	for iterator.Seek(prefix); iterator.Valid(); iterator.Next() {
+		if bytes.Equal(iterator.Key()[len(prefix):], c.Address.Marshal()) {
+			val, err := iterator.Value()
+			if err != nil {
+				return nil, err
+			}
+			nonce = new(felt.Felt)
+			return nonce.SetBytes(val), nil
+		}
+	}
+
+	return c.Nonce()
+}
+
 // UpdateNonce updates the nonce value in the database.
 func (c *Contract) UpdateNonce(nonce *felt.Felt) error {
 	nonceKey := db.ContractNonce.Key(c.Address.Marshal())
 	return c.txn.Set(nonceKey, nonce.Marshal())
+}
+
+// StoreNonceAt stores the nonce value at a given block number.
+func (c *Contract) StoreNonceAt(bNumber uint64) error {
+	bnBytes := binary.BigEndian.AppendUint64([]byte{}, bNumber)
+	bnAddressBytes := append(bnBytes, c.Address.Marshal()...)
+
+	key := db.ContractNonce.Key(c.Address.Marshal())
+	err := c.txn.Get(key, func(val []byte) error {
+		return c.txn.Set(db.HistoricalContractNonce.Key(bnAddressBytes), val)
+	})
+	return err
 }
 
 // ClassHash returns hash of the class that this contract instantiates.

--- a/core/state_test.go
+++ b/core/state_test.go
@@ -169,7 +169,7 @@ func TestUpdate(t *testing.T) {
 	testDb := pebble.NewMemTest()
 	state := core.NewState(testDb.NewTransaction(true))
 
-	assert.Equal(t, nil, state.Update(coreUpdate, nil))
+	assert.Equal(t, nil, state.Update(0, coreUpdate, nil))
 }
 
 func TestUpdateNonce(t *testing.T) {
@@ -188,11 +188,19 @@ func TestUpdateNonce(t *testing.T) {
 	testDb := pebble.NewMemTest()
 	state := core.NewState(testDb.NewTransaction(true))
 
-	assert.NoError(t, state.Update(coreUpdate, nil))
+	assert.NoError(t, state.Update(0, coreUpdate, nil))
 
 	nonce, err := state.ContractNonce(addr)
 	assert.NoError(t, err)
 	assert.Equal(t, true, nonce.Equal(&felt.Zero))
+
+	nonceAt, err := state.GetContractNonceAt(addr, 0)
+	assert.NoError(t, err)
+	assert.Equal(t, true, nonceAt.Equal(&felt.Zero))
+
+	noncesAt, err := state.GetNoncesAt(0)
+	assert.NoError(t, err)
+	assert.Equal(t, 0, len(noncesAt))
 
 	coreUpdate = new(core.StateUpdate)
 	coreUpdate.OldRoot, _ = new(felt.Felt).SetString("0x4bdef7bf8b81a868aeab4b48ef952415fe105ab479e2f7bc671c92173542368")
@@ -202,9 +210,17 @@ func TestUpdateNonce(t *testing.T) {
 
 	nonce.SetUint64(1)
 	coreUpdate.StateDiff.Nonces[*addr] = nonce
-	assert.NoError(t, state.Update(coreUpdate, nil))
+	assert.NoError(t, state.Update(1, coreUpdate, nil))
 
 	newNonce, err := state.ContractNonce(addr)
 	assert.NoError(t, err)
 	assert.Equal(t, true, nonce.Equal(newNonce))
+
+	nonceAt, err = state.GetContractNonceAt(addr, 1)
+	assert.NoError(t, err)
+	assert.Equal(t, true, nonceAt.Equal(&felt.Zero))
+
+	noncesAt, err = state.GetNoncesAt(1)
+	assert.NoError(t, err)
+	assert.Equal(t, len(coreUpdate.StateDiff.Nonces), len(noncesAt))
 }

--- a/db/buckets.go
+++ b/db/buckets.go
@@ -21,7 +21,8 @@ const (
 	TransactionBlockNumbersAndIndicesByHash // maps transaction hashes to block number and index
 	TransactionsByBlockNumberAndIndex       // maps block number and index to transaction
 	ReceiptsByBlockNumberAndIndex           // maps block number and index to transaction receipt
-	StateUpdatesByBlockNumber
+	StorageDiffsByBlockNumber
+	HistoricalContractNonce // maps [block number + contract address] to contract nonce
 )
 
 // Key flattens a prefix and series of byte arrays into a single []byte.


### PR DESCRIPTION
Some of the data stored in `StateUpdatesByBlockNumber` already exists in the database and shouldn't be stored again. Storing them again unnecessarily bloats our database. 

This PR removes duplicate data storage and introduces a new way to store the nonce.

### Changes

- **Nonce**: Introduces historical nonce storage outside `StateUpdate`. Storing nonces in a separate table allows us to be able to serve `starknet_getNonce` in the future.
- **Remove duplicate data storage**: Stop duplicated storage of `block hashes`, `roots`, `declaredClasses`, and `deployedContracts` since they are already stored as part of the `block`.