### PR TITLE
ci: Update concurrency settings in GitHub workflows

### DIFF
--- a/.github/workflows/ci-cd-pipeline.yml
+++ b/.github/workflows/ci-cd-pipeline.yml
@@ -14,6 +14,10 @@ on:
     tags: ["v*"]
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   id-token: write
   contents: write

--- a/.github/workflows/docs-deploy.yml
+++ b/.github/workflows/docs-deploy.yml
@@ -3,11 +3,15 @@ name: Deploy Documentation to GitHub Pages
 on:
   push:
     branches:
-      main
+      - main
   workflow_dispatch:
 
 permissions:
   contents: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   deploy:

--- a/.github/workflows/docs-test.yml
+++ b/.github/workflows/docs-test.yml
@@ -5,6 +5,10 @@ on:
     branches:
       - main
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   test-deploy:
     name: Test deployment

--- a/.github/workflows/juno-lint.yml
+++ b/.github/workflows/juno-lint.yml
@@ -6,9 +6,15 @@ on:
     branches:
       - main
   pull_request:
+
 permissions:
   contents: read
   pull-requests: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   golangci:
     name: lint

--- a/.github/workflows/juno-test.yml
+++ b/.github/workflows/juno-test.yml
@@ -7,6 +7,10 @@ on:
   pull_request:
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   test:
     name: Run Tests

--- a/.github/workflows/starknet-js-tests.yml
+++ b/.github/workflows/starknet-js-tests.yml
@@ -9,7 +9,11 @@ on:
         required: false
       TEST_ACCOUNT_PRIVATE_KEY:
           required: false
-          
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/starknet-rs-tests.yml
+++ b/.github/workflows/starknet-rs-tests.yml
@@ -6,6 +6,10 @@ on:
       STARKNET_RPC:
         required: true
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/sync_first_100_blocks_smoke_test.yml
+++ b/.github/workflows/sync_first_100_blocks_smoke_test.yml
@@ -7,7 +7,11 @@ on:
   pull_request:
     branches:
       - main
-      
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   run_smoke_tests:
     runs-on: ubuntu-latest


### PR DESCRIPTION
If there are two jobs running for the same branch, cancel the oldest one.  This is useful when merging many PRs at the same time (for example the ones from dependabot), avoiding running the tests/deployment for every single commit