### PR TITLE
Throttle number of VM instances RPC can utilize concurrently 

### DIFF
--- a/cmd/juno/juno.go
+++ b/cmd/juno/juno.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"os/signal"
 	"path/filepath"
+	"runtime"
 	"syscall"
 	"time"
 
@@ -54,6 +55,7 @@ const (
 	grpcF                = "grpc"
 	grpcHostF            = "grpc-host"
 	grpcPortF            = "grpc-port"
+	maxVMsF              = "max-vms"
 
 	defaultConfig              = ""
 	defaulHost                 = "localhost"
@@ -100,6 +102,7 @@ const (
 	grpcUsage                = "Enable the HTTP GRPC server on the default port."
 	grpcHostUsage            = "The interface on which the GRPC server will listen for requests."
 	grpcPortUsage            = "The port on which the GRPC server will listen for requests."
+	maxVMsUsage              = "Maximum number for VM instances to be used for RPC calls concurrently"
 )
 
 var Version string
@@ -191,6 +194,7 @@ func NewCmd(config *node.Config, run func(*cobra.Command, []string) error) *cobr
 	// may mutate their values.
 	defaultLogLevel := utils.INFO
 	defaultNetwork := utils.MAINNET
+	defaultMaxVMs := runtime.GOMAXPROCS(0)
 
 	junoCmd.Flags().StringVar(&cfgFile, configF, defaultConfig, configFlagUsage)
 	junoCmd.Flags().Var(&defaultLogLevel, logLevelF, logLevelFlagUsage)
@@ -217,6 +221,7 @@ func NewCmd(config *node.Config, run func(*cobra.Command, []string) error) *cobr
 	junoCmd.Flags().Bool(grpcF, defaultGRPC, grpcUsage)
 	junoCmd.Flags().String(grpcHostF, defaulHost, grpcHostUsage)
 	junoCmd.Flags().Uint16(grpcPortF, defaultGRPCPort, grpcPortUsage)
+	junoCmd.Flags().Uint(maxVMsF, uint(defaultMaxVMs), maxVMsUsage)
 
 	return junoCmd
 }

--- a/cmd/juno/juno_test.go
+++ b/cmd/juno/juno_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"os"
 	"path/filepath"
+	"runtime"
 	"testing"
 	"time"
 
@@ -41,6 +42,7 @@ func TestConfigPrecedence(t *testing.T) {
 	defaultGRPCPort := uint16(6064)
 	defaultColour := true
 	defaultPendingPollInterval := time.Duration(0)
+	defaultMaxVMs := uint(runtime.GOMAXPROCS(0))
 
 	tests := map[string]struct {
 		cfgFile         bool
@@ -72,6 +74,7 @@ func TestConfigPrecedence(t *testing.T) {
 				MetricsPort:         defaultMetricsPort,
 				Colour:              defaultColour,
 				PendingPollInterval: defaultPendingPollInterval,
+				MaxVMs:              defaultMaxVMs,
 			},
 		},
 		"config file path is empty string": {
@@ -97,6 +100,7 @@ func TestConfigPrecedence(t *testing.T) {
 				PprofPort:           defaultPprofPort,
 				Colour:              defaultColour,
 				PendingPollInterval: defaultPendingPollInterval,
+				MaxVMs:              defaultMaxVMs,
 			},
 		},
 		"config file doesn't exist": {
@@ -127,6 +131,7 @@ func TestConfigPrecedence(t *testing.T) {
 				PprofHost:           defaultHost,
 				PprofPort:           defaultPprofPort,
 				DatabasePath:        defaultDBPath,
+				MaxVMs:              defaultMaxVMs,
 			},
 		},
 		"config file with all settings but without any other flags": {
@@ -159,6 +164,7 @@ pprof: true
 				PprofPort:           defaultPprofPort,
 				Colour:              defaultColour,
 				PendingPollInterval: defaultPendingPollInterval,
+				MaxVMs:              defaultMaxVMs,
 			},
 		},
 		"config file with some settings but without any other flags": {
@@ -188,6 +194,7 @@ http-port: 4576
 				PprofPort:           defaultPprofPort,
 				Colour:              defaultColour,
 				PendingPollInterval: defaultPendingPollInterval,
+				MaxVMs:              defaultMaxVMs,
 			},
 		},
 		"all flags without config file": {
@@ -215,6 +222,7 @@ http-port: 4576
 				PprofHost:     defaultHost,
 				PprofPort:     defaultPprofPort,
 				Colour:        defaultColour,
+				MaxVMs:        defaultMaxVMs,
 			},
 		},
 		"some flags without config file": {
@@ -243,6 +251,7 @@ http-port: 4576
 				PprofPort:           defaultPprofPort,
 				Colour:              defaultColour,
 				PendingPollInterval: defaultPendingPollInterval,
+				MaxVMs:              defaultMaxVMs,
 			},
 		},
 		"all setting set in both config file and flags": {
@@ -293,6 +302,7 @@ pending-poll-interval: 5s
 				PprofPort:           6064,
 				Colour:              defaultColour,
 				PendingPollInterval: time.Millisecond,
+				MaxVMs:              defaultMaxVMs,
 			},
 		},
 		"some setting set in both config file and flags": {
@@ -324,6 +334,7 @@ network: goerli
 				PprofPort:           defaultPprofPort,
 				Colour:              defaultColour,
 				PendingPollInterval: defaultPendingPollInterval,
+				MaxVMs:              defaultMaxVMs,
 			},
 		},
 		"some setting set in default, config file and flags": {
@@ -351,6 +362,7 @@ network: goerli
 				PprofPort:           defaultPprofPort,
 				Colour:              defaultColour,
 				PendingPollInterval: defaultPendingPollInterval,
+				MaxVMs:              defaultMaxVMs,
 			},
 		},
 	}

--- a/jsonrpc/server.go
+++ b/jsonrpc/server.go
@@ -53,6 +53,13 @@ type Error struct {
 	Data    any    `json:"data,omitempty"`
 }
 
+// CloneWithData copies the error and sets the data field on the copy
+func (e *Error) CloneWithData(data any) *Error {
+	dup := *e
+	dup.Data = data
+	return &dup
+}
+
 func Err(code int, data any) *Error {
 	switch code {
 	case InvalidJSON:

--- a/node/throttled_vm.go
+++ b/node/throttled_vm.go
@@ -1,0 +1,45 @@
+package node
+
+import (
+	"encoding/json"
+
+	"github.com/NethermindEth/juno/core"
+	"github.com/NethermindEth/juno/core/felt"
+	"github.com/NethermindEth/juno/utils"
+	"github.com/NethermindEth/juno/vm"
+)
+
+var _ vm.VM = (*ThrottledVM)(nil)
+
+type ThrottledVM utils.Throttler[vm.VM]
+
+func NewThrottledVM(res vm.VM, concurrenyBudget uint, maxQueueLen int32) *ThrottledVM {
+	return (*ThrottledVM)(utils.NewThrottler[vm.VM](concurrenyBudget, &res).WithMaxQueueLen(maxQueueLen))
+}
+
+func (tvm *ThrottledVM) Call(contractAddr, selector *felt.Felt, calldata []felt.Felt, blockNumber,
+	blockTimestamp uint64, state core.StateReader, network utils.Network,
+) ([]*felt.Felt, error) {
+	var ret []*felt.Felt
+	throttler := (*utils.Throttler[vm.VM])(tvm)
+	return ret, throttler.Do(func(vm *vm.VM) error {
+		var err error
+		ret, err = (*vm).Call(contractAddr, selector, calldata, blockNumber, blockTimestamp, state, network)
+		return err
+	})
+}
+
+func (tvm *ThrottledVM) Execute(txns []core.Transaction, declaredClasses []core.Class, blockNumber, blockTimestamp uint64,
+	sequencerAddress *felt.Felt, state core.StateReader, network utils.Network, paidFeesOnL1 []*felt.Felt,
+	skipChargeFee bool, gasPrice *felt.Felt, legacyTraceJSON bool,
+) ([]*felt.Felt, []json.RawMessage, error) {
+	var ret []*felt.Felt
+	var traces []json.RawMessage
+	throttler := (*utils.Throttler[vm.VM])(tvm)
+	return ret, traces, throttler.Do(func(vm *vm.VM) error {
+		var err error
+		ret, traces, err = (*vm).Execute(txns, declaredClasses, blockNumber, blockTimestamp, sequencerAddress,
+			state, network, paidFeesOnL1, skipChargeFee, gasPrice, legacyTraceJSON)
+		return err
+	})
+}

--- a/rpc/handlers_test.go
+++ b/rpc/handlers_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/NethermindEth/juno/db/pebble"
 	"github.com/NethermindEth/juno/jsonrpc"
 	"github.com/NethermindEth/juno/mocks"
+	"github.com/NethermindEth/juno/node"
 	"github.com/NethermindEth/juno/rpc"
 	adaptfeeder "github.com/NethermindEth/juno/starknetdata/feeder"
 	"github.com/NethermindEth/juno/sync"
@@ -2522,5 +2523,69 @@ func TestTraceFallback(t *testing.T) {
 		require.NoError(t, err)
 		expectedTrace := `[{"trace_root":{"type":"INVOKE","validate_invocation":{"contract_address":"0x58b7ee817bd2978c7657d05d3131e83e301ed1aa79d5ad16f01925fd52d1da7","entry_point_selector":"0x162da33a4585851fe8d3af3c2a9c60b557814e221e0d4f30ff0b2189d9c7775","calldata":["0x1","0x332299dc083f3778122e5b7762bc9d399da18fefe93769aee67bb49f51c8d2","0x2d7cf5d5a324a320f9f37804b1615a533fde487400b41af80f13f7ac5581325","0x0","0x4","0x4","0xaf35ee8ed700ff132c5d1d298a73becda25ccdf9","0x2","0x6cd852fe1b2bbd8587bb0aaeb09813436c57c8ce21e75651e317273a1f22228","0x58feb991988e53fffcba71f6df23c803fb062f1b3bab126d2c9ce574255b36e"],"caller_address":"0x0","class_hash":"0x646a72e2aab2fca75d713fbe4a58f2d12cbd64105621b89dc9ce7045b5bf02b","entry_point_type":"EXTERNAL","call_type":"CALL","result":[],"calls":[],"events":[],"messages":[]},"execute_invocation":{"contract_address":"0x58b7ee817bd2978c7657d05d3131e83e301ed1aa79d5ad16f01925fd52d1da7","entry_point_selector":"0x15d40a3d6ca2ac30f4031e42be28da9b056fef9bb7357ac5e85627ee876e5ad","calldata":["0x1","0x332299dc083f3778122e5b7762bc9d399da18fefe93769aee67bb49f51c8d2","0x2d7cf5d5a324a320f9f37804b1615a533fde487400b41af80f13f7ac5581325","0x0","0x4","0x4","0xaf35ee8ed700ff132c5d1d298a73becda25ccdf9","0x2","0x6cd852fe1b2bbd8587bb0aaeb09813436c57c8ce21e75651e317273a1f22228","0x58feb991988e53fffcba71f6df23c803fb062f1b3bab126d2c9ce574255b36e"],"caller_address":"0x0","class_hash":"0x646a72e2aab2fca75d713fbe4a58f2d12cbd64105621b89dc9ce7045b5bf02b","entry_point_type":"EXTERNAL","call_type":"CALL","result":[],"calls":[{"contract_address":"0x332299dc083f3778122e5b7762bc9d399da18fefe93769aee67bb49f51c8d2","entry_point_selector":"0x2d7cf5d5a324a320f9f37804b1615a533fde487400b41af80f13f7ac5581325","calldata":["0xaf35ee8ed700ff132c5d1d298a73becda25ccdf9","0x2","0x6cd852fe1b2bbd8587bb0aaeb09813436c57c8ce21e75651e317273a1f22228","0x58feb991988e53fffcba71f6df23c803fb062f1b3bab126d2c9ce574255b36e"],"caller_address":"0x58b7ee817bd2978c7657d05d3131e83e301ed1aa79d5ad16f01925fd52d1da7","class_hash":"0x165e7db96ab97a63c621229617a6d49633737238673477a54720e4c952f2c7e","entry_point_type":"EXTERNAL","call_type":"CALL","result":[],"calls":[],"events":[],"messages":[{"order":0,"to_address":"0xaf35ee8ed700ff132c5d1d298a73becda25ccdf9","payload":["0x6cd852fe1b2bbd8587bb0aaeb09813436c57c8ce21e75651e317273a1f22228","0x58feb991988e53fffcba71f6df23c803fb062f1b3bab126d2c9ce574255b36e"]}]}],"events":[],"messages":[]},"fee_transfer_invocation":{"contract_address":"0x49d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7","entry_point_selector":"0x83afd3f4caedc6eebf44246fe54e38c95e3179a5ec9ea81740eca5b482d12e","calldata":["0x1176a1bd84444c89232ec27754698e5d2e7e1a7f1539f12027f28b23ec9f3d8","0x127089df3a1984","0x0"],"caller_address":"0x58b7ee817bd2978c7657d05d3131e83e301ed1aa79d5ad16f01925fd52d1da7","class_hash":"0xd0e183745e9dae3e4e78a8ffedcce0903fc4900beace4e0abf192d4c202da3","entry_point_type":"EXTERNAL","call_type":"CALL","result":["0x1"],"calls":[{"contract_address":"0x49d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7","entry_point_selector":"0x83afd3f4caedc6eebf44246fe54e38c95e3179a5ec9ea81740eca5b482d12e","calldata":["0x1176a1bd84444c89232ec27754698e5d2e7e1a7f1539f12027f28b23ec9f3d8","0x127089df3a1984","0x0"],"caller_address":"0x58b7ee817bd2978c7657d05d3131e83e301ed1aa79d5ad16f01925fd52d1da7","class_hash":"0x28d7d394810ad8c52741ad8f7564717fd02c10ced68657a81d0b6710ce22079","entry_point_type":"EXTERNAL","call_type":"DELEGATE","result":["0x1"],"calls":[],"events":[],"messages":[]}],"events":[],"messages":[]}},"transaction_hash":"0x2a648ab1aa6847eb38507fc842e050f256562bf87b26083c332f3f21318c2c3"},{"trace_root":{"type":"INVOKE","validate_invocation":{"contract_address":"0x58b7ee817bd2978c7657d05d3131e83e301ed1aa79d5ad16f01925fd52d1da7","entry_point_selector":"0x162da33a4585851fe8d3af3c2a9c60b557814e221e0d4f30ff0b2189d9c7775","calldata":["0x1","0x5f9211b05c9609d54a8bf5f9cfa4e2cd5a3cab3b5d79682c585575495a15dd1","0x317eb442b72a9fae758d4fb26830ed0d9f31c8e7da4dbff4e8c59ea6a158e7f","0x0","0x4","0x4","0x447379c077035ef4f442411d0407ce9aa66c558f0060137f6455f4f230eabeb","0x2","0x6811b7755a7dd0ec1fb6f51a883e3f255368e2dfd497b5f6480c00cf9cd5a2e","0x23b9e26720dd7aaf98c7cea56499f48f75dc1d4123f7e2d6c23bfc4d5f4a336"],"caller_address":"0x0","class_hash":"0x646a72e2aab2fca75d713fbe4a58f2d12cbd64105621b89dc9ce7045b5bf02b","entry_point_type":"EXTERNAL","call_type":"CALL","result":[],"calls":[],"events":[],"messages":[]},"execute_invocation":{"contract_address":"0x58b7ee817bd2978c7657d05d3131e83e301ed1aa79d5ad16f01925fd52d1da7","entry_point_selector":"0x15d40a3d6ca2ac30f4031e42be28da9b056fef9bb7357ac5e85627ee876e5ad","calldata":["0x1","0x5f9211b05c9609d54a8bf5f9cfa4e2cd5a3cab3b5d79682c585575495a15dd1","0x317eb442b72a9fae758d4fb26830ed0d9f31c8e7da4dbff4e8c59ea6a158e7f","0x0","0x4","0x4","0x447379c077035ef4f442411d0407ce9aa66c558f0060137f6455f4f230eabeb","0x2","0x6811b7755a7dd0ec1fb6f51a883e3f255368e2dfd497b5f6480c00cf9cd5a2e","0x23b9e26720dd7aaf98c7cea56499f48f75dc1d4123f7e2d6c23bfc4d5f4a336"],"caller_address":"0x0","class_hash":"0x646a72e2aab2fca75d713fbe4a58f2d12cbd64105621b89dc9ce7045b5bf02b","entry_point_type":"EXTERNAL","call_type":"CALL","result":[],"calls":[{"contract_address":"0x5f9211b05c9609d54a8bf5f9cfa4e2cd5a3cab3b5d79682c585575495a15dd1","entry_point_selector":"0x317eb442b72a9fae758d4fb26830ed0d9f31c8e7da4dbff4e8c59ea6a158e7f","calldata":["0x447379c077035ef4f442411d0407ce9aa66c558f0060137f6455f4f230eabeb","0x2","0x6811b7755a7dd0ec1fb6f51a883e3f255368e2dfd497b5f6480c00cf9cd5a2e","0x23b9e26720dd7aaf98c7cea56499f48f75dc1d4123f7e2d6c23bfc4d5f4a336"],"caller_address":"0x58b7ee817bd2978c7657d05d3131e83e301ed1aa79d5ad16f01925fd52d1da7","class_hash":"0x13abfd2f333f9c69f690f1569140cdae25f6f66e3f371c9cbb998b65f664a85","entry_point_type":"EXTERNAL","call_type":"CALL","result":[],"calls":[],"events":[],"messages":[]}],"events":[],"messages":[]},"fee_transfer_invocation":{"contract_address":"0x49d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7","entry_point_selector":"0x83afd3f4caedc6eebf44246fe54e38c95e3179a5ec9ea81740eca5b482d12e","calldata":["0x1176a1bd84444c89232ec27754698e5d2e7e1a7f1539f12027f28b23ec9f3d8","0x3b2d25cd7bccc","0x0"],"caller_address":"0x58b7ee817bd2978c7657d05d3131e83e301ed1aa79d5ad16f01925fd52d1da7","class_hash":"0xd0e183745e9dae3e4e78a8ffedcce0903fc4900beace4e0abf192d4c202da3","entry_point_type":"EXTERNAL","call_type":"CALL","result":["0x1"],"calls":[{"contract_address":"0x49d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7","entry_point_selector":"0x83afd3f4caedc6eebf44246fe54e38c95e3179a5ec9ea81740eca5b482d12e","calldata":["0x1176a1bd84444c89232ec27754698e5d2e7e1a7f1539f12027f28b23ec9f3d8","0x3b2d25cd7bccc","0x0"],"caller_address":"0x58b7ee817bd2978c7657d05d3131e83e301ed1aa79d5ad16f01925fd52d1da7","class_hash":"0x28d7d394810ad8c52741ad8f7564717fd02c10ced68657a81d0b6710ce22079","entry_point_type":"EXTERNAL","call_type":"DELEGATE","result":["0x1"],"calls":[],"events":[],"messages":[]}],"events":[],"messages":[]}},"transaction_hash":"0xbc984e8e1fe594dd518a3a51db4f338437a5d2fbdda772d4426b532a67ffff"}]`
 		assert.JSONEq(t, expectedTrace, string(jsonStr), string(jsonStr))
+	})
+}
+
+func TestThrottledVMError(t *testing.T) {
+	mockCtrl := gomock.NewController(t)
+	t.Cleanup(mockCtrl.Finish)
+	mockReader := mocks.NewMockReader(mockCtrl)
+	network := utils.INTEGRATION
+	mockVM := mocks.NewMockVM(mockCtrl)
+
+	throttledVM := node.NewThrottledVM(mockVM, 0, 0)
+	handler := rpc.New(mockReader, nil, network, nil, nil, throttledVM, "", nil)
+	mockState := mocks.NewMockStateHistoryReader(mockCtrl)
+
+	t.Run("call", func(t *testing.T) {
+		mockReader.EXPECT().HeadState().Return(mockState, nopCloser, nil)
+		mockReader.EXPECT().HeadsHeader().Return(new(core.Header), nil)
+		mockState.EXPECT().ContractClassHash(&felt.Zero).Return(new(felt.Felt), nil)
+		_, rpcErr := handler.Call(rpc.FunctionCall{}, rpc.BlockID{Latest: true})
+		assert.Equal(t, utils.ErrResourceBusy.Error(), rpcErr.Data)
+	})
+
+	t.Run("simulate", func(t *testing.T) {
+		mockReader.EXPECT().HeadState().Return(mockState, nopCloser, nil)
+		mockReader.EXPECT().HeadsHeader().Return(&core.Header{}, nil)
+		_, rpcErr := handler.SimulateTransactions(rpc.BlockID{Latest: true}, []rpc.BroadcastedTransaction{}, []rpc.SimulationFlag{rpc.SkipFeeChargeFlag})
+		assert.Equal(t, utils.ErrResourceBusy.Error(), rpcErr.Data)
+	})
+
+	t.Run("trace", func(t *testing.T) {
+		blockHash := utils.HexToFelt(t, "0x0001")
+		header := &core.Header{
+			// hash is not set because it's pending block
+			ParentHash:      utils.HexToFelt(t, "0x0C3"),
+			Number:          0,
+			GasPrice:        utils.HexToFelt(t, "0x777"),
+			ProtocolVersion: "0.12.3",
+		}
+		l1Tx := &core.L1HandlerTransaction{
+			TransactionHash: utils.HexToFelt(t, "0x000000C"),
+		}
+		declaredClass := &core.DeclaredClass{
+			At:    3002,
+			Class: &core.Cairo1Class{},
+		}
+		declareTx := &core.DeclareTransaction{
+			TransactionHash: utils.HexToFelt(t, "0x000000001"),
+			ClassHash:       utils.HexToFelt(t, "0x00000BC00"),
+		}
+		block := &core.Block{
+			Header:       header,
+			Transactions: []core.Transaction{l1Tx, declareTx},
+		}
+
+		mockReader.EXPECT().BlockByHash(blockHash).Return(block, nil)
+		state := mocks.NewMockStateHistoryReader(mockCtrl)
+		mockReader.EXPECT().StateAtBlockHash(header.ParentHash).Return(state, nopCloser, nil)
+		headState := mocks.NewMockStateHistoryReader(mockCtrl)
+		headState.EXPECT().Class(declareTx.ClassHash).Return(declaredClass, nil)
+		mockReader.EXPECT().PendingState().Return(headState, nopCloser, nil)
+		const height uint64 = 8
+		mockReader.EXPECT().Height().Return(height, nil)
+		_, rpcErr := handler.TraceBlockTransactions(context.Background(), rpc.BlockID{Hash: blockHash})
+		assert.Equal(t, utils.ErrResourceBusy.Error(), rpcErr.Data)
 	})
 }

--- a/rpc/handlers_test.go
+++ b/rpc/handlers_test.go
@@ -2496,7 +2496,6 @@ func TestTraceFallback(t *testing.T) {
 	handler := rpc.New(mockReader, nil, network, nil, client, nil, "", nil)
 
 	mockReader.EXPECT().BlockByNumber(gomock.Any()).DoAndReturn(func(number uint64) (block *core.Block, err error) {
-		fmt.Println("adasd", number)
 		return gateway.BlockByNumber(context.Background(), number)
 	}).AnyTimes()
 	mockReader.EXPECT().L1Head().Return(nil, db.ErrKeyNotFound).AnyTimes()

--- a/utils/throttler.go
+++ b/utils/throttler.go
@@ -1,0 +1,51 @@
+package utils
+
+import (
+	"errors"
+	"math"
+	"sync/atomic"
+)
+
+var ErrResourceBusy = errors.New("resource busy, try again")
+
+type Throttler[T any] struct {
+	resource *T
+	sem      chan struct{}
+	queue    atomic.Int32
+
+	maxQueueLen int32
+}
+
+func NewThrottler[T any](concurrencyBudget uint, resource *T) *Throttler[T] {
+	return &Throttler[T]{
+		resource:    resource,
+		sem:         make(chan struct{}, concurrencyBudget),
+		maxQueueLen: math.MaxInt32,
+	}
+}
+
+// WithMaxQueueLen sets the maximum length the queue can grow to
+func (t *Throttler[T]) WithMaxQueueLen(maxQueueLen int32) *Throttler[T] {
+	t.maxQueueLen = maxQueueLen
+	return t
+}
+
+// Do lets caller acquire the resource within the context of a callback
+func (t *Throttler[T]) Do(doer func(resource *T) error) error {
+	queueLen := t.queue.Add(1)
+	if queueLen > t.maxQueueLen {
+		t.queue.Add(-1)
+		return ErrResourceBusy
+	}
+	t.sem <- struct{}{}
+	defer func() {
+		<-t.sem
+	}()
+	t.queue.Add(-1)
+	return doer(t.resource)
+}
+
+// QueueLen returns the number of Do calls that is blocked on the resource
+func (t *Throttler[T]) QueueLen() int {
+	return int(t.queue.Load())
+}

--- a/utils/throttler_test.go
+++ b/utils/throttler_test.go
@@ -1,0 +1,57 @@
+package utils_test
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/NethermindEth/juno/utils"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestThrottler(t *testing.T) {
+	throttledRes := utils.NewThrottler(2, new(int)).WithMaxQueueLen(2)
+	waitOn := make(chan struct{})
+	ranCount := 0
+
+	doer := func(ptr *int) error {
+		if ptr == nil {
+			return errors.New("nilptr")
+		}
+		<-waitOn
+		ranCount++
+		return nil
+	}
+	do := func() {
+		go func() {
+			require.NoError(t, throttledRes.Do(doer))
+		}()
+		time.Sleep(time.Millisecond)
+	}
+
+	do()
+	assert.Equal(t, 0, throttledRes.QueueLen())
+	do()
+	assert.Equal(t, 0, throttledRes.QueueLen())
+
+	do() // should be queued
+	assert.Equal(t, 1, throttledRes.QueueLen())
+	do() // should be queued
+	assert.Equal(t, 2, throttledRes.QueueLen())
+
+	require.ErrorIs(t, throttledRes.Do(doer), utils.ErrResourceBusy)
+
+	waitOn <- struct{}{} // release one of the slots
+	time.Sleep(time.Millisecond)
+	assert.Equal(t, 1, throttledRes.QueueLen())
+	waitOn <- struct{}{} // release another slot, qeueue should be empty
+	time.Sleep(time.Millisecond)
+	assert.Equal(t, 0, throttledRes.QueueLen())
+
+	// release the jobs waiting
+	waitOn <- struct{}{}
+	waitOn <- struct{}{}
+	time.Sleep(time.Millisecond)
+	assert.Equal(t, 4, ranCount)
+}


### PR DESCRIPTION
Towards #1349

We should add metrics as well If this turns out to be useful