### PR TITLE
Add deployment version verification before running e2e tests

### DIFF
--- a/.github/workflow-scripts/verify_deployment.sh
+++ b/.github/workflow-scripts/verify_deployment.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+URL=$1
+EXPECTED_VERSION=$2
+MAX_ATTEMPTS=30
+SLEEP_DURATION=10
+
+for i in $(seq 1 $MAX_ATTEMPTS); do
+  DEPLOYED_VERSION=$(curl -s -X POST "$URL" -H "Content-Type: application/json" -d '{"method": "juno_version", "jsonrpc": "2.0", "id": 0}' | jq -r '.result')
+  echo "Attempt $i: Deployed version $DEPLOYED_VERSION"
+  if [[ "$DEPLOYED_VERSION" == "$EXPECTED_VERSION" ]]; then
+    echo "Deployment version matches the image tag."
+    exit 0
+  fi
+  sleep $SLEEP_DURATION
+done
+
+echo "Deployment version did not match the image tag within the expected time frame."
+exit 1

--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -53,6 +53,9 @@ jobs:
     environment: 
       name: Development
     steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
       - name: Repository Dispatch Dev
         env:
           EVENT_NAME: juno-dev
@@ -66,7 +69,10 @@ jobs:
           -H "X-GitHub-Api-Version: 2022-11-28" \
           https://api.github.com/repos/NethermindEth/argo/dispatches \
           -d '{"event_type": "${{ env.EVENT_NAME }}", "client_payload":{"name": "${{ env.EVENT_NAME }}", "sepolia_config": "${{ env.SEPOLIA }}", "tag": "${{ env.IMAGE_TAG }}"}}'
-  
+
+      - name: Verify Deployment Version (Dev)
+        run: bash .github/workflow-scripts/verify_deployment.sh ${{ secrets.DEV_SEPOLIA_URL }} ${{ needs.docker_build_and_publish.outputs.IMAGE_TAG }}        
+        
   dev-starknet-rs-tests:
     needs: [deploy_to_dev]
     uses: ./.github/workflows/starknet-rs-tests.yml
@@ -87,6 +93,9 @@ jobs:
     environment: 
       name: Staging
     steps:         
+    - name: Checkout
+      uses: actions/checkout@v4
+
     - name: Repository Dispatch Staging
       env:
           EVENT_NAME: juno-staging
@@ -102,6 +111,9 @@ jobs:
           -H "X-GitHub-Api-Version: 2022-11-28" \
           https://api.github.com/repos/NethermindEth/argo/dispatches \
           -d '{"event_type": "${{ env.EVENT_NAME }}", "client_payload":{"name": "${{ env.EVENT_NAME }}", "mainnet_config": "${{ env.MAINNET }}", "sepolia_config": "${{ env.SEPOLIA }}", "sepolia_integration_config": "${{ env.SEPOLIA_INTEGRATION}}", "tag": "${{ env.IMAGE_TAG }}"}}'
+    
+    - name: Verify Deployment Version (Staging)
+      run: bash .github/workflow-scripts/verify_deployment.sh ${{ secrets.STAGING_SEPOLIA_URL }} ${{ needs.docker_build_and_publish.outputs.IMAGE_TAG }}
 
   staging-starknet-rs-tests:
     needs: [deploy_to_staging]


### PR DESCRIPTION
Added a step to verify deployment versions before tests, ensuring tests run on the latest deployment, enhancing test accuracy and reliability.