### PR TITLE
Record when a contract was deployed

### DIFF
--- a/core/state_snapshot.go
+++ b/core/state_snapshot.go
@@ -19,6 +19,10 @@ func NewStateSnapshot(state StateHistoryReader, blockNumber uint64) StateReader 
 }
 
 func (s *stateSnapshot) ContractClassHash(addr *felt.Felt) (*felt.Felt, error) {
+	if err := s.checkDeployed(addr); err != nil {
+		return nil, err
+	}
+
 	val, err := s.state.ContractClassHashAt(addr, s.blockNumber)
 	if err != nil {
 		if errors.Is(err, ErrCheckHeadState) {
@@ -30,6 +34,10 @@ func (s *stateSnapshot) ContractClassHash(addr *felt.Felt) (*felt.Felt, error) {
 }
 
 func (s *stateSnapshot) ContractNonce(addr *felt.Felt) (*felt.Felt, error) {
+	if err := s.checkDeployed(addr); err != nil {
+		return nil, err
+	}
+
 	val, err := s.state.ContractNonceAt(addr, s.blockNumber)
 	if err != nil {
 		if errors.Is(err, ErrCheckHeadState) {
@@ -41,6 +49,10 @@ func (s *stateSnapshot) ContractNonce(addr *felt.Felt) (*felt.Felt, error) {
 }
 
 func (s *stateSnapshot) ContractStorage(addr, key *felt.Felt) (*felt.Felt, error) {
+	if err := s.checkDeployed(addr); err != nil {
+		return nil, err
+	}
+
 	val, err := s.state.ContractStorageAt(addr, key, s.blockNumber)
 	if err != nil {
 		if errors.Is(err, ErrCheckHeadState) {
@@ -49,4 +61,16 @@ func (s *stateSnapshot) ContractStorage(addr, key *felt.Felt) (*felt.Felt, error
 		return nil, err
 	}
 	return val, nil
+}
+
+func (s *stateSnapshot) checkDeployed(addr *felt.Felt) error {
+	isDeployed, err := s.state.ContractIsAlreadyDeployedAt(addr, s.blockNumber)
+	if err != nil {
+		return err
+	}
+
+	if !isDeployed {
+		return ErrContractNotDeployed
+	}
+	return nil
 }

--- a/db/buckets.go
+++ b/db/buckets.go
@@ -25,6 +25,7 @@ const (
 	ContractStorageHistory
 	ContractNonceHistory
 	ContractClassHashHistory
+	ContractDeploymentHeight
 )
 
 // Key flattens a prefix and series of byte arrays into a single []byte.

--- a/mocks/mock_state.go
+++ b/mocks/mock_state.go
@@ -64,6 +64,21 @@ func (mr *MockStateHistoryReaderMockRecorder) ContractClassHashAt(arg0, arg1 int
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ContractClassHashAt", reflect.TypeOf((*MockStateHistoryReader)(nil).ContractClassHashAt), arg0, arg1)
 }
 
+// ContractIsAlreadyDeployedAt mocks base method.
+func (m *MockStateHistoryReader) ContractIsAlreadyDeployedAt(arg0 *felt.Felt, arg1 uint64) (bool, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ContractIsAlreadyDeployedAt", arg0, arg1)
+	ret0, _ := ret[0].(bool)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ContractIsAlreadyDeployedAt indicates an expected call of ContractIsAlreadyDeployedAt.
+func (mr *MockStateHistoryReaderMockRecorder) ContractIsAlreadyDeployedAt(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ContractIsAlreadyDeployedAt", reflect.TypeOf((*MockStateHistoryReader)(nil).ContractIsAlreadyDeployedAt), arg0, arg1)
+}
+
 // ContractNonce mocks base method.
 func (m *MockStateHistoryReader) ContractNonce(arg0 *felt.Felt) (*felt.Felt, error) {
 	m.ctrl.T.Helper()


### PR DESCRIPTION
this is useful for snapshots to tell if a contract was deployed before the snapshot block number