### PR TITLE
Fix starknet-rs tests with v0.5 RPC-compatible commit

### DIFF
--- a/.github/workflows/starknet-rs-tests.yml
+++ b/.github/workflows/starknet-rs-tests.yml
@@ -14,7 +14,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: xJonathanLEI/starknet-rs
-          ref: dev/jsonrpc_0_5_0
+          ref: 64ebc364c0c346e81b715c5b4a3b32ef37b055c8
 
       - name: Setup Rust
         uses: actions-rs/toolchain@v1


### PR DESCRIPTION
Previously, we were relying on the `dev/jsonrpc_0_5_0` branch, but this branch has now been removed.

To ensure continuity and stability, I've switched to using a hardcoded commit that is compatible with v0.5 of the RPC.
