### PR TITLE
jsonrpc,clients/gateway,clients/feeder: fix superfluous headers

### DIFF
--- a/clients/feeder/feeder.go
+++ b/clients/feeder/feeder.go
@@ -142,10 +142,7 @@ func newTestServer(network utils.Network) *httptest.Server {
 			return
 		}
 
-		_, err = w.Write(read)
-		if err != nil {
-			w.WriteHeader(http.StatusInternalServerError)
-		}
+		w.Write(read)
 	}))
 }
 

--- a/clients/feeder/feeder.go
+++ b/clients/feeder/feeder.go
@@ -141,8 +141,7 @@ func newTestServer(network utils.Network) *httptest.Server {
 			w.WriteHeader(http.StatusNotFound)
 			return
 		}
-
-		w.Write(read)
+		w.Write(read) //nolint:errcheck
 	}))
 }
 

--- a/clients/gateway/gateway.go
+++ b/clients/gateway/gateway.go
@@ -62,7 +62,7 @@ func newTestServer() *httptest.Server {
 		b, err := io.ReadAll(r.Body)
 		if err != nil {
 			w.WriteHeader(http.StatusBadRequest)
-			w.Write([]byte(err.Error()))
+			w.Write([]byte(err.Error())) //nolint:errcheck
 			return
 		}
 
@@ -73,13 +73,13 @@ func newTestServer() *httptest.Server {
 			return
 		} else if len(b) <= emptyReqLen {
 			w.WriteHeader(http.StatusBadRequest)
-			w.Write([]byte(`{"code": "Malformed Request", "message": "empty request"}`))
+			w.Write([]byte(`{"code": "Malformed Request", "message": "empty request"}`)) //nolint:errcheck
 			return
 		}
 
 		hash := new(felt.Felt).SetBytes([]byte("random"))
 		resp := fmt.Sprintf("{\"code\": \"TRANSACTION_RECEIVED\", \"transaction_hash\": %q, \"address\": %q}", hash.String(), hash.String())
-		w.Write([]byte(resp))
+		w.Write([]byte(resp)) //nolint:errcheck
 	}))
 }
 

--- a/clients/gateway/gateway.go
+++ b/clients/gateway/gateway.go
@@ -62,10 +62,7 @@ func newTestServer() *httptest.Server {
 		b, err := io.ReadAll(r.Body)
 		if err != nil {
 			w.WriteHeader(http.StatusBadRequest)
-			_, err = w.Write([]byte(err.Error()))
-			if err != nil {
-				w.WriteHeader(http.StatusInternalServerError)
-			}
+			w.Write([]byte(err.Error()))
 			return
 		}
 
@@ -76,19 +73,13 @@ func newTestServer() *httptest.Server {
 			return
 		} else if len(b) <= emptyReqLen {
 			w.WriteHeader(http.StatusBadRequest)
-			_, err = w.Write([]byte(`{"code": "Malformed Request", "message": "empty request"}`))
-			if err != nil {
-				w.WriteHeader(http.StatusInternalServerError)
-			}
+			w.Write([]byte(`{"code": "Malformed Request", "message": "empty request"}`))
 			return
 		}
 
 		hash := new(felt.Felt).SetBytes([]byte("random"))
 		resp := fmt.Sprintf("{\"code\": \"TRANSACTION_RECEIVED\", \"transaction_hash\": %q, \"address\": %q}", hash.String(), hash.String())
-		_, err = w.Write([]byte(resp))
-		if err != nil {
-			w.WriteHeader(http.StatusInternalServerError)
-		}
+		w.Write([]byte(resp))
 	}))
 }
 

--- a/jsonrpc/http.go
+++ b/jsonrpc/http.go
@@ -50,13 +50,11 @@ func (h *HTTP) ServeHTTP(writer http.ResponseWriter, req *http.Request) {
 	writer.Header().Set("Content-Type", "application/json")
 	if err != nil {
 		writer.WriteHeader(http.StatusInternalServerError)
-	} else {
-		writer.WriteHeader(http.StatusOK)
 	}
 	if resp != nil {
 		_, err = writer.Write(resp)
 		if err != nil {
-			writer.WriteHeader(http.StatusInternalServerError)
+			h.log.Warnw("Failed writing response", "err", err)
 		}
 	}
 }


### PR DESCRIPTION
This pr fixes superfluous responses due to doubleheader writes.  
The issue comes from the fact that Write() method already writes the header. 
Write description:
> ... If WriteHeader has not yet been called, Write calls WriteHeader(http.StatusOK) before writing the data. ...

