### PR TITLE
Change juno db path in gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,5 +8,5 @@ config/
 .envrc
 # Default path for Juno DB files.  It will get created if you follow the
 # README and/or run `./build/juno` command.
-juno/
+/juno/
 p2p-dbs


### PR DESCRIPTION
Putting `juno/` in `.gitignore` will effectively ignore all the files in `cmd/juno` also. This gets annoying :(