### PR TITLE
Remove additional "kad" substring from discovery

### DIFF
--- a/p2p/p2p.go
+++ b/p2p/p2p.go
@@ -165,7 +165,7 @@ func NewWithHost(p2phost host.Host, peers string, feederNode bool, bc *blockchai
 
 func makeDHT(p2phost host.Host, addrInfos []peer.AddrInfo) (*dht.IpfsDHT, error) {
 	return dht.New(context.Background(), p2phost,
-		dht.ProtocolPrefix(starknet.KadPrefix()),
+		dht.ProtocolPrefix(starknet.Prefix),
 		dht.BootstrapPeers(addrInfos...),
 		dht.RoutingTableRefreshPeriod(routingTableRefreshPeriod),
 		dht.Mode(dht.ModeServer),

--- a/p2p/starknet/ids.go
+++ b/p2p/starknet/ids.go
@@ -6,10 +6,6 @@ import (
 
 const Prefix = "/starknet"
 
-func KadPrefix() protocol.ID {
-	return Prefix + "/kad"
-}
-
 func HeadersPID() protocol.ID {
 	return Prefix + "/headers/0.1.0-rc.0"
 }


### PR DESCRIPTION
Change discovery protocol name from `starknet/kad/kad/1.0.0` to `starknet/kad/1.0.0`.