### PR TITLE
Add Unit Tests Execution on Self-Hosted ARM Machine in CI/CD

### DIFF
--- a/.github/workflows/juno-test.yml
+++ b/.github/workflows/juno-test.yml
@@ -14,7 +14,7 @@ jobs:
       fail-fast: false
       matrix:
         go: [ '1.20.3' ]
-        os: [ ubuntu-latest, macOS-latest]
+        os: [ ubuntu-latest, macOS-latest, self-hosted-linux-arm64]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
closed #1104

Updated our CI/CD pipeline to run unit tests on our self-hosted ARM machine. This was inspired by a suggestion from @kirugan, ensuring we capture potential endianness issues, especially relevant when conducting p2p tests with machines of different endianness.