### PR TITLE
Remove duplicate libraries linked on MacOS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,8 @@ endif
 
 ifeq ($(shell uname -s),Darwin)
 	export CGO_LDFLAGS=-framework Foundation -framework SystemConfiguration
+else
+	export CGO_LDFLAGS=-ldl -lm
 endif
 
 rustdeps: vm core-rust compiler

--- a/core/class_hash.go
+++ b/core/class_hash.go
@@ -5,8 +5,8 @@ package core
 //#include <stddef.h>
 //
 // extern void Cairo0ClassHash(char* class_json_str, char* hash);
-// #cgo vm_debug  LDFLAGS: -L./rust/target/debug   -ljuno_starknet_core_rs -ldl -lm
-// #cgo !vm_debug LDFLAGS: -L./rust/target/release -ljuno_starknet_core_rs -ldl -lm
+// #cgo vm_debug  LDFLAGS: -L./rust/target/debug   -ljuno_starknet_core_rs
+// #cgo !vm_debug LDFLAGS: -L./rust/target/release -ljuno_starknet_core_rs
 import "C"
 
 import (

--- a/starknet/compiler.go
+++ b/starknet/compiler.go
@@ -6,8 +6,8 @@ package starknet
 // extern char* compileSierraToCasm(char* sierra_json);
 // extern void freeCstr(char* ptr);
 //
-// #cgo vm_debug  LDFLAGS: -L./rust/target/debug   -ljuno_starknet_compiler_rs -ldl -lm
-// #cgo !vm_debug LDFLAGS: -L./rust/target/release -ljuno_starknet_compiler_rs -ldl -lm
+// #cgo vm_debug  LDFLAGS: -L./rust/target/debug   -ljuno_starknet_compiler_rs
+// #cgo !vm_debug LDFLAGS: -L./rust/target/release -ljuno_starknet_compiler_rs
 import "C"
 
 import (

--- a/vm/vm.go
+++ b/vm/vm.go
@@ -38,8 +38,8 @@ extern void cairoVMExecute(char* txns_json, char* classes_json, char* paid_fees_
 extern char* setVersionedConstants(char* json);
 extern void freeString(char* str);
 
-#cgo vm_debug  LDFLAGS: -L./rust/target/debug   -ljuno_starknet_rs -ldl -lm
-#cgo !vm_debug LDFLAGS: -L./rust/target/release -ljuno_starknet_rs -ldl -lm
+#cgo vm_debug  LDFLAGS: -L./rust/target/debug   -ljuno_starknet_rs
+#cgo !vm_debug LDFLAGS: -L./rust/target/release -ljuno_starknet_rs
 */
 import "C"
 


### PR DESCRIPTION
These changes fix this warning on MacOS:
```
ld: warning: ignoring duplicate libraries: '-ldl', '-lm'
```