### PR TITLE
Fix indentation in ci-cd-pipeline.yml

### DIFF
--- a/.github/workflows/ci-cd-pipeline.yml
+++ b/.github/workflows/ci-cd-pipeline.yml
@@ -137,7 +137,7 @@ jobs:
         run: |
           jf rt dpr juno/${{ needs.build_docker_image.outputs.DOCKER_IMAGE_TAG }} ${{ env.REPO_STAGING }} ${{ env.REPO_PROD }}
 
-   test_in_production:
+  test_in_production:
     needs: [promote_to_production]
     runs-on: ubuntu-latest
     environment:


### PR DESCRIPTION
The test_in_production job had two extra spaces, making the YAML file invalid, since it couldn't detect that this was a job but as a step, and steps can't have the same attributes as jobs