### PR TITLE
Deploy documentation site to gh pages

### DIFF
--- a/.github/workflows/docs-deploy.yml
+++ b/.github/workflows/docs-deploy.yml
@@ -1,0 +1,43 @@
+name: Deploy Documentation to GitHub Pages
+
+on:
+  push:
+    branches:
+      main
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  deploy:
+    name: Deploy to GitHub Pages
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version-file: .nvmrc
+          cache: npm
+          cache-dependency-path: docs
+
+      - name: Install dependencies
+        run: npm ci
+        working-directory: docs
+      - name: Build website
+        run: npm run build
+        working-directory: docs
+
+      - name: Deploy to GitHub Pages
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          # Build output to publish to the `gh-pages` branch:
+          publish_dir: ./docs/build
+          # The following lines assign commit authorship to the official
+          # GH-Actions bot for deploys to `gh-pages` branch:
+          # https://github.com/actions/checkout/issues/13#issuecomment-724415212
+          # The GH actions bot is used by default if you didn't specify the two fields.
+          # You can swap them out with your own user credentials.
+          # user_name: github-actions[bot]
+          # user_email: 41898282+github-actions[bot]@users.noreply.github.com

--- a/.github/workflows/docs-test.yml
+++ b/.github/workflows/docs-test.yml
@@ -1,0 +1,25 @@
+name: Test Documentation Build
+
+on:
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  test-deploy:
+    name: Test deployment
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version-file: docs/.nvmrc
+          cache: npm
+          cache-dependency-path: docs
+
+      - name: Install dependencies
+        run: npm ci
+        working-directory: docs
+      - name: Build website
+        run: npm run build
+        working-directory: docs

--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -82,7 +82,7 @@ const config = {
             items: [
               {
                 label: 'Quick Start',
-                to: '/docs/intro',
+                to: '/',
               },
             ],
           },


### PR DESCRIPTION
Based on my understanding of gh pages, the `docs-deploy.yml` workflow will deploy the site to github pages at `nethermindeth.github.io/juno` on every push to `main`. We will add a custom domain later. I mostly lifted these from the [sedge](https://github.com/NethermindEth/sedge/tree/develop/.github/workflows) repo.

The `docs-test` workflow builds the site on every pull request, so we don't accidentally release a broken site.

Deploying the site unblocks @Brivan-26 to work on Algolia search integration.