### PR TITLE
Remove benchmark step from juno-test workflow

### DIFF
--- a/.github/workflows/juno-test.yml
+++ b/.github/workflows/juno-test.yml
@@ -56,9 +56,6 @@ jobs:
 #        if: matrix.os == 'ubuntu-latest'
 #        run: make test-race
 
-      - name: Benchmark
-        run: make benchmarks
-
       - name: Upload coverage to Codecov
         if: matrix.os == 'ubuntu-latest'
         uses: codecov/codecov-action@v4


### PR DESCRIPTION
No one is looking at the results here, so there is no point in keep running it.  By disabling it, we
will be able to save around 2min per run