### PR TITLE
RPC request can omit params if the handler's only argument is a context

### DIFF
--- a/jsonrpc/server.go
+++ b/jsonrpc/server.go
@@ -372,18 +372,6 @@ func (s *Server) handleRequest(ctx context.Context, req *request) (*response, er
 }
 
 func (s *Server) buildArguments(ctx context.Context, params any, method Method) ([]reflect.Value, error) {
-	if isNil(params) {
-		allParamsAreOptional := utils.All(method.Params, func(p Parameter) bool {
-			return p.Optional
-		})
-
-		if len(method.Params) > 0 && !allParamsAreOptional {
-			return nil, errors.New("missing non-optional param field")
-		}
-
-		return s.buildDefaultArguments(ctx, method)
-	}
-
 	handlerType := reflect.TypeOf(method.Handler)
 
 	numArgs := handlerType.NumIn()
@@ -393,6 +381,23 @@ func (s *Server) buildArguments(ctx context.Context, params any, method Method) 
 	if method.needsContext {
 		args = append(args, reflect.ValueOf(ctx))
 		addContext = 1
+	}
+
+	if isNil(params) {
+		allParamsAreOptional := utils.All(method.Params, func(p Parameter) bool {
+			return p.Optional
+		})
+
+		if len(method.Params) > 0 && !allParamsAreOptional {
+			return nil, errors.New("missing non-optional param field")
+		}
+
+		for i := addContext; i < numArgs; i++ {
+			arg := reflect.New(handlerType.In(i)).Elem()
+			args = append(args, arg)
+		}
+
+		return args, nil
 	}
 
 	switch reflect.TypeOf(params).Kind() {
@@ -434,20 +439,6 @@ func (s *Server) buildArguments(ctx context.Context, params any, method Method) 
 		// Todo: consider returning InternalError
 		return nil, errors.New("impossible param type: check request.isSane")
 	}
-	return args, nil
-}
-
-func (s *Server) buildDefaultArguments(_ context.Context, method Method) ([]reflect.Value, error) {
-	handlerType := reflect.TypeOf(method.Handler)
-
-	numArgs := handlerType.NumIn()
-	args := make([]reflect.Value, 0, numArgs)
-
-	for i := 0; i < numArgs; i++ {
-		arg := reflect.New(handlerType.In(i)).Elem()
-		args = append(args, arg)
-	}
-
 	return args, nil
 }
 

--- a/jsonrpc/server_test.go
+++ b/jsonrpc/server_test.go
@@ -138,13 +138,17 @@ func TestHandle(t *testing.T) {
 			},
 		},
 		{
-			Name:    "acceptsContext",
-			Handler: func(_ context.Context) (int, *jsonrpc.Error) { return 0, nil },
+			Name: "acceptsContext",
+			Handler: func(ctx context.Context) (int, *jsonrpc.Error) {
+				require.NotNil(t, ctx)
+				return 0, nil
+			},
 		},
 		{
 			Name:   "acceptsContextAndTwoParams",
 			Params: []jsonrpc.Parameter{{Name: "a"}, {Name: "b"}},
-			Handler: func(_ context.Context, a, b int) (int, *jsonrpc.Error) {
+			Handler: func(ctx context.Context, a, b int) (int, *jsonrpc.Error) {
+				require.NotNil(t, ctx)
 				return b - a, nil
 			},
 		},
@@ -379,6 +383,10 @@ func TestHandle(t *testing.T) {
 		},
 		"handler accepts context with array params": {
 			req: `{"jsonrpc": "2.0", "method": "acceptsContext", "params": [], "id": 1}`,
+			res: `{"jsonrpc":"2.0","result":0,"id":1}`,
+		},
+		"handler accepts context without params": {
+			req: `{"jsonrpc": "2.0", "method": "acceptsContext","id": 1}`,
 			res: `{"jsonrpc":"2.0","result":0,"id":1}`,
 		},
 		"handler accepts context and two params with array params": {


### PR DESCRIPTION
I think this was introduced in https://github.com/NethermindEth/juno/pull/1078

Added a regression test.