### PR TITLE
Fix core/state_test tests failure

### DIFF
--- a/core/class_test.go
+++ b/core/class_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"reflect"
 	"testing"
 
 	"github.com/NethermindEth/juno/clients/feeder"
@@ -168,7 +167,6 @@ func TestClassEncoding(t *testing.T) {
 
 func checkClassSymmetry(t *testing.T, input core.Class) {
 	t.Helper()
-	require.NoError(t, encoder.RegisterType(reflect.TypeOf(input)))
 
 	data, err := encoder.Marshal(input)
 	require.NoError(t, err)

--- a/core/state_test.go
+++ b/core/state_test.go
@@ -27,25 +27,22 @@ var (
 )
 
 func TestMain(m *testing.M) {
-	types := []reflect.Type{
-		reflect.TypeOf(core.DeclareTransaction{}),
-		reflect.TypeOf(core.DeployTransaction{}),
-		reflect.TypeOf(core.InvokeTransaction{}),
-		reflect.TypeOf(core.L1HandlerTransaction{}),
-		reflect.TypeOf(core.DeployAccountTransaction{}),
-		reflect.TypeOf(core.Cairo0Class{}),
-		reflect.TypeOf(core.Cairo1Class{}),
+	txTypes := []core.Transaction{
+		&core.DeclareTransaction{},
+		&core.DeployTransaction{},
+		&core.InvokeTransaction{},
+		&core.L1HandlerTransaction{},
+		&core.DeployAccountTransaction{},
 	}
 
-	for _, tp := range types {
-		_ = encoder.RegisterType(tp)
+	for _, tx := range txTypes {
+		_ = encoder.RegisterType(reflect.TypeOf(tx))
 	}
+
+	_ = encoder.RegisterType(reflect.TypeOf(core.Cairo0Class{}))
+	_ = encoder.RegisterType(reflect.TypeOf(core.Cairo1Class{}))
 
 	code := m.Run()
-
-	for _, tp := range types {
-		encoder.DeregisterType(tp)
-	}
 
 	os.Exit(code)
 }

--- a/core/transaction_test.go
+++ b/core/transaction_test.go
@@ -5,7 +5,6 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
-	"reflect"
 	"testing"
 
 	"github.com/Masterminds/semver/v3"
@@ -127,7 +126,6 @@ func TestTransactionEncoding(t *testing.T) {
 
 func checkTransactionSymmetry(t *testing.T, input core.Transaction) {
 	t.Helper()
-	require.NoError(t, encoder.RegisterType(reflect.TypeOf(input)))
 
 	data, err := encoder.Marshal(input)
 	require.NoError(t, err)

--- a/encoder/encoder.go
+++ b/encoder/encoder.go
@@ -50,11 +50,6 @@ func RegisterType(rType reflect.Type) error {
 	return nil
 }
 
-func DeregisterType(rType reflect.Type) {
-	ts.Remove(rType)
-	initEncAndDecModes()
-}
-
 // Marshal returns encoding of param v
 func Marshal(v any) ([]byte, error) {
 	initialiseEncoder.Do(initEncAndDecModes)

--- a/encoder/encoder.go
+++ b/encoder/encoder.go
@@ -50,6 +50,11 @@ func RegisterType(rType reflect.Type) error {
 	return nil
 }
 
+func DeregisterType(rType reflect.Type) {
+	ts.Remove(rType)
+	initEncAndDecModes()
+}
+
 // Marshal returns encoding of param v
 func Marshal(v any) ([]byte, error) {
 	initialiseEncoder.Do(initEncAndDecModes)


### PR DESCRIPTION
If we run the test in the following command:
```
go test ./core/state_test.go -v
```

We would get test errors as such:
```
...
cbor: cannot unmarshal map into Go struct field core.DeclaredClass.Class of type core.Class
```

But if we run the test with the following command, no errors are found:
```
go test ./core -v
```

The `cbor` encoder and decoder that we are using are initialized globally. In the case when are running tests, running all the tests in the `core` package would initialize the encoder/decoder correctly, but some struct types were registered properly if we only run the `state_test.go`.

This PR attempts to fix the proper registering and deregistering types in the `state_test.go` file.