### PR TITLE
Relax decoder max array elements limit

### DIFF
--- a/encoder/encoder.go
+++ b/encoder/encoder.go
@@ -29,7 +29,9 @@ func initEncAndDecModes() {
 		panic(err)
 	}
 
-	decMode, err = cbor.DecOptions{}.DecModeWithTags(ts)
+	decMode, err = cbor.DecOptions{
+		MaxArrayElements: 10485760, // Set to a reasonably high value, 10MiB
+	}.DecModeWithTags(ts)
 	if err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
Apparently our staging goerli node couldnt continue syncing because of this

```
new class cbor: exceeded max number of elements 131072 for CBOR array
new class cbor: exceeded max number of elements 131072 for CBOR array
new class cbor: exceeded max number of elements 131072 for CBOR array
new class cbor: exceeded max number of elements 131072 for CBOR array
new class cbor: exceeded max number of elements 131072 for CBOR array
```