### PR TITLE
Update `blockifier` to 0.8.0-rc.2

### DIFF
--- a/starknet/rust/Cargo.toml
+++ b/starknet/rust/Cargo.toml
@@ -6,9 +6,9 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-serde = "1.0.171"
-serde_json = { version = "1.0.96", features = ["raw_value"] }
-cairo-lang-starknet-classes = "=2.7.0-rc.3"
+serde = "1.0.208"
+serde_json = { version = "1.0.125", features = ["raw_value"] }
+cairo-lang-starknet-classes = "2.7.1"
 
 [lib]
 crate-type = ["staticlib"]

--- a/vm/rust/Cargo.toml
+++ b/vm/rust/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-serde = "1.0.171"
+serde = "1.0.208"
 serde_json = { version = "1.0.96", features = ["raw_value"] }
 blockifier = "0.8.0-rc.2"
 starknet_api = "0.13.0-rc.1"

--- a/vm/rust/Cargo.toml
+++ b/vm/rust/Cargo.toml
@@ -10,7 +10,7 @@ serde = "1.0.208"
 serde_json = { version = "1.0.125", features = ["raw_value"] }
 blockifier = "0.8.0-rc.2"
 starknet_api = "0.13.0-rc.1"
-cairo-vm = "1.0.1"
+cairo-vm = "=1.0.1"
 starknet-types-core = { version = "0.1.5", features = ["hash", "prime-bigint"] }
 indexmap = "2.1.0"
 cached = "0.53.1"

--- a/vm/rust/Cargo.toml
+++ b/vm/rust/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2021"
 [dependencies]
 serde = "1.0.171"
 serde_json = { version = "1.0.96", features = ["raw_value"] }
-blockifier = "=0.8.0-rc.1"
+blockifier = "=0.8.0-rc.2"
 starknet_api = "=0.13.0-rc.0"
 cairo-vm = "=1.0.0-rc5"
 starknet-types-core = { version = "0.1.5", features = ["hash", "prime-bigint"] }

--- a/vm/rust/Cargo.toml
+++ b/vm/rust/Cargo.toml
@@ -8,9 +8,9 @@ edition = "2021"
 [dependencies]
 serde = "1.0.171"
 serde_json = { version = "1.0.96", features = ["raw_value"] }
-blockifier = "=0.8.0-rc.2"
-starknet_api = "=0.13.0-rc.1"
-cairo-vm = "=1.0.1"
+blockifier = "0.8.0-rc.2"
+starknet_api = "0.13.0-rc.1"
+cairo-vm = "1.0.1"
 starknet-types-core = { version = "0.1.5", features = ["hash", "prime-bigint"] }
 indexmap = "2.1.0"
 cached = "0.53.1"

--- a/vm/rust/Cargo.toml
+++ b/vm/rust/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 
 [dependencies]
 serde = "1.0.208"
-serde_json = { version = "1.0.96", features = ["raw_value"] }
+serde_json = { version = "1.0.125", features = ["raw_value"] }
 blockifier = "0.8.0-rc.2"
 starknet_api = "0.13.0-rc.1"
 cairo-vm = "1.0.1"

--- a/vm/rust/Cargo.toml
+++ b/vm/rust/Cargo.toml
@@ -14,7 +14,7 @@ cairo-vm = "=1.0.1"
 starknet-types-core = { version = "0.1.5", features = ["hash", "prime-bigint"] }
 indexmap = "2.1.0"
 cached = "0.53.1"
-once_cell = "1.18.0"
+once_cell = "1.19.0"
 lazy_static = "1.4.0"
 semver = "1.0.22"
 anyhow = "1.0.81"

--- a/vm/rust/Cargo.toml
+++ b/vm/rust/Cargo.toml
@@ -9,8 +9,8 @@ edition = "2021"
 serde = "1.0.171"
 serde_json = { version = "1.0.96", features = ["raw_value"] }
 blockifier = "=0.8.0-rc.2"
-starknet_api = "=0.13.0-rc.0"
-cairo-vm = "=1.0.0-rc5"
+starknet_api = "=0.13.0-rc.1"
+cairo-vm = "=1.0.1"
 starknet-types-core = { version = "0.1.5", features = ["hash", "prime-bigint"] }
 indexmap = "2.1.0"
 cached = "0.53.1"


### PR DESCRIPTION
This pull request updates several dependencies in the project. The `blockifier` dependency is updated to version 0.8.0-rc.2, the `starknet_api` dependency is updated to version 0.13.0-rc.1, the `cairo-vm` dependency is updated to version 1.0.1, the `once_cell` dependency is updated to version 1.19.0, the `serde` dependency is updated to version 1.0.208, and the `serde_json` dependency is updated to version 1.0.125.