### PR TITLE
Update deploy nodes workflow to use proper eth-node

### DIFF
--- a/.github/workflows/sync_first_100_blocks_smoke_test.yml
+++ b/.github/workflows/sync_first_100_blocks_smoke_test.yml
@@ -40,4 +40,4 @@ jobs:
         env:
           TARGET_BLOCK: 100
           TIMEOUT: 5m
-          JUNO_PARAMETERS: "--network mainnet --eth-node ${{ secrets.ETH_NODE }}"
+          JUNO_PARAMETERS: "--network mainnet --eth-node ${{ secrets.ETH_NODE_MAINNET }}"

--- a/.github/workflows/upgrade-nodes-on-test-envs.yml
+++ b/.github/workflows/upgrade-nodes-on-test-envs.yml
@@ -57,6 +57,11 @@ jobs:
             for network in mainnet goerli goerli2; do
                 docker stop juno_$network
                 docker rm juno_$network
+                if [ "$network" == "mainnet" ]; then
+                    ETH_NODE=${{ secrets.ETH_NODE_MAINNET }}
+                else
+                    ETH_NODE=${{ secrets.ETH_NODE_GOERLI }}
+                fi
                 docker run -d \
                     --name juno_$network \
                     -p $port:$port \
@@ -66,8 +71,8 @@ jobs:
                     --rpc-port $port \
                     --network $network \
                     --colour=false \
-                    --eth-node ${{ secrets.ETH_NODE }} \
+                    --eth-node $ETH_NODE \
                     $(if [ "$network" = "mainnet" ]; then echo "--pprof"; fi)
-            port=$((port+1))
-            nohup sh -c "docker logs -f juno_$network > /var/log/juno_logs_$network.log 2>&1" &>/dev/null &
+                port=$((port+1))
+                nohup sh -c "docker logs -f juno_$network > /var/log/juno_logs_$network.log 2>&1" &>/dev/null &
             done


### PR DESCRIPTION
Upgraded workflow for deploying nodes to use eth-node depending on used network.