### PR TITLE
Update starknet-rs to v0.8.0

### DIFF
--- a/core/rust/Cargo.toml
+++ b/core/rust/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2021"
 [dependencies]
 serde = "1.0.171"
 serde_json = { version = "1.0.96", features = ["raw_value"] }
-starknet = { rev = "starknet-core/v0.4.0", git = "https://github.com/xJonathanLEI/starknet-rs" }
+starknet-core = "0.8.0"
 
 [lib]
 crate-type = ["staticlib"]

--- a/core/rust/src/lib.rs
+++ b/core/rust/src/lib.rs
@@ -1,4 +1,4 @@
-use starknet::core::types::contract::legacy::LegacyContractClass;
+use starknet_core::types::contract::legacy::LegacyContractClass;
 use std::{
     ffi::{c_char, c_uchar, CStr},
     slice,

--- a/vm/rust/Cargo.toml
+++ b/vm/rust/Cargo.toml
@@ -14,7 +14,6 @@ cairo-vm = "=0.8.2"
 cairo-lang-casm = "2.4.0-rc6"
 cairo-lang-starknet = "2.4.0-rc6"
 indexmap = "2.1.0"
-starknet = { rev = "starknet-core/v0.4.0", git = "https://github.com/xJonathanLEI/starknet-rs" }
 cached = "0.44.0"
 once_cell = "1.18.0"
 


### PR DESCRIPTION
Working on adding [The Graph](https://github.com/starknet-graph) support to Juno, and realized that `starknet-rs` is used by Juno:

1. as a dependency for `juno-starknet-core-rs`
1. as a dependency for `juno-starknet-rs`

Weird enough, `starknet-rs` doesn't seem to be used in `juno-starknet-rs` at all. As in `juno-starknet-core-rs` (which helps computes Cairo 0 class hashes):

1. it's pulling in the whole `starknet` crate when only the `starknet-core` crate is used, causing unnecessarily long compilation time
2. it's using version `0.4.0`, which is missing an important bug fix (https://github.com/xJonathanLEI/starknet-rs/pull/478)

In fact, issue 2 makes me wonder how come Juno has been able to correctly calculate (very old) class hashes at all? If Juno indeed relies on this for Cairo 0 hash calculation, certain ancient (pre-0.10.0) class hashes should be wrong.

In any case, I think it would be a good idea to:

1. remove `starknet` as a dependency for `juno-starknet-rs`
2. change to import the `starknet-core` crate directly in `juno-starknet-core-rs`
3. update dependency version in `juno-starknet-core-rs` to `0.8.0`.

That's exactly what this PR does.