### PR TITLE
Update pprof address to 0.0.0.0

### DIFF
--- a/pprof/pprof.go
+++ b/pprof/pprof.go
@@ -21,7 +21,7 @@ type Profiler struct {
 
 func New(port uint16, log utils.SimpleLogger) *Profiler {
 	server := &http.Server{
-		Addr:              "localhost:" + strconv.Itoa(int(port)),
+		Addr:              "0.0.0.0:" + strconv.Itoa(int(port)),
 		Handler:           http.DefaultServeMux,
 		ReadHeaderTimeout: 5 * time.Second,
 	}


### PR DESCRIPTION
This PR modifies the pprof configuration to listen on 0.0.0.0 instead of localhost. This allows external access to the pprof endpoint when running Juno inside a Docker container. By listening on all network interfaces (0.0.0.0), we can now easily connect to the pprof endpoints from outside of the Docker container.