### PR TITLE
feat: Update transactionCommitmentPoseidon function to handle different transaction types

### DIFF
--- a/core/block_pkg_test.go
+++ b/core/block_pkg_test.go
@@ -1,11 +1,12 @@
 package core
 
 import (
+	"testing"
+
 	"github.com/NethermindEth/juno/core/felt"
 	"github.com/NethermindEth/juno/utils"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"testing"
 )
 
 func TestTransactionCommitmentPoseidon(t *testing.T) {

--- a/core/block_pkg_test.go
+++ b/core/block_pkg_test.go
@@ -19,20 +19,22 @@ func TestTransactionCommitmentPoseidon(t *testing.T) {
 		var txs []Transaction
 
 		type signature = []*felt.Felt
+		// actual tx hash is irrelevant so it's ok to have different transactions with the same hash
+		txHash := utils.HexToFelt(t, "0xCAFEBABE")
 		// nil signature, empty signature and signature with some non-empty value
-		for i, sign := range []signature{nil, make(signature, 0), {new(felt.Felt).SetUint64(uint64(3))}} {
+		for _, sign := range []signature{nil, make(signature, 0), {new(felt.Felt).SetUint64(uint64(3))}} {
 			invoke := &InvokeTransaction{
-				TransactionHash:      new(felt.Felt).SetUint64(uint64(0 + i*3)),
+				TransactionHash:      txHash,
 				TransactionSignature: sign,
 			}
 			deployAccount := &DeployAccountTransaction{
 				DeployTransaction: DeployTransaction{
-					TransactionHash: new(felt.Felt).SetUint64(uint64(1 + i*3)),
+					TransactionHash: txHash,
 				},
 				TransactionSignature: sign,
 			}
 			declare := &DeclareTransaction{
-				TransactionHash:      new(felt.Felt).SetUint64(uint64(2 + i*3)),
+				TransactionHash:      txHash,
 				TransactionSignature: sign,
 			}
 			txs = append(txs, invoke, deployAccount, declare)
@@ -40,7 +42,7 @@ func TestTransactionCommitmentPoseidon(t *testing.T) {
 
 		c, err := transactionCommitmentPoseidon(txs)
 		require.NoError(t, err)
-		expected := utils.HexToFelt(t, "0x602c33ad4fecd30bc8857e87554ae3a1b87dd090f93b4c5ffd5940e98cb712e")
+		expected := utils.HexToFelt(t, "0x4ca6d4ceb367bf070d896a1479190d3c7b751f525e69a46ee2c83f0afe7cb8")
 		assert.Equal(t, expected, c, "expected: %s, got: %s", expected, c)
 	})
 	t.Run("txs without signature", func(t *testing.T) {

--- a/core/block_pkg_test.go
+++ b/core/block_pkg_test.go
@@ -22,17 +22,17 @@ func TestTransactionCommitmentPoseidon(t *testing.T) {
 		// nil signature, empty signature and signature with some non-empty value
 		for i, sign := range []signature{nil, make(signature, 0), {new(felt.Felt).SetUint64(uint64(3))}} {
 			invoke := &InvokeTransaction{
-				TransactionHash:      new(felt.Felt).SetUint64(uint64(0 + i)),
+				TransactionHash:      new(felt.Felt).SetUint64(uint64(0 + i*3)),
 				TransactionSignature: sign,
 			}
 			deployAccount := &DeployAccountTransaction{
 				DeployTransaction: DeployTransaction{
-					TransactionHash: new(felt.Felt).SetUint64(uint64(1 + i)),
+					TransactionHash: new(felt.Felt).SetUint64(uint64(1 + i*3)),
 				},
 				TransactionSignature: sign,
 			}
 			declare := &DeclareTransaction{
-				TransactionHash:      new(felt.Felt).SetUint64(uint64(2 + i)),
+				TransactionHash:      new(felt.Felt).SetUint64(uint64(2 + i*3)),
 				TransactionSignature: sign,
 			}
 			txs = append(txs, invoke, deployAccount, declare)
@@ -40,7 +40,7 @@ func TestTransactionCommitmentPoseidon(t *testing.T) {
 
 		c, err := transactionCommitmentPoseidon(txs)
 		require.NoError(t, err)
-		expected := utils.HexToFelt(t, "0x4a802df8da3cfcaeb57991c076801a6a8a513345b8c213f649258949971f213")
+		expected := utils.HexToFelt(t, "0x602c33ad4fecd30bc8857e87554ae3a1b87dd090f93b4c5ffd5940e98cb712e")
 		assert.Equal(t, expected, c, "expected: %s, got: %s", expected, c)
 	})
 	t.Run("txs without signature", func(t *testing.T) {

--- a/core/block_pkg_test.go
+++ b/core/block_pkg_test.go
@@ -1,0 +1,60 @@
+package core
+
+import (
+	"github.com/NethermindEth/juno/core/felt"
+	"github.com/NethermindEth/juno/utils"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"testing"
+)
+
+func TestTransactionCommitmentPoseidon(t *testing.T) {
+	t.Run("nil", func(t *testing.T) {
+		c, err := transactionCommitmentPoseidon(nil)
+		require.NoError(t, err)
+		assert.Equal(t, &felt.Zero, c)
+	})
+	t.Run("txs with signature", func(t *testing.T) {
+		var txs []Transaction
+
+		type signature = []*felt.Felt
+		// nil signature, empty signature and signature with some non-empty value
+		for i, sign := range []signature{nil, make(signature, 0), {new(felt.Felt).SetUint64(uint64(3))}} {
+			invoke := &InvokeTransaction{
+				TransactionHash:      new(felt.Felt).SetUint64(uint64(0 + i)),
+				TransactionSignature: sign,
+			}
+			deployAccount := &DeployAccountTransaction{
+				DeployTransaction: DeployTransaction{
+					TransactionHash: new(felt.Felt).SetUint64(uint64(1 + i)),
+				},
+				TransactionSignature: sign,
+			}
+			declare := &DeclareTransaction{
+				TransactionHash:      new(felt.Felt).SetUint64(uint64(2 + i)),
+				TransactionSignature: sign,
+			}
+			txs = append(txs, invoke, deployAccount, declare)
+		}
+
+		c, err := transactionCommitmentPoseidon(txs)
+		require.NoError(t, err)
+		expected := utils.HexToFelt(t, "0x4a802df8da3cfcaeb57991c076801a6a8a513345b8c213f649258949971f213")
+		assert.Equal(t, expected, c, "expected: %s, got: %s", expected, c)
+	})
+	t.Run("txs without signature", func(t *testing.T) {
+		txs := []Transaction{
+			&L1HandlerTransaction{
+				TransactionHash: utils.HexToFelt(t, "0x1"),
+			},
+			&DeployTransaction{
+				TransactionHash: utils.HexToFelt(t, "0x2"),
+			},
+		}
+
+		c, err := transactionCommitmentPoseidon(txs)
+		require.NoError(t, err)
+		expected := utils.HexToFelt(t, "0x6e067f82eefc8efa75b4ad389253757f4992eee0f81f0b43815fa56135ca801")
+		assert.Equal(t, expected, c, "expected: %s, got: %s", expected, c)
+	})
+}

--- a/core/transaction.go
+++ b/core/transaction.go
@@ -671,10 +671,11 @@ func transactionCommitmentPoseidon(transactions []Transaction) (*felt.Felt, erro
 			var digest crypto.PoseidonDigest
 			digest.Update(transaction.Hash())
 
-			if txSignature := transaction.Signature(); len(txSignature) > 0 {
-				digest.Update(txSignature...)
-			} else {
+			switch transaction.(type) {
+			case *DeployTransaction, *L1HandlerTransaction:
 				digest.Update(&felt.Zero)
+			default:
+				digest.Update(transaction.Signature()...)
 			}
 
 			if _, err := trie.Put(new(felt.Felt).SetUint64(uint64(i)), digest.Finish()); err != nil {


### PR DESCRIPTION
The code changes in `transactionCommitmentPoseidon` function update the logic to handle different transaction types. With the changes, the function now checks the type of the transaction and updates the digest accordingly. For `DeployTransaction` and `L1HandlerTransaction`, the digest is updated with a zero value, while for other transaction types, the digest is updated with the transaction signature.