### PR TITLE
Issue-1724: Add jemalloc dependency to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,19 @@
   the official Golang [download](https://go.dev/doc/install) page.
 - [Rust](https://www.rust-lang.org/tools/install).
 - A C compiler: `gcc` or `clang`.
+- Install `jemalloc` on your system:
+  
+  - macOS
+
+    ```bash
+    brew install jemalloc
+    ```
+
+  - Ubuntu
+
+    ```bash
+    sudo apt-get install -y libjemalloc-dev
+    ```
 
 ### Build and Run
 

--- a/README.md
+++ b/README.md
@@ -63,6 +63,8 @@
     sudo apt-get install -y libjemalloc-dev
     ```
 
+- To ensure a successful build, you either need to synchronize the tags from the upstream repository or create a new tag.
+
 ### Build and Run
 
 ```shell


### PR DESCRIPTION
Enhanced the prerequisites section of the README file with the addition of two bullet points: one highlighting the requirement for the `jemalloc` library, and another specifying the necessity of `tags` for the make script.

See issue: [#1724](https://github.com/NethermindEth/juno/issues/1724)