### PR TITLE
Allow for 10MB messages over grpc

### DIFF
--- a/db/remote/db.go
+++ b/db/remote/db.go
@@ -34,7 +34,12 @@ func New(rawURL string, ctx context.Context, log utils.SimpleLogger, opts ...grp
 }
 
 func (d *DB) NewTransaction(write bool) (db.Transaction, error) {
-	txClient, err := d.kvClient.Tx(d.ctx)
+	const (
+		megabyte = 1 << 20
+		// Some classes are larger than the default of 4MB.
+		maxCallMsgSize = 10 * megabyte
+	)
+	txClient, err := d.kvClient.Tx(d.ctx, grpc.MaxCallSendMsgSize(maxCallMsgSize), grpc.MaxCallRecvMsgSize(maxCallMsgSize))
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Got an error message that looked something like this:
```
JunoStateGetCompiledClass failed to read class
{
    "err": "rpc error: code = ResourceExhausted desc = grpc: received message larger than max (5877256 vs. 4194304)"
}
github.com/NethermindEth/juno/vm.JunoStateGetCompiledClass/home/user/repos/juno/vm/state_reader.go:80
```

https://stackoverflow.com/questions/55362342/grpc-received-message-larger-than-max-8653851-vs-4194304