### PR TITLE
Update Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -90,7 +90,7 @@ install-mockgen:
 	go install go.uber.org/mock/mockgen@latest
 
 install-golangci-lint:
-	@command -v golangci-lint >/dev/null 2>&1 || go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.62.0
+	@which golangci-lint ||  go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.62.0
 
 lint: install-golangci-lint ## Run linter
 	golangci-lint run

--- a/Makefile
+++ b/Makefile
@@ -162,13 +162,13 @@ node3: juno-cached ## Run a node №3
 
 pathfinder: juno-cached ## Run a node to sync from pathfinder feedernode
 	./build/juno \
-  --network=sepolia \
-  --log-level=debug \
-  --db-path=./p2p-dbs/node-pathfinder \
-  --p2p \
-  --p2p-peers=/ip4/127.0.0.1/tcp/8888/p2p/12D3KooWF1JrZWQoBiBSjsFSuLbDiDvqcmJQRLaFQLmpVkHA9duk \
-  --p2p-private-key="54a695e2a5d5717d5ba8730efcafe6f17251a1955733cffc55a4085fbf7f5d2c1b4009314092069ef7ca9b364ce3eb3072531c64dfb2799c6bad76720a5bdff0" \
-  --metrics-port=9094 \
+	--network=sepolia \
+	--log-level=debug \
+	--db-path=./p2p-dbs/node-pathfinder \
+	--p2p \
+	--p2p-peers=/ip4/127.0.0.1/tcp/8888/p2p/12D3KooWF1JrZWQoBiBSjsFSuLbDiDvqcmJQRLaFQLmpVkHA9duk \
+	--p2p-private-key="54a695e2a5d5717d5ba8730efcafe6f17251a1955733cffc55a4085fbf7f5d2c1b4009314092069ef7ca9b364ce3eb3072531c64dfb2799c6bad76720a5bdff0" \
+	--metrics-port=9094 \
 	--disable-l1-verification
 
 test-fuzz: ## run fuzzing script

--- a/Makefile
+++ b/Makefile
@@ -95,7 +95,7 @@ install-golangci-lint:
 lint: install-golangci-lint ## Run linter
 	golangci-lint run
 
-tidy: ## Tidy Go modules
+tidy: ## Add missing and remove unused modules
 	go mod tidy
 
 format: ## Format Go and Rust code
@@ -104,7 +104,7 @@ format: ## Format Go and Rust code
 	$(MAKE) -C starknet/compiler/rust format
 	gofumpt -l -w .
 
-clean: ## Clean builds
+clean: ## Clean project builds
 	$(MAKE) -C vm/rust clean
 	$(MAKE) -C core/rust clean
 	$(MAKE) -C starknet/compiler/rust clean
@@ -171,5 +171,5 @@ pathfinder: juno-cached ## Run a node to sync from pathfinder feedernode
 	--metrics-port=9094 \
 	--disable-l1-verification
 
-test-fuzz: ## run fuzzing script
+test-fuzz: ## Run fuzzing script
 	./scripts/fuzz_all.sh

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,8 @@
 .DEFAULT_GOAL := help
 
-.PHONY: vm
+.PHONY: vm rustdeps juno juno-cached check-rust generate clean-testcache test test-cached \
+        test-race benchmarks test-cover install-deps lint tidy format clean help feedernode node1 \
+        node2 node3 pathfinder test-fuzz
 
 ifeq ($(VM_DEBUG),true)
     GO_TAGS = -tags vm_debug
@@ -33,11 +35,11 @@ MAKEFLAGS += -j$(NPROCS)
 
 rustdeps: check-rust vm core-rust compiler
 
-juno: rustdeps ## compile
+juno: rustdeps ## Compile Juno
 	@mkdir -p build
 	@go build $(GO_TAGS) -a -ldflags="-X main.Version=$(shell git describe --tags)" -o build/juno ./cmd/juno/
 
-juno-cached:
+juno-cached: ## Cached Juno compilation
 	@mkdir -p build
 	@go build $(GO_TAGS) -ldflags="-X main.Version=$(shell git describe --tags)" -o build/juno ./cmd/juno/
 
@@ -57,31 +59,31 @@ core-rust:
 compiler:
 	$(MAKE) -C starknet/compiler/rust $(VM_TARGET)
 
-generate: ## generate
+generate: ## Generate mocks and code
 	mkdir -p mocks
 	go generate ./...
 
-clean-testcache:
+clean-testcache: ## Clean Go test cache
 	go clean -testcache
 
-test: clean-testcache rustdeps ## tests
+test: clean-testcache rustdeps ## Run tests
 	go test $(GO_TAGS) ./...
 
-test-cached: rustdeps ## tests with existing cache
+test-cached: rustdeps ## Run cached tests
 	go test $(GO_TAGS) ./...
 
-test-race: clean-testcache rustdeps
+test-race: clean-testcache rustdeps ## Run tests with race detection
 	go test $(GO_TAGS) ./... -race $(TEST_RACE_LDFLAGS)
 
-benchmarks: rustdeps ## benchmarking
+benchmarks: rustdeps ## Run benchmarks
 	go test $(GO_TAGS) ./... -run=^# -bench=. -benchmem
 
-test-cover: clean-testcache rustdeps ## tests with coverage
+test-cover: clean-testcache rustdeps ## Run tests with coverage
 	mkdir -p coverage
 	go test $(GO_TAGS) -coverpkg=./... -coverprofile=coverage/coverage.out -covermode=atomic ./...
 	go tool cover -html=coverage/coverage.out -o coverage/coverage.html
 
-install-deps: | install-gofumpt install-mockgen install-golangci-lint check-rust ## install some project dependencies
+install-deps: install-gofumpt install-mockgen install-golangci-lint check-rust ## Install dependencies
 
 install-gofumpt:
 	go install mvdan.cc/gofumpt@latest
@@ -90,28 +92,36 @@ install-mockgen:
 	go install go.uber.org/mock/mockgen@latest
 
 install-golangci-lint:
-	@which golangci-lint || go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.62.0
+	@command -v golangci-lint >/dev/null 2>&1 || go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.62.0
 
-lint: install-golangci-lint
+lint: install-golangci-lint ## Run linter
 	golangci-lint run
 
-tidy: ## add missing and remove unused modules
-	 go mod tidy
+tidy: ## Tidy Go modules
+	go mod tidy
 
-format: ## run go & rust formatters
+format: ## Format Go and Rust code
 	$(MAKE) -C vm/rust format
 	$(MAKE) -C core/rust format
 	$(MAKE) -C starknet/compiler/rust format
 	gofumpt -l -w .
 
-clean: ## clean project builds
+clean: ## Clean builds
 	$(MAKE) -C vm/rust clean
 	$(MAKE) -C core/rust clean
 	$(MAKE) -C starknet/compiler/rust clean
 	@rm -rf ./build
 
-help: ## show this help
+help: ## Show help
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
+
+FEEDER_KEY := 5f6cdc3aebcc74af494df054876100368ef6126e3a33fa65b90c765b381ffc37a0a63bbeeefab0740f24a6a38dabb513b9233254ad0020c721c23e69bc820089
+FEEDER_ADDR := /ip4/127.0.0.1/tcp/7777/p2p/12D3KooWLdURCjbp1D7hkXWk6ZVfcMDPtsNnPHuxoTcWXFtvrxGG
+NODE1_KEY := 8aeffc26c3c371565dbe634c5248ae26f4fa5c33bc8f7328ac95e73fb94eaf263550f02449521f7cf64af17d248c5f170be46c06986a29803124c0819cb8fac3
+NODE2_KEY := 2d87e1d1c9d8dda1cf9a662de1978d2cd0b96e6ba390c75ded87c6c4fab657057fa782ae5977c3bd02d58281dccd16f2c26990d1f6c22f818a84edac97957348
+NODE3_KEY := 54a695e2a5d5717d5ba8730efcafe6f17251a1955733cffc55a4085fbf7f5d2c1b4009314092069ef7ca9b364ce3eb3072531c64dfb2799c6bad76720a5bdff0
+PATHFINDER_ADDR := /ip4/127.0.0.1/tcp/8888/p2p/12D3KooWF1JrZWQoBiBSjsFSuLbDiDvqcmJQRLaFQLmpVkHA9duk
+PATHFINDER_KEY := 54a695e2a5d5717d5ba8730efcafe6f17251a1955733cffc55a4085fbf7f5d2c1b4009314092069ef7ca9b364ce3eb3072531c64dfb2799c6bad76720a5bdff0
 
 feedernode: juno-cached
 	./build/juno \
@@ -121,51 +131,32 @@ feedernode: juno-cached
 	--p2p \
 	--p2p-feeder-node \
 	--p2p-addr=/ip4/0.0.0.0/tcp/7777 \
-	--p2p-private-key="5f6cdc3aebcc74af494df054876100368ef6126e3a33fa65b90c765b381ffc37a0a63bbeeefab0740f24a6a38dabb513b9233254ad0020c721c23e69bc820089" \
+	--p2p-private-key=$(FEEDER_KEY) \
+	--disable-l1-verification
 
-node1: juno-cached
+define run_node
 	./build/juno \
 	--network=sepolia \
 	--log-level=debug \
-	--metrics \
-	--db-path=./p2p-dbs/node1 \
+	--db-path=./p2p-dbs/$(1) \
 	--p2p \
-	--p2p-peers=/ip4/127.0.0.1/tcp/7777/p2p/12D3KooWLdURCjbp1D7hkXWk6ZVfcMDPtsNnPHuxoTcWXFtvrxGG \
-	--p2p-addr=/ip4/0.0.0.0/tcp/7778 \
-	--p2p-private-key="8aeffc26c3c371565dbe634c5248ae26f4fa5c33bc8f7328ac95e73fb94eaf263550f02449521f7cf64af17d248c5f170be46c06986a29803124c0819cb8fac3" \
-	--metrics-port=9091
+	--p2p-peers=$(2) \
+	--p2p-private-key=$(3) \
+	--metrics-port=$(4) \
+	--disable-l1-verification
+endef
 
-#	--p2p-peers=/ip4/127.0.0.1/tcp/7778/p2p/12D3KooWDQVMmK6cQrfFcWUoFF8Ch5vYegfwiP5Do2SFC2NAXeBk \
+node1: juno-cached ## Run a node
+	$(call run_node,node1,$(FEEDER_ADDR),$(NODE1_KEY),9091)
 
-node2:
-	./build/juno \
-	--network=sepolia \
-	--log-level=debug \
-	--db-path=./p2p-dbs/node2 \
-	--p2p \
-	--p2p-peers=/ip4/127.0.0.1/tcp/7777/p2p/12D3KooWLdURCjbp1D7hkXWk6ZVfcMDPtsNnPHuxoTcWXFtvrxGG \
-	--p2p-private-key="2d87e1d1c9d8dda1cf9a662de1978d2cd0b96e6ba390c75ded87c6c4fab657057fa782ae5977c3bd02d58281dccd16f2c26990d1f6c22f818a84edac97957348" \
-	--metrics-port=9092
+node2: juno-cached ## Run a node
+	$(call run_node,node2,$(FEEDER_ADDR),$(NODE2_KEY),9092)
 
-node3:
-	./build/juno \
-	--network=sepolia \
-	--log-level=debug \
-	--db-path=./p2p-dbs/node3 \
-	--p2p \
-	--p2p-peers=/ip4/127.0.0.1/tcp/7777/p2p/12D3KooWLdURCjbp1D7hkXWk6ZVfcMDPtsNnPHuxoTcWXFtvrxGG \
-	--p2p-private-key="54a695e2a5d5717d5ba8730efcafe6f17251a1955733cffc55a4085fbf7f5d2c1b4009314092069ef7ca9b364ce3eb3072531c64dfb2799c6bad76720a5bdff0" \
-	--metrics-port=9093
+node3: juno-cached ## Run a node
+	$(call run_node,node3,$(FEEDER_ADDR),$(NODE3_KEY),9093)
 
-pathfinder: juno-cached
-	./build/juno \
-    	--network=sepolia \
-    	--log-level=debug \
-    	--db-path=./p2p-dbs/node-pathfinder \
-    	--p2p \
-    	--p2p-peers=/ip4/127.0.0.1/tcp/8888/p2p/12D3KooWF1JrZWQoBiBSjsFSuLbDiDvqcmJQRLaFQLmpVkHA9duk \
-    	--p2p-private-key="54a695e2a5d5717d5ba8730efcafe6f17251a1955733cffc55a4085fbf7f5d2c1b4009314092069ef7ca9b364ce3eb3072531c64dfb2799c6bad76720a5bdff0" \
-    	--metrics-port=9094
+pathfinder: juno-cached ## Run a node to sync from pathfinder
+	$(call run_node,pathfinder,$(PATHFINDER_ADDR),$(PATHFINDER_KEY),9094)
 
 test-fuzz: ## run fuzzing script
 	./scripts/fuzz_all.sh

--- a/Makefile
+++ b/Makefile
@@ -90,7 +90,7 @@ install-mockgen:
 	go install go.uber.org/mock/mockgen@latest
 
 install-golangci-lint:
-	@which golangci-lint ||  go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.62.0
+	@which golangci-lint || go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.62.0
 
 lint: install-golangci-lint ## Run linter
 	golangci-lint run

--- a/Makefile
+++ b/Makefile
@@ -113,7 +113,7 @@ clean: ## Clean project builds
 help: ## Show help
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
 
-feedernode: juno-cached ## Run a feedernode
+feedernode: juno-cached ## Run a feedernode. P2P usage only
 	./build/juno \
 	--network=sepolia \
 	--log-level=debug \
@@ -123,7 +123,7 @@ feedernode: juno-cached ## Run a feedernode
 	--p2p-addr=/ip4/0.0.0.0/tcp/7777 \
 	--p2p-private-key="5f6cdc3aebcc74af494df054876100368ef6126e3a33fa65b90c765b381ffc37a0a63bbeeefab0740f24a6a38dabb513b9233254ad0020c721c23e69bc820089" \
 
-node1: juno-cached ## Run a node №1
+node1: juno-cached ## Run a node №1. P2P usage only
 	./build/juno \
 	--network=sepolia \
 	--log-level=debug \
@@ -138,7 +138,7 @@ node1: juno-cached ## Run a node №1
 
 #	--p2p-peers=/ip4/127.0.0.1/tcp/7778/p2p/12D3KooWDQVMmK6cQrfFcWUoFF8Ch5vYegfwiP5Do2SFC2NAXeBk \
 
-node2: juno-cached ## Run a node №2
+node2: juno-cached ## Run a node №2. P2P usage only
 	./build/juno \
 	--network=sepolia \
 	--log-level=debug \
@@ -149,7 +149,7 @@ node2: juno-cached ## Run a node №2
 	--metrics-port=9092 \
 	--disable-l1-verification
 
-node3: juno-cached ## Run a node №3
+node3: juno-cached ## Run a node №3. P2P usage only
 	./build/juno \
 	--network=sepolia \
 	--log-level=debug \
@@ -160,7 +160,7 @@ node3: juno-cached ## Run a node №3
 	--metrics-port=9093 \
 	--disable-l1-verification
 
-pathfinder: juno-cached ## Run a node to sync from pathfinder feedernode
+pathfinder: juno-cached ## Run a node to sync from pathfinder feedernode. P2P usage only
 	./build/juno \
 	--network=sepolia \
 	--log-level=debug \


### PR DESCRIPTION
This pull request includes several updates to the `Makefile` to improve clarity and functionality. The most important changes include adding descriptions to various targets, ensuring the linter is run conditionally, and adding a new target for running a node with specific configurations.

Enhancements to target descriptions and functionality:

* Added descriptions to various targets to improve clarity, such as `juno`, `generate`, `clean-testcache`, `test`, `test-cached`, `test-race`, `benchmarks`, `test-cover`, `install-deps`, `lint`, `tidy`, `format`, `clean`, `help`, `feedernode`, `node1`, `node2`, `node3`, `pathfinder`, and `test-fuzz`. [[1]](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L36-R40) [[2]](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L60-R84) [[3]](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L93-R116) [[4]](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L126-R126) [[5]](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L136-R174)

* Modified the `install-golangci-lint` target to use `command -v` instead of `which` for checking if `golangci-lint` is installed.

* Added a new target `juno-cached` with a description for cached Juno compilation.

* Added `--disable-l1-verification` flag to node targets (`node1`, `node2`, `node3`, `pathfinder`) to disable L1 verification.