### PR TITLE
Remove transaction_hash from getBlockWithReceipts

### DIFF
--- a/rpc/block.go
+++ b/rpc/block.go
@@ -226,8 +226,10 @@ func (h *Handler) BlockWithReceipts(id BlockID) (*BlockWithReceipts, *jsonrpc.Er
 	for index, txn := range block.Transactions {
 		r := block.Receipts[index]
 
+		t := AdaptTransaction(txn)
+		t.Hash = nil
 		txsWithReceipts[index] = TransactionWithReceipt{
-			Transaction: AdaptTransaction(txn),
+			Transaction: t,
 			// block_hash, block_number are optional in BlockWithReceipts response
 			Receipt: AdaptReceipt(r, txn, finalityStatus, nil, 0),
 		}

--- a/rpc/block_test.go
+++ b/rpc/block_test.go
@@ -606,6 +606,7 @@ func TestBlockWithReceipts(t *testing.T) {
 		for i, tx := range block0.Transactions {
 			receipt := block0.Receipts[i]
 			adaptedTx := rpc.AdaptTransaction(tx)
+			adaptedTx.Hash = nil
 
 			txsWithReceipt = append(txsWithReceipt, rpc.TransactionWithReceipt{
 				Transaction: adaptedTx,
@@ -650,6 +651,7 @@ func TestBlockWithReceipts(t *testing.T) {
 		for i, tx := range block1.Transactions {
 			receipt := block1.Receipts[i]
 			adaptedTx := rpc.AdaptTransaction(tx)
+			adaptedTx.Hash = nil
 
 			transactions = append(transactions, rpc.TransactionWithReceipt{
 				Transaction: adaptedTx,


### PR DESCRIPTION
`starknet_getBlockWithReceipts` was added in 0.7.x rpc spec and its array of `transaction` doesn't contain `transaction_hash` instead it contains the `transaction_hash`.