### PR TITLE
Manage the root key in trie.TransactionStorage

### DIFF
--- a/core/contract.go
+++ b/core/contract.go
@@ -7,7 +7,6 @@ import (
 	"github.com/NethermindEth/juno/core/felt"
 	"github.com/NethermindEth/juno/core/trie"
 	"github.com/NethermindEth/juno/db"
-	"github.com/bits-and-blooms/bitset"
 )
 
 const contractStorageTrieHeight = 251
@@ -174,21 +173,6 @@ func (c *Contract) UpdateStorage(diff []StorageDiff, cb OnValueChanged) error {
 		return err
 	}
 
-	// update contract storage root in the database
-	rootKeyDBKey := db.ContractStorage.Key(c.Address.Marshal())
-	if rootKey := cStorage.RootKey(); rootKey != nil {
-		rootKeyBytes, err := rootKey.MarshalBinary()
-		if err != nil {
-			return err
-		}
-
-		if err := c.txn.Set(rootKeyDBKey, rootKeyBytes); err != nil {
-			return err
-		}
-	} else if err := c.txn.Delete(rootKeyDBKey); err != nil {
-		return err
-	}
-
 	return nil
 }
 
@@ -228,16 +212,6 @@ func (c *Contract) Replace(classHash *felt.Felt) error {
 // storage of the contract.
 func storage(addr *felt.Felt, txn db.Transaction) (*trie.Trie, error) {
 	addrBytes := addr.Marshal()
-	var contractRootKey *bitset.BitSet
-
-	if err := txn.Get(db.ContractStorage.Key(addrBytes), func(val []byte) error {
-		contractRootKey = new(bitset.BitSet)
-		return contractRootKey.UnmarshalBinary(val)
-	}); err != nil && !errors.Is(err, db.ErrKeyNotFound) {
-		// Don't continue normal operation with arbitrary
-		// database error.
-		return nil, err
-	}
 	trieTxn := trie.NewTransactionStorage(txn, db.ContractStorage.Key(addrBytes))
-	return trie.NewTriePedersen(trieTxn, contractStorageTrieHeight, contractRootKey)
+	return trie.NewTriePedersen(trieTxn, contractStorageTrieHeight)
 }

--- a/core/state.go
+++ b/core/state.go
@@ -158,7 +158,7 @@ func (s *State) globalTrie(bucket db.Bucket, newTrie trie.NewTrieFunc) (*trie.Tr
 		return nil, nil, err
 	}
 
-	gTrie, err := newTrie(tTxn, globalTrieHeight, rootKey)
+	gTrie, err := newTrie(tTxn, globalTrieHeight)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/core/trie/transaction_storage.go
+++ b/core/trie/transaction_storage.go
@@ -102,6 +102,29 @@ func (t *TransactionStorage) Delete(key *bitset.BitSet) error {
 	return t.txn.Delete(buffer.Bytes())
 }
 
+func (t *TransactionStorage) RootKey() (*bitset.BitSet, error) {
+	var rootKey *bitset.BitSet
+	if err := t.txn.Get(t.prefix, func(val []byte) error {
+		rootKey = new(bitset.BitSet)
+		return rootKey.UnmarshalBinary(val)
+	}); err != nil {
+		return nil, err
+	}
+	return rootKey, nil
+}
+
+func (t *TransactionStorage) PutRootKey(newRootKey *bitset.BitSet) error {
+	newRootKeyBytes, err := newRootKey.MarshalBinary()
+	if err != nil {
+		return err
+	}
+	return t.txn.Set(t.prefix, newRootKeyBytes)
+}
+
+func (t *TransactionStorage) DeleteRootKey() error {
+	return t.txn.Delete(t.prefix)
+}
+
 func newMemStorage() Storage {
 	return NewTransactionStorage(db.NewMemTransaction(), nil)
 }

--- a/core/trie/trie_pkg_test.go
+++ b/core/trie/trie_pkg_test.go
@@ -12,7 +12,7 @@ import (
 
 func TestTrieKeys(t *testing.T) {
 	t.Run("put to empty trie", func(t *testing.T) {
-		tempTrie, err := NewTriePedersen(newMemStorage(), 251, nil)
+		tempTrie, err := NewTriePedersen(newMemStorage(), 251)
 		require.NoError(t, err)
 		keyNum, err := strconv.ParseUint("1101", 2, 64)
 		require.NoError(t, err)
@@ -31,7 +31,7 @@ func TestTrieKeys(t *testing.T) {
 	})
 
 	t.Run("put a left then a right node", func(t *testing.T) {
-		tempTrie, err := NewTriePedersen(newMemStorage(), 251, nil)
+		tempTrie, err := NewTriePedersen(newMemStorage(), 251)
 		require.NoError(t, err)
 		// First put a left node
 		leftKeyNum, err := strconv.ParseUint("10001", 2, 64)
@@ -73,7 +73,7 @@ func TestTrieKeys(t *testing.T) {
 	})
 
 	t.Run("put a right node then a left node", func(t *testing.T) {
-		tempTrie, err := NewTriePedersen(newMemStorage(), 251, nil)
+		tempTrie, err := NewTriePedersen(newMemStorage(), 251)
 		require.NoError(t, err)
 		// First put a right node
 		rightKeyNum, err := strconv.ParseUint("10011", 2, 64)
@@ -110,7 +110,7 @@ func TestTrieKeys(t *testing.T) {
 	})
 
 	t.Run("Add new key to different branches", func(t *testing.T) {
-		tempTrie, err := NewTriePedersen(newMemStorage(), 251, nil)
+		tempTrie, err := NewTriePedersen(newMemStorage(), 251)
 		require.NoError(t, err)
 		// left branch
 		leftKeyNum, err := strconv.ParseUint("100", 2, 64)
@@ -235,7 +235,7 @@ func TestTrieKeysAfterDeleteSubtree(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			tempTrie, err := NewTriePedersen(newMemStorage(), 251, nil)
+			tempTrie, err := NewTriePedersen(newMemStorage(), 251)
 			require.NoError(t, err)
 			// Build a basic trie
 			_, err = tempTrie.Put(leftLeftKey, leftLeftVal)


### PR DESCRIPTION
The user of trie.Trie now only needs to know about the db prefix and make sure to call trie.Root or trie.Commit to save results.