### PR TITLE
Override network config with the one in database

### DIFF
--- a/cmd/juno/dbcmd.go
+++ b/cmd/juno/dbcmd.go
@@ -6,10 +6,10 @@ import (
 	"os"
 
 	"github.com/NethermindEth/juno/blockchain"
-	"github.com/NethermindEth/juno/core"
 	"github.com/NethermindEth/juno/core/felt"
 	"github.com/NethermindEth/juno/db"
 	"github.com/NethermindEth/juno/db/pebble"
+	"github.com/NethermindEth/juno/node"
 	"github.com/NethermindEth/juno/utils"
 	"github.com/olekukonko/tablewriter"
 	"github.com/spf13/cobra"
@@ -97,7 +97,7 @@ func dbInfo(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("failed to get the state update: %v", err)
 	}
 
-	info.Network = getNetwork(headBlock, stateUpdate.StateDiff)
+	info.Network = node.GetNetwork(headBlock, stateUpdate.StateDiff).Name
 	info.ChainHeight = headBlock.Number
 	info.LatestBlockHash = headBlock.Hash
 	info.LatestStateRoot = headBlock.GlobalStateRoot
@@ -233,25 +233,6 @@ func dbSize(cmd *cobra.Command, args []string) error {
 	tableState.Render()
 
 	return nil
-}
-
-func getNetwork(head *core.Block, stateDiff *core.StateDiff) string {
-	networks := []*utils.Network{
-		&utils.Mainnet,
-		&utils.Sepolia,
-		&utils.Goerli,
-		&utils.Goerli2,
-		&utils.Integration,
-		&utils.SepoliaIntegration,
-	}
-
-	for _, network := range networks {
-		if _, err := core.VerifyBlockHash(head, network, stateDiff); err == nil {
-			return network.Name
-		}
-	}
-
-	return "unknown"
 }
 
 func openDB(path string) (db.DB, error) {

--- a/node/node_test.go
+++ b/node/node_test.go
@@ -49,21 +49,12 @@ func TestNewNode(t *testing.T) {
 
 func TestNetworkVerificationOnNonEmptyDB(t *testing.T) {
 	network := utils.Integration
-	tests := map[string]struct {
-		network   utils.Network
-		errString string
-	}{
-		"same network": {
-			network:   network,
-			errString: "",
-		},
-		"different network": {
-			network:   utils.Mainnet,
-			errString: "unable to verify latest block hash; are the database and --network option compatible?",
-		},
+	tests := map[string]utils.Network{
+		"same network":      network,
+		"different network": utils.Mainnet,
 	}
 
-	for description, test := range tests {
+	for description, nw := range tests {
 		t.Run(description, func(t *testing.T) {
 			dbPath := t.TempDir()
 			log := utils.NewNopZapLogger()
@@ -78,13 +69,10 @@ func TestNetworkVerificationOnNonEmptyDB(t *testing.T) {
 
 			_, err = node.New(&node.Config{
 				DatabasePath: dbPath,
-				Network:      test.network,
+				Network:      nw,
 			}, "v0.1")
-			if test.errString == "" {
-				require.NoError(t, err)
-			} else {
-				require.ErrorContains(t, err, test.errString)
-			}
+
+			require.NoError(t, err)
 		})
 	}
 }


### PR DESCRIPTION
For an existing chain database, if a user provides a different network configuration via `--network`, automatically switches the network config that matches the one in the database. 