### PR TITLE
Persist and load peers from separate database

### DIFF
--- a/db/buckets.go
+++ b/db/buckets.go
@@ -32,6 +32,7 @@ const (
 	BlockCommitments
 	Temporary // used temporarily for migrations
 	SchemaIntermediateState
+	Peer // maps peer ID to peer multiaddresses
 )
 
 // Key flattens a prefix and series of byte arrays into a single []byte.

--- a/node/node.go
+++ b/node/node.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"net/url"
+	"path/filepath"
 	"reflect"
 	"runtime"
 	"time"
@@ -40,6 +41,7 @@ const (
 	upgraderDelay    = 5 * time.Minute
 	githubAPIUrl     = "https://api.github.com/repos/NethermindEth/juno/releases/latest"
 	latestReleaseURL = "https://github.com/NethermindEth/juno/releases/latest"
+	peersDBPath      = "peers"
 )
 
 // Config is the top-level juno configuration.
@@ -114,15 +116,28 @@ func New(cfg *Config, version string) (*Node, error) { //nolint:gocyclo,funlen
 	}
 
 	dbIsRemote := cfg.RemoteDB != ""
-	var database db.DB
-	if dbIsRemote {
-		database, err = remote.New(cfg.RemoteDB, context.TODO(), log, grpc.WithTransportCredentials(insecure.NewCredentials()))
-	} else {
-		database, err = pebble.New(cfg.DatabasePath, cfg.DBCacheSize, cfg.DBMaxHandles, dbLog)
+	var (
+		database db.DB
+		peersDB  db.DB
+	)
+
+	createDB := func(dbPath string) (db.DB, error) { // Use appropriate return type
+		if dbIsRemote {
+			return remote.New(dbPath, context.TODO(), log, grpc.WithTransportCredentials(insecure.NewCredentials()))
+		}
+		return pebble.New(dbPath, cfg.DBCacheSize, cfg.DBMaxHandles, dbLog)
 	}
+
+	database, err = createDB(cfg.DatabasePath)
 	if err != nil {
 		return nil, fmt.Errorf("open DB: %w", err)
 	}
+
+	peersDB, err = createDB(filepath.Join(cfg.DatabasePath, peersDBPath))
+	if err != nil {
+		return nil, fmt.Errorf("open peers DB: %w", err)
+	}
+
 	ua := fmt.Sprintf("Juno/%s Starknet Client", version)
 
 	services := make([]service.Service, 0)
@@ -164,7 +179,8 @@ func New(cfg *Config, version string) (*Node, error) { //nolint:gocyclo,funlen
 			// Do not start the feeder synchronisation
 			synchronizer = nil
 		}
-		p2pService, err = p2p.New(cfg.P2PAddr, "juno", cfg.P2PPeers, cfg.P2PPrivateKey, cfg.P2PFeederNode, chain, &cfg.Network, log)
+		p2pService, err = p2p.New(cfg.P2PAddr, "juno", cfg.P2PPeers, cfg.P2PPrivateKey, cfg.P2PFeederNode,
+			chain, &cfg.Network, log, peersDB)
 		if err != nil {
 			return nil, fmt.Errorf("set up p2p service: %w", err)
 		}

--- a/node/node.go
+++ b/node/node.go
@@ -120,11 +120,11 @@ func New(cfg *Config, version string) (*Node, error) { //nolint:gocyclo,funlen
 	} else {
 		database, err = pebble.New(cfg.DatabasePath, cfg.DBCacheSize, cfg.DBMaxHandles, dbLog)
 	}
-	ua := fmt.Sprintf("Juno/%s Starknet Client", version)
 
 	if err != nil {
 		return nil, fmt.Errorf("open DB: %w", err)
 	}
+	ua := fmt.Sprintf("Juno/%s Starknet Client", version)
 
 	services := make([]service.Service, 0)
 

--- a/p2p/p2p_test.go
+++ b/p2p/p2p_test.go
@@ -162,6 +162,7 @@ func TestValidKey(t *testing.T) {
 		nil,
 		&utils.Integration,
 		utils.NewNopZapLogger(),
+		nil,
 	)
 
 	require.NoError(t, err)

--- a/p2p/p2p_test.go
+++ b/p2p/p2p_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/NethermindEth/juno/db"
 	"github.com/NethermindEth/juno/db/pebble"
 	"github.com/NethermindEth/juno/p2p"
 	"github.com/NethermindEth/juno/utils"
@@ -183,7 +184,7 @@ func TestLoadAndPersistPeers(t *testing.T) {
 	encAddrs, err := p2p.EncodeAddrs(addrs)
 	require.NoError(t, err)
 
-	err = txn.Set([]byte(decodedID), encAddrs)
+	err = txn.Set(db.Peer.Key([]byte(decodedID)), encAddrs)
 	require.NoError(t, err)
 
 	err = txn.Commit()

--- a/p2p/peers.go
+++ b/p2p/peers.go
@@ -1,0 +1,43 @@
+package p2p
+
+import (
+	"bytes"
+	"fmt"
+
+	"github.com/fxamacker/cbor/v2"
+	"github.com/multiformats/go-multiaddr"
+)
+
+// EncodeAddrs encodes a slice of multiaddrs into a byte slice
+func EncodeAddrs(addrs []multiaddr.Multiaddr) ([]byte, error) {
+	multiAddrBytes := make([][]byte, len(addrs))
+	for i, addr := range addrs {
+		multiAddrBytes[i] = addr.Bytes()
+	}
+
+	var buf bytes.Buffer
+	if err := cbor.NewEncoder(&buf).Encode(multiAddrBytes); err != nil {
+		return nil, fmt.Errorf("encode addresses: %w", err)
+	}
+
+	return buf.Bytes(), nil
+}
+
+// decodeAddrs decodes a byte slice into a slice of multiaddrs
+func decodeAddrs(b []byte) ([]multiaddr.Multiaddr, error) {
+	var multiAddrBytes [][]byte
+	if err := cbor.NewDecoder(bytes.NewReader(b)).Decode(&multiAddrBytes); err != nil {
+		return nil, fmt.Errorf("decode addresses: %w", err)
+	}
+
+	addrs := make([]multiaddr.Multiaddr, 0, len(multiAddrBytes))
+	for _, addrBytes := range multiAddrBytes {
+		addr, err := multiaddr.NewMultiaddrBytes(addrBytes)
+		if err != nil {
+			return nil, fmt.Errorf("parse multiaddr: %w", err)
+		}
+		addrs = append(addrs, addr)
+	}
+
+	return addrs, nil
+}


### PR DESCRIPTION
### Description
This PR adds a P2P feature such that peers discovered and stored in the DHT table are persisted in the database upon node stop. When node is started, the previously stored peers are loaded from the database.

### Rationale
See #1908.

Nodes may reconnect to each other once they are back online. However, this is not immediate. For a better user experience, nodes should immediately reconnect to the peers that they have found previously.

### Implementation Details
Peers info is stored in the mainbase. Peers info is stored as a key-value pair, where the key is the prefix + peer ID and the value is the encoded list of multi addresses. The encoding is done through the gob data format with the `encoding/gob` module.

### Future Improvement
The current implementation persists peers only when the node is stopped. If a peer is disconnected, it will not be persisted.  We should persist the peers as we discover them.

This is technically possible, but slightly troublesome. We can subscribe to libP2P events when a peer is connected, but the event only surfaces the peer ID but not the multi-address. Therefore, we have to lookup the table using the peer ID to obtain the relevant multi-addresses. This adds slight complexity.

Or, another simpler idea is just to persist the peer store every certain interval.