### PR TITLE
feat: move compilation of native contracts into Juno

### DIFF
--- a/vm/rust/Cargo.toml
+++ b/vm/rust/Cargo.toml
@@ -8,8 +8,11 @@ edition = "2021"
 [dependencies]
 serde = "1.0.171"
 serde_json = { version = "1.0.96", features = ["raw_value"] }
-blockifier = { git = "https://github.com/NethermindEth/blockifier", branch = "native2.6.4" }
-# blockifier = { path = "../../../blockifier-neth/crates/blockifier/" }
+# blockifier = { git = "https://github.com/NethermindEth/blockifier", branch = "native2.6.4" }
+blockifier = { path = "../../../blockifier-neth/crates/blockifier/" }
+cairo-lang-sierra = "=2.6.4"
+cairo-lang-starknet = "=2.6.4"
+cairo-lang-starknet-classes = "=2.6.4" 
 cairo-native = { git = "https://github.com/lambdaclass/cairo_native", rev = "72d10b7923cb4f97ae0b1688ea7de1d34297b0b2" }
 starknet_api = "=0.12.0-dev.1"
 cairo-vm = "=0.9.2"

--- a/vm/rust/Cargo.toml
+++ b/vm/rust/Cargo.toml
@@ -8,8 +8,8 @@ edition = "2021"
 [dependencies]
 serde = "1.0.171"
 serde_json = { version = "1.0.96", features = ["raw_value"] }
-# blockifier = { git = "https://github.com/NethermindEth/blockifier", branch = "native2.6.4" }
-blockifier = { path = "../../../blockifier-neth/crates/blockifier/" }
+blockifier = { git = "https://github.com/NethermindEth/blockifier", branch = "native2.6.4" }
+# blockifier = { path = "../../../blockifier-neth/crates/blockifier/" }
 cairo-lang-sierra = "=2.6.4"
 cairo-lang-starknet = "=2.6.4"
 cairo-lang-starknet-classes = "=2.6.4" 

--- a/vm/rust/src/juno_state_reader.rs
+++ b/vm/rust/src/juno_state_reader.rs
@@ -255,9 +255,5 @@ fn native_try_from_json_string(
     let sierra_program = sierra_contract_class.extract_sierra_program()?;
     let executor = compile_and_load(&sierra_program)?;
 
-    Ok(NativeContractClassV1::new(
-        &sierra_program,
-        executor,
-        sierra_contract_class,
-    )?)
+    Ok(NativeContractClassV1::new(executor, sierra_contract_class)?)
 }


### PR DESCRIPTION
Since https://github.com/NethermindEth/blockifier/pull/122 compilation is not done in the blockifier anymore. This PR takes pulls `try_from_json_string` in. 