### PR TITLE
Use less explicit conversions in feeder adaption layer where applicable 

### DIFF
--- a/blockchain/event_filter.go
+++ b/blockchain/event_filter.go
@@ -81,7 +81,7 @@ func (c *ContinuationToken) FromString(str string) error {
 }
 
 type FilteredEvent struct {
-	*core.Event
+	core.Event
 	BlockNumber     uint64
 	BlockHash       *felt.Felt
 	TransactionHash *felt.Felt

--- a/clients/feeder/transaction.go
+++ b/clients/feeder/transaction.go
@@ -67,7 +67,7 @@ type BuiltinInstanceCounter struct {
 
 type TransactionReceipt struct {
 	ActualFee          *felt.Felt          `json:"actual_fee"`
-	Events             []*Event            `json:"events"`
+	Events             []Event             `json:"events"`
 	ExecutionResources *ExecutionResources `json:"execution_resources"`
 	L1ToL2Message      *L1ToL2Message      `json:"l1_to_l2_consumed_message"`
 	L2ToL1Message      []*L2ToL1Message    `json:"l2_to_l1_messages"`

--- a/core/transaction.go
+++ b/core/transaction.go
@@ -42,12 +42,12 @@ type ExecutionResources struct {
 }
 
 type BuiltinInstanceCounter struct {
-	Bitwise    uint64
-	EcOp       uint64
-	Ecsda      uint64
-	Output     uint64
 	Pedersen   uint64
 	RangeCheck uint64
+	Bitwise    uint64
+	Output     uint64
+	Ecsda      uint64
+	EcOp       uint64
 }
 
 type TransactionReceipt struct {

--- a/core/transaction.go
+++ b/core/transaction.go
@@ -16,8 +16,8 @@ import (
 )
 
 type Event struct {
-	Data []*felt.Felt
 	From *felt.Felt
+	Data []*felt.Felt
 	Keys []*felt.Felt
 }
 
@@ -52,7 +52,7 @@ type BuiltinInstanceCounter struct {
 
 type TransactionReceipt struct {
 	Fee                *felt.Felt
-	Events             []*Event
+	Events             []Event
 	ExecutionResources *ExecutionResources
 	L1ToL2Message      *L1ToL2Message
 	L2ToL1Message      []*L2ToL1Message

--- a/rpc/events.go
+++ b/rpc/events.go
@@ -20,12 +20,12 @@ type ResultPageRequest struct {
 }
 
 type EventsChunk struct {
-	Events            []*EmittedEvent `json:"events"`
-	ContinuationToken string          `json:"continuation_token,omitempty"`
+	Events            []EmittedEvent `json:"events"`
+	ContinuationToken string         `json:"continuation_token,omitempty"`
 }
 
 type EmittedEvent struct {
-	*Event
+	Event
 	BlockNumber     uint64     `json:"block_number"`
 	BlockHash       *felt.Felt `json:"block_hash"`
 	TransactionHash *felt.Felt `json:"transaction_hash"`

--- a/rpc/handlers.go
+++ b/rpc/handlers.go
@@ -691,17 +691,13 @@ func (h *Handler) Events(args *EventsArg) (*EventsChunk, *jsonrpc.Error) {
 		return nil, ErrInternal
 	}
 
-	emittedEvents := make([]*EmittedEvent, 0, len(filteredEvents))
+	emittedEvents := make([]EmittedEvent, 0, len(filteredEvents))
 	for _, fEvent := range filteredEvents {
-		emittedEvents = append(emittedEvents, &EmittedEvent{
+		emittedEvents = append(emittedEvents, EmittedEvent{
 			BlockNumber:     fEvent.BlockNumber,
 			BlockHash:       fEvent.BlockHash,
 			TransactionHash: fEvent.TransactionHash,
-			Event: &Event{
-				From: fEvent.From,
-				Keys: fEvent.Keys,
-				Data: fEvent.Data,
-			},
+			Event:           Event(fEvent.Event),
 		})
 	}
 

--- a/rpc/handlers_test.go
+++ b/rpc/handlers_test.go
@@ -1426,7 +1426,7 @@ func TestEvents(t *testing.T) {
 	})
 
 	t.Run("filter with no keys", func(t *testing.T) {
-		var allEvents []*rpc.EmittedEvent
+		var allEvents []rpc.EmittedEvent
 		t.Run("get all events without pagination", func(t *testing.T) {
 			args.ToBlock = &rpc.BlockID{Latest: true}
 			args.Address = from
@@ -1438,7 +1438,7 @@ func TestEvents(t *testing.T) {
 		})
 
 		t.Run("accumulate events with pagination", func(t *testing.T) {
-			var accEvents []*rpc.EmittedEvent
+			var accEvents []rpc.EmittedEvent
 			args.ChunkSize = 1
 
 			for i := 0; i < len(allEvents)+1; i++ {

--- a/rpc/transaction.go
+++ b/rpc/transaction.go
@@ -59,8 +59,8 @@ type MsgToL1 struct {
 
 type Event struct {
 	From *felt.Felt   `json:"from_address"`
-	Keys []*felt.Felt `json:"keys"`
 	Data []*felt.Felt `json:"data"`
+	Keys []*felt.Felt `json:"keys"`
 }
 
 // https://github.com/starkware-libs/starknet-specs/blob/master/api/starknet_api_openrpc.json#L1871

--- a/starknetdata/feeder/feeder.go
+++ b/starknetdata/feeder/feeder.go
@@ -92,9 +92,9 @@ func adaptTransactionReceipt(response *feeder.TransactionReceipt) *core.Transact
 		return nil
 	}
 
-	events := make([]*core.Event, len(response.Events))
+	events := make([]core.Event, len(response.Events))
 	for i, event := range response.Events {
-		events[i] = adaptEvent(event)
+		events[i] = core.Event(event)
 	}
 
 	l2ToL1Messages := make([]*core.L2ToL1Message, len(response.L2ToL1Message))
@@ -109,18 +109,6 @@ func adaptTransactionReceipt(response *feeder.TransactionReceipt) *core.Transact
 		ExecutionResources: adaptExecutionResources(response.ExecutionResources),
 		L1ToL2Message:      adaptL1ToL2Message(response.L1ToL2Message),
 		L2ToL1Message:      l2ToL1Messages,
-	}
-}
-
-func adaptEvent(response *feeder.Event) *core.Event {
-	if response == nil {
-		return nil
-	}
-
-	return &core.Event{
-		Data: response.Data,
-		From: response.From,
-		Keys: response.Keys,
 	}
 }
 

--- a/starknetdata/feeder/feeder.go
+++ b/starknetdata/feeder/feeder.go
@@ -281,15 +281,15 @@ func adaptCairo1Class(response *feeder.SierraDefinition, compiledClass json.RawM
 
 	class.EntryPoints.External = make([]core.SierraEntryPoint, len(response.EntryPoints.External))
 	for index, v := range response.EntryPoints.External {
-		class.EntryPoints.External[index] = core.SierraEntryPoint{Index: v.Index, Selector: v.Selector}
+		class.EntryPoints.External[index] = core.SierraEntryPoint(v)
 	}
 	class.EntryPoints.L1Handler = make([]core.SierraEntryPoint, len(response.EntryPoints.L1Handler))
 	for index, v := range response.EntryPoints.L1Handler {
-		class.EntryPoints.L1Handler[index] = core.SierraEntryPoint{Index: v.Index, Selector: v.Selector}
+		class.EntryPoints.L1Handler[index] = core.SierraEntryPoint(v)
 	}
 	class.EntryPoints.Constructor = make([]core.SierraEntryPoint, len(response.EntryPoints.Constructor))
 	for index, v := range response.EntryPoints.Constructor {
-		class.EntryPoints.Constructor[index] = core.SierraEntryPoint{Index: v.Index, Selector: v.Selector}
+		class.EntryPoints.Constructor[index] = core.SierraEntryPoint(v)
 	}
 
 	if err = json.Unmarshal(compiledClass, &class.Compiled); err != nil {
@@ -304,17 +304,17 @@ func adaptCairo0Class(response *feeder.Cairo0Definition) (core.Class, error) {
 
 	class.Externals = []core.EntryPoint{}
 	for _, v := range response.EntryPoints.External {
-		class.Externals = append(class.Externals, core.EntryPoint{Selector: v.Selector, Offset: v.Offset})
+		class.Externals = append(class.Externals, core.EntryPoint(v))
 	}
 
 	class.L1Handlers = []core.EntryPoint{}
 	for _, v := range response.EntryPoints.L1Handler {
-		class.L1Handlers = append(class.L1Handlers, core.EntryPoint{Selector: v.Selector, Offset: v.Offset})
+		class.L1Handlers = append(class.L1Handlers, core.EntryPoint(v))
 	}
 
 	class.Constructors = []core.EntryPoint{}
 	for _, v := range response.EntryPoints.Constructor {
-		class.Constructors = append(class.Constructors, core.EntryPoint{Selector: v.Selector, Offset: v.Offset})
+		class.Constructors = append(class.Constructors, core.EntryPoint(v))
 	}
 
 	var program feeder.Program

--- a/starknetdata/feeder/feeder.go
+++ b/starknetdata/feeder/feeder.go
@@ -118,20 +118,9 @@ func adaptExecutionResources(response *feeder.ExecutionResources) *core.Executio
 	}
 
 	return &core.ExecutionResources{
-		BuiltinInstanceCounter: adaptBuiltinInstanceCounter(response.BuiltinInstanceCounter),
+		BuiltinInstanceCounter: core.BuiltinInstanceCounter(response.BuiltinInstanceCounter),
 		MemoryHoles:            response.MemoryHoles,
 		Steps:                  response.Steps,
-	}
-}
-
-func adaptBuiltinInstanceCounter(response feeder.BuiltinInstanceCounter) core.BuiltinInstanceCounter {
-	return core.BuiltinInstanceCounter{
-		Bitwise:    response.Bitwise,
-		EcOp:       response.EcOp,
-		Ecsda:      response.Ecsda,
-		Output:     response.Output,
-		Pedersen:   response.Pedersen,
-		RangeCheck: response.RangeCheck,
 	}
 }
 

--- a/starknetdata/feeder/feeder.go
+++ b/starknetdata/feeder/feeder.go
@@ -356,26 +356,17 @@ func adaptStateUpdate(response *feeder.StateUpdate) (*core.StateUpdate, error) {
 
 	stateDiff.DeclaredV1Classes = make([]core.DeclaredV1Class, len(response.StateDiff.DeclaredClasses))
 	for index, declaredV1Class := range response.StateDiff.DeclaredClasses {
-		stateDiff.DeclaredV1Classes[index] = core.DeclaredV1Class{
-			ClassHash:         declaredV1Class.ClassHash,
-			CompiledClassHash: declaredV1Class.CompiledClassHash,
-		}
+		stateDiff.DeclaredV1Classes[index] = core.DeclaredV1Class(declaredV1Class)
 	}
 
 	stateDiff.ReplacedClasses = make([]core.ReplacedClass, len(response.StateDiff.ReplacedClasses))
 	for index, replacedClass := range response.StateDiff.ReplacedClasses {
-		stateDiff.ReplacedClasses[index] = core.ReplacedClass{
-			Address:   replacedClass.Address,
-			ClassHash: replacedClass.ClassHash,
-		}
+		stateDiff.ReplacedClasses[index] = core.ReplacedClass(replacedClass)
 	}
 
 	stateDiff.DeployedContracts = make([]core.DeployedContract, len(response.StateDiff.DeployedContracts))
 	for index, deployedContract := range response.StateDiff.DeployedContracts {
-		stateDiff.DeployedContracts[index] = core.DeployedContract{
-			Address:   deployedContract.Address,
-			ClassHash: deployedContract.ClassHash,
-		}
+		stateDiff.DeployedContracts[index] = core.DeployedContract(deployedContract)
 	}
 
 	stateDiff.Nonces = make(map[felt.Felt]*felt.Felt)
@@ -394,12 +385,9 @@ func adaptStateUpdate(response *feeder.StateUpdate) (*core.StateUpdate, error) {
 			return nil, err
 		}
 
-		stateDiff.StorageDiffs[*addr] = []core.StorageDiff{}
+		stateDiff.StorageDiffs[*addr] = make([]core.StorageDiff, 0, len(diffs))
 		for _, diff := range diffs {
-			stateDiff.StorageDiffs[*addr] = append(stateDiff.StorageDiffs[*addr], core.StorageDiff{
-				Key:   diff.Key,
-				Value: diff.Value,
-			})
+			stateDiff.StorageDiffs[*addr] = append(stateDiff.StorageDiffs[*addr], core.StorageDiff(diff))
 		}
 	}
 


### PR DESCRIPTION
Apparently when both types have exact same fields, there is no need to explicitly enumerate each field when doing conversions