### PR TITLE
Parallelize recursive calls in Trie.updateValueIfDirty

### DIFF
--- a/core/trie/transaction_storage.go
+++ b/core/trie/transaction_storage.go
@@ -122,6 +122,13 @@ func (t *TransactionStorage) DeleteRootKey() error {
 	return t.txn.Delete(t.prefix)
 }
 
+func (t *TransactionStorage) SyncedStorage() *TransactionStorage {
+	return &TransactionStorage{
+		txn:    db.NewSyncTransaction(t.txn),
+		prefix: t.prefix,
+	}
+}
+
 func newMemStorage() *TransactionStorage {
 	return NewTransactionStorage(db.NewMemTransaction(), nil)
 }

--- a/core/trie/transaction_storage.go
+++ b/core/trie/transaction_storage.go
@@ -7,8 +7,6 @@ import (
 	"github.com/NethermindEth/juno/db"
 )
 
-var _ Storage = (*TransactionStorage)(nil)
-
 // bufferPool caches unused buffer objects for later reuse.
 var bufferPool = sync.Pool{
 	New: func() any {
@@ -124,6 +122,6 @@ func (t *TransactionStorage) DeleteRootKey() error {
 	return t.txn.Delete(t.prefix)
 }
 
-func newMemStorage() Storage {
+func newMemStorage() *TransactionStorage {
 	return NewTransactionStorage(db.NewMemTransaction(), nil)
 }

--- a/core/trie/trie.go
+++ b/core/trie/trie.go
@@ -12,17 +12,6 @@ import (
 	"github.com/NethermindEth/juno/db"
 )
 
-// Storage is the Persistent storage for the [Trie]
-type Storage interface {
-	Put(key *Key, value *Node) error
-	Get(key *Key) (*Node, error)
-	Delete(key *Key) error
-
-	PutRootKey(newRootKey *Key) error
-	RootKey() (*Key, error)
-	DeleteRootKey() error
-}
-
 type hashFunc func(*felt.Felt, *felt.Felt) *felt.Felt
 
 // Trie is a dense Merkle Patricia Trie (i.e., all internal nodes have two children).
@@ -46,24 +35,24 @@ type Trie struct {
 	height  uint8
 	rootKey *Key
 	maxKey  *felt.Felt
-	storage Storage
+	storage *TransactionStorage
 	hash    hashFunc
 
 	dirtyNodes     []*Key
 	rootKeyIsDirty bool
 }
 
-type NewTrieFunc func(Storage, uint8) (*Trie, error)
+type NewTrieFunc func(*TransactionStorage, uint8) (*Trie, error)
 
-func NewTriePedersen(storage Storage, height uint8) (*Trie, error) {
+func NewTriePedersen(storage *TransactionStorage, height uint8) (*Trie, error) {
 	return newTrie(storage, height, crypto.Pedersen)
 }
 
-func NewTriePoseidon(storage Storage, height uint8) (*Trie, error) {
+func NewTriePoseidon(storage *TransactionStorage, height uint8) (*Trie, error) {
 	return newTrie(storage, height, crypto.Poseidon)
 }
 
-func newTrie(storage Storage, height uint8, hash hashFunc) (*Trie, error) {
+func newTrie(storage *TransactionStorage, height uint8, hash hashFunc) (*Trie, error) {
 	if height > felt.Bits {
 		return nil, fmt.Errorf("max trie height is %d, got: %d", felt.Bits, height)
 	}

--- a/db/sync_transaction.go
+++ b/db/sync_transaction.go
@@ -1,0 +1,62 @@
+package db
+
+import (
+	"errors"
+	"sync"
+)
+
+type SyncTransaction struct {
+	lock sync.RWMutex
+	txn  Transaction
+}
+
+func NewSyncTransaction(txn Transaction) *SyncTransaction {
+	return &SyncTransaction{
+		txn: txn,
+	}
+}
+
+// Discard : see db.Transaction.Discard
+func (t *SyncTransaction) Discard() error {
+	t.lock.Lock()
+	defer t.lock.Unlock()
+	return t.txn.Discard()
+}
+
+// Commit : see db.Transaction.Commit
+func (t *SyncTransaction) Commit() error {
+	t.lock.Lock()
+	defer t.lock.Unlock()
+	return t.txn.Commit()
+}
+
+// Set : see db.Transaction.Set
+func (t *SyncTransaction) Set(key, val []byte) error {
+	t.lock.Lock()
+	defer t.lock.Unlock()
+	return t.txn.Set(key, val)
+}
+
+// Delete : see db.Transaction.Delete
+func (t *SyncTransaction) Delete(key []byte) error {
+	t.lock.Lock()
+	defer t.lock.Unlock()
+	return t.txn.Delete(key)
+}
+
+// Get : see db.Transaction.Get
+func (t *SyncTransaction) Get(key []byte, cb func([]byte) error) error {
+	t.lock.RLock()
+	defer t.lock.RUnlock()
+	return t.txn.Get(key, cb)
+}
+
+// Impl : see db.Transaction.Impl
+func (t *SyncTransaction) Impl() any {
+	return t.txn
+}
+
+// NewIterator : see db.Transaction.NewIterator
+func (t *SyncTransaction) NewIterator() (Iterator, error) {
+	return nil, errors.New("sync transactions dont support iterators")
+}

--- a/db/sync_transaction.go
+++ b/db/sync_transaction.go
@@ -11,6 +11,10 @@ type SyncTransaction struct {
 }
 
 func NewSyncTransaction(txn Transaction) *SyncTransaction {
+	syncTxn, ok := txn.(*SyncTransaction)
+	if ok {
+		return syncTxn
+	}
 	return &SyncTransaction{
 		txn: txn,
 	}


### PR DESCRIPTION
Closes #1096 
Closes #904 

Significant speed up in state updates on my local machine.

Before
```BenchmarkMainnetBlock-16    	      10	 647261272 ns/op	16582017 B/op	  205653 allocs/op```

After
```BenchmarkMainnetBlock-16    	      10	 389617332 ns/op	17668045 B/op	  229347 allocs/op```