### PR TITLE
Fix missing backslash in running Juno instructions

### DIFF
--- a/docs/docs/snapshots.md
+++ b/docs/docs/snapshots.md
@@ -79,7 +79,7 @@ docker run -d \
   --http \
   --http-port 6060 \
   --http-host 0.0.0.0 \
-  --db-path /snapshots/juno_mainnet
+  --db-path /snapshots/juno_mainnet \
   --eth-node <YOUR ETH NODE>
 ```
 

--- a/docs/versioned_docs/version-0.11.8/snapshots.md
+++ b/docs/versioned_docs/version-0.11.8/snapshots.md
@@ -78,7 +78,7 @@ docker run -d \
   --http \
   --http-port 6060 \
   --http-host 0.0.0.0 \
-  --db-path /snapshots/juno_mainnet
+  --db-path /snapshots/juno_mainnet \
   --eth-node <YOUR ETH NODE>
 ```
 

--- a/docs/versioned_docs/version-0.12.4/snapshots.md
+++ b/docs/versioned_docs/version-0.12.4/snapshots.md
@@ -79,7 +79,7 @@ docker run -d \
   --http \
   --http-port 6060 \
   --http-host 0.0.0.0 \
-  --db-path /snapshots/juno_mainnet
+  --db-path /snapshots/juno_mainnet \
   --eth-node <YOUR ETH NODE>
 ```
 


### PR DESCRIPTION
This PR fixes a missing backslash in the documentation instructions for running Juno. The missing backslash caused the --eth-node command to not be recognized, leading to user confusion.