### PR TITLE
Enforce using cairo-lang-runner v2.8.5 and blockifier 0.8.0-rc.3

### DIFF
--- a/.github/workflows/find-smallest-rust.yml
+++ b/.github/workflows/find-smallest-rust.yml
@@ -35,7 +35,7 @@ jobs:
         with:
           script: |
             const msrv = '${{ steps.rust-version.outputs.highest-msrv }}'
-            const previous_msrv = '1.80.1'
+            const previous_msrv = '1.81.0'
 
             if (msrv != previous_msrv) {
               github.rest.issues.createComment({

--- a/Makefile
+++ b/Makefile
@@ -42,7 +42,7 @@ juno-cached:
 	@go build $(GO_TAGS) -ldflags="-X main.Version=$(shell git describe --tags)" -o build/juno ./cmd/juno/
 
 
-MINIMUM_RUST_VERSION = 1.80.1
+MINIMUM_RUST_VERSION = 1.81.0
 CURR_RUST_VERSION = $(shell rustc --version | grep -o '[0-9.]\+' | head -n1)
 check-rust: ## Ensure rust version is greater than minimum
 	@echo "Checking if current rust version >= $(MINIMUM_RUST_VERSION)"

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@
 
 - Golang 1.23 or higher is required to build and run the project. You can find the installer on
   the official Golang [download](https://go.dev/doc/install) page.
-- [Rust](https://www.rust-lang.org/tools/install) 1.80.1 or higher.
+- [Rust](https://www.rust-lang.org/tools/install) 1.81.0 or higher.
 - A C compiler: `gcc` or `clang`.
 - Install some dependencies on your system:
   

--- a/vm/rust/Cargo.toml
+++ b/vm/rust/Cargo.toml
@@ -8,7 +8,8 @@ edition = "2021"
 [dependencies]
 serde = "1.0.208"
 serde_json = { version = "1.0.125", features = ["raw_value"] }
-blockifier = "0.8.0-rc.3"
+blockifier = "=0.8.0-rc.3"
+cairo-lang-runner = { version = "=2.8.5" }
 starknet_api = "0.13.0-rc.1"
 cairo-vm = "=1.0.1"
 starknet-types-core = { version = "0.1.5", features = ["hash", "prime-bigint"] }


### PR DESCRIPTION
Fix failing builds/tests in pipelines after silent libs upgrade. E.g: https://github.com/NethermindEth/juno/actions/runs/12070879412/job/33661352665#step:9:845