### PR TITLE
Remove repeated close host call

### DIFF
--- a/p2p/p2p.go
+++ b/p2p/p2p.go
@@ -268,7 +268,7 @@ func (s *Service) Run(ctx context.Context) error {
 	if err := s.dht.Close(); err != nil {
 		s.log.Warnw("Failed stopping DHT", "err", err.Error())
 	}
-	return s.host.Close()
+	return nil
 }
 
 func (s *Service) setProtocolHandlers() {

--- a/p2p/p2p.go
+++ b/p2p/p2p.go
@@ -233,7 +233,11 @@ func (s *Service) SubscribePeerConnectednessChanged(ctx context.Context) (<-chan
 
 // Run starts the p2p service. Calling any other function before run is undefined behaviour
 func (s *Service) Run(ctx context.Context) error {
-	defer s.host.Close()
+	defer func() {
+		if err := s.host.Close(); err != nil {
+			s.log.Warnw("Failed to close host", "err", err)
+		}
+	}()
 
 	err := s.dht.Bootstrap(ctx)
 	if err != nil {


### PR DESCRIPTION
The previous line already does `defer s.host.Close()`, so there's no need to do `return s.host.Close()` again.