### PR TITLE
Change the use of the Goerli network to the Sepolia network in the TestHeight test

### DIFF
--- a/blockchain/blockchain_test.go
+++ b/blockchain/blockchain_test.go
@@ -54,7 +54,7 @@ func TestHeight(t *testing.T) {
 	client := feeder.NewTestClient(t, &utils.Mainnet)
 	gw := adaptfeeder.New(client)
 	t.Run("return nil if blockchain is empty", func(t *testing.T) {
-		chain := blockchain.New(pebble.NewMemTest(t), &utils.Goerli)
+		chain := blockchain.New(pebble.NewMemTest(t), &utils.Sepolia)
 		_, err := chain.Height()
 		assert.Error(t, err)
 	})


### PR DESCRIPTION
This PR is fixing the issue #1813, to update the test to use the Sepolia network instead of the deprecated Goerli network.