### PR TITLE
Immediately acknowledge panicing services

### DIFF
--- a/node/node.go
+++ b/node/node.go
@@ -228,9 +228,11 @@ func (n *Node) Run(ctx context.Context) {
 	for _, s := range n.services {
 		s := s
 		wg.Go(func() {
+			// Immediately acknowledge panicing services by shutting down the node
+			// Without the deffered cancel(), we would have to wait for user to hit Ctrl+C
+			defer cancel()
 			if err := s.Run(ctx); err != nil {
 				n.log.Errorw("Service error", "name", reflect.TypeOf(s), "err", err)
-				cancel()
 			}
 		})
 	}


### PR DESCRIPTION
```
and gracefully shutdown the node
```

we used to wait until the user shuts down the node with Ctrl+C