### PR TITLE
Implement docs feedback

### DIFF
--- a/cmd/juno/juno.go
+++ b/cmd/juno/juno.go
@@ -163,7 +163,7 @@ const (
 	dbMaxHandlesUsage    = "A soft limit on the number of open files that can be used by the DB"
 	gwAPIKeyUsage        = "API key for gateway endpoints to avoid throttling" //nolint: gosec
 	gwTimeoutUsage       = "Timeout for requests made to the gateway"          //nolint: gosec
-	callMaxStepsUsage    = "Maximum number of steps to be executed in starknet_call requests"
+	callMaxStepsUsage    = "Maximum number of steps to be executed in starknet_call requests. The upper limit is 4 million steps, and any higher value will still be capped at 4 million."
 	corsEnableUsage      = "Enable CORS on RPC endpoints"
 )
 

--- a/docs/docs/_config-options.md
+++ b/docs/docs/_config-options.md
@@ -24,8 +24,8 @@
 | `http-host` | `localhost` | The interface on which the HTTP RPC server will listen for requests |
 | `http-port` | `6060` | The port on which the HTTP server will listen for requests |
 | `log-level` | `info` | Options: trace, debug, info, warn, error |
-| `max-vm-queue` |  | Maximum number for requests to queue after reaching max-vms before starting to reject incoming requests. Default is set to double the value of `max-vms` |
-| `max-vms` |  | Maximum number for VM instances to be used for RPC calls concurrently. Default is set to three times the number of CPU cores |
+| `max-vm-queue` | `2 * max-vms` | Maximum number for requests to queue after reaching max-vms before starting to reject incoming requests |
+| `max-vms` | `3 * CPU Cores` | Maximum number for VM instances to be used for RPC calls concurrently |
 | `metrics` | `false` | Enables the Prometheus metrics endpoint on the default port |
 | `metrics-host` | `localhost` | The interface on which the Prometheus endpoint will listen for requests |
 | `metrics-port` | `9090` | The port on which the Prometheus endpoint will listen for requests |
@@ -40,7 +40,7 @@
 | `pprof-host` | `localhost` | The interface on which the pprof HTTP server will listen for requests |
 | `pprof-port` | `6062` | The port on which the pprof HTTP server will listen for requests |
 | `remote-db` |  | gRPC URL of a remote Juno node |
-| `rpc-call-max-steps` | `4000000` | Maximum number of steps to be executed in starknet_call requests |
+| `rpc-call-max-steps` | `4000000` | Maximum number of steps to be executed in starknet_call requests. The upper limit is 4 million steps, and any higher value will still be capped at 4 million |
 | `rpc-cors-enable` | `false` | Enable CORS on RPC endpoints |
 | `rpc-max-block-scan` | `18446744073709551615` | Maximum number of blocks scanned in single starknet_getEvents call |
 | `ws` | `false` | Enables the WebSocket RPC server on the default port |

--- a/docs/docs/json-rpc.md
+++ b/docs/docs/json-rpc.md
@@ -4,7 +4,7 @@ title: JSON-RPC Interface
 
 # JSON-RPC Interface :globe_with_meridians:
 
-Interacting with Juno requires sending requests to specific JSON-RPC API methods. Juno supports all of [Starknet's Node API Endpoints](https://playground.open-rpc.org/?uiSchema[appBar][ui:splitView]=false&schemaUrl=https://raw.githubusercontent.com/starkware-libs/starknet-specs/master/api/starknet_api_openrpc.json&uiSchema[appBar][ui:input]=false&uiSchema[appBar][ui:darkMode]=true&uiSchema[appBar][ui:examplesDropdown]=false) over HTTP and [WebSocket](websocket).
+Interacting with Juno requires sending requests to specific JSON-RPC API methods. Juno supports all of [Starknet's Node API Endpoints](https://playground.open-rpc.org/?uiSchema%5BappBar%5D%5Bui:splitView%5D=false&schemaUrl=https://raw.githubusercontent.com/starkware-libs/starknet-specs/master/api/starknet_api_openrpc.json&uiSchema%5BappBar%5D%5Bui:input%5D=false&uiSchema%5BappBar%5D%5Bui:darkMode%5D=true&uiSchema%5BappBar%5D%5Bui:examplesDropdown%5D=false) over HTTP and [WebSocket](websocket).
 
 ## Enable the JSON-RPC server
 
@@ -30,7 +30,7 @@ docker run -d \
 
 ## Making JSON-RPC requests
 
-You can use any of [Starknet's Node API Endpoints](https://playground.open-rpc.org/?uiSchema[appBar][ui:splitView]=false&schemaUrl=https://raw.githubusercontent.com/starkware-libs/starknet-specs/master/api/starknet_api_openrpc.json&uiSchema[appBar][ui:input]=false&uiSchema[appBar][ui:darkMode]=true&uiSchema[appBar][ui:examplesDropdown]=false) with Juno. Check the availability of Juno with the `juno_version` method:
+You can use any of [Starknet's Node API Endpoints](https://playground.open-rpc.org/?uiSchema%5BappBar%5D%5Bui:splitView%5D=false&schemaUrl=https://raw.githubusercontent.com/starkware-libs/starknet-specs/master/api/starknet_api_openrpc.json&uiSchema%5BappBar%5D%5Bui:input%5D=false&uiSchema%5BappBar%5D%5Bui:darkMode%5D=true&uiSchema%5BappBar%5D%5Bui:examplesDropdown%5D=false) with Juno. Check the availability of Juno with the `juno_version` method:
 
 ```mdx-code-block
 import Tabs from "@theme/Tabs";

--- a/docs/docs/running-on-gcp.md
+++ b/docs/docs/running-on-gcp.md
@@ -70,3 +70,7 @@ curl --location 'http://localhost:6060' \
 
 </TabItem>
 </Tabs>
+
+:::tip
+To learn how to configure Juno, check out the [Configuring Juno](configuring) guide.
+:::

--- a/docs/docs/updating.md
+++ b/docs/docs/updating.md
@@ -10,6 +10,10 @@ It is important to run the latest version of Juno as each update brings new feat
 - [Standalone binary](#standalone-binary)
 - [Updating from source](#updating-from-source)
 
+:::info
+When running an updated node, use the same `db-path` as before to avoid restarting the sync and use the already synced database.
+:::
+
 ## Docker container
 
 ### 1. Get the latest Docker image

--- a/docs/docs/updating.md
+++ b/docs/docs/updating.md
@@ -78,3 +78,7 @@ make juno
 # Rebuild the Docker image
 docker build -t nethermind/juno:latest .
 ```
+
+:::tip
+To learn how to configure Juno, check out the [Configuring Juno](configuring) guide.
+:::

--- a/docs/docs/websocket.md
+++ b/docs/docs/websocket.md
@@ -4,7 +4,7 @@ title: WebSocket Interface
 
 # WebSocket Interface :globe_with_meridians:
 
-Juno provides a WebSocket RPC interface that supports all of [Starknet's JSON-RPC API](https://github.com/starkware-libs/starknet-specs/blob/master/api/starknet_api_openrpc.json) endpoints and allows you to [subscribe to newly created blocks](#subscribe-to-newly-created-blocks).
+Juno provides a WebSocket RPC interface that supports all of [Starknet's JSON-RPC API](https://playground.open-rpc.org/?uiSchema%5BappBar%5D%5Bui:splitView%5D=false&schemaUrl=https://raw.githubusercontent.com/starkware-libs/starknet-specs/master/api/starknet_api_openrpc.json&uiSchema%5BappBar%5D%5Bui:input%5D=false&uiSchema%5BappBar%5D%5Bui:darkMode%5D=true&uiSchema%5BappBar%5D%5Bui:examplesDropdown%5D=false) endpoints and allows you to [subscribe to newly created blocks](#subscribe-to-newly-created-blocks).
 
 ## Enable the WebSocket server
 
@@ -30,7 +30,7 @@ docker run -d \
 
 ## Making WebSocket requests
 
-You can use any of [Starknet's Node API Endpoints](https://playground.open-rpc.org/?uiSchema[appBar][ui:splitView]=false&schemaUrl=https://raw.githubusercontent.com/starkware-libs/starknet-specs/master/api/starknet_api_openrpc.json&uiSchema[appBar][ui:input]=false&uiSchema[appBar][ui:darkMode]=true&uiSchema[appBar][ui:examplesDropdown]=false) with Juno. Check the availability of Juno with the `juno_version` method:
+You can use any of [Starknet's Node API Endpoints](https://playground.open-rpc.org/?uiSchema%5BappBar%5D%5Bui:splitView%5D=false&schemaUrl=https://raw.githubusercontent.com/starkware-libs/starknet-specs/master/api/starknet_api_openrpc.json&uiSchema%5BappBar%5D%5Bui:input%5D=false&uiSchema%5BappBar%5D%5Bui:darkMode%5D=true&uiSchema%5BappBar%5D%5Bui:examplesDropdown%5D=false) with Juno. Check the availability of Juno with the `juno_version` method:
 
 ```mdx-code-block
 import Tabs from "@theme/Tabs";

--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -53,7 +53,6 @@ const config = {
     [
       "@easyops-cn/docusaurus-search-local",
       {
-        hashed: true,
         highlightSearchTermsOnTargetPage: true,
       },
     ],

--- a/docs/generate-config.js
+++ b/docs/generate-config.js
@@ -74,11 +74,10 @@ const extractConfigs = (codebase) => {
 
       // Additional descriptions based on specific configurations
       if (configName === "max-vms") {
-        description +=
-          ". Default is set to three times the number of CPU cores";
+        defaultValue = "3 * CPU Cores";
       }
       if (configName === "max-vm-queue") {
-        description += ". Default is set to double the value of `max-vms`";
+        defaultValue = "2 * max-vms";
       }
 
       configs.push({

--- a/docs/sidebars.js
+++ b/docs/sidebars.js
@@ -27,7 +27,7 @@ const sidebars = {
         {
           type: "html",
           value:
-            '<a href="https://playground.open-rpc.org/?uiSchema[appBar][ui:splitView]=false&schemaUrl=https://raw.githubusercontent.com/starkware-libs/starknet-specs/master/api/starknet_api_openrpc.json&uiSchema[appBar][ui:input]=false&uiSchema[appBar][ui:darkMode]=true&uiSchema[appBar][ui:examplesDropdown]=false" target="_blank" rel="noopener noreferrer" class="menu__link external-link">Starknet Node API Endpoints&nbsp;<svg width="13.5" height="13.5" aria-hidden="true" viewBox="0 0 24 24" class="iconExternalLink_node_modules-@docusaurus-theme-classic-lib-theme-Icon-ExternalLink-styles-module"><path fill="currentColor" d="M21 13v10h-21v-19h12v2h-10v15h17v-8h2zm3-12h-10.988l4.035 4-6.977 7.07 2.828 2.828 6.977-7.07 4.125 4.172v-11z"></path></svg>',
+            '<a href="https://playground.open-rpc.org/?uiSchema%5BappBar%5D%5Bui:splitView%5D=false&schemaUrl=https://raw.githubusercontent.com/starkware-libs/starknet-specs/master/api/starknet_api_openrpc.json&uiSchema%5BappBar%5D%5Bui:input%5D=false&uiSchema%5BappBar%5D%5Bui:darkMode%5D=true&uiSchema%5BappBar%5D%5Bui:examplesDropdown%5D=false" target="_blank" rel="noopener noreferrer" class="menu__link external-link">Starknet Node API Endpoints&nbsp;<svg width="13.5" height="13.5" aria-hidden="true" viewBox="0 0 24 24" class="iconExternalLink_node_modules-@docusaurus-theme-classic-lib-theme-Icon-ExternalLink-styles-module"><path fill="currentColor" d="M21 13v10h-21v-19h12v2h-10v15h17v-8h2zm3-12h-10.988l4.035 4-6.977 7.07 2.828 2.828 6.977-7.07 4.125 4.172v-11z"></path></svg>',
         },
         {
           type: "html",


### PR DESCRIPTION
Follow up to https://github.com/NethermindEth/juno/pull/1857 and implementing feedback from the initial release:

- [x] Add 4m is the upper limit for `rpc-call-max-steps`
- [x] Add default values for `max-vm-queue` and `max-vms`
- [x] Update the OPEN-RPC playground URL for better presentation in link previews
- [x] Add a note in the updating guide to use the same `db-path` 