### PR TITLE
Fix providing juno version for docker images

### DIFF
--- a/.github/workflows/docker-image-build-push.yml
+++ b/.github/workflows/docker-image-build-push.yml
@@ -21,6 +21,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
+        with:
+            fetch-depth: 0
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM alpine:3.18 AS build
 
 # Install Alpine Dependencies
 RUN apk update && \
-    apk add build-base clang upx cargo go
+    apk add build-base clang upx cargo go git
 
 WORKDIR /app
 


### PR DESCRIPTION
This PR resolves an issue with the `juno_version` method for our Docker images. 