### PR TITLE
Add curl, grep, awk to dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,7 @@ RUN upx-ucl /app/build/juno
 # Stage 2: Build Docker image
 FROM ubuntu:23.10 AS runtime
 
-RUN apt-get update && apt-get install -y ca-certificates
+RUN apt-get update && apt-get install -y ca-certificates curl gawk grep
 
 COPY --from=build /app/build/juno /usr/local/bin/
 


### PR DESCRIPTION
```
@Manjeet-Nethermind 
We are presently in the process of implementing a readiness probe for Juno nodes in k8s. This probe ensures that newly spawned nodes must be fully synchronized before they can be used to serve any requests.
To accomplish this, the container image used should include the curl and awk command-line tools. Without these tools, the readiness probe logic will not function as intended.
The readiness probe is designed to determine the synchronization status by comparing two values obtained from the local node using curl, grep, and awk.
If the result of this comparison is equal to zero, the probe returns "ok," indicating that the node is fully synchronized and ready to serve requests.
Otherwise, if the result is not zero, it returns "wait," indicating that the node is still syncing and should not be used for serving requests.
Sample snippet:
    command:
    - /bin/sh
    - -c
    - |
      result=$(( $(curl -s localhost:9091 | grep sync_best_known_block_number | tail -n1 | awk '{print $2}') - $(curl -s localhost:9091 | grep sync_blockchain_height | tail -n1 | awk '{print $2}') ))
      if [ $result -eq 0 ]; then
        exit 0 # Return "ok" if result is 0
      else
        exit 1 # Return "wait" if result is not 0
      fi
```

Add curl, grep, awk to docker images to facilitate smoother scaling