### PR TITLE
node: include semantic version in agent version

### DIFF
--- a/node/node.go
+++ b/node/node.go
@@ -7,6 +7,7 @@ import (
 	"net/url"
 	"reflect"
 	"runtime"
+	"strings"
 	"time"
 
 	"github.com/Masterminds/semver/v3"
@@ -40,6 +41,7 @@ const (
 	upgraderDelay    = 5 * time.Minute
 	githubAPIUrl     = "https://api.github.com/repos/NethermindEth/juno/releases/latest"
 	latestReleaseURL = "https://github.com/NethermindEth/juno/releases/latest"
+	clientName       = "juno"
 )
 
 // Config is the top-level juno configuration.
@@ -160,7 +162,8 @@ func New(cfg *Config, version string) (*Node, error) { //nolint:gocyclo,funlen
 			// Do not start the feeder synchronisation
 			synchronizer = nil
 		}
-		p2pService, err = p2p.New(cfg.P2PAddr, "juno", cfg.P2PPeers, cfg.P2PPrivateKey, cfg.P2PFeederNode,
+		agentVersion := clientName + "/" + parseVersion(version, log)
+		p2pService, err = p2p.New(cfg.P2PAddr, agentVersion, cfg.P2PPeers, cfg.P2PPrivateKey, cfg.P2PFeederNode,
 			chain, &cfg.Network, log, database)
 		if err != nil {
 			return nil, fmt.Errorf("set up p2p service: %w", err)
@@ -363,4 +366,13 @@ func (n *Node) Run(ctx context.Context) {
 
 func (n *Node) Config() Config {
 	return *n.cfg
+}
+
+func parseVersion(version string, log *utils.ZapLogger) string {
+	semVer, err := semver.NewVersion(version)
+	if err != nil {
+		log.Warnw("Failed to parse Juno version", "version", version, "err", err)
+		return "0.0.0"
+	}
+	return strings.Split(semVer.String(), "-")[0]
 }

--- a/node/node.go
+++ b/node/node.go
@@ -7,7 +7,6 @@ import (
 	"net/url"
 	"reflect"
 	"runtime"
-	"strings"
 	"time"
 
 	"github.com/Masterminds/semver/v3"
@@ -41,7 +40,6 @@ const (
 	upgraderDelay    = 5 * time.Minute
 	githubAPIUrl     = "https://api.github.com/repos/NethermindEth/juno/releases/latest"
 	latestReleaseURL = "https://github.com/NethermindEth/juno/releases/latest"
-	clientName       = "juno"
 )
 
 // Config is the top-level juno configuration.
@@ -162,8 +160,7 @@ func New(cfg *Config, version string) (*Node, error) { //nolint:gocyclo,funlen
 			// Do not start the feeder synchronisation
 			synchronizer = nil
 		}
-		agentVersion := clientName + "/" + parseVersion(version, log)
-		p2pService, err = p2p.New(cfg.P2PAddr, agentVersion, cfg.P2PPeers, cfg.P2PPrivateKey, cfg.P2PFeederNode,
+		p2pService, err = p2p.New(cfg.P2PAddr, version, cfg.P2PPeers, cfg.P2PPrivateKey, cfg.P2PFeederNode,
 			chain, &cfg.Network, log, database)
 		if err != nil {
 			return nil, fmt.Errorf("set up p2p service: %w", err)
@@ -366,13 +363,4 @@ func (n *Node) Run(ctx context.Context) {
 
 func (n *Node) Config() Config {
 	return *n.cfg
-}
-
-func parseVersion(version string, log *utils.ZapLogger) string {
-	semVer, err := semver.NewVersion(version)
-	if err != nil {
-		log.Warnw("Failed to parse Juno version", "version", version, "err", err)
-		return "0.0.0"
-	}
-	return strings.Split(semVer.String(), "-")[0]
 }

--- a/p2p/p2p.go
+++ b/p2p/p2p.go
@@ -441,8 +441,8 @@ func makeAgentName(version string) string {
 	modVer := "0.0.0"
 	semVer, err := semver.NewVersion(version)
 	if err == nil {
-		modVer = strings.Split(semVer.String(), "-")[0]
+		modVer = fmt.Sprintf("%d.%d.%d", semVer.Major(), semVer.Minor(), semVer.Patch())
 	}
 
-	return clientName + "/" + modVer
+	return fmt.Sprintf("%s/%s", clientName, modVer)
 }

--- a/p2p/p2p.go
+++ b/p2p/p2p.go
@@ -10,6 +10,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/Masterminds/semver/v3"
 	"github.com/NethermindEth/juno/blockchain"
 	"github.com/NethermindEth/juno/db"
 	"github.com/NethermindEth/juno/p2p/starknet"
@@ -32,6 +33,7 @@ import (
 const (
 	keyLength                 = 2048
 	routingTableRefreshPeriod = 1 * time.Second
+	clientName                = "juno"
 )
 
 type Service struct {
@@ -52,7 +54,7 @@ type Service struct {
 	database   db.DB
 }
 
-func New(addr, userAgent, peers, privKeyStr string, feederNode bool, bc *blockchain.Blockchain, snNetwork *utils.Network,
+func New(addr, version, peers, privKeyStr string, feederNode bool, bc *blockchain.Blockchain, snNetwork *utils.Network,
 	log utils.SimpleLogger, database db.DB,
 ) (*Service, error) {
 	if addr == "" {
@@ -69,7 +71,7 @@ func New(addr, userAgent, peers, privKeyStr string, feederNode bool, bc *blockch
 		return nil, err
 	}
 
-	p2pHost, err := libp2p.New(libp2p.ListenAddrs(sourceMultiAddr), libp2p.Identity(prvKey), libp2p.UserAgent(userAgent))
+	p2pHost, err := libp2p.New(libp2p.ListenAddrs(sourceMultiAddr), libp2p.Identity(prvKey), libp2p.UserAgent(makeAgentName(version)))
 	if err != nil {
 		return nil, err
 	}
@@ -433,4 +435,14 @@ func loadPeers(database db.DB) ([]peer.AddrInfo, error) {
 	}
 
 	return peers, nil
+}
+
+func makeAgentName(version string) string {
+	modVer := "0.0.0"
+	semVer, err := semver.NewVersion(version)
+	if err == nil {
+		modVer = strings.Split(semVer.String(), "-")[0]
+	}
+
+	return clientName + "/" + modVer
 }


### PR DESCRIPTION
This PR adds the semantic version of the node to the user agent version such that it follows the appropriate format, as shown in the [Starknet P2P specifications](https://github.com/starknet-io/starknet-p2p-specs/blob/main/p2p/starknet-p2p.md#identifying-nodes).

**Before**: `juno`
**After**: `juno/<semantic-version>`