### PR TITLE
File path support for p2p private key

### DIFF
--- a/cmd/juno/genp2pkeypair.go
+++ b/cmd/juno/genp2pkeypair.go
@@ -3,13 +3,16 @@ package main
 import (
 	"encoding/hex"
 	"fmt"
+	"os"
 
 	"github.com/NethermindEth/juno/p2p"
 	"github.com/spf13/cobra"
 )
 
 func GenP2PKeyPair() *cobra.Command {
-	return &cobra.Command{
+	var filename string
+
+	cmd := &cobra.Command{
 		Use:   "genp2pkeypair",
 		Short: "Generate private key pair for p2p.",
 		RunE: func(cmd *cobra.Command, _ []string) error {
@@ -25,10 +28,6 @@ func GenP2PKeyPair() *cobra.Command {
 
 			privHex := make([]byte, hex.EncodedLen(len(rawPriv)))
 			hex.Encode(privHex, rawPriv)
-			_, err = fmt.Fprintln(cmd.OutOrStdout(), "P2P Private Key:", string(privHex))
-			if err != nil {
-				return err
-			}
 
 			rawPub, err := pub.Raw()
 			if err != nil {
@@ -37,13 +36,28 @@ func GenP2PKeyPair() *cobra.Command {
 
 			pubHex := make([]byte, hex.EncodedLen(len(rawPub)))
 			hex.Encode(pubHex, rawPub)
-			_, err = fmt.Fprintln(cmd.OutOrStdout(), "P2P Public Key:", string(pubHex))
-			if err != nil {
-				return err
-			}
 
-			_, err = fmt.Fprintln(cmd.OutOrStdout(), "P2P PeerID:", id)
+			output := "P2P Private Key: " + string(privHex) + "\n" +
+				"P2P Public Key: " + string(pubHex) + "\n" +
+				"P2P PeerID: " + id.String()
+
+			writeTo := cmd.OutOrStdout()
+			if filename != "" {
+				file, err := os.Create(filename)
+				if err != nil {
+					return err
+				}
+				defer file.Close()
+
+				writeTo = file
+			}
+			fmt.Fprintln(writeTo, output)
+
 			return err
 		},
 	}
+
+	cmd.Flags().StringVarP(&filename, "file", "f", "", "Optional file to write the keys to")
+
+	return cmd
 }

--- a/cmd/juno/juno.go
+++ b/cmd/juno/juno.go
@@ -253,7 +253,7 @@ func NewCmd(config *node.Config, run func(*cobra.Command, []string) error) *cobr
 		v.SetEnvPrefix("JUNO")
 		v.SetEnvKeyReplacer(strings.NewReplacer(".", "_", "-", "_"))
 		if err := v.BindPFlags(cmd.Flags()); err != nil {
-			return nil //nolint:nilerr
+			return nil
 		}
 
 		// TextUnmarshallerHookFunc allows us to unmarshal values that satisfy the

--- a/cmd/juno/juno_test.go
+++ b/cmd/juno/juno_test.go
@@ -2,6 +2,7 @@ package main_test
 
 import (
 	"context"
+	"fmt"
 	"math"
 	"math/big"
 	"os"
@@ -677,6 +678,58 @@ network: sepolia
 func TestGenP2PKeyPair(t *testing.T) {
 	cmd := juno.GenP2PKeyPair()
 	require.NoError(t, cmd.Execute())
+
+	tmpfile, err := os.CreateTemp("", "temp")
+	require.NoError(t, err)
+	cmd.SetArgs([]string{"--file", tmpfile.Name()})
+	require.NoError(t, cmd.Execute())
+}
+
+func TestP2PPrivateKeyFile(t *testing.T) {
+	privateKey := "38c54451f80617955671608da06ed6dd1749d66263103a9118235ab1ea2b3e4503bb86b895e17fc1618359d13e998ca05aa60751b762bf26ac570ac1e575ad81"
+
+	t.Run("private key with formatted message in a file", func(t *testing.T) {
+		tmpfile, err := os.CreateTemp("", "temp")
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer os.Remove(tmpfile.Name())
+
+		content := fmt.Sprintf("P2P Private Key: %s\n", privateKey)
+		if _, err := tmpfile.WriteString(content); err != nil {
+			t.Fatal(err)
+		}
+		if err := tmpfile.Close(); err != nil {
+			t.Fatal(err)
+		}
+
+		config := new(node.Config)
+		cmd := juno.NewCmd(config, func(_ *cobra.Command, _ []string) error { return nil })
+		cmd.SetArgs([]string{"--p2p-private-key-file", tmpfile.Name()})
+		require.NoError(t, cmd.Execute())
+		require.Equal(t, privateKey, config.P2PPrivateKey)
+	})
+
+	t.Run("plain private key in a file", func(t *testing.T) {
+		tmpfile, err := os.CreateTemp("", "temp")
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer os.Remove(tmpfile.Name())
+
+		if _, err := tmpfile.WriteString(privateKey); err != nil {
+			t.Fatal(err)
+		}
+		if err := tmpfile.Close(); err != nil {
+			t.Fatal(err)
+		}
+
+		config := new(node.Config)
+		cmd := juno.NewCmd(config, func(_ *cobra.Command, _ []string) error { return nil })
+		cmd.SetArgs([]string{"--p2p-private-key-file", tmpfile.Name()})
+		require.NoError(t, cmd.Execute())
+		require.Equal(t, privateKey, config.P2PPrivateKey)
+	})
 }
 
 func tempCfgFile(t *testing.T, cfg string) string {


### PR DESCRIPTION
### Description
This PR adds filepath support to two existing P2P-related tools and flags, namely `genp2pkeypair` and `--p2p-private-key`.

### Example
Command: `juno genp2pkeypair --file nodekey`
- This would generate a file containing the key pairs information.
- Note that users can still do `juno genp2pkeypair` just like before.

Command: `juno --p2p-private-key nodekey`
- This would read the private key given in the `nodekey` file.
- Note that users can also just parse the private key (i.e. `juno --p2p-private-key <private-key>`) just like before.
- The content of the file should either be just the private key or contains the "P2P Private Key:" prefix. Examples are shown below:
```
# Example 1: Pure private key
<private-key>

# Example 2: With prefix
P2P Private Key: <private-key>
```

### Rationale
It's more of a UX nicety to allow users to generate key pairs in a file and parse the file to use as a private key, rather than having to copy pasting manually.