### PR TITLE
Report patch coverage only on pull requests

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -7,7 +7,7 @@ coverage:
     patch:
       default:
         target: 60%
-      only_pulls: true
+        only_pulls: true
 ignore:
   - mocks
   - l1/internal/contract/starknet.go


### PR DESCRIPTION
The lack of indentation caused on "only_pulls" lead to patch coverage to be reported on the main branch.