### PR TITLE
Fix dependabot config again

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,4 +13,4 @@ updates:
     schedule:
       interval: "monthly"
     ignore:
-      dependency-name: "*"
+      - dependency-name: "*"


### PR DESCRIPTION
Third time's the charm.

I'll try to wait until every CI check is finished on the PR before merging. Maybe the dependabot action only runs at the end, which is why we only see it fail when we merge.