### PR TITLE
Fix dead docs links

### DIFF
--- a/docs/docs/installing_on_gcp.md
+++ b/docs/docs/installing_on_gcp.md
@@ -14,15 +14,15 @@ To quickly set up a Starkent RPC Juno Node VM environment on the Google Cloud Pl
 
 1. **Search “Starknet RPC Node” in [Google Marketplace](https://console.cloud.google.com/marketplace) and click the LAUNCH button to start the deployment process.**
    
-   ![step1](/img/installing_on_gcp/step1.png)
+   ![step1](../static/img/installing_on_gcp/step1.png)
 
 2. **Select the configuration for the Juno client and click the DEPLOY button.**
    
-   ![step2](/img/installing_on_gcp/step2.png)
+   ![step2](../static/img/installing_on_gcp/step2.png)
    
 3. **Post-Configuration and testing after deployment.**
    
-   ![step3](/img/installing_on_gcp/step3.png)
+   ![step3](../static/img/installing_on_gcp/step3.png)
    
 4. **Enable Juno Auto Start During Startup**
    1. Click the newly created VM instance name to view the detail.

--- a/docs/docs/intro.md
+++ b/docs/docs/intro.md
@@ -24,7 +24,7 @@ mkdir -p junodb
 docker run -d --name juno -p 6060:6060 -v junodb:/var/lib/juno nethermind/juno:latest --db-path /var/lib/juno --http
 ```
 
-For a complete list of options and their explanations, see the [Example Configuration](config) or run:
+For a complete list of options and their explanations, see the [Example Configuration](example_config.md) or run:
 
 ```shell
 docker run nethermind/juno --help


### PR DESCRIPTION
Found few dead links while reading the docs, thought I would correct them myself instead of opening an issue to save you some time.

I got the steps img from there, hopefully it's the right ones (i'm not quite familiar with the repo) : https://github.com/NethermindEth/juno/tree/main/docs/static/img/installing_on_gcp

Have a nice evening.