### PR TITLE
Use custom marshaler for trie.Node

### DIFF
--- a/core/trie/node.go
+++ b/core/trie/node.go
@@ -1,7 +1,9 @@
 package trie
 
 import (
+	"bytes"
 	"encoding/binary"
+	"errors"
 
 	"github.com/NethermindEth/juno/core/felt"
 	"github.com/bits-and-blooms/bitset"
@@ -41,4 +43,66 @@ func (n *Node) Hash(path *bitset.BitSet, hashFunc hashFunc) *felt.Felt {
 
 	pathFelt.SetUint64(uint64(path.Len()))
 	return hash.Add(hash, pathFelt)
+}
+
+func (n *Node) WriteTo(buf *bytes.Buffer) (int64, error) {
+	if n.Value == nil {
+		return 0, errors.New("cannot marshal node with nil value")
+	}
+
+	totalBytes := int64(0)
+
+	valueB := n.Value.Bytes()
+	wrote, err := buf.Write(valueB[:])
+	totalBytes += int64(wrote)
+	if err != nil {
+		return totalBytes, err
+	}
+
+	if n.Left != nil {
+		wrote, err := n.Left.WriteTo(buf)
+		totalBytes += wrote
+		if err != nil {
+			return totalBytes, err
+		}
+		wrote, err = n.Right.WriteTo(buf) // n.Right is non-nil by design
+		totalBytes += wrote
+		if err != nil {
+			return totalBytes, err
+		}
+	}
+
+	return totalBytes, nil
+}
+
+// UnmarshalBinary deserializes a [Node] from a byte array
+func (n *Node) UnmarshalBinary(data []byte) error {
+	if len(data) < felt.Bytes {
+		return errors.New("size of input data is less than felt size")
+	}
+	if n.Value == nil {
+		n.Value = new(felt.Felt)
+	}
+	n.Value.SetBytes(data[:felt.Bytes])
+	data = data[felt.Bytes:]
+
+	if len(data) == 0 {
+		n.Left = nil
+		n.Right = nil
+		return nil
+	}
+
+	stream := bytes.NewReader(data)
+
+	if n.Left == nil {
+		n.Left = new(bitset.BitSet)
+		n.Right = new(bitset.BitSet)
+	}
+
+	_, err := n.Left.ReadFrom(stream)
+	if err != nil {
+		return err
+	}
+	_, err = n.Right.ReadFrom(stream)
+	return err
 }

--- a/core/trie/transaction_storage.go
+++ b/core/trie/transaction_storage.go
@@ -5,7 +5,6 @@ import (
 	"sync"
 
 	"github.com/NethermindEth/juno/db"
-	"github.com/NethermindEth/juno/encoder"
 	"github.com/bits-and-blooms/bitset"
 )
 
@@ -64,8 +63,7 @@ func (t *TransactionStorage) Put(key *bitset.BitSet, value *Node) error {
 		return err
 	}
 
-	enc := encoder.NewEncoder(buffer)
-	err = enc.Encode(value)
+	_, err = value.WriteTo(buffer)
 	if err != nil {
 		return err
 	}
@@ -85,7 +83,7 @@ func (t *TransactionStorage) Get(key *bitset.BitSet) (*Node, error) {
 	var node *Node
 	if err = t.txn.Get(buffer.Bytes(), func(val []byte) error {
 		node = nodePool.Get().(*Node)
-		return encoder.Unmarshal(val, node)
+		return node.UnmarshalBinary(val)
 	}); err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
to minimize allocations

before

```
omer@omer-ThinkPad-E14-Gen-3:~/Documents/juno$ go test ./blockchain/ -bench=MainnetBlock -benchmem -memprofile mem.out
goos: linux
goarch: amd64
pkg: github.com/NethermindEth/juno/blockchain
cpu: AMD Ryzen 7 5700U with Radeon Graphics         
BenchmarkMainnetBlock-16              10         308859680 ns/op         9854500 B/op     265245 allocs/op
PASS
ok      github.com/NethermindEth/juno/blockchain        4.577s
```

after

```
omer@omer-ThinkPad-E14-Gen-3:~/Documents/juno$ go test ./blockchain/ -bench=MainnetBlock -benchmem -memprofile mem.out
goos: linux
goarch: amd64
pkg: github.com/NethermindEth/juno/blockchain
cpu: AMD Ryzen 7 5700U with Radeon Graphics         
BenchmarkMainnetBlock-16              10         268575622 ns/op         5724414 B/op     161778 allocs/op
PASS
ok      github.com/NethermindEth/juno/blockchain        4.164s
```