### PR TITLE
Add .envrc to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ coverage/*
 courtney/
 __pycache__/
 config/
+.envrc
 
 # pyenv
 .python-version


### PR DESCRIPTION
Useful for setting personal environment variables. For example, [`direnv`](https://direnv.net/) reads from `.envrc`.