### PR TITLE
Pass in jsonrpc.Server to HTTP and Websocket bridges

### DIFF
--- a/jsonrpc/http.go
+++ b/jsonrpc/http.go
@@ -21,14 +21,7 @@ type HTTP struct {
 	listener net.Listener
 }
 
-func NewHTTP(listener net.Listener, methods []Method, log utils.SimpleLogger, validator Validator) *HTTP {
-	rpc := NewServer().WithValidator(validator)
-	for _, method := range methods {
-		err := rpc.RegisterMethod(method)
-		if err != nil {
-			panic(err)
-		}
-	}
+func NewHTTP(listener net.Listener, rpc *Server, log utils.SimpleLogger) *HTTP {
 	return &HTTP{
 		rpc:      rpc,
 		log:      log,

--- a/jsonrpc/http_test.go
+++ b/jsonrpc/http_test.go
@@ -25,8 +25,10 @@ func TestHTTP(t *testing.T) {
 		},
 		Params: []jsonrpc.Parameter{{Name: "msg"}},
 	}
+	rpc := jsonrpc.NewServer()
+	require.NoError(t, rpc.RegisterMethod(method))
 	log := utils.NewNopZapLogger()
-	server := jsonrpc.NewHTTP(listener, []jsonrpc.Method{method}, log, nil)
+	server := jsonrpc.NewHTTP(listener, rpc, log)
 
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 	t.Cleanup(func() {

--- a/jsonrpc/websocket.go
+++ b/jsonrpc/websocket.go
@@ -21,18 +21,12 @@ type Websocket struct {
 	listener   net.Listener
 }
 
-func NewWebsocket(listener net.Listener, methods []Method, log utils.SimpleLogger, validator Validator) *Websocket {
+func NewWebsocket(listener net.Listener, rpc *Server, log utils.SimpleLogger) *Websocket {
 	ws := &Websocket{
-		rpc:        NewServer().WithValidator(validator),
+		rpc:        rpc,
 		log:        log,
 		connParams: DefaultWebsocketConnParams(),
 		listener:   listener,
-	}
-	for _, method := range methods {
-		err := ws.rpc.RegisterMethod(method)
-		if err != nil {
-			panic(err)
-		}
 	}
 	return ws
 }

--- a/jsonrpc/websocket_test.go
+++ b/jsonrpc/websocket_test.go
@@ -17,17 +17,19 @@ import (
 
 // The caller is responsible for closing the connection.
 func testConnection(t *testing.T) *websocket.Conn {
-	methods := []jsonrpc.Method{{
+	method := jsonrpc.Method{
 		Name:   "test_echo",
 		Params: []jsonrpc.Parameter{{Name: "msg"}},
 		Handler: func(msg string) (string, *jsonrpc.Error) {
 			return msg, nil
 		},
-	}}
+	}
 	l, err := net.Listen("tcp", ":0")
 	require.NoError(t, err)
 	ctx := context.Background()
-	ws := jsonrpc.NewWebsocket(l, methods, utils.NewNopZapLogger(), nil)
+	rpc := jsonrpc.NewServer()
+	require.NoError(t, rpc.RegisterMethod(method))
+	ws := jsonrpc.NewWebsocket(l, rpc, utils.NewNopZapLogger())
 	go func() {
 		t.Helper()
 		require.NoError(t, ws.Run(context.Background()))


### PR DESCRIPTION
Only register the validator and the methods once when possible.