### PR TITLE
Calculate Trie commitment lazily

### DIFF
--- a/core/contract.go
+++ b/core/contract.go
@@ -143,9 +143,9 @@ func (c *Contract) UpdateStorage(diff []StorageDiff, cb OnValueChanged) error {
 	}
 	// apply the diff
 	for _, pair := range diff {
-		oldValue, err := cStorage.Put(pair.Key, pair.Value)
-		if err != nil {
-			return err
+		oldValue, pErr := cStorage.Put(pair.Key, pair.Value)
+		if pErr != nil {
+			return pErr
 		}
 
 		if oldValue != nil {
@@ -153,6 +153,10 @@ func (c *Contract) UpdateStorage(diff []StorageDiff, cb OnValueChanged) error {
 				return err
 			}
 		}
+	}
+
+	if err = cStorage.Commit(); err != nil {
+		return err
 	}
 
 	// update contract storage root in the database

--- a/core/state.go
+++ b/core/state.go
@@ -166,6 +166,10 @@ func (s *State) globalTrie(bucket db.Bucket, newTrie trie.NewTrieFunc) (*trie.Tr
 
 	// prep closer
 	closer := func() error {
+		if err = gTrie.Commit(); err != nil {
+			return err
+		}
+
 		resultingRootKey := gTrie.RootKey()
 		// no updates on the trie, short circuit and return
 		if resultingRootKey.Equal(rootKey) {

--- a/core/state.go
+++ b/core/state.go
@@ -53,7 +53,7 @@ func NewState(txn db.Transaction) *State {
 
 // putNewContract creates a contract storage instance in the state and stores the relation between contract address and class hash to be
 // queried later with [GetContractClass].
-func (s *State) putNewContract(addr, classHash *felt.Felt, blockNumber uint64) error {
+func (s *State) putNewContract(stateTrie *trie.Trie, addr, classHash *felt.Felt, blockNumber uint64) error {
 	contract, err := DeployContract(addr, classHash, s.txn)
 	if err != nil {
 		return err
@@ -65,7 +65,7 @@ func (s *State) putNewContract(addr, classHash *felt.Felt, blockNumber uint64) e
 		return err
 	}
 
-	return s.updateContractCommitment(contract)
+	return s.updateContractCommitment(stateTrie, contract)
 }
 
 // ContractClassHash returns class hash of a contract at a given address.
@@ -228,16 +228,21 @@ func (s *State) Update(blockNumber uint64, update *StateUpdate, declaredClasses 
 }
 
 func (s *State) updateContracts(blockNumber uint64, diff *StateDiff) error {
+	stateTrie, storageCloser, err := s.storage()
+	if err != nil {
+		return err
+	}
+
 	// register deployed contracts
 	for _, contract := range diff.DeployedContracts {
-		if err := s.putNewContract(contract.Address, contract.ClassHash, blockNumber); err != nil {
+		if err := s.putNewContract(stateTrie, contract.Address, contract.ClassHash, blockNumber); err != nil {
 			return err
 		}
 	}
 
 	// replace contract instances
 	for _, replace := range diff.ReplacedClasses {
-		oldClassHash, err := s.replaceContract(replace.Address, replace.ClassHash)
+		oldClassHash, err := s.replaceContract(stateTrie, replace.Address, replace.ClassHash)
 		if err != nil {
 			return err
 		}
@@ -249,7 +254,7 @@ func (s *State) updateContracts(blockNumber uint64, diff *StateDiff) error {
 
 	// update contract nonces
 	for addr, nonce := range diff.Nonces {
-		oldNonce, err := s.updateContractNonce(&addr, nonce)
+		oldNonce, err := s.updateContractNonce(stateTrie, &addr, nonce)
 		if err != nil {
 			return err
 		}
@@ -265,16 +270,16 @@ func (s *State) updateContracts(blockNumber uint64, diff *StateDiff) error {
 			return s.LogContractStorage(&addr, location, oldValue, blockNumber)
 		}
 
-		if err := s.updateContractStorage(&addr, storageDiff, onValueChanged); err != nil {
+		if err := s.updateContractStorage(stateTrie, &addr, storageDiff, onValueChanged); err != nil {
 			return err
 		}
 	}
 
-	return nil
+	return storageCloser()
 }
 
 // replaceContract replaces the class that a contract at a given address instantiates
-func (s *State) replaceContract(addr, classHash *felt.Felt) (*felt.Felt, error) {
+func (s *State) replaceContract(stateTrie *trie.Trie, addr, classHash *felt.Felt) (*felt.Felt, error) {
 	contract, err := NewContract(addr, s.txn)
 	if err != nil {
 		return nil, err
@@ -289,7 +294,7 @@ func (s *State) replaceContract(addr, classHash *felt.Felt) (*felt.Felt, error) 
 		return nil, err
 	}
 
-	if err = s.updateContractCommitment(contract); err != nil {
+	if err = s.updateContractCommitment(stateTrie, contract); err != nil {
 		return nil, err
 	}
 
@@ -338,7 +343,7 @@ func (s *State) Class(classHash *felt.Felt) (*DeclaredClass, error) {
 
 // updateContractStorage applies the diff set to the Trie of the
 // contract at the given address in the given Txn context.
-func (s *State) updateContractStorage(addr *felt.Felt, diff []StorageDiff, onChanged OnValueChanged) error {
+func (s *State) updateContractStorage(stateTrie *trie.Trie, addr *felt.Felt, diff []StorageDiff, onChanged OnValueChanged) error {
 	contract, err := NewContract(addr, s.txn)
 	if err != nil {
 		return err
@@ -348,12 +353,12 @@ func (s *State) updateContractStorage(addr *felt.Felt, diff []StorageDiff, onCha
 		return err
 	}
 
-	return s.updateContractCommitment(contract)
+	return s.updateContractCommitment(stateTrie, contract)
 }
 
 // updateContractNonce updates nonce of the contract at the
 // given address in the given Txn context.
-func (s *State) updateContractNonce(addr, nonce *felt.Felt) (*felt.Felt, error) {
+func (s *State) updateContractNonce(stateTrie *trie.Trie, addr, nonce *felt.Felt) (*felt.Felt, error) {
 	contract, err := NewContract(addr, s.txn)
 	if err != nil {
 		return nil, err
@@ -368,7 +373,7 @@ func (s *State) updateContractNonce(addr, nonce *felt.Felt) (*felt.Felt, error) 
 		return nil, err
 	}
 
-	if err = s.updateContractCommitment(contract); err != nil {
+	if err = s.updateContractCommitment(stateTrie, contract); err != nil {
 		return nil, err
 	}
 
@@ -376,7 +381,7 @@ func (s *State) updateContractNonce(addr, nonce *felt.Felt) (*felt.Felt, error) 
 }
 
 // updateContractCommitment recalculates the contract commitment and updates its value in the global state Trie
-func (s *State) updateContractCommitment(contract *Contract) error {
+func (s *State) updateContractCommitment(stateTrie *trie.Trie, contract *Contract) error {
 	root, err := contract.Root()
 	if err != nil {
 		return err
@@ -394,16 +399,8 @@ func (s *State) updateContractCommitment(contract *Contract) error {
 
 	commitment := calculateContractCommitment(root, cHash, nonce)
 
-	state, storageCloser, err := s.storage()
-	if err != nil {
-		return err
-	}
-
-	if _, err = state.Put(contract.Address, commitment); err != nil {
-		return err
-	}
-
-	return storageCloser()
+	_, err = stateTrie.Put(contract.Address, commitment)
+	return err
 }
 
 func calculateContractCommitment(storageRoot, classHash, nonce *felt.Felt) *felt.Felt {

--- a/core/trie/trie.go
+++ b/core/trie/trie.go
@@ -45,6 +45,8 @@ type Trie struct {
 	maxKey  *felt.Felt
 	storage Storage
 	hash    hashFunc
+
+	dirtyNodes []*bitset.BitSet
 }
 
 type NewTrieFunc func(Storage, uint, *bitset.BitSet) (*Trie, error)
@@ -191,174 +193,175 @@ func (t *Trie) Put(key, value *felt.Felt) (*felt.Felt, error) {
 		Value: value,
 	}
 
-	// empty trie, make new value root
-	if t.rootKey == nil {
-		if value.IsZero() {
-			return nil, nil // no-op
-		}
-
-		if err := t.propagateValues([]storageNode{
-			{key: nodeKey, node: node},
-		}); err != nil {
-			return nil, err
-		}
-		t.rootKey = nodeKey
-		return old, nil
-	}
-
 	nodes, err := t.nodesFromRoot(nodeKey)
 	if err != nil {
 		return nil, err
 	}
 
-	// Replace if key already exist
-	sibling := &nodes[len(nodes)-1]
-	if nodeKey.Equal(sibling.key) {
-		old = sibling.node.Value // record old value to return to caller
-		sibling.node = node
+	// empty trie, make new value root
+	if len(nodes) == 0 {
 		if value.IsZero() {
-			if err = t.deleteLast(nodes); err != nil {
+			return nil, nil // no-op
+		}
+
+		if err = t.storage.Put(nodeKey, node); err != nil {
+			return nil, err
+		}
+		t.rootKey = nodeKey
+		return old, nil
+	} else {
+		// Replace if key already exist
+		sibling := nodes[len(nodes)-1]
+		if nodeKey.Equal(sibling.key) {
+			old = sibling.node.Value // record old value to return to caller
+			if value.IsZero() {
+				if err = t.deleteLast(nodes); err != nil {
+					return nil, err
+				}
+				return old, nil
+			}
+
+			if err = t.storage.Put(nodeKey, node); err != nil {
 				return nil, err
 			}
-		} else if err = t.propagateValues(nodes); err != nil {
+			t.dirtyNodes = append(t.dirtyNodes, nodeKey)
+			return old, nil
+		} else if value.IsZero() {
+			// trying to insert 0 to a key that does not exist
+			return nil, nil // no-op
+		}
+
+		commonKey, _ := findCommonKey(nodeKey, sibling.key)
+		newParent := &Node{}
+		var leftChild, rightChild *Node
+		if nodeKey.Test(nodeKey.Len() - commonKey.Len() - 1) {
+			newParent.Left, newParent.Right = sibling.key, nodeKey
+			leftChild, rightChild = sibling.node, node
+		} else {
+			newParent.Left, newParent.Right = nodeKey, sibling.key
+			leftChild, rightChild = node, sibling.node
+		}
+
+		leftPath := path(newParent.Left, commonKey)
+		rightPath := path(newParent.Right, commonKey)
+
+		newParent.Value = t.hash(leftChild.Hash(leftPath, t.hash), rightChild.Hash(rightPath, t.hash))
+		if err = t.storage.Put(commonKey, newParent); err != nil {
+			return nil, err
+		}
+
+		if len(nodes) > 1 { // sibling has a parent
+			siblingParent := nodes[len(nodes)-2]
+
+			// replace the link to our sibling with the new parent
+			if siblingParent.node.Left.Equal(sibling.key) {
+				siblingParent.node.Left = commonKey
+			} else {
+				siblingParent.node.Right = commonKey
+			}
+
+			if err = t.storage.Put(siblingParent.key, siblingParent.node); err != nil {
+				return nil, err
+			}
+			t.dirtyNodes = append(t.dirtyNodes, commonKey)
+		} else {
+			t.rootKey = commonKey
+		}
+
+		if err = t.storage.Put(nodeKey, node); err != nil {
 			return nil, err
 		}
 		return old, nil
 	}
+}
 
-	// trying to insert 0 to a key that does not exist
-	if value.IsZero() {
-		return nil, nil // no-op
+func (t *Trie) updateValueIfDirty(key *bitset.BitSet) (*Node, error) {
+	node, err := t.storage.Get(key)
+	if err != nil {
+		return nil, err
 	}
 
-	commonKey, _ := findCommonKey(nodeKey, sibling.key)
-	newParent := &Node{
-		Value: new(felt.Felt),
-	}
-	if nodeKey.Test(nodeKey.Len() - commonKey.Len() - 1) {
-		newParent.Left, newParent.Right = sibling.key, nodeKey
-	} else {
-		newParent.Left, newParent.Right = nodeKey, sibling.key
+	// leaf node
+	if key.Len() == t.height {
+		return node, nil
 	}
 
-	makeRoot := len(nodes) == 1
-	if !makeRoot { // sibling has a parent
-		siblingParent := &nodes[len(nodes)-2]
-
-		// replace the link to our sibling with the new parent
-		if siblingParent.node.Left.Equal(sibling.key) {
-			siblingParent.node.Left = commonKey
-		} else {
-			siblingParent.node.Right = commonKey
+	shouldUpdate := false
+	for _, dirtyNode := range t.dirtyNodes {
+		if key.Len() < dirtyNode.Len() {
+			_, shouldUpdate = findCommonKey(dirtyNode, key)
+			if shouldUpdate {
+				break
+			}
 		}
 	}
 
-	// replace sibling with new parent
-	nodes[len(nodes)-1] = storageNode{
-		key: commonKey, node: newParent,
+	if !shouldUpdate {
+		return node, nil
 	}
-	// add new node to steps
-	nodes = append(nodes, storageNode{
-		key: nodeKey, node: node,
-	})
 
-	// push commitment changes
-	if err = t.propagateValues(nodes); err != nil {
+	leftChild, err := t.updateValueIfDirty(node.Left)
+	if err != nil {
 		return nil, err
-	} else if makeRoot {
-		t.rootKey = commonKey
 	}
-	return old, nil
+	rightChild, err := t.updateValueIfDirty(node.Right)
+	if err != nil {
+		return nil, err
+	}
+
+	leftPath := path(node.Left, key)
+	rightPath := path(node.Right, key)
+
+	node.Value = t.hash(leftChild.Hash(leftPath, t.hash), rightChild.Hash(rightPath, t.hash))
+
+	if err = t.storage.Put(key, node); err != nil {
+		return nil, err
+	}
+	return node, nil
 }
 
-// deleteLast deletes the last node in the given list and recalculates commitment
-func (t *Trie) deleteLast(affectedNodes []storageNode) error {
-	last := affectedNodes[len(affectedNodes)-1]
+// deleteLast deletes the last node in the given list
+func (t *Trie) deleteLast(nodes []storageNode) error {
+	last := nodes[len(nodes)-1]
 	if err := t.storage.Delete(last.key); err != nil {
 		return err
 	}
 
-	if len(affectedNodes) == 1 { // deleted node was root
+	if len(nodes) == 1 { // deleted node was root
 		t.rootKey = nil
+		return nil
+	}
+
+	// parent now has only a single child, so delete
+	parent := nodes[len(nodes)-2]
+	if err := t.storage.Delete(parent.key); err != nil {
+		return err
+	}
+
+	var siblingKey *bitset.BitSet
+	if parent.node.Left.Equal(last.key) {
+		siblingKey = parent.node.Right
 	} else {
-		// parent now has only a single child, so delete
-		parent := affectedNodes[len(affectedNodes)-2]
-		if err := t.storage.Delete(parent.key); err != nil {
-			return err
-		}
-
-		var siblingKey *bitset.BitSet
-		if parent.node.Left.Equal(last.key) {
-			siblingKey = parent.node.Right
-		} else {
-			siblingKey = parent.node.Left
-		}
-
-		if len(affectedNodes) == 2 { // sibling should become root
-			t.rootKey = siblingKey
-		} else { // sibling should link to grandparent (len(affectedNodes) > 2)
-			grandParent := &affectedNodes[len(affectedNodes)-3]
-			// replace link to parent with a link to sibling
-			if grandParent.node.Left.Equal(parent.key) {
-				grandParent.node.Left = siblingKey
-			} else {
-				grandParent.node.Right = siblingKey
-			}
-
-			if sibling, err := t.storage.Get(siblingKey); err != nil {
-				return err
-			} else {
-				// rebuild the list of affected nodes
-				affectedNodes = affectedNodes[:len(affectedNodes)-2] // drop last and parent
-				// add sibling
-				affectedNodes = append(affectedNodes, storageNode{
-					key:  siblingKey,
-					node: sibling,
-				})
-
-				// finally recalculate commitment
-				return t.propagateValues(affectedNodes)
-			}
-		}
+		siblingKey = parent.node.Left
 	}
 
-	return nil
-}
-
-// Recalculates [Trie] commitment by propagating `bottom` values as described in the [docs]
-//
-// [docs]: https://docs.starknet.io/documentation/develop/State/starknet-state/
-func (t *Trie) propagateValues(affectedNodes []storageNode) error {
-	for idx := len(affectedNodes) - 1; idx >= 0; idx-- {
-		cur := affectedNodes[idx]
-
-		if (cur.node.Left == nil) != (cur.node.Right == nil) {
-			panic("should not happen")
-		}
-
-		if cur.node.Left != nil || cur.node.Right != nil {
-			// todo: one of the children is already in affectedNodes, use that instead of fetching from storage
-			left, err := t.storage.Get(cur.node.Left)
-			if err != nil {
-				return err
-			}
-
-			right, err := t.storage.Get(cur.node.Right)
-			if err != nil {
-				return err
-			}
-
-			leftPath := path(cur.node.Left, cur.key)
-			rightPath := path(cur.node.Right, cur.key)
-
-			cur.node.Value = t.hash(left.Hash(leftPath, t.hash), right.Hash(rightPath, t.hash))
-		}
-
-		if err := t.storage.Put(cur.key, cur.node); err != nil {
-			return err
-		}
+	if len(nodes) == 2 { // sibling should become root
+		t.rootKey = siblingKey
+		return nil
+	}
+	// sibling should link to grandparent (len(affectedNodes) > 2)
+	grandParent := &nodes[len(nodes)-3]
+	// replace link to parent with a link to sibling
+	if grandParent.node.Left.Equal(parent.key) {
+		grandParent.node.Left = siblingKey
+	} else {
+		grandParent.node.Right = siblingKey
 	}
 
+	if err := t.storage.Put(grandParent.key, grandParent.node); err != nil {
+		return err
+	}
+	t.dirtyNodes = append(t.dirtyNodes, siblingKey)
 	return nil
 }
 
@@ -368,13 +371,20 @@ func (t *Trie) Root() (*felt.Felt, error) {
 		return new(felt.Felt), nil
 	}
 
-	root, err := t.storage.Get(t.rootKey)
+	root, err := t.updateValueIfDirty(t.rootKey)
 	if err != nil {
 		return nil, err
 	}
+	t.dirtyNodes = nil
 
 	path := path(t.rootKey, nil)
 	return root.Hash(path, t.hash), nil
+}
+
+// Commit forces root calculation
+func (t *Trie) Commit() error {
+	_, err := t.Root()
+	return err
 }
 
 // RootKey returns db key of the [Trie] root node

--- a/core/trie/trie_test.go
+++ b/core/trie/trie_test.go
@@ -311,8 +311,10 @@ func BenchmarkTriePut(b *testing.B) {
 		b.ResetTimer()
 		for i := 0; i < b.N; i++ {
 			_, err := t.Put(keys[i], one)
-			require.NoError(b, err)
+			if err != nil {
+				return err
+			}
 		}
-		return nil
+		return t.Commit()
 	}))
 }


### PR DESCRIPTION
defer commitment calculation until the user calls Trie.Commit or Trie.Root explicitly. This results in %15 less Pedersen calculations during sync

Fixes #751