### PR TITLE
Improve build binaries pipeline

### DIFF
--- a/.github/workflows/build-binaries.yml
+++ b/.github/workflows/build-binaries.yml
@@ -5,6 +5,11 @@ on:
     tags:
       - 'v*'
   workflow_dispatch:
+  pull_request:
+    branches:
+      - main
+    paths:
+      - .github/workflows/build-binaries.yml
 
 jobs:
   build:
@@ -13,11 +18,9 @@ jobs:
       matrix:
         include:
           - os: ubuntu-latest
-            architecture: amd64
-          - os: macOS-latest
-            architecture: amd64
+          - os: macos-13
           - os: ubuntu-arm64-4-core
-            architecture: arm64
+          - os: macos-latest
     runs-on: ${{ matrix.os }}
 
     steps:
@@ -27,8 +30,10 @@ jobs:
           fetch-depth: 0
 
       - name: Get latest tag
-        id: tag
         run: echo "TAG=$(git describe --tags)" >> $GITHUB_ENV
+
+      - name: Get artifact name
+        run: echo "ARTIFACT_NAME=juno-${{ env.TAG }}-${{ runner.os }}-$(uname -m)" >> $GITHUB_ENV
 
       - name: Install dependencies (Linux)
         if: runner.os == 'Linux'
@@ -47,27 +52,21 @@ jobs:
         run: |
           make juno
           upx build/juno
-          mv build/juno juno-${{ env.TAG }}-${{ runner.os }}-${{ matrix.architecture }}
+          mv build/juno ${{ env.ARTIFACT_NAME }}
 
       - name: Generate Checksum
         id: checksum
         run: |
           if [[ "${{ runner.os }}" == "macOS" ]]; then
-            shasum -a 256 juno-${{ env.TAG }}-${{ runner.os }}-${{ matrix.architecture }} > juno-${{ env.TAG }}-${{ runner.os }}-${{ matrix.architecture }}.sha256
+            shasum -a 256 ${{ env.ARTIFACT_NAME }} > ${{ env.ARTIFACT_NAME }}.sha256
           else
-            sha256sum juno-${{ env.TAG }}-${{ runner.os }}-${{ matrix.architecture }} > juno-${{ env.TAG }}-${{ runner.os }}-${{ matrix.architecture }}.sha256
+            sha256sum ${{ env.ARTIFACT_NAME }} > ${{ env.ARTIFACT_NAME }}.sha256
           fi
 
       - name: Upload Artifact
         uses: actions/upload-artifact@v4
         with:
-          name: juno-${{ env.TAG }}-${{ runner.os }}-${{ matrix.architecture }}
+          name: ${{ env.ARTIFACT_NAME }}
           path: |
-            juno-${{ env.TAG }}-${{ runner.os }}-${{ matrix.architecture }}
-            juno-${{ env.TAG }}-${{ runner.os }}-${{ matrix.architecture }}.sha256
-
-      - name: Cleanup
-        if: matrix.os == 'self-hosted'
-        run: |
-          rm juno-${{ env.TAG }}-${{ runner.os }}-${{ matrix.architecture }}
-          rm juno-${{ env.TAG }}-${{ runner.os }}-${{ matrix.architecture }}.sha256
+            ${{ env.ARTIFACT_NAME }}
+            ${{ env.ARTIFACT_NAME }}.sha256


### PR DESCRIPTION
Changes made:
- build macOS arm and x86
- rename architecture from amd64 to x86_64, which is much easier to distinct from arm
- remove unnecessary step for self-hosted which is not being used anymore
- create ARTIFACT_NAME env var, so it's much easier to read the code
- remove unnecessary id
- add trigger on PR that change the build binaries files