### PR TITLE
Refactor ProofNode to use interface

### DIFF
--- a/core/trie/proof.go
+++ b/core/trie/proof.go
@@ -12,7 +12,6 @@ var (
 	ErrChildHashNotFound = errors.New("can't determine the child hash from the parent and child")
 )
 
-// https://github.com/starknet-io/starknet-p2p-specs/blob/main/p2p/proto/snapshot.proto#L6
 type ProofNode interface {
 	Hash(hash hashFunc) *felt.Felt
 	Len() uint8

--- a/core/trie/proof.go
+++ b/core/trie/proof.go
@@ -7,46 +7,16 @@ import (
 	"github.com/NethermindEth/juno/core/felt"
 )
 
+var (
+	ErrUnknownProofNode  = errors.New("unknown proof node")
+	ErrChildHashNotFound = errors.New("can't determine the child hash from the parent and child")
+)
+
 // https://github.com/starknet-io/starknet-p2p-specs/blob/main/p2p/proto/snapshot.proto#L6
-type ProofNode struct {
-	Binary *Binary
-	Edge   *Edge
-}
-
-// Note: does not work for leaves
-func (pn *ProofNode) Hash(hash hashFunc) *felt.Felt {
-	switch {
-	case pn.Binary != nil:
-		return hash(pn.Binary.LeftHash, pn.Binary.RightHash)
-	case pn.Edge != nil:
-		length := make([]byte, len(pn.Edge.Path.bitset))
-		length[len(pn.Edge.Path.bitset)-1] = pn.Edge.Path.len
-		pathFelt := pn.Edge.Path.Felt()
-		lengthFelt := new(felt.Felt).SetBytes(length)
-		return new(felt.Felt).Add(hash(pn.Edge.Child, &pathFelt), lengthFelt)
-	default:
-		return nil
-	}
-}
-
-func (pn *ProofNode) Len() uint8 {
-	if pn.Binary != nil {
-		return 1
-	}
-	return pn.Edge.Path.len
-}
-
-func (pn *ProofNode) PrettyPrint() {
-	if pn.Binary != nil {
-		fmt.Printf("  Binary:\n")
-		fmt.Printf("    LeftHash: %v\n", pn.Binary.LeftHash)
-		fmt.Printf("    RightHash: %v\n", pn.Binary.RightHash)
-	}
-	if pn.Edge != nil {
-		fmt.Printf("  Edge:\n")
-		fmt.Printf("    Child: %v\n", pn.Edge.Child)
-		fmt.Printf("    Path: %v\n", pn.Edge.Path)
-	}
+type ProofNode interface {
+	Hash(hash hashFunc) *felt.Felt
+	Len() uint8
+	PrettyPrint()
 }
 
 type Binary struct {
@@ -54,9 +24,41 @@ type Binary struct {
 	RightHash *felt.Felt
 }
 
+func (b *Binary) Hash(hash hashFunc) *felt.Felt {
+	return hash(b.LeftHash, b.RightHash)
+}
+
+func (b *Binary) Len() uint8 {
+	return 1
+}
+
+func (b *Binary) PrettyPrint() {
+	fmt.Printf("  Binary:\n")
+	fmt.Printf("    LeftHash: %v\n", b.LeftHash)
+	fmt.Printf("    RightHash: %v\n", b.RightHash)
+}
+
 type Edge struct {
 	Child *felt.Felt // child hash
 	Path  *Key       // path from parent to child
+}
+
+func (e *Edge) Hash(hash hashFunc) *felt.Felt {
+	length := make([]byte, len(e.Path.bitset))
+	length[len(e.Path.bitset)-1] = e.Path.len
+	pathFelt := e.Path.Felt()
+	lengthFelt := new(felt.Felt).SetBytes(length)
+	return new(felt.Felt).Add(hash(e.Child, &pathFelt), lengthFelt)
+}
+
+func (e *Edge) Len() uint8 {
+	return e.Path.Len()
+}
+
+func (e *Edge) PrettyPrint() {
+	fmt.Printf("  Edge:\n")
+	fmt.Printf("    Child: %v\n", e.Child)
+	fmt.Printf("    Path: %v\n", e.Path)
 }
 
 func GetBoundaryProofs(leftBoundary, rightBoundary *Key, tri *Trie) ([2][]ProofNode, error) {
@@ -110,19 +112,19 @@ func transformNode(tri *Trie, parentKey *Key, sNode StorageNode) (*Edge, *Binary
 	rightHash := rNode.Value
 	if isEdge(sNode.key, StorageNode{node: rNode, key: sNode.node.Right}) {
 		edgePath := path(sNode.node.Right, sNode.key)
-		rEdge := ProofNode{Edge: &Edge{
+		rEdge := &Edge{
 			Path:  &edgePath,
 			Child: rNode.Value,
-		}}
+		}
 		rightHash = rEdge.Hash(tri.hash)
 	}
 	leftHash := lNode.Value
 	if isEdge(sNode.key, StorageNode{node: lNode, key: sNode.node.Left}) {
 		edgePath := path(sNode.node.Left, sNode.key)
-		lEdge := ProofNode{Edge: &Edge{
+		lEdge := &Edge{
 			Path:  &edgePath,
 			Child: lNode.Value,
-		}}
+		}
 		leftHash = lEdge.Hash(tri.hash)
 	}
 	binary := &Binary{
@@ -139,19 +141,20 @@ func transformNode(tri *Trie, parentKey *Key, sNode StorageNode) (*Edge, *Binary
 func pathSplitOccurredCheck(mergedPath []ProofNode, nodeHashes map[felt.Felt]ProofNode) error {
 	splitHappened := false
 	for _, node := range mergedPath {
-		if node.Edge != nil {
+		switch node := node.(type) {
+		case *Edge:
 			continue
-		}
-
-		_, leftExists := nodeHashes[*node.Binary.LeftHash]
-		_, rightExists := nodeHashes[*node.Binary.RightHash]
-
-		if leftExists && rightExists {
-			if splitHappened {
-				return errors.New("split happened more than once")
+		case *Binary:
+			_, leftExists := nodeHashes[*node.LeftHash]
+			_, rightExists := nodeHashes[*node.RightHash]
+			if leftExists && rightExists {
+				if splitHappened {
+					return errors.New("split happened more than once")
+				}
+				splitHappened = true
 			}
-
-			splitHappened = true
+		default:
+			return ErrUnknownProofNode
 		}
 	}
 	return nil
@@ -173,9 +176,10 @@ func rootNodeExistsCheck(rootHash *felt.Felt, nodeHashes map[felt.Felt]ProofNode
 func traverseNodes(currNode ProofNode, path *[]ProofNode, nodeHashes map[felt.Felt]ProofNode) {
 	*path = append(*path, currNode)
 
-	if currNode.Binary != nil {
-		nodeLeft, leftExist := nodeHashes[*currNode.Binary.LeftHash]
-		nodeRight, rightExist := nodeHashes[*currNode.Binary.RightHash]
+	switch currNode := currNode.(type) {
+	case *Binary:
+		nodeLeft, leftExist := nodeHashes[*currNode.LeftHash]
+		nodeRight, rightExist := nodeHashes[*currNode.RightHash]
 
 		if leftExist && rightExist {
 			return
@@ -184,8 +188,8 @@ func traverseNodes(currNode ProofNode, path *[]ProofNode, nodeHashes map[felt.Fe
 		} else if rightExist {
 			traverseNodes(nodeRight, path, nodeHashes)
 		}
-	} else if currNode.Edge != nil {
-		edgeNode, exist := nodeHashes[*currNode.Edge.Child]
+	case *Edge:
+		edgeNode, exist := nodeHashes[*currNode.Child]
 		if exist {
 			traverseNodes(edgeNode, path, nodeHashes)
 		}
@@ -269,8 +273,8 @@ func SplitProofPath(mergedPath []ProofNode, rootHash *felt.Felt, hash hashFunc) 
 
 	currNode = commonPath[len(commonPath)-1]
 
-	leftNode := nodeHashes[*currNode.Binary.LeftHash]
-	rightNode := nodeHashes[*currNode.Binary.RightHash]
+	leftNode := nodeHashes[*currNode.(*Binary).LeftHash]
+	rightNode := nodeHashes[*currNode.(*Binary).RightHash]
 
 	traverseNodes(leftNode, &leftPath, nodeHashes)
 	traverseNodes(rightNode, &rightPath, nodeHashes)
@@ -298,11 +302,11 @@ func GetProof(key *Key, tri *Trie) ([]ProofNode, error) {
 		isLeaf := sNode.key.len == tri.height
 
 		if sNodeEdge != nil && !isLeaf { // Internal Edge
-			proofNodes = append(proofNodes, []ProofNode{{Edge: sNodeEdge}, {Binary: sNodeBinary}}...)
+			proofNodes = append(proofNodes, sNodeEdge, sNodeBinary)
 		} else if sNodeEdge == nil && !isLeaf { // Internal Binary
-			proofNodes = append(proofNodes, []ProofNode{{Binary: sNodeBinary}}...)
+			proofNodes = append(proofNodes, sNodeBinary)
 		} else if sNodeEdge != nil && isLeaf { // Leaf Edge
-			proofNodes = append(proofNodes, []ProofNode{{Edge: sNodeEdge}}...)
+			proofNodes = append(proofNodes, sNodeEdge)
 		} else if sNodeEdge == nil && sNodeBinary == nil { // sNode is a binary leaf
 			break
 		}
@@ -321,16 +325,16 @@ func VerifyProof(root *felt.Felt, key *Key, value *felt.Felt, proofs []ProofNode
 			return false
 		}
 
-		switch {
-		case proofNode.Binary != nil:
+		switch proofNode := proofNode.(type) {
+		case *Binary:
 			if remainingPath.Test(remainingPath.Len() - 1) {
-				expectedHash = proofNode.Binary.RightHash
+				expectedHash = proofNode.RightHash
 			} else {
-				expectedHash = proofNode.Binary.LeftHash
+				expectedHash = proofNode.LeftHash
 			}
 			remainingPath.RemoveLastBit()
-		case proofNode.Edge != nil:
-			subKey, err := remainingPath.SubKey(proofNode.Edge.Path.Len())
+		case *Edge:
+			subKey, err := remainingPath.SubKey(proofNode.Path.Len())
 			if err != nil {
 				return false
 			}
@@ -342,11 +346,11 @@ func VerifyProof(root *felt.Felt, key *Key, value *felt.Felt, proofs []ProofNode
 				return true
 			}
 
-			if !proofNode.Edge.Path.Equal(subKey) {
+			if !proofNode.Path.Equal(subKey) {
 				return false
 			}
-			expectedHash = proofNode.Edge.Child
-			remainingPath.Truncate(251 - proofNode.Edge.Path.Len()) //nolint:mnd
+			expectedHash = proofNode.Child
+			remainingPath.Truncate(251 - proofNode.Path.Len()) //nolint:mnd
 		}
 	}
 
@@ -438,27 +442,32 @@ func ensureMonotonicIncreasing(proofKeys [2]*Key, keys []*felt.Felt) error {
 
 // compressNode determines if the node needs compressed, and if so, the len needed to arrive at the next key
 func compressNode(idx int, proofNodes []ProofNode, hashF hashFunc) (int, uint8, error) {
-	parent := &proofNodes[idx]
+	parent := proofNodes[idx]
 
 	if idx == len(proofNodes)-1 {
-		if parent.Edge != nil {
+		if _, ok := parent.(*Edge); ok {
 			return 1, parent.Len(), nil
 		}
 		return 0, parent.Len(), nil
 	}
 
-	child := &proofNodes[idx+1]
+	child := proofNodes[idx+1]
 
-	switch {
-	case parent.Edge != nil && child.Binary != nil:
-		return 1, parent.Edge.Path.len, nil
-	case parent.Binary != nil && child.Edge != nil:
-		childHash := child.Hash(hashF)
-		if parent.Binary.LeftHash.Equal(childHash) || parent.Binary.RightHash.Equal(childHash) {
-			return 1, child.Edge.Path.len, nil
-		} else {
-			return 0, 0, errors.New("can't determine the child hash from the parent and child")
+	switch parent := parent.(type) {
+	case *Edge:
+		if _, ok := child.(*Binary); !ok {
+			break
 		}
+		return 1, parent.Len(), nil
+	case *Binary:
+		if _, ok := child.(*Edge); !ok {
+			break
+		}
+		childHash := child.Hash(hashF)
+		if parent.LeftHash.Equal(childHash) || parent.RightHash.Equal(childHash) {
+			return 1, child.Len(), nil
+		}
+		return 0, 0, errors.New("can't determine the child hash from the parent and child")
 	}
 
 	return 0, 1, nil
@@ -505,6 +514,7 @@ func ProofToPath(proofNodes []ProofNode, leafKey *Key, hashF hashFunc) ([]Storag
 
 		// Set the key of the current node
 		compressParent, compressParentOffset, err := compressNode(i, proofNodes, hashF)
+		fmt.Printf("compressParent: %d, compressParentOffset: %d\n", compressParent, compressParentOffset)
 		if err != nil {
 			return nil, err
 		}
@@ -539,6 +549,7 @@ func ProofToPath(proofNodes []ProofNode, leafKey *Key, hashF hashFunc) ([]Storag
 			break
 		}
 	}
+
 	return pathNodes, nil
 }
 
@@ -558,14 +569,19 @@ func skipNode(pNode ProofNode, pathNodes []StorageNode, hashF hashFunc) bool {
 }
 
 func getLeftRightHash(parentInd int, proofNodes []ProofNode) (*felt.Felt, *felt.Felt, error) {
-	parent := &proofNodes[parentInd]
-	if parent.Binary == nil {
+	parent := proofNodes[parentInd]
+
+	switch parent := parent.(type) {
+	case *Binary:
+		return parent.LeftHash, parent.RightHash, nil
+	case *Edge:
 		if parentInd+1 > len(proofNodes)-1 {
 			return nil, nil, errors.New("cant get hash of children from proof node, out of range")
 		}
-		parent = &proofNodes[parentInd+1]
+		return proofNodes[parentInd+1].(*Binary).LeftHash, proofNodes[parentInd+1].(*Binary).RightHash, nil
+	default:
+		return nil, nil, ErrUnknownProofNode
 	}
-	return parent.Binary.LeftHash, parent.Binary.RightHash, nil
 }
 
 func getParentKey(idx int, compressedParentOffset uint8, leafKey *Key,
@@ -576,16 +592,14 @@ func getParentKey(idx int, compressedParentOffset uint8, leafKey *Key,
 
 	var height uint8
 	if len(pathNodes) > 0 {
-		if proofNodes[idx].Edge != nil {
-			height = pathNodes[len(pathNodes)-1].key.len + proofNodes[idx].Edge.Path.len
+		if p, ok := proofNodes[idx].(*Edge); ok {
+			height = pathNodes[len(pathNodes)-1].key.len + p.Path.len
 		} else {
 			height = pathNodes[len(pathNodes)-1].key.len + 1
 		}
-	} else {
-		height = 0
 	}
 
-	if pNode.Binary != nil {
+	if _, ok := pNode.(*Binary); ok {
 		crntKey, err = leafKey.SubKey(height)
 	} else {
 		crntKey, err = leafKey.SubKey(height + compressedParentOffset)

--- a/core/trie/proof_test.go
+++ b/core/trie/proof_test.go
@@ -117,23 +117,17 @@ func buildSimpleDoubleBinaryTrie(t *testing.T) (*trie.Trie, []trie.ProofNode) {
 	key3Bytes := new(felt.Felt).SetUint64(1).Bytes()
 	path3 := trie.NewKey(1, key3Bytes[:])
 	expectedProofNodes := []trie.ProofNode{
-		{
-			Edge: &trie.Edge{
-				Path:  &zero,
-				Child: utils.HexToFelt(t, "0x055C81F6A791FD06FC2E2CCAD922397EC76C3E35F2E06C0C0D43D551005A8DEA"),
-			},
+		&trie.Edge{
+			Path:  &zero,
+			Child: utils.HexToFelt(t, "0x055C81F6A791FD06FC2E2CCAD922397EC76C3E35F2E06C0C0D43D551005A8DEA"),
 		},
-		{
-			Binary: &trie.Binary{
-				LeftHash:  utils.HexToFelt(t, "0x05774FA77B3D843AE9167ABD61CF80365A9B2B02218FC2F628494B5BDC9B33B8"),
-				RightHash: utils.HexToFelt(t, "0x07C5BC1CC68B7BC8CA2F632DE98297E6DA9594FA23EDE872DD2ABEAFDE353B43"),
-			},
+		&trie.Binary{
+			LeftHash:  utils.HexToFelt(t, "0x05774FA77B3D843AE9167ABD61CF80365A9B2B02218FC2F628494B5BDC9B33B8"),
+			RightHash: utils.HexToFelt(t, "0x07C5BC1CC68B7BC8CA2F632DE98297E6DA9594FA23EDE872DD2ABEAFDE353B43"),
 		},
-		{
-			Edge: &trie.Edge{
-				Path:  &path3,
-				Child: value3,
-			},
+		&trie.Edge{
+			Path:  &path3,
+			Child: value3,
 		},
 	}
 
@@ -292,13 +286,10 @@ func isSameProofPath(proofNodes, expectedProofNodes []trie.ProofNode) bool {
 	return true
 }
 
-func newBinaryProofNode() trie.ProofNode {
-	return trie.ProofNode{
-		Edge: nil,
-		Binary: &trie.Binary{
-			LeftHash:  new(felt.Felt).SetUint64(1),
-			RightHash: new(felt.Felt).SetUint64(2),
-		},
+func newBinaryProofNode() *trie.Binary {
+	return &trie.Binary{
+		LeftHash:  new(felt.Felt).SetUint64(1),
+		RightHash: new(felt.Felt).SetUint64(2),
 	}
 }
 
@@ -308,17 +299,14 @@ func TestGetProof(t *testing.T) {
 
 		zero := trie.NewKey(250, []byte{0})
 		expectedProofNodes := []trie.ProofNode{
-			{
-				Edge: &trie.Edge{
-					Path:  &zero,
-					Child: utils.HexToFelt(t, "0x05774FA77B3D843AE9167ABD61CF80365A9B2B02218FC2F628494B5BDC9B33B8"),
-				},
+			&trie.Edge{
+				Path:  &zero,
+				Child: utils.HexToFelt(t, "0x05774FA77B3D843AE9167ABD61CF80365A9B2B02218FC2F628494B5BDC9B33B8"),
 			},
-			{
-				Binary: &trie.Binary{
-					LeftHash:  utils.HexToFelt(t, "0x0000000000000000000000000000000000000000000000000000000000000002"),
-					RightHash: utils.HexToFelt(t, "0x0000000000000000000000000000000000000000000000000000000000000003"),
-				},
+
+			&trie.Binary{
+				LeftHash:  utils.HexToFelt(t, "0x0000000000000000000000000000000000000000000000000000000000000002"),
+				RightHash: utils.HexToFelt(t, "0x0000000000000000000000000000000000000000000000000000000000000003"),
 			},
 		}
 		leafFelt := new(felt.Felt).SetUint64(0).Bytes()
@@ -336,11 +324,9 @@ func TestGetProof(t *testing.T) {
 	t.Run("GP Simple Trie - simple double binary", func(t *testing.T) {
 		tempTrie, expectedProofNodes := buildSimpleDoubleBinaryTrie(t)
 
-		expectedProofNodes[2] = trie.ProofNode{
-			Binary: &trie.Binary{
-				LeftHash:  utils.HexToFelt(t, "0x0000000000000000000000000000000000000000000000000000000000000002"),
-				RightHash: utils.HexToFelt(t, "0x0000000000000000000000000000000000000000000000000000000000000003"),
-			},
+		expectedProofNodes[2] = &trie.Binary{
+			LeftHash:  utils.HexToFelt(t, "0x0000000000000000000000000000000000000000000000000000000000000002"),
+			RightHash: utils.HexToFelt(t, "0x0000000000000000000000000000000000000000000000000000000000000003"),
 		}
 
 		leafFelt := new(felt.Felt).SetUint64(0).Bytes()
@@ -375,17 +361,13 @@ func TestGetProof(t *testing.T) {
 		key1Bytes := new(felt.Felt).SetUint64(0).Bytes()
 		path1 := trie.NewKey(250, key1Bytes[:])
 		expectedProofNodes := []trie.ProofNode{
-			{
-				Binary: &trie.Binary{
-					LeftHash:  utils.HexToFelt(t, "0x06E08BF82793229338CE60B65D1845F836C8E2FBFE2BC59FF24AEDBD8BA219C4"),
-					RightHash: utils.HexToFelt(t, "0x04F9B8E66212FB528C0C1BD02F43309C53B895AA7D9DC91180001BDD28A588FA"),
-				},
+			&trie.Binary{
+				LeftHash:  utils.HexToFelt(t, "0x06E08BF82793229338CE60B65D1845F836C8E2FBFE2BC59FF24AEDBD8BA219C4"),
+				RightHash: utils.HexToFelt(t, "0x04F9B8E66212FB528C0C1BD02F43309C53B895AA7D9DC91180001BDD28A588FA"),
 			},
-			{
-				Edge: &trie.Edge{
-					Path:  &path1,
-					Child: utils.HexToFelt(t, "0xcc"),
-				},
+			&trie.Edge{
+				Path:  &path1,
+				Child: utils.HexToFelt(t, "0xcc"),
 			},
 		}
 		leafFelt := new(felt.Felt).SetUint64(0).Bytes()
@@ -426,11 +408,9 @@ func TestGetProof(t *testing.T) {
 
 		child := utils.HexToFelt(t, "0x00000000000000000000000000000000000000000000000000000000000000AA")
 		expectedProofNodes := []trie.ProofNode{
-			{
-				Edge: &trie.Edge{
-					Path:  &path1,
-					Child: child,
-				},
+			&trie.Edge{
+				Path:  &path1,
+				Child: child,
 			},
 		}
 		leafFelt := new(felt.Felt).SetUint64(0).Bytes()
@@ -497,17 +477,13 @@ func TestVerifyProof(t *testing.T) {
 		tempTrie := buildSimpleTrie(t)
 		zero := trie.NewKey(250, []byte{0})
 		expectedProofNodes := []trie.ProofNode{
-			{
-				Edge: &trie.Edge{
-					Path:  &zero,
-					Child: utils.HexToFelt(t, "0x05774FA77B3D843AE9167ABD61CF80365A9B2B02218FC2F628494B5BDC9B33B8"),
-				},
+			&trie.Edge{
+				Path:  &zero,
+				Child: utils.HexToFelt(t, "0x05774FA77B3D843AE9167ABD61CF80365A9B2B02218FC2F628494B5BDC9B33B8"),
 			},
-			{
-				Binary: &trie.Binary{
-					LeftHash:  utils.HexToFelt(t, "0x0000000000000000000000000000000000000000000000000000000000000002"),
-					RightHash: utils.HexToFelt(t, "0x0000000000000000000000000000000000000000000000000000000000000003"),
-				},
+			&trie.Binary{
+				LeftHash:  utils.HexToFelt(t, "0x0000000000000000000000000000000000000000000000000000000000000002"),
+				RightHash: utils.HexToFelt(t, "0x0000000000000000000000000000000000000000000000000000000000000003"),
 			},
 		}
 
@@ -525,23 +501,17 @@ func TestVerifyProof(t *testing.T) {
 		tempTrie, _ := buildSimpleDoubleBinaryTrie(t)
 		zero := trie.NewKey(249, []byte{0})
 		expectedProofNodes := []trie.ProofNode{
-			{
-				Edge: &trie.Edge{
-					Path:  &zero,
-					Child: utils.HexToFelt(t, "0x055C81F6A791FD06FC2E2CCAD922397EC76C3E35F2E06C0C0D43D551005A8DEA"),
-				},
+			&trie.Edge{
+				Path:  &zero,
+				Child: utils.HexToFelt(t, "0x055C81F6A791FD06FC2E2CCAD922397EC76C3E35F2E06C0C0D43D551005A8DEA"),
 			},
-			{
-				Binary: &trie.Binary{
-					LeftHash:  utils.HexToFelt(t, "0x05774FA77B3D843AE9167ABD61CF80365A9B2B02218FC2F628494B5BDC9B33B8"),
-					RightHash: utils.HexToFelt(t, "0x07C5BC1CC68B7BC8CA2F632DE98297E6DA9594FA23EDE872DD2ABEAFDE353B43"),
-				},
+			&trie.Binary{
+				LeftHash:  utils.HexToFelt(t, "0x05774FA77B3D843AE9167ABD61CF80365A9B2B02218FC2F628494B5BDC9B33B8"),
+				RightHash: utils.HexToFelt(t, "0x07C5BC1CC68B7BC8CA2F632DE98297E6DA9594FA23EDE872DD2ABEAFDE353B43"),
 			},
-			{
-				Binary: &trie.Binary{
-					LeftHash:  utils.HexToFelt(t, "0x0000000000000000000000000000000000000000000000000000000000000002"),
-					RightHash: utils.HexToFelt(t, "0x0000000000000000000000000000000000000000000000000000000000000003"),
-				},
+			&trie.Binary{
+				LeftHash:  utils.HexToFelt(t, "0x0000000000000000000000000000000000000000000000000000000000000002"),
+				RightHash: utils.HexToFelt(t, "0x0000000000000000000000000000000000000000000000000000000000000003"),
 			},
 		}
 
@@ -559,23 +529,17 @@ func TestVerifyProof(t *testing.T) {
 		felt2 := new(felt.Felt).SetUint64(0).Bytes()
 		lastPath := trie.NewKey(1, felt2[:])
 		expectedProofNodes := []trie.ProofNode{
-			{
-				Edge: &trie.Edge{
-					Path:  &zero,
-					Child: utils.HexToFelt(t, "0x0768DEB8D0795D80AAAC2E5E326141F33044759F97A1BF092D8EB9C4E4BE9234"),
-				},
+			&trie.Edge{
+				Path:  &zero,
+				Child: utils.HexToFelt(t, "0x0768DEB8D0795D80AAAC2E5E326141F33044759F97A1BF092D8EB9C4E4BE9234"),
 			},
-			{
-				Binary: &trie.Binary{
-					LeftHash:  utils.HexToFelt(t, "0x057166F9476D0A2D6875124251841EB85A9AE37462FAE3CBF7304BCD593938E7"),
-					RightHash: utils.HexToFelt(t, "0x060FBDE29F96F706498EFD132DC7F312A4C99A9AE051BF152C2AF2B3CAF31E5B"),
-				},
+			&trie.Binary{
+				LeftHash:  utils.HexToFelt(t, "0x057166F9476D0A2D6875124251841EB85A9AE37462FAE3CBF7304BCD593938E7"),
+				RightHash: utils.HexToFelt(t, "0x060FBDE29F96F706498EFD132DC7F312A4C99A9AE051BF152C2AF2B3CAF31E5B"),
 			},
-			{
-				Edge: &trie.Edge{
-					Path:  &lastPath,
-					Child: utils.HexToFelt(t, "0x6"),
-				},
+			&trie.Edge{
+				Path:  &lastPath,
+				Child: utils.HexToFelt(t, "0x6"),
 			},
 		}
 
@@ -630,17 +594,13 @@ func TestProofToPath(t *testing.T) {
 		leafValue := utils.HexToFelt(t, "0x0000000000000000000000000000000000000000000000000000000000000002")
 		siblingValue := utils.HexToFelt(t, "0x0000000000000000000000000000000000000000000000000000000000000003")
 		proofNodes := []trie.ProofNode{
-			{
-				Edge: &trie.Edge{
-					Path:  &zero,
-					Child: utils.HexToFelt(t, "0x05774FA77B3D843AE9167ABD61CF80365A9B2B02218FC2F628494B5BDC9B33B8"),
-				},
+			&trie.Edge{
+				Path:  &zero,
+				Child: utils.HexToFelt(t, "0x05774FA77B3D843AE9167ABD61CF80365A9B2B02218FC2F628494B5BDC9B33B8"),
 			},
-			{
-				Binary: &trie.Binary{
-					LeftHash:  leafValue,
-					RightHash: siblingValue,
-				},
+			&trie.Binary{
+				LeftHash:  leafValue,
+				RightHash: siblingValue,
 			},
 		}
 
@@ -664,17 +624,13 @@ func TestProofToPath(t *testing.T) {
 		leafkey := trie.NewKey(251, zeroFeltBytes[:])
 		path1 := trie.NewKey(250, zeroFeltBytes[:])
 		proofNodes := []trie.ProofNode{
-			{
-				Binary: &trie.Binary{
-					LeftHash:  utils.HexToFelt(t, "0x06E08BF82793229338CE60B65D1845F836C8E2FBFE2BC59FF24AEDBD8BA219C4"),
-					RightHash: utils.HexToFelt(t, "0x04F9B8E66212FB528C0C1BD02F43309C53B895AA7D9DC91180001BDD28A588FA"),
-				},
+			&trie.Binary{
+				LeftHash:  utils.HexToFelt(t, "0x06E08BF82793229338CE60B65D1845F836C8E2FBFE2BC59FF24AEDBD8BA219C4"),
+				RightHash: utils.HexToFelt(t, "0x04F9B8E66212FB528C0C1BD02F43309C53B895AA7D9DC91180001BDD28A588FA"),
 			},
-			{
-				Edge: &trie.Edge{
-					Path:  &path1,
-					Child: utils.HexToFelt(t, "0xcc"),
-				},
+			&trie.Edge{
+				Path:  &path1,
+				Child: utils.HexToFelt(t, "0xcc"),
 			},
 		}
 
@@ -1147,13 +1103,13 @@ func TestSplitProofPaths(t *testing.T) {
 		p4 := newBinaryProofNode()
 		p5 := newBinaryProofNode()
 
-		p4.Binary.LeftHash = new(felt.Felt).SetUint64(3)
-		p2.Binary.RightHash = new(felt.Felt).SetUint64(4)
+		p4.LeftHash = new(felt.Felt).SetUint64(3)
+		p2.RightHash = new(felt.Felt).SetUint64(4)
 
-		p3.Binary.RightHash = p5.Hash(crypto.Pedersen)
-		p3.Binary.LeftHash = p4.Hash(crypto.Pedersen)
-		p1.Binary.RightHash = p3.Hash(crypto.Pedersen)
-		p1.Binary.LeftHash = p2.Hash(crypto.Pedersen)
+		p3.RightHash = p5.Hash(crypto.Pedersen)
+		p3.LeftHash = p4.Hash(crypto.Pedersen)
+		p1.RightHash = p3.Hash(crypto.Pedersen)
+		p1.LeftHash = p2.Hash(crypto.Pedersen)
 
 		mergedProofs := []trie.ProofNode{p1, p2, p3, p4, p5}
 		rootHash := p1.Hash(crypto.Pedersen)
@@ -1169,10 +1125,10 @@ func TestSplitProofPaths(t *testing.T) {
 		p4 := newBinaryProofNode()
 		p5 := newBinaryProofNode()
 
-		p3.Binary.RightHash = p5.Hash(crypto.Pedersen)
-		p3.Binary.LeftHash = p4.Hash(crypto.Pedersen)
-		p1.Binary.RightHash = p3.Hash(crypto.Pedersen)
-		p1.Binary.LeftHash = p2.Hash(crypto.Pedersen)
+		p3.RightHash = p5.Hash(crypto.Pedersen)
+		p3.LeftHash = p4.Hash(crypto.Pedersen)
+		p1.RightHash = p3.Hash(crypto.Pedersen)
+		p1.LeftHash = p2.Hash(crypto.Pedersen)
 
 		mergedProofs := []trie.ProofNode{p1, p2, p3, p4, p5}
 		rootHash := p1.Hash(crypto.Pedersen)


### PR DESCRIPTION
### Description
This PR refactors the `ProofNode` struct into `ProofNode` interface where `Binary` and `Edge` implements it.

### Rationale
Throughout the codebase, I noticed a similar pattern with `ProofNode`, that is:

```
if proofNode.Binary != nil {
  // ... do something
} else if proofNode.Edge != nil {
  // ... do something
}
```

This suggests that a `ProofNode` can be either a `Binary` node or an `Edge` node, but not both simultaneously. Therefore, `ProofNode` should be represented as an interface. This approach makes the code more intuitive and easier to read.