### PR TITLE
Update starknet.go version to fix failing tests

### DIFF
--- a/.github/workflows/starknet-go-tests.yml
+++ b/.github/workflows/starknet-go-tests.yml
@@ -6,7 +6,7 @@ on:
       ref:
         description: 'The branch, tag or SHA to checkout'
         required: false
-        default: 'v0.7.1'
+        default: 'v0.7.2'
         type: string
     secrets:
       TEST_RPC_URL:


### PR DESCRIPTION
The tests TestBlockWithTxHashes and TestBlockWithTxs were failing due to outdated starknet.go. Updating starknet.go should resolve these failures, as seen in the [failing test sample](https://github.com/NethermindEth/juno/actions/runs/11323495412/job/31486863469#step:5:11).