### PR TITLE
Update network.go for broken docs link

### DIFF
--- a/utils/network.go
+++ b/utils/network.go
@@ -44,7 +44,7 @@ var (
 	_ pflag.Value              = (*Network)(nil)
 	_ encoding.TextUnmarshaler = (*Network)(nil)
 
-	// The docs states the addresses for each network: https://docs.starknet.io/documentation/useful_info/
+	// The docs states the addresses for each network: https://docs.starknet.io/documentation/tools/important_addresses/
 	Mainnet = Network{
 		Name:                "mainnet",
 		FeederURL:           "https://alpha-mainnet.starknet.io/feeder_gateway/",


### PR DESCRIPTION
The old URL https://docs.starknet.io/documentation/useful_info/ is returning 404 now.
![](https://github.com/NethermindEth/juno/assets/44869693/9d0245b4-186e-482e-ab59-99282bd5d903)

It should be changed to https://docs.starknet.io/documentation/tools/important_addresses/, this PR does this changes.
![](https://github.com/NethermindEth/juno/assets/44869693/00782017-af0c-4bdf-b6b5-aaaa9a155ba5)

By the way, should we remove all Goerli related content too, as starknet states:
> Goerli testnet support is now removed.
