### PR TITLE
Remove unused function CreateDir

### DIFF
--- a/utils/datadir.go
+++ b/utils/datadir.go
@@ -49,12 +49,3 @@ func DataDir(operatingSystem, userDataDir, homeDir string) string {
 	}
 	return filepath.Join(homeDir, local, share, juno)
 }
-
-func CreateDir(dirPath string) error {
-	if _, err := os.Stat(dirPath); err != nil {
-		if err = os.MkdirAll(dirPath, os.ModePerm); err != nil {
-			return err
-		}
-	}
-	return nil
-}


### PR DESCRIPTION
Pebble will create its own directory if necessary when we call `pebble.Open`.