### PR TITLE
Pin action versions in codeql-analysis.yml

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -38,11 +38,11 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@d632683dd7b4114ad314bca15554477dd762a938 #v4.2.0
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v3
+      uses: github/codeql-action/init@5618c9fc1e675841ca52c1c6b1304f5255a905a0 #v2.19.0
       with:
         languages: ${{ matrix.language }}
         # If you wish to specify custom queries, you can do so here or in a config file.
@@ -53,7 +53,7 @@ jobs:
     # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
     # If this step fails, then you should remove it and run the build manually (see below)
     - name: Autobuild
-      uses: github/codeql-action/autobuild@v3
+      uses: github/codeql-action/autobuild@5618c9fc1e675841ca52c1c6b1304f5255a905a0 #v2.19.0
 
     # ℹ️ Command-line programs to run using the OS shell.
     # 📚 https://git.io/JvXDl
@@ -67,4 +67,4 @@ jobs:
     #   make release
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v3
+      uses: github/codeql-action/analyze@5618c9fc1e675841ca52c1c6b1304f5255a905a0 #v2.19.0


### PR DESCRIPTION
## Changes

- Pinned the actions to specific commit hashes:
    - actions/checkout pinned to d632683dd7b4114ad314bca15554477dd762a938 #v4.2.0
    - github/codeql-action/init pinned to 5618c9fc1e675841ca52c1c6b1304f5255a905a0 #v2.19.0
    - github/codeql-action/analyze pinned to 5618c9fc1e675841ca52c1c6b1304f5255a905a0 #v2.19.0