### PR TITLE
Avoid double copy for strings in vm

### DIFF
--- a/vm/class.go
+++ b/vm/class.go
@@ -140,7 +140,7 @@ func Cairo0ClassHash(class *core.Cairo0Class) (*felt.Felt, error) {
 	if err != nil {
 		return nil, err
 	}
-	classJSONCStr := C.CString(string(classJSON))
+	classJSONCStr := cstring(classJSON)
 
 	var hash felt.Felt
 	hashBytes := hash.Bytes()

--- a/vm/state_reader.go
+++ b/vm/state_reader.go
@@ -89,5 +89,5 @@ func JunoStateGetCompiledClass(readerHandle C.uintptr_t, classHash unsafe.Pointe
 		return nil
 	}
 
-	return unsafe.Pointer(C.CString(string(compiledClass)))
+	return unsafe.Pointer(cstring(compiledClass))
 }

--- a/vm/string.go
+++ b/vm/string.go
@@ -1,0 +1,9 @@
+package vm
+
+import "C"
+import "unsafe"
+
+func cstring(data []byte) *C.char {
+	str := unsafe.String(unsafe.SliceData(data), len(data))
+	return C.CString(str)
+}

--- a/vm/string.go
+++ b/vm/string.go
@@ -3,6 +3,8 @@ package vm
 import "C"
 import "unsafe"
 
+// cstring creates a null-terminated C string from the given byte slice.
+// the caller is responsible for freeing the underlying memory
 func cstring(data []byte) *C.char {
 	str := unsafe.String(unsafe.SliceData(data), len(data))
 	return C.CString(str)

--- a/vm/vm.go
+++ b/vm/vm.go
@@ -172,9 +172,9 @@ func (v *vm) Execute(txns []core.Transaction, declaredClasses []core.Class, bloc
 		return nil, nil, err
 	}
 
-	paidFeesOnL1CStr := C.CString(string(paidFeesOnL1Bytes))
-	txnsJSONCstr := C.CString(string(txnsJSON))
-	classesJSONCStr := C.CString(string(classesJSON))
+	paidFeesOnL1CStr := cstring(paidFeesOnL1Bytes)
+	txnsJSONCstr := cstring(txnsJSON)
+	classesJSONCStr := cstring(classesJSON)
 
 	sequencerAddressBytes := sequencerAddress.Bytes()
 	gasPriceBytes := gasPrice.Bytes()


### PR DESCRIPTION
Functions `C.CString(...)` and `C.Bytes(...)` actually copy data where the former adds \0 at the end of string.
Here is small test how it works:
```
// #include <stdio.h>
// static void test(char* str) {
//.      printf("Call from C: '%s'\n", str);
//.      fflush(stdout);
// }
import "C"
func CopyExample() {
	data := []byte{'s', 't', 'r', 'i', 'n', 'g'}
	original := unsafe.String(unsafe.SliceData(data), len(data))

	str := C.CString(original)
	*str = 'c'
	data[2] = '!'
	C.test(str)

	fmt.Println("Original ", original)
}
```