### PR TITLE
Add more pebble database metrics collection

### DIFF
--- a/cmd/juno/dbcmd.go
+++ b/cmd/juno/dbcmd.go
@@ -66,7 +66,7 @@ func dbInfo(cmd *cobra.Command, args []string) error {
 		return nil
 	}
 
-	database, err := pebble.New(dbPath)
+	database, err := pebble.New(dbPath, false)
 	if err != nil {
 		return fmt.Errorf("open DB: %w", err)
 	}
@@ -125,7 +125,7 @@ func dbSize(cmd *cobra.Command, args []string) error {
 		return nil
 	}
 
-	pebbleDB, err := pebble.New(dbPath)
+	pebbleDB, err := pebble.New(dbPath, false)
 	if err != nil {
 		return err
 	}
@@ -145,7 +145,7 @@ func dbSize(cmd *cobra.Command, args []string) error {
 
 	for _, b := range db.BucketValues() {
 		fmt.Fprintf(cmd.OutOrStdout(), "Calculating size of %s, remaining buckets: %d\n", b, len(db.BucketValues())-int(b)-1)
-		bucketItem, err := pebble.CalculatePrefixSize(cmd.Context(), pebbleDB.(*pebble.DB), []byte{byte(b)})
+		bucketItem, err := pebble.CalculatePrefixSize(cmd.Context(), pebbleDB, []byte{byte(b)})
 		if err != nil {
 			return err
 		}

--- a/cmd/juno/dbcmd_test.go
+++ b/cmd/juno/dbcmd_test.go
@@ -41,7 +41,7 @@ func executeCmdInDB(t *testing.T, cmd *cobra.Command) {
 	require.NoError(t, err)
 
 	dbPath := t.TempDir()
-	testDB, err := pebble.New(dbPath)
+	testDB, err := pebble.New(dbPath, false)
 	require.NoError(t, err)
 
 	chain := blockchain.New(testDB, &utils.Mainnet)

--- a/db/db.go
+++ b/db/db.go
@@ -1,10 +1,12 @@
 package db
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"io"
 	"os"
+	"time"
 
 	"github.com/NethermindEth/juno/utils"
 )
@@ -33,6 +35,8 @@ type DB interface {
 
 	// WithListener registers an EventListener
 	WithListener(listener EventListener) DB
+
+	StartMetricsCollection(ctx context.Context, interval time.Duration)
 }
 
 // Iterator is an iterator over a DB's key/value pairs.

--- a/db/pebble/db.go
+++ b/db/pebble/db.go
@@ -4,19 +4,30 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"runtime"
 	"sync"
+	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/NethermindEth/juno/db"
 	"github.com/NethermindEth/juno/utils"
 	"github.com/cockroachdb/pebble"
 	"github.com/cockroachdb/pebble/vfs"
+	"github.com/prometheus/client_golang/prometheus"
 )
 
 const (
 	// minCache is the minimum amount of memory in megabytes to allocate to pebble read and write caching.
 	// This is also pebble's default value.
 	minCacheSizeMB = 8
+
+	// metricsGatheringInterval specifies the interval to retrieve pebble database
+	// compaction, io and pause stats to report to the user.
+	metricsGatheringInterval = 3 * time.Second
+
+	// dbNamespace is the namespace for the database metrics
+	dbNamespace = "db"
 )
 
 var (
@@ -29,38 +40,51 @@ type DB struct {
 	pebble   *pebble.DB
 	wMutex   *sync.Mutex
 	listener db.EventListener
+
+	compTimeMeter        prometheus.Counter // Total time spent in database compaction
+	compReadMeter        prometheus.Counter // Total bytes read during compaction
+	compWriteMeter       prometheus.Counter // Total bytes written during compaction
+	writeDelayCountMeter prometheus.Counter // Total write delay counts due to database compaction
+	writeDelayTimeMeter  prometheus.Counter // Total write delay duration due to database compaction
+	diskSizeGauge        prometheus.Gauge   // Tracks the size of all of the levels of the database
+	diskWriteMeter       prometheus.Counter // Measures the effective amount of data written to disk
+	memCompGauge         prometheus.Gauge   // Tracks the amount of memory allocated for compaction
+	level0CompGauge      prometheus.Gauge   // Tracks the number of level-zero compactions
+	nonlevel0CompGauge   prometheus.Gauge   // Tracks the number of non level-zero compactions
+	seekCompGauge        prometheus.Gauge   // Tracks the number of table compaction caused by read opt
+	manualMemAllocGauge  prometheus.Gauge   // Tracks the amount of non-managed memory currently allocated
+
+	activeComp          int           // Current number of active compactions
+	compStartTime       time.Time     // The start time of the earliest currently-active compaction
+	compTime            atomic.Int64  // Total time spent in compaction in ns
+	level0Comp          atomic.Uint32 // Total number of level-zero compactions
+	nonLevel0Comp       atomic.Uint32 // Total number of non level-zero compactions
+	writeDelayStartTime time.Time     // The start time of the latest write stall
+	writeDelayCount     atomic.Int64  // Total number of write stall counts
+	writeDelayTime      atomic.Int64  // Total time spent in write stalls
 }
 
-// New opens a new database at the given path with default options
-func New(path string) (db.DB, error) {
-	return newPebble(path, nil)
-}
-
-func NewWithOptions(path string, cacheSizeMB uint, maxOpenFiles int, colouredLogger bool) (db.DB, error) {
-	// Ensure that the specified cache size meets a minimum threshold.
-	cacheSizeMB = max(cacheSizeMB, minCacheSizeMB)
-
-	dbLog, err := utils.NewZapLogger(utils.ERROR, colouredLogger)
-	if err != nil {
-		return nil, fmt.Errorf("create DB logger: %w", err)
+func New(path string, enableMetrics bool, options ...Option) (*DB, error) {
+	opts := &pebble.Options{
+		MaxConcurrentCompactions: func() int { return runtime.NumCPU() },
 	}
 
-	return newPebble(path, &pebble.Options{
-		Logger:       dbLog,
-		Cache:        pebble.NewCache(int64(cacheSizeMB * utils.Megabyte)),
-		MaxOpenFiles: maxOpenFiles,
-	})
+	for _, option := range options {
+		option(opts)
+	}
+
+	return newPebble(path, enableMetrics, opts)
 }
 
 // NewMem opens a new in-memory database
-func NewMem() (db.DB, error) {
-	return newPebble("", &pebble.Options{
+func NewMem() (*DB, error) {
+	return newPebble("", false, &pebble.Options{
 		FS: vfs.NewMem(),
 	})
 }
 
 // NewMemTest opens a new in-memory database, panics on error
-func NewMemTest(t *testing.T) db.DB {
+func NewMemTest(t *testing.T) *DB {
 	memDB, err := NewMem()
 	if err != nil {
 		t.Fatalf("create in-memory db: %v", err)
@@ -73,18 +97,264 @@ func NewMemTest(t *testing.T) db.DB {
 	return memDB
 }
 
-func newPebble(path string, options *pebble.Options) (*DB, error) {
+func newPebble(path string, enableMetrics bool, options *pebble.Options) (*DB, error) {
+	database := &DB{
+		wMutex:   new(sync.Mutex),
+		listener: &db.SelectiveListener{},
+	}
+
+	if enableMetrics {
+		database.enableMetrics()
+
+		options.EventListener = &pebble.EventListener{
+			CompactionBegin: database.onCompactionBegin,
+			CompactionEnd:   database.onCompactionEnd,
+			WriteStallBegin: database.onWriteStallBegin,
+			WriteStallEnd:   database.onWriteStallEnd,
+		}
+	}
+
 	pDB, err := pebble.Open(path, options)
 	if err != nil {
 		return nil, err
 	}
+
 	return &DB{pebble: pDB, wMutex: new(sync.Mutex), listener: &db.SelectiveListener{}}, nil
+}
+
+// Option is a functional option for configuring the DB
+type Option func(*pebble.Options)
+
+// WithCacheSize sets the cache size in megabytes
+func WithCacheSize(cacheSizeMB uint) Option {
+	return func(opts *pebble.Options) {
+		// Ensure that the specified cache size meets a minimum threshold.
+		cacheSizeMB = max(cacheSizeMB, minCacheSizeMB)
+		opts.Cache = pebble.NewCache(int64(cacheSizeMB * utils.Megabyte))
+	}
+}
+
+// WithMaxOpenFiles sets the maximum number of open files
+func WithMaxOpenFiles(maxOpenFiles int) Option {
+	return func(opts *pebble.Options) {
+		opts.MaxOpenFiles = maxOpenFiles
+	}
+}
+
+// WithColouredLogger sets whether to use a coloured logger
+func WithColouredLogger(coloured bool) Option {
+	return func(opts *pebble.Options) {
+		dbLog, err := utils.NewZapLogger(utils.ERROR, coloured)
+		if err != nil {
+			// Since we can't return an error from this function, we'll panic instead
+			panic(fmt.Errorf("create DB logger: %w", err))
+		}
+		opts.Logger = dbLog
+	}
 }
 
 // WithListener registers an EventListener
 func (d *DB) WithListener(listener db.EventListener) db.DB {
 	d.listener = listener
 	return d
+}
+
+// EnableMetrics enables metrics collection for the database
+func (d *DB) enableMetrics() db.DB {
+	d.compTimeMeter = prometheus.NewCounter(prometheus.CounterOpts{
+		Namespace: dbNamespace,
+		Name:      "compaction_time",
+		Help:      "Total time spent in database compaction",
+	})
+	d.compReadMeter = prometheus.NewCounter(prometheus.CounterOpts{
+		Namespace: dbNamespace,
+		Name:      "compaction_read",
+		Help:      "Total bytes read during compaction",
+	})
+	d.compWriteMeter = prometheus.NewCounter(prometheus.CounterOpts{
+		Namespace: dbNamespace,
+		Name:      "compaction_write",
+		Help:      "Total bytes written during compaction",
+	})
+	d.writeDelayCountMeter = prometheus.NewCounter(prometheus.CounterOpts{
+		Namespace: dbNamespace,
+		Name:      "write_delay_count",
+		Help:      "Total write delay counts due to database compaction",
+	})
+	d.writeDelayTimeMeter = prometheus.NewCounter(prometheus.CounterOpts{
+		Namespace: dbNamespace,
+		Name:      "write_delay_time",
+		Help:      "Total time spent in write stalls",
+	})
+	d.diskSizeGauge = prometheus.NewGauge(prometheus.GaugeOpts{
+		Namespace: dbNamespace,
+		Name:      "disk_size",
+		Help:      "Tracks the size of all of the levels of the database",
+	})
+	d.diskWriteMeter = prometheus.NewCounter(prometheus.CounterOpts{
+		Namespace: dbNamespace,
+		Name:      "disk_write",
+		Help:      "Measures the effective amount of data written to disk",
+	})
+	d.memCompGauge = prometheus.NewGauge(prometheus.GaugeOpts{
+		Namespace: dbNamespace,
+		Name:      "mem_comp",
+		Help:      "Tracks the amount of memory allocated for compaction",
+	})
+	d.level0CompGauge = prometheus.NewGauge(prometheus.GaugeOpts{
+		Namespace: dbNamespace,
+		Name:      "level0_comp",
+		Help:      "Tracks the number of level-zero compactions",
+	})
+	d.nonlevel0CompGauge = prometheus.NewGauge(prometheus.GaugeOpts{
+		Namespace: dbNamespace,
+		Name:      "nonlevel0_comp",
+		Help:      "Tracks the number of non level-zero compactions",
+	})
+	d.seekCompGauge = prometheus.NewGauge(prometheus.GaugeOpts{
+		Namespace: dbNamespace,
+		Name:      "seek_comp",
+		Help:      "Tracks the number of table compaction caused by read opt",
+	})
+	d.manualMemAllocGauge = prometheus.NewGauge(prometheus.GaugeOpts{
+		Namespace: dbNamespace,
+		Name:      "manual_mem_alloc",
+		Help:      "Tracks the amount of non-managed memory currently allocated",
+	})
+
+	prometheus.MustRegister(
+		d.compTimeMeter,
+		d.compReadMeter,
+		d.compWriteMeter,
+		d.writeDelayCountMeter,
+		d.writeDelayTimeMeter,
+		d.diskSizeGauge,
+		d.diskWriteMeter,
+		d.memCompGauge,
+		d.level0CompGauge,
+		d.nonlevel0CompGauge,
+		d.seekCompGauge,
+		d.manualMemAllocGauge,
+	)
+
+	return d
+}
+
+func (d *DB) onCompactionBegin(info pebble.CompactionInfo) {
+	if d.activeComp == 0 {
+		d.compStartTime = time.Now()
+	}
+	l0 := info.Input[0]
+	if l0.Level == 0 {
+		d.level0Comp.Add(1)
+	} else {
+		d.nonLevel0Comp.Add(1)
+	}
+	d.activeComp++
+}
+
+func (d *DB) onCompactionEnd(info pebble.CompactionInfo) {
+	if d.activeComp == 1 {
+		d.compTime.Add(int64(time.Since(d.compStartTime)))
+	} else if d.activeComp == 0 {
+		panic("should not happen")
+	}
+	d.activeComp--
+}
+
+func (d *DB) onWriteStallBegin(b pebble.WriteStallBeginInfo) {
+	d.writeDelayStartTime = time.Now()
+}
+
+func (d *DB) onWriteStallEnd() {
+	d.writeDelayTime.Add(int64(time.Since(d.writeDelayStartTime)))
+}
+
+// collectMetrics periodically retrieves internal pebble counters and reports them to
+// the metrics subsystem.
+func (d *DB) StartMetricsCollection(ctx context.Context, refresh time.Duration) {
+	timer := time.NewTimer(refresh)
+	defer timer.Stop()
+
+	// Create storage and warning log tracer for write delay.
+	var (
+		compTimes        [2]int64
+		writeDelayTimes  [2]int64
+		writeDelayCounts [2]int64
+		compWrites       [2]int64
+		compReads        [2]int64
+
+		nWrites [2]int64
+	)
+
+	// Iterate ad infinitum and collect the stats
+	for i := 1; ; i++ {
+		var (
+			compWrite int64
+			compRead  int64
+			nWrite    int64
+
+			metrics            = d.pebble.Metrics()
+			compTime           = d.compTime.Load()
+			writeDelayCount    = d.writeDelayCount.Load()
+			writeDelayTime     = d.writeDelayTime.Load()
+			nonLevel0CompCount = int64(d.nonLevel0Comp.Load())
+			level0CompCount    = int64(d.level0Comp.Load())
+		)
+		writeDelayTimes[i%2] = writeDelayTime
+		writeDelayCounts[i%2] = writeDelayCount
+		compTimes[i%2] = compTime
+
+		for _, levelMetrics := range metrics.Levels {
+			nWrite += int64(levelMetrics.BytesCompacted)
+			nWrite += int64(levelMetrics.BytesFlushed)
+			compWrite += int64(levelMetrics.BytesCompacted)
+			compRead += int64(levelMetrics.BytesRead)
+		}
+
+		nWrite += int64(metrics.WAL.BytesWritten)
+
+		compWrites[i%2] = compWrite
+		compReads[i%2] = compRead
+		nWrites[i%2] = nWrite
+
+		if d.writeDelayCountMeter != nil {
+			d.writeDelayCountMeter.Add(float64(writeDelayCounts[i%2] - writeDelayCounts[(i-1)%2]))
+		}
+		if d.writeDelayTimeMeter != nil {
+			d.writeDelayTimeMeter.Add(float64(writeDelayTimes[i%2] - writeDelayTimes[(i-1)%2]))
+		}
+		if d.compTimeMeter != nil {
+			d.compTimeMeter.Add(float64(compTimes[i%2] - compTimes[(i-1)%2]))
+		}
+		if d.compReadMeter != nil {
+			d.compReadMeter.Add(float64(compReads[i%2] - compReads[(i-1)%2]))
+		}
+		if d.compWriteMeter != nil {
+			d.compWriteMeter.Add(float64(compWrites[i%2] - compWrites[(i-1)%2]))
+		}
+		if d.diskSizeGauge != nil {
+			d.diskSizeGauge.Set(float64(metrics.DiskSpaceUsage()))
+		}
+		if d.diskWriteMeter != nil {
+			d.diskWriteMeter.Add(float64(nWrites[i%2] - nWrites[(i-1)%2]))
+		}
+		// See https://github.com/cockroachdb/pebble/pull/1628#pullrequestreview-1026664054
+		manuallyAllocated := metrics.BlockCache.Size + int64(metrics.MemTable.Size) + int64(metrics.MemTable.ZombieSize)
+		d.manualMemAllocGauge.Set(float64(manuallyAllocated))
+		d.memCompGauge.Set(float64(metrics.Flush.Count))
+		d.nonlevel0CompGauge.Set(float64(nonLevel0CompCount))
+		d.level0CompGauge.Set(float64(level0CompCount))
+		d.seekCompGauge.Set(float64(metrics.Compact.ReadCount))
+
+		// Refresh the timer
+		select {
+		case <-ctx.Done():
+			return
+		case <-timer.C:
+			timer.Reset(refresh)
+		}
+	}
 }
 
 // NewTransaction : see db.DB.NewTransaction

--- a/db/pebble/db_test.go
+++ b/db/pebble/db_test.go
@@ -422,7 +422,7 @@ func TestPanic(t *testing.T) {
 
 func TestCalculatePrefixSize(t *testing.T) {
 	t.Run("empty db", func(t *testing.T) {
-		testDB := pebble.NewMemTest(t).(*pebble.DB)
+		testDB := pebble.NewMemTest(t)
 
 		s, err := pebble.CalculatePrefixSize(context.Background(), testDB, []byte("0"))
 		require.NoError(t, err)
@@ -435,7 +435,7 @@ func TestCalculatePrefixSize(t *testing.T) {
 		require.NoError(t, testDB.Update(func(txn db.Transaction) error {
 			return txn.Set(append([]byte("0"), []byte("randomKey")...), []byte("someValue"))
 		}))
-		s, err := pebble.CalculatePrefixSize(context.Background(), testDB.(*pebble.DB), []byte("1"))
+		s, err := pebble.CalculatePrefixSize(context.Background(), testDB, []byte("1"))
 		require.NoError(t, err)
 		assert.Zero(t, s.Count)
 		assert.Zero(t, s.Size)
@@ -455,7 +455,7 @@ func TestCalculatePrefixSize(t *testing.T) {
 			return txn.Set(k3, v3)
 		}))
 
-		s, err := pebble.CalculatePrefixSize(context.Background(), testDB.(*pebble.DB), p)
+		s, err := pebble.CalculatePrefixSize(context.Background(), testDB, p)
 		require.NoError(t, err)
 		assert.Equal(t, uint(3), s.Count)
 		assert.Equal(t, utils.DataSize(expectedSize), s.Size)
@@ -464,7 +464,7 @@ func TestCalculatePrefixSize(t *testing.T) {
 			ctx, cancel := context.WithCancel(context.Background())
 			cancel()
 
-			s, err := pebble.CalculatePrefixSize(ctx, testDB.(*pebble.DB), p)
+			s, err := pebble.CalculatePrefixSize(ctx, testDB, p)
 			assert.EqualError(t, err, context.Canceled.Error())
 			assert.Zero(t, s.Count)
 			assert.Zero(t, s.Size)

--- a/db/remote/db.go
+++ b/db/remote/db.go
@@ -73,6 +73,10 @@ func (d *DB) WithListener(listener db.EventListener) db.DB {
 	return d
 }
 
+func (d *DB) StartMetricsCollection(ctx context.Context, interval time.Duration) {
+	d.log.Errorw("Metrics collection not supported for remote DB")
+}
+
 func (d *DB) Close() error {
 	return d.grpcClient.Close()
 }

--- a/node/node.go
+++ b/node/node.go
@@ -38,10 +38,13 @@ import (
 )
 
 const (
-	upgraderDelay            = 5 * time.Minute
-	metricsGatheringInterval = 3 * time.Second
-	githubAPIUrl             = "https://api.github.com/repos/NethermindEth/juno/releases/latest"
-	latestReleaseURL         = "https://github.com/NethermindEth/juno/releases/latest"
+	upgraderDelay = 5 * time.Minute
+
+	// metricsGatheringInterval specifies the interval to retrieve pebble database
+	// compaction, io and pause stats to report to the user.
+	dbMetricsGatheringInterval = 3 * time.Second
+	githubAPIUrl               = "https://api.github.com/repos/NethermindEth/juno/releases/latest"
+	latestReleaseURL           = "https://github.com/NethermindEth/juno/releases/latest"
 )
 
 // Config is the top-level juno configuration.
@@ -349,7 +352,7 @@ func (n *Node) Run(ctx context.Context) {
 
 		wg.Go(func() {
 			defer cancel()
-			n.db.StartMetricsCollection(ctx, metricsGatheringInterval)
+			n.db.StartMetricsCollection(ctx, dbMetricsGatheringInterval)
 		})
 	}
 

--- a/node/node.go
+++ b/node/node.go
@@ -346,9 +346,7 @@ func (n *Node) Run(ctx context.Context) {
 				n.log.Errorw("Metrics error", "err", err)
 			}
 		})
-	}
 
-	if n.db != nil {
 		wg.Go(func() {
 			defer cancel()
 			n.db.StartMetricsCollection(ctx, metricsGatheringInterval)

--- a/node/node_test.go
+++ b/node/node_test.go
@@ -67,7 +67,7 @@ func TestNetworkVerificationOnNonEmptyDB(t *testing.T) {
 		t.Run(description, func(t *testing.T) {
 			dbPath := t.TempDir()
 			log := utils.NewNopZapLogger()
-			database, err := pebble.New(dbPath)
+			database, err := pebble.New(dbPath, false)
 			require.NoError(t, err)
 			chain := blockchain.New(database, &network)
 			syncer := sync.New(chain, adaptfeeder.New(feeder.NewTestClient(t, &network)), log, 0, false)


### PR DESCRIPTION
Adds the following metrics:

`db_compaction_time` - Total time spent in database compaction
`db_compaction_read` - Total bytes read during compaction
`db_compaction_write` - Total bytes written during compaction
`db_write_delay_count` - Total write delay counts due to database compaction
`db_write_delay_time` - Total time spent in write stalls
`db_disk_size` - Tracks the size of all of the levels of the database
`db_disk_write` - Measures the effective amount of data written to disk
`db_mem_comp` - Tracks the amount of memory allocated for compaction
`db_level0_comp` - Tracks the number of level-zero compactions
`db_nonlevel0_comp` - Tracks the number of non level-zero compactions
`db_seek_comp` - Tracks the number of table compactions caused by read operations
`db_manual_mem_alloc` - Tracks the amount of non-managed memory currently allocated