### PR TITLE
Use t.Cleanup in pebble.NewMemTest

### DIFF
--- a/blockchain/blockchain_test.go
+++ b/blockchain/blockchain_test.go
@@ -24,7 +24,7 @@ func TestNew(t *testing.T) {
 	gw := adaptfeeder.New(client)
 	log := utils.NewNopZapLogger()
 	t.Run("empty blockchain's head is nil", func(t *testing.T) {
-		chain := blockchain.New(pebble.NewMemTest(), utils.MAINNET, log)
+		chain := blockchain.New(pebble.NewMemTest(t), utils.MAINNET, log)
 		assert.Equal(t, utils.MAINNET, chain.Network())
 		b, err := chain.Head()
 		assert.Nil(t, b)
@@ -37,7 +37,7 @@ func TestNew(t *testing.T) {
 		stateUpdate0, err := gw.StateUpdate(context.Background(), 0)
 		require.NoError(t, err)
 
-		testDB := pebble.NewMemTest()
+		testDB := pebble.NewMemTest(t)
 		chain := blockchain.New(testDB, utils.MAINNET, log)
 		assert.NoError(t, chain.Store(block0, &emptyCommitments, stateUpdate0, nil))
 
@@ -53,7 +53,7 @@ func TestHeight(t *testing.T) {
 	gw := adaptfeeder.New(client)
 	log := utils.NewNopZapLogger()
 	t.Run("return nil if blockchain is empty", func(t *testing.T) {
-		chain := blockchain.New(pebble.NewMemTest(), utils.GOERLI, log)
+		chain := blockchain.New(pebble.NewMemTest(t), utils.GOERLI, log)
 		_, err := chain.Height()
 		assert.Error(t, err)
 	})
@@ -64,7 +64,7 @@ func TestHeight(t *testing.T) {
 		stateUpdate0, err := gw.StateUpdate(context.Background(), 0)
 		require.NoError(t, err)
 
-		testDB := pebble.NewMemTest()
+		testDB := pebble.NewMemTest(t)
 		chain := blockchain.New(testDB, utils.MAINNET, log)
 		assert.NoError(t, chain.Store(block0, &emptyCommitments, stateUpdate0, nil))
 
@@ -76,7 +76,7 @@ func TestHeight(t *testing.T) {
 }
 
 func TestBlockByNumberAndHash(t *testing.T) {
-	chain := blockchain.New(pebble.NewMemTest(), utils.GOERLI, utils.NewNopZapLogger())
+	chain := blockchain.New(pebble.NewMemTest(t), utils.GOERLI, utils.NewNopZapLogger())
 	t.Run("same block is returned for both GetBlockByNumber and GetBlockByHash", func(t *testing.T) {
 		client := feeder.NewTestClient(t, utils.MAINNET)
 		gw := adaptfeeder.New(client)
@@ -112,7 +112,7 @@ func TestVerifyBlock(t *testing.T) {
 	h1, err := new(felt.Felt).SetRandom()
 	require.NoError(t, err)
 
-	chain := blockchain.New(pebble.NewMemTest(), utils.MAINNET, utils.NewNopZapLogger())
+	chain := blockchain.New(pebble.NewMemTest(t), utils.MAINNET, utils.NewNopZapLogger())
 
 	t.Run("error if chain is empty and incoming block number is not 0", func(t *testing.T) {
 		block := &core.Block{Header: &core.Header{Number: 10}}
@@ -174,7 +174,7 @@ func TestSanityCheckNewHeight(t *testing.T) {
 	h1, err := new(felt.Felt).SetRandom()
 	require.NoError(t, err)
 
-	chain := blockchain.New(pebble.NewMemTest(), utils.MAINNET, utils.NewNopZapLogger())
+	chain := blockchain.New(pebble.NewMemTest(t), utils.MAINNET, utils.NewNopZapLogger())
 
 	client := feeder.NewTestClient(t, utils.MAINNET)
 
@@ -220,7 +220,7 @@ func TestStore(t *testing.T) {
 	require.NoError(t, err)
 
 	t.Run("add block to empty blockchain", func(t *testing.T) {
-		chain := blockchain.New(pebble.NewMemTest(), utils.MAINNET, log)
+		chain := blockchain.New(pebble.NewMemTest(t), utils.MAINNET, log)
 		require.NoError(t, chain.Store(block0, &emptyCommitments, stateUpdate0, nil))
 
 		headBlock, err := chain.Head()
@@ -246,7 +246,7 @@ func TestStore(t *testing.T) {
 		stateUpdate1, err := gw.StateUpdate(context.Background(), 1)
 		require.NoError(t, err)
 
-		chain := blockchain.New(pebble.NewMemTest(), utils.MAINNET, log)
+		chain := blockchain.New(pebble.NewMemTest(t), utils.MAINNET, log)
 		require.NoError(t, chain.Store(block0, &emptyCommitments, stateUpdate0, nil))
 		require.NoError(t, chain.Store(block1, &emptyCommitments, stateUpdate1, nil))
 
@@ -269,7 +269,7 @@ func TestStore(t *testing.T) {
 }
 
 func TestTransactionAndReceipt(t *testing.T) {
-	chain := blockchain.New(pebble.NewMemTest(), utils.MAINNET, utils.NewNopZapLogger())
+	chain := blockchain.New(pebble.NewMemTest(t), utils.MAINNET, utils.NewNopZapLogger())
 
 	client := feeder.NewTestClient(t, utils.MAINNET)
 	gw := adaptfeeder.New(client)
@@ -356,10 +356,7 @@ func TestTransactionAndReceipt(t *testing.T) {
 }
 
 func TestState(t *testing.T) {
-	testDB := pebble.NewMemTest()
-	t.Cleanup(func() {
-		require.NoError(t, testDB.Close())
-	})
+	testDB := pebble.NewMemTest(t)
 	chain := blockchain.New(testDB, utils.MAINNET, utils.NewNopZapLogger())
 
 	client := feeder.NewTestClient(t, utils.MAINNET)
@@ -422,10 +419,7 @@ func TestState(t *testing.T) {
 }
 
 func TestEvents(t *testing.T) {
-	testDB := pebble.NewMemTest()
-	t.Cleanup(func() {
-		require.NoError(t, testDB.Close())
-	})
+	testDB := pebble.NewMemTest(t)
 	chain := blockchain.New(testDB, utils.GOERLI2, utils.NewNopZapLogger())
 
 	client := feeder.NewTestClient(t, utils.GOERLI2)
@@ -544,7 +538,7 @@ func TestEvents(t *testing.T) {
 }
 
 func TestRevert(t *testing.T) {
-	testdb := pebble.NewMemTest()
+	testdb := pebble.NewMemTest(t)
 	chain := blockchain.New(testdb, utils.MAINNET, utils.NewNopZapLogger())
 
 	client := feeder.NewTestClient(t, utils.MAINNET)
@@ -606,7 +600,7 @@ func TestRevert(t *testing.T) {
 				return err
 			}
 			assert.False(t, it.Next(), it.Key())
-			return nil
+			return it.Close()
 		}))
 	})
 
@@ -629,7 +623,7 @@ func TestL1Update(t *testing.T) {
 
 	for _, head := range heads {
 		t.Run(fmt.Sprintf("update L1 head to block %d", head.BlockNumber), func(t *testing.T) {
-			chain := blockchain.New(pebble.NewMemTest(), utils.MAINNET, utils.NewNopZapLogger())
+			chain := blockchain.New(pebble.NewMemTest(t), utils.MAINNET, utils.NewNopZapLogger())
 			require.NoError(t, chain.SetL1Head(head))
 			got, err := chain.L1Head()
 			require.NoError(t, err)
@@ -639,10 +633,7 @@ func TestL1Update(t *testing.T) {
 }
 
 func TestPending(t *testing.T) {
-	testDB := pebble.NewMemTest()
-	t.Cleanup(func() {
-		require.NoError(t, testDB.Close())
-	})
+	testDB := pebble.NewMemTest(t)
 	chain := blockchain.New(testDB, utils.MAINNET, utils.NewNopZapLogger())
 	client := feeder.NewTestClient(t, utils.MAINNET)
 	gw := adaptfeeder.New(client)
@@ -769,10 +760,7 @@ func TestPending(t *testing.T) {
 }
 
 func TestSubscribeNewHeads(t *testing.T) {
-	testDB := pebble.NewMemTest()
-	t.Cleanup(func() {
-		require.NoError(t, testDB.Close())
-	})
+	testDB := pebble.NewMemTest(t)
 	chain := blockchain.New(testDB, utils.MAINNET, utils.NewNopZapLogger())
 	client := feeder.NewTestClient(t, utils.MAINNET)
 	gw := adaptfeeder.New(client)

--- a/core/contract_test.go
+++ b/core/contract_test.go
@@ -52,10 +52,7 @@ func TestContractAddress(t *testing.T) {
 }
 
 func TestNewContract(t *testing.T) {
-	testDB := pebble.NewMemTest()
-	t.Cleanup(func() {
-		require.NoError(t, testDB.Close())
-	})
+	testDB := pebble.NewMemTest(t)
 
 	txn := testDB.NewTransaction(true)
 	t.Cleanup(func() {
@@ -129,10 +126,7 @@ func TestNewContract(t *testing.T) {
 }
 
 func TestNonceAndClassHash(t *testing.T) {
-	testDB := pebble.NewMemTest()
-	t.Cleanup(func() {
-		require.NoError(t, testDB.Close())
-	})
+	testDB := pebble.NewMemTest(t)
 
 	txn := testDB.NewTransaction(true)
 	addr := new(felt.Felt).SetUint64(44)
@@ -170,10 +164,7 @@ func TestNonceAndClassHash(t *testing.T) {
 }
 
 func TestUpdateStorageAndStorage(t *testing.T) {
-	testDB := pebble.NewMemTest()
-	t.Cleanup(func() {
-		require.NoError(t, testDB.Close())
-	})
+	testDB := pebble.NewMemTest(t)
 
 	txn := testDB.NewTransaction(true)
 	addr := new(felt.Felt).SetUint64(44)
@@ -211,10 +202,7 @@ func TestUpdateStorageAndStorage(t *testing.T) {
 }
 
 func TestPurge(t *testing.T) {
-	testDB := pebble.NewMemTest()
-	t.Cleanup(func() {
-		require.NoError(t, testDB.Close())
-	})
+	testDB := pebble.NewMemTest(t)
 
 	txn := testDB.NewTransaction(true)
 	addr := new(felt.Felt).SetUint64(44)

--- a/core/history_pkg_test.go
+++ b/core/history_pkg_test.go
@@ -10,11 +10,10 @@ import (
 )
 
 func TestHistory(t *testing.T) {
-	testDB := pebble.NewMemTest()
+	testDB := pebble.NewMemTest(t)
 	txn := testDB.NewTransaction(true)
 	t.Cleanup(func() {
 		require.NoError(t, txn.Discard())
-		require.NoError(t, testDB.Close())
 	})
 
 	history := &history{txn: txn}

--- a/core/state_test.go
+++ b/core/state_test.go
@@ -23,7 +23,7 @@ func TestUpdate(t *testing.T) {
 	client := feeder.NewTestClient(t, utils.MAINNET)
 	gw := adaptfeeder.New(client)
 
-	testDB := pebble.NewMemTest()
+	testDB := pebble.NewMemTest(t)
 	txn := testDB.NewTransaction(true)
 	t.Cleanup(func() {
 		require.NoError(t, txn.Discard())
@@ -152,7 +152,7 @@ func TestContractClassHash(t *testing.T) {
 	client := feeder.NewTestClient(t, utils.MAINNET)
 	gw := adaptfeeder.New(client)
 
-	testDB := pebble.NewMemTest()
+	testDB := pebble.NewMemTest(t)
 	txn := testDB.NewTransaction(true)
 	t.Cleanup(func() {
 		require.NoError(t, txn.Discard())
@@ -211,7 +211,7 @@ func TestContractClassHash(t *testing.T) {
 }
 
 func TestNonce(t *testing.T) {
-	testDB := pebble.NewMemTest()
+	testDB := pebble.NewMemTest(t)
 	txn := testDB.NewTransaction(true)
 	t.Cleanup(func() {
 		require.NoError(t, txn.Discard())
@@ -262,7 +262,7 @@ func TestNonce(t *testing.T) {
 }
 
 func TestStateHistory(t *testing.T) {
-	testDB := pebble.NewMemTest()
+	testDB := pebble.NewMemTest(t)
 	txn := testDB.NewTransaction(true)
 	t.Cleanup(func() {
 		require.NoError(t, txn.Discard())
@@ -316,7 +316,7 @@ func TestContractIsDeployedAt(t *testing.T) {
 	client := feeder.NewTestClient(t, utils.MAINNET)
 	gw := adaptfeeder.New(client)
 
-	testDB := pebble.NewMemTest()
+	testDB := pebble.NewMemTest(t)
 	txn := testDB.NewTransaction(true)
 	t.Cleanup(func() {
 		require.NoError(t, txn.Discard())
@@ -364,7 +364,7 @@ func TestContractIsDeployedAt(t *testing.T) {
 }
 
 func TestClass(t *testing.T) {
-	testDB := pebble.NewMemTest()
+	testDB := pebble.NewMemTest(t)
 	txn := testDB.NewTransaction(true)
 	t.Cleanup(func() {
 		require.NoError(t, txn.Discard())
@@ -408,7 +408,7 @@ func TestClass(t *testing.T) {
 }
 
 func TestRevert(t *testing.T) {
-	testDB := pebble.NewMemTest()
+	testDB := pebble.NewMemTest(t)
 	txn := testDB.NewTransaction(true)
 	t.Cleanup(func() {
 		require.NoError(t, txn.Discard())
@@ -555,7 +555,7 @@ func TestRevert(t *testing.T) {
 				return err
 			}
 			assert.False(t, it.Next())
-			return nil
+			return it.Close()
 		}))
 	})
 }
@@ -564,7 +564,7 @@ func TestRevertNoClassContracts(t *testing.T) {
 	client := feeder.NewTestClient(t, utils.MAINNET)
 	gw := adaptfeeder.New(client)
 
-	testDB := pebble.NewMemTest()
+	testDB := pebble.NewMemTest(t)
 	txn := testDB.NewTransaction(true)
 	t.Cleanup(func() {
 		require.NoError(t, txn.Discard())
@@ -602,7 +602,7 @@ func TestRevertNoClassContracts(t *testing.T) {
 }
 
 func TestRevertDeclaredClasses(t *testing.T) {
-	testDB := pebble.NewMemTest()
+	testDB := pebble.NewMemTest(t)
 	txn := testDB.NewTransaction(true)
 	t.Cleanup(func() {
 		require.NoError(t, txn.Discard())

--- a/core/trie/transaction_storage_test.go
+++ b/core/trie/transaction_storage_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 func TestTransactionStorage(t *testing.T) {
-	testDB := pebble.NewMemTest()
+	testDB := pebble.NewMemTest(t)
 	prefix := []byte{37, 44}
 	key := trie.NewKey(44, nil)
 

--- a/db/pebble/db.go
+++ b/db/pebble/db.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"sync"
+	"testing"
 
 	"github.com/NethermindEth/juno/db"
 	"github.com/NethermindEth/juno/utils"
@@ -38,11 +39,16 @@ func NewMem() (db.DB, error) {
 }
 
 // NewMemTest opens a new in-memory database, panics on error
-func NewMemTest() db.DB {
+func NewMemTest(t *testing.T) db.DB {
 	memDB, err := NewMem()
 	if err != nil {
-		panic(err)
+		t.Fatalf("create in-memory db: %v", err)
 	}
+	t.Cleanup(func() {
+		if err := memDB.Close(); err != nil {
+			t.Errorf("close in-memory db: %v", err)
+		}
+	})
 	return memDB
 }
 

--- a/db/pebble/db_test.go
+++ b/db/pebble/db_test.go
@@ -32,10 +32,7 @@ func (l *eventListener) OnIO(write bool) {
 func TestTransaction(t *testing.T) {
 	listener := eventListener{}
 	t.Run("new transaction can retrieve existing value", func(t *testing.T) {
-		testDB := pebble.NewMemTest().WithListener(&listener)
-		t.Cleanup(func() {
-			require.NoError(t, testDB.Close())
-		})
+		testDB := pebble.NewMemTest(t).WithListener(&listener)
 
 		txn := testDB.NewTransaction(true)
 		require.NoError(t, txn.Set([]byte("key"), []byte("value")))
@@ -56,10 +53,7 @@ func TestTransaction(t *testing.T) {
 	})
 
 	t.Run("discarded transaction is not committed to DB", func(t *testing.T) {
-		testDB := pebble.NewMemTest()
-		t.Cleanup(func() {
-			require.NoError(t, testDB.Close())
-		})
+		testDB := pebble.NewMemTest(t)
 
 		txn := testDB.NewTransaction(true)
 		require.NoError(t, txn.Set([]byte("key"), []byte("value")))
@@ -72,10 +66,7 @@ func TestTransaction(t *testing.T) {
 
 	t.Run("value committed by a transactions are not accessible to other transactions created"+
 		" before Commit()", func(t *testing.T) {
-		testDB := pebble.NewMemTest()
-		t.Cleanup(func() {
-			require.NoError(t, testDB.Close())
-		})
+		testDB := pebble.NewMemTest(t)
 
 		txn1 := testDB.NewTransaction(true)
 		txn2 := testDB.NewTransaction(false)
@@ -96,10 +87,7 @@ func TestTransaction(t *testing.T) {
 	})
 
 	t.Run("discarded transaction cannot commit", func(t *testing.T) {
-		testDB := pebble.NewMemTest()
-		t.Cleanup(func() {
-			require.NoError(t, testDB.Close())
-		})
+		testDB := pebble.NewMemTest(t)
 
 		txn := testDB.NewTransaction(true)
 		require.NoError(t, txn.Set([]byte("key"), []byte("value")))
@@ -111,10 +99,7 @@ func TestTransaction(t *testing.T) {
 
 func TestViewUpdate(t *testing.T) {
 	t.Run("value after Update is committed to DB", func(t *testing.T) {
-		testDB := pebble.NewMemTest()
-		t.Cleanup(func() {
-			require.NoError(t, testDB.Close())
-		})
+		testDB := pebble.NewMemTest(t)
 
 		// Test View
 		require.EqualError(t, testDB.View(func(txn db.Transaction) error {
@@ -137,10 +122,7 @@ func TestViewUpdate(t *testing.T) {
 	})
 
 	t.Run("Update error does not commit value to DB", func(t *testing.T) {
-		testDB := pebble.NewMemTest()
-		t.Cleanup(func() {
-			require.NoError(t, testDB.Close())
-		})
+		testDB := pebble.NewMemTest(t)
 
 		// Test Update
 		require.EqualError(t, testDB.Update(func(txn db.Transaction) error {
@@ -156,10 +138,7 @@ func TestViewUpdate(t *testing.T) {
 	})
 
 	t.Run("setting a key with a zero-length value should be allowed", func(t *testing.T) {
-		testDB := pebble.NewMemTest()
-		t.Cleanup(func() {
-			require.NoError(t, testDB.Close())
-		})
+		testDB := pebble.NewMemTest(t)
 
 		assert.NoError(t, testDB.Update(func(txn db.Transaction) error {
 			require.NoError(t, txn.Set([]byte("key"), []byte{}))
@@ -172,10 +151,7 @@ func TestViewUpdate(t *testing.T) {
 	})
 
 	t.Run("setting a key with a nil value should be allowed", func(t *testing.T) {
-		testDB := pebble.NewMemTest()
-		t.Cleanup(func() {
-			require.NoError(t, testDB.Close())
-		})
+		testDB := pebble.NewMemTest(t)
 
 		assert.NoError(t, testDB.Update(func(txn db.Transaction) error {
 			require.NoError(t, txn.Set([]byte("key"), nil))
@@ -188,10 +164,7 @@ func TestViewUpdate(t *testing.T) {
 	})
 
 	t.Run("setting a key with a zero-length key should not be allowed", func(t *testing.T) {
-		testDB := pebble.NewMemTest()
-		t.Cleanup(func() {
-			require.NoError(t, testDB.Close())
-		})
+		testDB := pebble.NewMemTest(t)
 
 		assert.Error(t, testDB.Update(func(txn db.Transaction) error {
 			return txn.Set([]byte{}, []byte("value"))
@@ -199,10 +172,7 @@ func TestViewUpdate(t *testing.T) {
 	})
 
 	t.Run("setting a key with a nil key should not be allowed", func(t *testing.T) {
-		testDB := pebble.NewMemTest()
-		t.Cleanup(func() {
-			require.NoError(t, testDB.Close())
-		})
+		testDB := pebble.NewMemTest(t)
 
 		assert.Error(t, testDB.Update(func(txn db.Transaction) error {
 			return txn.Set(nil, []byte("value"))
@@ -211,10 +181,7 @@ func TestViewUpdate(t *testing.T) {
 }
 
 func TestConcurrentUpdate(t *testing.T) {
-	testDB := pebble.NewMemTest()
-	t.Cleanup(func() {
-		require.NoError(t, testDB.Close())
-	})
+	testDB := pebble.NewMemTest(t)
 	wg := sync.WaitGroup{}
 
 	key := []byte{0}
@@ -268,10 +235,7 @@ func TestConcurrentUpdate(t *testing.T) {
 }
 
 func TestSeek(t *testing.T) {
-	testDB := pebble.NewMemTest()
-	t.Cleanup(func() {
-		require.NoError(t, testDB.Close())
-	})
+	testDB := pebble.NewMemTest(t)
 
 	txn := testDB.NewTransaction(true)
 	t.Cleanup(func() {
@@ -323,10 +287,7 @@ func TestPrefixSearch(t *testing.T) {
 		{123, []byte("f")},
 	}
 
-	testDB := pebble.NewMemTest()
-	t.Cleanup(func() {
-		require.NoError(t, testDB.Close())
-	})
+	testDB := pebble.NewMemTest(t)
 
 	require.NoError(t, testDB.Update(func(txn db.Transaction) error {
 		for _, d := range data {
@@ -371,10 +332,7 @@ func TestPrefixSearch(t *testing.T) {
 }
 
 func TestNext(t *testing.T) {
-	testDB := pebble.NewMemTest()
-	t.Cleanup(func() {
-		require.NoError(t, testDB.Close())
-	})
+	testDB := pebble.NewMemTest(t)
 
 	txn := testDB.NewTransaction(true)
 	t.Cleanup(func() {
@@ -412,10 +370,7 @@ func TestNext(t *testing.T) {
 }
 
 func TestPanic(t *testing.T) {
-	testDB := pebble.NewMemTest()
-	t.Cleanup(func() {
-		require.NoError(t, testDB.Close())
-	})
+	testDB := pebble.NewMemTest(t)
 
 	t.Run("view", func(t *testing.T) {
 		defer func() {

--- a/grpc/handlers_test.go
+++ b/grpc/handlers_test.go
@@ -85,7 +85,9 @@ func createTxStream(t *testing.T, h Handler) *grpcStreamMock {
 }
 
 func TestHandlers_Tx(t *testing.T) {
-	memDB := pebble.NewMemTest()
+	t.Skip("We need to add Op_CLOSE to grpc server to close iterators in tests.")
+
+	memDB := pebble.NewMemTest(t)
 	h := Handler{db: memDB}
 	stream := createTxStream(t, h)
 

--- a/l1/l1_pkg_test.go
+++ b/l1/l1_pkg_test.go
@@ -337,7 +337,7 @@ func TestClient(t *testing.T) {
 			ctrl := gomock.NewController(t)
 			nopLog := utils.NewNopZapLogger()
 			network := utils.MAINNET
-			chain := blockchain.New(pebble.NewMemTest(), network, nopLog)
+			chain := blockchain.New(pebble.NewMemTest(t), network, nopLog)
 
 			client := NewClient(nil, chain, nopLog).WithResubscribeDelay(0).WithPollFinalisedInterval(time.Nanosecond)
 
@@ -398,7 +398,7 @@ func TestUnreliableSubscription(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	nopLog := utils.NewNopZapLogger()
 	network := utils.MAINNET
-	chain := blockchain.New(pebble.NewMemTest(), network, nopLog)
+	chain := blockchain.New(pebble.NewMemTest(t), network, nopLog)
 	client := NewClient(nil, chain, nopLog).WithResubscribeDelay(0).WithPollFinalisedInterval(time.Nanosecond)
 
 	err := errors.New("test err")

--- a/l1/l1_test.go
+++ b/l1/l1_test.go
@@ -46,7 +46,7 @@ func TestFailToCreateSubscription(t *testing.T) {
 	network := utils.MAINNET
 	ctrl := gomock.NewController(t)
 	nopLog := utils.NewNopZapLogger()
-	chain := blockchain.New(pebble.NewMemTest(), network, nopLog)
+	chain := blockchain.New(pebble.NewMemTest(t), network, nopLog)
 
 	subscriber := mocks.NewMockSubscriber(ctrl)
 
@@ -77,7 +77,7 @@ func TestMismatchedChainID(t *testing.T) {
 	network := utils.MAINNET
 	ctrl := gomock.NewController(t)
 	nopLog := utils.NewNopZapLogger()
-	chain := blockchain.New(pebble.NewMemTest(), network, nopLog)
+	chain := blockchain.New(pebble.NewMemTest(t), network, nopLog)
 
 	subscriber := mocks.NewMockSubscriber(ctrl)
 

--- a/migration/bucket_migrator_test.go
+++ b/migration/bucket_migrator_test.go
@@ -22,7 +22,7 @@ func TestBucketMover(t *testing.T) {
 		return len(b) > 1, nil
 	})
 
-	testDB := pebble.NewMemTest()
+	testDB := pebble.NewMemTest(t)
 	require.NoError(t, testDB.Update(func(txn db.Transaction) error {
 		for i := byte(0); i < 3; i++ {
 			if err := txn.Set(sourceBucket.Key([]byte{i}), []byte{i}); err != nil {

--- a/migration/migration_pkg_test.go
+++ b/migration/migration_pkg_test.go
@@ -21,10 +21,7 @@ import (
 )
 
 func TestMigration0000(t *testing.T) {
-	testDB := pebble.NewMemTest()
-	t.Cleanup(func() {
-		require.NoError(t, testDB.Close())
-	})
+	testDB := pebble.NewMemTest(t)
 
 	t.Run("empty DB", func(t *testing.T) {
 		require.NoError(t, testDB.View(func(txn db.Transaction) error {
@@ -43,10 +40,7 @@ func TestMigration0000(t *testing.T) {
 }
 
 func TestRelocateContractStorageRootKeys(t *testing.T) {
-	testDB := pebble.NewMemTest()
-	t.Cleanup(func() {
-		require.NoError(t, testDB.Close())
-	})
+	testDB := pebble.NewMemTest(t)
 
 	txn := testDB.NewTransaction(true)
 
@@ -81,10 +75,7 @@ func TestRelocateContractStorageRootKeys(t *testing.T) {
 }
 
 func TestRecalculateBloomFilters(t *testing.T) {
-	testdb := pebble.NewMemTest()
-	t.Cleanup(func() {
-		require.NoError(t, testdb.Close())
-	})
+	testdb := pebble.NewMemTest(t)
 	chain := blockchain.New(testdb, utils.MAINNET, utils.NewNopZapLogger())
 	client := feeder.NewTestClient(t, utils.MAINNET)
 	gw := adaptfeeder.New(client)
@@ -111,10 +102,7 @@ func TestRecalculateBloomFilters(t *testing.T) {
 }
 
 func TestChangeTrieNodeEncoding(t *testing.T) {
-	testdb := pebble.NewMemTest()
-	t.Cleanup(func() {
-		require.NoError(t, testdb.Close())
-	})
+	testdb := pebble.NewMemTest(t)
 
 	buckets := []db.Bucket{db.ClassesTrie, db.StateTrie, db.ContractStorage}
 
@@ -170,10 +158,7 @@ func TestChangeTrieNodeEncoding(t *testing.T) {
 }
 
 func TestCalculateBlockCommitments(t *testing.T) {
-	testdb := pebble.NewMemTest()
-	t.Cleanup(func() {
-		require.NoError(t, testdb.Close())
-	})
+	testdb := pebble.NewMemTest(t)
 	chain := blockchain.New(testdb, utils.MAINNET, utils.NewNopZapLogger())
 	client := feeder.NewTestClient(t, utils.MAINNET)
 	gw := adaptfeeder.New(client)

--- a/migration/migration_test.go
+++ b/migration/migration_test.go
@@ -10,10 +10,7 @@ import (
 )
 
 func TestMigrateIfNeeded(t *testing.T) {
-	testDB := pebble.NewMemTest()
-	t.Cleanup(func() {
-		require.NoError(t, testDB.Close())
-	})
+	testDB := pebble.NewMemTest(t)
 
 	t.Run("Migration should happen on empty DB", func(t *testing.T) {
 		require.NoError(t, migration.MigrateIfNeeded(testDB, utils.MAINNET, utils.NewNopZapLogger()))

--- a/rpc/handlers_test.go
+++ b/rpc/handlers_test.go
@@ -1568,10 +1568,7 @@ func TestClassAt(t *testing.T) {
 }
 
 func TestEvents(t *testing.T) {
-	testDB := pebble.NewMemTest()
-	t.Cleanup(func() {
-		require.NoError(t, testDB.Close())
-	})
+	testDB := pebble.NewMemTest(t)
 	chain := blockchain.New(testDB, utils.GOERLI2, utils.NewNopZapLogger())
 
 	client := feeder.NewTestClient(t, utils.GOERLI2)

--- a/sync/sync_test.go
+++ b/sync/sync_test.go
@@ -57,7 +57,7 @@ func TestSyncBlocks(t *testing.T) {
 	log := utils.NewNopZapLogger()
 	t.Run("sync multiple blocks in an empty db", func(t *testing.T) {
 		t.Parallel()
-		testDB := pebble.NewMemTest()
+		testDB := pebble.NewMemTest(t)
 		bc := blockchain.New(testDB, utils.MAINNET, log)
 		synchronizer := sync.New(bc, gw, log, time.Duration(0))
 		ctx, cancel := context.WithTimeout(context.Background(), timeout)
@@ -70,7 +70,7 @@ func TestSyncBlocks(t *testing.T) {
 
 	t.Run("sync multiple blocks in a non-empty db", func(t *testing.T) {
 		t.Parallel()
-		testDB := pebble.NewMemTest()
+		testDB := pebble.NewMemTest(t)
 		bc := blockchain.New(testDB, utils.MAINNET, log)
 		b0, err := gw.BlockByNumber(context.Background(), 0)
 		require.NoError(t, err)
@@ -89,7 +89,7 @@ func TestSyncBlocks(t *testing.T) {
 
 	t.Run("sync multiple blocks, with an unreliable gw", func(t *testing.T) {
 		t.Parallel()
-		testDB := pebble.NewMemTest()
+		testDB := pebble.NewMemTest(t)
 		bc := blockchain.New(testDB, utils.MAINNET, log)
 
 		mockSNData := mocks.NewMockStarknetData(mockCtrl)
@@ -149,7 +149,7 @@ func TestReorg(t *testing.T) {
 	integClient := feeder.NewTestClient(t, utils.INTEGRATION)
 	integGw := adaptfeeder.New(integClient)
 
-	testDB := pebble.NewMemTest()
+	testDB := pebble.NewMemTest(t)
 
 	// sync to integration for 2 blocks
 	bc := blockchain.New(testDB, utils.INTEGRATION, utils.NewNopZapLogger())
@@ -186,7 +186,7 @@ func TestPending(t *testing.T) {
 	client := feeder.NewTestClient(t, utils.MAINNET)
 	gw := adaptfeeder.New(client)
 
-	testDB := pebble.NewMemTest()
+	testDB := pebble.NewMemTest(t)
 	log := utils.NewNopZapLogger()
 	bc := blockchain.New(testDB, utils.MAINNET, log)
 	synchronizer := sync.New(bc, gw, log, time.Millisecond*100)

--- a/vm/vm_test.go
+++ b/vm/vm_test.go
@@ -17,13 +17,12 @@ import (
 )
 
 func TestV0Call(t *testing.T) {
-	testDB := pebble.NewMemTest()
+	testDB := pebble.NewMemTest(t)
 	txn := testDB.NewTransaction(true)
 	client := feeder.NewTestClient(t, utils.MAINNET)
 	gw := adaptfeeder.New(client)
 	t.Cleanup(func() {
 		require.NoError(t, txn.Discard())
-		require.NoError(t, testDB.Close())
 	})
 
 	contractAddr := utils.HexToFelt(t, "0xDEADBEEF")
@@ -76,13 +75,12 @@ func TestV0Call(t *testing.T) {
 }
 
 func TestV1Call(t *testing.T) {
-	testDB := pebble.NewMemTest()
+	testDB := pebble.NewMemTest(t)
 	txn := testDB.NewTransaction(true)
 	client := feeder.NewTestClient(t, utils.GOERLI)
 	gw := adaptfeeder.New(client)
 	t.Cleanup(func() {
 		require.NoError(t, txn.Discard())
-		require.NoError(t, testDB.Close())
 	})
 
 	contractAddr := utils.HexToFelt(t, "0xDEADBEEF")
@@ -143,11 +141,10 @@ func TestV1Call(t *testing.T) {
 func TestExecute(t *testing.T) {
 	const network = utils.GOERLI2
 
-	testDB := pebble.NewMemTest()
+	testDB := pebble.NewMemTest(t)
 	txn := testDB.NewTransaction(false)
 	t.Cleanup(func() {
 		require.NoError(t, txn.Discard())
-		require.NoError(t, testDB.Close())
 	})
 
 	state := core.NewState(txn)


### PR DESCRIPTION
There are cases where we aren't closing the in-memory db. In some cases, this causes fatal bugs in our tests that we aren't catching.