### PR TITLE
rust shorthand

### DIFF
--- a/vm/rust/src/lib.rs
+++ b/vm/rust/src/lib.rs
@@ -97,7 +97,7 @@ pub extern "C" fn cairoVMCall(
         calldata: Calldata(calldata_vec.into()),
         storage_address: contract_addr_felt.try_into().unwrap(),
         call_type: CallType::Call,
-        class_hash: class_hash,
+        class_hash,
         code_address: None,
         caller_address: ContractAddress::default(),
         initial_gas: INITIAL_GAS_COST,


### PR DESCRIPTION
We can use rust shorthand in struct.
https://rust-lang.github.io/rfcs/1682-field-init-shorthand.html