### PR TITLE
Double http ReadTimeout

### DIFF
--- a/node/http.go
+++ b/node/http.go
@@ -54,10 +54,11 @@ func makeHTTPService(host string, port uint16, handler http.Handler) *httpServic
 	portStr := strconv.FormatUint(uint64(port), 10)
 	return &httpService{
 		srv: &http.Server{
-			Addr:    net.JoinHostPort(host, portStr),
-			Handler: handler,
-			// ReadTimeout also sets ReadHeaderTimeout and IdleTimeout.
-			ReadTimeout: 30 * time.Second,
+			Addr:              net.JoinHostPort(host, portStr),
+			Handler:           handler,
+			ReadHeaderTimeout: 30 * time.Second,
+			IdleTimeout:       30 * time.Second,
+			ReadTimeout:       time.Minute,
 		},
 	}
 }


### PR DESCRIPTION
Large declare transactions can take more than 30s to read on a stable connection.