### PR TITLE
Explicitly calculate actual fee when using skip_fee_charge flag

### DIFF
--- a/vm/rust/src/jsonrpc.rs
+++ b/vm/rust/src/jsonrpc.rs
@@ -1,10 +1,10 @@
-use serde::Serialize;
 use blockifier;
-use starknet_api::core::{ContractAddress, EntryPointSelector, ClassHash};
-use starknet_api::hash::StarkFelt;
-use starknet_api::transaction::{Calldata, EventContent, EthAddress, L2ToL1Payload};
-use starknet_api::deprecated_contract_class::EntryPointType;
 use blockifier::execution::entry_point::CallType;
+use serde::Serialize;
+use starknet_api::core::{ClassHash, ContractAddress, EntryPointSelector};
+use starknet_api::deprecated_contract_class::EntryPointType;
+use starknet_api::hash::StarkFelt;
+use starknet_api::transaction::{Calldata, EthAddress, EventContent, L2ToL1Payload};
 
 #[derive(Serialize)]
 pub struct TransactionTrace {
@@ -55,7 +55,8 @@ impl From<BlockifierCallInfo> for FunctionInvocation {
             call_type: match val.call.call_type {
                 CallType::Call => "CALL",
                 CallType::Delegate => "LIBRARY_CALL",
-            }.to_string(),
+            }
+            .to_string(),
             caller_address: val.call.caller_address,
             class_hash: val.call.class_hash,
             result: Some(val.execution.retdata.0),
@@ -66,7 +67,13 @@ impl From<BlockifierCallInfo> for FunctionInvocation {
             },
             calls: Some(val.inner_calls.into_iter().map(|v| v.into()).collect()),
             events: Some(val.execution.events.into_iter().map(|v| v.event).collect()),
-            messages: Some(val.execution.l2_to_l1_messages.into_iter().map(|v| v.message.into()).collect()),
+            messages: Some(
+                val.execution
+                    .l2_to_l1_messages
+                    .into_iter()
+                    .map(|v| v.message.into())
+                    .collect(),
+            ),
         }
     }
 }
@@ -78,7 +85,7 @@ pub struct FunctionCall {
     pub calldata: Calldata,
 }
 
-#[derive(Debug,Serialize)]
+#[derive(Debug, Serialize)]
 pub struct MessageToL1 {
     pub to_address: EthAddress,
     pub payload: L2ToL1Payload,
@@ -94,5 +101,5 @@ impl From<BlockifierMessageToL1> for MessageToL1 {
     }
 }
 
-#[derive(Debug,Serialize)]
+#[derive(Debug, Serialize)]
 pub struct Retdata(pub Vec<StarkFelt>);

--- a/vm/rust/src/lib.rs
+++ b/vm/rust/src/lib.rs
@@ -1,11 +1,11 @@
 pub mod class;
-mod juno_state_reader;
 pub mod jsonrpc;
+mod juno_state_reader;
 
 use crate::juno_state_reader::{ptr_to_felt, JunoStateReader};
 use std::{
     collections::HashMap,
-    ffi::{c_char, c_uchar, c_ulonglong, CStr, CString, c_void},
+    ffi::{c_char, c_uchar, c_ulonglong, c_void, CStr, CString},
     slice,
 };
 
@@ -16,13 +16,12 @@ use blockifier::{
         contract_class::{ContractClass, ContractClassV1},
         entry_point::{CallEntryPoint, CallType, EntryPointExecutionContext, ExecutionResources},
     },
+    fee::fee_utils::calculate_tx_fee,
     state::cached_state::CachedState,
     transaction::{
-        objects::AccountTransactionContext,
-        transaction_execution::Transaction,
+        objects::AccountTransactionContext, transaction_execution::Transaction,
         transactions::ExecutableTransaction,
     },
-    fee::fee_utils::calculate_tx_fee,
 };
 use cairo_lang_starknet::casm_contract_class::CasmContractClass;
 use cairo_lang_starknet::contract_class::ContractClass as SierraContractClass;
@@ -32,13 +31,13 @@ use cairo_vm::vm::runners::builtin_runner::{
     SEGMENT_ARENA_BUILTIN_NAME, SIGNATURE_BUILTIN_NAME,
 };
 use juno_state_reader::{contract_class_from_json_str, felt_to_byte_array};
+use starknet_api::transaction::{Calldata, Transaction as StarknetApiTransaction};
 use starknet_api::{
     block::{BlockNumber, BlockTimestamp},
     deprecated_contract_class::EntryPointType,
     hash::StarkFelt,
     transaction::Fee,
 };
-use starknet_api::transaction::{Calldata, Transaction as StarknetApiTransaction};
 use starknet_api::{
     core::{ChainId, ContractAddress, EntryPointSelector},
     hash::StarkHash,
@@ -130,7 +129,7 @@ pub extern "C" fn cairoVMExecute(
     sequencer_address: *const c_uchar,
     paid_fees_on_l1_json: *const c_char,
     skip_charge_fee: c_uchar,
-    gas_price: *const c_uchar
+    gas_price: *const c_uchar,
 ) {
     let reader = JunoStateReader::new(reader_handle);
     let chain_id_str = unsafe { CStr::from_ptr(chain_id) }.to_str().unwrap();
@@ -152,7 +151,9 @@ pub extern "C" fn cairoVMExecute(
         return;
     }
 
-    let paid_fees_on_l1_json_str = unsafe { CStr::from_ptr(paid_fees_on_l1_json) }.to_str().unwrap();
+    let paid_fees_on_l1_json_str = unsafe { CStr::from_ptr(paid_fees_on_l1_json) }
+        .to_str()
+        .unwrap();
     let mut paid_fees_on_l1: Vec<Box<Fee>> = match serde_json::from_str(paid_fees_on_l1_json_str) {
         Ok(f) => f,
         Err(e) => {
@@ -203,11 +204,14 @@ pub extern "C" fn cairoVMExecute(
         let paid_fee_on_l1: Option<Fee> = match sn_api_txn.clone() {
             StarknetApiTransaction::L1Handler(_) => {
                 if paid_fees_on_l1.len() == 0 {
-                        report_error(reader_handle, "missing fee paid on l1b".to_string().as_str());
-                        return;
+                    report_error(
+                        reader_handle,
+                        "missing fee paid on l1b".to_string().as_str(),
+                    );
+                    return;
                 }
                 Some(*paid_fees_on_l1.remove(0))
-            },
+            }
             _ => None,
         };
 
@@ -219,7 +223,9 @@ pub extern "C" fn cairoVMExecute(
 
         let res = match txn.unwrap() {
             Transaction::AccountTransaction(t) => t.execute(&mut state, &block_context, charge_fee),
-            Transaction::L1HandlerTransaction(t) => t.execute(&mut state, &block_context, charge_fee),
+            Transaction::L1HandlerTransaction(t) => {
+                t.execute(&mut state, &block_context, charge_fee)
+            }
         };
 
         match res {
@@ -270,10 +276,16 @@ fn transaction_from_api(
 ) -> Result<Transaction, String> {
     match tx {
         StarknetApiTransaction::Deploy(deploy) => {
-            return Err(format!("Deploy transaction is not supported (transaction_hash={})", deploy.transaction_hash))
-        },
+            return Err(format!(
+                "Deploy transaction is not supported (transaction_hash={})",
+                deploy.transaction_hash
+            ))
+        }
         StarknetApiTransaction::Declare(declare) if contract_class.is_none() => {
-            return Err(format!("Declare transaction must be created with a ContractClass (transaction_hash={})", declare.transaction_hash()))
+            return Err(format!(
+                "Declare transaction must be created with a ContractClass (transaction_hash={})",
+                declare.transaction_hash()
+            ))
         }
         _ => {} // all ok
     };


### PR DESCRIPTION
Even tho skip fee charge is enabled, blockifier respects the max_fee field of the transaction. By recalculating the actual fee when it is used we can get an accurate fee estimation.