### PR TITLE
Remove unused ChainID field from genesis config

### DIFF
--- a/genesis/genesis.go
+++ b/genesis/genesis.go
@@ -17,7 +17,6 @@ import (
 )
 
 type GenesisConfig struct {
-	ChainID       string                         `json:"chain_id" validate:"required"`
 	Classes       []string                       `json:"classes"`        // []path-to-class.json
 	Contracts     map[string]GenesisContractData `json:"contracts"`      // address -> {classHash, constructorArgs}
 	FunctionCalls []FunctionCall                 `json:"function_calls"` // list of functionCalls to Call()

--- a/genesis/genesis_test.go
+++ b/genesis/genesis_test.go
@@ -53,7 +53,6 @@ func TestGenesisStateDiff(t *testing.T) {
 		require.NoError(t, err)
 
 		genesisConfig := genesis.GenesisConfig{
-			ChainID: network.ChainIDString(),
 			Classes: []string{
 				"./testdata/simpleStore.json",
 				"./testdata/simpleAccount.json",


### PR DESCRIPTION
If I'm forgetting a valid use-case for this field, feel free to close the PR.