### PR TITLE
Add block number to pending block

### DIFF
--- a/blockchain/blockchain_test.go
+++ b/blockchain/blockchain_test.go
@@ -777,6 +777,19 @@ func TestStorePendingIncludesNumber(t *testing.T) {
 	network := utils.Mainnet
 	chain := blockchain.New(pebble.NewMemTest(t), network)
 
+	// Store pending genesis.
+	require.NoError(t, chain.StorePending(&blockchain.Pending{
+		Block: &core.Block{
+			Header: &core.Header{
+				ParentHash: new(felt.Felt),
+				Hash:       new(felt.Felt),
+			},
+		},
+	}))
+	pending, err := chain.Pending()
+	require.NoError(t, err)
+	require.Equal(t, uint64(0), pending.Block.Number)
+
 	// Add block zero.
 	gw := adaptfeeder.New(feeder.NewTestClient(t, network))
 	b, err := gw.BlockByNumber(context.Background(), 0)
@@ -794,7 +807,7 @@ func TestStorePendingIncludesNumber(t *testing.T) {
 			},
 		},
 	}))
-	pending, err := chain.Pending()
+	pending, err = chain.Pending()
 	require.NoError(t, err)
 	require.Equal(t, uint64(1), pending.Block.Number)
 }

--- a/rpc/handlers_test.go
+++ b/rpc/handlers_test.go
@@ -3336,8 +3336,6 @@ func TestTraceBlockTransactions(t *testing.T) {
 		headState := mocks.NewMockStateHistoryReader(mockCtrl)
 		headState.EXPECT().Class(declareTx.ClassHash).Return(declaredClass, nil)
 		mockReader.EXPECT().PendingState().Return(headState, nopCloser, nil)
-		const height uint64 = 8
-		mockReader.EXPECT().Height().Return(height, nil)
 
 		sequencerAddress := core.NetworkBlockHashMetaInfo(network).FallBackSequencerAddress
 		paidL1Fees := []*felt.Felt{(&felt.Felt{}).SetUint64(1)}
@@ -3356,7 +3354,7 @@ func TestTraceBlockTransactions(t *testing.T) {
 		}`)
 		vmTrace := vm.TransactionTrace{}
 		require.NoError(t, json.Unmarshal(vmTraceJSON, &vmTrace))
-		mockVM.EXPECT().Execute(block.Transactions, []core.Class{declaredClass.Class}, height+1, header.Timestamp, sequencerAddress,
+		mockVM.EXPECT().Execute(block.Transactions, []core.Class{declaredClass.Class}, header.Number, header.Timestamp, sequencerAddress,
 			gomock.Any(), network, paidL1Fees, false, false, false, header.GasPrice, header.GasPriceSTRK, false).Return(nil, []vm.TransactionTrace{vmTrace, vmTrace}, nil)
 
 		result, err := handler.TraceBlockTransactions(context.Background(), rpc.BlockID{Hash: blockHash})
@@ -3754,8 +3752,6 @@ func TestThrottledVMError(t *testing.T) {
 		headState := mocks.NewMockStateHistoryReader(mockCtrl)
 		headState.EXPECT().Class(declareTx.ClassHash).Return(declaredClass, nil)
 		mockReader.EXPECT().PendingState().Return(headState, nopCloser, nil)
-		const height uint64 = 8
-		mockReader.EXPECT().Height().Return(height, nil)
 		_, rpcErr := handler.TraceBlockTransactions(context.Background(), rpc.BlockID{Hash: blockHash})
 		assert.Equal(t, utils.ErrResourceBusy.Error(), rpcErr.Data)
 	})


### PR DESCRIPTION
Helpful for sequencer work since it means the sequencer doesn't need to set the next block number.

Does anyone know why the feeder's pending block doesn't have a block number?