### PR TITLE
Add rpc test workflow

### DIFF
--- a/.github/workflows/rpc-tests.yml
+++ b/.github/workflows/rpc-tests.yml
@@ -1,0 +1,33 @@
+name: RPC Tests
+
+on:
+  workflow_dispatch:
+    inputs:
+      NODE_ADDRESS:
+        description: 'Target Node Address, e.g http://IP_ADDRESS:PORT'
+        required: true
+      NETWORK:
+        description: 'Target Network'
+        required: true
+        default: 'mainnet'
+
+jobs:
+  RPC_Tests:
+    name: RPC Test Execution
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Juno Smoke Tests
+        uses: actions/checkout@v3.5.2
+        with:
+          repository: NethermindEth/juno-smoke-tests
+          token: ${{ secrets.REPOSITORY_DISPATCH_TOKEN }}
+          
+      - name: Setup Go Environment
+        uses: actions/setup-go@v4.0.1
+        with:
+          go-version: '1.20.5'
+
+      - name: Execute RPC Tests
+        run: |
+          cd rpc-tests/tests
+          go test -v --nodeURL=${{ github.event.inputs.NODE_ADDRESS }} --network=${{ github.event.inputs.NETWORK }}


### PR DESCRIPTION
## Summary

This PR introduces a new GitHub Actions workflow that enables manual execution of RPC Tests. The tests are sourced from the [NethermindEth/juno-smoke-tests](https://github.com/NethermindEth/juno-smoke-tests) repository. The workflow can be triggered manually via the `workflow_dispatch` event, with necessary input parameters like `NODE_ADDRESS` and `NETWORK`.

## Future Plan

The intention is to eventually automate this workflow to be triggered by the "upgrade nodes on test env" action. This will allow us to execute these tests automatically for every main and release version.