### PR TITLE
Better error classification in clients/feeder

### DIFF
--- a/clients/feeder/feeder.go
+++ b/clients/feeder/feeder.go
@@ -256,9 +256,17 @@ func (c *Client) get(ctx context.Context, queryURL string) (io.ReadCloser, error
 				if res.StatusCode == http.StatusOK {
 					return res.Body, nil
 				} else {
-					err = errors.New(res.Status)
+					var errorResponse struct {
+						Code    string `json:"code"`
+						Message string `json:"message"`
+					}
+					err = json.NewDecoder(res.Body).Decode(&errorResponse)
+					if err == nil {
+						err = errors.New(errorResponse.Message)
+					} else {
+						err = errors.New(res.Status)
+					}
 				}
-
 				res.Body.Close()
 			}
 


### PR DESCRIPTION
To reflect error message in the response first I have made a struct of errorResponse It consist of two members, Code and Message. first res.body will be decoded if there is an error . after that message from decoded res.body will be returned.

Fixed #1888 