### PR TITLE
Fix spamming errors when requesting data from Juno that is not (yet) …

### DIFF
--- a/p2p/starknet/handlers.go
+++ b/p2p/starknet/handlers.go
@@ -4,6 +4,7 @@ package starknet
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"iter"
 	"sync"
@@ -411,7 +412,7 @@ func (h *Handler) processIterationRequest(iteration *spec.Iteration, finMsg prot
 			// pass it to handler function (some might be interested in header, others in entire block)
 			msg, err := getMsg(it)
 			if err != nil {
-				if err != db.ErrKeyNotFound {
+				if !errors.Is(err, db.ErrKeyNotFound) {
 					h.log.Errorw("Failed to generate data", "blockNumber", it.BlockNumber(), "err", err)
 				}
 				break
@@ -450,7 +451,7 @@ func (h *Handler) processIterationRequestMulti(iteration *spec.Iteration, finMsg
 			// pass it to handler function (some might be interested in header, others in entire block)
 			messages, err := getMsg(it)
 			if err != nil {
-				if err != db.ErrKeyNotFound {
+				if !errors.Is(err, db.ErrKeyNotFound) {
 					h.log.Errorw("Failed to generate data", "blockNumber", it.BlockNumber(), "err", err)
 				}
 				break

--- a/p2p/starknet/handlers.go
+++ b/p2p/starknet/handlers.go
@@ -13,6 +13,7 @@ import (
 	"github.com/NethermindEth/juno/blockchain"
 	"github.com/NethermindEth/juno/core"
 	"github.com/NethermindEth/juno/core/felt"
+	"github.com/NethermindEth/juno/db"
 	"github.com/NethermindEth/juno/p2p/starknet/spec"
 	"github.com/NethermindEth/juno/utils"
 	"github.com/libp2p/go-libp2p/core/network"
@@ -410,7 +411,9 @@ func (h *Handler) processIterationRequest(iteration *spec.Iteration, finMsg prot
 			// pass it to handler function (some might be interested in header, others in entire block)
 			msg, err := getMsg(it)
 			if err != nil {
-				h.log.Errorw("Failed to generate data", "blockNumber", it.BlockNumber(), "err", err)
+				if err != db.ErrKeyNotFound {
+					h.log.Errorw("Failed to generate data", "blockNumber", it.BlockNumber(), "err", err)
+				}
 				break
 			}
 
@@ -447,7 +450,9 @@ func (h *Handler) processIterationRequestMulti(iteration *spec.Iteration, finMsg
 			// pass it to handler function (some might be interested in header, others in entire block)
 			messages, err := getMsg(it)
 			if err != nil {
-				h.log.Errorw("Failed to generate data", "blockNumber", it.BlockNumber(), "err", err)
+				if err != db.ErrKeyNotFound {
+					h.log.Errorw("Failed to generate data", "blockNumber", it.BlockNumber(), "err", err)
+				}
 				break
 			}
 


### PR DESCRIPTION
This pull request includes changes to the `p2p/starknet/handlers.go` file to improve error handling and add a new import. The most important changes include adding a new import for the `db` package and modifying error handling to specifically check for `db.ErrKeyNotFound`.

### Import Addition:
* Added the `db` package to the import list in `p2p/starknet/handlers.go`.

### Error Handling Improvements:
* Updated the `processIterationRequest` function to log errors only if they are not `db.ErrKeyNotFound`.
* Updated the `processIterationRequestMulti` function to log errors only if they are not `db.ErrKeyNotFound`.

https://demerzelsolutions.slack.com/archives/C03HL8DH52N/p1732706848085409?thread_ts=1732286243.285989&cid=C03HL8DH52N