### PR TITLE
Use hardcoded macOS version to fix unit test

### DIFF
--- a/.github/workflows/juno-test.yml
+++ b/.github/workflows/juno-test.yml
@@ -3,9 +3,9 @@ on:
   push:
     branches:
       - main
-      - develop
   pull_request:
   workflow_dispatch:
+  workflow_call:
 
 jobs:
   test:
@@ -25,6 +25,11 @@ jobs:
         with:
           go-version-file: go.mod
           cache: true
+
+      - name: Install dependencies (macOS)
+        if: runner.os == 'macOS'
+        run: brew install upx cargo-c
+
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
         with:


### PR DESCRIPTION
Use hardcoded macOS version to make unit tests pass. Tests started to fail due to: [Undefined symbols for architecture x86_64](https://github.com/NethermindEth/juno/actions/runs/6403594491/job/17382800371?pr=1294#step:7:93)
