### PR TITLE
Update docs with docker run --http-port parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ docker run -d \
   nethermind/juno \
   --http \
   --http-port 6060 \
+  --http-host 0.0.0.0 \
   --db-path /var/lib/juno \
   --eth-node <YOUR-ETH-NODE>
 ```

--- a/docs/versioned_docs/version-0.6.2/snapshots.md
+++ b/docs/versioned_docs/version-0.6.2/snapshots.md
@@ -57,12 +57,14 @@ After downloading a snapshot and starting a Juno node, only recent blocks must b
 
    ```bash
    docker run -d \
-     --name juno \
-     -p 6060:6060 \
-     -v $HOME/snapshots/juno_mainnet:/var/lib/juno \
-     nethermind/juno \
-     --http-port 6060 \
-     --db-path /var/lib/juno
+      --name juno \
+      -p 6060:6060 \
+      -v $HOME/snapshots/juno_mainnet:/var/lib/juno \
+      nethermind/juno \
+      --http \
+      --http-port 6060 \
+      --http-host 0.0.0.0 \
+      --db-path /var/lib/juno
    ```
 
 After following these steps, Juno should be up and running on your machine, utilizing the provided snapshot.

--- a/docs/versioned_docs/version-0.6.3/snapshots.md
+++ b/docs/versioned_docs/version-0.6.3/snapshots.md
@@ -57,12 +57,14 @@ After downloading a snapshot and starting a Juno node, only recent blocks must b
 
    ```bash
    docker run -d \
-     --name juno \
-     -p 6060:6060 \
-     -v $HOME/snapshots/juno_mainnet:/var/lib/juno \
-     nethermind/juno \
-	 --http \
-     --db-path /var/lib/juno
+      --name juno \
+      -p 6060:6060 \
+      -v $HOME/snapshots/juno_mainnet:/var/lib/juno \
+      nethermind/juno \
+      --http \
+      --http-port 6060 \
+      --http-host 0.0.0.0 \
+      --db-path /var/lib/juno
    ```
 
 After following these steps, Juno should be up and running on your machine, utilizing the provided snapshot.


### PR DESCRIPTION
Some users faced issues accessing RPC HTTP using the default command provided by our docs. This update aims to clarify the setup and prevent further confusion.