### PR TITLE
Fix pprof log error

### DIFF
--- a/pprof/pprof.go
+++ b/pprof/pprof.go
@@ -37,7 +37,7 @@ func (p *Profiler) Run(ctx context.Context) error {
 	}
 
 	go func() {
-		p.log.Infow("Starting pprof...", p.server.Addr)
+		p.log.Infow("Starting pprof...", "address", p.server.Addr)
 		if err := p.server.ListenAndServe(); err != nil && err != http.ErrServerClosed {
 			p.log.Errorw("Pprof server error", "err", err)
 		}


### PR DESCRIPTION
`pprof` logs the following error when starting

```
18:15:21.960 16/03/2023 +01:00	ERROR	zap@v1.24.0/sugar.go:210	Ignored key without a value.	{"ignored": "localhost:9080"}
go.uber.org/zap.(*SugaredLogger).Infow
	/Users/jelilat/go/pkg/mod/go.uber.org/zap@v1.24.0/sugar.go:210
github.com/NethermindEth/juno/pprof.(*Profiler).Run.func1
	/Users/jelilat/nethermind/juno/pprof/pprof.go:40
```