### PR TITLE
Update and clean up smoke test workflow to not run on forked PR

### DIFF
--- a/.github/workflows/sync_first_100_blocks_smoke_test.yml
+++ b/.github/workflows/sync_first_100_blocks_smoke_test.yml
@@ -1,4 +1,4 @@
-name: Run Smoke Tests
+name: Sync First 100 Blocks Smoke Test
 
 on:
   push:
@@ -7,12 +7,11 @@ on:
   pull_request:
     branches:
       - main
-  workflow_dispatch:
-
+      
 jobs:
   run_smoke_tests:
     runs-on: ubuntu-latest
-
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
@@ -27,15 +26,16 @@ jobs:
 
       - name: Build docker image
         run: docker build -t nethermindeth/juno .
-
-      - name: Clone smoke tests repository
-        run: git clone https://$GITHUB_TOKEN@github.com/NethermindEth/juno-smoke-tests.git --single-branch --branch main
-        env:
-          GITHUB_TOKEN: ${{ secrets.REPOSITORY_DISPATCH_TOKEN }}
+        
+      - name: Checkout Juno Smoke Tests
+        uses: actions/checkout@v3.5.2
+        with:
+          repository: NethermindEth/juno-smoke-tests
+          token: ${{ secrets.REPOSITORY_DISPATCH_TOKEN }}
 
       - name: Run smoke tests
         run: |
-          cd juno-smoke-tests/smoke-tests/node_tests
+          cd smoke-tests/node_tests
           go test -v -run TestMonitorNodeSync -args -targetBlock=$TARGET_BLOCK -timeout=$TIMEOUT
         env:
           TARGET_BLOCK: 100


### PR DESCRIPTION
Updated smoke test workflow to not run from forked PR

This PR updates the smoke test workflow to prevent it from running on pull requests from forks. The workflow was failing on forked PRs before due to limited access to secrets data for security reasons.

Changes in this PR include:
- Added condition to run only when not from forked
- Refactoring names for improved clarity
- Replacing cloning with the `actions/checkout` action