### PR TITLE
Return zero felt on non-existent keys

### DIFF
--- a/core/contract_test.go
+++ b/core/contract_test.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/NethermindEth/juno/core"
 	"github.com/NethermindEth/juno/core/felt"
-	"github.com/NethermindEth/juno/db"
 	"github.com/NethermindEth/juno/db/pebble"
 	"github.com/NethermindEth/juno/utils"
 	"github.com/stretchr/testify/assert"
@@ -197,8 +196,9 @@ func TestUpdateStorageAndStorage(t *testing.T) {
 	t.Run("delete key from storage with storage diff", func(t *testing.T) {
 		require.NoError(t, contract.UpdateStorage([]core.StorageDiff{{Key: addr, Value: new(felt.Felt)}}))
 
-		_, err := contract.Storage(addr)
-		require.EqualError(t, err, db.ErrKeyNotFound.Error())
+		val, err := contract.Storage(addr)
+		require.NoError(t, err)
+		require.Equal(t, &felt.Zero, val)
 
 		sRoot, err := contract.Root()
 		require.NoError(t, err)

--- a/core/trie/trie.go
+++ b/core/trie/trie.go
@@ -2,12 +2,14 @@
 package trie
 
 import (
+	"errors"
 	"fmt"
 	"math/big"
 	"strings"
 
 	"github.com/NethermindEth/juno/core/crypto"
 	"github.com/NethermindEth/juno/core/felt"
+	"github.com/NethermindEth/juno/db"
 	"github.com/bits-and-blooms/bitset"
 )
 
@@ -167,6 +169,9 @@ func (t *Trie) nodesFromRoot(key *bitset.BitSet) ([]storageNode, error) {
 func (t *Trie) Get(key *felt.Felt) (*felt.Felt, error) {
 	value, err := t.storage.Get(t.feltToBitSet(key))
 	if err != nil {
+		if errors.Is(err, db.ErrKeyNotFound) {
+			return &felt.Zero, nil
+		}
 		return nil, err
 	}
 	return value.Value, nil

--- a/core/trie/trie_test.go
+++ b/core/trie/trie_test.go
@@ -46,10 +46,9 @@ func TestTriePut(t *testing.T) {
 			require.NoError(t, err)
 
 			value, err := tempTrie.Get(key)
-			// should return an error when try to access a non-exist key
-			assert.Error(t, err)
-			// after empty, the return value and Trie's root should be nil
-			assert.Nil(t, value)
+			assert.NoError(t, err)
+			assert.Equal(t, &felt.Zero, value)
+			// Trie's root should be nil
 			assert.Nil(t, tempTrie.RootKey())
 
 			return nil
@@ -138,8 +137,8 @@ func TestTrieDeleteBasic(t *testing.T) {
 
 					val, err := tempTrie.Get(key)
 
-					assert.Error(t, err, "should return an error when access a deleted key")
-					assert.Nil(t, val, "should return an nil value when access a deleted key")
+					assert.NoError(t, err, "shouldnt return an error when access a deleted key")
+					assert.Equal(t, &felt.Zero, val, "should return zero value when access a deleted key")
 				}
 
 				// Check the final rootKey


### PR DESCRIPTION
```
this is a valid scenario, non-existent keys should be considered to have a zero value associated with them
```

this came up while working on VM integration