### PR TITLE
Safely enable uploading report to Codecov

### DIFF
--- a/.github/workflows/juno-test.yml
+++ b/.github/workflows/juno-test.yml
@@ -50,11 +50,10 @@ jobs:
       - name: Benchmark
         run: make benchmarks
 
-      - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v4.2.0
+      - uses: actions/upload-artifact@v4
         if: matrix.os == 'ubuntu-latest'
         with:
-          token: ${{ secrets.CODECOV_TOKEN }}
-          fail_ci_if_error: true
-          files: ./coverage/coverage.out
-          verbose: true
+          name: code_coverage
+          path: ./coverage/coverage.out
+          if-no-files-found: error
+          retention-days: 1

--- a/.github/workflows/upload-codecov.yml
+++ b/.github/workflows/upload-codecov.yml
@@ -1,0 +1,43 @@
+name: Upload Codecov
+
+
+on:
+  workflow_run:
+    workflows: ["Juno Test"]
+    types:
+      - completed
+
+jobs:
+  upload:
+    runs-on: ubuntu-latest
+    if: github.event.workflow_run.conclusion == 'success'
+    steps:
+      - name: Download artifact
+        uses: dawidd6/action-download-artifact@v6
+        with:
+          workflow: ${{ github.event.workflow_run.name }}
+          run_id: ${{ github.event.workflow_run.id }}
+          name: code_coverage
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v4.2.0
+        if: matrix.os == 'ubuntu-latest'
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          fail_ci_if_error: true
+          files: coverage.out
+          verbose: true
+
+      - name: 'Comment on PR'
+        if: github.event.workflow_run.event == 'pull_request'
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            await github.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: ${{ github.event.workflow_run.pull_request.number }},
+              body: 'Coverage report uploaded to Codecov.  Results will be posted soon.'
+            });


### PR DESCRIPTION
This is done by saving the coverage output as an workflow artifact then loading it on a separate job and uploading it to codecov.

The reason why this is necessary is because when running the juno-test workflow from a fork / untrusted dev, the secrets is not available. This is done in order to secure the secrets to being exposed from an atacker that might want to create a PR and get them. More info: https://securitylab.github.com/research/github-actions-preventing-pwn-requests/

The second workflow will be trigger once the juno-test is completed so it only needs to download the artifact and upload to codecov. Since this workflow source code is only from main, in order for it to contain malicious code, it would've been required to go through a PR.

I've also added a small script to comment to the PR, so it's clear that the codecov will be uploaded shortly.  This can be reverted later on if it starts to become too spammy.