### PR TITLE
Add GitHub Action to deploy Juno

### DIFF
--- a/.github/workflows/juno-deploy.yml
+++ b/.github/workflows/juno-deploy.yml
@@ -1,0 +1,44 @@
+name: Deploy Juno
+
+on:
+  workflow_dispatch:
+    inputs:
+      branch:
+        description: 'Branch'
+        required: true
+      network:
+        description: 'Network'
+        required: false
+        default: 'mainnet'
+        enum: ['mainnet', 'goerli', 'goerli2', 'integration']
+
+jobs:
+  build_image_and_deploy:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Trigger build_and_push_docker_image
+      id: trigger-build
+      uses: benc-uk/workflow-dispatch@v1
+      with:
+        workflow: Build and publish Docker image
+        token: ${{ secrets.REPOSITORY_DISPATCH_TOKEN }}
+        inputs: '{"tag": "${{ github.actor }}-${{ github.sha }}"}'
+        
+    - name: Wait for build_and_push_docker_image workflow to complete
+      uses: fountainhead/action-wait-for-check@v1.1.0
+      id: wait-for-build
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        checkName: build_and_push_docker_image
+        intervalSeconds: 60
+        timeoutSeconds: 1500
+        
+    - name: Trigger Run Juno workflow when image is pushed with success
+      if: steps.wait-for-build.outputs.conclusion == 'success'
+      uses: benc-uk/workflow-dispatch@v1
+      with:
+        workflow: Run Juno
+        repo: NethermindEth/juno-smoke-tests
+        token: ${{ secrets.REPOSITORY_DISPATCH_TOKEN }}
+        inputs: '{"container_tag": "${{ github.actor }}-${{ github.sha }}", "network": "{{ github.event.inputs.network }}"}'
+        ref: main


### PR DESCRIPTION
This PR adds the "Deploy Juno" GitHub Action, which can only be triggered manually. Currently, action will deployed Juno on a VM that is already run and equipped with all necessary monitoring tools, such as Grafana or logs collector.

Input parameters: 

- branch from which Juno will be build
- network on which Juno will be run(mainnet, goerli, goerli2, integration)

Pipeline steps:
- Trigger build_and_push_docker_image workflow
- Wait for build_and_push_docker_image completion
- Trigger Run Juno workflow on successful image push