### PR TITLE
Refactor retrieve state history API

### DIFF
--- a/core/history.go
+++ b/core/history.go
@@ -26,7 +26,7 @@ func (h *history) deleteLog(key []byte, height uint64) error {
 	return h.txn.Delete(logDBKey(key, height))
 }
 
-// valueAt returns the value at the given height for the given key if it exists
+// valueAt returns the old value at the given height for the given key if it exists
 func (h *history) valueAt(key []byte, height uint64) ([]byte, error) {
 	var value []byte
 	err := h.txn.Get(logDBKey(key, height), func(val []byte) error {

--- a/core/history_pkg_test.go
+++ b/core/history_pkg_test.go
@@ -62,42 +62,36 @@ func TestHistory(t *testing.T) {
 				assert.NoError(t, test.logger(location, value, 10))
 			})
 
-			t.Run("get value before height 5", func(t *testing.T) {
-				oldValue, err := test.getter(location, 1)
-				require.NoError(t, err)
-				assert.Equal(t, &felt.Zero, oldValue)
+			t.Run("get value between height 5-10", func(t *testing.T) {
+				_, err := test.getter(location, 7)
+				require.ErrorIs(t, err, ErrCheckHeadState) // there's no history at height 7
 			})
 
-			t.Run("get value between height 5-10 ", func(t *testing.T) {
-				oldValue, err := test.getter(location, 7)
-				require.NoError(t, err)
-				assert.Equal(t, value, oldValue)
-			})
-
-			t.Run("get value on height that change happened ", func(t *testing.T) {
+			t.Run("get value on height that change happened", func(t *testing.T) {
 				oldValue, err := test.getter(location, 5)
 				require.NoError(t, err)
-				assert.Equal(t, value, oldValue)
+				assert.Equal(t, &felt.Zero, oldValue)
 
-				_, err = test.getter(location, 10)
-				assert.ErrorIs(t, err, ErrCheckHeadState)
+				oldValue, err = test.getter(location, 10)
+				require.NoError(t, err)
+				assert.Equal(t, value, oldValue)
 			})
 
 			t.Run("get value after height 10 ", func(t *testing.T) {
 				_, err := test.getter(location, 13)
-				assert.ErrorIs(t, err, ErrCheckHeadState)
+				assert.ErrorIs(t, err, ErrCheckHeadState) // there's no history at height 13
 			})
 
 			t.Run("get a random location ", func(t *testing.T) {
 				_, err := test.getter(new(felt.Felt).SetUint64(37), 13)
-				assert.ErrorIs(t, err, ErrCheckHeadState)
+				assert.ErrorIs(t, err, ErrCheckHeadState) // there's no history at height 13
 			})
 
 			require.NoError(t, test.deleter(location, 10))
 
 			t.Run("get after delete", func(t *testing.T) {
-				_, err := test.getter(location, 7)
-				assert.ErrorIs(t, err, ErrCheckHeadState)
+				_, err := test.getter(location, 10)
+				assert.ErrorIs(t, err, ErrCheckHeadState) // there's no history at height 10
 			})
 		})
 	}

--- a/core/state.go
+++ b/core/state.go
@@ -354,7 +354,7 @@ func (s *State) updateStorageBuffered(contractAddr *felt.Felt, updateDiff map[fe
 	}
 
 	onValueChanged := func(location, oldValue *felt.Felt) error {
-		if logChanges {
+		if blockNumber != 0 && logChanges {
 			return bufferedState.LogContractStorage(contractAddr, location, oldValue, blockNumber)
 		}
 		return nil
@@ -667,7 +667,7 @@ func (s *State) buildReverseDiff(blockNumber uint64, diff *StateDiff) (*StateDif
 		for key := range storageDiffs {
 			value := &felt.Zero
 			if blockNumber > 0 {
-				oldValue, err := s.ContractStorageAt(&addr, &key, blockNumber-1)
+				oldValue, err := s.ContractStorageAt(&addr, &key, blockNumber)
 				if err != nil {
 					return nil, err
 				}
@@ -689,7 +689,7 @@ func (s *State) buildReverseDiff(blockNumber uint64, diff *StateDiff) (*StateDif
 
 		if blockNumber > 0 {
 			var err error
-			oldNonce, err = s.ContractNonceAt(&addr, blockNumber-1)
+			oldNonce, err = s.ContractNonceAt(&addr, blockNumber)
 			if err != nil {
 				return nil, err
 			}
@@ -707,7 +707,7 @@ func (s *State) buildReverseDiff(blockNumber uint64, diff *StateDiff) (*StateDif
 		classHash := &felt.Zero
 		if blockNumber > 0 {
 			var err error
-			classHash, err = s.ContractClassHashAt(&addr, blockNumber-1)
+			classHash, err = s.ContractClassHashAt(&addr, blockNumber)
 			if err != nil {
 				return nil, err
 			}

--- a/core/state_test.go
+++ b/core/state_test.go
@@ -289,6 +289,9 @@ func TestStateHistory(t *testing.T) {
 		assert.ErrorIs(t, err, core.ErrCheckHeadState)
 	})
 
+	prevValue, err := state.ContractStorage(contractAddr, changedLoc)
+	require.NoError(t, err)
+
 	// update the same location again
 	su := &core.StateUpdate{
 		NewRoot: utils.HexToFelt(t, "0xac747e0ea7497dad7407ecf2baf24b1598b0b40943207fc9af8ded09a64f1c"),
@@ -304,9 +307,9 @@ func TestStateHistory(t *testing.T) {
 	require.NoError(t, state.Update(1, su, nil))
 
 	t.Run("should give old value for a location that changed after the given height", func(t *testing.T) {
-		oldValue, err := state.ContractStorageAt(contractAddr, changedLoc, 0)
+		oldValue, err := state.ContractStorageAt(contractAddr, changedLoc, 1)
 		require.NoError(t, err)
-		require.Equal(t, oldValue, utils.HexToFelt(t, "0x22b"))
+		require.Equal(t, oldValue, prevValue)
 	})
 }
 


### PR DESCRIPTION
Let's start straight away with an example:

Block 0: Alice initially has 10 STRK
Block 10: Alice now has 20 STRK
Block 25: Alice now has 30 STRK

We store state history (i.e. buckets which are `ContractNonceHistory`, `ContractStorageHistory`, `ContractClassHashHistory`) in the following key-value format:
```
(prefix, contract address, block height) = old value
```

In our given example, let's pretend Alice is the contract address, then we will have the following key-value pairs in the database:
```
(prefix, Alice, 10) = 10
(prefix, Alice, 25) = 20
```

Ok, now we have the database in mind, let's dive into the code. Look at the `func (h *history) valueAt(key []byte, height uint64)` method. The first intuition of this method is that it returns the history at a given key with the given height. This intuition is further solidified by the methods that uses it, which are `history.ContractStorageAt`, `history.ContractNonceAt` and `history.ContractClassHashAt` (check the comments). So I would expect something like:

```
valueAt((prefix+Alice), 10) = 10
valueAt((prefix+Alice), 25) = 20
``` 

Now, if you look at the implementation. That's actually not the case. What the method actually does is that it returns the value at given key **AFTER** the given height. Let me repeat it, it is **AFTER** a given block height.

The original intention of doing this is that, we can represent the history of a given state for a range of block heights. So something like:
- From block 0 to 9 = Alice has 10 STRK
- From block 10 to 24 = Alice has 20 STRK

Finally, let's check if the original intention was actually used. Look at the usage of `ContractClassHashAt`, `ContractNonceAt` and `ContractStorageAt`. They have this pattern:
```
oldValue, err := s.ContractStorageAt(&addr, &key, blockNumber-1)
oldNonce, err = s.ContractNonceAt(&addr, blockNumber-1)
classHash, err = s.ContractClassHashAt(&addr, blockNumber-1) 
```

So actually, the usage of these methods implies that all we really want to get is just the value of a state at a given key with the given height! So why do we bother with representing the history of a given state for a range of block heights in the first place?

Hence, this PR reimplements the methods to suit their intent.