### PR TITLE
update native dependencies

### DIFF
--- a/vm/rust/Cargo.toml
+++ b/vm/rust/Cargo.toml
@@ -8,8 +8,7 @@ edition = "2021"
 [dependencies]
 serde = "1.0.171"
 serde_json = { version = "1.0.96", features = ["raw_value"] }
-blockifier = { git = "https://github.com/NethermindEth/blockifier", branch = "native2.7.x" }
-# blockifier = { path = "../../../blockifier-neth/crates/blockifier/" }
+blockifier = { git = "https://github.com/NethermindEth/sequencer.git" }
 cairo-lang-sierra = "2.7.0"
 cairo-lang-starknet = "2.7.0"
 cairo-lang-starknet-classes = "2.7.0"
@@ -18,8 +17,8 @@ starknet-types-core = { version = "0.1.5", features = [
     "prime-bigint",
     "serde",
 ] }
-cairo-native = { git = "https://github.com/NethermindEth/cairo_native", branch = "remove-unused-deps" }
-starknet_api = "=0.13.0-rc.0"
+cairo-native = { git = "https://github.com/lambdaclass/cairo_native", rev = "0b77a8b9b4d1690768b7ea890632da6a45603e84" }
+starknet_api = { git = "https://github.com/NethermindEth/sequencer.git" }
 cairo-vm = "1.0.0"
 indexmap = "2.1.0"
 cached = "0.46.1"


### PR DESCRIPTION
In `Cargo.toml`, point the following to sequencer repo: starknet_api
blockifier

`src/lib.rs`: Update to match sequencer blockifier/src/transaction/objects.rs TransactionExecutionInfo::transaction_receipt
was changed to
TransactionExecutionInfo::receipt

Note: This will fail until corresponding update in sequencer is made.
Sequencer PR: NethermindEth/sequencer#11