### PR TITLE
feat: persist native compiled contracts

### DIFF
--- a/vm/rust/Cargo.toml
+++ b/vm/rust/Cargo.toml
@@ -26,3 +26,8 @@ anyhow = "1.0.81"
 
 [lib]
 crate-type = ["staticlib"]
+
+[build-dependencies]
+toml = "0.8.19"
+url = "2.5.2"
+

--- a/vm/rust/Cargo.toml
+++ b/vm/rust/Cargo.toml
@@ -13,7 +13,11 @@ blockifier = { git = "https://github.com/NethermindEth/blockifier", branch = "na
 cairo-lang-sierra = "2.7.0"
 cairo-lang-starknet = "2.7.0"
 cairo-lang-starknet-classes = "2.7.0"
-starknet-types-core = { version = "0.1.5", features = ["hash", "prime-bigint", "serde"] }
+starknet-types-core = { version = "0.1.5", features = [
+    "hash",
+    "prime-bigint",
+    "serde",
+] }
 cairo-native = { git = "https://github.com/lambdaclass/cairo_native", branch = "cairo-lang2.7.0-rc.3" } # main
 starknet_api = "=0.13.0-rc.0"
 cairo-vm = "1.0.0"
@@ -23,6 +27,7 @@ once_cell = "1.18.0"
 lazy_static = "1.4.0"
 semver = "1.0.22"
 anyhow = "1.0.81"
+libloading = "0.8.5"
 
 [lib]
 crate-type = ["staticlib"]
@@ -30,4 +35,3 @@ crate-type = ["staticlib"]
 [build-dependencies]
 toml = "0.8.19"
 url = "2.5.2"
-

--- a/vm/rust/build.rs
+++ b/vm/rust/build.rs
@@ -7,26 +7,21 @@ use toml::{self, Table};
 fn main() {
     let cairo_native = "cairo-native";
 
-    // Can you have globs?
     println!("cargo::rerun-if-changed=./Cargo.toml");
     println!("cargo::rerun-if-changed=./Cargo.lock");
     let config = fs::read_to_string("./Cargo.toml").unwrap();
     let t: Table = toml::from_str(&config).unwrap();
-    let b = t
+    let cairo_native_toml_table = t
         .get("dependencies")
-        .expect("No dependencies found") // TODO(xrvdg) see TOML on how this section should be called
+        .expect("No dependencies found")
         .get(cairo_native)
-        .expect("dependency {cairo_native} not found"); // TODO(xrvdg) how to create a format message?
+        .expect("dependency cairo_native not found");
 
-    // Both of these are error that should not happen
-    // because if this doesn't exist it also doesn't exist in the lock file
+    // Dependency specified via path?
+    let maybe_path = cairo_native_toml_table
+        .get("path")
+        .and_then(|path| path.as_str());
 
-    // How do you chain the values? You can keep using and_then, but then you can't get give feedback over
-    // file not found
-
-    let maybe_path = b.get("path").and_then(|path| path.as_str());
-
-    // todo(xrvdg) Read TigerBeetle naming convention
     let lock_file = fs::read_to_string("./Cargo.lock").unwrap();
     let lock_table: Table = toml::from_str(&lock_file).unwrap();
     let package = lock_table.get("package").unwrap().as_array().unwrap();
@@ -37,17 +32,15 @@ fn main() {
         .as_table()
         .unwrap();
 
-    // checksum from if it comes from registry
+    // Dependency specified via registry?
     let maybe_checksum = cairo_native_lock_table
         .get("checksum")
         .and_then(|c| c.as_str());
 
-    // Should work for both unspecified revision and specified revision, at least for github links
-    // source is optional
-    // Todo(xrvdg) could probably use ? if I make it into a function
+    // Dependency specified via git?
     let maybe_rev = extract_rev_from_source(cairo_native_lock_table);
 
-    let rn: String = match (maybe_rev, maybe_path, maybe_checksum) {
+    let native_version: String = match (maybe_rev, maybe_path, maybe_checksum) {
         (Some(rev), _, _) => rev,
         (_, Some(path), _) => get_git_rev(path),
         (_, _, Some(checksum)) => checksum.to_string(),
@@ -55,23 +48,21 @@ fn main() {
     };
 
     // Set environment variable NATIVE_CACHE_VERSION
-    println!("cargo::rustc-env=NATIVE_VERSION={rn}");
+    println!("cargo::rustc-env=NATIVE_VERSION={native_version}");
 }
 
 fn get_git_rev(path: &str) -> String {
     let path = fs::canonicalize(path).unwrap();
-    let p = Command::new("git")
+    let out = Command::new("git")
         .args(["rev-parse", "HEAD"])
         .current_dir(path)
         .output();
-    // TODO(xrvdg) convert to expects
-    let out = String::from_utf8(p.unwrap().stdout);
-    out.unwrap()
+    let git_rev = String::from_utf8(out.unwrap().stdout);
+    git_rev.unwrap()
 }
 
+/// Extract the revision from git source
 fn extract_rev_from_source(lock_table: &toml::Table) -> Option<String> {
-    // We now swallow a parse error. This makes it a bit harder to debug if something goes wrong
-    // Can also add warning and use the panic that comes later
     let source = Url::parse(lock_table.get("source")?.as_str()?).ok()?;
     Some(String::from(
         source

--- a/vm/rust/build.rs
+++ b/vm/rust/build.rs
@@ -1,0 +1,81 @@
+use std::{fs, process::Command};
+
+use url::Url;
+
+use toml::{self, Table};
+
+fn main() {
+    let cairo_native = "cairo-native";
+
+    // Can you have globs?
+    println!("cargo::rerun-if-changed=./Cargo.toml");
+    println!("cargo::rerun-if-changed=./Cargo.lock");
+    let config = fs::read_to_string("./Cargo.toml").unwrap();
+    let t: Table = toml::from_str(&config).unwrap();
+    let b = t
+        .get("dependencies")
+        .expect("No dependencies found") // TODO(xrvdg) see TOML on how this section should be called
+        .get(cairo_native)
+        .expect("dependency {cairo_native} not found"); // TODO(xrvdg) how to create a format message?
+
+    // Both of these are error that should not happen
+    // because if this doesn't exist it also doesn't exist in the lock file
+
+    // How do you chain the values? You can keep using and_then, but then you can't get give feedback over
+    // file not found
+
+    let maybe_path = b.get("path").and_then(|path| path.as_str());
+
+    // todo(xrvdg) Read TigerBeetle naming convention
+    let lock_file = fs::read_to_string("./Cargo.lock").unwrap();
+    let lock_table: Table = toml::from_str(&lock_file).unwrap();
+    let package = lock_table.get("package").unwrap().as_array().unwrap();
+    let cairo_native_lock_table = package
+        .iter()
+        .find(|v| v.get("name").unwrap().as_str().unwrap() == cairo_native)
+        .unwrap()
+        .as_table()
+        .unwrap();
+
+    // checksum from if it comes from registry
+    let maybe_checksum = cairo_native_lock_table
+        .get("checksum")
+        .and_then(|c| c.as_str());
+
+    // Should work for both unspecified revision and specified revision, at least for github links
+    // source is optional
+    // Todo(xrvdg) could probably use ? if I make it into a function
+    let maybe_rev = extract_rev_from_source(cairo_native_lock_table);
+
+    let rn: String = match (maybe_rev, maybe_path, maybe_checksum) {
+        (Some(rev), _, _) => rev,
+        (_, Some(path), _) => get_git_rev(path),
+        (_, _, Some(checksum)) => checksum.to_string(),
+        (_, _, _) => panic!("No revision, path, or checksum found"),
+    };
+
+    // Set environment variable NATIVE_CACHE_VERSION
+    println!("cargo::rustc-env=NATIVE_VERSION={rn}");
+}
+
+fn get_git_rev(path: &str) -> String {
+    let path = fs::canonicalize(path).unwrap();
+    let p = Command::new("git")
+        .args(["rev-parse", "HEAD"])
+        .current_dir(path)
+        .output();
+    // TODO(xrvdg) convert to expects
+    let out = String::from_utf8(p.unwrap().stdout);
+    out.unwrap()
+}
+
+fn extract_rev_from_source(lock_table: &toml::Table) -> Option<String> {
+    // We now swallow a parse error. This makes it a bit harder to debug if something goes wrong
+    // Can also add warning and use the panic that comes later
+    let source = Url::parse(lock_table.get("source")?.as_str()?).ok()?;
+    Some(String::from(
+        source
+            .fragment()
+            .expect("source must have a revision fragment"),
+    ))
+}

--- a/vm/rust/src/juno_state_reader.rs
+++ b/vm/rust/src/juno_state_reader.rs
@@ -260,9 +260,14 @@ fn native_try_from_json_string(
 
         // inlining from_native_module
 
-        let object_data =
-            cairo_native::module_to_object(native_program.module(), opt_level).unwrap();
-        cairo_native::object_to_shared_lib(&object_data, &library_path).unwrap();
+        if !library_path.is_file() {
+            println!("compiling {}", library_path.display());
+            let object_data =
+                cairo_native::module_to_object(native_program.module(), opt_level).unwrap();
+            cairo_native::object_to_shared_lib(&object_data, &library_path).unwrap();
+        } else {
+            println!("Loading {}", library_path.display());
+        }
 
         // Redoing work from compile
         let program_registry = ProgramRegistry::new(sierra_program).unwrap();

--- a/vm/rust/src/lib.rs
+++ b/vm/rust/src/lib.rs
@@ -224,14 +224,17 @@ pub extern "C" fn cairoVMExecute(
             txn_and_query_bit.txn_hash
         );
         let class_info = match txn_and_query_bit.txn.clone() {
-            StarknetApiTransaction::Declare(_declare_transaction) => {
+            StarknetApiTransaction::Declare(declare_transaction) => {
                 if classes.is_empty() {
                     report_error(reader_handle, "missing declared class", txn_index as i64);
                     return;
                 }
                 let class_json_str = classes.remove(0);
 
-                let maybe_cc = class_info_from_json_str(class_json_str.get());
+                let maybe_cc = class_info_from_json_str(
+                    class_json_str.get(),
+                    declare_transaction.class_hash(),
+                );
 
                 if let Err(e) = &maybe_cc {
                     report_error(reader_handle, e.to_string().as_str(), txn_index as i64);


### PR DESCRIPTION
Adds persistence for native compiled contracts. The directory where these are stored can be set via the environment variable `JUNO_NATIVE_CACHE_DIR`, otherwise the current active directory is used. 

The cache is invalidated by changing the revision of cairo native. The logic for getting the cairo native revision is in `build.rs`. 

Merging into the native2.6.4-blockifier branch as the 2.7.x branch is not ready yet. 