### PR TITLE
Use legacy `status` field while testnet and mainnet are 0.12

### DIFF
--- a/clients/feeder/testdata/integration/transaction/0x45d9c2c8e01bacae6dec3438874576a4a1ce65f1d4247f4e9748f0e7216838.json
+++ b/clients/feeder/testdata/integration/transaction/0x45d9c2c8e01bacae6dec3438874576a4a1ce65f1d4247f4e9748f0e7216838.json
@@ -1,0 +1,31 @@
+{
+    "execution_status": "SUCCEEDED",
+    "finality_status": "ACCEPTED_ON_L2",
+    "status": "ACCEPTED_ON_L2",
+    "block_hash": "0x4e6fb67147a34174546e09ff349cd34c6a62538da0cbf0fb4f7a67a39035ad",
+    "block_number": 305931,
+    "transaction_index": 0,
+    "transaction": {
+        "transaction_hash": "0x45d9c2c8e01bacae6dec3438874576a4a1ce65f1d4247f4e9748f0e7216838",
+        "version": "0x1",
+        "max_fee": "0x2386f26fc10000",
+        "signature": [
+            "0x89aa2f42e07913b6dee313c3ef680efb99892feb3e2d08287e01e63418da7a",
+            "0x458fb4c942d5407d8c1ef1557d29487ab8217842d28a907d75ee0828243361"
+        ],
+        "nonce": "0x99d",
+        "sender_address": "0x219937256cd88844f9fdc9c33a2d6d492e253ae13814c2dc0ecab7f26919d46",
+        "calldata": [
+            "0x1",
+            "0x7812357541c81dd9a320c2339c0c76add710db15f8cc29e8dde8e588cad4455",
+            "0x7772be8b80a8a33dc6c1f9a6ab820c02e537c73e859de67f288c70f92571bb",
+            "0x0",
+            "0x3",
+            "0x3",
+            "0x24b037cd0ffd500467f4cc7d0b9df27abdc8646379e818e3ce3d9925fc9daec",
+            "0x4b7797c3f6a6d9b1a28bbd6645d3f009bd12587581e21011aeb9b176f801ab0",
+            "0xdfeaf5f022324453e6058c00c7d35ee449c1d01bb897ccb5df20f697d98f26"
+        ],
+        "type": "INVOKE_FUNCTION"
+    }
+}

--- a/clients/feeder/testdata/mainnet/transaction/0x6c40890743aa220b10e5ee68cef694c5c23cc2defd0dbdf5546e687f9982ab1.json
+++ b/clients/feeder/testdata/mainnet/transaction/0x6c40890743aa220b10e5ee68cef694c5c23cc2defd0dbdf5546e687f9982ab1.json
@@ -1,0 +1,32 @@
+{
+    "status": "ACCEPTED_ON_L2",
+    "block_hash": "0x6c9dc1dc56efb62181377dba9d9cff9f00d21cb4521c75a4457345edca7e469",
+    "block_number": 123443,
+    "transaction_index": 3,
+    "transaction": {
+        "transaction_hash": "0x6c40890743aa220b10e5ee68cef694c5c23cc2defd0dbdf5546e687f9982ab1",
+        "version": "0x1",
+        "max_fee": "0x1a9a4bdc14000",
+        "signature": [
+            "0x5e817845ba6681fe39a14ac3b1749dbc98374ce9e4361cc7381bc82c1dedcf3",
+            "0x5439b1cb55171f22659fa3be441ce37be92f61167db9718c2ec43901350021"
+        ],
+        "nonce": "0x1d",
+        "sender_address": "0x4f1cb86e5067045d8264cc542da0517b9afcc4219575a184a76265423e8a213",
+        "calldata": [
+            "0x1",
+            "0x76503062d78f4481be03c9145022d6a4a71ec0719aa07756f79a2384dc7ef16",
+            "0x2f0b3c5710379609eb5495f1ecd348cb28167711b73609fe565a72734550354",
+            "0x0",
+            "0x6",
+            "0x6",
+            "0x1a869e20ba",
+            "0x0",
+            "0x3",
+            "0xf",
+            "0x306ca0efa231fd84c6fbeaf904c3e3ec7b1325e6f23e3050b73f795420d94e7",
+            "0x4f2547837bda05f61052b150a568d098bca8b03f072276836fc1c88e64d1d06"
+        ],
+        "type": "INVOKE_FUNCTION"
+    }
+}

--- a/rpc/handlers.go
+++ b/rpc/handlers.go
@@ -1068,7 +1068,12 @@ func (h *Handler) TransactionStatus(hash felt.Felt) (*TransactionStatus, *jsonrp
 		case feeder.AcceptedOnL2:
 			status.Finality = TxnAcceptedOnL2
 		default:
-			return nil, jsonrpc.Err(jsonrpc.InternalError, "unknown FinalityStatus")
+			// pre-0.12.1
+			if txStatus.Status == "ACCEPTED_ON_L1" {
+				status.Finality = TxnAcceptedOnL1
+			} else {
+				status.Finality = TxnAcceptedOnL2
+			}
 		}
 
 		switch txStatus.ExecutionStatus {
@@ -1077,7 +1082,8 @@ func (h *Handler) TransactionStatus(hash felt.Felt) (*TransactionStatus, *jsonrp
 		case feeder.Reverted:
 			status.Execution = TxnFailure
 		default:
-			return nil, jsonrpc.Err(jsonrpc.InternalError, "unknown ExecutionStatus")
+			// pre-0.12.1
+			status.Execution = TxnSuccess
 		}
 	default:
 		return nil, txErr


### PR DESCRIPTION
We can transition to the new status fields once the network upgrades to 0.12.1.