### PR TITLE
Replace custom code with maps package functions

### DIFF
--- a/core/state.go
+++ b/core/state.go
@@ -5,6 +5,7 @@ import (
 	"encoding/binary"
 	"errors"
 	"fmt"
+	"maps"
 	"runtime"
 	"slices"
 	"sort"
@@ -397,11 +398,8 @@ func (s *State) updateContractStorages(stateTrie *trie.Trie, diffs map[felt.Felt
 
 	// sort the contracts in decending diff size order
 	// so we start with the heaviest update first
-	keys := make([]felt.Felt, 0, len(diffs))
-	for key := range diffs {
-		keys = append(keys, key)
-	}
-	slices.SortStableFunc(keys, func(a, b felt.Felt) int { return len(diffs[a]) - len(diffs[b]) })
+	mapKeys := maps.Keys(diffs)
+	keys := slices.SortedStableFunc(mapKeys, func(a, b felt.Felt) int { return len(diffs[a]) - len(diffs[b]) })
 
 	// update per-contract storage Tries concurrently
 	contractUpdaters := pool.NewWithResults[*bufferedTransactionWithAddress]().WithErrors().WithMaxGoroutines(runtime.GOMAXPROCS(0))

--- a/core/state.go
+++ b/core/state.go
@@ -398,8 +398,7 @@ func (s *State) updateContractStorages(stateTrie *trie.Trie, diffs map[felt.Felt
 
 	// sort the contracts in decending diff size order
 	// so we start with the heaviest update first
-	mapKeys := maps.Keys(diffs)
-	keys := slices.SortedStableFunc(mapKeys, func(a, b felt.Felt) int { return len(diffs[a]) - len(diffs[b]) })
+	keys := slices.SortedStableFunc(maps.Keys(diffs), func(a, b felt.Felt) int { return len(diffs[a]) - len(diffs[b]) })
 
 	// update per-contract storage Tries concurrently
 	contractUpdaters := pool.NewWithResults[*bufferedTransactionWithAddress]().WithErrors().WithMaxGoroutines(runtime.GOMAXPROCS(0))

--- a/core/state_update.go
+++ b/core/state_update.go
@@ -143,8 +143,7 @@ func (d *StateDiff) Commitment() *felt.Felt {
 }
 
 func sortedFeltKeys[V any](m map[felt.Felt]V) []felt.Felt {
-	keys := maps.Keys(m)
-	return slices.SortedFunc(keys, func(a, b felt.Felt) int { return a.Cmp(&b) })
+	return slices.SortedFunc(maps.Keys(m), func(a, b felt.Felt) int { return a.Cmp(&b) })
 }
 
 func updatedContractsDigest(deployedContracts, replacedClasses map[felt.Felt]*felt.Felt, digest *crypto.PoseidonDigest) {

--- a/core/state_update.go
+++ b/core/state_update.go
@@ -143,12 +143,8 @@ func (d *StateDiff) Commitment() *felt.Felt {
 }
 
 func sortedFeltKeys[V any](m map[felt.Felt]V) []felt.Felt {
-	keys := make([]felt.Felt, 0, len(m))
-	for addr := range m {
-		keys = append(keys, addr)
-	}
-	slices.SortFunc(keys, func(a, b felt.Felt) int { return a.Cmp(&b) })
-	return keys
+	keys := maps.Keys(m)
+	return slices.SortedFunc(keys, func(a, b felt.Felt) int { return a.Cmp(&b) })
 }
 
 func updatedContractsDigest(deployedContracts, replacedClasses map[felt.Felt]*felt.Felt, digest *crypto.PoseidonDigest) {

--- a/migration/migration.go
+++ b/migration/migration.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"maps"
 	"runtime"
 	"sync"
 
@@ -598,9 +599,7 @@ func changeStateDiffStruct(txn db.Transaction, key, value []byte, _ *utils.Netwo
 	}
 
 	nonces := make(map[felt.Felt]*felt.Felt, len(old.StateDiff.Nonces))
-	for addr, nonce := range old.StateDiff.Nonces {
-		nonces[addr] = nonce
-	}
+	maps.Copy(nonces, old.StateDiff.Nonces)
 
 	deployedContracts := make(map[felt.Felt]*felt.Felt, len(old.StateDiff.DeployedContracts))
 	for _, deployedContract := range old.StateDiff.DeployedContracts {

--- a/utils/maps.go
+++ b/utils/maps.go
@@ -1,23 +1,5 @@
 package utils
 
-func MapValues[K comparable, V any](m map[K]V) []V {
-	sl := make([]V, 0, len(m))
-	for _, v := range m {
-		sl = append(sl, v)
-	}
-
-	return sl
-}
-
-func MapKeys[K comparable, V any](m map[K]V) []K {
-	sl := make([]K, 0, len(m))
-	for k := range m {
-		sl = append(sl, k)
-	}
-
-	return sl
-}
-
 func ToMap[T any, K comparable, V any](sl []T, f func(T) (K, V)) map[K]V {
 	m := make(map[K]V, len(sl))
 	for _, item := range sl {

--- a/vm/vm.go
+++ b/vm/vm.go
@@ -337,7 +337,6 @@ func (v *vm) Execute(txns []core.Transaction, declaredClasses []core.Class, paid
 		if err := json.Unmarshal(traceJSON, &traces[index]); err != nil {
 			return nil, nil, nil, fmt.Errorf("unmarshal trace: %v", err)
 		}
-		//
 	}
 
 	return context.actualFees, context.dataGasConsumed, traces, nil


### PR DESCRIPTION
Because of recent Go 1.23 update now we can use new functions from `maps` and remove our own (`utils.MapKeys` and `utils.MapValues`)