### PR TITLE
Add mainnet directory setup instructions.

### DIFF
--- a/docs/docs/snapshots.md
+++ b/docs/docs/snapshots.md
@@ -55,7 +55,7 @@ wget -O juno_mainnet.tar https://juno-snapshots.nethermind.io/files/mainnet/late
 Ensure you have a directory to store the snapshots. We will use the `$HOME/snapshots` directory:
 
 ```bash
-mkdir -p $HOME/snapshots
+mkdir -p $HOME/snapshots/juno_mainnet
 ```
 
 ### 3. Extract the snapshot
@@ -63,7 +63,7 @@ mkdir -p $HOME/snapshots
 Extract the contents of the downloaded `.tar` file into the directory:
 
 ```bash
-tar -xvf juno_mainnet.tar -C $HOME/snapshots
+tar -xvf juno_mainnet.tar -C $HOME/snapshots/juno_mainnet
 ```
 
 ### 4. Run Juno

--- a/docs/versioned_docs/version-0.11.8/snapshots.md
+++ b/docs/versioned_docs/version-0.11.8/snapshots.md
@@ -54,7 +54,7 @@ wget -O juno_mainnet.tar https://juno-snapshots.nethermind.io/files/mainnet/late
 Ensure you have a directory to store the snapshots. We will use the `$HOME/snapshots` directory:
 
 ```bash
-mkdir -p $HOME/snapshots
+mkdir -p $HOME/snapshots/juno_mainnet
 ```
 
 ### 3. Extract the snapshot
@@ -62,7 +62,7 @@ mkdir -p $HOME/snapshots
 Extract the contents of the downloaded `.tar` file into the directory:
 
 ```bash
-tar -xvf juno_mainnet.tar -C $HOME/snapshots
+tar -xvf juno_mainnet.tar -C $HOME/snapshots/juno_mainnet
 ```
 
 ### 4. Run Juno

--- a/docs/versioned_docs/version-0.12.4/snapshots.md
+++ b/docs/versioned_docs/version-0.12.4/snapshots.md
@@ -55,7 +55,7 @@ wget -O juno_mainnet.tar https://juno-snapshots.nethermind.io/files/mainnet/late
 Ensure you have a directory to store the snapshots. We will use the `$HOME/snapshots` directory:
 
 ```bash
-mkdir -p $HOME/snapshots
+mkdir -p $HOME/snapshots/juno_mainnet
 ```
 
 ### 3. Extract the snapshot
@@ -63,7 +63,7 @@ mkdir -p $HOME/snapshots
 Extract the contents of the downloaded `.tar` file into the directory:
 
 ```bash
-tar -xvf juno_mainnet.tar -C $HOME/snapshots
+tar -xvf juno_mainnet.tar -C $HOME/snapshots/juno_mainnet
 ```
 
 ### 4. Run Juno


### PR DESCRIPTION
### Description

**Problem**: The original instructions did not specify creating a dedicated directory for extracting snapshots. As a result, following the instructions led to Docker pointing to an incorrect path, causing synchronization to start from the first block instead of using the snapshot data.

**Solution**: Added commands to create a dedicated `juno_mainnet` directory and updated extraction instructions. This ensures the snapshot data is properly used during sync, avoiding unnecessary full blockchain synchronization from the start.

**Changes Made**:

1. Changes to directory creation command:
   ```diff
   - mkdir -p $HOME/snapshots
   + mkdir -p $HOME/snapshots/juno_mainnet
   ```

2. Changes to snapshot extraction command:
   ```diff
   - tar -xvf juno_mainnet.tar -C $HOME/snapshots
   + tar -xvf juno_mainnet.tar -C $HOME/snapshots/juno_mainnet
   ```

3. Example Docker run command after these changes:
```bash
docker run -d \
  --name juno \
  -p 6060:6060 \
  
  <!-- The problem is in the line: -->
  -v $HOME/snapshots/juno_mainnet:/snapshots/juno_mainnet \
  
  nethermind/juno \
  --http \
  --http-port 6060 \
  --http-host 0.0.0.0 \
  --db-path /snapshots/juno_mainnet \
  --eth-node <YOUR ETH NODE>
```
These changes ensure that the Docker container will use the correct path, utilizing the snapshot effectively instead of resynchronizing from the genesis block.

