### PR TITLE
Include starknet-rs tests for starknet-accounts in CI

### DIFF
--- a/.github/workflows/starknet-rs-tests.yml
+++ b/.github/workflows/starknet-rs-tests.yml
@@ -23,8 +23,9 @@ jobs:
         profile: minimal
         override: true
 
-    - name: Run tests in jsonrpc.rs
+    - name: Run jsonrpc tests
       run: |
-        cd starknet-providers && cargo test --test jsonrpc
+        cd starknet-providers && cargo test jsonrpc
+        cd ../starknet-accounts && cargo test jsonrpc
       env:
         STARKNET_RPC: ${{ github.event.inputs.NODE_URL }}


### PR DESCRIPTION
[Sample run](https://github.com/NethermindEth/juno/actions/runs/5937823435/job/16101013707#step:4:451) - one test fails due to: [VM cannot unmarshall Cairo0 classes without debug_info](https://github.com/NethermindEth/juno/issues/1130)