### PR TITLE
Ensure Syncing Follows the Rpc spec

### DIFF
--- a/rpc/handlers.go
+++ b/rpc/handlers.go
@@ -421,8 +421,8 @@ func (h *Handler) StateUpdate(id *BlockID) (*StateUpdate, *jsonrpc.Error) {
 //
 // It follows the specification defined here:
 // https://github.com/starkware-libs/starknet-specs/blob/a789ccc3432c57777beceaa53a34a7ae2f25fda0/api/starknet_api_openrpc.json#L569
-func (h *Handler) Syncing() (*SyncState, *jsonrpc.Error) {
-	defaultSyncState := &SyncState{False: new(bool)}
+func (h *Handler) Syncing() (*Sync, *jsonrpc.Error) {
+	defaultSyncState := &Sync{Syncing: new(bool)}
 
 	startingBlockNumber := h.synchronizer.StartingBlockNumber
 	if startingBlockNumber == nil {
@@ -443,15 +443,13 @@ func (h *Handler) Syncing() (*SyncState, *jsonrpc.Error) {
 	if highestBlockHeader.Number < head.Number {
 		return defaultSyncState, nil
 	}
-	return &SyncState{
-		Status: &SyncStatus{
-			StartingBlockHash:   startingBlockHeader.Hash,
-			StartingBlockNumber: NumAsHex(startingBlockHeader.Number),
-			CurrentBlockHash:    head.Hash,
-			CurrentBlockNumber:  NumAsHex(head.Number),
-			HighestBlockHash:    highestBlockHeader.Hash,
-			HighestBlockNumber:  NumAsHex(highestBlockHeader.Number),
-		},
+	return &Sync{
+		StartingBlockHash:   startingBlockHeader.Hash,
+		StartingBlockNumber: NumAsHex(startingBlockHeader.Number),
+		CurrentBlockHash:    head.Hash,
+		CurrentBlockNumber:  NumAsHex(head.Number),
+		HighestBlockHash:    highestBlockHeader.Hash,
+		HighestBlockNumber:  NumAsHex(highestBlockHeader.Number),
 	}, nil
 }
 

--- a/rpc/handlers_test.go
+++ b/rpc/handlers_test.go
@@ -904,12 +904,12 @@ func TestSyncing(t *testing.T) {
 
 	mockReader := mocks.NewMockReader(mockCtrl)
 	handler := rpc.New(mockReader, synchronizer, utils.MAINNET, nil)
-	defaultState := false
+	defaultSyncState := false
 
 	t.Run("undefined starting block", func(t *testing.T) {
 		syncing, err := handler.Syncing()
 		assert.Nil(t, err)
-		assert.Equal(t, &rpc.SyncState{False: &defaultState}, syncing)
+		assert.Equal(t, &rpc.Sync{Syncing: &defaultSyncState}, syncing)
 	})
 
 	startingBlock := uint64(0)
@@ -919,7 +919,7 @@ func TestSyncing(t *testing.T) {
 
 		syncing, err := handler.Syncing()
 		assert.Nil(t, err)
-		assert.Equal(t, &rpc.SyncState{False: &defaultState}, syncing)
+		assert.Equal(t, &rpc.Sync{Syncing: &defaultSyncState}, syncing)
 	})
 	t.Run("undefined highest block", func(t *testing.T) {
 		mockReader.EXPECT().BlockHeaderByNumber(startingBlock).Return(&core.Header{}, nil)
@@ -927,7 +927,7 @@ func TestSyncing(t *testing.T) {
 
 		syncing, err := handler.Syncing()
 		assert.Nil(t, err)
-		assert.Equal(t, &rpc.SyncState{False: &defaultState}, syncing)
+		assert.Equal(t, &rpc.Sync{Syncing: &defaultSyncState}, syncing)
 	})
 	t.Run("block height is greater than highest block", func(t *testing.T) {
 		mockReader.EXPECT().BlockHeaderByNumber(startingBlock).Return(&core.Header{}, nil)
@@ -935,22 +935,20 @@ func TestSyncing(t *testing.T) {
 
 		syncing, err := handler.Syncing()
 		assert.Nil(t, err)
-		assert.Equal(t, &rpc.SyncState{False: &defaultState}, syncing)
+		assert.Equal(t, &rpc.Sync{Syncing: &defaultSyncState}, syncing)
 	})
 	synchronizer.HighestBlockHeader = &core.Header{Number: 2, Hash: new(felt.Felt).SetUint64(2)}
 	t.Run("syncing", func(t *testing.T) {
 		mockReader.EXPECT().BlockHeaderByNumber(startingBlock).Return(&core.Header{Hash: &felt.Zero}, nil)
 		mockReader.EXPECT().HeadsHeader().Return(&core.Header{Number: 1, Hash: new(felt.Felt).SetUint64(1)}, nil)
 
-		expectedSyncing := &rpc.SyncState{
-			Status: &rpc.SyncStatus{
-				StartingBlockHash:   &felt.Zero,
-				StartingBlockNumber: rpc.NumAsHex(startingBlock),
-				CurrentBlockHash:    new(felt.Felt).SetUint64(1),
-				CurrentBlockNumber:  rpc.NumAsHex(1),
-				HighestBlockHash:    new(felt.Felt).SetUint64(2),
-				HighestBlockNumber:  rpc.NumAsHex(2),
-			},
+		expectedSyncing := &rpc.Sync{
+			StartingBlockHash:   &felt.Zero,
+			StartingBlockNumber: rpc.NumAsHex(startingBlock),
+			CurrentBlockHash:    new(felt.Felt).SetUint64(1),
+			CurrentBlockNumber:  rpc.NumAsHex(1),
+			HighestBlockHash:    new(felt.Felt).SetUint64(2),
+			HighestBlockNumber:  rpc.NumAsHex(2),
 		}
 		syncing, err := handler.Syncing()
 		assert.Nil(t, err)

--- a/rpc/sync.go
+++ b/rpc/sync.go
@@ -1,6 +1,7 @@
 package rpc
 
 import (
+	"encoding/json"
 	"fmt"
 
 	"github.com/NethermindEth/juno/core/felt"
@@ -12,17 +13,25 @@ func (n NumAsHex) MarshalJSON() ([]byte, error) {
 	return []byte(fmt.Sprintf(`"0x%x"`, n)), nil
 }
 
-type SyncState struct {
-	False  *bool       `json:"false,omitempty"`
-	Status *SyncStatus `json:"sync_status,omitempty"`
+// https://github.com/starkware-libs/starknet-specs/blob/a789ccc3432c57777beceaa53a34a7ae2f25fda0/api/starknet_api_openrpc.json#L852
+type Sync struct {
+	Syncing             *bool      `json:"-"`
+	StartingBlockHash   *felt.Felt `json:"starting_block_hash,omitempty"`
+	StartingBlockNumber NumAsHex   `json:"starting_block_number,omitempty"`
+	CurrentBlockHash    *felt.Felt `json:"current_block_hash,omitempty"`
+	CurrentBlockNumber  NumAsHex   `json:"current_block_number,omitempty"`
+	HighestBlockHash    *felt.Felt `json:"highest_block_hash,omitempty"`
+	HighestBlockNumber  NumAsHex   `json:"highest_block_number,omitempty"`
 }
 
-// https://github.com/starkware-libs/starknet-specs/blob/a789ccc3432c57777beceaa53a34a7ae2f25fda0/api/starknet_api_openrpc.json#L852
-type SyncStatus struct {
-	StartingBlockHash   *felt.Felt `json:"starting_block_hash"`
-	StartingBlockNumber NumAsHex   `json:"starting_block_number"`
-	CurrentBlockHash    *felt.Felt `json:"current_block_hash"`
-	CurrentBlockNumber  NumAsHex   `json:"current_block_number"`
-	HighestBlockHash    *felt.Felt `json:"highest_block_hash"`
-	HighestBlockNumber  NumAsHex   `json:"highest_block_number"`
+func (s Sync) MarshalJSON() ([]byte, error) {
+	if s.Syncing != nil && !*s.Syncing {
+		return json.Marshal(false)
+	}
+	type Alias Sync
+	return json.Marshal(&struct {
+		Alias
+	}{
+		Alias: Alias(s),
+	})
 }


### PR DESCRIPTION
Syncing
```
{
    "jsonrpc": "2.0",
    "result": {
        ...
    },
    "id": 1
}
```
Not syncing
```
{
    "jsonrpc": "2.0",
    "result": false,
    "id": 1
}
```