### PR TITLE
Allocate less per RPC request

### DIFF
--- a/jsonrpc/server.go
+++ b/jsonrpc/server.go
@@ -28,6 +28,7 @@ const (
 var (
 	ErrInvalidID = errors.New("id should be a string or an integer")
 
+	bufferSize       = 128
 	contextInterface = reflect.TypeOf((*context.Context)(nil)).Elem()
 )
 
@@ -198,7 +199,7 @@ func (s *Server) Handle(ctx context.Context, data []byte) ([]byte, error) {
 // It returns the response in a byte array, only returns an
 // error if it can not create the response byte array
 func (s *Server) HandleReader(ctx context.Context, reader io.Reader) ([]byte, error) {
-	bufferedReader := bufio.NewReader(reader)
+	bufferedReader := bufio.NewReaderSize(reader, bufferSize)
 	requestIsBatch := isBatch(bufferedReader)
 	res := &response{
 		Version: "2.0",

--- a/jsonrpc/server_test.go
+++ b/jsonrpc/server_test.go
@@ -482,3 +482,18 @@ func assertBatchResponse(t *testing.T, expectedStr, actualStr string) {
 
 	assert.ElementsMatch(t, expected, actual)
 }
+
+func BenchmarkHandle(b *testing.B) {
+	listener := CountingEventListener{}
+	server := jsonrpc.NewServer(1, utils.NewNopZapLogger()).WithValidator(validator.New()).WithListener(&listener)
+	require.NoError(b, server.RegisterMethods(jsonrpc.Method{
+		Name:    "bench",
+		Handler: func() (int, *jsonrpc.Error) { return 0, nil },
+	}))
+
+	const request = `{"jsonrpc":"2.0","id":1,"method":"test"}`
+	for i := 0; i < b.N; i++ {
+		_, err := server.Handle(context.Background(), []byte(request))
+		require.NoError(b, err)
+	}
+}


### PR DESCRIPTION
Right now:
```
BenchmarkHandle-12    	 288895	    17161 ns/op	   5693 B/op	     22 allocs/op
```
With `16`:
```
BenchmarkHandle-12    	 331896	    14534 ns/op	   3147 B/op	     23 allocs/op
```
With `80`:
```
BenchmarkHandle-12    	 350372	    11127 ns/op	   1673 B/op	     22 allocs/op
```
With `128`:
```
BenchmarkHandle-12    	 387760	    11151 ns/op	   1721 B/op	     22 allocs/op
```

I figured most realistic requests are less than 128 bytes, so I went with that.