### PR TITLE
Make `core.State` calculate commitment lazily

### DIFF
--- a/blockchain/blockchain.go
+++ b/blockchain/blockchain.go
@@ -82,7 +82,7 @@ func (b *Blockchain) Network() utils.Network {
 // If blockchain is empty zero felt is returned.
 func (b *Blockchain) StateCommitment() (*felt.Felt, error) {
 	var commitment *felt.Felt
-	return commitment, b.database.View(func(txn db.Transaction) error {
+	return commitment, b.database.Update(func(txn db.Transaction) error {
 		var err error
 		commitment, err = core.NewState(txn).Root()
 		return err

--- a/core/contract.go
+++ b/core/contract.go
@@ -160,7 +160,7 @@ func (c *Contract) UpdateStorage(diff []StorageDiff, cb OnValueChanged) error {
 	}
 
 	// update contract storage root in the database
-	rootKeyDBKey := db.ContractRootKey.Key(c.Address.Marshal())
+	rootKeyDBKey := db.ContractStorage.Key(c.Address.Marshal())
 	if rootKey := cStorage.RootKey(); rootKey != nil {
 		rootKeyBytes, err := rootKey.MarshalBinary()
 		if err != nil {
@@ -215,7 +215,7 @@ func storage(addr *felt.Felt, txn db.Transaction) (*trie.Trie, error) {
 	addrBytes := addr.Marshal()
 	var contractRootKey *bitset.BitSet
 
-	if err := txn.Get(db.ContractRootKey.Key(addrBytes), func(val []byte) error {
+	if err := txn.Get(db.ContractStorage.Key(addrBytes), func(val []byte) error {
 		contractRootKey = new(bitset.BitSet)
 		return contractRootKey.UnmarshalBinary(val)
 	}); err != nil && !errors.Is(err, db.ErrKeyNotFound) {

--- a/core/trie/transaction_storage_test.go
+++ b/core/trie/transaction_storage_test.go
@@ -61,6 +61,41 @@ func TestTransactionStorage(t *testing.T) {
 		}))
 	})
 
+	t.Run("get the root key", func(t *testing.T) {
+		// Root key should be empty
+		require.NoError(t, testDB.View(func(txn db.Transaction) error {
+			tTxn := trie.NewTransactionStorage(txn, prefix)
+			rootKey, err := tTxn.RootKey()
+			require.NoError(t, err)
+			assert.Nil(t, rootKey)
+			return err
+		}))
+	})
+
+	t.Run("update the root key", func(t *testing.T) {
+		require.NoError(t, testDB.Update(func(txn db.Transaction) error {
+			tTxn := trie.NewTransactionStorage(txn, prefix)
+			rootKey := bitset.New(3).Set(0)
+			err := tTxn.UpdateRootKey(rootKey)
+			require.NoError(t, err)
+
+			// Retrieve root key and ensure it matches.
+			txnRootKey, err := tTxn.RootKey()
+			require.NoError(t, err)
+			assert.Equal(t, rootKey, txnRootKey)
+
+			// Delete the root key by updating it to nil.
+			rootKey = nil
+			err = tTxn.UpdateRootKey(rootKey)
+			require.NoError(t, err)
+			txnRootKey, err = tTxn.RootKey()
+			require.NoError(t, err)
+			assert.Equal(t, rootKey, txnRootKey)
+
+			return err
+		}))
+	})
+
 	t.Run("delete a node", func(t *testing.T) {
 		// Delete a node.
 		require.NoError(t, testDB.Update(func(txn db.Transaction) error {

--- a/core/trie/trie_pkg_test.go
+++ b/core/trie/trie_pkg_test.go
@@ -12,7 +12,7 @@ import (
 
 func TestTrieKeys(t *testing.T) {
 	t.Run("put to empty trie", func(t *testing.T) {
-		tempTrie, err := NewTriePedersen(newMemStorage(), 251, nil)
+		tempTrie, err := NewTriePedersen(newMemStorage(), 251)
 		require.NoError(t, err)
 		keyNum, err := strconv.ParseUint("1101", 2, 64)
 		require.NoError(t, err)
@@ -31,7 +31,7 @@ func TestTrieKeys(t *testing.T) {
 	})
 
 	t.Run("put a left then a right node", func(t *testing.T) {
-		tempTrie, err := NewTriePedersen(newMemStorage(), 251, nil)
+		tempTrie, err := NewTriePedersen(newMemStorage(), 251)
 		require.NoError(t, err)
 		// First put a left node
 		leftKeyNum, err := strconv.ParseUint("10001", 2, 64)
@@ -73,7 +73,7 @@ func TestTrieKeys(t *testing.T) {
 	})
 
 	t.Run("put a right node then a left node", func(t *testing.T) {
-		tempTrie, err := NewTriePedersen(newMemStorage(), 251, nil)
+		tempTrie, err := NewTriePedersen(newMemStorage(), 251)
 		require.NoError(t, err)
 		// First put a right node
 		rightKeyNum, err := strconv.ParseUint("10011", 2, 64)
@@ -110,7 +110,7 @@ func TestTrieKeys(t *testing.T) {
 	})
 
 	t.Run("Add new key to different branches", func(t *testing.T) {
-		tempTrie, err := NewTriePedersen(newMemStorage(), 251, nil)
+		tempTrie, err := NewTriePedersen(newMemStorage(), 251)
 		require.NoError(t, err)
 		// left branch
 		leftKeyNum, err := strconv.ParseUint("100", 2, 64)
@@ -235,7 +235,7 @@ func TestTrieKeysAfterDeleteSubtree(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			tempTrie, err := NewTriePedersen(newMemStorage(), 251, nil)
+			tempTrie, err := NewTriePedersen(newMemStorage(), 251)
 			require.NoError(t, err)
 			// Build a basic trie
 			_, err = tempTrie.Put(leftLeftKey, leftLeftVal)

--- a/db/buckets.go
+++ b/db/buckets.go
@@ -9,7 +9,6 @@ type Bucket byte
 // man's bucket alternative.
 const (
 	StateTrie         Bucket = iota // state metadata (e.g., the state root)
-	ContractRootKey                 // contract storage roots
 	ContractClassHash               // maps contract addresses and class hashes
 	ContractStorage                 // contract storages
 	Class                           // maps class hashes to classes


### PR DESCRIPTION
Takes advantage of @omerfirmak's [foundational PR](https://github.com/NethermindEth/juno/commit/11e0d64375ce479cc0d3af409c49c44375656656) that made the trie commitment calculation lazy. 

This shouldn't improve or degrade performance, since the `blockchain` is still calculating the commitment after every block. For now, this PR is primarily a refactor that enables us to defer commitment calculation for multiple blocks if we decide to do so.

The first few commits refactor some code to make the last commit (the one that actually makes `state.Root()` lazy) easier to understand. 

The commit messages have more details.