### PR TITLE
Parallelize per-contract storage updates

### DIFF
--- a/db/buffered_transaction.go
+++ b/db/buffered_transaction.go
@@ -1,0 +1,84 @@
+package db
+
+import (
+	"errors"
+)
+
+// BufferedTransaction buffers the updates in the memory to be later flushed to the underlying Transaction
+type BufferedTransaction struct {
+	updates map[string][]byte
+	txn     Transaction
+}
+
+func NewBufferedTransaction(txn Transaction) *BufferedTransaction {
+	return &BufferedTransaction{
+		txn:     txn,
+		updates: make(map[string][]byte),
+	}
+}
+
+// Discard : see db.Transaction.Discard
+func (t *BufferedTransaction) Discard() error {
+	t.updates = nil
+	return t.txn.Discard()
+}
+
+// Commit : see db.Transaction.Commit
+func (t *BufferedTransaction) Commit() error {
+	if err := t.Flush(); err != nil {
+		return err
+	}
+	t.updates = nil
+	return t.txn.Commit()
+}
+
+// Set : see db.Transaction.Set
+func (t *BufferedTransaction) Set(key, val []byte) error {
+	valueCopy := make([]byte, 0, len(val))
+	t.updates[string(key)] = append(valueCopy, val...)
+	return nil
+}
+
+// Delete : see db.Transaction.Delete
+func (t *BufferedTransaction) Delete(key []byte) error {
+	t.updates[string(key)] = nil
+	return nil
+}
+
+// Get : see db.Transaction.Get
+func (t *BufferedTransaction) Get(key []byte, cb func([]byte) error) error {
+	if value, found := t.updates[string(key)]; found {
+		if value == nil {
+			return ErrKeyNotFound
+		}
+		return cb(value)
+	}
+	return t.txn.Get(key, cb)
+}
+
+// Flush applies the pending changes to the underlying Transaction
+func (t *BufferedTransaction) Flush() error {
+	for key, value := range t.updates {
+		keyBytes := []byte(key)
+		if value == nil {
+			if err := t.txn.Delete(keyBytes); err != nil {
+				return err
+			}
+		} else {
+			if err := t.txn.Set(keyBytes, value); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+// Impl : see db.Transaction.Impl
+func (t *BufferedTransaction) Impl() any {
+	return t.txn
+}
+
+// NewIterator : see db.Transaction.NewIterator
+func (t *BufferedTransaction) NewIterator() (Iterator, error) {
+	return nil, errors.New("buffered transactions dont support iterators")
+}

--- a/db/buffered_transaction_test.go
+++ b/db/buffered_transaction_test.go
@@ -1,0 +1,53 @@
+package db_test
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/NethermindEth/juno/db"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBufferedTransaction(t *testing.T) {
+	txn := db.NewMemTransaction()
+
+	existingKey := []byte("existingKey")
+	require.NoError(t, txn.Set(existingKey, []byte("existingValue")))
+
+	bufferedTxn := db.NewBufferedTransaction(txn)
+	require.NoError(t, bufferedTxn.Delete(existingKey))
+	newKey := []byte("newKey")
+	require.NoError(t, bufferedTxn.Set(newKey, []byte("newValue")))
+
+	t.Run("buffered changes should be visible on BufferedTransaction", func(t *testing.T) {
+		require.ErrorIs(t, bufferedTxn.Get(existingKey, nil), db.ErrKeyNotFound)
+		require.NoError(t, bufferedTxn.Get(newKey, func(b []byte) error {
+			if string(b) != "newValue" {
+				return errors.New("not expected value")
+			}
+			return nil
+		}))
+	})
+
+	t.Run("buffered changes should not be visible on the original transaction", func(t *testing.T) {
+		require.ErrorIs(t, txn.Get(newKey, nil), db.ErrKeyNotFound)
+		require.NoError(t, txn.Get(existingKey, func(b []byte) error {
+			if string(b) != "existingValue" {
+				return errors.New("not expected value")
+			}
+			return nil
+		}))
+	})
+
+	require.NoError(t, bufferedTxn.Commit())
+
+	t.Run("flushed changes should be visible on the original transaction", func(t *testing.T) {
+		require.ErrorIs(t, txn.Get(existingKey, nil), db.ErrKeyNotFound)
+		require.NoError(t, txn.Get(newKey, func(b []byte) error {
+			if string(b) != "newValue" {
+				return errors.New("not expected value")
+			}
+			return nil
+		}))
+	})
+}


### PR DESCRIPTION
Substantial speed ups

before 

```
omer@omer-ThinkPad-E14-Gen-3:~/Documents/juno$ go test ./... -bench=MainnetBlock -benchmem
PASS
ok      github.com/NethermindEth/juno/adapters/feeder2core      0.402s
goos: linux
goarch: amd64
pkg: github.com/NethermindEth/juno/blockchain
cpu: AMD Ryzen 7 5700U with Radeon Graphics         
BenchmarkMainnetBlock-16           10         917313646 ns/op        18574441 B/op     434711 allocs/op
```

after

```
omer@omer-ThinkPad-E14-Gen-3:~/Documents/juno$ go test ./... -bench=MainnetBlock -benchmem
PASS
ok      github.com/NethermindEth/juno/adapters/feeder2core      0.385s
goos: linux
goarch: amd64
pkg: github.com/NethermindEth/juno/blockchain
cpu: AMD Ryzen 7 5700U with Radeon Graphics         
BenchmarkMainnetBlock-16           10         544530601 ns/op        21892010 B/op     464761 allocs/op
PASS
```

we can optimize for memory later