### PR TITLE
Remove supported block version check

### DIFF
--- a/blockchain/blockchain.go
+++ b/blockchain/blockchain.go
@@ -8,7 +8,6 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/Masterminds/semver/v3"
 	"github.com/NethermindEth/juno/core"
 	"github.com/NethermindEth/juno/core/felt"
 	"github.com/NethermindEth/juno/db"
@@ -49,23 +48,7 @@ type Reader interface {
 	Network() *utils.Network
 }
 
-var (
-	ErrParentDoesNotMatchHead = errors.New("block's parent hash does not match head block hash")
-	supportedStarknetVersion  = semver.MustParse("0.13.3")
-)
-
-func checkBlockVersion(protocolVersion string) error {
-	blockVer, err := core.ParseBlockVersion(protocolVersion)
-	if err != nil {
-		return err
-	}
-
-	if blockVer.GreaterThan(supportedStarknetVersion) {
-		return errors.New("unsupported block version")
-	}
-
-	return nil
-}
+var ErrParentDoesNotMatchHead = errors.New("block's parent hash does not match head block hash")
 
 var _ Reader = (*Blockchain)(nil)
 
@@ -382,7 +365,7 @@ func (b *Blockchain) VerifyBlock(block *core.Block) error {
 }
 
 func verifyBlock(txn db.Transaction, block *core.Block) error {
-	if err := checkBlockVersion(block.ProtocolVersion); err != nil {
+	if _, err := core.ParseBlockVersion(block.ProtocolVersion); err != nil {
 		return err
 	}
 

--- a/blockchain/blockchain_test.go
+++ b/blockchain/blockchain_test.go
@@ -139,21 +139,6 @@ func TestVerifyBlock(t *testing.T) {
 		require.Error(t, chain.Store(mainnetBlock0, &emptyCommitments, mainnetStateUpdate0, nil))
 	})
 
-	t.Run("needs padding", func(t *testing.T) {
-		mainnetBlock0.ProtocolVersion = "99.0" // should be padded to "99.0.0"
-		require.EqualError(t, chain.Store(mainnetBlock0, &emptyCommitments, mainnetStateUpdate0, nil), "unsupported block version")
-	})
-
-	t.Run("needs truncating", func(t *testing.T) {
-		mainnetBlock0.ProtocolVersion = "99.0.0.0" // last 0 digit should be ignored
-		require.EqualError(t, chain.Store(mainnetBlock0, &emptyCommitments, mainnetStateUpdate0, nil), "unsupported block version")
-	})
-
-	t.Run("greater than supportedStarknetVersion", func(t *testing.T) {
-		mainnetBlock0.ProtocolVersion = "99.0.0"
-		require.EqualError(t, chain.Store(mainnetBlock0, &emptyCommitments, mainnetStateUpdate0, nil), "unsupported block version")
-	})
-
 	t.Run("no error with no version string", func(t *testing.T) {
 		mainnetBlock0.ProtocolVersion = ""
 		require.NoError(t, chain.Store(mainnetBlock0, &emptyCommitments, mainnetStateUpdate0, nil))


### PR DESCRIPTION
Allows processing of all versions without explicit checks