### PR TITLE
Replace Goerli2 network with Sepolia in the test TestEvents

### DIFF
--- a/clients/feeder/testdata/sepolia/block/0.json
+++ b/clients/feeder/testdata/sepolia/block/0.json
@@ -1,0 +1,309 @@
+{
+  "block_hash": "0x5c627d4aeb51280058bed93c7889bce78114d63baad1be0f0aeb32496d5f19c",
+  "parent_block_hash": "0x0",
+  "block_number": 0,
+  "state_root": "0xe005205a1327f3dff98074e528f7b96f30e0624a1dfcf571bdc81948d150a0",
+  "transaction_commitment": "0x6bc49c465936fa8b19a6773975bef3c1f9793463103ce679d5a2c10b0c3846e",
+  "event_commitment": "0x63e31e9955086a982d5d1b008c0a1579521d526fcf38445a8daf4799bde362e",
+  "status": "ACCEPTED_ON_L1",
+  "l1_da_mode": "CALLDATA",
+  "l1_gas_price": {
+    "price_in_wei": "0x3e617dc5",
+    "price_in_fri": "0x0"
+  },
+  "l1_data_gas_price": {
+    "price_in_wei": "0x1",
+    "price_in_fri": "0x1"
+  },
+  "transactions": [
+    {
+      "transaction_hash": "0x656e113cb27707d2147c271a79c51d1069b0273ae447b965e15154a17b3ec01",
+      "version": "0x0",
+      "max_fee": "0x0",
+      "signature": [],
+      "nonce": "0x0",
+      "class_hash": "0x5c478ee27f2112411f86f207605b2e2c58cdb647bac0df27f660ef2252359c6",
+      "sender_address": "0x1",
+      "type": "DECLARE"
+    },
+    {
+      "transaction_hash": "0x32538718071ad83ccd09fca03fe3a17add776ec12002d1c4e16ad4b92ddf752",
+      "version": "0x0",
+      "max_fee": "0x0",
+      "signature": [],
+      "nonce": "0x0",
+      "class_hash": "0xd0e183745e9dae3e4e78a8ffedcce0903fc4900beace4e0abf192d4c202da3",
+      "sender_address": "0x1",
+      "type": "DECLARE"
+    },
+    {
+      "transaction_hash": "0x144f41e654d0916810a83df0fe8984043671200f28df1206f58566144e302dd",
+      "version": "0x1",
+      "max_fee": "0x0",
+      "signature": [
+        "0x13f82fd9238dfc8d01543f89be2b5d5589b3eb93d9c3b888f1f94b089768771",
+        "0x2c279ec310c4dd58a296fab66b2624640780e79a1c5c87388e6150fb5384a9d"
+      ],
+      "nonce": "0x0",
+      "contract_address": "0x43abaa073c768ebf039c0c4f46db9acc39e9ec165690418060a652aab39e7d8",
+      "contract_address_salt": "0x0",
+      "class_hash": "0x5c478ee27f2112411f86f207605b2e2c58cdb647bac0df27f660ef2252359c6",
+      "constructor_calldata": [
+        "0x12c4df40394d06f157edec8d0e64db61fe0c271149ea860c8fe98def29ecf02"
+      ],
+      "type": "DEPLOY_ACCOUNT"
+    },
+    {
+      "transaction_hash": "0x6a5a493cf33919e58aa4c75777bffdef97c0e39cac968896d7bee8cc67905a1",
+      "version": "0x1",
+      "max_fee": "0x0",
+      "signature": [
+        "0x357dbb6c509a7d4b58f8ee7151236278b7959b39f7d05b8f7e2ef20593bdf7e",
+        "0x64d5f748eef19ca7f1c8cc533e5c9c85f80ef4f040c75da67bda82f5c58328d"
+      ],
+      "nonce": "0x1",
+      "sender_address": "0x43abaa073c768ebf039c0c4f46db9acc39e9ec165690418060a652aab39e7d8",
+      "calldata": [
+        "0x1",
+        "0x43abaa073c768ebf039c0c4f46db9acc39e9ec165690418060a652aab39e7d8",
+        "0x2730079d734ee55315f4f141eaed376bddd8c2133523d223a344c5604e0f7f8",
+        "0x0",
+        "0x5",
+        "0x5",
+        "0xd0e183745e9dae3e4e78a8ffedcce0903fc4900beace4e0abf192d4c202da3",
+        "0x322c2610264639f6b2cee681ac53fa65c37e187ea24292d1b21d859c55e1a78",
+        "0x1",
+        "0x0",
+        "0x1"
+      ],
+      "type": "INVOKE_FUNCTION"
+    },
+    {
+      "transaction_hash": "0x4a5a3a951244f37c97b258465db17ba235dc68fd369c539d763bae99b2cae1",
+      "version": "0x1",
+      "max_fee": "0x0",
+      "signature": [
+        "0x6b5baf01bf27386f1544efcf2e91aa69a42a41a9781e24b3cd984a91e815de7",
+        "0x2de46894d2f386d25f2258e80f464e05f08daab78df764d87c4381a7eae6c97"
+      ],
+      "nonce": "0x2",
+      "sender_address": "0x43abaa073c768ebf039c0c4f46db9acc39e9ec165690418060a652aab39e7d8",
+      "calldata": [
+        "0x1",
+        "0x43abaa073c768ebf039c0c4f46db9acc39e9ec165690418060a652aab39e7d8",
+        "0x2730079d734ee55315f4f141eaed376bddd8c2133523d223a344c5604e0f7f8",
+        "0x0",
+        "0x5",
+        "0x5",
+        "0xd0e183745e9dae3e4e78a8ffedcce0903fc4900beace4e0abf192d4c202da3",
+        "0x322c2610264639f6b2cee681ac53fa65c37e187ea24292d1b21d859c55e1a78",
+        "0x1",
+        "0x0",
+        "0x0"
+      ],
+      "type": "INVOKE_FUNCTION"
+    },
+    {
+      "transaction_hash": "0x1bec64a9f5ff52154b560fd489ae2aabbfcb31062f7ea70c3c674ddf14b0add",
+      "version": "0x1",
+      "max_fee": "0x0",
+      "signature": [
+        "0x44580ba3cd68e5d9509d2fcb8bd09933ae4a7b7dfe6744eaa2329f9a79d7408",
+        "0x68404a4da22c31d8367f873c043318750a24c669702c72de8518a3d52284b94"
+      ],
+      "nonce": "0x3",
+      "sender_address": "0x43abaa073c768ebf039c0c4f46db9acc39e9ec165690418060a652aab39e7d8",
+      "calldata": [
+        "0x1",
+        "0x49d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7",
+        "0x195d4289b867c3d98c335ea31402667f3592e227faf3d2991308563ed102aab",
+        "0x0",
+        "0x0",
+        "0x0"
+      ],
+      "type": "INVOKE_FUNCTION"
+    },
+    {
+      "transaction_hash": "0x72b2d3b79b3da51efe860da954a2f50d23da95f028a456c5356a08e61642754",
+      "version": "0x1",
+      "max_fee": "0x0",
+      "signature": [
+        "0x12ef79a31ed2ff357b290f40c8c1bbe53cbb253866f0dc52b25aabbfb443c2b",
+        "0x376b2ddfd1ba9c6a0d72e3e4dbc5bbb1f0d2601089999cbf477aed944ae5c03"
+      ],
+      "nonce": "0x4",
+      "sender_address": "0x43abaa073c768ebf039c0c4f46db9acc39e9ec165690418060a652aab39e7d8",
+      "calldata": [
+        "0x1",
+        "0x4c5772d1914fe6ce891b64eb35bf3522aeae1315647314aac58b01137607f3f",
+        "0x195d4289b867c3d98c335ea31402667f3592e227faf3d2991308563ed102aab",
+        "0x0",
+        "0x0",
+        "0x0"
+      ],
+      "type": "INVOKE_FUNCTION"
+    }
+  ],
+  "timestamp": 1700406220,
+  "sequencer_address": "0x1176a1bd84444c89232ec27754698e5d2e7e1a7f1539f12027f28b23ec9f3d8",
+  "transaction_receipts": [
+    {
+      "execution_status": "SUCCEEDED",
+      "transaction_index": 0,
+      "transaction_hash": "0x656e113cb27707d2147c271a79c51d1069b0273ae447b965e15154a17b3ec01",
+      "l2_to_l1_messages": [],
+      "events": [],
+      "execution_resources": {
+        "n_steps": 2711,
+        "builtin_instance_counter": {
+          "pedersen_builtin": 15,
+          "range_check_builtin": 63
+        },
+        "n_memory_holes": 0
+      },
+      "actual_fee": "0x0"
+    },
+    {
+      "execution_status": "SUCCEEDED",
+      "transaction_index": 1,
+      "transaction_hash": "0x32538718071ad83ccd09fca03fe3a17add776ec12002d1c4e16ad4b92ddf752",
+      "l2_to_l1_messages": [],
+      "events": [],
+      "execution_resources": {
+        "n_steps": 2711,
+        "builtin_instance_counter": {
+          "pedersen_builtin": 15,
+          "range_check_builtin": 63
+        },
+        "n_memory_holes": 0
+      },
+      "actual_fee": "0x0"
+    },
+    {
+      "execution_status": "SUCCEEDED",
+      "transaction_index": 2,
+      "transaction_hash": "0x144f41e654d0916810a83df0fe8984043671200f28df1206f58566144e302dd",
+      "l2_to_l1_messages": [],
+      "events": [],
+      "execution_resources": {
+        "n_steps": 3863,
+        "builtin_instance_counter": {
+          "pedersen_builtin": 23,
+          "range_check_builtin": 83,
+          "ecdsa_builtin": 1
+        },
+        "n_memory_holes": 0
+      },
+      "actual_fee": "0x0"
+    },
+    {
+      "execution_status": "SUCCEEDED",
+      "transaction_index": 3,
+      "transaction_hash": "0x6a5a493cf33919e58aa4c75777bffdef97c0e39cac968896d7bee8cc67905a1",
+      "l2_to_l1_messages": [],
+      "events": [],
+      "execution_resources": {
+        "n_steps": 5617,
+        "builtin_instance_counter": {
+          "pedersen_builtin": 23,
+          "ecdsa_builtin": 1,
+          "range_check_builtin": 122
+        },
+        "n_memory_holes": 0
+      },
+      "actual_fee": "0x0"
+    },
+    {
+      "execution_status": "SUCCEEDED",
+      "transaction_index": 4,
+      "transaction_hash": "0x4a5a3a951244f37c97b258465db17ba235dc68fd369c539d763bae99b2cae1",
+      "l2_to_l1_messages": [],
+      "events": [],
+      "execution_resources": {
+        "n_steps": 5617,
+        "builtin_instance_counter": {
+          "pedersen_builtin": 23,
+          "range_check_builtin": 122,
+          "ecdsa_builtin": 1
+        },
+        "n_memory_holes": 0
+      },
+      "actual_fee": "0x0"
+    },
+    {
+      "execution_status": "SUCCEEDED",
+      "transaction_index": 5,
+      "transaction_hash": "0x1bec64a9f5ff52154b560fd489ae2aabbfcb31062f7ea70c3c674ddf14b0add",
+      "l2_to_l1_messages": [],
+      "events": [
+        {
+          "from_address": "0x49d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7",
+          "keys": [
+            "0x3774b0545aabb37c45c1eddc6a7dae57de498aae6d5e3589e362d4b4323a533"
+          ],
+          "data": [
+            "0x43abaa073c768ebf039c0c4f46db9acc39e9ec165690418060a652aab39e7d8",
+            "0x43abaa073c768ebf039c0c4f46db9acc39e9ec165690418060a652aab39e7d8"
+          ]
+        },
+        {
+          "from_address": "0x49d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7",
+          "keys": [
+            "0x4595132f9b33b7077ebf2e7f3eb746a8e0a6d5c337c71cd8f9bf46cac3cfd7"
+          ],
+          "data": [
+            "0x43abaa073c768ebf039c0c4f46db9acc39e9ec165690418060a652aab39e7d8"
+          ]
+        }
+      ],
+      "execution_resources": {
+        "n_steps": 4854,
+        "builtin_instance_counter": {
+          "ecdsa_builtin": 1,
+          "range_check_builtin": 106,
+          "pedersen_builtin": 17
+        },
+        "n_memory_holes": 0
+      },
+      "actual_fee": "0x0"
+    },
+    {
+      "execution_status": "SUCCEEDED",
+      "transaction_index": 6,
+      "transaction_hash": "0x72b2d3b79b3da51efe860da954a2f50d23da95f028a456c5356a08e61642754",
+      "l2_to_l1_messages": [],
+      "events": [
+        {
+          "from_address": "0x4c5772d1914fe6ce891b64eb35bf3522aeae1315647314aac58b01137607f3f",
+          "keys": [
+            "0x3774b0545aabb37c45c1eddc6a7dae57de498aae6d5e3589e362d4b4323a533"
+          ],
+          "data": [
+            "0x43abaa073c768ebf039c0c4f46db9acc39e9ec165690418060a652aab39e7d8",
+            "0x43abaa073c768ebf039c0c4f46db9acc39e9ec165690418060a652aab39e7d8"
+          ]
+        },
+        {
+          "from_address": "0x4c5772d1914fe6ce891b64eb35bf3522aeae1315647314aac58b01137607f3f",
+          "keys": [
+            "0x4595132f9b33b7077ebf2e7f3eb746a8e0a6d5c337c71cd8f9bf46cac3cfd7"
+          ],
+          "data": [
+            "0x43abaa073c768ebf039c0c4f46db9acc39e9ec165690418060a652aab39e7d8"
+          ]
+        }
+      ],
+      "execution_resources": {
+        "n_steps": 4854,
+        "builtin_instance_counter": {
+          "ecdsa_builtin": 1,
+          "pedersen_builtin": 17,
+          "range_check_builtin": 106
+        },
+        "n_memory_holes": 0
+      },
+      "actual_fee": "0x0"
+    }
+  ],
+  "starknet_version": "0.12.3"
+}

--- a/clients/feeder/testdata/sepolia/block/1.json
+++ b/clients/feeder/testdata/sepolia/block/1.json
@@ -1,0 +1,51 @@
+{
+  "block_hash": "0x78b67b11f8c23850041e11fb0f3b39db0bcb2c99d756d5a81321d1b483d79f6",
+  "parent_block_hash": "0x5c627d4aeb51280058bed93c7889bce78114d63baad1be0f0aeb32496d5f19c",
+  "block_number": 1,
+  "state_root": "0xe005205a1327f3dff98074e528f7b96f30e0624a1dfcf571bdc81948d150a0",
+  "transaction_commitment": "0x301a3e7f3ae29c3463a5f753da62e63dc0b6738c36cb17e3d1696926457a40c",
+  "event_commitment": "0x0",
+  "status": "ACCEPTED_ON_L1",
+  "l1_da_mode": "CALLDATA",
+  "l1_gas_price": {
+    "price_in_wei": "0x3b9ada0f",
+    "price_in_fri": "0x0"
+  },
+  "l1_data_gas_price": {
+    "price_in_wei": "0x1",
+    "price_in_fri": "0x1"
+  },
+  "transactions": [
+    {
+      "transaction_hash": "0x30a541df2547ed9f94602c35daf61ce3a8e179ec75d26cbe34e0ec61f823695",
+      "version": "0x0",
+      "max_fee": "0x0",
+      "signature": [],
+      "nonce": "0x0",
+      "class_hash": "0x1b661756bf7d16210fc611626e1af4569baa1781ffc964bd018f4585ae241c1",
+      "sender_address": "0x1",
+      "type": "DECLARE"
+    }
+  ],
+  "timestamp": 1700474724,
+  "sequencer_address": "0x1176a1bd84444c89232ec27754698e5d2e7e1a7f1539f12027f28b23ec9f3d8",
+  "transaction_receipts": [
+    {
+      "execution_status": "SUCCEEDED",
+      "transaction_index": 0,
+      "transaction_hash": "0x30a541df2547ed9f94602c35daf61ce3a8e179ec75d26cbe34e0ec61f823695",
+      "l2_to_l1_messages": [],
+      "events": [],
+      "execution_resources": {
+        "n_steps": 2711,
+        "builtin_instance_counter": {
+          "pedersen_builtin": 15,
+          "range_check_builtin": 63
+        },
+        "n_memory_holes": 0
+      },
+      "actual_fee": "0x0"
+    }
+  ],
+  "starknet_version": "0.12.3"
+}

--- a/clients/feeder/testdata/sepolia/block/2.json
+++ b/clients/feeder/testdata/sepolia/block/2.json
@@ -1,0 +1,51 @@
+{
+  "block_hash": "0x7a906dfd1ff77a121b8048e6f750cda9e949d341c4487d4c6a449f183f0e61d",
+  "parent_block_hash": "0x78b67b11f8c23850041e11fb0f3b39db0bcb2c99d756d5a81321d1b483d79f6",
+  "block_number": 2,
+  "state_root": "0xe005205a1327f3dff98074e528f7b96f30e0624a1dfcf571bdc81948d150a0",
+  "transaction_commitment": "0x6f777eb09c00aed5fa717ceb34038c1b70051b229aad566421858811c106e1a",
+  "event_commitment": "0x0",
+  "status": "ACCEPTED_ON_L1",
+  "l1_da_mode": "CALLDATA",
+  "l1_gas_price": {
+    "price_in_wei": "0x3b9ad016",
+    "price_in_fri": "0x0"
+  },
+  "l1_data_gas_price": {
+    "price_in_wei": "0x1",
+    "price_in_fri": "0x1"
+  },
+  "transactions": [
+    {
+      "transaction_hash": "0x701d9adb9c60bc2fd837fe3989e15aeba4be1a6e72bb6f61ffe35a42866c772",
+      "version": "0x0",
+      "max_fee": "0x0",
+      "signature": [],
+      "nonce": "0x0",
+      "class_hash": "0x4f23a756b221f8ce46b72e6a6b10ee7ee6cf3b59790e76e02433104f9a8c5d1",
+      "sender_address": "0x1",
+      "type": "DECLARE"
+    }
+  ],
+  "timestamp": 1700475581,
+  "sequencer_address": "0x1176a1bd84444c89232ec27754698e5d2e7e1a7f1539f12027f28b23ec9f3d8",
+  "transaction_receipts": [
+    {
+      "execution_status": "SUCCEEDED",
+      "transaction_index": 0,
+      "transaction_hash": "0x701d9adb9c60bc2fd837fe3989e15aeba4be1a6e72bb6f61ffe35a42866c772",
+      "l2_to_l1_messages": [],
+      "events": [],
+      "execution_resources": {
+        "n_steps": 2711,
+        "builtin_instance_counter": {
+          "range_check_builtin": 63,
+          "pedersen_builtin": 15
+        },
+        "n_memory_holes": 0
+      },
+      "actual_fee": "0x0"
+    }
+  ],
+  "starknet_version": "0.12.3"
+}

--- a/clients/feeder/testdata/sepolia/block/3.json
+++ b/clients/feeder/testdata/sepolia/block/3.json
@@ -1,0 +1,107 @@
+{
+  "block_hash": "0x37644818236ee05b7e3b180bed64ea70ee3dd1553ca334a5c2a290ee276f380",
+  "parent_block_hash": "0x7a906dfd1ff77a121b8048e6f750cda9e949d341c4487d4c6a449f183f0e61d",
+  "block_number": 3,
+  "state_root": "0x1801be8c1f95003d643eb1601adad68585bae7536b7f28f7f3bd600adc39082",
+  "transaction_commitment": "0x13e890fabb2739f9ae2013f0cb643c1f93c8fbff6d063bb5ea4301058b8d708",
+  "event_commitment": "0x0",
+  "status": "ACCEPTED_ON_L1",
+  "l1_da_mode": "CALLDATA",
+  "l1_gas_price": {
+    "price_in_wei": "0x3b9aca2f",
+    "price_in_fri": "0x0"
+  },
+  "l1_data_gas_price": {
+    "price_in_wei": "0x1",
+    "price_in_fri": "0x1"
+  },
+  "transactions": [
+    {
+      "transaction_hash": "0x3f786ecc4955a2602c91a291328518ef866cb7f3d50e4b16fd42282952623aa",
+      "version": "0x1",
+      "max_fee": "0x0",
+      "signature": [
+        "0x7c2e9dde7b35bde7c3256f6f1e5b37b5cb5f1f4f40eb770e34325325f975041",
+        "0x6d80001e7f11e340e0223072560da8191ba7abb334cfd90f69c02582b2755c5"
+      ],
+      "nonce": "0x5",
+      "sender_address": "0x43abaa073c768ebf039c0c4f46db9acc39e9ec165690418060a652aab39e7d8",
+      "calldata": [
+        "0x1",
+        "0x43abaa073c768ebf039c0c4f46db9acc39e9ec165690418060a652aab39e7d8",
+        "0x2730079d734ee55315f4f141eaed376bddd8c2133523d223a344c5604e0f7f8",
+        "0x0",
+        "0x4",
+        "0x4",
+        "0x1b661756bf7d16210fc611626e1af4569baa1781ffc964bd018f4585ae241c1",
+        "0x0",
+        "0x0",
+        "0x1"
+      ],
+      "type": "INVOKE_FUNCTION"
+    },
+    {
+      "transaction_hash": "0x4010bd7b00e591c163729aa501691e89784c2afe77d71f7b27613e377738843",
+      "version": "0x1",
+      "max_fee": "0x0",
+      "signature": [
+        "0x612cf81ad73556a0f26e3e766de04c909a56d874f384e830d9d0deb2e9cb70d",
+        "0x6d9f06480c32e0b6a96af5b9ff5476bae94bed6c806124ae39a9f7fa987be7a"
+      ],
+      "nonce": "0x6",
+      "sender_address": "0x43abaa073c768ebf039c0c4f46db9acc39e9ec165690418060a652aab39e7d8",
+      "calldata": [
+        "0x1",
+        "0x43abaa073c768ebf039c0c4f46db9acc39e9ec165690418060a652aab39e7d8",
+        "0x2730079d734ee55315f4f141eaed376bddd8c2133523d223a344c5604e0f7f8",
+        "0x0",
+        "0x4",
+        "0x4",
+        "0x4f23a756b221f8ce46b72e6a6b10ee7ee6cf3b59790e76e02433104f9a8c5d1",
+        "0x0",
+        "0x0",
+        "0x1"
+      ],
+      "type": "INVOKE_FUNCTION"
+    }
+  ],
+  "timestamp": 1700477864,
+  "sequencer_address": "0x1176a1bd84444c89232ec27754698e5d2e7e1a7f1539f12027f28b23ec9f3d8",
+  "transaction_receipts": [
+    {
+      "execution_status": "SUCCEEDED",
+      "transaction_index": 0,
+      "transaction_hash": "0x3f786ecc4955a2602c91a291328518ef866cb7f3d50e4b16fd42282952623aa",
+      "l2_to_l1_messages": [],
+      "events": [],
+      "execution_resources": {
+        "n_steps": 5531,
+        "builtin_instance_counter": {
+          "range_check_builtin": 122,
+          "ecdsa_builtin": 1,
+          "pedersen_builtin": 23
+        },
+        "n_memory_holes": 0
+      },
+      "actual_fee": "0x0"
+    },
+    {
+      "execution_status": "SUCCEEDED",
+      "transaction_index": 1,
+      "transaction_hash": "0x4010bd7b00e591c163729aa501691e89784c2afe77d71f7b27613e377738843",
+      "l2_to_l1_messages": [],
+      "events": [],
+      "execution_resources": {
+        "n_steps": 5531,
+        "builtin_instance_counter": {
+          "pedersen_builtin": 23,
+          "ecdsa_builtin": 1,
+          "range_check_builtin": 122
+        },
+        "n_memory_holes": 0
+      },
+      "actual_fee": "0x0"
+    }
+  ],
+  "starknet_version": "0.12.3"
+}

--- a/clients/feeder/testdata/sepolia/block/4.json
+++ b/clients/feeder/testdata/sepolia/block/4.json
@@ -1,0 +1,259 @@
+{
+  "block_hash": "0x445152a69e628774b0f78a952e6f9ba0ffcda1374724b314140928fd2f31f4c",
+  "parent_block_hash": "0x37644818236ee05b7e3b180bed64ea70ee3dd1553ca334a5c2a290ee276f380",
+  "block_number": 4,
+  "state_root": "0xe290a369aa37fb11008ffea52cf207cd5e2a66fed9ad4e551aa46ec0ed58b",
+  "transaction_commitment": "0x69e3b5485916dd0c3faf2568bd5c9520363a8a3ebf8728497b5dcd10e2d3ed4",
+  "event_commitment": "0x49ab436426f304955088d1093ff5eeef9dc1b5d6b9362510a6a428889884201",
+  "status": "ACCEPTED_ON_L1",
+  "l1_da_mode": "CALLDATA",
+  "l1_gas_price": {
+    "price_in_wei": "0x3b9aca12",
+    "price_in_fri": "0x0"
+  },
+  "l1_data_gas_price": {
+    "price_in_wei": "0x1",
+    "price_in_fri": "0x1"
+  },
+  "transactions": [
+    {
+      "transaction_hash": "0x3c9dfcd3fe66be18b661ee4ebb62520bb4f13d4182b040b3c2be9a12dbcc09b",
+      "version": "0x1",
+      "max_fee": "0x0",
+      "signature": [
+        "0x67f921af8ead287fa21a8c0c168ab3cfecb4542fec5dd0c16a4b8708a92ff9c",
+        "0x7e8c6a9289e49b2f61b5c8af5225225b3190f13b922e3219c63055295deafa5"
+      ],
+      "nonce": "0x7",
+      "sender_address": "0x43abaa073c768ebf039c0c4f46db9acc39e9ec165690418060a652aab39e7d8",
+      "calldata": [
+        "0x1",
+        "0x49d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7",
+        "0xd43941048da98e5d91155f568f15da2ac665270f823156af4a151cc6f01869",
+        "0x0",
+        "0x8",
+        "0x8",
+        "0x23be95f90bf41685e18a4356e57b0cfdc1da22bf382ead8b64108353915c1e5",
+        "0x0",
+        "0x4",
+        "0x4574686572",
+        "0x455448",
+        "0x12",
+        "0x4c5772d1914fe6ce891b64eb35bf3522aeae1315647314aac58b01137607f3f",
+        "0x0"
+      ],
+      "type": "INVOKE_FUNCTION"
+    },
+    {
+      "transaction_hash": "0x24ae8900d238a120e927d6a5f2e4ddf85419e97020d92c1fadc615bff666ab1",
+      "version": "0x1",
+      "max_fee": "0x0",
+      "signature": [
+        "0x666c1b3e14548468b2e15d414dee1cdecb76f9d2a88da657450b8fa60e7f73c",
+        "0x5755d4ca07ac85c1494db9a0b6916eba26427bfcf919e9d21f20ed8774ac861"
+      ],
+      "nonce": "0x8",
+      "sender_address": "0x43abaa073c768ebf039c0c4f46db9acc39e9ec165690418060a652aab39e7d8",
+      "calldata": [
+        "0x1",
+        "0x49d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7",
+        "0xed163e8350935d550d16de1f53fd8284b06f37685f9d20c7f1735f719f336e",
+        "0x0",
+        "0x8",
+        "0x8",
+        "0x23be95f90bf41685e18a4356e57b0cfdc1da22bf382ead8b64108353915c1e5",
+        "0x0",
+        "0x4",
+        "0x4574686572",
+        "0x455448",
+        "0x12",
+        "0x4c5772d1914fe6ce891b64eb35bf3522aeae1315647314aac58b01137607f3f",
+        "0x0"
+      ],
+      "type": "INVOKE_FUNCTION"
+    },
+    {
+      "transaction_hash": "0x48f6c73e794a46f4199fc94ce21f5697c8c3b1e5812de6bf9cd8e4867d82608",
+      "version": "0x1",
+      "max_fee": "0x0",
+      "signature": [
+        "0xadf40654702062788735a62944c47c0a453ae72b8efd1767cf8765edb90581",
+        "0x696fb410d281aadba4c5806f37fd6cba819f01fbda59be2122582841053f472"
+      ],
+      "nonce": "0x9",
+      "sender_address": "0x43abaa073c768ebf039c0c4f46db9acc39e9ec165690418060a652aab39e7d8",
+      "calldata": [
+        "0x1",
+        "0x4c5772d1914fe6ce891b64eb35bf3522aeae1315647314aac58b01137607f3f",
+        "0xd43941048da98e5d91155f568f15da2ac665270f823156af4a151cc6f01869",
+        "0x0",
+        "0x5",
+        "0x5",
+        "0x6d8ff7b212b08760c82e4a8f354f6ebc69d748290fa38e92eb859726a88f379",
+        "0x0",
+        "0x1",
+        "0x43abaa073c768ebf039c0c4f46db9acc39e9ec165690418060a652aab39e7d8",
+        "0x0"
+      ],
+      "type": "INVOKE_FUNCTION"
+    },
+    {
+      "transaction_hash": "0x3aab0f1723f38bb12db2c417f39b143c713621122233b9c3bbc02095be8a50e",
+      "version": "0x1",
+      "max_fee": "0x0",
+      "signature": [
+        "0x7143551fc3355fc90a7b5564a8c0120d850d8142b8efbf3f87bd161daf4ad",
+        "0x305aeaedcac5742f085c0abd0422bf8dda3e74d41de49e7c9c29e037ae9a462"
+      ],
+      "nonce": "0xa",
+      "sender_address": "0x43abaa073c768ebf039c0c4f46db9acc39e9ec165690418060a652aab39e7d8",
+      "calldata": [
+        "0x1",
+        "0x4c5772d1914fe6ce891b64eb35bf3522aeae1315647314aac58b01137607f3f",
+        "0xed163e8350935d550d16de1f53fd8284b06f37685f9d20c7f1735f719f336e",
+        "0x0",
+        "0x5",
+        "0x5",
+        "0x6d8ff7b212b08760c82e4a8f354f6ebc69d748290fa38e92eb859726a88f379",
+        "0x0",
+        "0x1",
+        "0x43abaa073c768ebf039c0c4f46db9acc39e9ec165690418060a652aab39e7d8",
+        "0x0"
+      ],
+      "type": "INVOKE_FUNCTION"
+    }
+  ],
+  "timestamp": 1700480071,
+  "sequencer_address": "0x1176a1bd84444c89232ec27754698e5d2e7e1a7f1539f12027f28b23ec9f3d8",
+  "transaction_receipts": [
+    {
+      "execution_status": "SUCCEEDED",
+      "transaction_index": 0,
+      "transaction_hash": "0x3c9dfcd3fe66be18b661ee4ebb62520bb4f13d4182b040b3c2be9a12dbcc09b",
+      "l2_to_l1_messages": [],
+      "events": [
+        {
+          "from_address": "0x49d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7",
+          "keys": [
+            "0x2e8a4ec40a36a027111fafdb6a46746ff1b0125d5067fbaebd8b5f227185a1e"
+          ],
+          "data": [
+            "0x23be95f90bf41685e18a4356e57b0cfdc1da22bf382ead8b64108353915c1e5",
+            "0x0",
+            "0x4",
+            "0x4574686572",
+            "0x455448",
+            "0x12",
+            "0x4c5772d1914fe6ce891b64eb35bf3522aeae1315647314aac58b01137607f3f",
+            "0x0"
+          ]
+        }
+      ],
+      "execution_resources": {
+        "n_steps": 5140,
+        "builtin_instance_counter": {
+          "range_check_builtin": 111,
+          "pedersen_builtin": 27,
+          "ecdsa_builtin": 1
+        },
+        "n_memory_holes": 0
+      },
+      "actual_fee": "0x0"
+    },
+    {
+      "execution_status": "SUCCEEDED",
+      "transaction_index": 1,
+      "transaction_hash": "0x24ae8900d238a120e927d6a5f2e4ddf85419e97020d92c1fadc615bff666ab1",
+      "l2_to_l1_messages": [],
+      "events": [
+        {
+          "from_address": "0x49d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7",
+          "keys": [
+            "0x1205ec81562fc65c367136bd2fe1c0fff2d1986f70e4ba365e5dd747bd08753"
+          ],
+          "data": [
+            "0x23be95f90bf41685e18a4356e57b0cfdc1da22bf382ead8b64108353915c1e5",
+            "0x0",
+            "0x4",
+            "0x4574686572",
+            "0x455448",
+            "0x12",
+            "0x4c5772d1914fe6ce891b64eb35bf3522aeae1315647314aac58b01137607f3f"
+          ]
+        }
+      ],
+      "execution_resources": {
+        "n_steps": 7587,
+        "builtin_instance_counter": {
+          "range_check_builtin": 156,
+          "pedersen_builtin": 28,
+          "ecdsa_builtin": 1
+        },
+        "n_memory_holes": 0
+      },
+      "actual_fee": "0x0"
+    },
+    {
+      "execution_status": "SUCCEEDED",
+      "transaction_index": 2,
+      "transaction_hash": "0x48f6c73e794a46f4199fc94ce21f5697c8c3b1e5812de6bf9cd8e4867d82608",
+      "l2_to_l1_messages": [],
+      "events": [
+        {
+          "from_address": "0x4c5772d1914fe6ce891b64eb35bf3522aeae1315647314aac58b01137607f3f",
+          "keys": [
+            "0x2e8a4ec40a36a027111fafdb6a46746ff1b0125d5067fbaebd8b5f227185a1e"
+          ],
+          "data": [
+            "0x6d8ff7b212b08760c82e4a8f354f6ebc69d748290fa38e92eb859726a88f379",
+            "0x0",
+            "0x1",
+            "0x43abaa073c768ebf039c0c4f46db9acc39e9ec165690418060a652aab39e7d8",
+            "0x0"
+          ]
+        }
+      ],
+      "execution_resources": {
+        "n_steps": 5100,
+        "builtin_instance_counter": {
+          "ecdsa_builtin": 1,
+          "range_check_builtin": 111,
+          "pedersen_builtin": 24
+        },
+        "n_memory_holes": 0
+      },
+      "actual_fee": "0x0"
+    },
+    {
+      "execution_status": "SUCCEEDED",
+      "transaction_index": 3,
+      "transaction_hash": "0x3aab0f1723f38bb12db2c417f39b143c713621122233b9c3bbc02095be8a50e",
+      "l2_to_l1_messages": [],
+      "events": [
+        {
+          "from_address": "0x4c5772d1914fe6ce891b64eb35bf3522aeae1315647314aac58b01137607f3f",
+          "keys": [
+            "0x1205ec81562fc65c367136bd2fe1c0fff2d1986f70e4ba365e5dd747bd08753"
+          ],
+          "data": [
+            "0x6d8ff7b212b08760c82e4a8f354f6ebc69d748290fa38e92eb859726a88f379",
+            "0x0",
+            "0x1",
+            "0x43abaa073c768ebf039c0c4f46db9acc39e9ec165690418060a652aab39e7d8"
+          ]
+        }
+      ],
+      "execution_resources": {
+        "n_steps": 7296,
+        "builtin_instance_counter": {
+          "pedersen_builtin": 25,
+          "range_check_builtin": 154,
+          "ecdsa_builtin": 1
+        },
+        "n_memory_holes": 0
+      },
+      "actual_fee": "0x0"
+    }
+  ],
+  "starknet_version": "0.12.3"
+}

--- a/clients/feeder/testdata/sepolia/block/5.json
+++ b/clients/feeder/testdata/sepolia/block/5.json
@@ -1,0 +1,121 @@
+{
+  "block_hash": "0x13b390a0b2c48f907cda28c73a12aa31b96d51bc1be004ba5f71174d8d70e4f",
+  "parent_block_hash": "0x445152a69e628774b0f78a952e6f9ba0ffcda1374724b314140928fd2f31f4c",
+  "block_number": 5,
+  "state_root": "0x79c232ec00890309f011037762ed19439ce50c2245ed8934c48e737bcb4f7f0",
+  "transaction_commitment": "0x344abbf9435f8cc14e9480d65a7accf81f9545285a861b3f09911974333561a",
+  "event_commitment": "0x25afeb9ac157801a3fbc66c5d7c689ddaf59633e188e29dc61fea20044856b2",
+  "status": "ACCEPTED_ON_L1",
+  "l1_da_mode": "CALLDATA",
+  "l1_gas_price": {
+    "price_in_wei": "0x3b9aca12",
+    "price_in_fri": "0x0"
+  },
+  "l1_data_gas_price": {
+    "price_in_wei": "0x1",
+    "price_in_fri": "0x1"
+  },
+  "transactions": [
+    {
+      "transaction_hash": "0xcc475316c44b764c852e4ce721b15afcc8b9c53a5a54c85020f5dee067b8ce",
+      "version": "0x1",
+      "max_fee": "0x0",
+      "signature": [
+        "0x193eec72e2d84fcc5e0e1986130b95d9d7f52de5c0d33c7c7e9b353207b481d",
+        "0x1ff8880e792e978868f0c49293f0934c14c257a506cf5568f0105006e302c62"
+      ],
+      "nonce": "0xb",
+      "sender_address": "0x43abaa073c768ebf039c0c4f46db9acc39e9ec165690418060a652aab39e7d8",
+      "calldata": [
+        "0x1",
+        "0x4c5772d1914fe6ce891b64eb35bf3522aeae1315647314aac58b01137607f3f",
+        "0x2991bb19305a4d6507010cd65c3b5ae1573665f684593f23c839f2011e46bf1",
+        "0x0",
+        "0x1",
+        "0x1",
+        "0x8453fc6cd1bcfe8d4dfc069c400b433054d47bdc"
+      ],
+      "type": "INVOKE_FUNCTION"
+    },
+    {
+      "transaction_hash": "0x755fab24e9e7a4c61cc27b9a69cc682b42e55ba63d727aeb9a232afc4300e43",
+      "version": "0x1",
+      "max_fee": "0x0",
+      "signature": [
+        "0x4a0722fbcf7a90b75b9b9711eeaf1069ca0b6d6b2f24fb647d4a1a85b06646c",
+        "0x19978890911d3f1b0248fbb0ccbf377c80acc0bbe0fdb8f0eb7c012944964b3"
+      ],
+      "nonce": "0xc",
+      "sender_address": "0x43abaa073c768ebf039c0c4f46db9acc39e9ec165690418060a652aab39e7d8",
+      "calldata": [
+        "0x1",
+        "0x4c5772d1914fe6ce891b64eb35bf3522aeae1315647314aac58b01137607f3f",
+        "0x2dc43b5b06e7678e8776ee682b94dd95787b1157b364f83f82cf83b12cb9cf8",
+        "0x0",
+        "0x1",
+        "0x1",
+        "0x49d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7"
+      ],
+      "type": "INVOKE_FUNCTION"
+    }
+  ],
+  "timestamp": 1700482082,
+  "sequencer_address": "0x1176a1bd84444c89232ec27754698e5d2e7e1a7f1539f12027f28b23ec9f3d8",
+  "transaction_receipts": [
+    {
+      "execution_status": "SUCCEEDED",
+      "transaction_index": 0,
+      "transaction_hash": "0xcc475316c44b764c852e4ce721b15afcc8b9c53a5a54c85020f5dee067b8ce",
+      "l2_to_l1_messages": [],
+      "events": [
+        {
+          "from_address": "0x4c5772d1914fe6ce891b64eb35bf3522aeae1315647314aac58b01137607f3f",
+          "keys": [
+            "0x3ff59241d81a9867be9176fe598bc7da392e838791cc7f65a2b05a8c17dac10"
+          ],
+          "data": [
+            "0x8453fc6cd1bcfe8d4dfc069c400b433054d47bdc"
+          ]
+        }
+      ],
+      "execution_resources": {
+        "n_steps": 5631,
+        "builtin_instance_counter": {
+          "ecdsa_builtin": 1,
+          "range_check_builtin": 126,
+          "pedersen_builtin": 16
+        },
+        "n_memory_holes": 0
+      },
+      "actual_fee": "0x0"
+    },
+    {
+      "execution_status": "SUCCEEDED",
+      "transaction_index": 1,
+      "transaction_hash": "0x755fab24e9e7a4c61cc27b9a69cc682b42e55ba63d727aeb9a232afc4300e43",
+      "l2_to_l1_messages": [],
+      "events": [
+        {
+          "from_address": "0x4c5772d1914fe6ce891b64eb35bf3522aeae1315647314aac58b01137607f3f",
+          "keys": [
+            "0xa680cdd5fe5551f01a9945dc29a4a9048b0eb55e9d3145921c7768db1492b7"
+          ],
+          "data": [
+            "0x49d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7"
+          ]
+        }
+      ],
+      "execution_resources": {
+        "n_steps": 5596,
+        "builtin_instance_counter": {
+          "ecdsa_builtin": 1,
+          "pedersen_builtin": 16,
+          "range_check_builtin": 122
+        },
+        "n_memory_holes": 0
+      },
+      "actual_fee": "0x0"
+    }
+  ],
+  "starknet_version": "0.12.3"
+}

--- a/clients/feeder/testdata/sepolia/block/6.json
+++ b/clients/feeder/testdata/sepolia/block/6.json
@@ -1,0 +1,90 @@
+{
+  "block_hash": "0x7e16179ff54fa8bb1533fe2eea930e9e2bd658faaf9972533c9d3a9303171fc",
+  "parent_block_hash": "0x13b390a0b2c48f907cda28c73a12aa31b96d51bc1be004ba5f71174d8d70e4f",
+  "block_number": 6,
+  "state_root": "0x2729a9ded030fa182a4802b9accf662d071d23fdfb2011504d1777927c9abaf",
+  "transaction_commitment": "0x444c6162583b532826dedb2be39c91a5d01c97692050bdcfbfac408bc321fa6",
+  "event_commitment": "0xbe9049bd97da9886c30ebbdfb16ef6d34b1c69649cf5be3d348bb642f29b91",
+  "status": "ACCEPTED_ON_L1",
+  "l1_da_mode": "CALLDATA",
+  "l1_gas_price": {
+    "price_in_wei": "0x3b9aca12",
+    "price_in_fri": "0x0"
+  },
+  "l1_data_gas_price": {
+    "price_in_wei": "0x1",
+    "price_in_fri": "0x1"
+  },
+  "transactions": [
+    {
+      "transaction_hash": "0x785c2ada3f53fbc66078d47715c27718f92e6e48b96372b36e5197de69b82b5",
+      "version": "0x0",
+      "contract_address": "0x4c5772d1914fe6ce891b64eb35bf3522aeae1315647314aac58b01137607f3f",
+      "entry_point_selector": "0x2d757788a8d8d6f21d1cd40bce38a8222d70654214e96ff95d8086e684fbee5",
+      "nonce": "0x0",
+      "calldata": [
+        "0x8453fc6cd1bcfe8d4dfc069c400b433054d47bdc",
+        "0x43abaa073c768ebf039c0c4f46db9acc39e9ec165690418060a652aab39e7d8",
+        "0xde0b6b3a7640000",
+        "0x0"
+      ],
+      "type": "L1_HANDLER"
+    }
+  ],
+  "timestamp": 1700483673,
+  "sequencer_address": "0x1176a1bd84444c89232ec27754698e5d2e7e1a7f1539f12027f28b23ec9f3d8",
+  "transaction_receipts": [
+    {
+      "execution_status": "SUCCEEDED",
+      "transaction_index": 0,
+      "transaction_hash": "0x785c2ada3f53fbc66078d47715c27718f92e6e48b96372b36e5197de69b82b5",
+      "l1_to_l2_consumed_message": {
+        "from_address": "0x8453FC6Cd1bCfE8D4dFC069C400B433054d47bDc",
+        "to_address": "0x4c5772d1914fe6ce891b64eb35bf3522aeae1315647314aac58b01137607f3f",
+        "selector": "0x2d757788a8d8d6f21d1cd40bce38a8222d70654214e96ff95d8086e684fbee5",
+        "payload": [
+          "0x43abaa073c768ebf039c0c4f46db9acc39e9ec165690418060a652aab39e7d8",
+          "0xde0b6b3a7640000",
+          "0x0"
+        ],
+        "nonce": "0x0"
+      },
+      "l2_to_l1_messages": [],
+      "events": [
+        {
+          "from_address": "0x49d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7",
+          "keys": [
+            "0x99cd8bde557814842a3121e8ddfd433a539b8c9f14bf31ebf108d12e6196e9"
+          ],
+          "data": [
+            "0x0",
+            "0x43abaa073c768ebf039c0c4f46db9acc39e9ec165690418060a652aab39e7d8",
+            "0xde0b6b3a7640000",
+            "0x0"
+          ]
+        },
+        {
+          "from_address": "0x4c5772d1914fe6ce891b64eb35bf3522aeae1315647314aac58b01137607f3f",
+          "keys": [
+            "0x221e5a5008f7a28564f0eaa32cdeb0848d10657c449aed3e15d12150a7c2db3"
+          ],
+          "data": [
+            "0x43abaa073c768ebf039c0c4f46db9acc39e9ec165690418060a652aab39e7d8",
+            "0xde0b6b3a7640000",
+            "0x0"
+          ]
+        }
+      ],
+      "execution_resources": {
+        "n_steps": 8057,
+        "builtin_instance_counter": {
+          "range_check_builtin": 168,
+          "pedersen_builtin": 15
+        },
+        "n_memory_holes": 0
+      },
+      "actual_fee": "0x0"
+    }
+  ],
+  "starknet_version": "0.12.3"
+}

--- a/clients/feeder/testdata/sepolia/signature/0.json
+++ b/clients/feeder/testdata/sepolia/signature/0.json
@@ -1,0 +1,11 @@
+{
+    "block_number": 0,
+    "signature": [
+        "0x30a199364f1cec47d386da1839015413a464456ca6d63d6f45156d0a1254356",
+        "0x784aba6f4948a6a1caa4f7247adcabdfe41a8ec21668c30621cd9d265516dc6"
+    ],
+    "signature_input": {
+        "block_hash": "0x5c627d4aeb51280058bed93c7889bce78114d63baad1be0f0aeb32496d5f19c",
+        "state_diff_commitment": "0x7c1ac561302d1f4a84ae34cdac3bb55cda085874e23ce48da6492ab2ce4211a"
+    }
+}

--- a/clients/feeder/testdata/sepolia/signature/1.json
+++ b/clients/feeder/testdata/sepolia/signature/1.json
@@ -1,0 +1,11 @@
+{
+    "block_number": 1,
+    "signature": [
+        "0x47fe7aea2435f8be68f0dce8f859f0f2f31db43eddc9269a200ef7a530e34a0",
+        "0x636260cd4a8a9991a9a2f7b09a4d8ebdfbfdb7d32d0a2b8e23d8ebc0ae014dc"
+    ],
+    "signature_input": {
+        "block_hash": "0x78b67b11f8c23850041e11fb0f3b39db0bcb2c99d756d5a81321d1b483d79f6",
+        "state_diff_commitment": "0x70188b63055c343725f88de0f84a702b50cd81b5a426ecc75b0922d78fdac78"
+    }
+}

--- a/clients/feeder/testdata/sepolia/signature/2.json
+++ b/clients/feeder/testdata/sepolia/signature/2.json
@@ -1,0 +1,11 @@
+{
+    "block_number": 2,
+    "signature": [
+        "0x328251965bcf8dc8f870a027eebe73627b8dbd82d6981cfbd4231a197da53ae",
+        "0x75bb4eb017f274f1f6e2a785c921a51baa761dad2d85fe54fd8607d816b829f"
+    ],
+    "signature_input": {
+        "block_hash": "0x7a906dfd1ff77a121b8048e6f750cda9e949d341c4487d4c6a449f183f0e61d",
+        "state_diff_commitment": "0x7d4abf2975cd79627ed1bf8040b7ae2d10e4db59ede80661caedb647da21720"
+    }
+}

--- a/clients/feeder/testdata/sepolia/signature/3.json
+++ b/clients/feeder/testdata/sepolia/signature/3.json
@@ -1,0 +1,11 @@
+{
+    "block_number": 3,
+    "signature": [
+        "0x523b44ec1514af3449d22bfc35f2af542631a15bc6f8223767f4647eaace23",
+        "0xac37a6ccc3170099cf47238e5741d6e9924894e2753090d2f95e21d24d972a"
+    ],
+    "signature_input": {
+        "block_hash": "0x37644818236ee05b7e3b180bed64ea70ee3dd1553ca334a5c2a290ee276f380",
+        "state_diff_commitment": "0x778d74f0f6c992baeff6baf959c1d978871412cc6fdf336c315bc8434ae66c3"
+    }
+}

--- a/clients/feeder/testdata/sepolia/signature/4.json
+++ b/clients/feeder/testdata/sepolia/signature/4.json
@@ -1,0 +1,11 @@
+{
+    "block_number": 4,
+    "signature": [
+        "0x664ef8a30a1a564bdc20d95b40425e9811a3fd8f4f4b0f2b177b1f50b966f04",
+        "0x6b1006eab7f392ebde652aa9423bccccb9c1aa2eb6e4b42ca4f2017e6c9e20"
+    ],
+    "signature_input": {
+        "block_hash": "0x445152a69e628774b0f78a952e6f9ba0ffcda1374724b314140928fd2f31f4c",
+        "state_diff_commitment": "0x79424797387597babe544c96dca19c6f0d8b17dd1c5d1e24d0422a774ba1f17"
+    }
+}

--- a/clients/feeder/testdata/sepolia/signature/5.json
+++ b/clients/feeder/testdata/sepolia/signature/5.json
@@ -1,0 +1,11 @@
+{
+    "block_number": 5,
+    "signature": [
+        "0x30453e35a82d00aacfb6b9c2fb6ee98f24abccf823016ada45b2cb552f46328",
+        "0x7cd027b5cff5fb99b05f695eccaf6d0342c15664314974859c5aca2e914300e"
+    ],
+    "signature_input": {
+        "block_hash": "0x13b390a0b2c48f907cda28c73a12aa31b96d51bc1be004ba5f71174d8d70e4f",
+        "state_diff_commitment": "0x3087c6d483a6f5e554b847a6eb4449f124c38a1b5eb314aa6a61ea242e339e"
+    }
+}

--- a/clients/feeder/testdata/sepolia/signature/6.json
+++ b/clients/feeder/testdata/sepolia/signature/6.json
@@ -1,0 +1,11 @@
+{
+    "block_number": 6,
+    "signature": [
+        "0x6458071a3062f2e4e9477943c408c7b1181cdc4ccbbf0aa90c5fc931c01a78f",
+        "0x513206c9714506bb099181d810159a80bb4753feef82532de1d52f2c83b7e79"
+    ],
+    "signature_input": {
+        "block_hash": "0x7e16179ff54fa8bb1533fe2eea930e9e2bd658faaf9972533c9d3a9303171fc",
+        "state_diff_commitment": "0x68c1a07e2c09d13b4a0c57fe381a2c02a723ba6795b3d4457848e05d740ec6b"
+    }
+}

--- a/clients/feeder/testdata/sepolia/state_update/0.json
+++ b/clients/feeder/testdata/sepolia/state_update/0.json
@@ -1,0 +1,58 @@
+{
+  "block_hash": "0x5c627d4aeb51280058bed93c7889bce78114d63baad1be0f0aeb32496d5f19c",
+  "new_root": "0xe005205a1327f3dff98074e528f7b96f30e0624a1dfcf571bdc81948d150a0",
+  "old_root": "0x0",
+  "state_diff": {
+    "storage_diffs": {
+      "0x4c5772d1914fe6ce891b64eb35bf3522aeae1315647314aac58b01137607f3f": [
+        {
+          "key": "0xe8fc4f1b6b3dc661208f9a8a5017a6c059098327e31518722e0a5c3a5a7e86",
+          "value": "0x1"
+        },
+        {
+          "key": "0x6d56a3a16e0bf05482515c10fcf552437cdd1b7b409a6e8cec88c4b8fa03c13",
+          "value": "0x1"
+        }
+      ],
+      "0x43abaa073c768ebf039c0c4f46db9acc39e9ec165690418060a652aab39e7d8": [
+        {
+          "key": "0x3b28019ccfdbd30ffc65951d94bb85c9e2b8434111a000b5afd533ce65f57a4",
+          "value": "0x12c4df40394d06f157edec8d0e64db61fe0c271149ea860c8fe98def29ecf02"
+        }
+      ],
+      "0x49d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7": [
+        {
+          "key": "0xe8fc4f1b6b3dc661208f9a8a5017a6c059098327e31518722e0a5c3a5a7e86",
+          "value": "0x1"
+        },
+        {
+          "key": "0x6d56a3a16e0bf05482515c10fcf552437cdd1b7b409a6e8cec88c4b8fa03c13",
+          "value": "0x1"
+        }
+      ]
+    },
+    "nonces": {
+      "0x43abaa073c768ebf039c0c4f46db9acc39e9ec165690418060a652aab39e7d8": "0x5"
+    },
+    "deployed_contracts": [
+      {
+        "address": "0x43abaa073c768ebf039c0c4f46db9acc39e9ec165690418060a652aab39e7d8",
+        "class_hash": "0x5c478ee27f2112411f86f207605b2e2c58cdb647bac0df27f660ef2252359c6"
+      },
+      {
+        "address": "0x49d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7",
+        "class_hash": "0xd0e183745e9dae3e4e78a8ffedcce0903fc4900beace4e0abf192d4c202da3"
+      },
+      {
+        "address": "0x4c5772d1914fe6ce891b64eb35bf3522aeae1315647314aac58b01137607f3f",
+        "class_hash": "0xd0e183745e9dae3e4e78a8ffedcce0903fc4900beace4e0abf192d4c202da3"
+      }
+    ],
+    "old_declared_contracts": [
+      "0xd0e183745e9dae3e4e78a8ffedcce0903fc4900beace4e0abf192d4c202da3",
+      "0x5c478ee27f2112411f86f207605b2e2c58cdb647bac0df27f660ef2252359c6"
+    ],
+    "declared_classes": [],
+    "replaced_classes": []
+  }
+}

--- a/clients/feeder/testdata/sepolia/state_update/1.json
+++ b/clients/feeder/testdata/sepolia/state_update/1.json
@@ -1,0 +1,15 @@
+{
+  "block_hash": "0x78b67b11f8c23850041e11fb0f3b39db0bcb2c99d756d5a81321d1b483d79f6",
+  "new_root": "0xe005205a1327f3dff98074e528f7b96f30e0624a1dfcf571bdc81948d150a0",
+  "old_root": "0xe005205a1327f3dff98074e528f7b96f30e0624a1dfcf571bdc81948d150a0",
+  "state_diff": {
+    "storage_diffs": {},
+    "nonces": {},
+    "deployed_contracts": [],
+    "old_declared_contracts": [
+      "0x1b661756bf7d16210fc611626e1af4569baa1781ffc964bd018f4585ae241c1"
+    ],
+    "declared_classes": [],
+    "replaced_classes": []
+  }
+}

--- a/clients/feeder/testdata/sepolia/state_update/2.json
+++ b/clients/feeder/testdata/sepolia/state_update/2.json
@@ -1,0 +1,15 @@
+{
+  "block_hash": "0x7a906dfd1ff77a121b8048e6f750cda9e949d341c4487d4c6a449f183f0e61d",
+  "new_root": "0xe005205a1327f3dff98074e528f7b96f30e0624a1dfcf571bdc81948d150a0",
+  "old_root": "0xe005205a1327f3dff98074e528f7b96f30e0624a1dfcf571bdc81948d150a0",
+  "state_diff": {
+    "storage_diffs": {},
+    "nonces": {},
+    "deployed_contracts": [],
+    "old_declared_contracts": [
+      "0x4f23a756b221f8ce46b72e6a6b10ee7ee6cf3b59790e76e02433104f9a8c5d1"
+    ],
+    "declared_classes": [],
+    "replaced_classes": []
+  }
+}

--- a/clients/feeder/testdata/sepolia/state_update/3.json
+++ b/clients/feeder/testdata/sepolia/state_update/3.json
@@ -1,0 +1,24 @@
+{
+  "block_hash": "0x37644818236ee05b7e3b180bed64ea70ee3dd1553ca334a5c2a290ee276f380",
+  "new_root": "0x1801be8c1f95003d643eb1601adad68585bae7536b7f28f7f3bd600adc39082",
+  "old_root": "0xe005205a1327f3dff98074e528f7b96f30e0624a1dfcf571bdc81948d150a0",
+  "state_diff": {
+    "storage_diffs": {},
+    "nonces": {
+      "0x43abaa073c768ebf039c0c4f46db9acc39e9ec165690418060a652aab39e7d8": "0x7"
+    },
+    "deployed_contracts": [
+      {
+        "address": "0x23be95f90bf41685e18a4356e57b0cfdc1da22bf382ead8b64108353915c1e5",
+        "class_hash": "0x1b661756bf7d16210fc611626e1af4569baa1781ffc964bd018f4585ae241c1"
+      },
+      {
+        "address": "0x6d8ff7b212b08760c82e4a8f354f6ebc69d748290fa38e92eb859726a88f379",
+        "class_hash": "0x4f23a756b221f8ce46b72e6a6b10ee7ee6cf3b59790e76e02433104f9a8c5d1"
+      }
+    ],
+    "old_declared_contracts": [],
+    "declared_classes": [],
+    "replaced_classes": []
+  }
+}

--- a/clients/feeder/testdata/sepolia/state_update/4.json
+++ b/clients/feeder/testdata/sepolia/state_update/4.json
@@ -1,0 +1,64 @@
+{
+  "block_hash": "0x445152a69e628774b0f78a952e6f9ba0ffcda1374724b314140928fd2f31f4c",
+  "new_root": "0xe290a369aa37fb11008ffea52cf207cd5e2a66fed9ad4e551aa46ec0ed58b",
+  "old_root": "0x1801be8c1f95003d643eb1601adad68585bae7536b7f28f7f3bd600adc39082",
+  "state_diff": {
+    "storage_diffs": {
+      "0x4c5772d1914fe6ce891b64eb35bf3522aeae1315647314aac58b01137607f3f": [
+        {
+          "key": "0x5d2e9527cbeb1a51aa084b0de7501f343b7b1bf24a0c427d6204a7b7988970",
+          "value": "0x6d8ff7b212b08760c82e4a8f354f6ebc69d748290fa38e92eb859726a88f379"
+        },
+        {
+          "key": "0x246cebd6689d8c64011118478db0c61a89aa2646c860df401de476fbf378983",
+          "value": "0x43abaa073c768ebf039c0c4f46db9acc39e9ec165690418060a652aab39e7d8"
+        },
+        {
+          "key": "0x2cd2687c06d341ffd0b635e3229e2ca36108201a2112da0d058d03b77eb5092",
+          "value": "0x1"
+        },
+        {
+          "key": "0x313e5e25432fae312f83d275c24a3d7b1413d1b1e5a14be9c9feb7b0e09d076",
+          "value": "0x655b4447"
+        }
+      ],
+      "0x49d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7": [
+        {
+          "key": "0x5d2e9527cbeb1a51aa084b0de7501f343b7b1bf24a0c427d6204a7b7988970",
+          "value": "0x23be95f90bf41685e18a4356e57b0cfdc1da22bf382ead8b64108353915c1e5"
+        },
+        {
+          "key": "0xb6ce5410fca59d078ee9b2a4371a9d684c530d697c64fbef0ae6d5e8f0ac72",
+          "value": "0x455448"
+        },
+        {
+          "key": "0x1390569bb0a3a722eb4228e8700301347da081211d5c2ded2db22ef389551ab",
+          "value": "0x4c5772d1914fe6ce891b64eb35bf3522aeae1315647314aac58b01137607f3f"
+        },
+        {
+          "key": "0x1f0d4aa99431d246bac9b8e48c33e888245b15e9678f64f9bdfc8823dc8f979",
+          "value": "0x12"
+        },
+        {
+          "key": "0x2cd2687c06d341ffd0b635e3229e2ca36108201a2112da0d058d03b77eb5092",
+          "value": "0x1"
+        },
+        {
+          "key": "0x341c1bdfd89f69748aa00b5742b03adbffd79b8e80cab5c50d91cd8c2a79be1",
+          "value": "0x4574686572"
+        },
+        {
+          "key": "0x47a7f4add7797836a6e7ab22d35a37254d68a478e5d0b0e48698595c7da9ab9",
+          "value": "0x655b4447"
+        }
+      ]
+    },
+    "nonces": {
+      "0x43abaa073c768ebf039c0c4f46db9acc39e9ec165690418060a652aab39e7d8": "0xb"
+    },
+    "deployed_contracts": [],
+    "old_declared_contracts": [],
+    "declared_classes": [],
+    "replaced_classes": []
+  }
+}

--- a/clients/feeder/testdata/sepolia/state_update/5.json
+++ b/clients/feeder/testdata/sepolia/state_update/5.json
@@ -1,0 +1,26 @@
+{
+  "block_hash": "0x13b390a0b2c48f907cda28c73a12aa31b96d51bc1be004ba5f71174d8d70e4f",
+  "new_root": "0x79c232ec00890309f011037762ed19439ce50c2245ed8934c48e737bcb4f7f0",
+  "old_root": "0xe290a369aa37fb11008ffea52cf207cd5e2a66fed9ad4e551aa46ec0ed58b",
+  "state_diff": {
+    "storage_diffs": {
+      "0x4c5772d1914fe6ce891b64eb35bf3522aeae1315647314aac58b01137607f3f": [
+        {
+          "key": "0xc88ee7a00e0b95f1138ef53d396c4327eeed7f9677bbd02ce82a663537b1cf",
+          "value": "0x8453fc6cd1bcfe8d4dfc069c400b433054d47bdc"
+        },
+        {
+          "key": "0x1dc79e2fd056704ede52dca5746b720269aaa5da53301dff546657c16ca07af",
+          "value": "0x49d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7"
+        }
+      ]
+    },
+    "nonces": {
+      "0x43abaa073c768ebf039c0c4f46db9acc39e9ec165690418060a652aab39e7d8": "0xd"
+    },
+    "deployed_contracts": [],
+    "old_declared_contracts": [],
+    "declared_classes": [],
+    "replaced_classes": []
+  }
+}

--- a/clients/feeder/testdata/sepolia/state_update/6.json
+++ b/clients/feeder/testdata/sepolia/state_update/6.json
@@ -1,0 +1,24 @@
+{
+  "block_hash": "0x7e16179ff54fa8bb1533fe2eea930e9e2bd658faaf9972533c9d3a9303171fc",
+  "new_root": "0x2729a9ded030fa182a4802b9accf662d071d23fdfb2011504d1777927c9abaf",
+  "old_root": "0x79c232ec00890309f011037762ed19439ce50c2245ed8934c48e737bcb4f7f0",
+  "state_diff": {
+    "storage_diffs": {
+      "0x49d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7": [
+        {
+          "key": "0x110e2f729c9c2b988559994a3daccd838cf52faf88e18101373e67dd061455a",
+          "value": "0xde0b6b3a7640000"
+        },
+        {
+          "key": "0x5b5882587b3ff6d12140843c6db4a845fe568f0e7e0d028cb4fff6b5e988eff",
+          "value": "0xde0b6b3a7640000"
+        }
+      ]
+    },
+    "nonces": {},
+    "deployed_contracts": [],
+    "old_declared_contracts": [],
+    "declared_classes": [],
+    "replaced_classes": []
+  }
+}

--- a/rpc/events_test.go
+++ b/rpc/events_test.go
@@ -26,7 +26,7 @@ import (
 
 func TestEvents(t *testing.T) {
 	testDB := pebble.NewMemTest(t)
-	n := utils.Ptr(utils.Goerli2)
+	n := utils.Ptr(utils.Sepolia)
 	chain := blockchain.New(testDB, n)
 
 	client := feeder.NewTestClient(t, n)
@@ -70,7 +70,7 @@ func TestEvents(t *testing.T) {
 			args.ToBlock = &rpc.BlockID{Number: 55}
 			events, err := handler.Events(args)
 			require.Nil(t, err)
-			require.Len(t, events.Events, 3)
+			require.Len(t, events.Events, 5)
 		})
 
 		t.Run("block hash", func(t *testing.T) {
@@ -108,7 +108,7 @@ func TestEvents(t *testing.T) {
 			args.Address = from
 			events, err := handler.Events(args)
 			require.Nil(t, err)
-			require.Len(t, events.Events, 2)
+			require.Len(t, events.Events, 4)
 			require.Empty(t, events.ContinuationToken)
 			allEvents = events.Events
 		})
@@ -131,7 +131,7 @@ func TestEvents(t *testing.T) {
 	})
 
 	t.Run("filter with keys", func(t *testing.T) {
-		key := utils.HexToFelt(t, "0x3774b0545aabb37c45c1eddc6a7dae57de498aae6d5e3589e362d4b4323a533")
+		key := utils.HexToFelt(t, "0x2e8a4ec40a36a027111fafdb6a46746ff1b0125d5067fbaebd8b5f227185a1e")
 
 		t.Run("get all events without pagination", func(t *testing.T) {
 			args.ChunkSize = 100
@@ -144,12 +144,18 @@ func TestEvents(t *testing.T) {
 			require.Equal(t, from, events.Events[0].From)
 			require.Equal(t, []*felt.Felt{key}, events.Events[0].Keys)
 			require.Equal(t, []*felt.Felt{
-				utils.HexToFelt(t, "0x2ee9bf3da86f3715e8a20429feed8e37fef58004ee5cf52baf2d8fc0d94c9c8"),
-				utils.HexToFelt(t, "0x2ee9bf3da86f3715e8a20429feed8e37fef58004ee5cf52baf2d8fc0d94c9c8"),
+				utils.HexToFelt(t, "0x23be95f90bf41685e18a4356e57b0cfdc1da22bf382ead8b64108353915c1e5"),
+				utils.HexToFelt(t, "0x0"),
+				utils.HexToFelt(t, "0x4"),
+				utils.HexToFelt(t, "0x4574686572"),
+				utils.HexToFelt(t, "0x455448"),
+				utils.HexToFelt(t, "0x12"),
+				utils.HexToFelt(t, "0x4c5772d1914fe6ce891b64eb35bf3522aeae1315647314aac58b01137607f3f"),
+				utils.HexToFelt(t, "0x0"),
 			}, events.Events[0].Data)
-			require.Equal(t, uint64(5), *events.Events[0].BlockNumber)
-			require.Equal(t, utils.HexToFelt(t, "0x3b43b334f46b921938854ba85ffc890c1b1321f8fd69e7b2961b18b4260de14"), events.Events[0].BlockHash)
-			require.Equal(t, utils.HexToFelt(t, "0x6d1431d875ba082365b888c1651e026012a94172b04589c91c2adeb6c1b7ace"), events.Events[0].TransactionHash)
+			require.Equal(t, uint64(4), *events.Events[0].BlockNumber)
+			require.Equal(t, utils.HexToFelt(t, "0x445152a69e628774b0f78a952e6f9ba0ffcda1374724b314140928fd2f31f4c"), events.Events[0].BlockHash)
+			require.Equal(t, utils.HexToFelt(t, "0x3c9dfcd3fe66be18b661ee4ebb62520bb4f13d4182b040b3c2be9a12dbcc09b"), events.Events[0].TransactionHash)
 		})
 	})
 
@@ -170,7 +176,7 @@ func TestEvents(t *testing.T) {
 
 	t.Run("filter with limit", func(t *testing.T) {
 		handler = handler.WithFilterLimit(1)
-		key := utils.HexToFelt(t, "0x3774b0545aabb37c45c1eddc6a7dae57de498aae6d5e3589e362d4b4323a533")
+		key := utils.HexToFelt(t, "0x2e8a4ec40a36a027111fafdb6a46746ff1b0125d5067fbaebd8b5f227185a1e")
 		args.ChunkSize = 100
 		args.Keys = make([][]felt.Felt, 0)
 		args.Keys = append(args.Keys, []felt.Felt{*key})
@@ -198,12 +204,12 @@ func TestEvents(t *testing.T) {
 		}
 		events, err := handler.Events(args)
 		require.Nil(t, err)
-		require.Len(t, events.Events, 1)
+		require.Len(t, events.Events, 2)
 		require.Empty(t, events.ContinuationToken)
 
 		assert.Nil(t, events.Events[0].BlockHash)
 		assert.Nil(t, events.Events[0].BlockNumber)
-		assert.Equal(t, utils.HexToFelt(t, "0x5fe34d6903420e489b6faa8804c7a1af311446934bac1ba1e79b53cee61756c"), events.Events[0].TransactionHash)
+		assert.Equal(t, utils.HexToFelt(t, "0x785c2ada3f53fbc66078d47715c27718f92e6e48b96372b36e5197de69b82b5"), events.Events[0].TransactionHash)
 	})
 }
 


### PR DESCRIPTION
This PR is fixing the issue #1790, includes making a copy of the necessary testdata used from the `goerli2` directory to a new `sepolia` directory.