### PR TITLE
Fix how to upload coverage to codecov

### DIFF
--- a/.github/workflows/upload-codecov.yml
+++ b/.github/workflows/upload-codecov.yml
@@ -22,22 +22,8 @@ jobs:
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v4.2.0
-        if: matrix.os == 'ubuntu-latest'
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           fail_ci_if_error: true
           files: coverage.out
           verbose: true
-
-      - name: 'Comment on PR'
-        if: github.event.workflow_run.event == 'pull_request'
-        uses: actions/github-script@v7
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          script: |
-            await github.issues.createComment({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: ${{ github.event.workflow_run.pull_request.number }},
-              body: 'Coverage report uploaded to Codecov.  Results will be posted soon.'
-            });


### PR DESCRIPTION
When I copied the Upload coverage to Codecov step from the juno-test I forgot to remove the condition that it would only do it when running on ubuntu-latest machine.

Also, the Comment on PR didn't work, so I'm just removing it since it doesn't provide much benefit