### PR TITLE
Stop ignoring node package

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -4,12 +4,10 @@ coverage:
     project:
       default:
         target: 75%
-        threshold: 0%
+        threshold: 1%
     patch:
       default:
         target: 80%
         threshold: 1%
         branches: 
           - main
-ignore:
-  - "node"


### PR DESCRIPTION
As more code is added to other packages, node package's coverage will become less significant.