### PR TITLE
Bump supported starknet version

### DIFF
--- a/blockchain/blockchain.go
+++ b/blockchain/blockchain.go
@@ -40,7 +40,7 @@ type Reader interface {
 	EventFilter(from *felt.Felt, keys []*felt.Felt) (*EventFilter, error)
 }
 
-var supportedStarknetVersion = semver.MustParse("0.11.1")
+var supportedStarknetVersion = semver.MustParse("0.11.2")
 
 func checkBlockVersion(protocolVersion string) error {
 	blockVer, err := core.ParseBlockVersion(protocolVersion)


### PR DESCRIPTION
go straight from 0.11.1 to 0.11.2 as it will only be a compiler update