### PR TITLE
 Make read-only contract functions standalone

### DIFF
--- a/core/contract.go
+++ b/core/contract.go
@@ -16,9 +16,9 @@ var (
 	ErrContractAlreadyDeployed = errors.New("contract already deployed")
 )
 
-// NewContract creates a contract instance at the given address.
+// NewContractUpdater creates an updater for the contract instance at the given address.
 // Deploy should be called for contracts that were just deployed to the network.
-func NewContract(addr *felt.Felt, txn db.Transaction) (*Contract, error) {
+func NewContractUpdater(addr *felt.Felt, txn db.Transaction) (*ContractUpdater, error) {
 	contractDeployed, err := deployed(addr, txn)
 	if err != nil {
 		return nil, err
@@ -28,14 +28,14 @@ func NewContract(addr *felt.Felt, txn db.Transaction) (*Contract, error) {
 		return nil, ErrContractNotDeployed
 	}
 
-	return &Contract{
+	return &ContractUpdater{
 		Address: addr,
 		txn:     txn,
 	}, nil
 }
 
 // DeployContract sets up the database for a new contract.
-func DeployContract(addr, classHash *felt.Felt, txn db.Transaction) (*Contract, error) {
+func DeployContract(addr, classHash *felt.Felt, txn db.Transaction) (*ContractUpdater, error) {
 	contractDeployed, err := deployed(addr, txn)
 	if err != nil {
 		return nil, err
@@ -50,7 +50,7 @@ func DeployContract(addr, classHash *felt.Felt, txn db.Transaction) (*Contract, 
 		return nil, err
 	}
 
-	c, err := NewContract(addr, txn)
+	c, err := NewContractUpdater(addr, txn)
 	if err != nil {
 		return nil, err
 	}
@@ -89,8 +89,8 @@ func deployed(addr *felt.Felt, txn db.Transaction) (bool, error) {
 	return true, nil
 }
 
-// Contract is an instance of a [Class].
-type Contract struct {
+// ContractUpdater is a helper to update an existing contract instance.
+type ContractUpdater struct {
 	// Address that this contract instance is deployed to
 	Address *felt.Felt
 	// txn to access the database
@@ -99,7 +99,7 @@ type Contract struct {
 
 // Purge eliminates the contract instance, deleting all associated data from storage
 // assumes storage is cleared in revert process
-func (c *Contract) Purge() error {
+func (c *ContractUpdater) Purge() error {
 	addrBytes := c.Address.Marshal()
 	buckets := []db.Bucket{db.ContractNonce, db.ContractClassHash}
 
@@ -128,7 +128,7 @@ func ContractNonce(addr *felt.Felt, txn db.Transaction) (*felt.Felt, error) {
 }
 
 // UpdateNonce updates the nonce value in the database.
-func (c *Contract) UpdateNonce(nonce *felt.Felt) error {
+func (c *ContractUpdater) UpdateNonce(nonce *felt.Felt) error {
 	nonceKey := db.ContractNonce.Key(c.Address.Marshal())
 	return c.txn.Set(nonceKey, nonce.Marshal())
 }
@@ -145,7 +145,7 @@ func ContractRoot(addr *felt.Felt, txn db.Transaction) (*felt.Felt, error) {
 type OnValueChanged = func(location, oldValue *felt.Felt) error
 
 // UpdateStorage applies a change-set to the contract storage.
-func (c *Contract) UpdateStorage(diff []StorageDiff, cb OnValueChanged) error {
+func (c *ContractUpdater) UpdateStorage(diff []StorageDiff, cb OnValueChanged) error {
 	cStorage, err := storage(c.Address, c.txn)
 	if err != nil {
 		return err
@@ -199,7 +199,7 @@ func setClassHash(txn db.Transaction, addr, classHash *felt.Felt) error {
 }
 
 // Replace replaces the class that the contract instantiates
-func (c *Contract) Replace(classHash *felt.Felt) error {
+func (c *ContractUpdater) Replace(classHash *felt.Felt) error {
 	return setClassHash(c.txn, c.Address, classHash)
 }
 

--- a/core/contract_test.go
+++ b/core/contract_test.go
@@ -63,7 +63,7 @@ func TestNewContract(t *testing.T) {
 	classHash := new(felt.Felt).SetBytes([]byte("class hash"))
 
 	t.Run("cannot create Contract instance if un-deployed", func(t *testing.T) {
-		_, err = core.NewContract(addr, txn)
+		_, err = core.NewContractUpdater(addr, txn)
 		require.EqualError(t, err, core.ErrContractNotDeployed.Error())
 	})
 
@@ -192,6 +192,6 @@ func TestPurge(t *testing.T) {
 	require.NoError(t, err)
 
 	require.NoError(t, contract.Purge())
-	_, err = core.NewContract(addr, txn)
+	_, err = core.NewContractUpdater(addr, txn)
 	assert.ErrorIs(t, err, core.ErrContractNotDeployed)
 }

--- a/core/contract_test.go
+++ b/core/contract_test.go
@@ -75,46 +75,22 @@ func TestNewContract(t *testing.T) {
 		require.EqualError(t, err, core.ErrContractAlreadyDeployed.Error())
 	})
 
-	t.Run("instantiate previously deployed contract", func(t *testing.T) {
-		t.Run("contract with empty storage", func(t *testing.T) {
-			newContract, err := core.NewContract(addr, txn)
-			require.NoError(t, err)
-
-			root, err := newContract.Root()
-			require.NoError(t, err)
-			assert.Equal(t, &felt.Zero, root)
-		})
-		t.Run("contract with non-empty storage", func(t *testing.T) {
-			oldRoot, err := contract.Root()
-			require.NoError(t, err)
-
-			require.NoError(t, contract.UpdateStorage([]core.StorageDiff{{Key: addr, Value: classHash}}, NoopOnValueChanged))
-
-			newContract, err := core.NewContract(addr, txn)
-			require.NoError(t, err)
-
-			root, err := newContract.Root()
-			require.NoError(t, err)
-			assert.NotEqual(t, oldRoot, root)
-		})
-	})
-
 	t.Run("a call to contract should fail with a committed txn", func(t *testing.T) {
 		assert.NoError(t, txn.Commit())
 		t.Run("ClassHash()", func(t *testing.T) {
-			_, err := contract.ClassHash()
+			_, err := core.ContractClassHash(addr, txn)
 			assert.Error(t, err)
 		})
 		t.Run("Root()", func(t *testing.T) {
-			_, err := contract.Root()
+			_, err := core.ContractRoot(addr, txn)
 			assert.Error(t, err)
 		})
 		t.Run("Nonce()", func(t *testing.T) {
-			_, err := contract.Nonce()
+			_, err := core.ContractNonce(addr, txn)
 			assert.Error(t, err)
 		})
 		t.Run("Storage()", func(t *testing.T) {
-			_, err := contract.Storage(classHash)
+			_, err := core.ContractStorage(addr, classHash, txn)
 			assert.Error(t, err)
 		})
 		t.Run("UpdateNonce()", func(t *testing.T) {
@@ -138,20 +114,20 @@ func TestNonceAndClassHash(t *testing.T) {
 	require.NoError(t, err)
 
 	t.Run("initial nonce should be 0", func(t *testing.T) {
-		got, err := contract.Nonce()
+		got, err := core.ContractNonce(addr, txn)
 		require.NoError(t, err)
 		assert.Equal(t, new(felt.Felt), got)
 	})
 	t.Run("UpdateNonce()", func(t *testing.T) {
 		require.NoError(t, contract.UpdateNonce(classHash))
 
-		got, err := contract.Nonce()
+		got, err := core.ContractNonce(addr, txn)
 		require.NoError(t, err)
 		assert.Equal(t, classHash, got)
 	})
 
 	t.Run("ClassHash()", func(t *testing.T) {
-		got, err := contract.ClassHash()
+		got, err := core.ContractClassHash(addr, txn)
 		require.NoError(t, err)
 		assert.Equal(t, classHash, got)
 	})
@@ -159,7 +135,7 @@ func TestNonceAndClassHash(t *testing.T) {
 	t.Run("Replace()", func(t *testing.T) {
 		replaceWith := utils.HexToFelt(t, "0xDEADBEEF")
 		require.NoError(t, contract.Replace(replaceWith))
-		got, err := contract.ClassHash()
+		got, err := core.ContractClassHash(addr, txn)
 		require.NoError(t, err)
 		assert.Equal(t, replaceWith, got)
 	})
@@ -177,16 +153,16 @@ func TestUpdateStorageAndStorage(t *testing.T) {
 	require.NoError(t, err)
 
 	t.Run("apply storage diff", func(t *testing.T) {
-		oldRoot, err := contract.Root()
+		oldRoot, err := core.ContractRoot(addr, txn)
 		require.NoError(t, err)
 
 		require.NoError(t, contract.UpdateStorage([]core.StorageDiff{{Key: addr, Value: classHash}}, NoopOnValueChanged))
 
-		gotValue, err := contract.Storage(addr)
+		gotValue, err := core.ContractStorage(addr, addr, txn)
 		require.NoError(t, err)
 		assert.Equal(t, classHash, gotValue)
 
-		newRoot, err := contract.Root()
+		newRoot, err := core.ContractRoot(addr, txn)
 		require.NoError(t, err)
 		assert.NotEqual(t, oldRoot, newRoot)
 	})
@@ -194,11 +170,11 @@ func TestUpdateStorageAndStorage(t *testing.T) {
 	t.Run("delete key from storage with storage diff", func(t *testing.T) {
 		require.NoError(t, contract.UpdateStorage([]core.StorageDiff{{Key: addr, Value: new(felt.Felt)}}, NoopOnValueChanged))
 
-		val, err := contract.Storage(addr)
+		val, err := core.ContractStorage(addr, addr, txn)
 		require.NoError(t, err)
 		require.Equal(t, &felt.Zero, val)
 
-		sRoot, err := contract.Root()
+		sRoot, err := core.ContractRoot(addr, txn)
 		require.NoError(t, err)
 		assert.Equal(t, new(felt.Felt), sRoot)
 	})

--- a/core/state.go
+++ b/core/state.go
@@ -279,7 +279,7 @@ func (s *State) updateContracts(stateTrie *trie.Trie, blockNumber uint64, diff *
 
 // replaceContract replaces the class that a contract at a given address instantiates
 func (s *State) replaceContract(stateTrie *trie.Trie, addr, classHash *felt.Felt) (*felt.Felt, error) {
-	contract, err := NewContract(addr, s.txn)
+	contract, err := NewContractUpdater(addr, s.txn)
 	if err != nil {
 		return nil, err
 	}
@@ -346,7 +346,7 @@ func (s *State) updateStorageBuffered(contractAddr *felt.Felt, updateDiff []Stor
 	// to avoid multiple transactions writing to s.txn, create a buffered transaction and use that in the worker goroutine
 	bufferedTxn := db.NewBufferedTransaction(s.txn)
 	bufferedState := NewState(bufferedTxn)
-	bufferedContract, err := NewContract(contractAddr, bufferedTxn)
+	bufferedContract, err := NewContractUpdater(contractAddr, bufferedTxn)
 	if err != nil {
 		return nil, err
 	}
@@ -374,7 +374,7 @@ func (s *State) updateContractStorages(stateTrie *trie.Trie, diffs map[felt.Felt
 			continue
 		}
 
-		_, err := NewContract(&addr, s.txn)
+		_, err := NewContractUpdater(&addr, s.txn)
 		if err != nil {
 			if !errors.Is(err, ErrContractNotDeployed) {
 				return err
@@ -420,7 +420,7 @@ func (s *State) updateContractStorages(stateTrie *trie.Trie, diffs map[felt.Felt
 	}
 
 	for addr := range diffs {
-		contract, err := NewContract(&addr, s.txn)
+		contract, err := NewContractUpdater(&addr, s.txn)
 		if err != nil {
 			return err
 		}
@@ -436,7 +436,7 @@ func (s *State) updateContractStorages(stateTrie *trie.Trie, diffs map[felt.Felt
 // updateContractNonce updates nonce of the contract at the
 // given address in the given Txn context.
 func (s *State) updateContractNonce(stateTrie *trie.Trie, addr, nonce *felt.Felt) (*felt.Felt, error) {
-	contract, err := NewContract(addr, s.txn)
+	contract, err := NewContractUpdater(addr, s.txn)
 	if err != nil {
 		return nil, err
 	}
@@ -458,7 +458,7 @@ func (s *State) updateContractNonce(stateTrie *trie.Trie, addr, nonce *felt.Felt
 }
 
 // updateContractCommitment recalculates the contract commitment and updates its value in the global state Trie
-func (s *State) updateContractCommitment(stateTrie *trie.Trie, contract *Contract) error {
+func (s *State) updateContractCommitment(stateTrie *trie.Trie, contract *ContractUpdater) error {
 	root, err := ContractRoot(contract.Address, s.txn)
 	if err != nil {
 		return err
@@ -563,7 +563,7 @@ func (s *State) Revert(blockNumber uint64, update *StateUpdate) error {
 	// we can use the lack of key's existence as reason for purging noClassContracts.
 
 	for addr := range noClassContracts {
-		noClassC, err := NewContract(&addr, s.txn)
+		noClassC, err := NewContractUpdater(&addr, s.txn)
 		if err != nil {
 			if !errors.Is(err, ErrContractNotDeployed) {
 				return err
@@ -621,7 +621,7 @@ func (s *State) removeDeclaredClasses(blockNumber uint64, v0Classes []*felt.Felt
 }
 
 func (s *State) purgeContract(addr *felt.Felt) error {
-	contract, err := NewContract(addr, s.txn)
+	contract, err := NewContractUpdater(addr, s.txn)
 	if err != nil {
 		return err
 	}

--- a/core/state.go
+++ b/core/state.go
@@ -72,30 +72,17 @@ func (s *State) putNewContract(stateTrie *trie.Trie, addr, classHash *felt.Felt,
 
 // ContractClassHash returns class hash of a contract at a given address.
 func (s *State) ContractClassHash(addr *felt.Felt) (*felt.Felt, error) {
-	contract, err := NewContract(addr, s.txn)
-	if err != nil {
-		return nil, err
-	}
-	return contract.ClassHash()
+	return ContractClassHash(addr, s.txn)
 }
 
 // ContractNonce returns nonce of a contract at a given address.
 func (s *State) ContractNonce(addr *felt.Felt) (*felt.Felt, error) {
-	contract, err := NewContract(addr, s.txn)
-	if err != nil {
-		return nil, err
-	}
-	return contract.Nonce()
+	return ContractNonce(addr, s.txn)
 }
 
 // ContractStorage returns value of a key in the storage of the contract at the given address.
 func (s *State) ContractStorage(addr, key *felt.Felt) (*felt.Felt, error) {
-	contract, err := NewContract(addr, s.txn)
-	if err != nil {
-		return nil, err
-	}
-
-	return contract.Storage(key)
+	return ContractStorage(addr, key, s.txn)
 }
 
 // Root returns the state commitment.
@@ -297,7 +284,7 @@ func (s *State) replaceContract(stateTrie *trie.Trie, addr, classHash *felt.Felt
 		return nil, err
 	}
 
-	oldClassHash, err := contract.ClassHash()
+	oldClassHash, err := ContractClassHash(addr, s.txn)
 	if err != nil {
 		return nil, err
 	}
@@ -454,7 +441,7 @@ func (s *State) updateContractNonce(stateTrie *trie.Trie, addr, nonce *felt.Felt
 		return nil, err
 	}
 
-	oldNonce, err := contract.Nonce()
+	oldNonce, err := ContractNonce(addr, s.txn)
 	if err != nil {
 		return nil, err
 	}
@@ -472,17 +459,17 @@ func (s *State) updateContractNonce(stateTrie *trie.Trie, addr, nonce *felt.Felt
 
 // updateContractCommitment recalculates the contract commitment and updates its value in the global state Trie
 func (s *State) updateContractCommitment(stateTrie *trie.Trie, contract *Contract) error {
-	root, err := contract.Root()
+	root, err := ContractRoot(contract.Address, s.txn)
 	if err != nil {
 		return err
 	}
 
-	cHash, err := contract.ClassHash()
+	cHash, err := ContractClassHash(contract.Address, s.txn)
 	if err != nil {
 		return err
 	}
 
-	nonce, err := contract.Nonce()
+	nonce, err := ContractNonce(contract.Address, s.txn)
 	if err != nil {
 		return err
 	}
@@ -584,7 +571,7 @@ func (s *State) Revert(blockNumber uint64, update *StateUpdate) error {
 			continue
 		}
 
-		r, err := noClassC.Root()
+		r, err := ContractRoot(noClassC.Address, s.txn)
 		if err != nil {
 			return err
 		}

--- a/mocks/mock_vm.go
+++ b/mocks/mock_vm.go
@@ -42,18 +42,18 @@ func (m *MockVM) EXPECT() *MockVMMockRecorder {
 }
 
 // Call mocks base method.
-func (m *MockVM) Call(arg0, arg1 *felt.Felt, arg2 []felt.Felt, arg3, arg4 uint64, arg5 core.StateReader, arg6 utils.Network) ([]*felt.Felt, error) {
+func (m *MockVM) Call(arg0, arg1, arg2 *felt.Felt, arg3 []felt.Felt, arg4, arg5 uint64, arg6 core.StateReader, arg7 utils.Network) ([]*felt.Felt, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Call", arg0, arg1, arg2, arg3, arg4, arg5, arg6)
+	ret := m.ctrl.Call(m, "Call", arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7)
 	ret0, _ := ret[0].([]*felt.Felt)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // Call indicates an expected call of Call.
-func (mr *MockVMMockRecorder) Call(arg0, arg1, arg2, arg3, arg4, arg5, arg6 any) *gomock.Call {
+func (mr *MockVMMockRecorder) Call(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Call", reflect.TypeOf((*MockVM)(nil).Call), arg0, arg1, arg2, arg3, arg4, arg5, arg6)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Call", reflect.TypeOf((*MockVM)(nil).Call), arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7)
 }
 
 // Execute mocks base method.

--- a/node/throttled_vm.go
+++ b/node/throttled_vm.go
@@ -17,14 +17,14 @@ func NewThrottledVM(res vm.VM, concurrenyBudget uint, maxQueueLen int32) *Thrott
 	return (*ThrottledVM)(utils.NewThrottler[vm.VM](concurrenyBudget, &res).WithMaxQueueLen(maxQueueLen))
 }
 
-func (tvm *ThrottledVM) Call(contractAddr, selector *felt.Felt, calldata []felt.Felt, blockNumber,
+func (tvm *ThrottledVM) Call(contractAddr, classHash, selector *felt.Felt, calldata []felt.Felt, blockNumber,
 	blockTimestamp uint64, state core.StateReader, network utils.Network,
 ) ([]*felt.Felt, error) {
 	var ret []*felt.Felt
 	throttler := (*utils.Throttler[vm.VM])(tvm)
 	return ret, throttler.Do(func(vm *vm.VM) error {
 		var err error
-		ret, err = (*vm).Call(contractAddr, selector, calldata, blockNumber, blockTimestamp, state, network)
+		ret, err = (*vm).Call(contractAddr, classHash, selector, calldata, blockNumber, blockTimestamp, state, network)
 		return err
 	})
 }

--- a/rpc/handlers.go
+++ b/rpc/handlers.go
@@ -1129,7 +1129,7 @@ func (h *Handler) Call(call FunctionCall, id BlockID) ([]*felt.Felt, *jsonrpc.Er
 		return nil, ErrBlockNotFound
 	}
 
-	_, err = state.ContractClassHash(&call.ContractAddress)
+	classHash, err := state.ContractClassHash(&call.ContractAddress)
 	if err != nil {
 		return nil, ErrContractNotFound
 	}
@@ -1143,7 +1143,8 @@ func (h *Handler) Call(call FunctionCall, id BlockID) ([]*felt.Felt, *jsonrpc.Er
 		blockNumber = height + 1
 	}
 
-	res, err := h.vm.Call(&call.ContractAddress, &call.EntryPointSelector, call.Calldata, blockNumber, header.Timestamp, state, h.network)
+	res, err := h.vm.Call(&call.ContractAddress, classHash, &call.EntryPointSelector,
+		call.Calldata, blockNumber, header.Timestamp, state, h.network)
 	if err != nil {
 		if errors.Is(err, utils.ErrResourceBusy) {
 			return nil, ErrUnexpectedError.CloneWithData(err.Error())

--- a/vm/vm_test.go
+++ b/vm/vm_test.go
@@ -51,7 +51,7 @@ func TestV0Call(t *testing.T) {
 	}))
 
 	entryPoint := utils.HexToFelt(t, "0x39e11d48192e4333233c7eb19d10ad67c362bb28580c604d67884c85da39695")
-	ret, err := New(nil).Call(contractAddr, entryPoint, nil, 0, 0, testState, utils.MAINNET)
+	ret, err := New(nil).Call(contractAddr, classHash, entryPoint, nil, 0, 0, testState, utils.MAINNET)
 	require.NoError(t, err)
 	assert.Equal(t, []*felt.Felt{&felt.Zero}, ret)
 
@@ -70,7 +70,7 @@ func TestV0Call(t *testing.T) {
 		},
 	}, nil))
 
-	ret, err = New(nil).Call(contractAddr, entryPoint, nil, 1, 0, testState, utils.MAINNET)
+	ret, err = New(nil).Call(contractAddr, classHash, entryPoint, nil, 1, 0, testState, utils.MAINNET)
 	require.NoError(t, err)
 	assert.Equal(t, []*felt.Felt{new(felt.Felt).SetUint64(1337)}, ret)
 }
@@ -112,7 +112,7 @@ func TestV1Call(t *testing.T) {
 	// test_storage_read
 	entryPoint := utils.HexToFelt(t, "0x5df99ae77df976b4f0e5cf28c7dcfe09bd6e81aab787b19ac0c08e03d928cf")
 	storageLocation := utils.HexToFelt(t, "0x44")
-	ret, err := New(nil).Call(contractAddr, entryPoint, []felt.Felt{
+	ret, err := New(nil).Call(contractAddr, nil, entryPoint, []felt.Felt{
 		*storageLocation,
 	}, 0, 0, testState, utils.GOERLI)
 	require.NoError(t, err)
@@ -133,7 +133,7 @@ func TestV1Call(t *testing.T) {
 		},
 	}, nil))
 
-	ret, err = New(nil).Call(contractAddr, entryPoint, []felt.Felt{
+	ret, err = New(nil).Call(contractAddr, nil, entryPoint, []felt.Felt{
 		*storageLocation,
 	}, 1, 0, testState, utils.GOERLI)
 	require.NoError(t, err)


### PR DESCRIPTION
Towards better `starknet_call` performance