### PR TITLE
Enable nilness check in govet linter

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -47,6 +47,7 @@ linters-settings:
       - strings.SplitN
 
   govet:
+    enable: [nilness]
     shadow: true
     settings:
       printf:


### PR DESCRIPTION
This pull reqest enables the nilness check in the govet linter configuration. 

The changes in the code ensure that the govet linter checks for nilness.