### PR TITLE
Check that the L1 node is on the correct network

### DIFF
--- a/l1/eth_subscriber.go
+++ b/l1/eth_subscriber.go
@@ -2,6 +2,7 @@ package l1
 
 import (
 	"context"
+	"math/big"
 
 	"github.com/NethermindEth/juno/l1/contract"
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
@@ -39,6 +40,10 @@ func (s *EthSubscriber) WatchHeader(ctx context.Context, sink chan<- *types.Head
 
 func (s *EthSubscriber) WatchLogStateUpdate(ctx context.Context, sink chan<- *contract.StarknetLogStateUpdate) (event.Subscription, error) {
 	return s.filterer.WatchLogStateUpdate(&bind.WatchOpts{Context: ctx}, sink)
+}
+
+func (s *EthSubscriber) ChainID(ctx context.Context) (*big.Int, error) {
+	return s.ethClient.ChainID(ctx)
 }
 
 func (s *EthSubscriber) Close() {

--- a/l1/l1.go
+++ b/l1/l1.go
@@ -3,6 +3,7 @@ package l1
 import (
 	"context"
 	"fmt"
+	"math/big"
 
 	"github.com/NethermindEth/juno/blockchain"
 	"github.com/NethermindEth/juno/core"
@@ -18,6 +19,7 @@ import (
 type Subscriber interface {
 	WatchHeader(ctx context.Context, sink chan<- *types.Header) (event.Subscription, error)
 	WatchLogStateUpdate(ctx context.Context, sink chan<- *contract.StarknetLogStateUpdate) (event.Subscription, error)
+	ChainID(ctx context.Context) (*big.Int, error)
 }
 
 type Client struct {
@@ -25,6 +27,7 @@ type Client struct {
 	l2Chain           *blockchain.Blockchain
 	log               utils.SimpleLogger
 	confirmationQueue *queue
+	network           utils.Network
 }
 
 var _ service.Service = (*Client)(nil)
@@ -34,6 +37,7 @@ func NewClient(l1 Subscriber, chain *blockchain.Blockchain, confirmationPeriod u
 		l1:                l1,
 		l2Chain:           chain,
 		log:               log,
+		network:           chain.Network(),
 		confirmationQueue: newQueue(confirmationPeriod),
 	}
 }
@@ -56,7 +60,27 @@ func (c *Client) subscribeToUpdates(ctx context.Context,
 	return sub, nil
 }
 
+func (c *Client) checkChainID(ctx context.Context) error {
+	gotChainID, err := c.l1.ChainID(ctx)
+	if err != nil {
+		return fmt.Errorf("retrieve Ethereum chain ID: %w", err)
+	}
+
+	wantChainID := c.network.DefaultL1ChainID()
+	if gotChainID.Cmp(wantChainID) == 0 {
+		return nil
+	}
+
+	// NOTE: for now we return an error. If we want to support users who fork
+	// Starknet to create a "custom" Starknet network, we will need to log a warning instead.
+	return fmt.Errorf("mismatched L1 and L2 networks: L2 network %s; is the L1 node on the correct network?", c.network)
+}
+
 func (c *Client) Run(ctx context.Context) error {
+	if err := c.checkChainID(ctx); err != nil {
+		return err
+	}
+
 	buffer := 128
 
 	logStateUpdateChan := make(chan *contract.StarknetLogStateUpdate, buffer)

--- a/l1/l1_pkg_test.go
+++ b/l1/l1_pkg_test.go
@@ -305,7 +305,8 @@ func TestClient(t *testing.T) {
 
 			ctrl := gomock.NewController(t)
 			nopLog := utils.NewNopZapLogger()
-			chain := blockchain.New(pebble.NewMemTest(), utils.MAINNET, nopLog)
+			network := utils.MAINNET
+			chain := blockchain.New(pebble.NewMemTest(), network, nopLog)
 			client := NewClient(nil, chain, tt.confirmationPeriod, nopLog)
 
 			// We loop over each block and check that the state of the chain aligns with our expectations.
@@ -329,6 +330,12 @@ func TestClient(t *testing.T) {
 						sink <- block.Header()
 					}).
 					Return(newFakeSubscription(), nil).
+					Times(1)
+
+				subscriber.
+					EXPECT().
+					ChainID(gomock.Any()).
+					Return(network.DefaultL1ChainID(), nil).
 					Times(1)
 
 				// Replace the subscriber.
@@ -360,7 +367,8 @@ func TestUnreliableSubscription(t *testing.T) {
 
 	ctrl := gomock.NewController(t)
 	nopLog := utils.NewNopZapLogger()
-	chain := blockchain.New(pebble.NewMemTest(), utils.MAINNET, nopLog)
+	network := utils.MAINNET
+	chain := blockchain.New(pebble.NewMemTest(), network, nopLog)
 	client := NewClient(nil, chain, 3, nopLog)
 
 	err := errors.New("test err")
@@ -389,6 +397,12 @@ func TestUnreliableSubscription(t *testing.T) {
 			Return(successUpdateSub, nil).
 			Times(1).
 			After(failedUpdateCall)
+
+		subscriber.
+			EXPECT().
+			ChainID(gomock.Any()).
+			Return(network.DefaultL1ChainID(), nil).
+			Times(1)
 
 		failedHeaderSub := newFakeSubscription(err)
 		failedHeaderCall := subscriber.

--- a/l1/mocks/mock_subscriber.go
+++ b/l1/mocks/mock_subscriber.go
@@ -6,6 +6,7 @@ package mocks
 
 import (
 	context "context"
+	big "math/big"
 	reflect "reflect"
 
 	contract "github.com/NethermindEth/juno/l1/contract"
@@ -35,6 +36,21 @@ func NewMockSubscriber(ctrl *gomock.Controller) *MockSubscriber {
 // EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockSubscriber) EXPECT() *MockSubscriberMockRecorder {
 	return m.recorder
+}
+
+// ChainID mocks base method.
+func (m *MockSubscriber) ChainID(arg0 context.Context) (*big.Int, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ChainID", arg0)
+	ret0, _ := ret[0].(*big.Int)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ChainID indicates an expected call of ChainID.
+func (mr *MockSubscriberMockRecorder) ChainID(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ChainID", reflect.TypeOf((*MockSubscriber)(nil).ChainID), arg0)
 }
 
 // WatchHeader mocks base method.

--- a/utils/network.go
+++ b/utils/network.go
@@ -3,6 +3,7 @@ package utils
 import (
 	"encoding"
 	"errors"
+	"math/big"
 
 	"github.com/NethermindEth/juno/core/felt"
 	"github.com/ethereum/go-ethereum/common"
@@ -106,6 +107,20 @@ func (n Network) ChainID() *felt.Felt {
 		// Should not happen.
 		panic(ErrUnknownNetwork)
 	}
+}
+
+func (n Network) DefaultL1ChainID() *big.Int {
+	var chainID int64
+	switch n {
+	case MAINNET:
+		chainID = 1
+	case GOERLI, GOERLI2, INTEGRATION:
+		chainID = 5
+	default:
+		// Should not happen.
+		panic(ErrUnknownNetwork)
+	}
+	return big.NewInt(chainID)
 }
 
 func (n Network) CoreContractAddress() (common.Address, error) {

--- a/utils/network_test.go
+++ b/utils/network_test.go
@@ -1,6 +1,7 @@
 package utils_test
 
 import (
+	"math/big"
 	"strings"
 	"testing"
 
@@ -49,6 +50,19 @@ func TestNetwork(t *testing.T) {
 				assert.Equal(t, new(felt.Felt).SetBytes([]byte("SN_MAIN")), n.ChainID())
 			case utils.GOERLI2:
 				assert.Equal(t, new(felt.Felt).SetBytes([]byte("SN_GOERLI2")), n.ChainID())
+			default:
+				assert.Fail(t, "unexpected network")
+			}
+		}
+	})
+	t.Run("default L1 chainId", func(t *testing.T) {
+		for n := range networkStrings {
+			got := n.DefaultL1ChainID()
+			switch n {
+			case utils.MAINNET:
+				assert.Equal(t, big.NewInt(1), got)
+			case utils.GOERLI, utils.GOERLI2, utils.INTEGRATION:
+				assert.Equal(t, big.NewInt(5), got)
 			default:
 				assert.Fail(t, "unexpected network")
 			}


### PR DESCRIPTION
Resolves: #827 

How we achieve this:

- Add a `ChainID` method to the `l1.Subscriber` interface.
- Add a `network` field to the `l1.Client` struct.
- Set the `l1.Client.network` field with the value retrieved from `blockchain.Network()` in `l1.NewClient(...)`.
- Compare the result of `l1.Subscriber.ChainID` to `l1.Client.network` in `l1.Client.checkChainID`, which is called in `l1.Client.Run`.

The behavior can be manually tested with a command like:

```
juno --eth-node <mainnet-eth-node> --network goerli
```

which should log an error and exit.