### PR TITLE
Report patch coverage only on pull requests

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -9,3 +9,4 @@ coverage:
       default:
         target: 80%
         threshold: 1%
+        only_pulls: true


### PR DESCRIPTION
`main` is red because of patch coverage.