### PR TITLE
Skip declare cairo 0 test

### DIFF
--- a/.github/workflows/starknet-rs-tests.yml
+++ b/.github/workflows/starknet-rs-tests.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Run jsonrpc tests
         run: |
           cd starknet-providers && cargo test jsonrpc
-          cd ../starknet-accounts && cargo test jsonrpc
+          cd ../starknet-accounts && cargo test jsonrpc -- --skip can_declare_cairo0_contract_with_jsonrpc
         env:
           STARKNET_RPC: ${{ secrets.STARKNET_RPC }}
           RUST_BACKTRACE: full


### PR DESCRIPTION
This PR skips the `can_declare_cairo0_contract_with_jsonrpc` test because Starknet has disabled Cairo 0 contract declarations (`Declare of cairo 0 is blocked`), causing test suite to fail. Updated the GitHub Actions workflow to skip this failing test.