### PR TITLE
feat: Add GitHub Actions workflow to find the smallest supported Rust version

### DIFF
--- a/.github/workflows/find-smallest-rust.yml
+++ b/.github/workflows/find-smallest-rust.yml
@@ -1,0 +1,42 @@
+name: Minimum Supported Rust
+
+on:
+  pull_request:
+    branches:
+      - main
+    paths:
+      - .github/workflows/find-smallest-rust.yml
+      - core/rust/*
+      - vm/rust/*
+      - starknet/rust/*
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  find-smallest-rust:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Find smallest supported Rust version
+        id: rust-version
+        uses: derrix060/detect-rust-minimum-version@v1
+        with:
+          paths: core/rust/,vm/rust/,starknet/rust/
+      - name: Send notification on PR
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const msrv = '${{ steps.rust-version.outputs.highest-msrv }}'
+            const previous_msrv = '1.80.1'
+
+            if (msrv != previous_msrv) {
+              github.rest.issues.createComment({
+                issue_number: context.issue.number,
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                body: 'Minimum supported Rust version is `' + msrv + '`, previous `' + previous_msrv + '`.  Please update the README file and this workflow.'
+              })
+            }

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@
 
 - Golang 1.23 or higher is required to build and run the project. You can find the installer on
   the official Golang [download](https://go.dev/doc/install) page.
-- [Rust](https://www.rust-lang.org/tools/install).
+- [Rust](https://www.rust-lang.org/tools/install) 1.80.1 or higher.
 - A C compiler: `gcc` or `clang`.
 - Install `jemalloc` and `pkg-config` on your system:
   


### PR DESCRIPTION
The idea of this workflow is to ensure we have up-to-date documentation on
the minimum required version of rust.  It will only run on PRs that touch either
this workflow or rust files

Since there is no easy way to have a workflow to be required and only run on
some cases, it will send a message to the PR every time the minimum version
changes