### PR TITLE
Set Keccak builtin weight

### DIFF
--- a/vm/rust/src/class.rs
+++ b/vm/rust/src/class.rs
@@ -1,21 +1,21 @@
+use starknet::core::types::contract::legacy::LegacyContractClass;
 use std::{
     ffi::{c_char, c_uchar, CStr},
     slice,
 };
-use starknet::core::types::contract::legacy::LegacyContractClass;
 
 #[no_mangle]
 pub extern "C" fn Cairo0ClassHash(class_json_str: *const c_char, hash: *mut c_uchar) {
     let class_json = unsafe { CStr::from_ptr(class_json_str) }.to_str().unwrap();
     let class: Result<LegacyContractClass, serde_json::Error> = serde_json::from_str(class_json);
     if class.is_err() {
-        return
+        return;
     }
     let class_hash = class.unwrap().class_hash();
     if class_hash.is_err() {
-        return
+        return;
     }
-    let hash_slice: &mut[u8] = unsafe { slice::from_raw_parts_mut(hash, 32) };
+    let hash_slice: &mut [u8] = unsafe { slice::from_raw_parts_mut(hash, 32) };
     let hash_bytes = class_hash.unwrap().to_bytes_be();
     hash_slice.copy_from_slice(hash_bytes.as_slice());
 }

--- a/vm/rust/src/juno_state_reader.rs
+++ b/vm/rust/src/juno_state_reader.rs
@@ -30,7 +30,8 @@ extern "C" {
         reader_handle: usize,
         contract_address: *const c_uchar,
     ) -> *const c_uchar;
-    fn JunoStateGetCompiledClass(reader_handle: usize, class_hash: *const c_uchar) -> *const c_char;
+    fn JunoStateGetCompiledClass(reader_handle: usize, class_hash: *const c_uchar)
+        -> *const c_char;
 }
 
 pub struct JunoStateReader {

--- a/vm/rust/src/lib.rs
+++ b/vm/rust/src/lib.rs
@@ -1,6 +1,5 @@
-mod juno_state_reader;
 pub mod class;
-
+mod juno_state_reader;
 
 use crate::juno_state_reader::{ptr_to_felt, JunoStateReader};
 use std::{
@@ -93,7 +92,12 @@ pub extern "C" fn cairoVMCall(
     let mut state = CachedState::new(reader);
     let mut resources = ExecutionResources::default();
     let mut context = EntryPointExecutionContext::new(
-        build_block_context(chain_id_str, block_number, block_timestamp, StarkFelt::default()),
+        build_block_context(
+            chain_id_str,
+            block_number,
+            block_timestamp,
+            StarkFelt::default(),
+        ),
         AccountTransactionContext::default(),
         4_000_000,
     );
@@ -260,7 +264,8 @@ fn build_block_context(
                 N_STEPS_FEE_WEIGHT * 10.0,
             ),
             (KECCAK_BUILTIN_NAME.to_string(), 0.0),
-        ]).into(),
+        ])
+        .into(),
         invoke_tx_max_n_steps: 1_000_000,
         validate_max_n_steps: 1_000_000,
         max_recursion_depth: 50,

--- a/vm/rust/src/lib.rs
+++ b/vm/rust/src/lib.rs
@@ -263,7 +263,7 @@ fn build_block_context(
                 SEGMENT_ARENA_BUILTIN_NAME.to_string(),
                 N_STEPS_FEE_WEIGHT * 10.0,
             ),
-            (KECCAK_BUILTIN_NAME.to_string(), 0.0),
+            (KECCAK_BUILTIN_NAME.to_string(), N_STEPS_FEE_WEIGHT * 2048.0),
         ])
         .into(),
         invoke_tx_max_n_steps: 1_000_000,


### PR DESCRIPTION
Starknet v0.12.1 enables Keccak builtin
got the weight from https://github.com/starkware-libs/cairo-lang/blob/c98fc0b50529185b7018208cb3460191eeb53e0d/src/starkware/cairo/lang/instances.py#L288-L292