### PR TITLE
chore: update how to deploy dev and staging envs

### DIFF
--- a/.github/workflows/ci-cd-pipeline.yml
+++ b/.github/workflows/ci-cd-pipeline.yml
@@ -58,7 +58,9 @@ jobs:
           context: .
           platforms: "linux/amd64"
           push: true
-          tags: ${{ env.DOCKER_REGISTRY }}/${{ env.REPO_DEV }}/juno:${{ env.DOCKER_IMAGE_TAG }}
+          tags: |
+            ${{ env.DOCKER_REGISTRY }}/${{ env.REPO_DEV }}/juno:${{ env.DOCKER_IMAGE_TAG }}
+            ${{ env.DOCKER_REGISTRY }}/${{ env.REPO_DEV }}/juno:latest
 
 
   validate_dev:
@@ -108,10 +110,14 @@ jobs:
         run: |
           OLD_TAG=${{ env.DOCKER_REGISTRY }}/${{ env.REPO_DEV }}/juno:${{ needs.build_docker_image.outputs.DOCKER_IMAGE_TAG }}
           NEW_TAG=${{ env.DOCKER_REGISTRY }}/${{ env.REPO_STAGING }}/juno:${{ needs.build_docker_image.outputs.DOCKER_IMAGE_TAG }}
+          LATEST_TAG=${{ env.DOCKER_REGISTRY }}/${{ env.REPO_STAGING }}/juno:latest
 
           docker pull $OLD_TAG
           docker tag $OLD_TAG $NEW_TAG
           docker push $NEW_TAG
+
+          docker tag $OLD_TAG $LATEST_TAG
+          docker push $LATEST_TAG
 
       - name: Verify Deployment Version (Staging)
         run: |


### PR DESCRIPTION
With the https://github.com/NethermindEth/argo/pull/1094 change, it will now always track the latest tag which can be overwriten everytime this workflow runs.

It means that even performing roll-backs will work