### PR TITLE
Dynamically assign pprof server port

### DIFF
--- a/node/node.go
+++ b/node/node.go
@@ -27,10 +27,6 @@ type StarknetNode interface {
 
 type NewStarknetNodeFn func(cfg *Config) (StarknetNode, error)
 
-const (
-	defaultPprofPort = uint16(9080)
-)
-
 // Config is the top-level juno configuration.
 type Config struct {
 	Verbosity    utils.LogLevel `mapstructure:"verbosity"`
@@ -158,7 +154,7 @@ func (n *Node) Run(ctx context.Context) {
 	client := feeder.NewClient(n.cfg.Network.URL())
 	synchronizer := sync.New(n.blockchain, adaptfeeder.New(client), n.log)
 	http := makeHttp(n.cfg.RpcPort, rpc.New(n.blockchain, n.cfg.Network), n.log)
-	profiler := pprof.New(n.cfg.Pprof, defaultPprofPort, n.log)
+	profiler := pprof.New(n.cfg.Pprof, n.log)
 	n.services = []service.Service{synchronizer, http, profiler}
 
 	ctx, cancel := context.WithCancel(ctx)

--- a/pprof/pprof.go
+++ b/pprof/pprof.go
@@ -3,7 +3,6 @@ package pprof
 import (
 	"context"
 	"net/http"
-	"strconv"
 	"time"
 
 	"github.com/NethermindEth/juno/utils"
@@ -17,9 +16,9 @@ type Profiler struct {
 	server  *http.Server
 }
 
-func New(enabled bool, port uint16, log utils.SimpleLogger) *Profiler {
+func New(enabled bool, log utils.SimpleLogger) *Profiler {
 	server := &http.Server{
-		Addr:              "localhost:" + strconv.Itoa(int(port)),
+		Addr:              "localhost:0", // Have kernel select arbitrary open port
 		Handler:           http.DefaultServeMux,
 		ReadHeaderTimeout: 5 * time.Second,
 	}

--- a/pprof/pprof_test.go
+++ b/pprof/pprof_test.go
@@ -19,7 +19,7 @@ func TestPprofServerEnabled(t *testing.T) {
 	log := utils.NewNopZapLogger()
 	url := fmt.Sprintf("http://localhost:%s/debug/pprof/", strconv.Itoa(int(port)))
 	t.Run("create a new Pprof instance and run it", func(t *testing.T) {
-		profiler := pprof.New(true, port, log)
+		profiler := pprof.New(true, log)
 		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 		defer cancel()
 
@@ -43,7 +43,7 @@ func TestPprofServerDisabled(t *testing.T) {
 	log := utils.NewNopZapLogger()
 	url := fmt.Sprintf("http://localhost:%s/debug/pprof/", strconv.Itoa(int(port)))
 	t.Run("create a new Pprof instance with enabled set to false and ensure it doesn't start", func(t *testing.T) {
-		profiler := pprof.New(false, port, log)
+		profiler := pprof.New(false, log)
 		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 		defer cancel()
 		go func() {


### PR DESCRIPTION
This is done by giving pprof a zero port number. Also ensures the tests succeed no matter what ports are currently in use on the system.