### PR TITLE
Send docker images to artifactory

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -13,8 +13,7 @@ permissions:
 jobs:
   docker_build_and_publish:
     runs-on: ubuntu-latest
-    outputs:
-      IMAGE_TAG: ${{ steps.image_tag.outputs.IMAGE_TAG }}
+
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -22,10 +21,8 @@ jobs:
           fetch-depth: 0
 
       - name: Define_docker_image_tag
-        id: image_tag
         run: |
           echo "DOCKER_IMAGE_TAG=$(git describe --tags)" >> $GITHUB_ENV
-          echo "IMAGE_TAG=$(git describe --tags)" >> "$GITHUB_OUTPUT"
 
       - name: Setup Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -57,7 +54,6 @@ jobs:
       - name: Repository Dispatch Dev
         env:
           EVENT_NAME: juno-dev
-          IMAGE_TAG: ${{ needs.docker_build_and_publish.outputs.IMAGE_TAG }}
           SEPOLIA: apps/juno-dev/overlays/dev-sepolia/config.yaml
         run: |
           curl -L \
@@ -66,10 +62,10 @@ jobs:
           -H "Authorization: token ${{ secrets.ACCESS_TOKEN }}" \
           -H "X-GitHub-Api-Version: 2022-11-28" \
           https://api.github.com/repos/NethermindEth/argo/dispatches \
-          -d '{"event_type": "${{ env.EVENT_NAME }}", "client_payload":{"name": "${{ env.EVENT_NAME }}", "sepolia_config": "${{ env.SEPOLIA }}", "tag": "${{ env.IMAGE_TAG }}"}}'
+          -d '{"event_type": "${{ env.EVENT_NAME }}", "client_payload":{"name": "${{ env.EVENT_NAME }}", "sepolia_config": "${{ env.SEPOLIA }}", "tag": "${{ env.DOCKER_IMAGE_TAG }}"}}'
 
       - name: Verify Deployment Version (Dev)
-        run: bash .github/workflow-scripts/verify_deployment.sh ${{ secrets.DEV_SEPOLIA_URL }} ${{ needs.docker_build_and_publish.outputs.IMAGE_TAG }}
+        run: bash .github/workflow-scripts/verify_deployment.sh ${{ secrets.DEV_SEPOLIA_URL }} ${{ env.DOCKER_IMAGE_TAG }}
 
   dev-starknet-rs-tests:
     needs: [deploy_to_dev]
@@ -97,7 +93,6 @@ jobs:
       - name: Repository Dispatch Staging
         env:
           EVENT_NAME: juno-staging
-          IMAGE_TAG: ${{ needs.docker_build_and_publish.outputs.IMAGE_TAG }}
           MAINNET: apps/juno-staging/overlays/staging-mainnet/config.yaml
           SEPOLIA: apps/juno-staging/overlays/staging-sepolia/config.yaml
           SEPOLIA_INTEGRATION: apps/juno-staging/overlays/staging-sepolia-integration/config.yaml
@@ -108,10 +103,10 @@ jobs:
           -H "Authorization: token ${{ secrets.ACCESS_TOKEN }}" \
           -H "X-GitHub-Api-Version: 2022-11-28" \
           https://api.github.com/repos/NethermindEth/argo/dispatches \
-          -d '{"event_type": "${{ env.EVENT_NAME }}", "client_payload":{"name": "${{ env.EVENT_NAME }}", "mainnet_config": "${{ env.MAINNET }}", "sepolia_config": "${{ env.SEPOLIA }}", "sepolia_integration_config": "${{ env.SEPOLIA_INTEGRATION}}", "tag": "${{ env.IMAGE_TAG }}"}}'
+          -d '{"event_type": "${{ env.EVENT_NAME }}", "client_payload":{"name": "${{ env.EVENT_NAME }}", "mainnet_config": "${{ env.MAINNET }}", "sepolia_config": "${{ env.SEPOLIA }}", "sepolia_integration_config": "${{ env.SEPOLIA_INTEGRATION}}", "tag": "${{ env.DOCKER_IMAGE_TAG }}"}}'
 
       - name: Verify Deployment Version (Staging)
-        run: bash .github/workflow-scripts/verify_deployment.sh ${{ secrets.STAGING_SEPOLIA_URL }} ${{ needs.docker_build_and_publish.outputs.IMAGE_TAG }}
+        run: bash .github/workflow-scripts/verify_deployment.sh ${{ secrets.STAGING_SEPOLIA_URL }} ${{ env.DOCKER_IMAGE_TAG }}
 
   staging-starknet-rs-tests:
     needs: [deploy_to_staging]
@@ -136,7 +131,6 @@ jobs:
       - name: Repository Dispatch Prod
         env:
           EVENT_NAME: juno-prod
-          IMAGE_TAG: ${{ needs.docker_build_and_publish.outputs.IMAGE_TAG }}
           MAINNET: apps/juno-prod/overlays/prod-mainnet/config.yaml
           SEPOLIA: apps/juno-prod/overlays/prod-sepolia/config.yaml
           SEPOLIA_INTEGRATION: apps/juno-prod/overlays/prod-sepolia-integration/config.yaml
@@ -147,7 +141,7 @@ jobs:
           -H "Authorization: token ${{ secrets.ACCESS_TOKEN }}" \
           -H "X-GitHub-Api-Version: 2022-11-28" \
           https://api.github.com/repos/NethermindEth/argo/dispatches \
-          -d '{"event_type": "${{ env.EVENT_NAME }}", "client_payload":{"name": "${{ env.EVENT_NAME }}", "mainnet_config": "${{ env.MAINNET }}", "sepolia_config": "${{ env.SEPOLIA }}", "sepolia_integration_config": "${{ env.SEPOLIA_INTEGRATION }}", "tag": "${{ env.IMAGE_TAG }}"}}'
+          -d '{"event_type": "${{ env.EVENT_NAME }}", "client_payload":{"name": "${{ env.EVENT_NAME }}", "mainnet_config": "${{ env.MAINNET }}", "sepolia_config": "${{ env.SEPOLIA }}", "sepolia_integration_config": "${{ env.SEPOLIA_INTEGRATION }}", "tag": "${{ env.DOCKER_IMAGE_TAG }}"}}'
 
   prod-starknet-rs-tests:
     needs: [deploy_to_production]

--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -11,7 +11,7 @@ permissions:
   contents: write
 
 jobs:
-  docker_build_and_publish:
+  build_docker_image:
     runs-on: ubuntu-latest
 
     steps:
@@ -20,18 +20,18 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Define_docker_image_tag
+      - name: Define image tag
         run: |
           echo "DOCKER_IMAGE_TAG=$(git describe --tags)" >> $GITHUB_ENV
 
       - name: Setup Docker Buildx
         uses: docker/setup-buildx-action@v3
 
-      - name: Login to Artifactory Docker registry
+      - name: Login to registry
         run: |
           docker login nethermind.jfrog.io -u antoni.tomaszuk@nethermind.io -p ${{ secrets.ARTIFACTORY_ANGKOR_CONTRIBUTOR }}
 
-      - name: Build and Push to Artifactory Docker
+      - name: Build and Push
         uses: docker/build-push-action@v5
         with:
           context: .
@@ -39,11 +39,11 @@ jobs:
           push: true
           tags: nethermind.jfrog.io/angkor-docker-local-dev/juno:${{ env.DOCKER_IMAGE_TAG }}
 
-  deploy_to_dev:
+  validate_dev:
     permissions:
       id-token: write
       contents: write
-    needs: [docker_build_and_publish]
+    needs: [build_docker_image]
     runs-on: ubuntu-latest
     environment:
       name: Development
@@ -68,21 +68,21 @@ jobs:
         run: bash .github/workflow-scripts/verify_deployment.sh ${{ secrets.DEV_SEPOLIA_URL }} ${{ env.DOCKER_IMAGE_TAG }}
 
   dev-starknet-rs-tests:
-    needs: [deploy_to_dev]
+    needs: [validate_dev]
     uses: ./.github/workflows/starknet-rs-tests.yml
     secrets:
       STARKNET_RPC: ${{ secrets.DEV_SEPOLIA_URL }}/v0_6
 
   dev-starknet-js-tests:
-    needs: [deploy_to_dev]
+    needs: [validate_dev]
     uses: ./.github/workflows/starknet-js-tests.yml
     secrets:
       TEST_RPC_URL: ${{ secrets.DEV_SEPOLIA_URL }}/v0_7
       TEST_ACCOUNT_ADDRESS: ${{ secrets.TEST_ACCOUNT_ADDRESS }}
       TEST_ACCOUNT_PRIVATE_KEY: ${{ secrets.TEST_ACCOUNT_PRIVATE_KEY }}
 
-  deploy_to_staging:
-    needs: [docker_build_and_publish, deploy_to_dev]
+  promote_to_staging:
+    needs: [build_docker_image, validate_dev]
     runs-on: ubuntu-latest
     environment:
       name: Staging
@@ -109,21 +109,21 @@ jobs:
         run: bash .github/workflow-scripts/verify_deployment.sh ${{ secrets.STAGING_SEPOLIA_URL }} ${{ env.DOCKER_IMAGE_TAG }}
 
   staging-starknet-rs-tests:
-    needs: [deploy_to_staging]
+    needs: [promote_to_staging]
     uses: ./.github/workflows/starknet-rs-tests.yml
     secrets:
       STARKNET_RPC: ${{ secrets.STAGING_SEPOLIA_URL }}/v0_6
 
   staging-starknet-js-tests:
-    needs: [deploy_to_staging]
+    needs: [promote_to_staging]
     uses: ./.github/workflows/starknet-js-tests.yml
     secrets:
       TEST_RPC_URL: ${{ secrets.STAGING_SEPOLIA_URL }}/v0_7
       TEST_ACCOUNT_ADDRESS: ${{ secrets.TEST_ACCOUNT_ADDRESS }}
       TEST_ACCOUNT_PRIVATE_KEY: ${{ secrets.TEST_ACCOUNT_PRIVATE_KEY }}
 
-  deploy_to_production:
-    needs: [docker_build_and_publish, deploy_to_staging]
+  promote_to_production:
+    needs: [build_docker_image, promote_to_staging]
     runs-on: ubuntu-latest
     environment:
       name: Production
@@ -144,13 +144,13 @@ jobs:
           -d '{"event_type": "${{ env.EVENT_NAME }}", "client_payload":{"name": "${{ env.EVENT_NAME }}", "mainnet_config": "${{ env.MAINNET }}", "sepolia_config": "${{ env.SEPOLIA }}", "sepolia_integration_config": "${{ env.SEPOLIA_INTEGRATION }}", "tag": "${{ env.DOCKER_IMAGE_TAG }}"}}'
 
   prod-starknet-rs-tests:
-    needs: [deploy_to_production]
+    needs: [promote_to_production]
     uses: ./.github/workflows/starknet-rs-tests.yml
     secrets:
       STARKNET_RPC: ${{ secrets.PROD_SEPOLIA_URL }}/v0_6
 
   prod-starknet-js-tests:
-    needs: [deploy_to_production]
+    needs: [promote_to_production]
     uses: ./.github/workflows/starknet-js-tests.yml
     secrets:
       TEST_RPC_URL: ${{ secrets.PROD_SEPOLIA_URL }}/v0_7

--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -3,7 +3,7 @@ name: Docker Build, Publish and Deploy
 on:
   push:
     branches: [main]
-    tags: ['v*']
+    tags: ["v*"]
   workflow_dispatch:
 
 permissions:
@@ -20,19 +20,19 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      
+
       - name: Define_docker_image_tag
         id: image_tag
         run: |
           echo "DOCKER_IMAGE_TAG=$(git describe --tags)" >> $GITHUB_ENV
           echo "IMAGE_TAG=$(git describe --tags)" >> "$GITHUB_OUTPUT"
-      
+
       - name: Setup Docker Buildx
         uses: docker/setup-buildx-action@v3
-      
+
       - name: Login to Docker Hub
         uses: docker/login-action@v3
-        with: 
+        with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
       
@@ -40,7 +40,7 @@ jobs:
         uses: docker/build-push-action@v5
         with:
           context: .
-          platforms: 'linux/amd64'
+          platforms: "linux/amd64"
           push: true
           tags: nethermindeth/juno:${{ env.DOCKER_IMAGE_TAG }}
     
@@ -50,7 +50,7 @@ jobs:
       contents: write
     needs: [docker_build_and_publish]
     runs-on: ubuntu-latest
-    environment: 
+    environment:
       name: Development
     steps:
       - name: Checkout
@@ -71,14 +71,14 @@ jobs:
           -d '{"event_type": "${{ env.EVENT_NAME }}", "client_payload":{"name": "${{ env.EVENT_NAME }}", "sepolia_config": "${{ env.SEPOLIA }}", "tag": "${{ env.IMAGE_TAG }}"}}'
 
       - name: Verify Deployment Version (Dev)
-        run: bash .github/workflow-scripts/verify_deployment.sh ${{ secrets.DEV_SEPOLIA_URL }} ${{ needs.docker_build_and_publish.outputs.IMAGE_TAG }}        
-        
+        run: bash .github/workflow-scripts/verify_deployment.sh ${{ secrets.DEV_SEPOLIA_URL }} ${{ needs.docker_build_and_publish.outputs.IMAGE_TAG }}
+
   dev-starknet-rs-tests:
     needs: [deploy_to_dev]
     uses: ./.github/workflows/starknet-rs-tests.yml
     secrets:
       STARKNET_RPC: ${{ secrets.DEV_SEPOLIA_URL }}/v0_6
-      
+
   dev-starknet-js-tests:
     needs: [deploy_to_dev]
     uses: ./.github/workflows/starknet-js-tests.yml
@@ -86,24 +86,24 @@ jobs:
       TEST_RPC_URL: ${{ secrets.DEV_SEPOLIA_URL }}/v0_7
       TEST_ACCOUNT_ADDRESS: ${{ secrets.TEST_ACCOUNT_ADDRESS }}
       TEST_ACCOUNT_PRIVATE_KEY: ${{ secrets.TEST_ACCOUNT_PRIVATE_KEY }}
-            
+
   deploy_to_staging:
     needs: [docker_build_and_publish, deploy_to_dev]
     runs-on: ubuntu-latest
-    environment: 
+    environment:
       name: Staging
-    steps:         
-    - name: Checkout
-      uses: actions/checkout@v4
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
 
-    - name: Repository Dispatch Staging
-      env:
+      - name: Repository Dispatch Staging
+        env:
           EVENT_NAME: juno-staging
           IMAGE_TAG: ${{ needs.docker_build_and_publish.outputs.IMAGE_TAG }}
           MAINNET: apps/juno-staging/overlays/staging-mainnet/config.yaml
           SEPOLIA: apps/juno-staging/overlays/staging-sepolia/config.yaml
           SEPOLIA_INTEGRATION: apps/juno-staging/overlays/staging-sepolia-integration/config.yaml
-      run: |
+        run: |
           curl -L \
           -X POST \
           -H "Accept: application/vnd.github+json" \
@@ -111,16 +111,16 @@ jobs:
           -H "X-GitHub-Api-Version: 2022-11-28" \
           https://api.github.com/repos/NethermindEth/argo/dispatches \
           -d '{"event_type": "${{ env.EVENT_NAME }}", "client_payload":{"name": "${{ env.EVENT_NAME }}", "mainnet_config": "${{ env.MAINNET }}", "sepolia_config": "${{ env.SEPOLIA }}", "sepolia_integration_config": "${{ env.SEPOLIA_INTEGRATION}}", "tag": "${{ env.IMAGE_TAG }}"}}'
-    
-    - name: Verify Deployment Version (Staging)
-      run: bash .github/workflow-scripts/verify_deployment.sh ${{ secrets.STAGING_SEPOLIA_URL }} ${{ needs.docker_build_and_publish.outputs.IMAGE_TAG }}
+
+      - name: Verify Deployment Version (Staging)
+        run: bash .github/workflow-scripts/verify_deployment.sh ${{ secrets.STAGING_SEPOLIA_URL }} ${{ needs.docker_build_and_publish.outputs.IMAGE_TAG }}
 
   staging-starknet-rs-tests:
     needs: [deploy_to_staging]
     uses: ./.github/workflows/starknet-rs-tests.yml
     secrets:
       STARKNET_RPC: ${{ secrets.STAGING_SEPOLIA_URL }}/v0_6
-      
+
   staging-starknet-js-tests:
     needs: [deploy_to_staging]
     uses: ./.github/workflows/starknet-js-tests.yml
@@ -136,7 +136,7 @@ jobs:
       name: Production
     steps:
       - name: Repository Dispatch Prod
-        env: 
+        env:
           EVENT_NAME: juno-prod
           IMAGE_TAG: ${{ needs.docker_build_and_publish.outputs.IMAGE_TAG }}
           MAINNET: apps/juno-prod/overlays/prod-mainnet/config.yaml
@@ -150,13 +150,13 @@ jobs:
           -H "X-GitHub-Api-Version: 2022-11-28" \
           https://api.github.com/repos/NethermindEth/argo/dispatches \
           -d '{"event_type": "${{ env.EVENT_NAME }}", "client_payload":{"name": "${{ env.EVENT_NAME }}", "mainnet_config": "${{ env.MAINNET }}", "sepolia_config": "${{ env.SEPOLIA }}", "sepolia_integration_config": "${{ env.SEPOLIA_INTEGRATION }}", "tag": "${{ env.IMAGE_TAG }}"}}'
-          
+
   prod-starknet-rs-tests:
     needs: [deploy_to_production]
     uses: ./.github/workflows/starknet-rs-tests.yml
     secrets:
       STARKNET_RPC: ${{ secrets.PROD_SEPOLIA_URL }}/v0_6
-      
+
   prod-starknet-js-tests:
     needs: [deploy_to_production]
     uses: ./.github/workflows/starknet-js-tests.yml

--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -30,20 +30,18 @@ jobs:
       - name: Setup Docker Buildx
         uses: docker/setup-buildx-action@v3
 
-      - name: Login to Docker Hub
-        uses: docker/login-action@v3
-        with:
-          username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_PASSWORD }}
-      
-      - name: Build and Push
+      - name: Login to Artifactory Docker registry
+        run: |
+          docker login nethermind.jfrog.io -u antoni.tomaszuk@nethermind.io -p ${{ secrets.ARTIFACTORY_ANGKOR_CONTRIBUTOR }}
+
+      - name: Build and Push to Artifactory Docker
         uses: docker/build-push-action@v5
         with:
           context: .
           platforms: "linux/amd64"
           push: true
-          tags: nethermindeth/juno:${{ env.DOCKER_IMAGE_TAG }}
-    
+          tags: nethermind.jfrog.io/angkor-docker-local-dev/juno:${{ env.DOCKER_IMAGE_TAG }}
+
   deploy_to_dev:
     permissions:
       id-token: write

--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -1,5 +1,13 @@
 name: Docker Build, Publish and Deploy
 
+env:
+  DOCKER_REGISTRY: nethermind.jfrog.io
+
+  REPO_DEV: angkor-docker-local-dev
+  REPO_STAGING: angkor-docker-local-staging
+  REPO_PROD: angkor-docker-local-prod
+
+
 on:
   push:
     branches: [main]
@@ -29,7 +37,7 @@ jobs:
 
       - name: Login to registry
         run: |
-          docker login nethermind.jfrog.io -u antoni.tomaszuk@nethermind.io -p ${{ secrets.ARTIFACTORY_ANGKOR_CONTRIBUTOR }}
+          docker login ${{ env.DOCKER_REGISTRY }} -u ${{ vars.ARTIFACTORY_ANGKOR_USER }} -p ${{ secrets.ARTIFACTORY_ANGKOR_CONTRIBUTOR }}
 
       - name: Build and Push
         uses: docker/build-push-action@v5
@@ -37,7 +45,8 @@ jobs:
           context: .
           platforms: "linux/amd64"
           push: true
-          tags: nethermind.jfrog.io/angkor-docker-local-dev/juno:${{ env.DOCKER_IMAGE_TAG }}
+          tags: ${{ env.DOCKER_REGISTRY }}/${{ env.REPO_DEV }}/juno:${{ env.DOCKER_IMAGE_TAG }}
+
 
   validate_dev:
     permissions:
@@ -50,19 +59,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-
-      - name: Repository Dispatch Dev
-        env:
-          EVENT_NAME: juno-dev
-          SEPOLIA: apps/juno-dev/overlays/dev-sepolia/config.yaml
-        run: |
-          curl -L \
-          -X POST \
-          -H "Accept: application/vnd.github+json" \
-          -H "Authorization: token ${{ secrets.ACCESS_TOKEN }}" \
-          -H "X-GitHub-Api-Version: 2022-11-28" \
-          https://api.github.com/repos/NethermindEth/argo/dispatches \
-          -d '{"event_type": "${{ env.EVENT_NAME }}", "client_payload":{"name": "${{ env.EVENT_NAME }}", "sepolia_config": "${{ env.SEPOLIA }}", "tag": "${{ env.DOCKER_IMAGE_TAG }}"}}'
 
       - name: Verify Deployment Version (Dev)
         run: bash .github/workflow-scripts/verify_deployment.sh ${{ secrets.DEV_SEPOLIA_URL }} ${{ env.DOCKER_IMAGE_TAG }}
@@ -87,26 +83,15 @@ jobs:
     environment:
       name: Staging
     steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Repository Dispatch Staging
+      - name: Setup JFrog CLI
+        uses: jfrog/setup-jfrog-cli@v4
         env:
-          EVENT_NAME: juno-staging
-          MAINNET: apps/juno-staging/overlays/staging-mainnet/config.yaml
-          SEPOLIA: apps/juno-staging/overlays/staging-sepolia/config.yaml
-          SEPOLIA_INTEGRATION: apps/juno-staging/overlays/staging-sepolia-integration/config.yaml
-        run: |
-          curl -L \
-          -X POST \
-          -H "Accept: application/vnd.github+json" \
-          -H "Authorization: token ${{ secrets.ACCESS_TOKEN }}" \
-          -H "X-GitHub-Api-Version: 2022-11-28" \
-          https://api.github.com/repos/NethermindEth/argo/dispatches \
-          -d '{"event_type": "${{ env.EVENT_NAME }}", "client_payload":{"name": "${{ env.EVENT_NAME }}", "mainnet_config": "${{ env.MAINNET }}", "sepolia_config": "${{ env.SEPOLIA }}", "sepolia_integration_config": "${{ env.SEPOLIA_INTEGRATION}}", "tag": "${{ env.DOCKER_IMAGE_TAG }}"}}'
+          JF_URL: ${{ vars.JFROG_URL}}
+          JF_ACCESS_TOKEN: ${{ secrets.ARTIFACTORY_ANGKOR_CONTRIBUTOR }}
 
-      - name: Verify Deployment Version (Staging)
-        run: bash .github/workflow-scripts/verify_deployment.sh ${{ secrets.STAGING_SEPOLIA_URL }} ${{ env.DOCKER_IMAGE_TAG }}
+      - name: Promote to Staging
+        run: |
+          jf rt dpr juno/${{ env.DOCKER_IMAGE_TAG }} ${{ env.REPO_DEV }} ${{ env.REPO_STAGING }}
 
   staging-starknet-rs-tests:
     needs: [promote_to_staging]
@@ -128,20 +113,15 @@ jobs:
     environment:
       name: Production
     steps:
-      - name: Repository Dispatch Prod
+      - name: Setup JFrog CLI
+        uses: jfrog/setup-jfrog-cli@v4
         env:
-          EVENT_NAME: juno-prod
-          MAINNET: apps/juno-prod/overlays/prod-mainnet/config.yaml
-          SEPOLIA: apps/juno-prod/overlays/prod-sepolia/config.yaml
-          SEPOLIA_INTEGRATION: apps/juno-prod/overlays/prod-sepolia-integration/config.yaml
+          JF_URL: ${{ vars.JFROG_URL}}
+          JF_ACCESS_TOKEN: ${{ secrets.ARTIFACTORY_ANGKOR_CONTRIBUTOR }}
+
+      - name: Promote to Production
         run: |
-          curl -L \
-          -X POST \
-          -H "Accept: application/vnd.github+json" \
-          -H "Authorization: token ${{ secrets.ACCESS_TOKEN }}" \
-          -H "X-GitHub-Api-Version: 2022-11-28" \
-          https://api.github.com/repos/NethermindEth/argo/dispatches \
-          -d '{"event_type": "${{ env.EVENT_NAME }}", "client_payload":{"name": "${{ env.EVENT_NAME }}", "mainnet_config": "${{ env.MAINNET }}", "sepolia_config": "${{ env.SEPOLIA }}", "sepolia_integration_config": "${{ env.SEPOLIA_INTEGRATION }}", "tag": "${{ env.DOCKER_IMAGE_TAG }}"}}'
+          jf rt dpr juno/${{ env.DOCKER_IMAGE_TAG }} ${{ env.REPO_STAGING }} ${{ env.REPO_PROD }}
 
   prod-starknet-rs-tests:
     needs: [promote_to_production]


### PR DESCRIPTION
Due security reasons, we had to stop using the dispatch token and
change the way we trigger the deployment in argo.  For this, it was
necessary to change to push the docker images to jFrog Artifactory