### PR TITLE
Make parts of SanityCheckNewHeight run in parallel

### DIFF
--- a/core/block.go
+++ b/core/block.go
@@ -9,6 +9,7 @@ import (
 	"github.com/NethermindEth/juno/core/felt"
 	"github.com/NethermindEth/juno/utils"
 	"github.com/bits-and-blooms/bloom/v3"
+	"github.com/sourcegraph/conc"
 )
 
 type Header struct {
@@ -180,14 +181,23 @@ func post07Hash(b *Block, overrideSeqAddr *felt.Felt) (*felt.Felt, error) {
 		seqAddr = overrideSeqAddr
 	}
 
-	txCommitment, err := transactionCommitment(b.Transactions, b.Header.ProtocolVersion)
-	if err != nil {
-		return nil, err
-	}
+	wg := conc.NewWaitGroup()
+	var txCommitment, eCommitment *felt.Felt
+	var tErr, eErr error
 
-	eCommitment, err := eventCommitment(b.Receipts)
-	if err != nil {
-		return nil, err
+	wg.Go(func() {
+		txCommitment, tErr = transactionCommitment(b.Transactions, b.Header.ProtocolVersion)
+	})
+	wg.Go(func() {
+		eCommitment, eErr = eventCommitment(b.Receipts)
+	})
+	wg.Wait()
+
+	if tErr != nil {
+		return nil, tErr
+	}
+	if eErr != nil {
+		return nil, eErr
 	}
 
 	// Unlike the pre07Hash computation, we exclude the chain

--- a/core/transaction.go
+++ b/core/transaction.go
@@ -4,7 +4,9 @@ import (
 	"encoding/binary"
 	"errors"
 	"fmt"
+	"runtime"
 	"strings"
+	"sync"
 
 	"github.com/Masterminds/semver/v3"
 	"github.com/NethermindEth/juno/core/crypto"
@@ -13,6 +15,7 @@ import (
 	"github.com/NethermindEth/juno/utils"
 	"github.com/bits-and-blooms/bloom/v3"
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/sourcegraph/conc/pool"
 )
 
 type Event struct {
@@ -428,20 +431,52 @@ func ParseBlockVersion(protocolVersion string) (*semver.Version, error) {
 func eventCommitment(receipts []*TransactionReceipt) (*felt.Felt, error) {
 	var commitment *felt.Felt
 	return commitment, trie.RunOnTempTrie(commitmentTrieHeight, func(trie *trie.Trie) error {
-		count := uint64(0)
-		for _, receipt := range receipts {
-			for _, event := range receipt.Events {
-				eventHash := crypto.PedersenArray(
-					event.From,
-					crypto.PedersenArray(event.Keys...),
-					crypto.PedersenArray(event.Data...),
-				)
+		eventCount := uint64(0)
+		numWorkers := runtime.GOMAXPROCS(0)
+		receiptPerWorker := len(receipts) / numWorkers
+		if receiptPerWorker == 0 {
+			receiptPerWorker = 1
+		}
+		workerPool := pool.New().WithErrors().WithMaxGoroutines(numWorkers)
+		var trieMutex sync.Mutex
 
-				if _, err := trie.Put(new(felt.Felt).SetUint64(count), eventHash); err != nil {
-					return err
-				}
-				count++
+		for receiptIdx := range receipts {
+			if receiptIdx%receiptPerWorker == 0 {
+				curReceiptIdx := receiptIdx
+				curEventIdx := eventCount
+
+				workerPool.Go(func() error {
+					maxIndex := curReceiptIdx + receiptPerWorker
+					if maxIndex > len(receipts) {
+						maxIndex = len(receipts)
+					}
+					receiptsSliced := receipts[curReceiptIdx:maxIndex]
+
+					for _, receipt := range receiptsSliced {
+						for _, event := range receipt.Events {
+							eventHash := crypto.PedersenArray(
+								event.From,
+								crypto.PedersenArray(event.Keys...),
+								crypto.PedersenArray(event.Data...),
+							)
+
+							eventTrieKey := new(felt.Felt).SetUint64(curEventIdx)
+							trieMutex.Lock()
+							_, err := trie.Put(eventTrieKey, eventHash)
+							trieMutex.Unlock()
+							if err != nil {
+								return err
+							}
+							curEventIdx++
+						}
+					}
+					return nil
+				})
 			}
+			eventCount += uint64(len(receipts[receiptIdx].Events))
+		}
+		if err := workerPool.Wait(); err != nil {
+			return err
 		}
 		root, err := trie.Root()
 		if err != nil {


### PR DESCRIPTION
Before

`BenchmarkMainnetBlock           10         754074777 ns/op         3112717 B/op     118761 allocs/op`

After

`BenchmarkMainnetBlock           10         424905598 ns/op         3677447 B/op     140130 allocs/op`

for some blocks sanity checks take even longer(>1sec), so this should help with our latency when tracking the HEAD 