### PR TITLE
feat: add trace transactions feature

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,6 +20,12 @@ juno: rustdeps ## compile
 	@mkdir -p build
 	@go build $(GO_TAGS) -a -ldflags='-X main.Version=$(shell git describe --tags), -extldflags "-lpthread -lstdc++ -lz -lncurses"' -o build/juno ./cmd/juno/
 
+juno-tracing:
+	@$(MAKE) VM_TARGET=tracing vm
+	@$(MAKE) VM_TARGET=all core-rust compiler
+	@mkdir -p build
+	@go build $(GO_TAGS) -a -ldflags='-X main.Version=$(shell git describe --tags), -extldflags "-lpthread -lstdc++ -lz -lncurses"' -o build/juno ./cmd/juno/
+
 juno-cached:
 	@mkdir -p build
 	@go build $(GO_TAGS) -ldflags="-X main.Version=$(shell git describe --tags)" -o build/juno ./cmd/juno/

--- a/vm/rust/Cargo.toml
+++ b/vm/rust/Cargo.toml
@@ -5,11 +5,14 @@ edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
+[features]
+tracing = ["blockifier/tracing"]
+
 [dependencies]
 serde = "1.0.171"
 serde_json = { version = "1.0.96", features = ["raw_value"] }
 blockifier = { git = "https://github.com/NethermindEth/blockifier", branch = "native2.6.4" }
-# blockifier = { path = "../../../blockifier-neth/crates/blockifier/" }
+# blockifier = { path = "../../../blockifier-neth/crates/blockifier/", features = ["tracing] }
 cairo-native = { git = "https://github.com/lambdaclass/cairo_native", rev = "72d10b7923cb4f97ae0b1688ea7de1d34297b0b2" }
 starknet_api = "=0.12.0-dev.1"
 cairo-vm = "=0.9.2"

--- a/vm/rust/Cargo.toml
+++ b/vm/rust/Cargo.toml
@@ -12,7 +12,7 @@ tracing = ["blockifier/tracing"]
 serde = "1.0.171"
 serde_json = { version = "1.0.96", features = ["raw_value"] }
 blockifier = { git = "https://github.com/NethermindEth/blockifier", branch = "native2.6.4" }
-# blockifier = { path = "../../../blockifier-neth/crates/blockifier/", features = ["tracing] }
+# blockifier = { path = "../../../blockifier-neth/crates/blockifier/", features = ["tracing"] }
 cairo-native = { git = "https://github.com/lambdaclass/cairo_native", rev = "72d10b7923cb4f97ae0b1688ea7de1d34297b0b2" }
 starknet_api = "=0.12.0-dev.1"
 cairo-vm = "=0.9.2"

--- a/vm/rust/Makefile
+++ b/vm/rust/Makefile
@@ -1,6 +1,9 @@
 all:
 	cargo build --release
 
+tracing:
+	cargo build --release --features tracing
+
 debug:
 	cargo build
 

--- a/vm/rust/Makefile
+++ b/vm/rust/Makefile
@@ -24,3 +24,4 @@ format:
 
 install-rustfmt:
 	cargo install rustfmt
+

--- a/vm/rust/Makefile
+++ b/vm/rust/Makefile
@@ -24,4 +24,3 @@ format:
 
 install-rustfmt:
 	cargo install rustfmt
-

--- a/vm/rust/src/jsonrpc.rs
+++ b/vm/rust/src/jsonrpc.rs
@@ -1,3 +1,6 @@
+#[cfg(feature = "tracing")]
+use std::time::Duration;
+
 use blockifier;
 use blockifier::execution::call_info::OrderedL2ToL1Message;
 use blockifier::execution::entry_point::CallType;
@@ -46,6 +49,9 @@ pub struct TransactionTrace {
     function_invocation: Option<FunctionInvocation>,
     r#type: TransactionType,
     state_diff: StateDiff,
+    #[cfg(feature = "tracing")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    duration: Option<u64>,
 }
 
 #[derive(Serialize, Default)]
@@ -109,6 +115,12 @@ pub fn new_transaction_trace(
 ) -> Result<TransactionTrace, StateError> {
     let mut trace = TransactionTrace::default();
     let mut deprecated_declared_class: Option<ClassHash> = None;
+
+    #[cfg(feature = "tracing")]
+    {
+        trace.duration = info.duration.as_secs();
+    }
+
     match tx {
         StarknetApiTransaction::L1Handler(_) => {
             trace.function_invocation = info.execute_call_info.map(|v| v.into());

--- a/vm/rust/src/jsonrpc.rs
+++ b/vm/rust/src/jsonrpc.rs
@@ -1,6 +1,3 @@
-#[cfg(feature = "tracing")]
-use std::time::Duration;
-
 use blockifier;
 use blockifier::execution::call_info::OrderedL2ToL1Message;
 use blockifier::execution::entry_point::CallType;
@@ -51,7 +48,7 @@ pub struct TransactionTrace {
     state_diff: StateDiff,
     #[cfg(feature = "tracing")]
     #[serde(skip_serializing_if = "Option::is_none")]
-    duration: Option<u64>,
+    pub duration: Option<u128>,
 }
 
 #[derive(Serialize, Default)]
@@ -118,7 +115,7 @@ pub fn new_transaction_trace(
 
     #[cfg(feature = "tracing")]
     {
-        trace.duration = info.duration.as_secs();
+        trace.duration = info.duration.map(|duration| duration.as_nanos());
     }
 
     match tx {

--- a/vm/trace.go
+++ b/vm/trace.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"errors"
 	"slices"
+	"time"
 
 	"github.com/NethermindEth/juno/core"
 	"github.com/NethermindEth/juno/core/felt"
@@ -106,6 +107,7 @@ type TransactionTrace struct {
 	FunctionInvocation    *FunctionInvocation `json:"function_invocation,omitempty"`
 	StateDiff             *StateDiff          `json:"state_diff,omitempty"`
 	ExecutionResources    *ExecutionResources `json:"execution_resources,omitempty"`
+	Duration              *time.Duration      `json:"duration"`
 }
 
 func (t *TransactionTrace) allInvocations() []*FunctionInvocation {

--- a/vm/trace.go
+++ b/vm/trace.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"errors"
 	"slices"
-	"time"
 
 	"github.com/NethermindEth/juno/core"
 	"github.com/NethermindEth/juno/core/felt"
@@ -107,7 +106,6 @@ type TransactionTrace struct {
 	FunctionInvocation    *FunctionInvocation `json:"function_invocation,omitempty"`
 	StateDiff             *StateDiff          `json:"state_diff,omitempty"`
 	ExecutionResources    *ExecutionResources `json:"execution_resources,omitempty"`
-	Duration              *time.Duration      `json:"duration"`
 }
 
 func (t *TransactionTrace) allInvocations() []*FunctionInvocation {

--- a/vm/vm.go
+++ b/vm/vm.go
@@ -315,7 +315,10 @@ func (v *vm) Execute(txns []core.Transaction, declaredClasses []core.Class, paid
 		if err := json.Unmarshal(traceJSON, &traces[index]); err != nil {
 			return nil, nil, nil, fmt.Errorf("unmarshal trace: %v", err)
 		}
-		//
+	}
+
+	for index, trace := range traces {
+		v.log.Debugw("Trace", "trace index", index, "trace", trace)
 	}
 
 	return context.actualFees, context.dataGasConsumed, traces, nil

--- a/vm/vm.go
+++ b/vm/vm.go
@@ -316,9 +316,6 @@ func (v *vm) Execute(txns []core.Transaction, declaredClasses []core.Class, paid
 			return nil, nil, nil, fmt.Errorf("unmarshal trace: %v", err)
 		}
 	}
-
-	for index, trace := range traces {
-		v.log.Debugw("Trace", "trace index", index, "trace", trace)
 	}
 
 	return context.actualFees, context.dataGasConsumed, traces, nil

--- a/vm/vm.go
+++ b/vm/vm.go
@@ -316,7 +316,6 @@ func (v *vm) Execute(txns []core.Transaction, declaredClasses []core.Class, paid
 			return nil, nil, nil, fmt.Errorf("unmarshal trace: %v", err)
 		}
 	}
-	}
 
 	return context.actualFees, context.dataGasConsumed, traces, nil
 }


### PR DESCRIPTION
## Description

Enables tracing to be done for clients who wish to trace how long transactions take in a block. The output is generated in a file called `trace.csv` in the root directory where `juno` is being run.

This only happens when building with the `make juno-tracing` command.

## Changes

- add a `tracing` flag to `Cargo.toml` in Rust `vm` package
- pass `tracing` flag to `blockifier`

## Results

Tested on block `633333` on Juno mainnet.

<details>
<summary>Generated with the following Python script</summary>

```python
import pandas as pd
import matplotlib.pyplot as plt

# Read the CSV file
df = pd.read_csv('./trace.csv')

# Function to truncate strings
def truncate(string, length=5):
    if len(string) <= length:
        return string
    return string[:length//2] + '...' + string[-length//2:]

# Truncate the transaction hashes
df['truncated_hash'] = df['txn_hash'].apply(truncate)

# Create the bar chart
plt.figure(figsize=(10, 6))
plt.bar(df['truncated_hash'], df['duration'])

# Customize the chart
plt.title('Transaction Duration')
plt.xlabel('Transaction Hash (truncated)')
plt.ylabel('Duration (nanoseconds)')

# Rotate x-axis labels for better readability
plt.xticks(rotation=45, ha='right')

# Adjust layout to prevent label cutoff
plt.tight_layout()

# Save the plot as an image file
plt.savefig('transaction_duration_plot.png', dpi=300, bbox_inches='tight')

# Clear the current figure
plt.clf()
```

</details>


![2024-07-30 00 44 01](https://github.com/user-attachments/assets/5e097b96-3539-479e-9418-7932a63795f8)



Related PR: https://github.com/NethermindEth/blockifier/pull/119