### PR TITLE
Revert "Specify syn and genco-macros version for rust vm"

### DIFF
--- a/vm/rust/Cargo.toml
+++ b/vm/rust/Cargo.toml
@@ -17,7 +17,6 @@ indexmap = "1.9.2"
 starknet = { rev = "starknet-core/v0.4.0", git = "https://github.com/xJonathanLEI/starknet-rs" }
 cached = "0.44.0"
 once_cell = "1.18.0"
-syn = "=2.0.38"
 
 [lib]
 crate-type = ["staticlib"]


### PR DESCRIPTION
This reverts commit 3484b213da68a637e46224f80015a0036a0d594e.

https://github.com/udoprog/genco/issues/50 is fixed in a new release