### PR TITLE
Only count internal errors as failed requests

### DIFF
--- a/jsonrpc/server.go
+++ b/jsonrpc/server.go
@@ -422,7 +422,6 @@ func (s *Server) handleRequest(ctx context.Context, req *Request) (*response, er
 	args, err := s.buildArguments(ctx, req.Params, calledMethod)
 	if err != nil {
 		res.Error = Err(InvalidParams, err.Error())
-		s.listener.OnRequestFailed(req.Method, err)
 		return res, nil
 	}
 	defer func() {
@@ -438,7 +437,9 @@ func (s *Server) handleRequest(ctx context.Context, req *Request) (*response, er
 
 	if errAny := tuple[1].Interface(); !isNil(errAny) {
 		res.Error = errAny.(*Error)
-		s.listener.OnRequestFailed(req.Method, err)
+		if res.Error.Code == InternalError {
+			s.listener.OnRequestFailed(req.Method, err)
+		}
 		return res, nil
 	}
 	res.Result = tuple[0].Interface()

--- a/jsonrpc/server_test.go
+++ b/jsonrpc/server_test.go
@@ -156,6 +156,13 @@ func TestHandle(t *testing.T) {
 				return b - a, nil
 			},
 		},
+		{
+			Name:   "errorsInternally",
+			Params: []jsonrpc.Parameter{},
+			Handler: func() (int, *jsonrpc.Error) {
+				return 0, jsonrpc.Err(jsonrpc.InternalError, nil)
+			},
+		},
 	}
 
 	listener := CountingEventListener{}
@@ -198,9 +205,8 @@ func TestHandle(t *testing.T) {
 			res: `{"jsonrpc":"2.0","error":{"code":-32602,"message":"Invalid Params","data":"missing/unexpected params in list"},"id":3}`,
 		},
 		"too many params": {
-			req:              `{"jsonrpc" : "2.0", "method" : "method", "params" : [3, false, "error message", "too many"] , "id" : 3}`,
-			res:              `{"jsonrpc":"2.0","error":{"code":-32602,"message":"Invalid Params","data":"missing/unexpected params in list"},"id":3}`,
-			checkFailedEvent: true,
+			req: `{"jsonrpc" : "2.0", "method" : "method", "params" : [3, false, "error message", "too many"] , "id" : 3}`,
+			res: `{"jsonrpc":"2.0","error":{"code":-32602,"message":"Invalid Params","data":"missing/unexpected params in list"},"id":3}`,
 		},
 		"list params": {
 			req: `{"jsonrpc" : "2.0", "method" : "method", "params" : [3, false, "error message"] , "id" : 3}`,
@@ -352,9 +358,8 @@ func TestHandle(t *testing.T) {
 			res: `[{"jsonrpc":"2.0","error":{"code":-32600,"message":"Invalid Request","data":"unsupported RPC request version"},"id":5},{"jsonrpc":"2.0","result":{"doubled":88},"id":6}]`,
 		},
 		"invalid value in struct": {
-			req:              `{"jsonrpc" : "2.0", "method" : "validation", "params" : [ {"A": 0} ], "id" : 1}`,
-			res:              `{"jsonrpc":"2.0","error":{"code":-32602,"message":"Invalid Params","data":"Key: 'validationStruct.A' Error:Field validation for 'A' failed on the 'min' tag"},"id":1}`,
-			checkFailedEvent: true,
+			req: `{"jsonrpc" : "2.0", "method" : "validation", "params" : [ {"A": 0} ], "id" : 1}`,
+			res: `{"jsonrpc":"2.0","error":{"code":-32602,"message":"Invalid Params","data":"Key: 'validationStruct.A' Error:Field validation for 'A' failed on the 'min' tag"},"id":1}`,
 		},
 		"valid value in struct": {
 			req:                  `{"jsonrpc" : "2.0", "method" : "validation", "params" : [{"A": 1}], "id" : 1}`,
@@ -453,6 +458,11 @@ func TestHandle(t *testing.T) {
 			isBatch: true,
 			req:     `[1,2,3]`,
 			res:     `[{"jsonrpc":"2.0","error":{"code":-32600,"message":"Invalid Request","data":"json: cannot unmarshal number into Go value of type jsonrpc.Request"},"id":null},{"jsonrpc":"2.0","error":{"code":-32600,"message":"Invalid Request","data":"json: cannot unmarshal number into Go value of type jsonrpc.Request"},"id":null},{"jsonrpc":"2.0","error":{"code":-32600,"message":"Invalid Request","data":"json: cannot unmarshal number into Go value of type jsonrpc.Request"},"id":null}]`,
+		},
+		"fails internally": {
+			req:              `{"jsonrpc": "2.0", "method": "errorsInternally", "params": {}, "id": 1}`,
+			res:              `{"jsonrpc":"2.0","error":{"code":-32603,"message":"Internal Error"},"id":1}`,
+			checkFailedEvent: true,
 		},
 	}
 


### PR DESCRIPTION
request related errors are not really relevant for us and they keep triggering alerts on production