### PR TITLE
Parallelize bucket migrator

### DIFF
--- a/db/pebble/db.go
+++ b/db/pebble/db.go
@@ -48,7 +48,7 @@ func NewMem() (db.DB, error) {
 }
 
 // NewMemTest opens a new in-memory database, panics on error
-func NewMemTest(t *testing.T) db.DB {
+func NewMemTest(t testing.TB) db.DB {
 	memDB, err := NewMem()
 	if err != nil {
 		t.Fatalf("create in-memory db: %v", err)

--- a/migration/bucket_migrator.go
+++ b/migration/bucket_migrator.go
@@ -3,9 +3,12 @@ package migration
 import (
 	"bytes"
 	"context"
+	"fmt"
+	"runtime"
 
 	"github.com/NethermindEth/juno/db"
 	"github.com/NethermindEth/juno/utils"
+	"github.com/sourcegraph/conc/pool"
 )
 
 var _ Migration = (*BucketMigrator)(nil)
@@ -76,34 +79,62 @@ func (m *BucketMigrator) Migrate(_ context.Context, txn db.Transaction, network 
 	remainingInBatch := m.batchSize
 	iterator, err := txn.NewIterator()
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("new iterator: %v", err)
 	}
 
+	keyValue := make([][2][]byte, 0)
+	callWithNewTransaction := false
 	for iterator.Seek(m.startFrom); iterator.Valid(); iterator.Next() {
 		key := iterator.Key()
 		if !bytes.HasPrefix(key, m.target.Key()) {
 			break
 		}
-
-		if pass, err := m.keyFilter(key); err != nil {
-			return nil, utils.RunAndWrapOnError(iterator.Close, err)
-		} else if pass {
-			if remainingInBatch == 0 {
-				m.startFrom = key
-				return nil, utils.RunAndWrapOnError(iterator.Close, ErrCallWithNewTransaction)
-			}
-
-			remainingInBatch--
-			value, err := iterator.Value()
-			if err != nil {
-				return nil, utils.RunAndWrapOnError(iterator.Close, err)
-			}
-
-			if err = m.do(txn, key, value, network); err != nil {
-				return nil, utils.RunAndWrapOnError(iterator.Close, err)
-			}
+		if do, filterErr := m.keyFilter(key); filterErr != nil {
+			return nil, fmt.Errorf("filter: %v", filterErr)
+		} else if !do {
+			continue
 		}
+		if remainingInBatch == 0 {
+			m.startFrom = key
+			callWithNewTransaction = true
+			break
+		}
+		remainingInBatch--
+
+		var value []byte
+		value, err = iterator.Value()
+		if err != nil {
+			return nil, utils.RunAndWrapOnError(iterator.Close, fmt.Errorf("get value from iterator: %v", err))
+		}
+		keyValue = append(keyValue, [2][]byte{key, value})
+	}
+	if err = iterator.Close(); err != nil {
+		return nil, fmt.Errorf("close iterator: %v", err)
 	}
 
-	return nil, iterator.Close()
+	syncTxn := db.NewSyncTransaction(txn)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	p := pool.New().WithErrors().WithFirstError().WithMaxGoroutines(3 * runtime.GOMAXPROCS(0))
+	for _, kv := range keyValue {
+		if ctx.Err() != nil {
+			break
+		}
+		kv := kv
+		p.Go(func() error {
+			if doErr := m.do(syncTxn, kv[0], kv[1], network); doErr != nil {
+				cancel()
+				return fmt.Errorf("do: %v", doErr)
+			}
+			return nil
+		})
+	}
+	if err = p.Wait(); err != nil {
+		return nil, fmt.Errorf("worker: %v", err)
+	}
+
+	if callWithNewTransaction {
+		return nil, ErrCallWithNewTransaction
+	}
+	return nil, nil
 }

--- a/migration/bucket_migrator_test.go
+++ b/migration/bucket_migrator_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"errors"
+	"fmt"
 	"testing"
 
 	"github.com/NethermindEth/juno/db"
@@ -60,7 +61,7 @@ func TestBucketMover(t *testing.T) {
 			return nil
 		})
 		if err != nil {
-			return err
+			return fmt.Errorf("get sourcebucket key's value: %v", err)
 		}
 
 		for i := byte(0); i < 3; i++ {
@@ -71,7 +72,7 @@ func TestBucketMover(t *testing.T) {
 				return nil
 			})
 			if err != nil {
-				return err
+				return fmt.Errorf("get destbucket %d value: %v", i, err)
 			}
 
 			err = txn.Get(sourceBucket.Key([]byte{i}), func(b []byte) error { return nil })


### PR DESCRIPTION
Memory usage roughly doubles because we build the list of keys and values from the iterator. 

If this is a problem, we could break up the batch into smaller batches and parallelize each individually, giving the garbage collector a chance to clean up some of the memory.

Before

```
% go test -bench=. -benchtime=20s      
BenchmarkBucketMigratorMemDB-12    	    302	 82_671_637 ns/op

% go test -bench=. -benchtime=20s -benchmem
BenchmarkBucketMigratorMemDB-12    	    303	 79092378 ns/op	44442478 B/op	 200_507 allocs/op
```

After

```
% go test -bench=. -benchtime=20s
BenchmarkBucketMigratorMemDB-12              160         147_339_162 ns/op

% go test -bench=. -benchtime=20s -benchmem
BenchmarkBucketMigratorMemDB-12              160         165104490 ns/op        82721453 B/op     400_645 allocs/op
```