### PR TITLE
Fix: typos in comments

### DIFF
--- a/core/state.go
+++ b/core/state.go
@@ -389,7 +389,7 @@ func (s *State) updateContractStorages(stateTrie *trie.Trie, diffs map[felt.Felt
 		}
 	}
 
-	// sort the contracts in decending diff size order
+	// sort the contracts in descending diff size order
 	// so we start with the heaviest update first
 	keys := make([]felt.Felt, 0, len(diffs))
 	for key := range diffs {

--- a/utils/throttler_test.go
+++ b/utils/throttler_test.go
@@ -45,7 +45,7 @@ func TestThrottler(t *testing.T) {
 	waitOn <- struct{}{} // release one of the slots
 	time.Sleep(time.Millisecond)
 	assert.Equal(t, 1, throttledRes.QueueLen())
-	waitOn <- struct{}{} // release another slot, qeueue should be empty
+	waitOn <- struct{}{} // release another slot, queue should be empty
 	time.Sleep(time.Millisecond)
 	assert.Equal(t, 0, throttledRes.QueueLen())
 


### PR DESCRIPTION
Fix typos in comments: 

`core/state.go`
`utils/throttler_test.go`