### PR TITLE
Add workflow to close stale issues and PRs

### DIFF
--- a/.github/workflows/close-stale.yml
+++ b/.github/workflows/close-stale.yml
@@ -1,0 +1,23 @@
+name: 'Close stale issues and PRs'
+on:
+  schedule:
+    - cron: '0 0 * * *'
+
+permissions:
+  issues: write
+  pull-requests: write
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v9
+        with:
+          stale-issue-message: 'This issue is stale because it has been open 35 days with no activity. Remove stale label or comment or this will be closed in 14 days.'
+          stale-pr-message: 'This pull request is stale because it has been open 35 days with no activity. Remove stale label or comment or this will be closed in 14 days.'
+          days-before-stale: 60
+          days-before-close: 14
+          exempt-all-milestones: true
+          exempt-issue-labels: no-stale
+          exempt-pr-labels: no-stale
+          delete-branch: true


### PR DESCRIPTION
Introduce a GitHub Actions workflow to automatically close stale issues and pull requests. This helps maintain repository hygiene by reducing clutter from inactive items. The workflow marks issues as stale after 60 days of inactivity and closes them 14 days later if no further activity occurs.

The issues and PRs that have a milestone assigned will not be looked
at by the bot. This means that it is still possible to plan work that
won't be worked for some time