### PR TITLE
Fix invalid params error

### DIFF
--- a/jsonrpc/server.go
+++ b/jsonrpc/server.go
@@ -311,7 +311,7 @@ func buildArguments(params, handler any, configuredParams []Parameter) ([]reflec
 		paramsList := params.([]any)
 
 		if len(paramsList) != handlerType.NumIn() {
-			return nil, errors.New("missing param in list")
+			return nil, errors.New("missing/unexpected params in list")
 		}
 
 		for i, param := range paramsList {

--- a/jsonrpc/server_test.go
+++ b/jsonrpc/server_test.go
@@ -128,9 +128,13 @@ func TestHandle(t *testing.T) {
 			req: `{"jsonrpc" : "2.0", "method" : "doesnotexits" , "id" : 2}`,
 			res: `{"jsonrpc":"2.0","error":{"code":-32601,"message":"method not found"},"id":2}`,
 		},
-		"missing param": {
+		"missing param(s)": {
 			req: `{"jsonrpc" : "2.0", "method" : "method", "params" : [3, false] , "id" : 3}`,
-			res: `{"jsonrpc":"2.0","error":{"code":-32602,"message":"missing param in list"},"id":3}`,
+			res: `{"jsonrpc":"2.0","error":{"code":-32602,"message":"missing/unexpected params in list"},"id":3}`,
+		},
+		"too many params": {
+			req: `{"jsonrpc" : "2.0", "method" : "method", "params" : [3, false, "error message", "too many"] , "id" : 3}`,
+			res: `{"jsonrpc":"2.0","error":{"code":-32602,"message":"missing/unexpected params in list"},"id":3}`,
 		},
 		"list params": {
 			req: `{"jsonrpc" : "2.0", "method" : "method", "params" : [3, false, "error message"] , "id" : 3}`,


### PR DESCRIPTION
json RPC was returning `missing param in list` even when the call didn't require any parameters. 