### PR TITLE
Reduce pending-poll-interval on Test Envs

### DIFF
--- a/.github/workflows/upgrade-nodes-on-test-envs.yml
+++ b/.github/workflows/upgrade-nodes-on-test-envs.yml
@@ -80,7 +80,7 @@ jobs:
                     --http-port $httpPort \
                     --network $network \
                     --colour=false \
-                    --pending-poll-interval 5s \
+                    --pending-poll-interval 2s \
                     --metrics \
                     --metrics-port $metricsPort \
                     --pprof \


### PR DESCRIPTION
In our testing environments, the starknet-rs -> jsonrpc_pending_transactions tests were failing because of long pending-poll-interval. This PR reduces the interval for better test reliability.