### PR TITLE
Node setup and configuration refactors

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,6 @@ docker run -it \
   nethermindeth/juno \
   --rpc-port 6060 \
   --db-path /var/lib/juno \
-  --verbosity 0 \
   --network 0
 ```
 

--- a/README.md
+++ b/README.md
@@ -59,11 +59,13 @@ docker run -it \
   -v /home/juno:/var/lib/juno \
   nethermindeth/juno \
   --rpc-port 6060 \
-  --db-path /var/lib/juno \
-  --network 0
+  --db-path /var/lib/juno
 ```
 
 Before running the docker run command, please ensure that the directory `/home/juno` exists on your local machine.
+
+Use the `--help` flag for configuration information.
+Flags and their values can also be placed in a `.yaml` file that is passed in through `--config`.
 
 ## ✔ Supported Features
 

--- a/cmd/juno/juno.go
+++ b/cmd/juno/juno.go
@@ -14,29 +14,22 @@ const (
 	configF   = "config"
 	logLevelF = "log-level"
 	rpcPortF  = "rpc-port"
-	metricsF  = "metrics"
 	dbPathF   = "db-path"
 	networkF  = "network"
-	ethNodeF  = "eth-node"
 	pprofF    = "pprof"
 
 	defaultConfig  = ""
 	defaultRpcPort = uint16(6060)
-	defaultMetrics = false
 	defaultDbPath  = ""
-	defaultEthNode = ""
 	defaultPprof   = false
 
 	configFlagUsage   = "The yaml configuration file."
 	logLevelFlagUsage = "Options: debug, info, warn, error."
 	rpcPortUsage      = "The port on which the RPC server will listen for requests. " +
 		"Warning: this exposes the node to external requests and potentially DoS attacks."
-	metricsUsage = "Enables the metrics server and listens on port 9090."
 	dbPathUsage  = "Location of the database files."
 	networkUsage = "Options: mainnet, goerli, goerli2, integration."
-	ethNodeUsage = "The Ethereum endpoint to synchronise with. " +
-		"If unset feeder gateway will be used."
-	pprofUsage = "Enables the pprof server and listens on port 9080."
+	pprofUsage   = "Enables the pprof server and listens on port 9080."
 )
 
 // NewCmd returns a command that can be exected with any of the Cobra Execute* functions.
@@ -85,10 +78,8 @@ func NewCmd(config *node.Config, run func(*cobra.Command, []string) error) *cobr
 	junoCmd.Flags().StringVar(&cfgFile, configF, defaultConfig, configFlagUsage)
 	junoCmd.Flags().Var(&defaultLogLevel, logLevelF, logLevelFlagUsage)
 	junoCmd.Flags().Uint16(rpcPortF, defaultRpcPort, rpcPortUsage)
-	junoCmd.Flags().Bool(metricsF, defaultMetrics, metricsUsage)
 	junoCmd.Flags().String(dbPathF, defaultDbPath, dbPathUsage)
 	junoCmd.Flags().Var(&defaultNetwork, networkF, networkUsage)
-	junoCmd.Flags().String(ethNodeF, defaultEthNode, ethNodeUsage)
 	junoCmd.Flags().Bool(pprofF, defaultPprof, pprofUsage)
 
 	return junoCmd

--- a/cmd/juno/juno.go
+++ b/cmd/juno/juno.go
@@ -19,8 +19,8 @@ const (
 	pprofF    = "pprof"
 
 	defaultConfig  = ""
-	defaultRpcPort = uint16(6060)
-	defaultDbPath  = ""
+	defaultRPCPort = uint16(6060)
+	defaultDBPath  = ""
 	defaultPprof   = false
 
 	configFlagUsage   = "The yaml configuration file."
@@ -77,8 +77,8 @@ func NewCmd(config *node.Config, run func(*cobra.Command, []string) error) *cobr
 
 	junoCmd.Flags().StringVar(&cfgFile, configF, defaultConfig, configFlagUsage)
 	junoCmd.Flags().Var(&defaultLogLevel, logLevelF, logLevelFlagUsage)
-	junoCmd.Flags().Uint16(rpcPortF, defaultRpcPort, rpcPortUsage)
-	junoCmd.Flags().String(dbPathF, defaultDbPath, dbPathUsage)
+	junoCmd.Flags().Uint16(rpcPortF, defaultRPCPort, rpcPortUsage)
+	junoCmd.Flags().String(dbPathF, defaultDBPath, dbPathUsage)
 	junoCmd.Flags().Var(&defaultNetwork, networkF, networkUsage)
 	junoCmd.Flags().Bool(pprofF, defaultPprof, pprofUsage)
 

--- a/cmd/juno/juno.go
+++ b/cmd/juno/juno.go
@@ -24,7 +24,6 @@ const (
 	defaultRpcPort = uint16(6060)
 	defaultMetrics = false
 	defaultDbPath  = ""
-	defaultNetwork = utils.MAINNET
 	defaultEthNode = ""
 	defaultPprof   = false
 
@@ -34,11 +33,7 @@ const (
 		"Warning: this exposes the node to external requests and potentially DoS attacks."
 	metricsUsage = "Enables the metrics server and listens on port 9090."
 	dbPathUsage  = "Location of the database files."
-	networkUsage = `Available Starknet networks. Options:
-0 = mainnet
-1 = goerli
-2 = goerli2
-3 = integration`
+	networkUsage = "Options: mainnet, goerli, goerli2, integration."
 	ethNodeUsage = "The Ethereum endpoint to synchronise with. " +
 		"If unset feeder gateway will be used."
 	pprofUsage = "Enables the pprof server and listens on port 9080."
@@ -82,15 +77,17 @@ func NewCmd(config *node.Config, run func(*cobra.Command, []string) error) *cobr
 		return v.Unmarshal(config, viper.DecodeHook(mapstructure.TextUnmarshallerHookFunc()))
 	}
 
-	junoCmd.Flags().StringVar(&cfgFile, configF, defaultConfig, configFlagUsage)
-	// For testing purposes, this variable cannot be declared outside the function because Cobra
-	// mutates the value.
+	// For testing purposes, these variables cannot be declared outside the function because Cobra
+	// may mutate their values.
 	defaultLogLevel := utils.INFO
+	defaultNetwork := utils.MAINNET
+
+	junoCmd.Flags().StringVar(&cfgFile, configF, defaultConfig, configFlagUsage)
 	junoCmd.Flags().Var(&defaultLogLevel, logLevelF, logLevelFlagUsage)
 	junoCmd.Flags().Uint16(rpcPortF, defaultRpcPort, rpcPortUsage)
 	junoCmd.Flags().Bool(metricsF, defaultMetrics, metricsUsage)
 	junoCmd.Flags().String(dbPathF, defaultDbPath, dbPathUsage)
-	junoCmd.Flags().Uint8(networkF, uint8(defaultNetwork), networkUsage)
+	junoCmd.Flags().Var(&defaultNetwork, networkF, networkUsage)
 	junoCmd.Flags().String(ethNodeF, defaultEthNode, ethNodeUsage)
 	junoCmd.Flags().Bool(pprofF, defaultPprof, pprofUsage)
 

--- a/cmd/juno/juno.go
+++ b/cmd/juno/juno.go
@@ -11,14 +11,14 @@ import (
 var Version string
 
 const (
-	configF    = "config"
-	verbosityF = "verbosity"
-	rpcPortF   = "rpc-port"
-	metricsF   = "metrics"
-	dbPathF    = "db-path"
-	networkF   = "network"
-	ethNodeF   = "eth-node"
-	pprofF     = "pprof"
+	configF   = "config"
+	logLevelF = "log-level"
+	rpcPortF  = "rpc-port"
+	metricsF  = "metrics"
+	dbPathF   = "db-path"
+	networkF  = "network"
+	ethNodeF  = "eth-node"
+	pprofF    = "pprof"
 
 	defaultConfig  = ""
 	defaultRpcPort = uint16(6060)
@@ -28,9 +28,9 @@ const (
 	defaultEthNode = ""
 	defaultPprof   = false
 
-	configFlagUsage    = "The yaml configuration file."
-	verbosityFlagUsage = "Verbosity of the logs. Options: debug, info, warn, error."
-	rpcPortUsage       = "The port on which the RPC server will listen for requests. " +
+	configFlagUsage   = "The yaml configuration file."
+	logLevelFlagUsage = "Options: debug, info, warn, error."
+	rpcPortUsage      = "The port on which the RPC server will listen for requests. " +
 		"Warning: this exposes the node to external requests and potentially DoS attacks."
 	metricsUsage = "Enables the metrics server and listens on port 9090."
 	dbPathUsage  = "Location of the database files."
@@ -85,8 +85,8 @@ func NewCmd(config *node.Config, run func(*cobra.Command, []string) error) *cobr
 	junoCmd.Flags().StringVar(&cfgFile, configF, defaultConfig, configFlagUsage)
 	// For testing purposes, this variable cannot be declared outside the function because Cobra
 	// mutates the value.
-	defaultVerbosity := utils.INFO
-	junoCmd.Flags().Var(&defaultVerbosity, verbosityF, verbosityFlagUsage)
+	defaultLogLevel := utils.INFO
+	junoCmd.Flags().Var(&defaultLogLevel, logLevelF, logLevelFlagUsage)
 	junoCmd.Flags().Uint16(rpcPortF, defaultRpcPort, rpcPortUsage)
 	junoCmd.Flags().Bool(metricsF, defaultMetrics, metricsUsage)
 	junoCmd.Flags().String(dbPathF, defaultDbPath, dbPathUsage)

--- a/cmd/juno/juno_test.go
+++ b/cmd/juno/juno_test.go
@@ -20,7 +20,7 @@ func TestConfigPrecedence(t *testing.T) {
 	// tested for sanity. These tests are not intended to perform semantics
 	// checks on the config, those will be checked by the StarknetNode
 	// implementation.
-	defaultVerbosity := utils.INFO
+	defaultLogLevel := utils.INFO
 	defaultRpcPort := uint16(6060)
 	defaultMetrics := false
 	defaultDbPath := ""
@@ -38,7 +38,7 @@ func TestConfigPrecedence(t *testing.T) {
 		"default config with no flags": {
 			inputArgs: []string{""},
 			expectedConfig: &node.Config{
-				Verbosity:    defaultVerbosity,
+				LogLevel:     defaultLogLevel,
 				RpcPort:      defaultRpcPort,
 				Metrics:      defaultMetrics,
 				DatabasePath: defaultDbPath,
@@ -49,7 +49,7 @@ func TestConfigPrecedence(t *testing.T) {
 		"config file path is empty string": {
 			inputArgs: []string{"--config", ""},
 			expectedConfig: &node.Config{
-				Verbosity:    defaultVerbosity,
+				LogLevel:     defaultLogLevel,
 				RpcPort:      defaultRpcPort,
 				Metrics:      defaultMetrics,
 				DatabasePath: defaultDbPath,
@@ -65,15 +65,15 @@ func TestConfigPrecedence(t *testing.T) {
 			cfgFile:         true,
 			cfgFileContents: "\n",
 			expectedConfig: &node.Config{
-				Verbosity: defaultVerbosity,
-				RpcPort:   defaultRpcPort,
-				Metrics:   defaultMetrics,
-				Network:   defaultNetwork, EthNode: defaultEthNode,
+				LogLevel: defaultLogLevel,
+				RpcPort:  defaultRpcPort,
+				Metrics:  defaultMetrics,
+				Network:  defaultNetwork, EthNode: defaultEthNode,
 			},
 		},
 		"config file with all settings but without any other flags": {
 			cfgFile: true,
-			cfgFileContents: `verbosity: debug
+			cfgFileContents: `log-level: debug
 rpc-port: 4576
 metrics: true
 db-path: /home/.juno
@@ -82,7 +82,7 @@ eth-node: "https://some-ethnode:5673"
 pprof: true
 `,
 			expectedConfig: &node.Config{
-				Verbosity:    utils.DEBUG,
+				LogLevel:     utils.DEBUG,
 				RpcPort:      4576,
 				Metrics:      true,
 				DatabasePath: "/home/.juno",
@@ -93,12 +93,12 @@ pprof: true
 		},
 		"config file with some settings but without any other flags": {
 			cfgFile: true,
-			cfgFileContents: `verbosity: debug
+			cfgFileContents: `log-level: debug
 rpc-port: 4576
 metrics: true
 `,
 			expectedConfig: &node.Config{
-				Verbosity:    utils.DEBUG,
+				LogLevel:     utils.DEBUG,
 				RpcPort:      4576,
 				Metrics:      true,
 				DatabasePath: defaultDbPath,
@@ -109,12 +109,12 @@ metrics: true
 		},
 		"all flags without config file": {
 			inputArgs: []string{
-				"--verbosity", "debug", "--rpc-port", "4576",
+				"--log-level", "debug", "--rpc-port", "4576",
 				"--metrics", "--db-path", "/home/.juno", "--network", "1",
 				"--eth-node", "https://some-ethnode:5673", "--pprof",
 			},
 			expectedConfig: &node.Config{
-				Verbosity:    utils.DEBUG,
+				LogLevel:     utils.DEBUG,
 				RpcPort:      4576,
 				Metrics:      true,
 				DatabasePath: "/home/.juno",
@@ -125,11 +125,11 @@ metrics: true
 		},
 		"some flags without config file": {
 			inputArgs: []string{
-				"--verbosity", "debug", "--rpc-port", "4576", "--db-path", "/home/.juno",
+				"--log-level", "debug", "--rpc-port", "4576", "--db-path", "/home/.juno",
 				"--network", "3",
 			},
 			expectedConfig: &node.Config{
-				Verbosity:    utils.DEBUG,
+				LogLevel:     utils.DEBUG,
 				RpcPort:      4576,
 				Metrics:      defaultMetrics,
 				DatabasePath: "/home/.juno",
@@ -139,7 +139,7 @@ metrics: true
 		},
 		"all setting set in both config file and flags": {
 			cfgFile: true,
-			cfgFileContents: `verbosity: debug
+			cfgFileContents: `log-level: debug
 rpc-port: 4576
 metrics: true
 db-path: /home/config-file/.juno
@@ -148,12 +148,12 @@ eth-node: "https://some-ethnode:5673"
 pprof: true
 `,
 			inputArgs: []string{
-				"--verbosity", "error", "--rpc-port", "4577",
+				"--log-level", "error", "--rpc-port", "4577",
 				"--metrics", "--db-path", "/home/flag/.juno", "--network", "3",
 				"--eth-node", "https://some-ethnode:5674", "--pprof",
 			},
 			expectedConfig: &node.Config{
-				Verbosity:    utils.ERROR,
+				LogLevel:     utils.ERROR,
 				RpcPort:      4577,
 				Metrics:      true,
 				DatabasePath: "/home/flag/.juno",
@@ -164,7 +164,7 @@ pprof: true
 		},
 		"some setting set in both config file and flags": {
 			cfgFile: true,
-			cfgFileContents: `verbosity: warn
+			cfgFileContents: `log-level: warn
 rpc-port: 4576
 network: 1
 `,
@@ -173,7 +173,7 @@ network: 1
 				"https://some-ethnode:5674",
 			},
 			expectedConfig: &node.Config{
-				Verbosity:    utils.WARN,
+				LogLevel:     utils.WARN,
 				RpcPort:      4576,
 				Metrics:      true,
 				DatabasePath: "/home/flag/.juno",
@@ -190,7 +190,7 @@ network: 1
 				"https://some-ethnode:5674", "--pprof",
 			},
 			expectedConfig: &node.Config{
-				Verbosity:    defaultVerbosity,
+				LogLevel:     defaultLogLevel,
 				RpcPort:      defaultRpcPort,
 				Metrics:      true,
 				DatabasePath: "/home/flag/.juno",

--- a/cmd/juno/juno_test.go
+++ b/cmd/juno/juno_test.go
@@ -1,132 +1,79 @@
 package main_test
 
 import (
-	"bytes"
 	"context"
 	"os"
-	"sync"
 	"testing"
 
 	juno "github.com/NethermindEth/juno/cmd/juno"
 	"github.com/NethermindEth/juno/node"
 	"github.com/NethermindEth/juno/utils"
+	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
-type spyJuno struct {
-	sync.RWMutex
-	cfg   *node.Config
-	calls []string
-}
+func TestConfigPrecedence(t *testing.T) {
+	// The purpose of these tests are to ensure the precedence of our config
+	// values is respected. Since viper offers this feature, it would be
+	// redundant to enumerate all combinations. Thus, only a select few are
+	// tested for sanity. These tests are not intended to perform semantics
+	// checks on the config, those will be checked by the StarknetNode
+	// implementation.
+	defaultVerbosity := utils.INFO
+	defaultRpcPort := uint16(6060)
+	defaultMetrics := false
+	defaultDbPath := ""
+	defaultNetwork := utils.MAINNET
+	defaultEthNode := ""
+	defaultPprof := false
 
-func newSpyJuno(junoCfg *node.Config) (node.StarknetNode, error) {
-	return &spyJuno{cfg: junoCfg}, nil
-}
-
-func (s *spyJuno) Run(ctx context.Context) {
-	s.Lock()
-	s.calls = append(s.calls, "run")
-	s.Unlock()
-}
-
-func (s *spyJuno) Config() node.Config {
-	return *s.cfg
-}
-
-func TestNewCmd(t *testing.T) {
-	t.Run("greeting", func(t *testing.T) {
-		expected := `
-       _                    
-      | |                   
-      | |_   _ _ __   ___   
-  _   | | | | | '_ \ / _ \  
- | |__| | |_| | | | | (_) |  
-  \____/ \__,_|_| |_|\___/  
-
-Juno is a Go implementation of a Starknet full node client created by Nethermind.
-
-`
-		b := new(bytes.Buffer)
-
-		cmd := juno.NewCmd(newSpyJuno)
-		cmd.SetOut(b)
-		err := cmd.ExecuteContext(context.Background())
-		require.NoError(t, err)
-
-		actual := b.String()
-		assert.Equal(t, expected, actual)
-
-		n, ok := juno.StarknetNode.(*spyJuno)
-		require.Equal(t, true, ok)
-		assert.Equal(t, []string{"run"}, n.calls)
-	})
-
-	t.Run("config precedence", func(t *testing.T) {
-		// The purpose of these tests are to ensure the precedence of our config
-		// values is respected. Since viper offers this feature, it would be
-		// redundant to enumerate all combinations. Thus, only a select few are
-		// tested for sanity. These tests are not intended to perform semantics
-		// checks on the config, those will be checked by the StarknetNode
-		// implementation.
-		defaultVerbosity := utils.INFO
-		defaultRpcPort := uint16(6060)
-		defaultMetrics := false
-		defaultDbPath := ""
-		defaultNetwork := utils.MAINNET
-		defaultEthNode := ""
-		defaultPprof := false
-
-		tests := map[string]struct {
-			cfgFile         func(t *testing.T, cfg string) (string, func())
-			cfgFileContents string
-			expectErr       bool
-			inputArgs       []string
-			expectedConfig  *node.Config
-		}{
-			"default config with no flags": {
-				inputArgs: []string{""},
-				expectedConfig: &node.Config{
-					Verbosity:    defaultVerbosity,
-					RpcPort:      defaultRpcPort,
-					Metrics:      defaultMetrics,
-					DatabasePath: defaultDbPath,
-					Network:      defaultNetwork,
-					EthNode:      defaultEthNode,
-					Pprof:        defaultPprof,
-				},
+	tests := map[string]struct {
+		cfgFile         bool
+		cfgFileContents string
+		expectErr       bool
+		inputArgs       []string
+		expectedConfig  *node.Config
+	}{
+		"default config with no flags": {
+			inputArgs: []string{""},
+			expectedConfig: &node.Config{
+				Verbosity:    defaultVerbosity,
+				RpcPort:      defaultRpcPort,
+				Metrics:      defaultMetrics,
+				DatabasePath: defaultDbPath,
+				Network:      defaultNetwork, EthNode: defaultEthNode,
+				Pprof:        defaultPprof,
 			},
-			"config file path is empty string": {
-				inputArgs: []string{"--config", ""},
-				expectedConfig: &node.Config{
-					Verbosity:    defaultVerbosity,
-					RpcPort:      defaultRpcPort,
-					Metrics:      defaultMetrics,
-					DatabasePath: defaultDbPath,
-					Network:      defaultNetwork,
-					EthNode:      defaultEthNode,
-					Pprof:        defaultPprof,
-				},
+		},
+		"config file path is empty string": {
+			inputArgs: []string{"--config", ""},
+			expectedConfig: &node.Config{
+				Verbosity:    defaultVerbosity,
+				RpcPort:      defaultRpcPort,
+				Metrics:      defaultMetrics,
+				DatabasePath: defaultDbPath,
+				Network:      defaultNetwork, EthNode: defaultEthNode,
+				Pprof:        defaultPprof,
 			},
-			"config file doesn't exist": {
-				inputArgs: []string{"--config", "config-file-test.yaml"},
-				expectErr: true,
+		},
+		"config file doesn't exist": {
+			inputArgs: []string{"--config", "config-file-test.yaml"},
+			expectErr: true,
+		},
+		"config file contents are empty": {
+			cfgFile:         true,
+			cfgFileContents: "\n",
+			expectedConfig: &node.Config{
+				Verbosity: defaultVerbosity,
+				RpcPort:   defaultRpcPort,
+				Metrics:   defaultMetrics,
+				Network:   defaultNetwork, EthNode: defaultEthNode,
 			},
-			"config file contents are empty": {
-				cfgFile:         tempCfgFile,
-				cfgFileContents: "\n",
-				expectedConfig: &node.Config{
-					Verbosity: defaultVerbosity,
-					RpcPort:   defaultRpcPort,
-					Metrics:   defaultMetrics,
-					Network:   defaultNetwork,
-					EthNode:   defaultEthNode,
-					Pprof:     defaultPprof,
-				},
-			},
-			"config file with all settings but without any other flags": {
-				cfgFile: tempCfgFile,
-				cfgFileContents: `verbosity: 0
+		},
+		"config file with all settings but without any other flags": {
+			cfgFile: true,
+			cfgFileContents: `verbosity: 0
 rpc-port: 4576
 metrics: true
 db-path: /home/.juno
@@ -134,66 +81,65 @@ network: 2
 eth-node: "https://some-ethnode:5673"
 pprof: true
 `,
-				expectedConfig: &node.Config{
-					Verbosity:    utils.DEBUG,
-					RpcPort:      4576,
-					Metrics:      true,
-					DatabasePath: "/home/.juno",
-					Network:      utils.GOERLI2,
-					EthNode:      "https://some-ethnode:5673",
-					Pprof:        true,
-				},
+			expectedConfig: &node.Config{
+				Verbosity:    utils.DEBUG,
+				RpcPort:      4576,
+				Metrics:      true,
+				DatabasePath: "/home/.juno",
+				Network:      utils.GOERLI2,
+				EthNode:      "https://some-ethnode:5673",
+				Pprof:        true,
 			},
-			"config file with some settings but without any other flags": {
-				cfgFile: tempCfgFile,
-				cfgFileContents: `verbosity: 0
+		},
+		"config file with some settings but without any other flags": {
+			cfgFile: true,
+			cfgFileContents: `verbosity: 0
 rpc-port: 4576
 metrics: true
 `,
-				expectedConfig: &node.Config{
-					Verbosity:    utils.DEBUG,
-					RpcPort:      4576,
-					Metrics:      true,
-					DatabasePath: defaultDbPath,
-					Network:      defaultNetwork,
-					EthNode:      defaultEthNode,
-					Pprof:        defaultPprof,
-				},
+			expectedConfig: &node.Config{
+				Verbosity:    utils.DEBUG,
+				RpcPort:      4576,
+				Metrics:      true,
+				DatabasePath: defaultDbPath,
+				Network:      defaultNetwork,
+				EthNode:      defaultEthNode,
+				Pprof:        defaultPprof,
 			},
-			"all flags without config file": {
-				inputArgs: []string{
-					"--verbosity", "0", "--rpc-port", "4576",
-					"--metrics", "--db-path", "/home/.juno", "--network", "1",
-					"--eth-node", "https://some-ethnode:5673", "--pprof", "true",
-				},
-				expectedConfig: &node.Config{
-					Verbosity:    utils.DEBUG,
-					RpcPort:      4576,
-					Metrics:      true,
-					DatabasePath: "/home/.juno",
-					Network:      utils.GOERLI,
-					EthNode:      "https://some-ethnode:5673",
-					Pprof:        true,
-				},
+		},
+		"all flags without config file": {
+			inputArgs: []string{
+				"--verbosity", "0", "--rpc-port", "4576",
+				"--metrics", "--db-path", "/home/.juno", "--network", "1",
+				"--eth-node", "https://some-ethnode:5673", "--pprof",
 			},
-			"some flags without config file": {
-				inputArgs: []string{
-					"--verbosity", "0", "--rpc-port", "4576", "--db-path", "/home/.juno",
-					"--network", "3", "--pprof",
-				},
-				expectedConfig: &node.Config{
-					Verbosity:    utils.DEBUG,
-					RpcPort:      4576,
-					Metrics:      defaultMetrics,
-					DatabasePath: "/home/.juno",
-					Network:      utils.INTEGRATION,
-					EthNode:      defaultEthNode,
-					Pprof:        true,
-				},
+			expectedConfig: &node.Config{
+				Verbosity:    utils.DEBUG,
+				RpcPort:      4576,
+				Metrics:      true,
+				DatabasePath: "/home/.juno",
+				Network:      utils.GOERLI,
+				EthNode:      "https://some-ethnode:5673",
+				Pprof:        true,
 			},
-			"all setting set in both config file and flags": {
-				cfgFile: tempCfgFile,
-				cfgFileContents: `verbosity: 0
+		},
+		"some flags without config file": {
+			inputArgs: []string{
+				"--verbosity", "0", "--rpc-port", "4576", "--db-path", "/home/.juno",
+				"--network", "3",
+			},
+			expectedConfig: &node.Config{
+				Verbosity:    utils.DEBUG,
+				RpcPort:      4576,
+				Metrics:      defaultMetrics,
+				DatabasePath: "/home/.juno",
+				Network:      utils.INTEGRATION,
+				EthNode:      defaultEthNode,
+			},
+		},
+		"all setting set in both config file and flags": {
+			cfgFile: true,
+			cfgFileContents: `verbosity: 0
 rpc-port: 4576
 metrics: true
 db-path: /home/config-file/.juno
@@ -201,85 +147,82 @@ network: 1
 eth-node: "https://some-ethnode:5673"
 pprof: true
 `,
-				inputArgs: []string{
-					"--verbosity", "3", "--rpc-port", "4577",
-					"--metrics", "--db-path", "/home/flag/.juno", "--network", "3",
-					"--eth-node", "https://some-ethnode:5674", "--pprof",
-				},
-				expectedConfig: &node.Config{
-					Verbosity:    utils.ERROR,
-					RpcPort:      4577,
-					Metrics:      true,
-					DatabasePath: "/home/flag/.juno",
-					Network:      utils.INTEGRATION,
-					EthNode:      "https://some-ethnode:5674",
-					Pprof:        true,
-				},
+			inputArgs: []string{
+				"--verbosity", "3", "--rpc-port", "4577",
+				"--metrics", "--db-path", "/home/flag/.juno", "--network", "3",
+				"--eth-node", "https://some-ethnode:5674", "--pprof",
 			},
-			"some setting set in both config file and flags": {
-				cfgFile: tempCfgFile,
-				cfgFileContents: `verbosity: 2
+			expectedConfig: &node.Config{
+				Verbosity:    utils.ERROR,
+				RpcPort:      4577,
+				Metrics:      true,
+				DatabasePath: "/home/flag/.juno",
+				Network:      utils.INTEGRATION,
+				EthNode:      "https://some-ethnode:5674",
+				Pprof:        true,
+			},
+		},
+		"some setting set in both config file and flags": {
+			cfgFile: true,
+			cfgFileContents: `verbosity: 2
 rpc-port: 4576
 network: 1
 `,
-				inputArgs: []string{
-					"--metrics", "--db-path", "/home/flag/.juno", "--eth-node",
-					"https://some-ethnode:5674",
-				},
-				expectedConfig: &node.Config{
-					Verbosity:    utils.WARN,
-					RpcPort:      4576,
-					Metrics:      true,
-					DatabasePath: "/home/flag/.juno",
-					Network:      utils.GOERLI,
-					EthNode:      "https://some-ethnode:5674",
-					Pprof:        false,
-				},
+			inputArgs: []string{
+				"--metrics", "--db-path", "/home/flag/.juno", "--eth-node",
+				"https://some-ethnode:5674",
 			},
-			"some setting set in default, config file and flags": {
-				cfgFile:         tempCfgFile,
-				cfgFileContents: `network: 2`,
-				inputArgs: []string{
-					"--metrics", "--db-path", "/home/flag/.juno", "--eth-node",
-					"https://some-ethnode:5674", "--pprof", "true",
-				},
-				expectedConfig: &node.Config{
-					Verbosity:    defaultVerbosity,
-					RpcPort:      defaultRpcPort,
-					Metrics:      true,
-					DatabasePath: "/home/flag/.juno",
-					Network:      utils.GOERLI2,
-					EthNode:      "https://some-ethnode:5674",
-					Pprof:        true,
-				},
+			expectedConfig: &node.Config{
+				Verbosity:    utils.WARN,
+				RpcPort:      4576,
+				Metrics:      true,
+				DatabasePath: "/home/flag/.juno",
+				Network:      utils.GOERLI,
+				EthNode:      "https://some-ethnode:5674",
+				Pprof:        defaultPprof,
 			},
-		}
+		},
+		"some setting set in default, config file and flags": {
+			cfgFile:         true,
+			cfgFileContents: `network: 2`,
+			inputArgs: []string{
+				"--metrics", "--db-path", "/home/flag/.juno", "--eth-node",
+				"https://some-ethnode:5674", "--pprof",
+			},
+			expectedConfig: &node.Config{
+				Verbosity:    defaultVerbosity,
+				RpcPort:      defaultRpcPort,
+				Metrics:      true,
+				DatabasePath: "/home/flag/.juno",
+				Network:      utils.GOERLI2,
+				EthNode:      "https://some-ethnode:5674",
+				Pprof:        true,
+			},
+		},
+	}
 
-		for name, tc := range tests {
-			t.Run(name, func(t *testing.T) {
-				if tc.cfgFile != nil {
-					fileN, cleanup := tc.cfgFile(t, tc.cfgFileContents)
-					defer cleanup()
-					tc.inputArgs = append(tc.inputArgs, []string{"--config", fileN}...)
-				}
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			if tc.cfgFile {
+				fileN, cleanup := tempCfgFile(t, tc.cfgFileContents)
+				defer cleanup()
+				tc.inputArgs = append(tc.inputArgs, "--config", fileN)
+			}
 
-				cmd := juno.NewCmd(newSpyJuno)
-				cmd.SetArgs(tc.inputArgs)
+			config := new(node.Config)
+			cmd := juno.NewCmd(config, func(_ *cobra.Command, _ []string) error { return nil })
+			cmd.SetArgs(tc.inputArgs)
 
-				err := cmd.ExecuteContext(context.Background())
-				if tc.expectErr {
-					require.Error(t, err)
-					return
-				}
-				require.NoError(t, err)
+			err := cmd.ExecuteContext(context.Background())
+			if tc.expectErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
 
-				n, ok := juno.StarknetNode.(*spyJuno)
-				require.Equal(t, true, ok)
-				assert.Equal(t, tc.expectedConfig, n.cfg)
-				assert.Equal(t, []string{"run"}, n.calls)
-			})
-		}
-	})
+			assert.Equal(t, tc.expectedConfig, config)
+		})
+	}
 }
 
 func tempCfgFile(t *testing.T, cfg string) (string, func()) {

--- a/cmd/juno/juno_test.go
+++ b/cmd/juno/juno_test.go
@@ -21,8 +21,8 @@ func TestConfigPrecedence(t *testing.T) {
 	// checks on the config, those will be checked by the StarknetNode
 	// implementation.
 	defaultLogLevel := utils.INFO
-	defaultRpcPort := uint16(6060)
-	defaultDbPath := ""
+	defaultRPCPort := uint16(6060)
+	defaultDBPath := ""
 	defaultNetwork := utils.MAINNET
 	defaultPprof := false
 
@@ -37,8 +37,8 @@ func TestConfigPrecedence(t *testing.T) {
 			inputArgs: []string{""},
 			expectedConfig: &node.Config{
 				LogLevel:     defaultLogLevel,
-				RpcPort:      defaultRpcPort,
-				DatabasePath: defaultDbPath,
+				RpcPort:      defaultRPCPort,
+				DatabasePath: defaultDBPath,
 				Network:      defaultNetwork,
 				Pprof:        defaultPprof,
 			},
@@ -47,8 +47,8 @@ func TestConfigPrecedence(t *testing.T) {
 			inputArgs: []string{"--config", ""},
 			expectedConfig: &node.Config{
 				LogLevel:     defaultLogLevel,
-				RpcPort:      defaultRpcPort,
-				DatabasePath: defaultDbPath,
+				RpcPort:      defaultRPCPort,
+				DatabasePath: defaultDBPath,
 				Network:      defaultNetwork,
 				Pprof:        defaultPprof,
 			},
@@ -62,7 +62,7 @@ func TestConfigPrecedence(t *testing.T) {
 			cfgFileContents: "\n",
 			expectedConfig: &node.Config{
 				LogLevel: defaultLogLevel,
-				RpcPort:  defaultRpcPort,
+				RpcPort:  defaultRPCPort,
 				Network:  defaultNetwork,
 			},
 		},
@@ -90,7 +90,7 @@ rpc-port: 4576
 			expectedConfig: &node.Config{
 				LogLevel:     utils.DEBUG,
 				RpcPort:      4576,
-				DatabasePath: defaultDbPath,
+				DatabasePath: defaultDBPath,
 				Network:      defaultNetwork,
 				Pprof:        defaultPprof,
 			},
@@ -161,7 +161,7 @@ network: goerli
 			inputArgs:       []string{"--db-path", "/home/flag/.juno", "--pprof"},
 			expectedConfig: &node.Config{
 				LogLevel:     defaultLogLevel,
-				RpcPort:      defaultRpcPort,
+				RpcPort:      defaultRPCPort,
 				DatabasePath: "/home/flag/.juno",
 				Network:      utils.GOERLI2,
 				Pprof:        true,

--- a/cmd/juno/juno_test.go
+++ b/cmd/juno/juno_test.go
@@ -73,7 +73,7 @@ func TestConfigPrecedence(t *testing.T) {
 		},
 		"config file with all settings but without any other flags": {
 			cfgFile: true,
-			cfgFileContents: `verbosity: 0
+			cfgFileContents: `verbosity: debug
 rpc-port: 4576
 metrics: true
 db-path: /home/.juno
@@ -93,7 +93,7 @@ pprof: true
 		},
 		"config file with some settings but without any other flags": {
 			cfgFile: true,
-			cfgFileContents: `verbosity: 0
+			cfgFileContents: `verbosity: debug
 rpc-port: 4576
 metrics: true
 `,
@@ -109,7 +109,7 @@ metrics: true
 		},
 		"all flags without config file": {
 			inputArgs: []string{
-				"--verbosity", "0", "--rpc-port", "4576",
+				"--verbosity", "debug", "--rpc-port", "4576",
 				"--metrics", "--db-path", "/home/.juno", "--network", "1",
 				"--eth-node", "https://some-ethnode:5673", "--pprof",
 			},
@@ -125,7 +125,7 @@ metrics: true
 		},
 		"some flags without config file": {
 			inputArgs: []string{
-				"--verbosity", "0", "--rpc-port", "4576", "--db-path", "/home/.juno",
+				"--verbosity", "debug", "--rpc-port", "4576", "--db-path", "/home/.juno",
 				"--network", "3",
 			},
 			expectedConfig: &node.Config{
@@ -139,7 +139,7 @@ metrics: true
 		},
 		"all setting set in both config file and flags": {
 			cfgFile: true,
-			cfgFileContents: `verbosity: 0
+			cfgFileContents: `verbosity: debug
 rpc-port: 4576
 metrics: true
 db-path: /home/config-file/.juno
@@ -148,7 +148,7 @@ eth-node: "https://some-ethnode:5673"
 pprof: true
 `,
 			inputArgs: []string{
-				"--verbosity", "3", "--rpc-port", "4577",
+				"--verbosity", "error", "--rpc-port", "4577",
 				"--metrics", "--db-path", "/home/flag/.juno", "--network", "3",
 				"--eth-node", "https://some-ethnode:5674", "--pprof",
 			},
@@ -164,7 +164,7 @@ pprof: true
 		},
 		"some setting set in both config file and flags": {
 			cfgFile: true,
-			cfgFileContents: `verbosity: 2
+			cfgFileContents: `verbosity: warn
 rpc-port: 4576
 network: 1
 `,
@@ -184,7 +184,7 @@ network: 1
 		},
 		"some setting set in default, config file and flags": {
 			cfgFile:         true,
-			cfgFileContents: `network: 2`,
+			cfgFileContents: "network: 2",
 			inputArgs: []string{
 				"--metrics", "--db-path", "/home/flag/.juno", "--eth-node",
 				"https://some-ethnode:5674", "--pprof",

--- a/cmd/juno/juno_test.go
+++ b/cmd/juno/juno_test.go
@@ -42,7 +42,8 @@ func TestConfigPrecedence(t *testing.T) {
 				RpcPort:      defaultRpcPort,
 				Metrics:      defaultMetrics,
 				DatabasePath: defaultDbPath,
-				Network:      defaultNetwork, EthNode: defaultEthNode,
+				Network:      defaultNetwork,
+				EthNode:      defaultEthNode,
 				Pprof:        defaultPprof,
 			},
 		},
@@ -53,7 +54,8 @@ func TestConfigPrecedence(t *testing.T) {
 				RpcPort:      defaultRpcPort,
 				Metrics:      defaultMetrics,
 				DatabasePath: defaultDbPath,
-				Network:      defaultNetwork, EthNode: defaultEthNode,
+				Network:      defaultNetwork,
+				EthNode:      defaultEthNode,
 				Pprof:        defaultPprof,
 			},
 		},
@@ -68,7 +70,8 @@ func TestConfigPrecedence(t *testing.T) {
 				LogLevel: defaultLogLevel,
 				RpcPort:  defaultRpcPort,
 				Metrics:  defaultMetrics,
-				Network:  defaultNetwork, EthNode: defaultEthNode,
+				Network:  defaultNetwork,
+				EthNode:  defaultEthNode,
 			},
 		},
 		"config file with all settings but without any other flags": {
@@ -77,7 +80,7 @@ func TestConfigPrecedence(t *testing.T) {
 rpc-port: 4576
 metrics: true
 db-path: /home/.juno
-network: 2
+network: goerli2
 eth-node: "https://some-ethnode:5673"
 pprof: true
 `,
@@ -110,7 +113,7 @@ metrics: true
 		"all flags without config file": {
 			inputArgs: []string{
 				"--log-level", "debug", "--rpc-port", "4576",
-				"--metrics", "--db-path", "/home/.juno", "--network", "1",
+				"--metrics", "--db-path", "/home/.juno", "--network", "goerli",
 				"--eth-node", "https://some-ethnode:5673", "--pprof",
 			},
 			expectedConfig: &node.Config{
@@ -126,7 +129,7 @@ metrics: true
 		"some flags without config file": {
 			inputArgs: []string{
 				"--log-level", "debug", "--rpc-port", "4576", "--db-path", "/home/.juno",
-				"--network", "3",
+				"--network", "integration",
 			},
 			expectedConfig: &node.Config{
 				LogLevel:     utils.DEBUG,
@@ -143,13 +146,13 @@ metrics: true
 rpc-port: 4576
 metrics: true
 db-path: /home/config-file/.juno
-network: 1
+network: goerli
 eth-node: "https://some-ethnode:5673"
 pprof: true
 `,
 			inputArgs: []string{
 				"--log-level", "error", "--rpc-port", "4577",
-				"--metrics", "--db-path", "/home/flag/.juno", "--network", "3",
+				"--metrics", "--db-path", "/home/flag/.juno", "--network", "integration",
 				"--eth-node", "https://some-ethnode:5674", "--pprof",
 			},
 			expectedConfig: &node.Config{
@@ -166,7 +169,7 @@ pprof: true
 			cfgFile: true,
 			cfgFileContents: `log-level: warn
 rpc-port: 4576
-network: 1
+network: goerli
 `,
 			inputArgs: []string{
 				"--metrics", "--db-path", "/home/flag/.juno", "--eth-node",
@@ -184,7 +187,7 @@ network: 1
 		},
 		"some setting set in default, config file and flags": {
 			cfgFile:         true,
-			cfgFileContents: "network: 2",
+			cfgFileContents: "network: goerli2",
 			inputArgs: []string{
 				"--metrics", "--db-path", "/home/flag/.juno", "--eth-node",
 				"https://some-ethnode:5674", "--pprof",

--- a/cmd/juno/juno_test.go
+++ b/cmd/juno/juno_test.go
@@ -22,10 +22,8 @@ func TestConfigPrecedence(t *testing.T) {
 	// implementation.
 	defaultLogLevel := utils.INFO
 	defaultRpcPort := uint16(6060)
-	defaultMetrics := false
 	defaultDbPath := ""
 	defaultNetwork := utils.MAINNET
-	defaultEthNode := ""
 	defaultPprof := false
 
 	tests := map[string]struct {
@@ -40,10 +38,8 @@ func TestConfigPrecedence(t *testing.T) {
 			expectedConfig: &node.Config{
 				LogLevel:     defaultLogLevel,
 				RpcPort:      defaultRpcPort,
-				Metrics:      defaultMetrics,
 				DatabasePath: defaultDbPath,
 				Network:      defaultNetwork,
-				EthNode:      defaultEthNode,
 				Pprof:        defaultPprof,
 			},
 		},
@@ -52,10 +48,8 @@ func TestConfigPrecedence(t *testing.T) {
 			expectedConfig: &node.Config{
 				LogLevel:     defaultLogLevel,
 				RpcPort:      defaultRpcPort,
-				Metrics:      defaultMetrics,
 				DatabasePath: defaultDbPath,
 				Network:      defaultNetwork,
-				EthNode:      defaultEthNode,
 				Pprof:        defaultPprof,
 			},
 		},
@@ -69,28 +63,22 @@ func TestConfigPrecedence(t *testing.T) {
 			expectedConfig: &node.Config{
 				LogLevel: defaultLogLevel,
 				RpcPort:  defaultRpcPort,
-				Metrics:  defaultMetrics,
 				Network:  defaultNetwork,
-				EthNode:  defaultEthNode,
 			},
 		},
 		"config file with all settings but without any other flags": {
 			cfgFile: true,
 			cfgFileContents: `log-level: debug
 rpc-port: 4576
-metrics: true
 db-path: /home/.juno
 network: goerli2
-eth-node: "https://some-ethnode:5673"
 pprof: true
 `,
 			expectedConfig: &node.Config{
 				LogLevel:     utils.DEBUG,
 				RpcPort:      4576,
-				Metrics:      true,
 				DatabasePath: "/home/.juno",
 				Network:      utils.GOERLI2,
-				EthNode:      "https://some-ethnode:5673",
 				Pprof:        true,
 			},
 		},
@@ -98,31 +86,25 @@ pprof: true
 			cfgFile: true,
 			cfgFileContents: `log-level: debug
 rpc-port: 4576
-metrics: true
 `,
 			expectedConfig: &node.Config{
 				LogLevel:     utils.DEBUG,
 				RpcPort:      4576,
-				Metrics:      true,
 				DatabasePath: defaultDbPath,
 				Network:      defaultNetwork,
-				EthNode:      defaultEthNode,
 				Pprof:        defaultPprof,
 			},
 		},
 		"all flags without config file": {
 			inputArgs: []string{
 				"--log-level", "debug", "--rpc-port", "4576",
-				"--metrics", "--db-path", "/home/.juno", "--network", "goerli",
-				"--eth-node", "https://some-ethnode:5673", "--pprof",
+				"--db-path", "/home/.juno", "--network", "goerli", "--pprof",
 			},
 			expectedConfig: &node.Config{
 				LogLevel:     utils.DEBUG,
 				RpcPort:      4576,
-				Metrics:      true,
 				DatabasePath: "/home/.juno",
 				Network:      utils.GOERLI,
-				EthNode:      "https://some-ethnode:5673",
 				Pprof:        true,
 			},
 		},
@@ -134,34 +116,27 @@ metrics: true
 			expectedConfig: &node.Config{
 				LogLevel:     utils.DEBUG,
 				RpcPort:      4576,
-				Metrics:      defaultMetrics,
 				DatabasePath: "/home/.juno",
 				Network:      utils.INTEGRATION,
-				EthNode:      defaultEthNode,
 			},
 		},
 		"all setting set in both config file and flags": {
 			cfgFile: true,
 			cfgFileContents: `log-level: debug
 rpc-port: 4576
-metrics: true
 db-path: /home/config-file/.juno
 network: goerli
-eth-node: "https://some-ethnode:5673"
 pprof: true
 `,
 			inputArgs: []string{
 				"--log-level", "error", "--rpc-port", "4577",
-				"--metrics", "--db-path", "/home/flag/.juno", "--network", "integration",
-				"--eth-node", "https://some-ethnode:5674", "--pprof",
+				"--db-path", "/home/flag/.juno", "--network", "integration", "--pprof",
 			},
 			expectedConfig: &node.Config{
 				LogLevel:     utils.ERROR,
 				RpcPort:      4577,
-				Metrics:      true,
 				DatabasePath: "/home/flag/.juno",
 				Network:      utils.INTEGRATION,
-				EthNode:      "https://some-ethnode:5674",
 				Pprof:        true,
 			},
 		},
@@ -171,34 +146,24 @@ pprof: true
 rpc-port: 4576
 network: goerli
 `,
-			inputArgs: []string{
-				"--metrics", "--db-path", "/home/flag/.juno", "--eth-node",
-				"https://some-ethnode:5674",
-			},
+			inputArgs: []string{"--db-path", "/home/flag/.juno"},
 			expectedConfig: &node.Config{
 				LogLevel:     utils.WARN,
 				RpcPort:      4576,
-				Metrics:      true,
 				DatabasePath: "/home/flag/.juno",
 				Network:      utils.GOERLI,
-				EthNode:      "https://some-ethnode:5674",
 				Pprof:        defaultPprof,
 			},
 		},
 		"some setting set in default, config file and flags": {
 			cfgFile:         true,
 			cfgFileContents: "network: goerli2",
-			inputArgs: []string{
-				"--metrics", "--db-path", "/home/flag/.juno", "--eth-node",
-				"https://some-ethnode:5674", "--pprof",
-			},
+			inputArgs:       []string{"--db-path", "/home/flag/.juno", "--pprof"},
 			expectedConfig: &node.Config{
 				LogLevel:     defaultLogLevel,
 				RpcPort:      defaultRpcPort,
-				Metrics:      true,
 				DatabasePath: "/home/flag/.juno",
 				Network:      utils.GOERLI2,
-				EthNode:      "https://some-ethnode:5674",
 				Pprof:        true,
 			},
 		},

--- a/cmd/juno/main.go
+++ b/cmd/juno/main.go
@@ -2,12 +2,24 @@ package main
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"os/signal"
 	"syscall"
 
 	"github.com/NethermindEth/juno/node"
+	"github.com/spf13/cobra"
 )
+
+const greeting = `
+       _                    
+      | |                   
+      | |_   _ _ __   ___   
+  _   | | | | | '_ \ / _ \  
+ | |__| | |_| | | | | (_) |  
+  \____/ \__,_|_| |_|\___/  
+
+Juno is a Go implementation of a Starknet full node client created by Nethermind.`
 
 func main() {
 	quit := make(chan os.Signal, 1)
@@ -19,7 +31,20 @@ func main() {
 		cancel()
 	}()
 
-	if err := NewCmd(node.New).ExecuteContext(ctx); err != nil {
+	config := new(node.Config)
+	cmd := NewCmd(config, func(cmd *cobra.Command, _ []string) error {
+		fmt.Printf("%s\n\n", greeting)
+
+		n, err := node.New(config)
+		if err != nil {
+			return err
+		}
+
+		n.Run(cmd.Context())
+		return nil
+	})
+
+	if err := cmd.ExecuteContext(ctx); err != nil {
 		os.Exit(1)
 	}
 }

--- a/go.mod
+++ b/go.mod
@@ -9,8 +9,10 @@ require (
 	github.com/ethereum/go-ethereum v1.10.26
 	github.com/fxamacker/cbor/v2 v2.4.0
 	github.com/golang/mock v1.6.0
+	github.com/mitchellh/mapstructure v1.5.0
 	github.com/sourcegraph/conc v0.2.0
 	github.com/spf13/cobra v1.5.0
+	github.com/spf13/pflag v1.0.5
 	github.com/spf13/viper v1.12.0
 	github.com/stretchr/testify v1.8.1
 	go.uber.org/zap v1.24.0
@@ -40,7 +42,6 @@ require (
 	github.com/kr/text v0.2.0 // indirect
 	github.com/magiconair/properties v1.8.6 // indirect
 	github.com/matttproud/golang_protobuf_extensions v1.0.2-0.20181231171920-c182affec369 // indirect
-	github.com/mitchellh/mapstructure v1.5.0 // indirect
 	github.com/mmcloughlin/addchain v0.4.0 // indirect
 	github.com/pelletier/go-toml v1.9.5 // indirect
 	github.com/pelletier/go-toml/v2 v2.0.1 // indirect
@@ -55,7 +56,6 @@ require (
 	github.com/spf13/afero v1.8.2 // indirect
 	github.com/spf13/cast v1.5.0 // indirect
 	github.com/spf13/jwalterweatherman v1.1.0 // indirect
-	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/subosito/gotenv v1.3.0 // indirect
 	github.com/x448/float16 v0.8.4 // indirect
 	go.uber.org/atomic v1.10.0 // indirect

--- a/node/node.go
+++ b/node/node.go
@@ -50,9 +50,6 @@ func New(cfg *Config) (*Node, error) {
 	if !utils.IsValidNetwork(cfg.Network) {
 		return nil, utils.ErrUnknownNetwork
 	}
-	if !cfg.Verbosity.IsValid() {
-		return nil, utils.ErrUnknownLogLevel
-	}
 	if cfg.DatabasePath == "" {
 		dirPrefix, err := utils.DefaultDataDir()
 		if err != nil {

--- a/node/node.go
+++ b/node/node.go
@@ -26,7 +26,7 @@ const (
 
 // Config is the top-level juno configuration.
 type Config struct {
-	Verbosity    utils.LogLevel `mapstructure:"verbosity"`
+	LogLevel     utils.LogLevel `mapstructure:"log-level"`
 	RpcPort      uint16         `mapstructure:"rpc-port"`
 	Metrics      bool           `mapstructure:"metrics"`
 	DatabasePath string         `mapstructure:"db-path"`
@@ -57,7 +57,7 @@ func New(cfg *Config) (*Node, error) {
 		}
 		cfg.DatabasePath = filepath.Join(dirPrefix, cfg.Network.String())
 	}
-	log, err := utils.NewZapLogger(cfg.Verbosity)
+	log, err := utils.NewZapLogger(cfg.LogLevel)
 	if err != nil {
 		return nil, err
 	}

--- a/node/node.go
+++ b/node/node.go
@@ -20,13 +20,6 @@ import (
 	"github.com/sourcegraph/conc"
 )
 
-type StarknetNode interface {
-	Run(ctx context.Context)
-	Config() Config
-}
-
-type NewStarknetNodeFn func(cfg *Config) (StarknetNode, error)
-
 const (
 	defaultPprofPort = uint16(9080)
 )
@@ -53,7 +46,7 @@ type Node struct {
 
 // New sets the config and logger to the StarknetNode.
 // Any errors while parsing the config on creating logger will be returned.
-func New(cfg *Config) (StarknetNode, error) {
+func New(cfg *Config) (*Node, error) {
 	if !utils.IsValidNetwork(cfg.Network) {
 		return nil, utils.ErrUnknownNetwork
 	}

--- a/node/node.go
+++ b/node/node.go
@@ -28,10 +28,8 @@ const (
 type Config struct {
 	LogLevel     utils.LogLevel `mapstructure:"log-level"`
 	RpcPort      uint16         `mapstructure:"rpc-port"`
-	Metrics      bool           `mapstructure:"metrics"`
 	DatabasePath string         `mapstructure:"db-path"`
 	Network      utils.Network  `mapstructure:"network"`
-	EthNode      string         `mapstructure:"eth-node"`
 	Pprof        bool           `mapstructure:"pprof"`
 }
 

--- a/node/node.go
+++ b/node/node.go
@@ -47,9 +47,6 @@ type Node struct {
 // New sets the config and logger to the StarknetNode.
 // Any errors while parsing the config on creating logger will be returned.
 func New(cfg *Config) (*Node, error) {
-	if !utils.IsValidNetwork(cfg.Network) {
-		return nil, utils.ErrUnknownNetwork
-	}
 	if cfg.DatabasePath == "" {
 		dirPrefix, err := utils.DefaultDataDir()
 		if err != nil {

--- a/node/node_test.go
+++ b/node/node_test.go
@@ -1,7 +1,6 @@
 package node_test
 
 import (
-	"fmt"
 	"path/filepath"
 	"testing"
 
@@ -11,46 +10,23 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestNew(t *testing.T) {
-	t.Run("network", func(t *testing.T) {
-		networks := []utils.Network{
-			utils.GOERLI, utils.MAINNET, utils.GOERLI2, utils.INTEGRATION, utils.Network(2),
-			utils.Network(20), utils.Network(100),
-		}
-		for _, n := range networks {
-			t.Run(fmt.Sprintf("%s", n), func(t *testing.T) {
-				cfg := &node.Config{Network: n}
+func TestDefaultDbPath(t *testing.T) {
+	defaultDataDir, err := utils.DefaultDataDir()
+	require.NoError(t, err)
 
-				snNode, err := node.New(cfg)
-				if utils.IsValidNetwork(cfg.Network) {
-					require.NoError(t, err)
+	networks := []utils.Network{utils.GOERLI, utils.MAINNET, utils.GOERLI2, utils.INTEGRATION}
 
-					require.Equal(t, cfg.Network, snNode.Config().Network)
-				} else {
-					assert.Error(t, err, utils.ErrUnknownNetwork)
-				}
-			})
-		}
-	})
+	for _, n := range networks {
+		t.Run(n.String(), func(t *testing.T) {
+			cfg := &node.Config{Network: n, DatabasePath: ""}
+			expectedCfg := node.Config{
+				Network:      n,
+				DatabasePath: filepath.Join(defaultDataDir, n.String()),
+			}
+			snNode, err := node.New(cfg)
+			require.NoError(t, err)
 
-	t.Run("default db-path", func(t *testing.T) {
-		defaultDataDir, err := utils.DefaultDataDir()
-		require.NoError(t, err)
-
-		networks := []utils.Network{utils.GOERLI, utils.MAINNET, utils.GOERLI2, utils.INTEGRATION}
-
-		for _, n := range networks {
-			t.Run(n.String(), func(t *testing.T) {
-				cfg := &node.Config{Network: n, DatabasePath: ""}
-				expectedCfg := node.Config{
-					Network:      n,
-					DatabasePath: filepath.Join(defaultDataDir, n.String()),
-				}
-				snNode, err := node.New(cfg)
-				require.NoError(t, err)
-
-				assert.Equal(t, expectedCfg, snNode.Config())
-			})
-		}
-	})
+			assert.Equal(t, expectedCfg, snNode.Config())
+		})
+	}
 }

--- a/utils/log.go
+++ b/utils/log.go
@@ -1,17 +1,26 @@
 package utils
 
 import (
+	"encoding"
 	"errors"
 	"time"
 
 	"github.com/cockroachdb/pebble"
+	"github.com/spf13/pflag"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
 )
 
-var ErrUnknownLogLevel = errors.New("unknown log level")
+var ErrUnknownLogLevel = errors.New("unknown log level (known: debug, info, warn, error)")
 
-type LogLevel uint8
+type LogLevel int
+
+// The following are necessary for Cobra and Viper, respectively, to unmarshal log level
+// CLI/config parameters properly.
+var (
+	_ pflag.Value              = (*LogLevel)(nil)
+	_ encoding.TextUnmarshaler = (*LogLevel)(nil)
+)
 
 const (
 	DEBUG LogLevel = iota
@@ -31,12 +40,33 @@ func (l LogLevel) String() string {
 	case ERROR:
 		return "error"
 	default:
-		return ""
+		// Should not happen.
+		panic(ErrUnknownLogLevel)
 	}
 }
 
-func (l LogLevel) IsValid() bool {
-	return l.String() != ""
+func (l *LogLevel) Set(s string) error {
+	switch s {
+	case "DEBUG", "debug":
+		*l = DEBUG
+	case "INFO", "info":
+		*l = INFO
+	case "WARN", "warn":
+		*l = WARN
+	case "ERROR", "error":
+		*l = ERROR
+	default:
+		return ErrUnknownLogLevel
+	}
+	return nil
+}
+
+func (l *LogLevel) Type() string {
+	return "LogLevel"
+}
+
+func (l *LogLevel) UnmarshalText(text []byte) error {
+	return l.Set(string(text))
 }
 
 type Logger interface {

--- a/utils/log_test.go
+++ b/utils/log_test.go
@@ -1,19 +1,79 @@
-package utils
+package utils_test
 
 import (
+	"strings"
 	"testing"
 
+	"github.com/NethermindEth/juno/utils"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
-func TestZap(t *testing.T) {
-	levels := []LogLevel{
-		DEBUG, INFO, WARN, ERROR,
+var levelStrings = map[utils.LogLevel]string{
+	utils.DEBUG: "debug",
+	utils.INFO:  "info",
+	utils.WARN:  "warn",
+	utils.ERROR: "error",
+}
+
+func TestLogLevelString(t *testing.T) {
+	for level, str := range levelStrings {
+		t.Run("level "+str, func(t *testing.T) {
+			assert.Equal(t, str, level.String())
+		})
+	}
+}
+
+func TestLogLevelSet(t *testing.T) {
+	for level, str := range levelStrings {
+		t.Run("level "+str, func(t *testing.T) {
+			l := new(utils.LogLevel)
+			require.NoError(t, l.Set(str))
+			assert.Equal(t, level, *l)
+		})
+		uppercase := strings.ToUpper(str)
+		t.Run("level "+uppercase, func(t *testing.T) {
+			l := new(utils.LogLevel)
+			require.NoError(t, l.Set(uppercase))
+			assert.Equal(t, level, *l)
+		})
 	}
 
-	for _, level := range levels {
-		t.Run("test level: "+level.String(), func(t *testing.T) {
-			_, err := NewZapLogger(level)
+	t.Run("unknown log level", func(t *testing.T) {
+		l := new(utils.LogLevel)
+		require.ErrorIs(t, l.Set("blah"), utils.ErrUnknownLogLevel)
+	})
+}
+
+func TestLogLevelUnmarshalText(t *testing.T) {
+	for level, str := range levelStrings {
+		t.Run("level "+str, func(t *testing.T) {
+			l := new(utils.LogLevel)
+			require.NoError(t, l.UnmarshalText([]byte(str)))
+			assert.Equal(t, level, *l)
+		})
+		uppercase := strings.ToUpper(str)
+		t.Run("level "+uppercase, func(t *testing.T) {
+			l := new(utils.LogLevel)
+			require.NoError(t, l.UnmarshalText([]byte(uppercase)))
+			assert.Equal(t, level, *l)
+		})
+	}
+
+	t.Run("unknown log level", func(t *testing.T) {
+		l := new(utils.LogLevel)
+		require.ErrorIs(t, l.UnmarshalText([]byte("blah")), utils.ErrUnknownLogLevel)
+	})
+}
+
+func TestLogLevelType(t *testing.T) {
+	assert.Equal(t, "LogLevel", new(utils.LogLevel).Type())
+}
+
+func TestZap(t *testing.T) {
+	for level, str := range levelStrings {
+		t.Run("level: "+str, func(t *testing.T) {
+			_, err := utils.NewZapLogger(level)
 			assert.NoError(t, err)
 		})
 	}

--- a/utils/log_test.go
+++ b/utils/log_test.go
@@ -24,6 +24,12 @@ func TestLogLevelString(t *testing.T) {
 	}
 }
 
+// Tests are similar for LogLevel and Network since they
+// both implement the pflag.Value and encoding.TextUnmarshaller interfaces.
+// We can open a PR on github.com/thediveo/enumflag to add TextUnmarshaller
+// support.
+//
+//nolint:dupl
 func TestLogLevelSet(t *testing.T) {
 	for level, str := range levelStrings {
 		t.Run("level "+str, func(t *testing.T) {

--- a/utils/network.go
+++ b/utils/network.go
@@ -1,14 +1,23 @@
 package utils
 
 import (
+	"encoding"
 	"errors"
 
 	"github.com/NethermindEth/juno/core/felt"
+	"github.com/spf13/pflag"
 )
 
-var ErrUnknownNetwork = errors.New("unknown network")
+var ErrUnknownNetwork = errors.New("unknown network (known: mainnet, goerli, goerli2, integration)")
 
-type Network uint8
+type Network int
+
+// The following are necessary for Cobra and Viper, respectively, to unmarshal log level
+// CLI/config parameters properly.
+var (
+	_ pflag.Value              = (*Network)(nil)
+	_ encoding.TextUnmarshaler = (*Network)(nil)
+)
 
 const (
 	MAINNET Network = iota
@@ -19,17 +28,42 @@ const (
 
 func (n Network) String() string {
 	switch n {
-	case GOERLI:
-		return "goerli"
 	case MAINNET:
 		return "mainnet"
+	case GOERLI:
+		return "goerli"
 	case GOERLI2:
 		return "goerli2"
 	case INTEGRATION:
 		return "integration"
 	default:
-		return ""
+		// Should not happen.
+		panic(ErrUnknownNetwork)
 	}
+}
+
+func (l *Network) Set(s string) error {
+	switch s {
+	case "MAINNET", "mainnet":
+		*l = MAINNET
+	case "GOERLI", "goerli":
+		*l = GOERLI
+	case "GOERLI2", "goerli2":
+		*l = GOERLI2
+	case "INTEGRATION", "integration":
+		*l = INTEGRATION
+	default:
+		return ErrUnknownNetwork
+	}
+	return nil
+}
+
+func (l *Network) Type() string {
+	return "Network"
+}
+
+func (l *Network) UnmarshalText(text []byte) error {
+	return l.Set(string(text))
 }
 
 func (n Network) URL() string {
@@ -43,7 +77,8 @@ func (n Network) URL() string {
 	case INTEGRATION:
 		return "https://external.integration.starknet.io/feeder_gateway/"
 	default:
-		return ""
+		// Should not happen.
+		panic(ErrUnknownNetwork)
 	}
 }
 
@@ -58,10 +93,7 @@ func (n Network) ChainId() *felt.Felt {
 	case INTEGRATION:
 		return new(felt.Felt).SetBytes([]byte("SN_INTEGRATION"))
 	default:
-		return nil
+		// Should not happen.
+		panic(ErrUnknownNetwork)
 	}
-}
-
-func IsValidNetwork(n Network) bool {
-	return !(n.String() == "")
 }

--- a/utils/network_test.go
+++ b/utils/network_test.go
@@ -57,6 +57,7 @@ func TestNetwork(t *testing.T) {
 	})
 }
 
+//nolint:dupl // see comment in utils/log_test.go
 func TestNetworkSet(t *testing.T) {
 	for network, str := range networkStrings {
 		t.Run("network "+str, func(t *testing.T) {

--- a/utils/network_test.go
+++ b/utils/network_test.go
@@ -1,33 +1,30 @@
 package utils_test
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/NethermindEth/juno/core/felt"
 	"github.com/NethermindEth/juno/utils"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
+var networkStrings = map[utils.Network]string{
+	utils.MAINNET:     "mainnet",
+	utils.GOERLI:      "goerli",
+	utils.GOERLI2:     "goerli2",
+	utils.INTEGRATION: "integration",
+}
+
 func TestNetwork(t *testing.T) {
-	networks := []utils.Network{0, 1, 2, 56, 3, 100}
 	t.Run("string", func(t *testing.T) {
-		for _, n := range networks {
-			switch n {
-			case utils.GOERLI:
-				assert.Equal(t, "goerli", n.String())
-			case utils.MAINNET:
-				assert.Equal(t, "mainnet", n.String())
-			case utils.GOERLI2:
-				assert.Equal(t, "goerli2", n.String())
-			case utils.INTEGRATION:
-				assert.Equal(t, "integration", n.String())
-			default:
-				assert.Equal(t, "", n.String())
-			}
+		for network, str := range networkStrings {
+			assert.Equal(t, str, network.String())
 		}
 	})
 	t.Run("url", func(t *testing.T) {
-		for _, n := range networks {
+		for n := range networkStrings {
 			switch n {
 			case utils.GOERLI:
 				assert.Equal(t, "https://alpha4.starknet.io/feeder_gateway/", n.URL())
@@ -38,13 +35,12 @@ func TestNetwork(t *testing.T) {
 			case utils.INTEGRATION:
 				assert.Equal(t, "https://external.integration.starknet.io/feeder_gateway/", n.URL())
 			default:
-				assert.Equal(t, "", n.URL())
-
+				t.Error("unexpected network")
 			}
 		}
 	})
 	t.Run("chainId", func(t *testing.T) {
-		for _, n := range networks {
+		for n := range networkStrings {
 			switch n {
 			case utils.GOERLI:
 				assert.Equal(t, new(felt.Felt).SetBytes([]byte("SN_GOERLI")), n.ChainId())
@@ -55,23 +51,54 @@ func TestNetwork(t *testing.T) {
 			case utils.INTEGRATION:
 				assert.Equal(t, new(felt.Felt).SetBytes([]byte("SN_INTEGRATION")), n.ChainId())
 			default:
-				assert.Equal(t, (*felt.Felt)(nil), n.ChainId())
+				t.Error("unexpected network")
 			}
 		}
 	})
 }
 
-func TestValidNetwork(t *testing.T) {
-	t.Run("valid networks", func(t *testing.T) {
-		networks := []utils.Network{0, 1, 2, 3}
-		for _, n := range networks {
-			assert.True(t, utils.IsValidNetwork(n))
-		}
+func TestNetworkSet(t *testing.T) {
+	for network, str := range networkStrings {
+		t.Run("network "+str, func(t *testing.T) {
+			n := new(utils.Network)
+			require.NoError(t, n.Set(str))
+			assert.Equal(t, network, *n)
+		})
+		uppercase := strings.ToUpper(str)
+		t.Run("network "+uppercase, func(t *testing.T) {
+			n := new(utils.Network)
+			require.NoError(t, n.Set(uppercase))
+			assert.Equal(t, network, *n)
+		})
+	}
+
+	t.Run("unknown network", func(t *testing.T) {
+		n := new(utils.Network)
+		require.ErrorIs(t, n.Set("blah"), utils.ErrUnknownNetwork)
 	})
-	t.Run("invalid networks", func(t *testing.T) {
-		networks := []utils.Network{6, 5, 7, 12, 34, 255}
-		for _, n := range networks {
-			assert.False(t, utils.IsValidNetwork(n))
-		}
+}
+
+func TestNetworkUnmarshalText(t *testing.T) {
+	for network, str := range networkStrings {
+		t.Run("network "+str, func(t *testing.T) {
+			n := new(utils.Network)
+			require.NoError(t, n.UnmarshalText([]byte(str)))
+			assert.Equal(t, network, *n)
+		})
+		uppercase := strings.ToUpper(str)
+		t.Run("network "+uppercase, func(t *testing.T) {
+			n := new(utils.Network)
+			require.NoError(t, n.UnmarshalText([]byte(uppercase)))
+			assert.Equal(t, network, *n)
+		})
+	}
+
+	t.Run("unknown network", func(t *testing.T) {
+		l := new(utils.Network)
+		require.ErrorIs(t, l.UnmarshalText([]byte("blah")), utils.ErrUnknownNetwork)
 	})
+}
+
+func TestNetworkType(t *testing.T) {
+	assert.Equal(t, "Network", new(utils.Network).Type())
 }


### PR DESCRIPTION
- Simplifies the cobra-centric flow for setting up the node. The key thing to notice here is how we are passing in a `node.Config` to `NewCmd`, populating it in `junoCmd.PreRunE`, and then running the node with the user-provided `run` function.
- Pass in log level and network as strings instead of uint8s. Not only is this more ergonomic, but it also prevents overflows.
- Remove unused configuration parameters. 