### PR TITLE
Update golangci-lint

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -83,7 +83,7 @@ install-mockgen:
 	go install go.uber.org/mock/mockgen@latest
 
 install-golangci-lint:
-	@which golangci-lint || go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.59.1
+	@which golangci-lint || go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.60.1
 
 lint: install-golangci-lint
 	golangci-lint run

--- a/core/state.go
+++ b/core/state.go
@@ -145,7 +145,7 @@ func (s *State) globalTrie(bucket db.Bucket, newTrie trie.NewTrieFunc) (*trie.Tr
 	})
 
 	// if some error other than "not found"
-	if err != nil && !errors.Is(db.ErrKeyNotFound, err) {
+	if err != nil && !errors.Is(err, db.ErrKeyNotFound) {
 		return nil, nil, err
 	}
 

--- a/db/pebble/transaction.go
+++ b/db/pebble/transaction.go
@@ -94,6 +94,7 @@ func (t *Transaction) Get(key []byte, cb func([]byte) error) error {
 		return ErrDiscardedTransaction
 	}
 
+	// We need it evaluated immediately so the duration doesn't include the runtime of the user callback that we call below.
 	defer t.listener.OnIO(false, time.Since(start)) //nolint:govet
 	if err != nil {
 		if errors.Is(err, pebble.ErrNotFound) {

--- a/p2p/sync.go
+++ b/p2p/sync.go
@@ -64,7 +64,7 @@ func (s *syncService) start(ctx context.Context) {
 		var nextHeight int
 		if curHeight, err := s.blockchain.Height(); err == nil {
 			nextHeight = int(curHeight) + 1
-		} else if !errors.Is(db.ErrKeyNotFound, err) {
+		} else if !errors.Is(err, db.ErrKeyNotFound) {
 			s.log.Errorw("Failed to get current height", "err", err)
 		}
 


### PR DESCRIPTION
The [Makefile](https://github.com/NethermindEth/juno/pull/2057/files#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52) has been updated to install the latest version of [golangci-lint](https://github.com/golangci/golangci-lint/releases). Additionally, the error handling in the [state.go](https://github.com/NethermindEth/juno/pull/2057/files#diff-c075eb780b39817edd44ca2456cee339e3c84f432658a27a58cbb44bc9204780) and [sync.go](https://github.com/NethermindEth/juno/pull/2057/files#diff-340ab7cacf9cfea20ff4dc3ab318bf9d74bb2aaf1f9c1ef169505bf14d944205) files has been fixed to fix a linter issue.

Updated [transaction.go](https://github.com/NethermindEth/juno/pull/2057/files#diff-dcbd417002047da58346e54c1136d97f99e9672421b29ef565e80be9c6416150) and [compiler_test.go](https://github.com/NethermindEth/juno/pull/2057/files#diff-a32b31fe24540eba69449658f352900ff6fceb97bce7e28f685891bd540aa166) to pass [codecov](https://github.com/apps/codecov) ([5a3ba49](https://github.com/NethermindEth/juno/pull/2057/commits/5a3ba49d8b36eb3cab6911db9d6465eba7ef6486))