### PR TITLE
Rename trie/TransactionStorage to Storage (#1783)

### DIFF
--- a/core/trie/storage.go
+++ b/core/trie/storage.go
@@ -27,7 +27,7 @@ func getBuffer() *bytes.Buffer {
 	return buffer
 }
 
-// TransactionStorage is a database transaction on a trie.
+// Storage is a database transaction on a trie.
 type Storage struct {
 	txn    db.Transaction
 	prefix []byte


### PR DESCRIPTION
Rename `trie/TransactionStorage` to `Storage` to resolve issue #1783