### PR TITLE
Fix fleaky test for pprof server

### DIFF
--- a/pprof/pprof_test.go
+++ b/pprof/pprof_test.go
@@ -25,7 +25,7 @@ func TestPprofServer(t *testing.T) {
 		require.NoError(t, err)
 	}()
 
-	waitForServerReady(t, url, time.Second)
+	waitForServerReady(t, url, 5*time.Second)
 }
 
 func waitForServerReady(t *testing.T, url string, timeout time.Duration) {
@@ -50,7 +50,8 @@ func waitForServerReady(t *testing.T, url string, timeout time.Duration) {
 			return
 		}
 
-		require.Greaterf(t, timeout, start, "server is not ready after %v", timeout)
+		elapsed := time.Since(start)
+		require.Greaterf(t, timeout, elapsed, "server is not ready after %v", timeout)
 
 		time.Sleep(100 * time.Millisecond)
 	}


### PR DESCRIPTION
This PR fixes randomly failing `TestPprofServer` in the `pprof_test.go` file. The changes are:

- In the `waitForServerReady` function, we now compare the time passed since the start with the timeout, instead of comparing the start time with the timeout.
- We increased the timeout value in the `TestPprofServer` function to 5 seconds, giving the server more time to get ready.
