### PR TITLE
Fix how to staging promotion

### DIFF
--- a/.github/workflow-scripts/verify_deployment.sh
+++ b/.github/workflow-scripts/verify_deployment.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -ux
+
 URL=$1
 EXPECTED_VERSION=$2
 MAX_ATTEMPTS=30

--- a/.github/workflows/ci-cd-pipeline.yml
+++ b/.github/workflows/ci-cd-pipeline.yml
@@ -21,6 +21,8 @@ permissions:
 jobs:
   build_docker_image:
     runs-on: ubuntu-latest
+    outputs:
+      DOCKER_IMAGE_TAG: ${{ steps.set_tag.outputs.DOCKER_IMAGE_TAG }}
 
     steps:
       - name: Checkout
@@ -29,8 +31,15 @@ jobs:
           fetch-depth: 0
 
       - name: Define image tag
+        id: set_tag
         run: |
-          echo "DOCKER_IMAGE_TAG=$(git describe --tags)" >> $GITHUB_ENV
+          export DOCKER_IMAGE_TAG=$(git describe --tags)
+
+          # This one is to be able to use the image tag in the next steps in this job
+          echo "DOCKER_IMAGE_TAG=$DOCKER_IMAGE_TAG" >> $GITHUB_ENV
+
+          # This one is to be able to use the image tag in the next jobs
+          echo "DOCKER_IMAGE_TAG=$DOCKER_IMAGE_TAG" >> $GITHUB_OUTPUT
 
       - name: Setup Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -61,7 +70,8 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Verify Deployment Version (Dev)
-        run: bash .github/workflow-scripts/verify_deployment.sh ${{ secrets.DEV_SEPOLIA_URL }} ${{ env.DOCKER_IMAGE_TAG }}
+        run: |
+          bash .github/workflow-scripts/verify_deployment.sh ${{ secrets.DEV_SEPOLIA_URL }} ${{ needs.build_docker_image.outputs.DOCKER_IMAGE_TAG }}
 
   dev-starknet-rs-tests:
     needs: [validate_dev]
@@ -91,7 +101,11 @@ jobs:
 
       - name: Promote to Staging
         run: |
-          jf rt dpr juno/${{ env.DOCKER_IMAGE_TAG }} ${{ env.REPO_DEV }} ${{ env.REPO_STAGING }}
+          jf rt dpr juno/${{ needs.build_docker_image.outputs.DOCKER_IMAGE_TAG }} ${{ env.REPO_DEV }} ${{ env.REPO_STAGING }}
+
+      - name: Verify Deployment Version (Staging)
+        run: |
+          bash .github/workflow-scripts/verify_deployment.sh ${{ secrets.STAGING_SEPOLIA_URL }} ${{ needs.build_docker_image.outputs.DOCKER_IMAGE_TAG }}
 
   staging-starknet-rs-tests:
     needs: [promote_to_staging]
@@ -121,16 +135,26 @@ jobs:
 
       - name: Promote to Production
         run: |
-          jf rt dpr juno/${{ env.DOCKER_IMAGE_TAG }} ${{ env.REPO_STAGING }} ${{ env.REPO_PROD }}
+          jf rt dpr juno/${{ needs.build_docker_image.outputs.DOCKER_IMAGE_TAG }} ${{ env.REPO_STAGING }} ${{ env.REPO_PROD }}
+
+   test_in_production:
+    needs: [promote_to_production]
+    runs-on: ubuntu-latest
+    environment:
+      name: ProductionTests  # Artificial gate to enforce manual approval
+    steps:
+      - name: Starting production tests
+        run: |
+          echo "Tests in production will start shortly."
 
   prod-starknet-rs-tests:
-    needs: [promote_to_production]
+    needs: [test_in_production]
     uses: ./.github/workflows/starknet-rs-tests.yml
     secrets:
       STARKNET_RPC: ${{ secrets.PROD_SEPOLIA_URL }}/v0_6
 
   prod-starknet-js-tests:
-    needs: [promote_to_production]
+    needs: [test_in_production]
     uses: ./.github/workflows/starknet-js-tests.yml
     secrets:
       TEST_RPC_URL: ${{ secrets.PROD_SEPOLIA_URL }}/v0_7


### PR DESCRIPTION
Fix how to get DOCKER_IMAGE_TAG:

By using GITHUB_ENV, only the steps on the same job will be able to get the value.  When trying to get it from steps from different jobs the value is empty.

This was causing issues to promote to staging because it was trying to promote EVERYTHING in dev to staging.  Luckly there was a check to not allow to overwrite the same tag, so things that were already promoted couldn't be overwritten

By using GITHUB_OUTPUT instead, it is now possible to get the variable on any step from any subsequent job

Add deployment version verification for staging and production:

The CI/CD pipeline has been updated to include a new step for verifying the deployment version in the staging and production environments. This ensures that the correct version of the Docker image is deployed to each environment before running the tests

Add set -ux to deployment verification script:

- -u will treat any unitialized variable as an error
- -x will print the command that is being executed

This will make sure that cases where the EXPECTED_VERSION not being passed won't cause any problem.
One example where the variable was not set and the job succeeded: https://github.com/NethermindEth/juno/actions/runs/9800486115/job/27062611554#step:3:15

By using -x, it will be useful to understand exactly what's the expected version, so no confusion will be made