### PR TITLE
Revert removing required dependabot option

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,5 +10,7 @@ updates:
       interval: "daily"
   - package-ecosystem: "npm"
     directory: "/docs"
+    schedule:
+      interval: "monthly"
     ignore:
       dependency-name: "*"


### PR DESCRIPTION
Take two. See dependabot CI failure in the last "disable dependabot" commit.