### PR TITLE
Build only amd arch for unofficial images

### DIFF
--- a/.github/workflows/docker-image-build-push.yml
+++ b/.github/workflows/docker-image-build-push.yml
@@ -35,7 +35,7 @@ jobs:
         uses: docker/build-push-action@v4
         with:
           context: .
-          platforms: linux/amd64,linux/arm64
+          platforms: ${{ github.event.inputs.repo_type == 'official' && 'linux/amd64,linux/arm64' || 'linux/amd64' }}
           push: true
           tags: ${{ github.event.inputs.repo_type == 'official' && 'nethermind/juno' || 'nethermindeth/juno' }}:${{ github.event.inputs.tag }}
           


### PR DESCRIPTION
Building ARM images on AMD GitHub agents, including Rust, takes about two hours. To save time and resources in our daily CI/CD routines, let's only build these for releases. 