### PR TITLE
Implement History

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -28,6 +28,7 @@ linters-settings:
       - ifElseChain
       - octalLiteral
       - whyNoLint
+      - unnamedResult
   gocyclo:
     min-complexity: 15
   goimports:

--- a/blockchain/blockchain.go
+++ b/blockchain/blockchain.go
@@ -230,7 +230,7 @@ func (b *Blockchain) Store(block *core.Block, stateUpdate *core.StateUpdate, dec
 		if err := b.verifyBlock(txn, block); err != nil {
 			return err
 		}
-		if err := core.NewState(txn).Update(stateUpdate, declaredClasses); err != nil {
+		if err := core.NewState(txn).Update(block.Number, stateUpdate, declaredClasses); err != nil {
 			return err
 		}
 		if err := storeBlockHeader(txn, block.Header); err != nil {

--- a/core/contract.go
+++ b/core/contract.go
@@ -134,16 +134,25 @@ func (c *Contract) Root() (*felt.Felt, error) {
 	return cStorage.Root()
 }
 
+type OnValueChanged = func(*felt.Felt, *felt.Felt) error
+
 // UpdateStorage applies a change-set to the contract storage.
-func (c *Contract) UpdateStorage(diff []StorageDiff) error {
+func (c *Contract) UpdateStorage(diff []StorageDiff, cb OnValueChanged) error {
 	cStorage, err := storage(c.Address, c.txn)
 	if err != nil {
 		return err
 	}
 	// apply the diff
 	for _, pair := range diff {
-		if _, err := cStorage.Put(pair.Key, pair.Value); err != nil {
+		oldValue, err := cStorage.Put(pair.Key, pair.Value)
+		if err != nil {
 			return err
+		}
+
+		if oldValue != nil {
+			if err = cb(pair.Key, oldValue); err != nil {
+				return err
+			}
 		}
 	}
 

--- a/core/contract_test.go
+++ b/core/contract_test.go
@@ -12,6 +12,10 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+var NoopOnValueChanged = func(location, oldValue *felt.Felt) error {
+	return nil
+}
+
 func TestContractAddress(t *testing.T) {
 	tests := []struct {
 		callerAddress       *felt.Felt
@@ -87,7 +91,7 @@ func TestNewContract(t *testing.T) {
 			oldRoot, err := contract.Root()
 			require.NoError(t, err)
 
-			require.NoError(t, contract.UpdateStorage([]core.StorageDiff{{Key: addr, Value: classHash}}))
+			require.NoError(t, contract.UpdateStorage([]core.StorageDiff{{Key: addr, Value: classHash}}, NoopOnValueChanged))
 
 			newContract, err := core.NewContract(addr, txn)
 			require.NoError(t, err)
@@ -120,7 +124,7 @@ func TestNewContract(t *testing.T) {
 			assert.Error(t, contract.UpdateNonce(&felt.Zero))
 		})
 		t.Run("UpdateStorage()", func(t *testing.T) {
-			assert.Error(t, contract.UpdateStorage(nil))
+			assert.Error(t, contract.UpdateStorage(nil, NoopOnValueChanged))
 		})
 	})
 }
@@ -175,7 +179,7 @@ func TestUpdateStorageAndStorage(t *testing.T) {
 		oldRoot, err := contract.Root()
 		require.NoError(t, err)
 
-		require.NoError(t, contract.UpdateStorage([]core.StorageDiff{{Key: addr, Value: classHash}}))
+		require.NoError(t, contract.UpdateStorage([]core.StorageDiff{{Key: addr, Value: classHash}}, NoopOnValueChanged))
 
 		gotValue, err := contract.Storage(addr)
 		require.NoError(t, err)
@@ -187,7 +191,7 @@ func TestUpdateStorageAndStorage(t *testing.T) {
 	})
 
 	t.Run("delete key from storage with storage diff", func(t *testing.T) {
-		require.NoError(t, contract.UpdateStorage([]core.StorageDiff{{Key: addr, Value: new(felt.Felt)}}))
+		require.NoError(t, contract.UpdateStorage([]core.StorageDiff{{Key: addr, Value: new(felt.Felt)}}, NoopOnValueChanged))
 
 		_, err := contract.Storage(addr)
 		require.EqualError(t, err, db.ErrKeyNotFound.Error())

--- a/core/history.go
+++ b/core/history.go
@@ -1,0 +1,78 @@
+package core
+
+import (
+	"bytes"
+	"encoding/binary"
+	"errors"
+
+	"github.com/NethermindEth/juno/core/felt"
+	"github.com/NethermindEth/juno/db"
+)
+
+type History struct {
+	txn db.Transaction
+}
+
+func NewHistory(txn db.Transaction) *History {
+	return &History{txn: txn}
+}
+
+func (h *History) logOldValue(key, value []byte, height uint64) error {
+	return h.txn.Set(binary.BigEndian.AppendUint64(key, height), value)
+}
+
+func (h *History) valueAt(key []byte, height uint64) ([]byte, error) {
+	it, err := h.txn.NewIterator()
+	if err != nil {
+		return nil, err
+	}
+
+	for it.Seek(binary.BigEndian.AppendUint64(key, height)); it.Valid(); it.Next() {
+		seekedKey := it.Key()
+		// seekedKey size should be `len(key) + sizeof(uint64)` and seekedKey should match key prefix
+		if len(seekedKey) != len(key)+8 || !bytes.HasPrefix(seekedKey, key) {
+			break
+		}
+
+		seekedHeight := binary.BigEndian.Uint64(seekedKey[len(key):])
+		if seekedHeight < height {
+			// last change happened before the height we are looking for
+			// check head state
+			break
+		} else if seekedHeight == height {
+			// a log exists for the height we are looking for, so the old value in this log entry is not useful.
+			// advance the iterator and see we can use the next entry. If not, ErrCheckHeadState will be returned
+			continue
+		}
+
+		val, itErr := it.Value()
+		if err = db.CloseAndWrapOnError(it.Close, itErr); err != nil {
+			return nil, err
+		}
+		// seekedHeight > height
+		return val, nil
+	}
+
+	return nil, db.CloseAndWrapOnError(it.Close, errors.New("check head state"))
+}
+
+func storageLogKey(contractAddress, storageLocation *felt.Felt) []byte {
+	return db.ContractStorageValueHistory.Key(contractAddress.Marshal(), storageLocation.Marshal())
+}
+
+// LogContractStorage logs the old value of a storage location for the given contract which changed on height `height`
+func (h *History) LogContractStorage(contractAddress, storageLocation, oldValue *felt.Felt, height uint64) error {
+	key := storageLogKey(contractAddress, storageLocation)
+	return h.logOldValue(key, oldValue.Marshal(), height)
+}
+
+// ContractStorageAt returns the value of a storage location of the given contract at the height `height`
+func (h *History) ContractStorageAt(contractAddress, storageLocation *felt.Felt, height uint64) (*felt.Felt, error) {
+	key := storageLogKey(contractAddress, storageLocation)
+	value, err := h.valueAt(key, height)
+	if err != nil {
+		return nil, err
+	}
+
+	return new(felt.Felt).SetBytes(value), nil
+}

--- a/core/history_test.go
+++ b/core/history_test.go
@@ -1,0 +1,68 @@
+package core_test
+
+import (
+	"testing"
+
+	"github.com/NethermindEth/juno/core"
+	"github.com/NethermindEth/juno/core/felt"
+	"github.com/NethermindEth/juno/db/pebble"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestStorageValueAt(t *testing.T) {
+	testDB := pebble.NewMemTest()
+	txn := testDB.NewTransaction(true)
+	t.Cleanup(func() {
+		require.NoError(t, txn.Discard())
+		require.NoError(t, testDB.Close())
+	})
+
+	history := core.NewHistory(txn)
+
+	contractAddres := new(felt.Felt).SetUint64(123)
+	location := new(felt.Felt).SetUint64(456)
+
+	t.Run("no history", func(t *testing.T) {
+		_, err := history.ContractStorageAt(contractAddres, location, 1)
+		assert.EqualError(t, err, "check head state")
+	})
+
+	value := new(felt.Felt).SetUint64(789)
+
+	t.Run("log value changed at height 5 and 10", func(t *testing.T) {
+		assert.NoError(t, history.LogContractStorage(contractAddres, location, &felt.Zero, 5))
+		assert.NoError(t, history.LogContractStorage(contractAddres, location, value, 10))
+	})
+
+	t.Run("get value before height 5", func(t *testing.T) {
+		oldValue, err := history.ContractStorageAt(contractAddres, location, 1)
+		require.NoError(t, err)
+		assert.Equal(t, &felt.Zero, oldValue)
+	})
+
+	t.Run("get value between height 5-10 ", func(t *testing.T) {
+		oldValue, err := history.ContractStorageAt(contractAddres, location, 7)
+		require.NoError(t, err)
+		assert.Equal(t, value, oldValue)
+	})
+
+	t.Run("get value on height that change happened ", func(t *testing.T) {
+		oldValue, err := history.ContractStorageAt(contractAddres, location, 5)
+		require.NoError(t, err)
+		assert.Equal(t, value, oldValue)
+
+		_, err = history.ContractStorageAt(contractAddres, location, 10)
+		assert.EqualError(t, err, "check head state")
+	})
+
+	t.Run("get value between after height 10 ", func(t *testing.T) {
+		_, err := history.ContractStorageAt(contractAddres, location, 13)
+		assert.EqualError(t, err, "check head state")
+	})
+
+	t.Run("get a random location ", func(t *testing.T) {
+		_, err := history.ContractStorageAt(contractAddres, new(felt.Felt).SetUint64(37), 13)
+		assert.EqualError(t, err, "check head state")
+	})
+}

--- a/core/state.go
+++ b/core/state.go
@@ -14,6 +14,21 @@ import (
 
 const stateTrieHeight = 251
 
+var _ StateReader = (*State)(nil)
+
+type StateReader interface {
+	HeadStateReader
+
+	ContractStorageAt(addr, key *felt.Felt, blockNumber uint64) (*felt.Felt, error)
+	// todo: extend
+}
+
+type HeadStateReader interface {
+	ContractClassHash(addr *felt.Felt) (*felt.Felt, error)
+	ContractNonce(addr *felt.Felt) (*felt.Felt, error)
+	ContractStorage(addr, key *felt.Felt) (*felt.Felt, error)
+}
+
 type State struct {
 	*History
 	txn db.Transaction
@@ -52,6 +67,16 @@ func (s *State) ContractNonce(addr *felt.Felt) (*felt.Felt, error) {
 		return nil, err
 	}
 	return contract.Nonce()
+}
+
+// ContractStorage returns value of a key in the storage of the contract at the given address.
+func (s *State) ContractStorage(addr, key *felt.Felt) (*felt.Felt, error) {
+	contract, err := NewContract(addr, s.txn)
+	if err != nil {
+		return nil, err
+	}
+
+	return contract.Storage(key)
 }
 
 // Root returns the state commitment.

--- a/db/buckets.go
+++ b/db/buckets.go
@@ -22,6 +22,7 @@ const (
 	TransactionsByBlockNumberAndIndex       // maps block number and index to transaction
 	ReceiptsByBlockNumberAndIndex           // maps block number and index to transaction receipt
 	StateUpdatesByBlockNumber
+	ContractStorageValueHistory
 )
 
 // Key flattens a prefix and series of byte arrays into a single []byte.


### PR DESCRIPTION
Lets us log the changes in the state to be retrieved later by height

We can extend this by adding more functions like `LogStorageValue` and `StorageValueAt`. For example; nonces, class hashes (they are mutable after v0.11.0 with replace syscall) etc