### PR TITLE
Fix upper bound issue in `CalculatePrefixSize`

### DIFF
--- a/cmd/juno/dbcmd.go
+++ b/cmd/juno/dbcmd.go
@@ -231,6 +231,7 @@ func dbSize(cmd *cobra.Command, args []string) error {
 
 	// check if there is any data left in the db
 	lastBucket := buckets[len(buckets)-1]
+	fmt.Fprintln(cmd.OutOrStdout(), "Calculating remaining data in the db")
 	lastBucketItem, err := pebble.CalculatePrefixSize(cmd.Context(), pebbleDB.(*pebble.DB), []byte{byte(lastBucket + 1)}, false)
 	if err != nil {
 		return err

--- a/cmd/juno/dbcmd.go
+++ b/cmd/juno/dbcmd.go
@@ -206,7 +206,7 @@ func dbSize(cmd *cobra.Command, args []string) error {
 	buckets := db.BucketValues()
 	for _, b := range buckets {
 		fmt.Fprintf(cmd.OutOrStdout(), "Calculating size of %s, remaining buckets: %d\n", b, len(db.BucketValues())-int(b)-1)
-		bucketItem, err := pebble.CalculatePrefixSize(cmd.Context(), pebbleDB.(*pebble.DB), []byte{byte(b)})
+		bucketItem, err := pebble.CalculatePrefixSize(cmd.Context(), pebbleDB.(*pebble.DB), []byte{byte(b)}, true)
 		if err != nil {
 			return err
 		}
@@ -232,7 +232,7 @@ func dbSize(cmd *cobra.Command, args []string) error {
 	// check if there is any data left in the db
 	lastBucket := buckets[len(buckets)-1]
 	fmt.Fprintln(cmd.OutOrStdout(), "Calculating remaining data in the db")
-	lastBucketItem, err := pebble.CalculatePrefixSize(cmd.Context(), pebbleDB.(*pebble.DB), []byte{byte(lastBucket + 1)})
+	lastBucketItem, err := pebble.CalculatePrefixSize(cmd.Context(), pebbleDB.(*pebble.DB), []byte{byte(lastBucket + 1)}, false)
 	if err != nil {
 		return err
 	}

--- a/cmd/juno/dbcmd.go
+++ b/cmd/juno/dbcmd.go
@@ -206,7 +206,7 @@ func dbSize(cmd *cobra.Command, args []string) error {
 	buckets := db.BucketValues()
 	for _, b := range buckets {
 		fmt.Fprintf(cmd.OutOrStdout(), "Calculating size of %s, remaining buckets: %d\n", b, len(db.BucketValues())-int(b)-1)
-		bucketItem, err := pebble.CalculatePrefixSize(cmd.Context(), pebbleDB.(*pebble.DB), []byte{byte(b)}, true)
+		bucketItem, err := pebble.CalculatePrefixSize(cmd.Context(), pebbleDB.(*pebble.DB), []byte{byte(b)})
 		if err != nil {
 			return err
 		}
@@ -232,7 +232,7 @@ func dbSize(cmd *cobra.Command, args []string) error {
 	// check if there is any data left in the db
 	lastBucket := buckets[len(buckets)-1]
 	fmt.Fprintln(cmd.OutOrStdout(), "Calculating remaining data in the db")
-	lastBucketItem, err := pebble.CalculatePrefixSize(cmd.Context(), pebbleDB.(*pebble.DB), []byte{byte(lastBucket + 1)}, false)
+	lastBucketItem, err := pebble.CalculatePrefixSize(cmd.Context(), pebbleDB.(*pebble.DB), []byte{byte(lastBucket + 1)})
 	if err != nil {
 		return err
 	}

--- a/db/pebble/db.go
+++ b/db/pebble/db.go
@@ -17,7 +17,7 @@ const (
 	// minCache is the minimum amount of memory in megabytes to allocate to pebble read and write caching.
 	// This is also pebble's default value.
 	minCacheSizeMB = 8
-	byteLimit      = 0xff
+	maxByte = ^byte(0)
 )
 
 var (

--- a/db/pebble/db.go
+++ b/db/pebble/db.go
@@ -17,7 +17,7 @@ const (
 	// minCache is the minimum amount of memory in megabytes to allocate to pebble read and write caching.
 	// This is also pebble's default value.
 	minCacheSizeMB = 8
-	maxByte = ^byte(0)
+	maxByte        = ^byte(0)
 )
 
 var (
@@ -168,7 +168,7 @@ func upperBound(prefix []byte) []byte {
 	var ub []byte
 
 	for i := len(prefix) - 1; i >= 0; i-- {
-		if prefix[i] == byteLimit {
+		if prefix[i] == maxByte {
 			continue
 		}
 		ub = make([]byte, i+1)

--- a/db/pebble/db.go
+++ b/db/pebble/db.go
@@ -129,7 +129,7 @@ func (i *Item) add(size utils.DataSize) {
 	i.Size += size
 }
 
-func CalculatePrefixSize(ctx context.Context, pDB *DB, prefix []byte) (*Item, error) {
+func CalculatePrefixSize(ctx context.Context, pDB *DB, prefix []byte, withUpperBound bool) (*Item, error) {
 	var (
 		err error
 		v   []byte
@@ -138,8 +138,12 @@ func CalculatePrefixSize(ctx context.Context, pDB *DB, prefix []byte) (*Item, er
 	)
 
 	pebbleDB := pDB.Impl().(*pebble.DB)
+	iterOpt := &pebble.IterOptions{LowerBound: prefix}
+	if withUpperBound {
+		iterOpt.UpperBound = upperBound(prefix)
+	}
 
-	it, err := pebbleDB.NewIter(&pebble.IterOptions{LowerBound: prefix, UpperBound: upperBound(prefix)})
+	it, err := pebbleDB.NewIter(iterOpt)
 	if err != nil {
 		// No need to call utils.RunAndWrapOnError() since iterator couldn't be created
 		return nil, err

--- a/db/pebble/db.go
+++ b/db/pebble/db.go
@@ -129,7 +129,7 @@ func (i *Item) add(size utils.DataSize) {
 	i.Size += size
 }
 
-func CalculatePrefixSize(ctx context.Context, pDB *DB, prefix []byte, withUpperBound bool) (*Item, error) {
+func CalculatePrefixSize(ctx context.Context, pDB *DB, prefix []byte) (*Item, error) {
 	var (
 		err error
 		v   []byte
@@ -138,12 +138,8 @@ func CalculatePrefixSize(ctx context.Context, pDB *DB, prefix []byte, withUpperB
 	)
 
 	pebbleDB := pDB.Impl().(*pebble.DB)
-	iterOpt := &pebble.IterOptions{LowerBound: prefix}
-	if withUpperBound {
-		iterOpt.UpperBound = upperBound(prefix)
-	}
 
-	it, err := pebbleDB.NewIter(iterOpt)
+	it, err := pebbleDB.NewIter(&pebble.IterOptions{LowerBound: prefix, UpperBound: upperBound(prefix)})
 	if err != nil {
 		// No need to call utils.RunAndWrapOnError() since iterator couldn't be created
 		return nil, err

--- a/db/pebble/db_test.go
+++ b/db/pebble/db_test.go
@@ -424,7 +424,7 @@ func TestCalculatePrefixSize(t *testing.T) {
 	t.Run("empty db", func(t *testing.T) {
 		testDB := pebble.NewMemTest(t).(*pebble.DB)
 
-		s, err := pebble.CalculatePrefixSize(context.Background(), testDB, []byte("0"))
+		s, err := pebble.CalculatePrefixSize(context.Background(), testDB, []byte("0"), true)
 		require.NoError(t, err)
 		assert.Zero(t, s.Count)
 		assert.Zero(t, s.Size)
@@ -435,7 +435,7 @@ func TestCalculatePrefixSize(t *testing.T) {
 		require.NoError(t, testDB.Update(func(txn db.Transaction) error {
 			return txn.Set(append([]byte("0"), []byte("randomKey")...), []byte("someValue"))
 		}))
-		s, err := pebble.CalculatePrefixSize(context.Background(), testDB.(*pebble.DB), []byte("1"))
+		s, err := pebble.CalculatePrefixSize(context.Background(), testDB.(*pebble.DB), []byte("1"), true)
 		require.NoError(t, err)
 		assert.Zero(t, s.Count)
 		assert.Zero(t, s.Size)
@@ -455,7 +455,7 @@ func TestCalculatePrefixSize(t *testing.T) {
 			return txn.Set(k3, v3)
 		}))
 
-		s, err := pebble.CalculatePrefixSize(context.Background(), testDB.(*pebble.DB), p)
+		s, err := pebble.CalculatePrefixSize(context.Background(), testDB.(*pebble.DB), p, true)
 		require.NoError(t, err)
 		assert.Equal(t, uint(3), s.Count)
 		assert.Equal(t, utils.DataSize(expectedSize), s.Size)
@@ -464,7 +464,7 @@ func TestCalculatePrefixSize(t *testing.T) {
 			ctx, cancel := context.WithCancel(context.Background())
 			cancel()
 
-			s, err := pebble.CalculatePrefixSize(ctx, testDB.(*pebble.DB), p)
+			s, err := pebble.CalculatePrefixSize(ctx, testDB.(*pebble.DB), p, true)
 			assert.EqualError(t, err, context.Canceled.Error())
 			assert.Zero(t, s.Count)
 			assert.Zero(t, s.Size)

--- a/db/pebble/db_test.go
+++ b/db/pebble/db_test.go
@@ -424,7 +424,7 @@ func TestCalculatePrefixSize(t *testing.T) {
 	t.Run("empty db", func(t *testing.T) {
 		testDB := pebble.NewMemTest(t).(*pebble.DB)
 
-		s, err := pebble.CalculatePrefixSize(context.Background(), testDB, []byte("0"), true)
+		s, err := pebble.CalculatePrefixSize(context.Background(), testDB, []byte("0"))
 		require.NoError(t, err)
 		assert.Zero(t, s.Count)
 		assert.Zero(t, s.Size)
@@ -435,7 +435,7 @@ func TestCalculatePrefixSize(t *testing.T) {
 		require.NoError(t, testDB.Update(func(txn db.Transaction) error {
 			return txn.Set(append([]byte("0"), []byte("randomKey")...), []byte("someValue"))
 		}))
-		s, err := pebble.CalculatePrefixSize(context.Background(), testDB.(*pebble.DB), []byte("1"), true)
+		s, err := pebble.CalculatePrefixSize(context.Background(), testDB.(*pebble.DB), []byte("1"))
 		require.NoError(t, err)
 		assert.Zero(t, s.Count)
 		assert.Zero(t, s.Size)
@@ -455,7 +455,7 @@ func TestCalculatePrefixSize(t *testing.T) {
 			return txn.Set(k3, v3)
 		}))
 
-		s, err := pebble.CalculatePrefixSize(context.Background(), testDB.(*pebble.DB), p, true)
+		s, err := pebble.CalculatePrefixSize(context.Background(), testDB.(*pebble.DB), p)
 		require.NoError(t, err)
 		assert.Equal(t, uint(3), s.Count)
 		assert.Equal(t, utils.DataSize(expectedSize), s.Size)
@@ -464,7 +464,7 @@ func TestCalculatePrefixSize(t *testing.T) {
 			ctx, cancel := context.WithCancel(context.Background())
 			cancel()
 
-			s, err := pebble.CalculatePrefixSize(ctx, testDB.(*pebble.DB), p, true)
+			s, err := pebble.CalculatePrefixSize(ctx, testDB.(*pebble.DB), p)
 			assert.EqualError(t, err, context.Canceled.Error())
 			assert.Zero(t, s.Count)
 			assert.Zero(t, s.Size)


### PR DESCRIPTION
### Description
This PR modifies the `db size` command to also check for leftover key-value pairs in the database. It also fixes an upper bound bug as the `UpperBound` iterator option is exclusive, not inclusive.