### PR TITLE
Use maps instead of slices in state diff struct

### DIFF
--- a/adapters/core2p2p/state.go
+++ b/adapters/core2p2p/state.go
@@ -1,13 +1,11 @@
 package core2p2p
 
 import (
-	"github.com/NethermindEth/juno/core"
 	"github.com/NethermindEth/juno/core/felt"
 	"github.com/NethermindEth/juno/p2p/starknet/spec"
-	"github.com/NethermindEth/juno/utils"
 )
 
-func AdaptStateDiff(addr, classHash, nonce *felt.Felt, diff []core.StorageDiff) *spec.StateDiff_ContractDiff {
+func AdaptStateDiff(addr, classHash, nonce *felt.Felt, diff map[felt.Felt]*felt.Felt) *spec.StateDiff_ContractDiff {
 	return &spec.StateDiff_ContractDiff{
 		Address:   AdaptAddress(addr),
 		Nonce:     AdaptFelt(nonce),
@@ -16,11 +14,14 @@ func AdaptStateDiff(addr, classHash, nonce *felt.Felt, diff []core.StorageDiff) 
 	}
 }
 
-func AdaptStorageDiff(diff []core.StorageDiff) []*spec.ContractStoredValue {
-	return utils.Map(diff, func(item core.StorageDiff) *spec.ContractStoredValue {
-		return &spec.ContractStoredValue{
-			Key:   AdaptFelt(item.Key),
-			Value: AdaptFelt(item.Value),
-		}
-	})
+func AdaptStorageDiff(diff map[felt.Felt]*felt.Felt) []*spec.ContractStoredValue {
+	result := make([]*spec.ContractStoredValue, len(diff))
+	for key, value := range diff {
+		keyCopy := key
+		result = append(result, &spec.ContractStoredValue{
+			Key:   AdaptFelt(&keyCopy),
+			Value: AdaptFelt(value),
+		})
+	}
+	return result
 }

--- a/adapters/core2p2p/state.go
+++ b/adapters/core2p2p/state.go
@@ -17,9 +17,8 @@ func AdaptStateDiff(addr, classHash, nonce *felt.Felt, diff map[felt.Felt]*felt.
 func AdaptStorageDiff(diff map[felt.Felt]*felt.Felt) []*spec.ContractStoredValue {
 	result := make([]*spec.ContractStoredValue, len(diff))
 	for key, value := range diff {
-		keyCopy := key
 		result = append(result, &spec.ContractStoredValue{
-			Key:   AdaptFelt(&keyCopy),
+			Key:   AdaptFelt(&key),
 			Value: AdaptFelt(value),
 		})
 	}

--- a/adapters/sn2core/sn2core_test.go
+++ b/adapters/sn2core/sn2core_test.go
@@ -137,11 +137,10 @@ func TestStateUpdate(t *testing.T) {
 			}
 
 			assert.Equal(t, len(response.StateDiff.DeployedContracts), len(feederUpdate.StateDiff.DeployedContracts))
-			for idx := range response.StateDiff.DeployedContracts {
+			for idx, deployedContract := range response.StateDiff.DeployedContracts {
 				gw := response.StateDiff.DeployedContracts[idx]
-				coreDeployedContract := feederUpdate.StateDiff.DeployedContracts[idx]
-				assert.True(t, gw.ClassHash.Equal(coreDeployedContract.ClassHash))
-				assert.True(t, gw.Address.Equal(coreDeployedContract.Address))
+				coreDeployedContractClassHash := feederUpdate.StateDiff.DeployedContracts[*deployedContract.Address]
+				assert.True(t, gw.ClassHash.Equal(coreDeployedContractClassHash))
 			}
 
 			assert.Equal(t, len(response.StateDiff.StorageDiffs), len(feederUpdate.StateDiff.StorageDiffs))
@@ -150,9 +149,8 @@ func TestStateUpdate(t *testing.T) {
 				coreDiffs := feederUpdate.StateDiff.StorageDiffs[*key]
 				assert.Equal(t, true, len(diffs) > 0)
 				assert.Equal(t, len(diffs), len(coreDiffs))
-				for idx := range diffs {
-					assert.Equal(t, true, diffs[idx].Key.Equal(coreDiffs[idx].Key))
-					assert.Equal(t, true, diffs[idx].Value.Equal(coreDiffs[idx].Value))
+				for _, diff := range diffs {
+					assert.True(t, diff.Value.Equal(coreDiffs[*diff.Key]))
 				}
 			}
 		})

--- a/blockchain/blockchain.go
+++ b/blockchain/blockchain.go
@@ -1065,11 +1065,8 @@ func MakeStateDiffForEmptyBlock(bc Reader, blockNumber uint64) (*core.StateDiff,
 	}
 
 	blockHashStorageContract := new(felt.Felt).SetUint64(1)
-	stateDiff.StorageDiffs[*blockHashStorageContract] = []core.StorageDiff{
-		{
-			Key:   new(felt.Felt).SetUint64(header.Number),
-			Value: header.Hash,
-		},
+	stateDiff.StorageDiffs[*blockHashStorageContract] = map[felt.Felt]*felt.Felt{
+		*new(felt.Felt).SetUint64(header.Number): header.Hash,
 	}
 	return stateDiff, nil
 }

--- a/blockchain/blockchain_test.go
+++ b/blockchain/blockchain_test.go
@@ -691,9 +691,8 @@ func TestPending(t *testing.T) {
 		})
 
 		for addr, diff := range su.StateDiff.StorageDiffs {
-			addrCopy := addr
 			for key, diffVal := range diff {
-				value, csErr := reader.ContractStorage(&addrCopy, &key)
+				value, csErr := reader.ContractStorage(&addr, &key)
 				require.NoError(t, csErr)
 				require.Equal(t, diffVal, value)
 			}

--- a/blockchain/blockchain_test.go
+++ b/blockchain/blockchain_test.go
@@ -690,11 +690,12 @@ func TestPending(t *testing.T) {
 			require.NoError(t, closer())
 		})
 
-		for address, diff := range su.StateDiff.StorageDiffs {
-			for _, kv := range diff {
-				value, csErr := reader.ContractStorage(&address, kv.Key)
+		for addr, diff := range su.StateDiff.StorageDiffs {
+			addrCopy := addr
+			for key, diffVal := range diff {
+				value, csErr := reader.ContractStorage(&addrCopy, &key)
 				require.NoError(t, csErr)
-				require.Equal(t, kv.Value, value)
+				require.Equal(t, diffVal, value)
 			}
 		}
 
@@ -786,7 +787,6 @@ func TestMakeStateDiffForEmptyBlock(t *testing.T) {
 		}, nil)
 		sd, err := blockchain.MakeStateDiffForEmptyBlock(mockReader, 10)
 		require.NoError(t, err)
-		assert.Equal(t, &felt.Zero, sd.StorageDiffs[*storageContractAddr][0].Key)
-		assert.Equal(t, blockHash, sd.StorageDiffs[*storageContractAddr][0].Value)
+		assert.Equal(t, blockHash, sd.StorageDiffs[*storageContractAddr][felt.Zero])
 	})
 }

--- a/blockchain/pending.go
+++ b/blockchain/pending.go
@@ -26,43 +26,31 @@ func NewPendingState(stateDiff *core.StateDiff, newClasses map[felt.Felt]core.Cl
 }
 
 func (p *PendingState) ContractClassHash(addr *felt.Felt) (*felt.Felt, error) {
-	for _, replaced := range p.stateDiff.ReplacedClasses {
-		if replaced.Address.Equal(addr) {
-			return replaced.ClassHash, nil
-		}
+	if classHash, ok := p.stateDiff.ReplacedClasses[*addr]; ok {
+		return classHash, nil
+	} else if classHash, ok = p.stateDiff.DeployedContracts[*addr]; ok {
+		return classHash, nil
 	}
-
-	for _, deployed := range p.stateDiff.DeployedContracts {
-		if deployed.Address.Equal(addr) {
-			return deployed.ClassHash, nil
-		}
-	}
-
 	return p.head.ContractClassHash(addr)
 }
 
 func (p *PendingState) ContractNonce(addr *felt.Felt) (*felt.Felt, error) {
 	if nonce, found := p.stateDiff.Nonces[*addr]; found {
 		return nonce, nil
-	}
-
-	if p.isDeployedInPending(addr) {
-		return &felt.Zero, nil
+	} else if _, found = p.stateDiff.DeployedContracts[*addr]; found {
+		return &felt.Felt{}, nil
 	}
 	return p.head.ContractNonce(addr)
 }
 
 func (p *PendingState) ContractStorage(addr, key *felt.Felt) (*felt.Felt, error) {
 	if diffs, found := p.stateDiff.StorageDiffs[*addr]; found {
-		for _, diff := range diffs {
-			if diff.Key.Equal(key) {
-				return diff.Value, nil
-			}
+		if value, found := diffs[*key]; found {
+			return value, nil
 		}
 	}
-
-	if p.isDeployedInPending(addr) {
-		return &felt.Zero, nil
+	if _, found := p.stateDiff.DeployedContracts[*addr]; found {
+		return &felt.Felt{}, nil
 	}
 	return p.head.ContractStorage(addr, key)
 }
@@ -76,13 +64,4 @@ func (p *PendingState) Class(classHash *felt.Felt) (*core.DeclaredClass, error) 
 	}
 
 	return p.head.Class(classHash)
-}
-
-func (p *PendingState) isDeployedInPending(addr *felt.Felt) bool {
-	for _, deployed := range p.stateDiff.DeployedContracts {
-		if deployed.Address.Equal(addr) {
-			return true
-		}
-	}
-	return false
 }

--- a/blockchain/pending_test.go
+++ b/blockchain/pending_test.go
@@ -36,31 +36,19 @@ func TestPendingState(t *testing.T) {
 			NewRoot:   nil,
 			OldRoot:   nil,
 			StateDiff: &core.StateDiff{
-				DeployedContracts: []core.AddressClassHashPair{
-					{
-						Address:   deployedAddr,
-						ClassHash: deployedClassHash,
-					},
-					{
-						Address:   deployedAddr2,
-						ClassHash: deployedClassHash,
-					},
+				DeployedContracts: map[felt.Felt]*felt.Felt{
+					*deployedAddr:  deployedClassHash,
+					*deployedAddr2: deployedClassHash,
 				},
-				ReplacedClasses: []core.AddressClassHashPair{
-					{
-						Address:   replacedAddr,
-						ClassHash: replacedClassHash,
-					},
+				ReplacedClasses: map[felt.Felt]*felt.Felt{
+					*replacedAddr: replacedClassHash,
 				},
 				Nonces: map[felt.Felt]*felt.Felt{
 					*deployedAddr: new(felt.Felt).SetUint64(44),
 				},
-				StorageDiffs: map[felt.Felt][]core.StorageDiff{
+				StorageDiffs: map[felt.Felt]map[felt.Felt]*felt.Felt{
 					*deployedAddr: {
-						{
-							Key:   new(felt.Felt).SetUint64(44),
-							Value: new(felt.Felt).SetUint64(37),
-						},
+						*new(felt.Felt).SetUint64(44): new(felt.Felt).SetUint64(37),
 					},
 				},
 			},

--- a/core/contract.go
+++ b/core/contract.go
@@ -145,20 +145,20 @@ func ContractRoot(addr *felt.Felt, txn db.Transaction) (*felt.Felt, error) {
 type OnValueChanged = func(location, oldValue *felt.Felt) error
 
 // UpdateStorage applies a change-set to the contract storage.
-func (c *ContractUpdater) UpdateStorage(diff []StorageDiff, cb OnValueChanged) error {
+func (c *ContractUpdater) UpdateStorage(diff map[felt.Felt]*felt.Felt, cb OnValueChanged) error {
 	cStorage, err := storage(c.Address, c.txn)
 	if err != nil {
 		return err
 	}
 	// apply the diff
-	for _, pair := range diff {
-		oldValue, pErr := cStorage.Put(pair.Key, pair.Value)
+	for key, value := range diff {
+		oldValue, pErr := cStorage.Put(&key, value)
 		if pErr != nil {
 			return pErr
 		}
 
 		if oldValue != nil {
-			if err = cb(pair.Key, oldValue); err != nil {
+			if err = cb(&key, oldValue); err != nil {
 				return err
 			}
 		}

--- a/core/contract_test.go
+++ b/core/contract_test.go
@@ -156,7 +156,7 @@ func TestUpdateStorageAndStorage(t *testing.T) {
 		oldRoot, err := core.ContractRoot(addr, txn)
 		require.NoError(t, err)
 
-		require.NoError(t, contract.UpdateStorage([]core.StorageDiff{{Key: addr, Value: classHash}}, NoopOnValueChanged))
+		require.NoError(t, contract.UpdateStorage(map[felt.Felt]*felt.Felt{*addr: classHash}, NoopOnValueChanged))
 
 		gotValue, err := core.ContractStorage(addr, addr, txn)
 		require.NoError(t, err)
@@ -168,7 +168,7 @@ func TestUpdateStorageAndStorage(t *testing.T) {
 	})
 
 	t.Run("delete key from storage with storage diff", func(t *testing.T) {
-		require.NoError(t, contract.UpdateStorage([]core.StorageDiff{{Key: addr, Value: new(felt.Felt)}}, NoopOnValueChanged))
+		require.NoError(t, contract.UpdateStorage(map[felt.Felt]*felt.Felt{*addr: new(felt.Felt)}, NoopOnValueChanged))
 
 		val, err := core.ContractStorage(addr, addr, txn)
 		require.NoError(t, err)

--- a/core/felt/felt.go
+++ b/core/felt/felt.go
@@ -242,3 +242,7 @@ func (z *Felt) SetBigInt(v *big.Int) *Felt {
 func (z *Felt) Uint64() uint64 {
 	return z.val.Uint64()
 }
+
+func (z *Felt) Clone() *Felt {
+	return &Felt{val: z.val}
+}

--- a/core/state.go
+++ b/core/state.go
@@ -592,8 +592,7 @@ func (s *State) removeDeclaredClasses(blockNumber uint64, v0Classes []*felt.Felt
 	var classHashes []*felt.Felt
 	classHashes = append(classHashes, v0Classes...)
 	for classHash := range v1Classes {
-		classHashCopy := classHash
-		classHashes = append(classHashes, &classHashCopy)
+		classHashes = append(classHashes, classHash.Clone())
 	}
 
 	classesTrie, classesCloser, err := s.classesTrie()

--- a/core/state_test.go
+++ b/core/state_test.go
@@ -19,6 +19,12 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// Address of first deployed contract in mainnet block 1's state update.
+var (
+	_su1FirstDeployedAddress, _ = new(felt.Felt).SetString("0x6538fdd3aa353af8a87f5fe77d1f533ea82815076e30a86d65b72d3eb4f0b80")
+	su1FirstDeployedAddress     = *_su1FirstDeployedAddress
+)
+
 func TestUpdate(t *testing.T) {
 	client := feeder.NewTestClient(t, utils.Mainnet)
 	gw := adaptfeeder.New(client)
@@ -84,11 +90,8 @@ func TestUpdate(t *testing.T) {
 		OldRoot: su2.NewRoot,
 		NewRoot: utils.HexToFelt(t, "0x46f1033cfb8e0b2e16e1ad6f95c41fd3a123f168fe72665452b6cddbc1d8e7a"),
 		StateDiff: &core.StateDiff{
-			DeclaredV1Classes: []core.DeclaredV1Class{
-				{
-					ClassHash:         utils.HexToFelt(t, "0xDEADBEEF"),
-					CompiledClassHash: utils.HexToFelt(t, "0xBEEFDEAD"),
-				},
+			DeclaredV1Classes: map[felt.Felt]*felt.Felt{
+				*utils.HexToFelt(t, "0xDEADBEEF"): utils.HexToFelt(t, "0xBEEFDEAD"),
 			},
 		},
 	}
@@ -113,7 +116,7 @@ func TestUpdate(t *testing.T) {
 		OldRoot: su3.NewRoot,
 		NewRoot: utils.HexToFelt(t, "0x68ac0196d9b6276b8d86f9e92bca0ed9f854d06ded5b7f0b8bc0eeaa4377d9e"),
 		StateDiff: &core.StateDiff{
-			StorageDiffs: map[felt.Felt][]core.StorageDiff{*scAddr: {{Key: scKey, Value: scValue}}},
+			StorageDiffs: map[felt.Felt]map[felt.Felt]*felt.Felt{*scAddr: {*scKey: scValue}},
 		},
 	}
 
@@ -142,7 +145,7 @@ func TestUpdate(t *testing.T) {
 			OldRoot: su4.NewRoot,
 			NewRoot: utils.HexToFelt(t, "0x68ac0196d9b6276b8d86f9e92bca0ed9f854d06ded5b7f0b8bc0eeaa4377d9e"),
 			StateDiff: &core.StateDiff{
-				StorageDiffs: map[felt.Felt][]core.StorageDiff{*scAddr2: {{Key: scKey, Value: scValue}}},
+				StorageDiffs: map[felt.Felt]map[felt.Felt]*felt.Felt{*scAddr2: {*scKey: scValue}},
 			},
 		}
 		assert.ErrorIs(t, state.Update(5, su5, nil), core.ErrContractNotDeployed)
@@ -173,12 +176,12 @@ func TestContractClassHash(t *testing.T) {
 
 	allDeployedContracts := make(map[felt.Felt]*felt.Felt)
 
-	for _, dc := range su0.StateDiff.DeployedContracts {
-		allDeployedContracts[*dc.Address] = dc.ClassHash
+	for addr, classHash := range su0.StateDiff.DeployedContracts {
+		allDeployedContracts[addr] = classHash
 	}
 
-	for _, dc := range su1.StateDiff.DeployedContracts {
-		allDeployedContracts[*dc.Address] = dc.ClassHash
+	for addr, classHash := range su1.StateDiff.DeployedContracts {
+		allDeployedContracts[addr] = classHash
 	}
 
 	for addr, expectedClassHash := range allDeployedContracts {
@@ -194,18 +197,15 @@ func TestContractClassHash(t *testing.T) {
 			BlockHash: utils.HexToFelt(t, "0xDEADBEEF"),
 			NewRoot:   utils.HexToFelt(t, "0x484ff378143158f9af55a1210b380853ae155dfdd8cd4c228f9ece918bb982b"),
 			StateDiff: &core.StateDiff{
-				ReplacedClasses: []core.AddressClassHashPair{
-					{
-						Address:   su1.StateDiff.DeployedContracts[0].Address,
-						ClassHash: utils.HexToFelt(t, "0x1337"),
-					},
+				ReplacedClasses: map[felt.Felt]*felt.Felt{
+					su1FirstDeployedAddress: utils.HexToFelt(t, "0x1337"),
 				},
 			},
 		}
 
 		require.NoError(t, state.Update(2, replaceUpdate, nil))
 
-		gotClassHash, err := state.ContractClassHash(su1.StateDiff.DeployedContracts[0].Address)
+		gotClassHash, err := state.ContractClassHash(new(felt.Felt).Set(&su1FirstDeployedAddress))
 		require.NoError(t, err)
 
 		assert.Equal(t, utils.HexToFelt(t, "0x1337"), gotClassHash)
@@ -229,11 +229,8 @@ func TestNonce(t *testing.T) {
 		OldRoot: &felt.Zero,
 		NewRoot: root,
 		StateDiff: &core.StateDiff{
-			DeployedContracts: []core.AddressClassHashPair{
-				{
-					Address:   addr,
-					ClassHash: utils.HexToFelt(t, "0x10455c752b86932ce552f2b0fe81a880746649b9aee7e0d842bf3f52378f9f8"),
-				},
+			DeployedContracts: map[felt.Felt]*felt.Felt{
+				*addr: utils.HexToFelt(t, "0x10455c752b86932ce552f2b0fe81a880746649b9aee7e0d842bf3f52378f9f8"),
 			},
 		},
 	}
@@ -297,12 +294,9 @@ func TestStateHistory(t *testing.T) {
 		NewRoot: utils.HexToFelt(t, "0xac747e0ea7497dad7407ecf2baf24b1598b0b40943207fc9af8ded09a64f1c"),
 		OldRoot: su0.NewRoot,
 		StateDiff: &core.StateDiff{
-			StorageDiffs: map[felt.Felt][]core.StorageDiff{
+			StorageDiffs: map[felt.Felt]map[felt.Felt]*felt.Felt{
 				*contractAddr: {
-					{
-						Key:   changedLoc,
-						Value: utils.HexToFelt(t, "0x44"),
-					},
+					*changedLoc: utils.HexToFelt(t, "0x44"),
 				},
 			},
 		},
@@ -433,42 +427,37 @@ func TestRevert(t *testing.T) {
 	require.NoError(t, state.Update(1, su1, nil))
 
 	t.Run("revert a replaced class", func(t *testing.T) {
-		addr := su1.StateDiff.DeployedContracts[0].Address
 		replaceStateUpdate := &core.StateUpdate{
 			NewRoot: utils.HexToFelt(t, "0x30b1741b28893b892ac30350e6372eac3a6f32edee12f9cdca7fbe7540a5ee"),
 			OldRoot: su1.NewRoot,
 			StateDiff: &core.StateDiff{
-				ReplacedClasses: []core.AddressClassHashPair{
-					{
-						Address:   addr,
-						ClassHash: utils.HexToFelt(t, "0xDEADBEEF"),
-					},
+				ReplacedClasses: map[felt.Felt]*felt.Felt{
+					su1FirstDeployedAddress: utils.HexToFelt(t, "0xDEADBEEF"),
 				},
 			},
 		}
 
 		require.NoError(t, state.Update(2, replaceStateUpdate, nil))
 		require.NoError(t, state.Revert(2, replaceStateUpdate))
-		classHash, sErr := state.ContractClassHash(addr)
+		classHash, sErr := state.ContractClassHash(new(felt.Felt).Set(&su1FirstDeployedAddress))
 		require.NoError(t, sErr)
-		assert.Equal(t, su1.StateDiff.DeployedContracts[0].ClassHash, classHash)
+		assert.Equal(t, su1.StateDiff.DeployedContracts[*new(felt.Felt).Set(&su1FirstDeployedAddress)], classHash)
 	})
 
 	t.Run("revert a nonce update", func(t *testing.T) {
-		addr := su1.StateDiff.DeployedContracts[0].Address
 		nonceStateUpdate := &core.StateUpdate{
 			NewRoot: utils.HexToFelt(t, "0x6683657d2b6797d95f318e7c6091dc2255de86b72023c15b620af12543eb62c"),
 			OldRoot: su1.NewRoot,
 			StateDiff: &core.StateDiff{
 				Nonces: map[felt.Felt]*felt.Felt{
-					*addr: utils.HexToFelt(t, "0xDEADBEEF"),
+					su1FirstDeployedAddress: utils.HexToFelt(t, "0xDEADBEEF"),
 				},
 			},
 		}
 
 		require.NoError(t, state.Update(2, nonceStateUpdate, nil))
 		require.NoError(t, state.Revert(2, nonceStateUpdate))
-		nonce, sErr := state.ContractNonce(addr)
+		nonce, sErr := state.ContractNonce(new(felt.Felt).Set(&su1FirstDeployedAddress))
 		require.NoError(t, sErr)
 		assert.Equal(t, &felt.Zero, nonce)
 	})
@@ -512,11 +501,8 @@ func TestRevert(t *testing.T) {
 			OldRoot: su1.NewRoot,
 			StateDiff: &core.StateDiff{
 				DeclaredV0Classes: []*felt.Felt{cairo0Addr},
-				DeclaredV1Classes: []core.DeclaredV1Class{
-					{
-						ClassHash:         cairo1Addr,
-						CompiledClassHash: utils.HexToFelt(t, "0xef9123"),
-					},
+				DeclaredV1Classes: map[felt.Felt]*felt.Felt{
+					*cairo1Addr: utils.HexToFelt(t, "0xef9123"),
 				},
 			},
 		}
@@ -567,6 +553,35 @@ func TestRevert(t *testing.T) {
 	})
 }
 
+// TestRevertGenesisStateDiff ensures the reverse diff for the genesis block sets all storage values to zero.
+func TestRevertGenesisStateDiff(t *testing.T) {
+	testDB := pebble.NewMemTest(t)
+	txn, err := testDB.NewTransaction(true)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		require.NoError(t, txn.Discard())
+	})
+	state := core.NewState(txn)
+
+	addr := new(felt.Felt).SetUint64(1)
+	key := new(felt.Felt).SetUint64(2)
+	value := new(felt.Felt).SetUint64(3)
+	su := &core.StateUpdate{
+		BlockHash: new(felt.Felt),
+		NewRoot:   utils.HexToFelt(t, "0xa89ee2d272016fd3708435efda2ce766692231f8c162e27065ce1607d5a9e8"),
+		OldRoot:   new(felt.Felt),
+		StateDiff: &core.StateDiff{
+			StorageDiffs: map[felt.Felt]map[felt.Felt]*felt.Felt{
+				*addr: {
+					*key: value,
+				},
+			},
+		},
+	}
+	require.NoError(t, state.Update(0, su, nil))
+	require.NoError(t, state.Revert(0, su))
+}
+
 func TestRevertNoClassContracts(t *testing.T) {
 	client := feeder.NewTestClient(t, utils.Mainnet)
 	gw := adaptfeeder.New(client)
@@ -597,7 +612,7 @@ func TestRevertNoClassContracts(t *testing.T) {
 	// update state root
 	su1.NewRoot = utils.HexToFelt(t, "0x2829ac1aea81c890339e14422fe757d6831744031479cf33a9260d14282c341")
 
-	su1.StateDiff.StorageDiffs[*scAddr] = []core.StorageDiff{{scKey, scValue}}
+	su1.StateDiff.StorageDiffs[*scAddr] = map[felt.Felt]*felt.Felt{*scKey: scValue}
 
 	require.NoError(t, state.Update(1, su1, nil))
 
@@ -626,11 +641,8 @@ func TestRevertDeclaredClasses(t *testing.T) {
 		BlockHash: &felt.Zero,
 		StateDiff: &core.StateDiff{
 			DeclaredV0Classes: []*felt.Felt{classHash},
-			DeclaredV1Classes: []core.DeclaredV1Class{
-				{
-					ClassHash:         sierraHash,
-					CompiledClassHash: sierraHash,
-				},
+			DeclaredV1Classes: map[felt.Felt]*felt.Felt{
+				*sierraHash: sierraHash,
 			},
 		},
 	}

--- a/core/state_update.go
+++ b/core/state_update.go
@@ -1,6 +1,7 @@
 package core
 
 import (
+	"fmt"
 	"sort"
 
 	"github.com/NethermindEth/juno/core/crypto"
@@ -15,38 +16,23 @@ type StateUpdate struct {
 }
 
 type StateDiff struct {
-	StorageDiffs      map[felt.Felt][]StorageDiff
-	Nonces            map[felt.Felt]*felt.Felt
-	DeployedContracts []AddressClassHashPair
-	DeclaredV0Classes []*felt.Felt
-	DeclaredV1Classes []DeclaredV1Class
-	ReplacedClasses   []AddressClassHashPair
+	StorageDiffs      map[felt.Felt]map[felt.Felt]*felt.Felt // addr -> {key -> value, ...}
+	Nonces            map[felt.Felt]*felt.Felt               // addr -> nonce
+	DeployedContracts map[felt.Felt]*felt.Felt               // addr -> class hash
+	DeclaredV0Classes []*felt.Felt                           // class hashes
+	DeclaredV1Classes map[felt.Felt]*felt.Felt               // class hash -> compiled class hash
+	ReplacedClasses   map[felt.Felt]*felt.Felt               // addr -> class hash
 }
 
 func EmptyStateDiff() *StateDiff {
 	return &StateDiff{
-		StorageDiffs:      make(map[felt.Felt][]StorageDiff, 0),
-		Nonces:            make(map[felt.Felt]*felt.Felt, 0),
-		DeployedContracts: make([]AddressClassHashPair, 0),
+		StorageDiffs:      make(map[felt.Felt]map[felt.Felt]*felt.Felt),
+		Nonces:            make(map[felt.Felt]*felt.Felt),
+		DeployedContracts: make(map[felt.Felt]*felt.Felt),
 		DeclaredV0Classes: make([]*felt.Felt, 0),
-		DeclaredV1Classes: make([]DeclaredV1Class, 0),
-		ReplacedClasses:   make([]AddressClassHashPair, 0),
+		DeclaredV1Classes: make(map[felt.Felt]*felt.Felt),
+		ReplacedClasses:   make(map[felt.Felt]*felt.Felt),
 	}
-}
-
-type StorageDiff struct {
-	Key   *felt.Felt
-	Value *felt.Felt
-}
-
-type AddressClassHashPair struct {
-	Address   *felt.Felt
-	ClassHash *felt.Felt
-}
-
-type DeclaredV1Class struct {
-	ClassHash         *felt.Felt
-	CompiledClassHash *felt.Felt
 }
 
 func (d *StateDiff) Commitment() *felt.Felt {
@@ -58,20 +44,35 @@ func (d *StateDiff) Commitment() *felt.Felt {
 			address_2, class_hash_2, ...])
 	*/
 	var hashOfDeployedContracts crypto.PoseidonDigest
-	deployedReplacedContracts := append([]AddressClassHashPair{}, d.DeployedContracts...)
-	deployedReplacedContracts = append(deployedReplacedContracts, d.ReplacedClasses...)
-	hashOfDeployedContracts.Update(tmpFelt.SetUint64(uint64(len(deployedReplacedContracts))))
-	sort.Slice(deployedReplacedContracts, func(i, j int) bool {
-		cmpRes := deployedReplacedContracts[i].Address.Cmp(deployedReplacedContracts[j].Address)
-		if cmpRes == -1 {
+	deployedReplacedAddresses := make([]felt.Felt, 0, len(d.DeployedContracts)+len(d.ReplacedClasses))
+	for addr := range d.DeployedContracts {
+		deployedReplacedAddresses = append(deployedReplacedAddresses, addr)
+	}
+	for addr := range d.ReplacedClasses {
+		deployedReplacedAddresses = append(deployedReplacedAddresses, addr)
+	}
+	hashOfDeployedContracts.Update(tmpFelt.SetUint64(uint64(len(deployedReplacedAddresses))))
+	sort.Slice(deployedReplacedAddresses, func(i, j int) bool {
+		switch deployedReplacedAddresses[i].Cmp(&deployedReplacedAddresses[j]) {
+		case -1:
 			return true
-		} else if cmpRes == 1 {
+		case 1:
 			return false
+		default:
+			// The sequencer guarantees that a contract cannot be:
+			// - deployed twice,
+			// - deployed and have its class replaced in the same state diff, or
+			// - have its class replaced multiple times in the same state diff.
+			panic(fmt.Sprintf("address appears twice in deployed and replaced addresses: %s", &deployedReplacedAddresses[i]))
 		}
-		return deployedReplacedContracts[i].ClassHash.Cmp(deployedReplacedContracts[j].ClassHash) == -1
 	})
-	for idx := range deployedReplacedContracts {
-		hashOfDeployedContracts.Update(deployedReplacedContracts[idx].Address, deployedReplacedContracts[idx].ClassHash)
+	for idx := range deployedReplacedAddresses {
+		addr := deployedReplacedAddresses[idx]
+		classHash, ok := d.DeployedContracts[addr]
+		if !ok {
+			classHash = d.ReplacedClasses[addr]
+		}
+		hashOfDeployedContracts.Update(&addr, classHash)
 	}
 
 	/*
@@ -80,11 +81,10 @@ func (d *StateDiff) Commitment() *felt.Felt {
 	*/
 	var hashOfDeclaredClasses crypto.PoseidonDigest
 	hashOfDeclaredClasses.Update(tmpFelt.SetUint64(uint64(len(d.DeclaredV1Classes))))
-	sort.Slice(d.DeclaredV1Classes, func(i, j int) bool {
-		return d.DeclaredV1Classes[i].ClassHash.Cmp(d.DeclaredV1Classes[j].ClassHash) == -1
-	})
-	for idx := range d.DeclaredV1Classes {
-		hashOfDeclaredClasses.Update(d.DeclaredV1Classes[idx].ClassHash, d.DeclaredV1Classes[idx].CompiledClassHash)
+	declaredV1ClassHashes := sortedFeltKeys(d.DeclaredV1Classes)
+	for idx := range declaredV1ClassHashes {
+		classHash := declaredV1ClassHashes[idx]
+		hashOfDeclaredClasses.Update(&classHash, d.DeclaredV1Classes[classHash])
 	}
 
 	/*
@@ -106,18 +106,16 @@ func (d *StateDiff) Commitment() *felt.Felt {
 	daModeL1 := 0
 	hashOfStorageDomains := make([]crypto.PoseidonDigest, 1)
 
-	sortedStorageDiffKeys := sortedFeltKeys(d.StorageDiffs)
-	hashOfStorageDomains[daModeL1].Update(tmpFelt.SetUint64(uint64(len(sortedStorageDiffKeys))))
-	for idx := range sortedStorageDiffKeys {
-		hashOfStorageDomains[daModeL1].Update(&sortedStorageDiffKeys[idx])
-		diff := d.StorageDiffs[sortedStorageDiffKeys[idx]]
-		sort.Slice(diff, func(i, j int) bool {
-			return diff[i].Key.Cmp(diff[j].Key) == -1
-		})
+	sortedStorageDiffAddrs := sortedFeltKeys(d.StorageDiffs)
+	hashOfStorageDomains[daModeL1].Update(tmpFelt.SetUint64(uint64(len(sortedStorageDiffAddrs))))
+	for idx, addr := range sortedStorageDiffAddrs {
+		hashOfStorageDomains[daModeL1].Update(&sortedStorageDiffAddrs[idx])
+		diffKeys := sortedFeltKeys(d.StorageDiffs[sortedStorageDiffAddrs[idx]])
 
-		hashOfStorageDomains[daModeL1].Update(tmpFelt.SetUint64(uint64(len(diff))))
-		for idx := range diff {
-			hashOfStorageDomains[daModeL1].Update(diff[idx].Key, diff[idx].Value)
+		hashOfStorageDomains[daModeL1].Update(tmpFelt.SetUint64(uint64(len(diffKeys))))
+		for idx := range diffKeys {
+			key := diffKeys[idx]
+			hashOfStorageDomains[daModeL1].Update(&key, d.StorageDiffs[addr][key])
 		}
 	}
 

--- a/migration/migration.go
+++ b/migration/migration.go
@@ -60,7 +60,7 @@ var defaultMigrations = []Migration{
 	NewBucketMigrator(db.ContractStorage, migrateTrieNodesFromBitsetToTrieKey(db.ContractStorage)).
 		WithKeyFilter(nodesFilter(db.ContractStorage)),
 	NewBucketMover(db.Temporary, db.ContractStorage),
-	NewBucketMigrator(db.StateUpdatesByBlockNumber, changeStateDiffStruct).WithBatchSize(100_000), //nolint:gomnd
+	NewBucketMigrator(db.StateUpdatesByBlockNumber, changeStateDiffStruct).WithBatchSize(10_000), //nolint:gomnd
 }
 
 var ErrCallWithNewTransaction = errors.New("call with new transaction")

--- a/migration/migration.go
+++ b/migration/migration.go
@@ -60,6 +60,7 @@ var defaultMigrations = []Migration{
 	NewBucketMigrator(db.ContractStorage, migrateTrieNodesFromBitsetToTrieKey(db.ContractStorage)).
 		WithKeyFilter(nodesFilter(db.ContractStorage)),
 	NewBucketMover(db.Temporary, db.ContractStorage),
+	NewBucketMigrator(db.StateUpdatesByBlockNumber, changeStateDiffStruct).WithBatchSize(100_000), //nolint:gomnd
 }
 
 var ErrCallWithNewTransaction = errors.New("call with new transaction")
@@ -542,4 +543,90 @@ func migrateTrieNodesFromBitsetToTrieKey(target db.Bucket) BucketMigratorDoFunc 
 		orgKeyPrefix[0] = byte(db.Temporary) // move the node to temporary bucket
 		return txn.Set(append(orgKeyPrefix, keyBuffer.Bytes()...), tempBuf.Bytes())
 	}
+}
+
+type oldStorageDiff struct {
+	Key   *felt.Felt
+	Value *felt.Felt
+}
+type oldAddressClassHashPair struct {
+	Address   *felt.Felt
+	ClassHash *felt.Felt
+}
+type oldDeclaredV1Class struct {
+	ClassHash         *felt.Felt
+	CompiledClassHash *felt.Felt
+}
+type oldStateDiff struct {
+	StorageDiffs      map[felt.Felt][]oldStorageDiff
+	Nonces            map[felt.Felt]*felt.Felt
+	DeployedContracts []oldAddressClassHashPair
+	DeclaredV0Classes []*felt.Felt
+	DeclaredV1Classes []oldDeclaredV1Class
+	ReplacedClasses   []oldAddressClassHashPair
+}
+type oldStateUpdate struct {
+	BlockHash *felt.Felt
+	NewRoot   *felt.Felt
+	OldRoot   *felt.Felt
+	StateDiff *oldStateDiff
+}
+
+func changeStateDiffStruct(txn db.Transaction, key, value []byte, _ utils.Network) error {
+	old := new(oldStateUpdate)
+	if err := encoder.Unmarshal(value, old); err != nil {
+		return fmt.Errorf("unmarshal: %v", err)
+	}
+
+	storageDiffs := make(map[felt.Felt]map[felt.Felt]*felt.Felt, len(old.StateDiff.StorageDiffs))
+	for addr, diff := range old.StateDiff.StorageDiffs {
+		newStorageDiffs := make(map[felt.Felt]*felt.Felt, len(diff))
+		for _, kv := range diff {
+			newStorageDiffs[*kv.Key] = kv.Value
+		}
+		storageDiffs[addr] = newStorageDiffs
+	}
+
+	nonces := make(map[felt.Felt]*felt.Felt, len(old.StateDiff.Nonces))
+	for addr, nonce := range old.StateDiff.Nonces {
+		nonces[addr] = nonce
+	}
+
+	deployedContracts := make(map[felt.Felt]*felt.Felt, len(old.StateDiff.DeployedContracts))
+	for _, deployedContract := range old.StateDiff.DeployedContracts {
+		deployedContracts[*deployedContract.Address] = deployedContract.ClassHash
+	}
+
+	declaredV1Classes := make(map[felt.Felt]*felt.Felt, len(old.StateDiff.DeclaredV1Classes))
+	for _, declaredV1Class := range old.StateDiff.DeclaredV1Classes {
+		declaredV1Classes[*declaredV1Class.ClassHash] = declaredV1Class.CompiledClassHash
+	}
+
+	replacedClasses := make(map[felt.Felt]*felt.Felt, len(old.StateDiff.ReplacedClasses))
+	for _, replacedClass := range old.StateDiff.ReplacedClasses {
+		replacedClasses[*replacedClass.Address] = replacedClass.ClassHash
+	}
+
+	newValue, err := encoder.Marshal(&core.StateUpdate{
+		BlockHash: old.BlockHash,
+		NewRoot:   old.NewRoot,
+		OldRoot:   old.OldRoot,
+		StateDiff: &core.StateDiff{
+			StorageDiffs:      storageDiffs,
+			Nonces:            nonces,
+			DeployedContracts: deployedContracts,
+			DeclaredV0Classes: old.StateDiff.DeclaredV0Classes,
+			DeclaredV1Classes: declaredV1Classes,
+			ReplacedClasses:   replacedClasses,
+		},
+	})
+	if err != nil {
+		return fmt.Errorf("marshal state update: %v", err)
+	}
+
+	if err := txn.Set(key, newValue); err != nil {
+		return fmt.Errorf("set new state update for key: %v", key)
+	}
+
+	return nil
 }

--- a/migration/migration_pkg_test.go
+++ b/migration/migration_pkg_test.go
@@ -425,42 +425,44 @@ func TestChangeStateDiffStruct(t *testing.T) {
 	binary.BigEndian.PutUint64(one, 1)
 	su1Key := db.StateUpdatesByBlockNumber.Key(one)
 	require.NoError(t, testdb.Update(func(txn db.Transaction) error {
+		//nolint: dupl
 		su0 := oldStateUpdate{
-			BlockHash: new(felt.Felt),
-			NewRoot:   new(felt.Felt),
-			OldRoot:   new(felt.Felt),
+			BlockHash: utils.HexToFelt(t, "0x0"),
+			NewRoot:   utils.HexToFelt(t, "0x1"),
+			OldRoot:   utils.HexToFelt(t, "0x2"),
 			StateDiff: &oldStateDiff{
 				StorageDiffs: map[felt.Felt][]oldStorageDiff{
-					{}: {{Key: new(felt.Felt), Value: new(felt.Felt)}},
+					*utils.HexToFelt(t, "0x3"): {{Key: utils.HexToFelt(t, "0x4"), Value: utils.HexToFelt(t, "0x5")}},
 				},
 				Nonces: map[felt.Felt]*felt.Felt{
-					{}: new(felt.Felt),
+					*utils.HexToFelt(t, "0x6"): utils.HexToFelt(t, "0x7"),
 				},
-				DeployedContracts: []oldAddressClassHashPair{{Address: new(felt.Felt), ClassHash: new(felt.Felt)}},
-				DeclaredV0Classes: []*felt.Felt{new(felt.Felt)},
-				DeclaredV1Classes: []oldDeclaredV1Class{{ClassHash: new(felt.Felt), CompiledClassHash: new(felt.Felt)}},
-				ReplacedClasses:   []oldAddressClassHashPair{{Address: new(felt.Felt), ClassHash: new(felt.Felt)}},
+				DeployedContracts: []oldAddressClassHashPair{{Address: utils.HexToFelt(t, "0x8"), ClassHash: utils.HexToFelt(t, "0x9")}},
+				DeclaredV0Classes: []*felt.Felt{utils.HexToFelt(t, "0x10")},
+				DeclaredV1Classes: []oldDeclaredV1Class{{ClassHash: utils.HexToFelt(t, "0x11"), CompiledClassHash: utils.HexToFelt(t, "0x12")}},
+				ReplacedClasses:   []oldAddressClassHashPair{{Address: utils.HexToFelt(t, "0x13"), ClassHash: utils.HexToFelt(t, "0x14")}},
 			},
 		}
 		su0Bytes, err := encoder.Marshal(su0)
 		require.NoError(t, err)
 		require.NoError(t, txn.Set(su0Key, su0Bytes))
 
+		//nolint: dupl
 		su1 := oldStateUpdate{
-			BlockHash: new(felt.Felt).SetUint64(1),
-			NewRoot:   new(felt.Felt).SetUint64(1),
-			OldRoot:   new(felt.Felt).SetUint64(1),
+			BlockHash: utils.HexToFelt(t, "0x15"),
+			NewRoot:   utils.HexToFelt(t, "0x16"),
+			OldRoot:   utils.HexToFelt(t, "0x17"),
 			StateDiff: &oldStateDiff{
 				StorageDiffs: map[felt.Felt][]oldStorageDiff{
-					*new(felt.Felt).SetUint64(1): {{Key: new(felt.Felt).SetUint64(1), Value: new(felt.Felt).SetUint64(1)}},
+					*utils.HexToFelt(t, "0x18"): {{Key: utils.HexToFelt(t, "0x19"), Value: utils.HexToFelt(t, "0x20")}},
 				},
 				Nonces: map[felt.Felt]*felt.Felt{
-					*new(felt.Felt).SetUint64(1): new(felt.Felt).SetUint64(1),
+					*utils.HexToFelt(t, "0x21"): utils.HexToFelt(t, "0x22"),
 				},
-				DeployedContracts: []oldAddressClassHashPair{{Address: new(felt.Felt).SetUint64(1), ClassHash: new(felt.Felt).SetUint64(1)}},
-				DeclaredV0Classes: []*felt.Felt{new(felt.Felt).SetUint64(1)},
-				DeclaredV1Classes: []oldDeclaredV1Class{{ClassHash: new(felt.Felt).SetUint64(1), CompiledClassHash: new(felt.Felt).SetUint64(1)}},
-				ReplacedClasses:   []oldAddressClassHashPair{{Address: new(felt.Felt).SetUint64(1), ClassHash: new(felt.Felt).SetUint64(1)}},
+				DeployedContracts: []oldAddressClassHashPair{{Address: utils.HexToFelt(t, "0x23"), ClassHash: utils.HexToFelt(t, "0x24")}},
+				DeclaredV0Classes: []*felt.Felt{utils.HexToFelt(t, "0x25")},
+				DeclaredV1Classes: []oldDeclaredV1Class{{ClassHash: utils.HexToFelt(t, "0x26"), CompiledClassHash: utils.HexToFelt(t, "0x27")}},
+				ReplacedClasses:   []oldAddressClassHashPair{{Address: utils.HexToFelt(t, "0x28"), ClassHash: utils.HexToFelt(t, "0x29")}},
 			},
 		}
 		su1Bytes, err := encoder.Marshal(su1)
@@ -493,58 +495,60 @@ func TestChangeStateDiffStruct(t *testing.T) {
 			key  []byte
 			want *core.StateUpdate
 		}{
+			//nolint: dupl
 			{
 				key: su0Key,
 				want: &core.StateUpdate{
-					BlockHash: new(felt.Felt),
-					NewRoot:   new(felt.Felt),
-					OldRoot:   new(felt.Felt),
+					BlockHash: utils.HexToFelt(t, "0x0"),
+					NewRoot:   utils.HexToFelt(t, "0x1"),
+					OldRoot:   utils.HexToFelt(t, "0x2"),
 					StateDiff: &core.StateDiff{
 						StorageDiffs: map[felt.Felt]map[felt.Felt]*felt.Felt{
-							{}: {
-								{}: new(felt.Felt),
+							*utils.HexToFelt(t, "0x3"): {
+								*utils.HexToFelt(t, "0x4"): utils.HexToFelt(t, "0x5"),
 							},
 						},
 						Nonces: map[felt.Felt]*felt.Felt{
-							{}: new(felt.Felt),
+							*utils.HexToFelt(t, "0x6"): utils.HexToFelt(t, "0x7"),
 						},
 						DeployedContracts: map[felt.Felt]*felt.Felt{
-							{}: new(felt.Felt),
+							*utils.HexToFelt(t, "0x8"): utils.HexToFelt(t, "0x9"),
 						},
-						DeclaredV0Classes: []*felt.Felt{new(felt.Felt)},
+						DeclaredV0Classes: []*felt.Felt{utils.HexToFelt(t, "0x10")},
 						DeclaredV1Classes: map[felt.Felt]*felt.Felt{
-							{}: new(felt.Felt),
+							*utils.HexToFelt(t, "0x11"): utils.HexToFelt(t, "0x12"),
 						},
 						ReplacedClasses: map[felt.Felt]*felt.Felt{
-							{}: new(felt.Felt),
+							*utils.HexToFelt(t, "0x13"): utils.HexToFelt(t, "0x14"),
 						},
 					},
 				},
 			},
+			//nolint: dupl
 			{
 				key: su1Key,
 				want: &core.StateUpdate{
-					BlockHash: new(felt.Felt).SetUint64(1),
-					NewRoot:   new(felt.Felt).SetUint64(1),
-					OldRoot:   new(felt.Felt).SetUint64(1),
+					BlockHash: utils.HexToFelt(t, "0x15"),
+					NewRoot:   utils.HexToFelt(t, "0x16"),
+					OldRoot:   utils.HexToFelt(t, "0x17"),
 					StateDiff: &core.StateDiff{
 						StorageDiffs: map[felt.Felt]map[felt.Felt]*felt.Felt{
-							*new(felt.Felt).SetUint64(1): {
-								*new(felt.Felt).SetUint64(1): new(felt.Felt).SetUint64(1),
+							*utils.HexToFelt(t, "0x18"): {
+								*utils.HexToFelt(t, "0x19"): utils.HexToFelt(t, "0x20"),
 							},
 						},
 						Nonces: map[felt.Felt]*felt.Felt{
-							*new(felt.Felt).SetUint64(1): new(felt.Felt).SetUint64(1),
+							*utils.HexToFelt(t, "0x21"): utils.HexToFelt(t, "0x22"),
 						},
 						DeployedContracts: map[felt.Felt]*felt.Felt{
-							*new(felt.Felt).SetUint64(1): new(felt.Felt).SetUint64(1),
+							*utils.HexToFelt(t, "0x23"): utils.HexToFelt(t, "0x24"),
 						},
-						DeclaredV0Classes: []*felt.Felt{new(felt.Felt).SetUint64(1)},
+						DeclaredV0Classes: []*felt.Felt{utils.HexToFelt(t, "0x25")},
 						DeclaredV1Classes: map[felt.Felt]*felt.Felt{
-							*new(felt.Felt).SetUint64(1): new(felt.Felt).SetUint64(1),
+							*utils.HexToFelt(t, "0x26"): utils.HexToFelt(t, "0x27"),
 						},
 						ReplacedClasses: map[felt.Felt]*felt.Felt{
-							*new(felt.Felt).SetUint64(1): new(felt.Felt).SetUint64(1),
+							*utils.HexToFelt(t, "0x28"): utils.HexToFelt(t, "0x29"),
 						},
 					},
 				},

--- a/p2p/starknet/block_bodies.go
+++ b/p2p/starknet/block_bodies.go
@@ -103,8 +103,7 @@ func (b *blockBodyIterator) classes() (proto.Message, bool) {
 		classesM[*hash] = core2p2p.AdaptClass(cls.Class, hash)
 	}
 	for classHash := range stateDiff.DeclaredV1Classes {
-		classHashCopy := classHash
-		cls, err := b.stateReader.Class(&classHashCopy)
+		cls, err := b.stateReader.Class(&classHash)
 		if err != nil {
 			return b.fin()
 		}
@@ -113,7 +112,7 @@ func (b *blockBodyIterator) classes() (proto.Message, bool) {
 		if err != nil {
 			return b.fin()
 		}
-		classesM[classHashCopy] = core2p2p.AdaptClass(cls.Class, hash)
+		classesM[classHash] = core2p2p.AdaptClass(cls.Class, hash)
 	}
 	for _, classHash := range stateDiff.DeployedContracts {
 		if _, ok := classesM[*classHash]; ok {

--- a/rpc/handlers.go
+++ b/rpc/handlers.go
@@ -722,52 +722,46 @@ func (h *Handler) StateUpdate(id BlockID) (*StateUpdate, *jsonrpc.Error) {
 
 	nonces := make([]Nonce, 0, len(update.StateDiff.Nonces))
 	for addr, nonce := range update.StateDiff.Nonces {
-		addrCopy := addr
-		nonces = append(nonces, Nonce{ContractAddress: &addrCopy, Nonce: nonce})
+		nonces = append(nonces, Nonce{ContractAddress: addr, Nonce: *nonce})
 	}
 
 	storageDiffs := make([]StorageDiff, 0, len(update.StateDiff.StorageDiffs))
 	for addr, diffs := range update.StateDiff.StorageDiffs {
 		entries := make([]Entry, 0, len(diffs))
 		for key, value := range diffs {
-			keyCopy := key
 			entries = append(entries, Entry{
-				Key:   &keyCopy,
-				Value: new(felt.Felt).Set(value),
+				Key:   key,
+				Value: *value,
 			})
 		}
 
-		addrCopy := addr
 		storageDiffs = append(storageDiffs, StorageDiff{
-			Address:        &addrCopy,
+			Address:        addr,
 			StorageEntries: entries,
 		})
 	}
 
 	deployedContracts := make([]DeployedContract, 0, len(update.StateDiff.DeployedContracts))
 	for addr, classHash := range update.StateDiff.DeployedContracts {
-		addrCopy := addr
 		deployedContracts = append(deployedContracts, DeployedContract{
-			Address:   &addrCopy,
-			ClassHash: new(felt.Felt).Set(classHash),
+			Address:   addr,
+			ClassHash: *classHash,
 		})
 	}
 
 	declaredClasses := make([]DeclaredClass, 0, len(update.StateDiff.DeclaredV1Classes))
 	for classHash, compiledClassHash := range update.StateDiff.DeclaredV1Classes {
-		classHashCopy := classHash
 		declaredClasses = append(declaredClasses, DeclaredClass{
-			ClassHash:         &classHashCopy,
-			CompiledClassHash: compiledClassHash,
+			ClassHash:         classHash,
+			CompiledClassHash: *compiledClassHash,
 		})
 	}
 
 	replacedClasses := make([]ReplacedClass, 0, len(update.StateDiff.ReplacedClasses))
 	for addr, classHash := range update.StateDiff.ReplacedClasses {
-		addrCopy := addr
 		replacedClasses = append(replacedClasses, ReplacedClass{
-			ClassHash:       classHash,
-			ContractAddress: &addrCopy,
+			ClassHash:       *classHash,
+			ContractAddress: addr,
 		})
 	}
 

--- a/rpc/handlers.go
+++ b/rpc/handlers.go
@@ -722,41 +722,52 @@ func (h *Handler) StateUpdate(id BlockID) (*StateUpdate, *jsonrpc.Error) {
 
 	nonces := make([]Nonce, 0, len(update.StateDiff.Nonces))
 	for addr, nonce := range update.StateDiff.Nonces {
-		nonces = append(nonces, Nonce{ContractAddress: new(felt.Felt).Set(&addr), Nonce: nonce})
+		addrCopy := addr
+		nonces = append(nonces, Nonce{ContractAddress: &addrCopy, Nonce: nonce})
 	}
 
 	storageDiffs := make([]StorageDiff, 0, len(update.StateDiff.StorageDiffs))
 	for addr, diffs := range update.StateDiff.StorageDiffs {
-		entries := make([]Entry, len(diffs))
-
-		for index, diff := range diffs {
-			entries[index] = Entry{Key: diff.Key, Value: diff.Value}
+		entries := make([]Entry, 0, len(diffs))
+		for key, value := range diffs {
+			keyCopy := key
+			entries = append(entries, Entry{
+				Key:   &keyCopy,
+				Value: new(felt.Felt).Set(value),
+			})
 		}
 
-		storageDiffs = append(storageDiffs, StorageDiff{Address: new(felt.Felt).Set(&addr), StorageEntries: entries})
+		addrCopy := addr
+		storageDiffs = append(storageDiffs, StorageDiff{
+			Address:        &addrCopy,
+			StorageEntries: entries,
+		})
 	}
 
 	deployedContracts := make([]DeployedContract, 0, len(update.StateDiff.DeployedContracts))
-	for _, deployedContract := range update.StateDiff.DeployedContracts {
+	for addr, classHash := range update.StateDiff.DeployedContracts {
+		addrCopy := addr
 		deployedContracts = append(deployedContracts, DeployedContract{
-			Address:   deployedContract.Address,
-			ClassHash: deployedContract.ClassHash,
+			Address:   &addrCopy,
+			ClassHash: new(felt.Felt).Set(classHash),
 		})
 	}
 
 	declaredClasses := make([]DeclaredClass, 0, len(update.StateDiff.DeclaredV1Classes))
-	for _, declaredClass := range update.StateDiff.DeclaredV1Classes {
+	for classHash, compiledClassHash := range update.StateDiff.DeclaredV1Classes {
+		classHashCopy := classHash
 		declaredClasses = append(declaredClasses, DeclaredClass{
-			ClassHash:         declaredClass.ClassHash,
-			CompiledClassHash: declaredClass.CompiledClassHash,
+			ClassHash:         &classHashCopy,
+			CompiledClassHash: compiledClassHash,
 		})
 	}
 
 	replacedClasses := make([]ReplacedClass, 0, len(update.StateDiff.ReplacedClasses))
-	for _, replacedClass := range update.StateDiff.ReplacedClasses {
+	for addr, classHash := range update.StateDiff.ReplacedClasses {
+		addrCopy := addr
 		replacedClasses = append(replacedClasses, ReplacedClass{
-			ClassHash:       replacedClass.ClassHash,
-			ContractAddress: replacedClass.Address,
+			ClassHash:       classHash,
+			ContractAddress: &addrCopy,
 		})
 	}
 

--- a/rpc/handlers_test.go
+++ b/rpc/handlers_test.go
@@ -1778,34 +1778,34 @@ func TestStateUpdate(t *testing.T) {
 
 		require.Equal(t, len(coreUpdate.StateDiff.StorageDiffs), len(rpcUpdate.StateDiff.StorageDiffs))
 		for _, diff := range rpcUpdate.StateDiff.StorageDiffs {
-			coreDiffs := coreUpdate.StateDiff.StorageDiffs[*diff.Address]
+			coreDiffs := coreUpdate.StateDiff.StorageDiffs[diff.Address]
 			require.Equal(t, len(coreDiffs), len(diff.StorageEntries))
 			for _, entry := range diff.StorageEntries {
-				require.Equal(t, coreDiffs[*entry.Key], entry.Value)
+				require.Equal(t, *coreDiffs[entry.Key], entry.Value)
 			}
 		}
 
 		require.Equal(t, len(coreUpdate.StateDiff.Nonces), len(rpcUpdate.StateDiff.Nonces))
 		for _, nonce := range rpcUpdate.StateDiff.Nonces {
-			require.Equal(t, coreUpdate.StateDiff.Nonces[*nonce.ContractAddress], nonce.Nonce)
+			require.Equal(t, *coreUpdate.StateDiff.Nonces[nonce.ContractAddress], nonce.Nonce)
 		}
 
 		require.Equal(t, len(coreUpdate.StateDiff.DeployedContracts), len(rpcUpdate.StateDiff.DeployedContracts))
 		for _, deployedContract := range rpcUpdate.StateDiff.DeployedContracts {
-			require.Equal(t, coreUpdate.StateDiff.DeployedContracts[*deployedContract.Address], deployedContract.ClassHash)
+			require.Equal(t, *coreUpdate.StateDiff.DeployedContracts[deployedContract.Address], deployedContract.ClassHash)
 		}
 
 		require.Equal(t, coreUpdate.StateDiff.DeclaredV0Classes, rpcUpdate.StateDiff.DeprecatedDeclaredClasses)
 
 		require.Equal(t, len(coreUpdate.StateDiff.ReplacedClasses), len(rpcUpdate.StateDiff.ReplacedClasses))
 		for index := range rpcUpdate.StateDiff.ReplacedClasses {
-			require.Equal(t, coreUpdate.StateDiff.ReplacedClasses[*rpcUpdate.StateDiff.ReplacedClasses[index].ContractAddress],
+			require.Equal(t, *coreUpdate.StateDiff.ReplacedClasses[rpcUpdate.StateDiff.ReplacedClasses[index].ContractAddress],
 				rpcUpdate.StateDiff.ReplacedClasses[index].ClassHash)
 		}
 
 		require.Equal(t, len(coreUpdate.StateDiff.DeclaredV1Classes), len(rpcUpdate.StateDiff.DeclaredClasses))
 		for index := range rpcUpdate.StateDiff.DeclaredClasses {
-			require.Equal(t, coreUpdate.StateDiff.DeclaredV1Classes[*rpcUpdate.StateDiff.DeclaredClasses[index].ClassHash],
+			require.Equal(t, *coreUpdate.StateDiff.DeclaredV1Classes[rpcUpdate.StateDiff.DeclaredClasses[index].ClassHash],
 				rpcUpdate.StateDiff.DeclaredClasses[index].CompiledClassHash)
 		}
 	}

--- a/rpc/handlers_test.go
+++ b/rpc/handlers_test.go
@@ -1772,49 +1772,41 @@ func TestStateUpdate(t *testing.T) {
 
 	checkUpdate := func(t *testing.T, coreUpdate *core.StateUpdate, rpcUpdate *rpc.StateUpdate) {
 		t.Helper()
-		assert.Equal(t, coreUpdate.BlockHash, rpcUpdate.BlockHash)
-		assert.Equal(t, coreUpdate.NewRoot, rpcUpdate.NewRoot)
-		assert.Equal(t, coreUpdate.OldRoot, rpcUpdate.OldRoot)
+		require.Equal(t, coreUpdate.BlockHash, rpcUpdate.BlockHash)
+		require.Equal(t, coreUpdate.NewRoot, rpcUpdate.NewRoot)
+		require.Equal(t, coreUpdate.OldRoot, rpcUpdate.OldRoot)
 
-		assert.Equal(t, len(coreUpdate.StateDiff.StorageDiffs), len(rpcUpdate.StateDiff.StorageDiffs))
+		require.Equal(t, len(coreUpdate.StateDiff.StorageDiffs), len(rpcUpdate.StateDiff.StorageDiffs))
 		for _, diff := range rpcUpdate.StateDiff.StorageDiffs {
 			coreDiffs := coreUpdate.StateDiff.StorageDiffs[*diff.Address]
-			assert.Equal(t, len(coreDiffs), len(diff.StorageEntries))
-			for index, entry := range diff.StorageEntries {
-				assert.Equal(t, entry.Key, coreDiffs[index].Key)
-				assert.Equal(t, entry.Value, coreDiffs[index].Value)
+			require.Equal(t, len(coreDiffs), len(diff.StorageEntries))
+			for _, entry := range diff.StorageEntries {
+				require.Equal(t, coreDiffs[*entry.Key], entry.Value)
 			}
 		}
 
-		assert.Equal(t, len(coreUpdate.StateDiff.Nonces), len(rpcUpdate.StateDiff.Nonces))
+		require.Equal(t, len(coreUpdate.StateDiff.Nonces), len(rpcUpdate.StateDiff.Nonces))
 		for _, nonce := range rpcUpdate.StateDiff.Nonces {
-			assert.Equal(t, coreUpdate.StateDiff.Nonces[*nonce.ContractAddress], nonce.Nonce)
+			require.Equal(t, coreUpdate.StateDiff.Nonces[*nonce.ContractAddress], nonce.Nonce)
 		}
 
-		assert.Equal(t, len(coreUpdate.StateDiff.DeployedContracts), len(rpcUpdate.StateDiff.DeployedContracts))
-		for index := range rpcUpdate.StateDiff.DeployedContracts {
-			assert.Equal(t, coreUpdate.StateDiff.DeployedContracts[index].Address,
-				rpcUpdate.StateDiff.DeployedContracts[index].Address)
-			assert.Equal(t, coreUpdate.StateDiff.DeployedContracts[index].ClassHash,
-				rpcUpdate.StateDiff.DeployedContracts[index].ClassHash)
+		require.Equal(t, len(coreUpdate.StateDiff.DeployedContracts), len(rpcUpdate.StateDiff.DeployedContracts))
+		for _, deployedContract := range rpcUpdate.StateDiff.DeployedContracts {
+			require.Equal(t, coreUpdate.StateDiff.DeployedContracts[*deployedContract.Address], deployedContract.ClassHash)
 		}
 
-		assert.Equal(t, coreUpdate.StateDiff.DeclaredV0Classes, rpcUpdate.StateDiff.DeprecatedDeclaredClasses)
+		require.Equal(t, coreUpdate.StateDiff.DeclaredV0Classes, rpcUpdate.StateDiff.DeprecatedDeclaredClasses)
 
-		assert.Equal(t, len(coreUpdate.StateDiff.ReplacedClasses), len(rpcUpdate.StateDiff.ReplacedClasses))
+		require.Equal(t, len(coreUpdate.StateDiff.ReplacedClasses), len(rpcUpdate.StateDiff.ReplacedClasses))
 		for index := range rpcUpdate.StateDiff.ReplacedClasses {
-			assert.Equal(t, coreUpdate.StateDiff.ReplacedClasses[index].Address,
-				rpcUpdate.StateDiff.ReplacedClasses[index].ContractAddress)
-			assert.Equal(t, coreUpdate.StateDiff.ReplacedClasses[index].ClassHash,
+			require.Equal(t, coreUpdate.StateDiff.ReplacedClasses[*rpcUpdate.StateDiff.ReplacedClasses[index].ContractAddress],
 				rpcUpdate.StateDiff.ReplacedClasses[index].ClassHash)
 		}
 
-		assert.Equal(t, len(coreUpdate.StateDiff.DeclaredV1Classes), len(rpcUpdate.StateDiff.DeclaredClasses))
+		require.Equal(t, len(coreUpdate.StateDiff.DeclaredV1Classes), len(rpcUpdate.StateDiff.DeclaredClasses))
 		for index := range rpcUpdate.StateDiff.DeclaredClasses {
-			assert.Equal(t, coreUpdate.StateDiff.DeclaredV1Classes[index].CompiledClassHash,
+			require.Equal(t, coreUpdate.StateDiff.DeclaredV1Classes[*rpcUpdate.StateDiff.DeclaredClasses[index].ClassHash],
 				rpcUpdate.StateDiff.DeclaredClasses[index].CompiledClassHash)
-			assert.Equal(t, coreUpdate.StateDiff.DeclaredV1Classes[index].ClassHash,
-				rpcUpdate.StateDiff.DeclaredClasses[index].ClassHash)
 		}
 	}
 

--- a/rpc/state_update.go
+++ b/rpc/state_update.go
@@ -20,31 +20,31 @@ type StateDiff struct {
 }
 
 type Nonce struct {
-	ContractAddress *felt.Felt `json:"contract_address"`
-	Nonce           *felt.Felt `json:"nonce"`
+	ContractAddress felt.Felt `json:"contract_address"`
+	Nonce           felt.Felt `json:"nonce"`
 }
 
 type StorageDiff struct {
-	Address        *felt.Felt `json:"address"`
-	StorageEntries []Entry    `json:"storage_entries"`
+	Address        felt.Felt `json:"address"`
+	StorageEntries []Entry   `json:"storage_entries"`
 }
 
 type Entry struct {
-	Key   *felt.Felt `json:"key"`
-	Value *felt.Felt `json:"value"`
+	Key   felt.Felt `json:"key"`
+	Value felt.Felt `json:"value"`
 }
 
 type DeployedContract struct {
-	Address   *felt.Felt `json:"address"`
-	ClassHash *felt.Felt `json:"class_hash"`
+	Address   felt.Felt `json:"address"`
+	ClassHash felt.Felt `json:"class_hash"`
 }
 
 type ReplacedClass struct {
-	ContractAddress *felt.Felt `json:"contract_address"`
-	ClassHash       *felt.Felt `json:"class_hash"`
+	ContractAddress felt.Felt `json:"contract_address"`
+	ClassHash       felt.Felt `json:"class_hash"`
 }
 
 type DeclaredClass struct {
-	ClassHash         *felt.Felt `json:"class_hash"`
-	CompiledClassHash *felt.Felt `json:"compiled_class_hash"`
+	ClassHash         felt.Felt `json:"class_hash"`
+	CompiledClassHash felt.Felt `json:"compiled_class_hash"`
 }

--- a/sync/sync.go
+++ b/sync/sync.go
@@ -144,8 +144,8 @@ func (s *Synchronizer) fetchUnknownClasses(ctx context.Context, stateUpdate *cor
 		return stateErr
 	}
 
-	for _, deployedContract := range stateUpdate.StateDiff.DeployedContracts {
-		if err = fetchIfNotFound(deployedContract.ClassHash); err != nil {
+	for _, classHash := range stateUpdate.StateDiff.DeployedContracts {
+		if err = fetchIfNotFound(classHash); err != nil {
 			return nil, utils.RunAndWrapOnError(closer, err)
 		}
 	}
@@ -154,8 +154,8 @@ func (s *Synchronizer) fetchUnknownClasses(ctx context.Context, stateUpdate *cor
 			return nil, utils.RunAndWrapOnError(closer, err)
 		}
 	}
-	for _, declaredV1 := range stateUpdate.StateDiff.DeclaredV1Classes {
-		if err = fetchIfNotFound(declaredV1.ClassHash); err != nil {
+	for _, classHash := range stateUpdate.StateDiff.DeclaredV1Classes {
+		if err = fetchIfNotFound(classHash); err != nil {
 			return nil, utils.RunAndWrapOnError(closer, err)
 		}
 	}

--- a/sync/sync.go
+++ b/sync/sync.go
@@ -154,8 +154,8 @@ func (s *Synchronizer) fetchUnknownClasses(ctx context.Context, stateUpdate *cor
 			return nil, utils.RunAndWrapOnError(closer, err)
 		}
 	}
-	for _, classHash := range stateUpdate.StateDiff.DeclaredV1Classes {
-		if err = fetchIfNotFound(classHash); err != nil {
+	for classHash := range stateUpdate.StateDiff.DeclaredV1Classes {
+		if err = fetchIfNotFound(&classHash); err != nil {
 			return nil, utils.RunAndWrapOnError(closer, err)
 		}
 	}

--- a/vm/vm_test.go
+++ b/vm/vm_test.go
@@ -39,11 +39,8 @@ func TestV0Call(t *testing.T) {
 		OldRoot: &felt.Zero,
 		NewRoot: utils.HexToFelt(t, "0x3d452fbb3c3a32fe85b1a3fbbcdec316d5fc940cefc028ee808ad25a15991c8"),
 		StateDiff: &core.StateDiff{
-			DeployedContracts: []core.AddressClassHashPair{
-				{
-					Address:   contractAddr,
-					ClassHash: classHash,
-				},
+			DeployedContracts: map[felt.Felt]*felt.Felt{
+				*contractAddr: classHash,
 			},
 		},
 	}, map[felt.Felt]core.Class{
@@ -59,12 +56,9 @@ func TestV0Call(t *testing.T) {
 		OldRoot: utils.HexToFelt(t, "0x3d452fbb3c3a32fe85b1a3fbbcdec316d5fc940cefc028ee808ad25a15991c8"),
 		NewRoot: utils.HexToFelt(t, "0x4a948783e8786ba9d8edaf42de972213bd2deb1b50c49e36647f1fef844890f"),
 		StateDiff: &core.StateDiff{
-			StorageDiffs: map[felt.Felt][]core.StorageDiff{
+			StorageDiffs: map[felt.Felt]map[felt.Felt]*felt.Felt{
 				*contractAddr: {
-					core.StorageDiff{
-						Key:   utils.HexToFelt(t, "0x206f38f7e4f15e87567361213c28f235cccdaa1d7fd34c9db1dfe9489c6a091"),
-						Value: new(felt.Felt).SetUint64(1337),
-					},
+					*utils.HexToFelt(t, "0x206f38f7e4f15e87567361213c28f235cccdaa1d7fd34c9db1dfe9489c6a091"): new(felt.Felt).SetUint64(1337),
 				},
 			},
 		},
@@ -98,11 +92,8 @@ func TestV1Call(t *testing.T) {
 		OldRoot: &felt.Zero,
 		NewRoot: utils.HexToFelt(t, "0x2650cef46c190ec6bb7dc21a5a36781132e7c883b27175e625031149d4f1a84"),
 		StateDiff: &core.StateDiff{
-			DeployedContracts: []core.AddressClassHashPair{
-				{
-					Address:   contractAddr,
-					ClassHash: classHash,
-				},
+			DeployedContracts: map[felt.Felt]*felt.Felt{
+				*contractAddr: classHash,
 			},
 		},
 	}, map[felt.Felt]core.Class{
@@ -122,12 +113,9 @@ func TestV1Call(t *testing.T) {
 		OldRoot: utils.HexToFelt(t, "0x2650cef46c190ec6bb7dc21a5a36781132e7c883b27175e625031149d4f1a84"),
 		NewRoot: utils.HexToFelt(t, "0x7a9da0a7471a8d5118d3eefb8c26a6acbe204eb1eaa934606f4757a595fe552"),
 		StateDiff: &core.StateDiff{
-			StorageDiffs: map[felt.Felt][]core.StorageDiff{
+			StorageDiffs: map[felt.Felt]map[felt.Felt]*felt.Felt{
 				*contractAddr: {
-					core.StorageDiff{
-						Key:   storageLocation,
-						Value: new(felt.Felt).SetUint64(37),
-					},
+					*storageLocation: new(felt.Felt).SetUint64(37),
 				},
 			},
 		},


### PR DESCRIPTION
Makes it much easier to build a state diff incrementally during execution.