### PR TITLE
chore: Remove concurrency settings in child workflow

### DIFF
--- a/.github/workflows/starknet-js-tests.yml
+++ b/.github/workflows/starknet-js-tests.yml
@@ -10,10 +10,6 @@ on:
       TEST_ACCOUNT_PRIVATE_KEY:
           required: false
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
-
 jobs:
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/starknet-rs-tests.yml
+++ b/.github/workflows/starknet-rs-tests.yml
@@ -6,10 +6,6 @@ on:
       STARKNET_RPC:
         required: true
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
-
 jobs:
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
When the parent and the child workflow set the concurrency, it creates a deadlock.

More info:
https://github.com/github/vscode-github-actions/issues/135