### PR TITLE
Decrease the maximum backoff between feeder requests

### DIFF
--- a/clients/feeder/feeder.go
+++ b/clients/feeder/feeder.go
@@ -181,8 +181,8 @@ func NewClient(clientURL string) *Client {
 		url:        clientURL,
 		client:     http.DefaultClient,
 		backoff:    ExponentialBackoff,
-		maxRetries: 35, // ~3.5 minutes with default backoff and maxWait (block time on mainnet is 1-2 minutes)
-		maxWait:    10 * time.Second,
+		maxRetries: 10, // ~40 secs with default backoff and maxWait (block time on mainnet is 20 seconds on average)
+		maxWait:    4 * time.Second,
 		minWait:    time.Second,
 		log:        utils.NewNopZapLogger(),
 	}


### PR DESCRIPTION
Blocks are frequent enough to warrant faster polling