### PR TITLE
Fix over-reading websocket requests

### DIFF
--- a/jsonrpc/websocket.go
+++ b/jsonrpc/websocket.go
@@ -132,9 +132,8 @@ func (wsc *websocketConn) Write(p []byte) (int, error) {
 	writeCtx, writeCancel := context.WithTimeout(wsc.ctx, wsc.params.WriteDuration)
 	defer writeCancel()
 	// Use MessageText since JSON is a text format.
-	err := wsc.conn.Write(writeCtx, websocket.MessageText, p)
-	if err != nil {
+	if err := wsc.conn.Write(writeCtx, websocket.MessageText, p); err != nil {
 		return 0, err
 	}
-	return len(p), err
+	return len(p), nil
 }


### PR DESCRIPTION
The JSON decoder can read past the end of the JSON message and into the next request, causing decoding to fail when the next request is processed.

This commit ensures we only give the decoder a single message at a time.