### PR TITLE
cmd/juno: add --instance flag

### DIFF
--- a/cmd/juno/juno.go
+++ b/cmd/juno/juno.go
@@ -118,7 +118,7 @@ const (
 	defaultCallMaxSteps             = 4_000_000
 	defaultGwTimeout                = 5 * time.Second
 	defaultCorsEnable               = false
-	defaultInstance                 = 1
+	defaultInstance                 = 0
 	defaultInstanceInc              = 10
 
 	configFlagUsage                       = "The YAML configuration file."
@@ -288,7 +288,7 @@ func NewCmd(config *node.Config, run func(*cobra.Command, []string) error) *cobr
 
 		// Configure ports for multiple instances
 		if config.Instance > defaultInstance {
-			inc := defaultInstanceInc * (config.Instance - defaultInstance)
+			inc := defaultInstanceInc * config.Instance
 			if !v.IsSet(httpPortF) {
 				config.HTTPPort = defaultHTTPPort + inc
 			}

--- a/cmd/juno/juno_test.go
+++ b/cmd/juno/juno_test.go
@@ -65,6 +65,7 @@ func TestConfigPrecedence(t *testing.T) {
 	defaultMaxHandles := 1024
 	defaultCallMaxSteps := uint(4_000_000)
 	defaultGwTimeout := 5 * time.Second
+	defaultInstance := uint16(1)
 
 	tests := map[string]struct {
 		cfgFile         bool
@@ -111,6 +112,7 @@ func TestConfigPrecedence(t *testing.T) {
 				DBMaxHandles:        defaultMaxHandles,
 				RPCCallMaxSteps:     defaultCallMaxSteps,
 				GatewayTimeout:      defaultGwTimeout,
+				Instance:            defaultInstance,
 			},
 		},
 		"custom network config file": {
@@ -156,6 +158,7 @@ cn-unverifiable-range: [0,10]
 				DBMaxHandles:        defaultMaxHandles,
 				RPCCallMaxSteps:     defaultCallMaxSteps,
 				GatewayTimeout:      defaultGwTimeout,
+				Instance:            defaultInstance,
 			},
 		},
 		"default config with no flags": {
@@ -188,6 +191,7 @@ cn-unverifiable-range: [0,10]
 				DBMaxHandles:        defaultMaxHandles,
 				RPCCallMaxSteps:     defaultCallMaxSteps,
 				GatewayTimeout:      defaultGwTimeout,
+				Instance:            defaultInstance,
 			},
 		},
 		"config file path is empty string": {
@@ -220,6 +224,7 @@ cn-unverifiable-range: [0,10]
 				DBMaxHandles:        defaultMaxHandles,
 				RPCCallMaxSteps:     defaultCallMaxSteps,
 				GatewayTimeout:      defaultGwTimeout,
+				Instance:            defaultInstance,
 			},
 		},
 		"config file doesn't exist": {
@@ -257,6 +262,7 @@ cn-unverifiable-range: [0,10]
 				DBMaxHandles:        defaultMaxHandles,
 				RPCCallMaxSteps:     defaultCallMaxSteps,
 				GatewayTimeout:      defaultGwTimeout,
+				Instance:            defaultInstance,
 			},
 		},
 		"config file with all settings but without any other flags": {
@@ -296,6 +302,7 @@ pprof: true
 				DBMaxHandles:        defaultMaxHandles,
 				RPCCallMaxSteps:     defaultCallMaxSteps,
 				GatewayTimeout:      defaultGwTimeout,
+				Instance:            defaultInstance,
 			},
 		},
 		"config file with some settings but without any other flags": {
@@ -332,6 +339,7 @@ http-port: 4576
 				DBMaxHandles:        defaultMaxHandles,
 				RPCCallMaxSteps:     defaultCallMaxSteps,
 				GatewayTimeout:      defaultGwTimeout,
+				Instance:            defaultInstance,
 			},
 		},
 		"all flags without config file": {
@@ -367,6 +375,7 @@ http-port: 4576
 				RPCCallMaxSteps:     defaultCallMaxSteps,
 				GatewayTimeout:      defaultGwTimeout,
 				PendingPollInterval: defaultPendingPollInterval,
+				Instance:            defaultInstance,
 			},
 		},
 		"some flags without config file": {
@@ -402,6 +411,7 @@ http-port: 4576
 				DBMaxHandles:        defaultMaxHandles,
 				RPCCallMaxSteps:     defaultCallMaxSteps,
 				GatewayTimeout:      defaultGwTimeout,
+				Instance:            defaultInstance,
 			},
 		},
 		"all setting set in both config file and flags": {
@@ -461,6 +471,7 @@ db-cache-size: 8
 				DBMaxHandles:        defaultMaxHandles,
 				RPCCallMaxSteps:     defaultCallMaxSteps,
 				GatewayTimeout:      defaultGwTimeout,
+				Instance:            defaultInstance,
 			},
 		},
 		"some setting set in both config file and flags": {
@@ -499,6 +510,7 @@ network: sepolia
 				DBMaxHandles:        defaultMaxHandles,
 				RPCCallMaxSteps:     defaultCallMaxSteps,
 				GatewayTimeout:      defaultGwTimeout,
+				Instance:            defaultInstance,
 			},
 		},
 		"some setting set in default, config file and flags": {
@@ -533,6 +545,7 @@ network: sepolia
 				DBMaxHandles:        defaultMaxHandles,
 				RPCCallMaxSteps:     defaultCallMaxSteps,
 				GatewayTimeout:      defaultGwTimeout,
+				Instance:            defaultInstance,
 			},
 		},
 		"only set env variables": {
@@ -565,6 +578,7 @@ network: sepolia
 				DBMaxHandles:        defaultMaxHandles,
 				RPCCallMaxSteps:     defaultCallMaxSteps,
 				GatewayTimeout:      defaultGwTimeout,
+				Instance:            defaultInstance,
 			},
 		},
 		"some setting set in both env variables and flags": {
@@ -598,6 +612,7 @@ network: sepolia
 				DBMaxHandles:        defaultMaxHandles,
 				RPCCallMaxSteps:     defaultCallMaxSteps,
 				GatewayTimeout:      defaultGwTimeout,
+				Instance:            defaultInstance,
 			},
 		},
 		"some setting set in both env variables and config file": {
@@ -632,6 +647,7 @@ network: sepolia
 				DBMaxHandles:        defaultMaxHandles,
 				RPCCallMaxSteps:     defaultCallMaxSteps,
 				GatewayTimeout:      defaultGwTimeout,
+				Instance:            defaultInstance,
 			},
 		},
 	}
@@ -678,6 +694,152 @@ network: sepolia
 func TestGenP2PKeyPair(t *testing.T) {
 	cmd := juno.GenP2PKeyPair()
 	require.NoError(t, cmd.Execute())
+}
+
+func TestInstance(t *testing.T) {
+	type ports struct {
+		HTTPPort      uint16
+		WebsocketPort uint16
+		GRPCPort      uint16
+		MetricsPort   uint16
+		PprofPort     uint16
+	}
+
+	tests := map[string]struct {
+		cfgFile         bool
+		cfgFileContents string
+		env             []string
+		inputArgs       []string
+		expectedPorts   *ports
+	}{
+		"default instance on flag": {
+			inputArgs: []string{"--instance", "1"},
+			expectedPorts: &ports{
+				HTTPPort:      6060,
+				WebsocketPort: 6061,
+				GRPCPort:      6064,
+				MetricsPort:   9090,
+				PprofPort:     6062,
+			},
+		},
+		"instance 2 on flag": {
+			inputArgs: []string{"--instance", "2"},
+			expectedPorts: &ports{
+				HTTPPort:      6070,
+				WebsocketPort: 6071,
+				GRPCPort:      6074,
+				MetricsPort:   9100,
+				PprofPort:     6072,
+			},
+		},
+		"instance 2 on config": {
+			cfgFile:         true,
+			cfgFileContents: `instance: 2`,
+			expectedPorts: &ports{
+				HTTPPort:      6070,
+				WebsocketPort: 6071,
+				GRPCPort:      6074,
+				MetricsPort:   9100,
+				PprofPort:     6072,
+			},
+		},
+		"instance 2 on env": {
+			env: []string{"JUNO_INSTANCE", "2"},
+			expectedPorts: &ports{
+				HTTPPort:      6070,
+				WebsocketPort: 6071,
+				GRPCPort:      6074,
+				MetricsPort:   9100,
+				PprofPort:     6072,
+			},
+		},
+		"instance 2 on flag with ports override": {
+			inputArgs: []string{"--instance", "2", "--http-port", "8080", "--ws-port", "8081", "--grpc-port", "8084", "--metrics-port", "10000", "--pprof-port", "8082"},
+			expectedPorts: &ports{
+				HTTPPort:      8080,
+				WebsocketPort: 8081,
+				GRPCPort:      8084,
+				MetricsPort:   10000,
+				PprofPort:     8082,
+			},
+		},
+		"instance 2 on config with ports override": {
+			cfgFile: true,
+			cfgFileContents: `instance: 2
+http-port: 8080
+ws-port: 8081
+grpc-port: 8084
+metrics-port: 10000
+pprof-port: 8082`,
+			expectedPorts: &ports{
+				HTTPPort:      8080,
+				WebsocketPort: 8081,
+				GRPCPort:      8084,
+				MetricsPort:   10000,
+				PprofPort:     8082,
+			},
+		},
+		"instance 2 on env with ports override": {
+			env: []string{"JUNO_INSTANCE", "2", "JUNO_HTTP_PORT", "8080", "JUNO_WS_PORT", "8081", "JUNO_GRPC_PORT", "8084", "JUNO_METRICS_PORT", "10000", "JUNO_PPROF_PORT", "8082"},
+			expectedPorts: &ports{
+				HTTPPort:      8080,
+				WebsocketPort: 8081,
+				GRPCPort:      8084,
+				MetricsPort:   10000,
+				PprofPort:     8082,
+			},
+		},
+		"instance 2 with a mix of flags, config and env": {
+			cfgFile:         true,
+			cfgFileContents: `grpc-port: 8084`,
+			inputArgs:       []string{"--instance", "2", "--http-port", "8083"},
+			env:             []string{"JUNO_INSTANCE", "2", "JUNO_WS_PORT", "8088"},
+			expectedPorts: &ports{
+				HTTPPort:      8083,
+				WebsocketPort: 8088,
+				GRPCPort:      8084,
+				MetricsPort:   9100,
+				PprofPort:     6072,
+			},
+		},
+	}
+
+	junoEnv := unsetJunoPrefixedEnv(t)
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			if tc.cfgFile {
+				fileN := tempCfgFile(t, tc.cfgFileContents)
+				tc.inputArgs = append(tc.inputArgs, "--config", fileN)
+			}
+
+			require.True(t, len(tc.env)%2 == 0, "The number of env variables should be an even number")
+
+			if len(tc.env) > 0 {
+				for i := 0; i < len(tc.env)/2; i++ {
+					require.NoError(t, os.Setenv(tc.env[2*i], tc.env[2*i+1]))
+				}
+			}
+
+			config := new(node.Config)
+			cmd := juno.NewCmd(config, func(_ *cobra.Command, _ []string) error { return nil })
+			cmd.SetArgs(tc.inputArgs)
+			require.NoError(t, cmd.Execute())
+
+			assert.Equal(t, tc.expectedPorts.HTTPPort, config.HTTPPort)
+			assert.Equal(t, tc.expectedPorts.WebsocketPort, config.WebsocketPort)
+			assert.Equal(t, tc.expectedPorts.GRPCPort, config.GRPCPort)
+			assert.Equal(t, tc.expectedPorts.MetricsPort, config.MetricsPort)
+			assert.Equal(t, tc.expectedPorts.PprofPort, config.PprofPort)
+
+			if len(tc.env) > 0 {
+				for i := 0; i < len(tc.env)/2; i++ {
+					require.NoError(t, os.Unsetenv(tc.env[2*i]))
+				}
+			}
+		})
+	}
+	setJunoPrefixedEnv(t, junoEnv)
 }
 
 func tempCfgFile(t *testing.T, cfg string) string {

--- a/cmd/juno/juno_test.go
+++ b/cmd/juno/juno_test.go
@@ -65,7 +65,7 @@ func TestConfigPrecedence(t *testing.T) {
 	defaultMaxHandles := 1024
 	defaultCallMaxSteps := uint(4_000_000)
 	defaultGwTimeout := 5 * time.Second
-	defaultInstance := uint16(1)
+	defaultInstance := uint16(0)
 
 	tests := map[string]struct {
 		cfgFile         bool
@@ -713,7 +713,7 @@ func TestInstance(t *testing.T) {
 		expectedPorts   *ports
 	}{
 		"default instance on flag": {
-			inputArgs: []string{"--instance", "1"},
+			inputArgs: []string{"--instance", "0"},
 			expectedPorts: &ports{
 				HTTPPort:      6060,
 				WebsocketPort: 6061,
@@ -722,8 +722,8 @@ func TestInstance(t *testing.T) {
 				PprofPort:     6062,
 			},
 		},
-		"instance 2 on flag": {
-			inputArgs: []string{"--instance", "2"},
+		"instance 1 on flag": {
+			inputArgs: []string{"--instance", "1"},
 			expectedPorts: &ports{
 				HTTPPort:      6070,
 				WebsocketPort: 6071,
@@ -732,9 +732,9 @@ func TestInstance(t *testing.T) {
 				PprofPort:     6072,
 			},
 		},
-		"instance 2 on config": {
+		"instance 1 on config": {
 			cfgFile:         true,
-			cfgFileContents: `instance: 2`,
+			cfgFileContents: `instance: 1`,
 			expectedPorts: &ports{
 				HTTPPort:      6070,
 				WebsocketPort: 6071,
@@ -743,8 +743,8 @@ func TestInstance(t *testing.T) {
 				PprofPort:     6072,
 			},
 		},
-		"instance 2 on env": {
-			env: []string{"JUNO_INSTANCE", "2"},
+		"instance 1 on env": {
+			env: []string{"JUNO_INSTANCE", "1"},
 			expectedPorts: &ports{
 				HTTPPort:      6070,
 				WebsocketPort: 6071,
@@ -753,8 +753,8 @@ func TestInstance(t *testing.T) {
 				PprofPort:     6072,
 			},
 		},
-		"instance 2 on flag with ports override": {
-			inputArgs: []string{"--instance", "2", "--http-port", "8080", "--ws-port", "8081", "--grpc-port", "8084", "--metrics-port", "10000", "--pprof-port", "8082"},
+		"instance 1 on flag with ports override": {
+			inputArgs: []string{"--instance", "1", "--http-port", "8080", "--ws-port", "8081", "--grpc-port", "8084", "--metrics-port", "10000", "--pprof-port", "8082"},
 			expectedPorts: &ports{
 				HTTPPort:      8080,
 				WebsocketPort: 8081,
@@ -763,9 +763,9 @@ func TestInstance(t *testing.T) {
 				PprofPort:     8082,
 			},
 		},
-		"instance 2 on config with ports override": {
+		"instance 1 on config with ports override": {
 			cfgFile: true,
-			cfgFileContents: `instance: 2
+			cfgFileContents: `instance: 1
 http-port: 8080
 ws-port: 8081
 grpc-port: 8084
@@ -779,8 +779,8 @@ pprof-port: 8082`,
 				PprofPort:     8082,
 			},
 		},
-		"instance 2 on env with ports override": {
-			env: []string{"JUNO_INSTANCE", "2", "JUNO_HTTP_PORT", "8080", "JUNO_WS_PORT", "8081", "JUNO_GRPC_PORT", "8084", "JUNO_METRICS_PORT", "10000", "JUNO_PPROF_PORT", "8082"},
+		"instance 1 on env with ports override": {
+			env: []string{"JUNO_INSTANCE", "1", "JUNO_HTTP_PORT", "8080", "JUNO_WS_PORT", "8081", "JUNO_GRPC_PORT", "8084", "JUNO_METRICS_PORT", "10000", "JUNO_PPROF_PORT", "8082"},
 			expectedPorts: &ports{
 				HTTPPort:      8080,
 				WebsocketPort: 8081,
@@ -789,10 +789,10 @@ pprof-port: 8082`,
 				PprofPort:     8082,
 			},
 		},
-		"instance 2 with a mix of flags, config and env": {
+		"instance 1 with a mix of flags, config and env": {
 			cfgFile:         true,
 			cfgFileContents: `grpc-port: 8084`,
-			inputArgs:       []string{"--instance", "2", "--http-port", "8083"},
+			inputArgs:       []string{"--instance", "1", "--http-port", "8083"},
 			env:             []string{"JUNO_INSTANCE", "2", "JUNO_WS_PORT", "8088"},
 			expectedPorts: &ports{
 				HTTPPort:      8083,

--- a/node/node.go
+++ b/node/node.go
@@ -64,6 +64,7 @@ type Config struct {
 	Colour              bool           `mapstructure:"colour"`
 	PendingPollInterval time.Duration  `mapstructure:"pending-poll-interval"`
 	RemoteDB            string         `mapstructure:"remote-db"`
+	Instance            uint16         `mapstructure:"instance"`
 
 	Metrics     bool   `mapstructure:"metrics"`
 	MetricsHost string `mapstructure:"metrics-host"`


### PR DESCRIPTION
### Description
This PR adds a new flag called `--instance` to initialize port numbers automatically based on the instance count. This flag affects the following ports:
- `http-port`
- `grpc-port`
- `metrics-port`
- `pprof-port`
- `ws-port` 

### Example
Each instance count will increment the default value of the respective ports by 10. For example:

The default value of each port is as follows:
- `grpc-port` = 6064
- `http-port` = 6060
- `metrics-port` = 9090
- `pprof-port` = 6062
- `ws-port` = 6061

Command: `./juno --instance 2`
Then the ports would have the following numbers:
- `grpc-port` = 6074
- `http-port` = 6070
- `metrics-port` = 9100
- `pprof-port` = 6072
- `ws-port` = 6071

### Rationale
This feature is useful for initializing multiple instances of Juno nodes, without having to care for the port conflict issues. 