### PR TITLE
Decrease batch size for heavy migration

### DIFF
--- a/migration/migration.go
+++ b/migration/migration.go
@@ -63,8 +63,8 @@ var defaultMigrations = []Migration{
 	NewBucketMigrator(db.ContractStorage, migrateTrieNodesFromBitsetToTrieKey(db.ContractStorage)).
 		WithKeyFilter(nodesFilter(db.ContractStorage)),
 	NewBucketMover(db.Temporary, db.ContractStorage),
-	NewBucketMigrator(db.StateUpdatesByBlockNumber, changeStateDiffStruct).WithBatchSize(10_000), //nolint:gomnd
-	NewBucketMigrator(db.Class, migrateCairo1CompiledClass).WithBatchSize(1_000),                 //nolint:gomnd
+	NewBucketMigrator(db.StateUpdatesByBlockNumber, changeStateDiffStruct).WithBatchSize(1_000), //nolint:gomnd
+	NewBucketMigrator(db.Class, migrateCairo1CompiledClass).WithBatchSize(1_000),                //nolint:gomnd
 }
 
 var ErrCallWithNewTransaction = errors.New("call with new transaction")


### PR DESCRIPTION
Mitigate the risk of OOMs on weak machines.