### PR TITLE
vm/rust/src: Abort execution at reverted tx

### DIFF
--- a/vm/rust/src/lib.rs
+++ b/vm/rust/src/lib.rs
@@ -244,17 +244,31 @@ pub extern "C" fn cairoVMExecute(
                 );
                 return;
             }
-            Ok(t) => unsafe {
-                JunoAppendActualFee(
-                    reader_handle,
-                    felt_to_byte_array(&t.actual_fee.0.into()).as_ptr(),
-                );
+            Ok(t) => {
+                if t.is_reverted() {
+                    report_error(
+                        reader_handle,
+                        format!(
+                            "reverted txn {:?} reason:{:?}",
+                            sn_api_txn.transaction_hash(),
+                            t.revert_error
+                        )
+                        .as_str(),
+                    );
+                    return
+                }
+                unsafe {
+                    JunoAppendActualFee(
+                        reader_handle,
+                        felt_to_byte_array(&t.actual_fee.0.into()).as_ptr(),
+                    );
 
-                append_trace(
-                    reader_handle,
-                    t.into(),
-                );
-            },
+                    append_trace(
+                        reader_handle,
+                        t.into(),
+                    );
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
Should close #1108 if I understood correctly.
Not sure how to test it, `vm_test.go` doesn't have much content that I could base on. 