### PR TITLE
Pass required libbz2 to linker to fix compilation error on macOS

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,3 +1,3 @@
 # do not copy local database files
 p2p-dbs/
-juon/
+juno/

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+# do not copy local database files
+p2p-dbs/
+juon/

--- a/.github/workflows/juno-test.yml
+++ b/.github/workflows/juno-test.yml
@@ -40,7 +40,7 @@ jobs:
 
       - name: Install Jemalloc (Linux)
         if: runner.os == 'Linux'
-        run: sudo apt-get update -qq && sudo apt-get install -y libjemalloc-dev libjemalloc2 -y
+        run: sudo apt-get update -qq && sudo apt-get install -y libjemalloc-dev libjemalloc2 libbz2-dev
 
       - name: Install dependencies (macOS)
         if: runner.os == 'macOS'

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ ARG VM_DEBUG
 
 
 RUN apt-get -qq update && \
-    apt-get -qq install curl build-essential git golang upx-ucl libjemalloc-dev libjemalloc2 -y
+    apt-get -qq install curl build-essential git golang upx-ucl libjemalloc-dev libjemalloc2 libbz2-dev
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -q -y
 
 WORKDIR /app

--- a/vm/vm.go
+++ b/vm/vm.go
@@ -39,8 +39,8 @@ extern void cairoVMExecute(char* txns_json, char* classes_json, char* paid_fees_
 extern char* setVersionedConstants(char* json);
 extern void freeString(char* str);
 
-#cgo vm_debug  LDFLAGS: -L./rust/target/debug   -ljuno_starknet_rs
-#cgo !vm_debug LDFLAGS: -L./rust/target/release -ljuno_starknet_rs
+#cgo vm_debug  LDFLAGS: -L./rust/target/debug   -ljuno_starknet_rs -lbz2
+#cgo !vm_debug LDFLAGS: -L./rust/target/release -ljuno_starknet_rs -lbz2
 */
 import "C"
 


### PR DESCRIPTION
For some reason macOS build started to failing. Seem like they update default linked libraries and now it's required to pass `libbz2`