### PR TITLE
make http addr configurable

### DIFF
--- a/cmd/juno/juno.go
+++ b/cmd/juno/juno.go
@@ -28,6 +28,7 @@ Juno is a Go implementation of a Starknet full node client created by Nethermind
 const (
 	configF              = "config"
 	logLevelF            = "log-level"
+	httpHostF            = "http-host"
 	httpPortF            = "http-port"
 	wsPortF              = "ws-port"
 	grpcPortF            = "grpc-port"
@@ -44,6 +45,7 @@ const (
 	metricsPortF         = "metrics-port"
 
 	defaultConfig              = ""
+	defaultHTTPHost            = "localhost"
 	defaultHTTPPort            = 6060
 	defaultWSPort              = 6061
 	defaultGRPCPort            = 0
@@ -60,6 +62,7 @@ const (
 
 	configFlagUsage   = "The yaml configuration file."
 	logLevelFlagUsage = "Options: debug, info, warn, error."
+	httpHostUsage     = "The interface on which the HTTP RPC server will listen for requests."
 	httpPortUsage     = "The port on which the HTTP RPC server will listen for requests."
 	wsPortUsage       = "The port on which the Websocket RPC server will listen for requests."
 	grpcPortUsage     = "The port on which the gRPC server will listen for requests."
@@ -153,6 +156,7 @@ func NewCmd(config *node.Config, run func(*cobra.Command, []string) error) *cobr
 
 	junoCmd.Flags().StringVar(&cfgFile, configF, defaultConfig, configFlagUsage)
 	junoCmd.Flags().Var(&defaultLogLevel, logLevelF, logLevelFlagUsage)
+	junoCmd.Flags().String(httpHostF, defaultHTTPHost, httpPortUsage)
 	junoCmd.Flags().Uint16(httpPortF, defaultHTTPPort, httpPortUsage)
 	junoCmd.Flags().Uint16(wsPortF, defaultWSPort, wsPortUsage)
 	junoCmd.Flags().Uint16(grpcPortF, defaultGRPCPort, grpcPortUsage)

--- a/cmd/juno/juno_test.go
+++ b/cmd/juno/juno_test.go
@@ -22,6 +22,7 @@ func TestConfigPrecedence(t *testing.T) {
 	// checks on the config, those will be checked by the StarknetNode
 	// implementation.
 	defaultLogLevel := utils.INFO
+	defaultHTTPHost := "localhost"
 	defaultHTTPPort := uint16(6060)
 	defaultWSPort := uint16(6061)
 	defaultDBPath := ""
@@ -42,6 +43,7 @@ func TestConfigPrecedence(t *testing.T) {
 			inputArgs: []string{""},
 			expectedConfig: &node.Config{
 				LogLevel:            defaultLogLevel,
+				HTTPHost:            defaultHTTPHost,
 				HTTPPort:            defaultHTTPPort,
 				WSPort:              defaultWSPort,
 				DatabasePath:        defaultDBPath,
@@ -56,6 +58,7 @@ func TestConfigPrecedence(t *testing.T) {
 			inputArgs: []string{"--config", ""},
 			expectedConfig: &node.Config{
 				LogLevel:            defaultLogLevel,
+				HTTPHost:            defaultHTTPHost,
 				HTTPPort:            defaultHTTPPort,
 				WSPort:              defaultWSPort,
 				DatabasePath:        defaultDBPath,
@@ -75,6 +78,7 @@ func TestConfigPrecedence(t *testing.T) {
 			cfgFileContents: "\n",
 			expectedConfig: &node.Config{
 				LogLevel:            defaultLogLevel,
+				HTTPHost:            defaultHTTPHost,
 				HTTPPort:            defaultHTTPPort,
 				WSPort:              defaultWSPort,
 				Network:             defaultNetwork,
@@ -86,6 +90,7 @@ func TestConfigPrecedence(t *testing.T) {
 		"config file with all settings but without any other flags": {
 			cfgFile: true,
 			cfgFileContents: `log-level: debug
+http-host: 0.0.0.0
 http-port: 4576
 db-path: /home/.juno
 network: goerli2
@@ -93,6 +98,7 @@ pprof: true
 `,
 			expectedConfig: &node.Config{
 				LogLevel:            utils.DEBUG,
+				HTTPHost:            "0.0.0.0",
 				HTTPPort:            4576,
 				WSPort:              defaultWSPort,
 				DatabasePath:        "/home/.juno",
@@ -106,10 +112,12 @@ pprof: true
 		"config file with some settings but without any other flags": {
 			cfgFile: true,
 			cfgFileContents: `log-level: debug
+http-host: 0.0.0.0
 http-port: 4576
 `,
 			expectedConfig: &node.Config{
 				LogLevel:            utils.DEBUG,
+				HTTPHost:            "0.0.0.0",
 				HTTPPort:            4576,
 				WSPort:              defaultWSPort,
 				DatabasePath:        defaultDBPath,
@@ -122,11 +130,12 @@ http-port: 4576
 		},
 		"all flags without config file": {
 			inputArgs: []string{
-				"--log-level", "debug", "--http-port", "4576",
+				"--log-level", "debug", "--http-port", "4576", "--http-host", "0.0.0.0",
 				"--db-path", "/home/.juno", "--network", "goerli", "--pprof",
 			},
 			expectedConfig: &node.Config{
 				LogLevel:     utils.DEBUG,
+				HTTPHost:     "0.0.0.0",
 				HTTPPort:     4576,
 				WSPort:       defaultWSPort,
 				DatabasePath: "/home/.juno",
@@ -138,11 +147,12 @@ http-port: 4576
 		},
 		"some flags without config file": {
 			inputArgs: []string{
-				"--log-level", "debug", "--http-port", "4576", "--db-path", "/home/.juno",
+				"--log-level", "debug", "--http-port", "4576", "--http-host", "0.0.0.0", "--db-path", "/home/.juno",
 				"--network", "integration",
 			},
 			expectedConfig: &node.Config{
 				LogLevel:            utils.DEBUG,
+				HTTPHost:            "0.0.0.0",
 				HTTPPort:            4576,
 				WSPort:              defaultWSPort,
 				DatabasePath:        "/home/.juno",
@@ -155,6 +165,7 @@ http-port: 4576
 		"all setting set in both config file and flags": {
 			cfgFile: true,
 			cfgFileContents: `log-level: debug
+http-host: 0.0.0.0
 http-port: 4576
 db-path: /home/config-file/.juno
 network: goerli
@@ -162,11 +173,12 @@ pprof: true
 pending-poll-interval: 5s
 `,
 			inputArgs: []string{
-				"--log-level", "error", "--http-port", "4577",
+				"--log-level", "error", "--http-port", "4577", "--http-host", "127.0.0.1",
 				"--db-path", "/home/flag/.juno", "--network", "integration", "--pprof", "--pending-poll-interval", time.Millisecond.String(),
 			},
 			expectedConfig: &node.Config{
 				LogLevel:            utils.ERROR,
+				HTTPHost:            "127.0.0.1",
 				HTTPPort:            4577,
 				WSPort:              defaultWSPort,
 				DatabasePath:        "/home/flag/.juno",
@@ -180,12 +192,14 @@ pending-poll-interval: 5s
 		"some setting set in both config file and flags": {
 			cfgFile: true,
 			cfgFileContents: `log-level: warn
+http-host: 0.0.0.0
 http-port: 4576
 network: goerli
 `,
 			inputArgs: []string{"--db-path", "/home/flag/.juno", "--ws-port", "4577"},
 			expectedConfig: &node.Config{
 				LogLevel:            utils.WARN,
+				HTTPHost:            "0.0.0.0",
 				HTTPPort:            4576,
 				WSPort:              4577,
 				DatabasePath:        "/home/flag/.juno",
@@ -203,6 +217,7 @@ ws-port: 4577`,
 			inputArgs: []string{"--db-path", "/home/flag/.juno", "--pprof"},
 			expectedConfig: &node.Config{
 				LogLevel:            defaultLogLevel,
+				HTTPHost:            defaultHTTPHost,
 				HTTPPort:            defaultHTTPPort,
 				WSPort:              4577,
 				DatabasePath:        "/home/flag/.juno",


### PR DESCRIPTION
Implemets #1019. 
To note: It includes an extra flag for the address instead of collapsing it with the port. I believe that this is a better approach, as seen in most other packages that have opted for this way.