### PR TITLE
Increase MaxIdleConnsPerHost for feeder TestClient

### DIFF
--- a/clients/feeder/feeder.go
+++ b/clients/feeder/feeder.go
@@ -68,7 +68,23 @@ type closeTestClient func()
 // NewTestClient returns a client and a function to close a test server.
 func NewTestClient(network utils.Network) (*Client, closeTestClient) {
 	srv := newTestServer(network)
-	return NewClient(srv.URL).WithBackoff(NopBackoff).WithMaxRetries(0), srv.Close
+	c := NewClient(srv.URL).WithBackoff(NopBackoff).WithMaxRetries(0)
+	c.client = &http.Client{
+		Transport: &http.Transport{
+			// On macOS tests often fail with the following error:
+			//
+			// "Get "http://127.0.0.1:xxxx/get_{feeder gateway method}?{arg}={value}": dial tcp 127.0.0.1:xxxx:
+			//    connect: can't assign requested address"
+			//
+			// This error makes running local tests, in quick succession, difficult because we have to wait for the OS to release ports.
+			// Sometimes the sync tests will hang because sync process will keep making requests if there was some error.
+			// This problem is further exacerbated by having parallel tests.
+			//
+			// Increasing test client's idle conns allows for large concurrent requests to be made from a single test client.
+			MaxIdleConnsPerHost: 1000,
+		},
+	}
+	return c, srv.Close
 }
 
 func newTestServer(network utils.Network) *httptest.Server {


### PR DESCRIPTION
On macOS tests often fail with the following error:

"Get "http://127.0.0.1:xxxx/get_{feeder gateway method}?{arg}={value}": dial tcp 127.0.0.1:xxxx: connect: can't assign requested address"

This error make running local tests, in quick succession, difficult because we have to wait for the OS to release ports. Sometimes the sync tests will hang because sync process will keep requesting if there was some error. This problem is further exacerbated by having parallel tests.

Increasing test client's idle conns allow for large concurrent requests to be made from a single test client.