### PR TITLE
feat: GetNodesFromRoot rpc handler added

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,5 +9,7 @@ __pycache__/
 config/
 .envrc
 
+juno/
+
 # pyenv
 .python-version

--- a/blockchain/pending.go
+++ b/blockchain/pending.go
@@ -3,6 +3,7 @@ package blockchain
 import (
 	"github.com/NethermindEth/juno/core"
 	"github.com/NethermindEth/juno/core/felt"
+	"github.com/NethermindEth/juno/core/trie"
 )
 
 type Pending struct {
@@ -64,4 +65,8 @@ func (p *PendingState) Class(classHash *felt.Felt) (*core.DeclaredClass, error) 
 	}
 
 	return p.head.Class(classHash)
+}
+
+func (p *PendingState) GlobalTrie() (*trie.Trie, func() error, error) {
+	return p.head.GlobalTrie()
 }

--- a/core/state.go
+++ b/core/state.go
@@ -40,6 +40,7 @@ type StateReader interface {
 	ContractNonce(addr *felt.Felt) (*felt.Felt, error)
 	ContractStorage(addr, key *felt.Felt) (*felt.Felt, error)
 	Class(classHash *felt.Felt) (*DeclaredClass, error)
+	GlobalTrie() (*trie.Trie, func() error, error)
 }
 
 type State struct {
@@ -120,6 +121,10 @@ func (s *State) Root() (*felt.Felt, error) {
 	}
 
 	return crypto.PoseidonArray(stateVersion, storageRoot, classesRoot), nil
+}
+
+func (s *State) GlobalTrie() (*trie.Trie, func() error, error) {
+	return s.globalTrie(db.StateTrie, trie.NewTriePedersen)
 }
 
 // storage returns a [core.Trie] that represents the Starknet global state in the given Txn context.

--- a/core/state_snapshot.go
+++ b/core/state_snapshot.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 
 	"github.com/NethermindEth/juno/core/felt"
+	"github.com/NethermindEth/juno/core/trie"
 	"github.com/NethermindEth/juno/db"
 )
 
@@ -86,4 +87,8 @@ func (s *stateSnapshot) Class(classHash *felt.Felt) (*DeclaredClass, error) {
 		return nil, db.ErrKeyNotFound
 	}
 	return declaredClass, nil
+}
+
+func (s *stateSnapshot) GlobalTrie() (*trie.Trie, func() error, error) {
+	return s.state.GlobalTrie()
 }

--- a/core/trie/trie.go
+++ b/core/trie/trie.go
@@ -45,6 +45,32 @@ type Trie struct {
 
 type NewTrieFunc func(*Storage, uint8) (*Trie, error)
 
+type SerializableNode struct {
+    Key   string
+    Value string
+}
+
+func ConvertToSerializableNodes(nodes []storageNode) []SerializableNode {
+    var serializableNodes []SerializableNode
+    for _, node := range nodes {
+        serializableNode := SerializableNode{
+            Key:   fmt.Sprintf("%v", node.key),  // Assuming node.key can be stringified
+            Value: fmt.Sprintf("%v", node.node), // Assuming node.node can be stringified
+        }
+        serializableNodes = append(serializableNodes, serializableNode)
+    }
+    return serializableNodes
+}
+
+
+func (t *Trie) ConvertFeltToKey(f *felt.Felt) Key {
+    return t.feltToKey(f)
+}
+
+func (t *Trie) GetNodesFromRoot(key *Key) ([]storageNode, error){
+	return t.nodesFromRoot(key)
+}
+
 func NewTriePedersen(storage *Storage, height uint8) (*Trie, error) {
 	return newTrie(storage, height, crypto.Pedersen)
 }
@@ -184,6 +210,9 @@ func (t *Trie) Get(key *felt.Felt) (*felt.Felt, error) {
 
 // check if we are updating an existing leaf, if yes avoid traversing the trie
 func (t *Trie) updateLeaf(nodeKey Key, node *Node, value *felt.Felt) (*felt.Felt, error) {
+
+	// fmt.Println("updateLeaf")
+	// fmt.Println("nodeKey", nodeKey.Felt())
 	// Check if we are updating an existing leaf
 	if !value.IsZero() {
 		if existingLeaf, err := t.storage.Get(&nodeKey); err == nil {

--- a/rpc/handlers.go
+++ b/rpc/handlers.go
@@ -7,11 +7,13 @@ import (
 	"encoding/json"
 	"math"
 	stdsync "sync"
+	"fmt"
 
 	"github.com/NethermindEth/juno/blockchain"
 	"github.com/NethermindEth/juno/clients/feeder"
 	"github.com/NethermindEth/juno/core"
 	"github.com/NethermindEth/juno/core/felt"
+	"github.com/NethermindEth/juno/core/trie"
 	"github.com/NethermindEth/juno/feed"
 	"github.com/NethermindEth/juno/jsonrpc"
 	"github.com/NethermindEth/juno/sync"
@@ -175,6 +177,19 @@ func (h *Handler) SpecVersionV0_6() (string, *jsonrpc.Error) {
 	return "0.6.0", nil
 }
 
+func (h *Handler) GetNodesFromRoot(key *felt.Felt) (string, *jsonrpc.Error) {
+	// TODO: Implement this method
+	// Implement a new rpc method “juno_getNodesFromRoot(key felt.Felt)” 
+	// that returns the set of nodes from the root to the key for the classes Trie. 
+	// See nodesFromRoot(). Remember to implement tests for the new logic
+
+	// trie :=
+	// key_ := trie.feltToKey(key)
+	// storageNodes, _ := trie.nodesFromRoot(key_)
+
+	return "0x1", nil
+}
+
 func (h *Handler) Methods() ([]jsonrpc.Method, string) { //nolint: funlen
 	return []jsonrpc.Method{
 		{
@@ -329,6 +344,11 @@ func (h *Handler) Methods() ([]jsonrpc.Method, string) { //nolint: funlen
 			Name:    "starknet_getBlockWithReceipts",
 			Params:  []jsonrpc.Parameter{{Name: "block_id"}},
 			Handler: h.BlockWithReceipts,
+		},
+		{
+			Name:    "juno_getNodesFromRoot",
+			Params:  []jsonrpc.Parameter{{Name: "key"}},
+			Handler: h.GetNodesFromRoot,
 		},
 	}, "/v0_7"
 }

--- a/rpc/handlers.go
+++ b/rpc/handlers.go
@@ -7,7 +7,6 @@ import (
 	"encoding/json"
 	"math"
 	stdsync "sync"
-	"fmt"
 
 	"github.com/NethermindEth/juno/blockchain"
 	"github.com/NethermindEth/juno/clients/feeder"
@@ -43,6 +42,7 @@ var (
 	ErrTooManyKeysInFilter             = &jsonrpc.Error{Code: 34, Message: "Too many keys provided in a filter"}
 	ErrContractError                   = &jsonrpc.Error{Code: 40, Message: "Contract error"}
 	ErrTransactionExecutionError       = &jsonrpc.Error{Code: 41, Message: "Transaction execution error"}
+	ErrFailedToSerialize               = &jsonrpc.Error{Code: 42, Message: "Failed to serialize response"}
 	ErrInvalidContractClass            = &jsonrpc.Error{Code: 50, Message: "Invalid contract class"}
 	ErrClassAlreadyDeclared            = &jsonrpc.Error{Code: 51, Message: "Class already declared"}
 	ErrInternal                        = &jsonrpc.Error{Code: jsonrpc.InternalError, Message: "Internal error"}
@@ -177,17 +177,35 @@ func (h *Handler) SpecVersionV0_6() (string, *jsonrpc.Error) {
 	return "0.6.0", nil
 }
 
-func (h *Handler) GetNodesFromRoot(key *felt.Felt) (string, *jsonrpc.Error) {
+func (h *Handler) GetNodesFromRoot(key felt.Felt) (string, *jsonrpc.Error) {
 	// TODO: Implement this method
 	// Implement a new rpc method “juno_getNodesFromRoot(key felt.Felt)” 
 	// that returns the set of nodes from the root to the key for the classes Trie. 
 	// See nodesFromRoot(). Remember to implement tests for the new logic
 
-	// trie :=
-	// key_ := trie.feltToKey(key)
-	// storageNodes, _ := trie.nodesFromRoot(key_)
+	stateReader, _, error := h.bcReader.HeadState()
+	if error != nil {
+		return "", ErrBlockNotFound
+	}
+	trie_ ,_, errTrie := stateReader.GlobalTrie()
+	if errTrie != nil {
+		return "", ErrBlockNotFound
+	}
 
-	return "0x1", nil
+	key_ := trie_.ConvertFeltToKey(&key)
+	storageNodes, err := trie_.GetNodesFromRoot(&key_)
+	if err != nil {
+        return "", ErrBlockNotFound
+    }
+
+	serializableNodes := trie.ConvertToSerializableNodes(storageNodes)
+
+    // Serialize to JSON
+    jsonBytes, err := json.Marshal(serializableNodes)
+    if err != nil {
+        return "", ErrFailedToSerialize
+    }
+	return string(jsonBytes), nil
 }
 
 func (h *Handler) Methods() ([]jsonrpc.Method, string) { //nolint: funlen


### PR DESCRIPTION
Onboarding exercise 5

Implement a new rpc method “juno_getNodesFromRoot(key felt.Felt)” that returns the set of nodes from the root to the key for the classes Trie. See [nodesFromRoot()](https://github.com/NethermindEth/juno/blob/main/core/trie/trie.go#L141). Remember to implement tests for the new logic