### PR TITLE
grpc: Match pkg name with dir

### DIFF
--- a/grpc/handlers.go
+++ b/grpc/handlers.go
@@ -1,4 +1,4 @@
-package junogrpc
+package grpc
 
 import (
 	"bytes"

--- a/grpc/handlers_test.go
+++ b/grpc/handlers_test.go
@@ -1,4 +1,4 @@
-package junogrpc
+package grpc
 
 import (
 	"context"

--- a/grpc/tx.go
+++ b/grpc/tx.go
@@ -1,4 +1,4 @@
-package junogrpc
+package grpc
 
 import (
 	"errors"


### PR DESCRIPTION
This pr resolves inconsistent behavior across multiple users due to breaking go naming convention.
Previously it was seen in module node/http but after some codebase changes, it currently affects only grpc.

**Issue:**
Importing multiple packages where the name differs from the directory, results in undefined and not friendly behavior.
Eg. import of `"a/b/c"`  where c declares package foo. Such package components are then accessed through `foo.` instead of `c.`
As shown in #1043  VSCode automatically enforces aliasing in such situations meanwhile some IDEs do not despite using the same formatting tool.

**Reason for package names reflecting their path:**
Golang official source: https://go.dev/blog/package-names

> A Go package has both a name and a path. The package name is specified in the package statement of its source files; client code uses it as the prefix for the package’s exported names. Client code uses the package path when importing the package. **By convention, the last element of the package path is the package name**:

**Solution**
Either rename folder to match package name or rename package to match directory. This PR opts for the latter. 

**Impact**
This pr does not impact the codebase at all. The reference to grpc module (change from junogrpc to grpc) was already aliased before as `junogrpc "github.com/NethermindEth/juno/grpc"` in `node/http.go` 
A similar case was seen before with node/http package. Back then the wanted behavior was removing alias. Based on that logic current import is inconsistent. (Documented in #1043)  


 