### PR TITLE
TestTransaction - Remove Goerli

### DIFF
--- a/adapters/sn2core/sn2core_test.go
+++ b/adapters/sn2core/sn2core_test.go
@@ -263,13 +263,13 @@ func TestClassV0(t *testing.T) {
 }
 
 func TestTransaction(t *testing.T) {
-	clientGoerli := feeder.NewTestClient(t, &utils.Goerli)
+	clientSepolia := feeder.NewTestClient(t, &utils.Sepolia)
 	clientMainnet := feeder.NewTestClient(t, &utils.Mainnet)
 	ctx := context.Background()
 
 	t.Run("invoke transaction", func(t *testing.T) {
-		hash := utils.HexToFelt(t, "0x7e3a229febf47c6edfd96582d9476dd91a58a5ba3df4553ae448a14a2f132d9")
-		response, err := clientGoerli.Transaction(ctx, hash)
+		hash := utils.HexToFelt(t, "0x33010b2dd27dc2abf6cf36269c00e054ceecd3b1452c29764230af228df823")
+		response, err := clientSepolia.Transaction(ctx, hash)
 		require.NoError(t, err)
 		responseTx := response.Transaction
 
@@ -290,8 +290,8 @@ func TestTransaction(t *testing.T) {
 	})
 
 	t.Run("deploy transaction", func(t *testing.T) {
-		hash := utils.HexToFelt(t, "0x15b51c2f4880b1e7492d30ada7254fc59c09adde636f37eb08cdadbd9dabebb")
-		response, err := clientGoerli.Transaction(ctx, hash)
+		hash := utils.HexToFelt(t, "0x6d3e06989ee2245139cd677f59b4da7f360a27b2b614a4eb088fdf5862d23ee")
+		response, err := clientMainnet.Transaction(ctx, hash)
 		require.NoError(t, err)
 		responseTx := response.Transaction
 
@@ -333,8 +333,8 @@ func TestTransaction(t *testing.T) {
 	})
 
 	t.Run("declare transaction", func(t *testing.T) {
-		hash := utils.HexToFelt(t, "0x6eab8252abfc9bbfd72c8d592dde4018d07ce467c5ce922519d7142fcab203f")
-		response, err := clientGoerli.Transaction(ctx, hash)
+		hash := utils.HexToFelt(t, "0x32538718071ad83ccd09fca03fe3a17add776ec12002d1c4e16ad4b92ddf752")
+		response, err := clientSepolia.Transaction(ctx, hash)
 		require.NoError(t, err)
 		responseTx := response.Transaction
 

--- a/clients/feeder/testdata/sepolia/transaction/0x32538718071ad83ccd09fca03fe3a17add776ec12002d1c4e16ad4b92ddf752.json
+++ b/clients/feeder/testdata/sepolia/transaction/0x32538718071ad83ccd09fca03fe3a17add776ec12002d1c4e16ad4b92ddf752.json
@@ -1,0 +1,18 @@
+{
+    "execution_status": "SUCCEEDED",
+    "finality_status": "ACCEPTED_ON_L1",
+    "status": "ACCEPTED_ON_L1",
+    "block_hash": "0x5c627d4aeb51280058bed93c7889bce78114d63baad1be0f0aeb32496d5f19c",
+    "block_number": 0,
+    "transaction_index": 1,
+    "transaction": {
+        "transaction_hash": "0x32538718071ad83ccd09fca03fe3a17add776ec12002d1c4e16ad4b92ddf752",
+        "version": "0x0",
+        "max_fee": "0x0",
+        "signature": [],
+        "nonce": "0x0",
+        "class_hash": "0xd0e183745e9dae3e4e78a8ffedcce0903fc4900beace4e0abf192d4c202da3",
+        "sender_address": "0x1",
+        "type": "DECLARE"
+    }
+}

--- a/clients/feeder/testdata/sepolia/transaction/0x33010b2dd27dc2abf6cf36269c00e054ceecd3b1452c29764230af228df823.json
+++ b/clients/feeder/testdata/sepolia/transaction/0x33010b2dd27dc2abf6cf36269c00e054ceecd3b1452c29764230af228df823.json
@@ -1,0 +1,30 @@
+{
+    "execution_status": "SUCCEEDED",
+    "finality_status": "ACCEPTED_ON_L2",
+    "status": "ACCEPTED_ON_L2",
+    "block_hash": "0x2c5cc464d833b36f859be81245a35add12d767909dcff7a6c6989112a75caf1",
+    "block_number": 75101,
+    "transaction_index": 45,
+    "transaction": {
+        "transaction_hash": "0x33010b2dd27dc2abf6cf36269c00e054ceecd3b1452c29764230af228df823",
+        "version": "0x1",
+        "max_fee": "0x4dfc0e9b8be",
+        "signature": [
+            "0x1",
+            "0x5fa8164b77e4caf3e724ab15204f577b584ecb2ebb405a006ee7d36121ef142",
+            "0x5ec11452c5cf4094e0a2502531f2342d29ac3d2b4d2819d182c25346f5fba91"
+        ],
+        "nonce": "0x24",
+        "sender_address": "0x13cb9710d0f06e6548ac58b5d9d8299803eb3ceac3813cb4daf78c6fbd1ba3a",
+        "calldata": [
+            "0x1",
+            "0x5f3efe0b4493cd63bafb010fdcfcd58264d6f5aeed3a3fcac39870786ee406c",
+            "0x219209e083275171774dab1df80982e9df2096516f06319c5c6d71ae0a8480c",
+            "0x3",
+            "0x5036543fe098a2fdc3d8d7bfd2bdfed5388ea8dd2d1f1beb8367594a5038c5f",
+            "0x1b1ae4d6e2ef500000",
+            "0x0"
+        ],
+        "type": "INVOKE_FUNCTION"
+    }
+}

--- a/starknetdata/feeder/feeder_test.go
+++ b/starknetdata/feeder/feeder_test.go
@@ -104,8 +104,8 @@ func TestClassV0(t *testing.T) {
 }
 
 func TestTransaction(t *testing.T) {
-	clientGoerli := feeder.NewTestClient(t, &utils.Goerli)
-	adapterGoerli := adaptfeeder.New(clientGoerli)
+	clientSepolia := feeder.NewTestClient(t, &utils.Sepolia)
+	adapterSepolia := adaptfeeder.New(clientSepolia)
 
 	clientMainnet := feeder.NewTestClient(t, &utils.Mainnet)
 	adapterMainnet := adaptfeeder.New(clientMainnet)
@@ -113,12 +113,12 @@ func TestTransaction(t *testing.T) {
 	ctx := context.Background()
 
 	t.Run("invoke transaction", func(t *testing.T) {
-		hash := utils.HexToFelt(t, "0x7e3a229febf47c6edfd96582d9476dd91a58a5ba3df4553ae448a14a2f132d9")
-		response, err := clientGoerli.Transaction(ctx, hash)
+		hash := utils.HexToFelt(t, "0x33010b2dd27dc2abf6cf36269c00e054ceecd3b1452c29764230af228df823")
+		response, err := clientSepolia.Transaction(ctx, hash)
 		require.NoError(t, err)
 		responseTx := response.Transaction
 
-		txn, err := adapterGoerli.Transaction(ctx, hash)
+		txn, err := adapterSepolia.Transaction(ctx, hash)
 		require.NoError(t, err)
 		invokeTx, ok := txn.(*core.InvokeTransaction)
 		require.True(t, ok)
@@ -126,12 +126,12 @@ func TestTransaction(t *testing.T) {
 	})
 
 	t.Run("deploy transaction", func(t *testing.T) {
-		hash := utils.HexToFelt(t, "0x15b51c2f4880b1e7492d30ada7254fc59c09adde636f37eb08cdadbd9dabebb")
-		response, err := clientGoerli.Transaction(ctx, hash)
+		hash := utils.HexToFelt(t, "0x6d3e06989ee2245139cd677f59b4da7f360a27b2b614a4eb088fdf5862d23ee")
+		response, err := clientMainnet.Transaction(ctx, hash)
 		require.NoError(t, err)
 		responseTx := response.Transaction
 
-		txn, err := adapterGoerli.Transaction(ctx, hash)
+		txn, err := adapterMainnet.Transaction(ctx, hash)
 		require.NoError(t, err)
 		deployTx, ok := txn.(*core.DeployTransaction)
 		require.True(t, ok)
@@ -152,12 +152,12 @@ func TestTransaction(t *testing.T) {
 	})
 
 	t.Run("declare transaction", func(t *testing.T) {
-		hash := utils.HexToFelt(t, "0x6eab8252abfc9bbfd72c8d592dde4018d07ce467c5ce922519d7142fcab203f")
-		response, err := clientGoerli.Transaction(ctx, hash)
+		hash := utils.HexToFelt(t, "0x32538718071ad83ccd09fca03fe3a17add776ec12002d1c4e16ad4b92ddf752")
+		response, err := clientSepolia.Transaction(ctx, hash)
 		require.NoError(t, err)
 		responseTx := response.Transaction
 
-		txn, err := adapterGoerli.Transaction(ctx, hash)
+		txn, err := adapterSepolia.Transaction(ctx, hash)
 		require.NoError(t, err)
 		declareTx, ok := txn.(*core.DeclareTransaction)
 		require.True(t, ok)


### PR DESCRIPTION
This is a sub-task to the issue #1758 that concerns the `TestTransaction` test. The test is using the Goerli network and therefore needs to be updated to use the Sepolia network instead. I added 2 transactions from Sepolia network to `clients/feeder/testdata/sepolia/transaction`.