### PR TITLE
l1: avoid spam calling L1 RPC subscription

### DIFF
--- a/l1/eth_subscriber.go
+++ b/l1/eth_subscriber.go
@@ -2,15 +2,15 @@ package l1
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"math/big"
-	"strconv"
-	"strings"
 	"time"
 
 	"github.com/NethermindEth/juno/l1/contract"
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/ethclient"
 	"github.com/ethereum/go-ethereum/event"
 	"github.com/ethereum/go-ethereum/rpc"
@@ -54,28 +54,21 @@ func (s *EthSubscriber) ChainID(ctx context.Context) (*big.Int, error) {
 }
 
 func (s *EthSubscriber) FinalisedHeight(ctx context.Context) (uint64, error) {
-	finalisedBlock := make(map[string]any, 0)
-	if err := s.client.CallContext(ctx, &finalisedBlock, "eth_getBlockByNumber", "finalized", false); err != nil { //nolint:misspell
+	var raw json.RawMessage
+	if err := s.client.CallContext(ctx, &raw, "eth_getBlockByNumber", "finalized", false); err != nil { //nolint:misspell
 		return 0, fmt.Errorf("get finalised Ethereum block: %w", err)
 	}
 
-	number, ok := finalisedBlock["number"]
-	if !ok {
-		return 0, fmt.Errorf("number field not present in Ethereum block")
+	var head *types.Header
+	if err := json.Unmarshal(raw, &head); err != nil {
+		return 0, err
 	}
 
-	numberString, ok := number.(string)
-	if !ok {
-		return 0, fmt.Errorf("block number is not a string: %v", number)
+	if head == nil {
+		return 0, fmt.Errorf("finalised block not found")
 	}
 
-	numberString = strings.TrimPrefix(numberString, "0x")
-	numberUint, err := strconv.ParseUint(numberString, 16, 64)
-	if err != nil {
-		return 0, fmt.Errorf("parse block number: %s", numberString)
-	}
-
-	return numberUint, nil
+	return head.Number.Uint64(), nil
 }
 
 func (s *EthSubscriber) Close() {

--- a/l1/l1.go
+++ b/l1/l1.go
@@ -178,6 +178,7 @@ func (c *Client) finalisedHeight(ctx context.Context) uint64 {
 				return finalisedHeight
 			}
 			c.log.Debugw("Failed to retrieve L1 finalised height, retrying...", "error", err)
+			time.Sleep(c.resubscribeDelay)
 		}
 	}
 }


### PR DESCRIPTION
### Description
This PR fixes the spam issue described in #1915 by delaying L1 RPC calls with a fixed interval.

### Additional notes
Also added a small refactor on unmarshalling the output of `eth_getBlockByNumber`. The implementation references the geth code [here](https://github.com/ethereum/go-ethereum/blob/master/ethclient/ethclient.go#L128-L139).
