### PR TITLE
Update trace fallback to v0.13.1

### DIFF
--- a/rpc/trace.go
+++ b/rpc/trace.go
@@ -15,7 +15,8 @@ import (
 	"github.com/NethermindEth/juno/vm"
 )
 
-var traceFallbackVersion = semver.MustParse("0.12.3")
+var traceFallbackVersion = semver.MustParse("0.13.1")
+var excludedVersion = "0.13.1.1"
 
 func adaptBlockTrace(block *BlockWithTxs, blockTrace *starknet.BlockTrace) ([]TracedBlockTransaction, error) {
 	if blockTrace == nil {
@@ -198,8 +199,8 @@ func (h *Handler) traceBlockTransactions(ctx context.Context, block *core.Block,
 	if !isPending {
 		if blockVer, err := core.ParseBlockVersion(block.ProtocolVersion); err != nil {
 			return nil, ErrUnexpectedError.CloneWithData(err.Error())
-		} else if blockVer.Compare(traceFallbackVersion) != 1 || h.forceFeederTracesForBlocks.Contains(block.Number) {
-			// version <= 0.12.3 or forcing fetch some blocks from feeder gateway
+		} else if (blockVer.Compare(traceFallbackVersion) != 1 && block.ProtocolVersion != excludedVersion) || h.forceFeederTracesForBlocks.Contains(block.Number) {
+			// version <= 0.13.1 and not 0.13.1.1 or forcing fetch some blocks from feeder gateway
 			return h.fetchTraces(ctx, block.Hash)
 		}
 

--- a/rpc/trace.go
+++ b/rpc/trace.go
@@ -16,7 +16,8 @@ import (
 )
 
 var traceFallbackVersion = semver.MustParse("0.13.1")
-var excludedVersion = "0.13.1.1"
+
+const excludedVersion = "0.13.1.1"
 
 func adaptBlockTrace(block *BlockWithTxs, blockTrace *starknet.BlockTrace) ([]TracedBlockTransaction, error) {
 	if blockTrace == nil {
@@ -199,7 +200,8 @@ func (h *Handler) traceBlockTransactions(ctx context.Context, block *core.Block,
 	if !isPending {
 		if blockVer, err := core.ParseBlockVersion(block.ProtocolVersion); err != nil {
 			return nil, ErrUnexpectedError.CloneWithData(err.Error())
-		} else if (blockVer.Compare(traceFallbackVersion) != 1 && block.ProtocolVersion != excludedVersion) || h.forceFeederTracesForBlocks.Contains(block.Number) {
+		} else if (blockVer.Compare(traceFallbackVersion) != 1 && block.ProtocolVersion != excludedVersion) ||
+			h.forceFeederTracesForBlocks.Contains(block.Number) {
 			// version <= 0.13.1 and not 0.13.1.1 or forcing fetch some blocks from feeder gateway
 			return h.fetchTraces(ctx, block.Hash)
 		}


### PR DESCRIPTION
This PR updates the trace fallback version to v0.13.1 to address discrepancies in transaction traces. Some transactions traced using the buggy blockifier version showed different results due to changes in the blockifier between Starknet v0.13.1 and v0.13.1.1. By updating the fallback version, we aim to ensure consistency in transaction tracing.