### PR TITLE
Make sure class cache is not serving classes from the future

### DIFF
--- a/vm/rust/src/juno_state_reader.rs
+++ b/vm/rust/src/juno_state_reader.rs
@@ -35,18 +35,22 @@ extern "C" {
         -> *const c_char;
 }
 
-static CLASS_CACHE: Lazy<Mutex<SizedCache<ClassHash, ContractClass>>> = Lazy::new(|| {
-    Mutex::new(SizedCache::with_size(128))
-});
+struct CachedContractClass {
+    pub definition: ContractClass,
+    pub cached_on_height: u64,
+}
 
+static CLASS_CACHE: Lazy<Mutex<SizedCache<ClassHash, CachedContractClass>>> =
+    Lazy::new(|| Mutex::new(SizedCache::with_size(128)));
 
 pub struct JunoStateReader {
     pub handle: usize, // uintptr_t equivalent
+    pub height: u64,
 }
 
 impl JunoStateReader {
-    pub fn new(handle: usize) -> Self {
-        Self { handle }
+    pub fn new(handle: usize, height: u64) -> Self {
+        Self { handle, height }
     }
 }
 
@@ -115,7 +119,11 @@ impl StateReader for JunoStateReader {
         class_hash: &ClassHash,
     ) -> StateResult<ContractClass> {
         if let Some(cached_class) = CLASS_CACHE.lock().unwrap().cache_get(class_hash) {
-            return Ok(cached_class.clone())
+            // skip the cache if it comes from a height higher than ours. Class might be undefined on the height
+            // that we are reading from right now.
+            if cached_class.cached_on_height <= self.height {
+                return Ok(cached_class.definition.clone());
+            }
         }
 
         let class_hash_bytes = felt_to_byte_array(&class_hash.0);
@@ -126,7 +134,13 @@ impl StateReader for JunoStateReader {
             let json_str = unsafe { CStr::from_ptr(ptr) }.to_str().unwrap();
             let contract_class = contract_class_from_json_str(json_str);
             if let Ok(class) = &contract_class {
-                CLASS_CACHE.lock().unwrap().cache_set(*class_hash, class.clone());
+                CLASS_CACHE.lock().unwrap().cache_set(
+                    *class_hash,
+                    CachedContractClass {
+                        definition: class.clone(),
+                        cached_on_height: self.height,
+                    },
+                );
             }
 
             unsafe { JunoFree(ptr as *const c_void) };

--- a/vm/rust/src/juno_state_reader.rs
+++ b/vm/rust/src/juno_state_reader.rs
@@ -1,19 +1,20 @@
 use std::{
     ffi::{c_char, c_uchar, c_void, CStr},
-    slice, sync::Mutex,
+    slice,
+    sync::Mutex,
 };
 
+use blockifier::execution::contract_class::ContractClass;
+use blockifier::state::errors::StateError;
 use blockifier::{
     execution::contract_class::{ContractClassV0, ContractClassV1},
     state::state_api::{StateReader, StateResult},
 };
+use cached::{Cached, SizedCache};
+use once_cell::sync::Lazy;
 use starknet_api::core::{ClassHash, CompiledClassHash, ContractAddress, Nonce};
 use starknet_api::hash::StarkFelt;
 use starknet_api::state::StorageKey;
-use cached::{SizedCache, Cached};
-use blockifier::execution::contract_class::ContractClass;
-use blockifier::state::errors::StateError;
-use once_cell::sync::Lazy;
 
 extern "C" {
     fn JunoFree(ptr: *const c_void);

--- a/vm/rust/src/lib.rs
+++ b/vm/rust/src/lib.rs
@@ -67,7 +67,7 @@ pub extern "C" fn cairoVMCall(
     block_timestamp: c_ulonglong,
     chain_id: *const c_char,
 ) {
-    let reader = JunoStateReader::new(reader_handle);
+    let reader = JunoStateReader::new(reader_handle, block_number);
     let contract_addr_felt = ptr_to_felt(contract_address);
     let class_hash = if class_hash.is_null() {
         None
@@ -148,7 +148,7 @@ pub extern "C" fn cairoVMExecute(
     gas_price: *const c_uchar,
     legacy_json: c_uchar,
 ) {
-    let reader = JunoStateReader::new(reader_handle);
+    let reader = JunoStateReader::new(reader_handle, block_number);
     let chain_id_str = unsafe { CStr::from_ptr(chain_id) }.to_str().unwrap();
     let txn_json_str = unsafe { CStr::from_ptr(txns_json) }.to_str().unwrap();
     let txns_and_query_bits: Result<Vec<TxnAndQueryBit>, serde_json::Error> =

--- a/vm/rust/src/lib.rs
+++ b/vm/rust/src/lib.rs
@@ -13,9 +13,9 @@ use blockifier::{
     abi::constants::{INITIAL_GAS_COST, N_STEPS_RESOURCE},
     block_context::BlockContext,
     execution::{
+        common_hints::ExecutionMode,
         contract_class::{ContractClass, ContractClassV1},
         entry_point::{CallEntryPoint, CallType, EntryPointExecutionContext, ExecutionResources},
-        common_hints::ExecutionMode,
     },
     fee::fee_utils::calculate_tx_fee,
     state::cached_state::CachedState,
@@ -41,7 +41,7 @@ use starknet_api::{
     transaction::Fee,
 };
 use starknet_api::{
-    core::{ChainId, ContractAddress, EntryPointSelector, ClassHash},
+    core::{ChainId, ClassHash, ContractAddress, EntryPointSelector},
     hash::StarkHash,
     transaction::TransactionVersion,
 };
@@ -232,7 +232,12 @@ pub extern "C" fn cairoVMExecute(
             _ => None,
         };
 
-        let txn = transaction_from_api(txn_and_query_bit.txn.clone(), contract_class, paid_fee_on_l1, txn_and_query_bit.query_bit);
+        let txn = transaction_from_api(
+            txn_and_query_bit.txn.clone(),
+            contract_class,
+            paid_fee_on_l1,
+            txn_and_query_bit.query_bit,
+        );
         if let Err(e) = txn {
             report_error(reader_handle, e.to_string().as_str());
             return;
@@ -268,7 +273,8 @@ pub extern "C" fn cairoVMExecute(
                 }
 
                 let actual_fee = t.actual_fee.0.into();
-                let mut trace = jsonrpc::new_transaction_trace(txn_and_query_bit.txn, t, &mut txn_state);
+                let mut trace =
+                    jsonrpc::new_transaction_trace(txn_and_query_bit.txn, t, &mut txn_state);
                 if trace.is_err() {
                     report_error(
                         reader_handle,


### PR DESCRIPTION
Can be tested on Goerli with running these two requests back to back.

```
{
    "jsonrpc":"2.0",
    "method":"starknet_traceTransaction",
    "params":{
        "transaction_hash": "0x00b56b03731379e3b4d53834e1f8edee7afb69aeb9bd889f5f33c8476cb717be"
    },
    "id":1
}
```
```
{
    "jsonrpc":"2.0",
    "method":"starknet_traceTransaction",
    "params":{
        "transaction_hash": "0x48b0346433513e1ed38cd99bfbbfbf74ed0f0ba1bd0c56272789775b40e0d89"
    },
    "id":1
}
```