### PR TITLE
Make starknet_getTransactionReceipt and other function calls response conform to the 0.7.1 spec

### DIFF
--- a/rpc/block_test.go
+++ b/rpc/block_test.go
@@ -604,7 +604,7 @@ func TestBlockWithReceipts(t *testing.T) {
 
 			txsWithReceipt = append(txsWithReceipt, rpc.TransactionWithReceipt{
 				Transaction: adaptedTx,
-				Receipt:     rpc.AdaptReceipt(receipt, tx, rpc.TxnAcceptedOnL2, nil, 0, true),
+				Receipt:     rpc.AdaptReceipt(receipt, tx, rpc.TxnAcceptedOnL2, nil, 0, false),
 			})
 		}
 
@@ -648,7 +648,7 @@ func TestBlockWithReceipts(t *testing.T) {
 
 			transactions = append(transactions, rpc.TransactionWithReceipt{
 				Transaction: adaptedTx,
-				Receipt:     rpc.AdaptReceipt(receipt, tx, rpc.TxnAcceptedOnL1, nil, 0, true),
+				Receipt:     rpc.AdaptReceipt(receipt, tx, rpc.TxnAcceptedOnL1, nil, 0, false),
 			})
 		}
 

--- a/rpc/helpers.go
+++ b/rpc/helpers.go
@@ -91,10 +91,7 @@ func adaptExecutionResources(resources *core.ExecutionResources, v0_6Response bo
 	if resources == nil {
 		if !v0_6Response {
 			return &ExecutionResources{
-				DataAvailability: &DataAvailability{
-					L1Gas:     uint64(0),
-					L1DataGas: uint64(0),
-				},
+				DataAvailability: &DataAvailability{},
 			}
 		} else {
 			return &ExecutionResources{}
@@ -117,10 +114,7 @@ func adaptExecutionResources(resources *core.ExecutionResources, v0_6Response bo
 	}
 	if !v0_6Response {
 		if resources.DataAvailability == nil {
-			res.DataAvailability = &DataAvailability{
-				L1Gas:     uint64(0),
-				L1DataGas: uint64(0),
-			}
+			res.DataAvailability = &DataAvailability{}
 		} else {
 			res.DataAvailability = &DataAvailability{
 				L1Gas:     resources.DataAvailability.L1Gas,

--- a/rpc/helpers.go
+++ b/rpc/helpers.go
@@ -89,12 +89,13 @@ func (h *Handler) blockHeaderByID(id *BlockID) (*core.Header, *jsonrpc.Error) {
 
 func adaptExecutionResources(resources *core.ExecutionResources, v0_6Response bool) *ExecutionResources {
 	if resources == nil {
+		var dataAvailability *DataAvailability
 		if !v0_6Response {
-			return &ExecutionResources{
-				DataAvailability: &DataAvailability{},
-			}
-		} else {
-			return &ExecutionResources{}
+			dataAvailability = &DataAvailability{}
+		}
+
+		return &ExecutionResources{
+			DataAvailability: dataAvailability,
 		}
 	}
 

--- a/rpc/helpers.go
+++ b/rpc/helpers.go
@@ -89,7 +89,16 @@ func (h *Handler) blockHeaderByID(id *BlockID) (*core.Header, *jsonrpc.Error) {
 
 func adaptExecutionResources(resources *core.ExecutionResources, v0_6Response bool) *ExecutionResources {
 	if resources == nil {
-		return &ExecutionResources{}
+		if !v0_6Response {
+			return &ExecutionResources{
+				DataAvailability: &DataAvailability{
+					L1Gas:     uint64(0),
+					L1DataGas: uint64(0),
+				},
+			}
+		} else {
+			return &ExecutionResources{}
+		}
 	}
 
 	res := &ExecutionResources{
@@ -106,10 +115,17 @@ func adaptExecutionResources(resources *core.ExecutionResources, v0_6Response bo
 			SegmentArena: resources.BuiltinInstanceCounter.SegmentArena,
 		},
 	}
-	if !v0_6Response && resources.DataAvailability != nil {
-		res.DataAvailability = &DataAvailability{
-			L1Gas:     resources.DataAvailability.L1Gas,
-			L1DataGas: resources.DataAvailability.L1DataGas,
+	if !v0_6Response {
+		if resources.DataAvailability == nil {
+			res.DataAvailability = &DataAvailability{
+				L1Gas:     uint64(0),
+				L1DataGas: uint64(0),
+			}
+		} else {
+			res.DataAvailability = &DataAvailability{
+				L1Gas:     resources.DataAvailability.L1Gas,
+				L1DataGas: resources.DataAvailability.L1DataGas,
+			}
 		}
 	}
 

--- a/rpc/transaction_test.go
+++ b/rpc/transaction_test.go
@@ -1036,44 +1036,50 @@ func TestTransactionReceiptByHash(t *testing.T) {
 		checkTxReceipt(t, txnHash, expected)
 	})
 
-	t.Run("v0.7 blocks >= 0.13.2", func(t *testing.T) {
-		t.Skip()
+	t.Run("tx with non empty data_availability", func(t *testing.T) {
 		expected := `{
-			"type": "DEPLOY",
-			"transaction_hash": "0x7b6dc0e1157c2eb6e3e5126b99f51939283d03302bf5bdb4207e571bbf4120e",
+			"type": "DECLARE",
+			"transaction_hash": "0x5ac644bbd6ae98d3be2d988439854e33f0961e24f349a63b43e16d172bfe747",
 			"actual_fee": {
-				"amount": "0x0",
+				"amount": "0xd07af45c84550",
 				"unit": "WEI"
 			},
 			"execution_status": "SUCCEEDED",
-			"finality_status": "ACCEPTED_ON_L1",
-			"block_hash": "0x63ef7dc50c7575d3eeb3732e6deb0c98de078b0b222109a597ef996249c36b3",
-			"block_number": 5001,
+			"finality_status": "ACCEPTED_ON_L2",
+			"block_hash": "0x1ea2a9cfa3df5297d58c0a04d09d276bc68d40fe64701305bbe2ed8f417e869",
+			"block_number": 35748,
 			"messages_sent": [],
 			"events": [
 				{
-					"from_address": "0xccec275c57df25ff315756c80e321c57fab4c4abeb3c0a9daf3606700bb255",
+					"from_address": "0x49d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7",
 					"keys": [
-						"0x10c19bef19acd19b2c9f4caa40fd47c9fbe1d9f91324d44dcd36be2dae96784"
+						"0x99cd8bde557814842a3121e8ddfd433a539b8c9f14bf31ebf108d12e6196e9"
 					],
 					"data": [
-						"0xccec275c57df25ff315756c80e321c57fab4c4abeb3c0a9daf3606700bb255",
-						"0x78467d2b7018392510e2816a13ac9a7a49a3a39f5b631dcd2f210ac0c40f6e1",
+						"0x472aa8128e01eb0df145810c9511a92852d62a68ba8198ce5fa414e6337a365",
+						"0x1176a1bd84444c89232ec27754698e5d2e7e1a7f1539f12027f28b23ec9f3d8",
+						"0xd07af45c84550",
 						"0x0"
 					]
 				}
 			],
-			"contract_address": "0xccec275c57df25ff315756c80e321c57fab4c4abeb3c0a9daf3606700bb255",
 			"execution_resources": {
-				"steps": 978,
-				"range_check_builtin_applications": 18
+				"steps": 3950,
+				"ecdsa_builtin_applications": 1,
+				"pedersen_builtin_applications": 16,
+				"poseidon_builtin_applications": 4,
+				"range_check_builtin_applications": 157,
+				"data_availability": {
+					"l1_gas": 0,
+					"l1_data_gas": 192
+				}
 			}
 		}`
 
-		netClient := feeder.NewTestClient(t, utils.Ptr(utils.Mainnet))
+		netClient := feeder.NewTestClient(t, utils.Ptr(utils.SepoliaIntegration))
 		netGW := adaptfeeder.New(netClient)
 
-		block, err := netGW.BlockByNumber(context.Background(), 5_001)
+		block, err := netGW.BlockByNumber(context.Background(), 35748)
 		require.NoError(t, err)
 
 		index := 0
@@ -1081,12 +1087,7 @@ func TestTransactionReceiptByHash(t *testing.T) {
 		mockReader.EXPECT().TransactionByHash(txnHash).Return(block.Transactions[index], nil)
 		mockReader.EXPECT().Receipt(txnHash).Return(block.Receipts[index],
 			block.Hash, block.Number, nil)
-		// mockReader.EXPECT().L1Head().Return(nil, db.ErrKeyNotFound)
-		mockReader.EXPECT().L1Head().Return(&core.L1Head{
-			BlockNumber: block.Number,
-			BlockHash:   block.Hash,
-			StateRoot:   block.GlobalStateRoot,
-		}, nil)
+		mockReader.EXPECT().L1Head().Return(nil, db.ErrKeyNotFound)
 
 		checkTxReceipt(t, txnHash, expected)
 	})

--- a/rpc/transaction_test.go
+++ b/rpc/transaction_test.go
@@ -803,7 +803,13 @@ func TestTransactionReceiptByHash(t *testing.T) {
 					"messages_sent": [],
 					"events": [],
 					"contract_address": "0x20cfa74ee3564b4cd5435cdace0f9c4d43b939620e4a0bb5076105df0a626c6",
-					"execution_resources":{"steps":29}
+					"execution_resources": {
+						"data_availability": {
+							"l1_data_gas": 0,
+							"l1_gas": 0
+						},
+						"steps": 29
+					}
 				}`,
 		},
 		"without contract addr": {
@@ -827,7 +833,13 @@ func TestTransactionReceiptByHash(t *testing.T) {
 						}
 					],
 					"events": [],
-					"execution_resources":{"steps":31}
+					"execution_resources": {
+						"data_availability": {
+							"l1_data_gas": 0,
+							"l1_gas": 0
+						},
+						"steps": 31
+					}
 				}`,
 		},
 	}
@@ -861,7 +873,13 @@ func TestTransactionReceiptByHash(t *testing.T) {
 						}
 					],
 					"events": [],
-					"execution_resources":{"steps":31}
+					"execution_resources": {
+						"data_availability": {
+							"l1_data_gas": 0,
+							"l1_gas": 0
+						},
+						"steps": 31
+					}
 				}`
 
 		txHash := block0.Transactions[i].Hash()
@@ -892,7 +910,13 @@ func TestTransactionReceiptByHash(t *testing.T) {
 						}
 					],
 					"events": [],
-					"execution_resources":{"steps":31}
+					"execution_resources": {
+						"data_availability": {
+							"l1_data_gas": 0,
+							"l1_gas": 0
+						},
+						"steps": 31
+					}
 				}`
 
 		txHash := block0.Transactions[i].Hash()
@@ -918,7 +942,13 @@ func TestTransactionReceiptByHash(t *testing.T) {
 			"messages_sent": [],
 			"events": [],
 			"revert_reason": "Error in the called contract (0x00b1461de04c6a1aa3375bdf9b7723a8779c082ffe21311d683a0b15c078b5dc):\nError at pc=0:25:\nGot an exception while executing a hint.\nCairo traceback (most recent call last):\nUnknown location (pc=0:731)\nUnknown location (pc=0:677)\nUnknown location (pc=0:291)\nUnknown location (pc=0:314)\n\nError in the called contract (0x049d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7):\nError at pc=0:104:\nGot an exception while executing a hint.\nCairo traceback (most recent call last):\nUnknown location (pc=0:1678)\nUnknown location (pc=0:1664)\n\nError in the called contract (0x049d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7):\nError at pc=0:6:\nGot an exception while executing a hint: Assertion failed, 0 % 0x800000000000011000000000000000000000000000000000000000000000001 is equal to 0\nCairo traceback (most recent call last):\nUnknown location (pc=0:1238)\nUnknown location (pc=0:1215)\nUnknown location (pc=0:836)\n",
-			"execution_resources":{"steps":0}
+			"execution_resources": {
+				"data_availability": {
+					"l1_data_gas": 0,
+					"l1_gas": 0
+				},
+				"steps": 0
+			}
 		}`
 
 		integClient := feeder.NewTestClient(t, &utils.Integration)
@@ -976,7 +1006,11 @@ func TestTransactionReceiptByHash(t *testing.T) {
 			"execution_resources": {
 				"steps": 615,
 				"range_check_builtin_applications": 19,
-				"memory_holes": 4
+				"memory_holes": 4,
+				"data_availability": {
+					"l1_data_gas": 0,
+					"l1_gas": 0
+				}
 			},
 			"actual_fee": {
 				"amount": "0x16d8b4ad4000",


### PR DESCRIPTION
Fixes #1805 

## Changes

- Ensures `execution_resources.data_availability` is not omited for non `v0_6` api
- Adds default values of 0 for both `execution_resource.data_availability.l1_gas` and  `execution_resource.data_availability.l1_data_gas`
- Fixes mismatch api version calls in transaction tests..

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: Adds templates to improve contribution flow.

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [x] Yes
- [ ] No

#### Notes on testing
Some tests where updated, to match the required calls.
This is because some test calls previously made use of both v6 and v7 api within the same setup for the same test case.

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No

## Remarks
Updates the api response for `starknet_getTransactionReceipt` to match the spec for v0.7.
Since the field is required for every call in which `execution_resources` is returned it affects a couple of other remote procedures also.