### PR TITLE
Expect status strings in quotes for JSON unmarshaling

### DIFF
--- a/clients/feeder/transaction.go
+++ b/clients/feeder/transaction.go
@@ -15,9 +15,9 @@ const (
 
 func (es *ExecutionStatus) UnmarshalJSON(data []byte) error {
 	switch string(data) {
-	case "SUCCEEDED":
+	case `"SUCCEEDED"`:
 		*es = Succeeded
-	case "REVERTED":
+	case `"REVERTED"`:
 		*es = Reverted
 	default:
 		return errors.New("unknown ExecutionStatus")
@@ -34,9 +34,9 @@ const (
 
 func (fs *FinalityStatus) UnmarshalJSON(data []byte) error {
 	switch string(data) {
-	case "ACCEPTED_ON_L2":
+	case `"ACCEPTED_ON_L2"`:
 		*fs = AcceptedOnL2
-	case "ACCEPTED_ON_L1":
+	case `"ACCEPTED_ON_L1"`:
 		*fs = AcceptedOnL1
 	default:
 		return errors.New("unknown FinalityStatus")

--- a/clients/feeder/transaction_test.go
+++ b/clients/feeder/transaction_test.go
@@ -10,10 +10,10 @@ import (
 
 func TestUnmarshalExecutionStatus(t *testing.T) {
 	es := new(feeder.ExecutionStatus)
-	require.NoError(t, es.UnmarshalJSON([]byte("SUCCEEDED")))
+	require.NoError(t, es.UnmarshalJSON([]byte(`"SUCCEEDED"`)))
 	assert.Equal(t, feeder.Succeeded, *es)
 
-	require.NoError(t, es.UnmarshalJSON([]byte("REVERTED")))
+	require.NoError(t, es.UnmarshalJSON([]byte(`"REVERTED"`)))
 	assert.Equal(t, feeder.Reverted, *es)
 
 	require.ErrorContains(t, es.UnmarshalJSON([]byte("ABC")), "unknown ExecutionStatus")
@@ -21,10 +21,10 @@ func TestUnmarshalExecutionStatus(t *testing.T) {
 
 func TestUnmarshalFinalityStatus(t *testing.T) {
 	fs := new(feeder.FinalityStatus)
-	require.NoError(t, fs.UnmarshalJSON([]byte("ACCEPTED_ON_L1")))
+	require.NoError(t, fs.UnmarshalJSON([]byte(`"ACCEPTED_ON_L1"`)))
 	assert.Equal(t, feeder.AcceptedOnL1, *fs)
 
-	require.NoError(t, fs.UnmarshalJSON([]byte("ACCEPTED_ON_L2")))
+	require.NoError(t, fs.UnmarshalJSON([]byte(`"ACCEPTED_ON_L2"`)))
 	assert.Equal(t, feeder.AcceptedOnL2, *fs)
 
 	require.ErrorContains(t, fs.UnmarshalJSON([]byte("ABC")), "unknown FinalityStatus")


### PR DESCRIPTION
JSON parser does not strip the quotes before passing the string to the UnmarshalJSON functions