### PR TITLE
Skip error logs for FGW responses with NOT_RECEIVED status

### DIFF
--- a/rpc/transaction.go
+++ b/rpc/transaction.go
@@ -585,13 +585,11 @@ func (h *Handler) TransactionStatus(ctx context.Context, hash felt.Felt) (*Trans
 
 		status, err := adaptTransactionStatus(txStatus)
 		if err != nil {
-			h.log.Errorw("Failed to adapt transaction status", "err", err)
+			if !errors.Is(err, fmt.Errorf("%s", ErrTxnHashNotFound.Message)) {
+				h.log.Errorw("Failed to adapt transaction status", "err", err)
+			}
 			return nil, ErrTxnHashNotFound
 		}
-		if status == nil {
-			return nil, ErrTxnHashNotFound
-		}
-
 		return status, nil
 	}
 	return nil, txErr
@@ -755,7 +753,7 @@ func adaptTransactionStatus(txStatus *starknet.TransactionStatus) (*TransactionS
 	case starknet.Received:
 		status.Finality = TxnStatusReceived
 	case starknet.NotReceived:
-		return nil, nil
+		return nil, fmt.Errorf("%s", ErrTxnHashNotFound.Message)
 	default:
 		return nil, fmt.Errorf("unknown finality status: %v", finalityStatus)
 	}

--- a/rpc/transaction.go
+++ b/rpc/transaction.go
@@ -588,6 +588,9 @@ func (h *Handler) TransactionStatus(ctx context.Context, hash felt.Felt) (*Trans
 			h.log.Errorw("Failed to adapt transaction status", "err", err)
 			return nil, ErrTxnHashNotFound
 		}
+		if status == nil {
+			return nil, ErrTxnHashNotFound
+		}
 
 		return status, nil
 	}
@@ -751,6 +754,8 @@ func adaptTransactionStatus(txStatus *starknet.TransactionStatus) (*TransactionS
 		status.Finality = TxnStatusAcceptedOnL2
 	case starknet.Received:
 		status.Finality = TxnStatusReceived
+	case starknet.NotReceived:
+		return nil, nil
 	default:
 		return nil, fmt.Errorf("unknown finality status: %v", finalityStatus)
 	}

--- a/starknet/compiler/rust/src/lib.rs
+++ b/starknet/compiler/rust/src/lib.rs
@@ -1,6 +1,8 @@
-use cairo_lang_starknet_classes::casm_contract_class::{CasmContractClass, StarknetSierraCompilationError};
+use cairo_lang_starknet_classes::casm_contract_class::{
+    CasmContractClass, StarknetSierraCompilationError,
+};
 use std::ffi::{c_char, CStr, CString};
-use std::panic::{self,AssertUnwindSafe};
+use std::panic::{self, AssertUnwindSafe};
 
 #[no_mangle]
 #[allow(clippy::not_unsafe_ptr_arg_deref)]
@@ -25,9 +27,14 @@ pub extern "C" fn compileSierraToCasm(sierra_json: *const c_char, result: *mut *
         }
     };
 
-    let mut casm_class_result: Option<Result<CasmContractClass, StarknetSierraCompilationError>> = None;
+    let mut casm_class_result: Option<Result<CasmContractClass, StarknetSierraCompilationError>> =
+        None;
     let compilation_result = panic::catch_unwind(AssertUnwindSafe(|| {
-        casm_class_result = Some(CasmContractClass::from_contract_class(sierra_class, true, usize::MAX));
+        casm_class_result = Some(CasmContractClass::from_contract_class(
+            sierra_class,
+            true,
+            usize::MAX,
+        ));
     }));
     if let Err(_) = compilation_result {
         unsafe {


### PR DESCRIPTION
Do not log an error when FGW returns NOT_RECEIVED as this is a common scenario and should not generate misleading or confusing log entries for users.