### PR TITLE
fix: Remove unnecessary go in matrix

### DIFF
--- a/.github/workflows/juno-test.yml
+++ b/.github/workflows/juno-test.yml
@@ -13,7 +13,6 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        go: ["1.23.0"]
         os: [ubuntu-latest, macos-latest, ubuntu-arm64-2-core]
     runs-on: ${{ matrix.os }}
     env:


### PR DESCRIPTION
CI is getting the go version from go.mod, and there is no reference for matrix.go.  Therefore we can
conclude that this is not being used.

The annoying part with this is when upgrading the go version, the job will be a different name, and someone needs to manually go to the protected rule for the main branch and update what's the name of the tests