### PR TITLE
Onboarding

### DIFF
--- a/rpc/handlers.go
+++ b/rpc/handlers.go
@@ -186,6 +186,11 @@ func (h *Handler) Methods() ([]jsonrpc.Method, string) { //nolint: funlen
 			Handler: h.BlockHashAndNumber,
 		},
 		{
+			Name:    "starknet_getBlockWithTxHashesAndReceipts",
+			Params:  []jsonrpc.Parameter{{Name: "block_id"}},
+			Handler: h.BlockWithTxHashesAndReceipts,
+		},
+		{
 			Name:    "starknet_getBlockWithTxHashes",
 			Params:  []jsonrpc.Parameter{{Name: "block_id"}},
 			Handler: h.BlockWithTxHashes,


### PR DESCRIPTION
Onboarding task 4:
Implement a new rpc method “juno_getBlockWithTxnHashesAndReceipts”, that returns the block, the transaction hashes and the transaction receipts. Remember to implement tests for the new logic. 