### PR TITLE
Change the use of the Goerli network to the Sepolia network in the TestBlockByNumberAndHash test

### DIFF
--- a/blockchain/blockchain_test.go
+++ b/blockchain/blockchain_test.go
@@ -77,7 +77,7 @@ func TestHeight(t *testing.T) {
 }
 
 func TestBlockByNumberAndHash(t *testing.T) {
-	chain := blockchain.New(pebble.NewMemTest(t), &utils.Goerli)
+	chain := blockchain.New(pebble.NewMemTest(t), &utils.Sepolia)
 	t.Run("same block is returned for both GetBlockByNumber and GetBlockByHash", func(t *testing.T) {
 		client := feeder.NewTestClient(t, &utils.Mainnet)
 		gw := adaptfeeder.New(client)


### PR DESCRIPTION
This PR is fixing the issue #1815, to update the test to use the Sepolia network instead of the deprecated Goerli network.