### PR TITLE
Add Smoke Tests GitHub Action Workflow

### DIFF
--- a/.github/workflows/smoke-tests.yml
+++ b/.github/workflows/smoke-tests.yml
@@ -1,0 +1,43 @@
+name: Run Smoke Tests
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+  workflow_dispatch:
+
+jobs:
+  run_smoke_tests:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Set up Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: '1.19'
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Build docker image
+        run: docker build -t nethermindeth/juno .
+
+      - name: Clone smoke tests repository
+        run: git clone https://$GITHUB_TOKEN@github.com/NethermindEth/juno-smoke-tests.git --single-branch --branch main
+        env:
+          GITHUB_TOKEN: ${{ secrets.REPOSITORY_DISPATCH_TOKEN }}
+
+      - name: Run smoke tests
+        run: |
+          cd juno-smoke-tests/smoke-tests/node_tests
+          go test -v -run TestMonitorNodeSync -args -targetBlock=$TARGET_BLOCK -timeout=$TIMEOUT
+        env:
+          TARGET_BLOCK: 100
+          TIMEOUT: 5m
+          NETWORK: mainnet


### PR DESCRIPTION
Smoke Tests action for verifying the sync of the first 100 blocks on the mainnet added. Triggered manually or on PR to main. 