### PR TITLE
Refactor `syncService.start` method

### DIFF
--- a/p2p/sync.go
+++ b/p2p/sync.go
@@ -61,7 +61,7 @@ func (s *syncService) start(ctx context.Context) {
 		iterCtx, cancelIteration := context.WithCancel(ctx)
 		nextHeight, err := s.getNextHeight()
 		if err != nil {
-			s.logError("Failed to get current height", err)
+			s.logError("Failed to get current height", fmt.Errorf("blockNumber: %d, err: %w", nextHeight, err))
 			cancelIteration()
 			continue
 		}
@@ -71,7 +71,7 @@ func (s *syncService) start(ctx context.Context) {
 		// todo change iteration to fetch several objects uint64(min(blockBehind, maxBlocks))
 		blockNumber := uint64(nextHeight)
 		if err := s.processBlock(iterCtx, blockNumber); err != nil {
-			s.logError("Failed to process block", err)
+			s.logError("Failed to process block", fmt.Errorf("blockNumber: %d, err: %w", blockNumber, err))
 			cancelIteration()
 			continue
 		}

--- a/p2p/sync.go
+++ b/p2p/sync.go
@@ -61,7 +61,7 @@ func (s *syncService) start(ctx context.Context) {
 		iterCtx, cancelIteration := context.WithCancel(ctx)
 		nextHeight, err := s.getNextHeight()
 		if err != nil {
-			s.logError("Failed to get current height", fmt.Errorf("blockNumber: %d, err: %w", nextHeight, err))
+			s.logError("Failed to get current height", err)
 			cancelIteration()
 			continue
 		}


### PR DESCRIPTION
- Extracted logic for getting the next block height into a separate method `getNextHeight`.
- Moved block processing logic into a new method `processBlock` to reduce the complexity of the `start` method.
- Improved error handling by using `fmt.Errorf` to wrap errors.
- Enhanced code readability and maintainability by breaking down large functions into smaller.

These changes aim to reduce complexity.