### PR TITLE
Bootnode Registry

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -10,7 +10,7 @@ coverage:
         only_pulls: true
 ignore:
   - mocks
-  - l1/internal/contract/starknet.go
+  - l1/contract/*
   - grpc/gen/*
   - vm
   - p2p

--- a/l1/abi/bootnode_registry.json
+++ b/l1/abi/bootnode_registry.json
@@ -1,0 +1,217 @@
+[
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_updater",
+        "type": "address"
+      }
+    ],
+    "name": "addAuthorizedUpdater",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "string",
+        "name": "_ipAddress",
+        "type": "string"
+      }
+    ],
+    "name": "addIPAddress",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "stateMutability": "nonpayable",
+    "type": "constructor"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "owner",
+        "type": "address"
+      }
+    ],
+    "name": "OwnableInvalidOwner",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "account",
+        "type": "address"
+      }
+    ],
+    "name": "OwnableUnauthorizedAccount",
+    "type": "error"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "string",
+        "name": "ipAddress",
+        "type": "string"
+      }
+    ],
+    "name": "IPAdded",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "string",
+        "name": "ipAddress",
+        "type": "string"
+      }
+    ],
+    "name": "IPRemoved",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "previousOwner",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "newOwner",
+        "type": "address"
+      }
+    ],
+    "name": "OwnershipTransferred",
+    "type": "event"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_updater",
+        "type": "address"
+      }
+    ],
+    "name": "removeAuthorizedUpdater",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "index",
+        "type": "uint256"
+      }
+    ],
+    "name": "removeIPAddress",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "renounceOwnership",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "newOwner",
+        "type": "address"
+      }
+    ],
+    "name": "transferOwnership",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "updater",
+        "type": "address"
+      }
+    ],
+    "name": "UpdaterAdded",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "updater",
+        "type": "address"
+      }
+    ],
+    "name": "UpdaterRemoved",
+    "type": "event"
+  },
+  {
+    "inputs": [],
+    "name": "getIPAddresses",
+    "outputs": [
+      {
+        "internalType": "string[]",
+        "name": "",
+        "type": "string[]"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_updater",
+        "type": "address"
+      }
+    ],
+    "name": "isAuthorizedUpdater",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "owner",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  }
+]

--- a/l1/contract/bootnode_registry.go
+++ b/l1/contract/bootnode_registry.go
@@ -1,0 +1,1089 @@
+// Code generated - DO NOT EDIT.
+// This file is a generated binding and any manual changes will be lost.
+
+package contract
+
+import (
+	"errors"
+	"math/big"
+	"strings"
+
+	ethereum "github.com/ethereum/go-ethereum"
+	"github.com/ethereum/go-ethereum/accounts/abi"
+	"github.com/ethereum/go-ethereum/accounts/abi/bind"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/event"
+)
+
+// Reference imports to suppress errors if they are not otherwise used.
+var (
+	_ = errors.New
+	_ = big.NewInt
+	_ = strings.NewReader
+	_ = ethereum.NotFound
+	_ = bind.Bind
+	_ = common.Big1
+	_ = types.BloomLookup
+	_ = event.NewSubscription
+	_ = abi.ConvertType
+)
+
+// BootnodeRegistryMetaData contains all meta data concerning the BootnodeRegistry contract.
+var BootnodeRegistryMetaData = &bind.MetaData{
+	ABI: "[{\"inputs\":[{\"internalType\":\"address\",\"name\":\"_updater\",\"type\":\"address\"}],\"name\":\"addAuthorizedUpdater\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"string\",\"name\":\"_ipAddress\",\"type\":\"string\"}],\"name\":\"addIPAddress\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"constructor\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"owner\",\"type\":\"address\"}],\"name\":\"OwnableInvalidOwner\",\"type\":\"error\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"account\",\"type\":\"address\"}],\"name\":\"OwnableUnauthorizedAccount\",\"type\":\"error\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":false,\"internalType\":\"string\",\"name\":\"ipAddress\",\"type\":\"string\"}],\"name\":\"IPAdded\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":false,\"internalType\":\"string\",\"name\":\"ipAddress\",\"type\":\"string\"}],\"name\":\"IPRemoved\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"address\",\"name\":\"previousOwner\",\"type\":\"address\"},{\"indexed\":true,\"internalType\":\"address\",\"name\":\"newOwner\",\"type\":\"address\"}],\"name\":\"OwnershipTransferred\",\"type\":\"event\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"_updater\",\"type\":\"address\"}],\"name\":\"removeAuthorizedUpdater\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint256\",\"name\":\"index\",\"type\":\"uint256\"}],\"name\":\"removeIPAddress\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"renounceOwnership\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"newOwner\",\"type\":\"address\"}],\"name\":\"transferOwnership\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":false,\"internalType\":\"address\",\"name\":\"updater\",\"type\":\"address\"}],\"name\":\"UpdaterAdded\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":false,\"internalType\":\"address\",\"name\":\"updater\",\"type\":\"address\"}],\"name\":\"UpdaterRemoved\",\"type\":\"event\"},{\"inputs\":[],\"name\":\"getIPAddresses\",\"outputs\":[{\"internalType\":\"string[]\",\"name\":\"\",\"type\":\"string[]\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"_updater\",\"type\":\"address\"}],\"name\":\"isAuthorizedUpdater\",\"outputs\":[{\"internalType\":\"bool\",\"name\":\"\",\"type\":\"bool\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"owner\",\"outputs\":[{\"internalType\":\"address\",\"name\":\"\",\"type\":\"address\"}],\"stateMutability\":\"view\",\"type\":\"function\"}]",
+}
+
+// BootnodeRegistryABI is the input ABI used to generate the binding from.
+// Deprecated: Use BootnodeRegistryMetaData.ABI instead.
+var BootnodeRegistryABI = BootnodeRegistryMetaData.ABI
+
+// BootnodeRegistry is an auto generated Go binding around an Ethereum contract.
+type BootnodeRegistry struct {
+	BootnodeRegistryCaller     // Read-only binding to the contract
+	BootnodeRegistryTransactor // Write-only binding to the contract
+	BootnodeRegistryFilterer   // Log filterer for contract events
+}
+
+// BootnodeRegistryCaller is an auto generated read-only Go binding around an Ethereum contract.
+type BootnodeRegistryCaller struct {
+	contract *bind.BoundContract // Generic contract wrapper for the low level calls
+}
+
+// BootnodeRegistryTransactor is an auto generated write-only Go binding around an Ethereum contract.
+type BootnodeRegistryTransactor struct {
+	contract *bind.BoundContract // Generic contract wrapper for the low level calls
+}
+
+// BootnodeRegistryFilterer is an auto generated log filtering Go binding around an Ethereum contract events.
+type BootnodeRegistryFilterer struct {
+	contract *bind.BoundContract // Generic contract wrapper for the low level calls
+}
+
+// BootnodeRegistrySession is an auto generated Go binding around an Ethereum contract,
+// with pre-set call and transact options.
+type BootnodeRegistrySession struct {
+	Contract     *BootnodeRegistry // Generic contract binding to set the session for
+	CallOpts     bind.CallOpts     // Call options to use throughout this session
+	TransactOpts bind.TransactOpts // Transaction auth options to use throughout this session
+}
+
+// BootnodeRegistryCallerSession is an auto generated read-only Go binding around an Ethereum contract,
+// with pre-set call options.
+type BootnodeRegistryCallerSession struct {
+	Contract *BootnodeRegistryCaller // Generic contract caller binding to set the session for
+	CallOpts bind.CallOpts           // Call options to use throughout this session
+}
+
+// BootnodeRegistryTransactorSession is an auto generated write-only Go binding around an Ethereum contract,
+// with pre-set transact options.
+type BootnodeRegistryTransactorSession struct {
+	Contract     *BootnodeRegistryTransactor // Generic contract transactor binding to set the session for
+	TransactOpts bind.TransactOpts           // Transaction auth options to use throughout this session
+}
+
+// BootnodeRegistryRaw is an auto generated low-level Go binding around an Ethereum contract.
+type BootnodeRegistryRaw struct {
+	Contract *BootnodeRegistry // Generic contract binding to access the raw methods on
+}
+
+// BootnodeRegistryCallerRaw is an auto generated low-level read-only Go binding around an Ethereum contract.
+type BootnodeRegistryCallerRaw struct {
+	Contract *BootnodeRegistryCaller // Generic read-only contract binding to access the raw methods on
+}
+
+// BootnodeRegistryTransactorRaw is an auto generated low-level write-only Go binding around an Ethereum contract.
+type BootnodeRegistryTransactorRaw struct {
+	Contract *BootnodeRegistryTransactor // Generic write-only contract binding to access the raw methods on
+}
+
+// NewBootnodeRegistry creates a new instance of BootnodeRegistry, bound to a specific deployed contract.
+func NewBootnodeRegistry(address common.Address, backend bind.ContractBackend) (*BootnodeRegistry, error) {
+	contract, err := bindBootnodeRegistry(address, backend, backend, backend)
+	if err != nil {
+		return nil, err
+	}
+	return &BootnodeRegistry{BootnodeRegistryCaller: BootnodeRegistryCaller{contract: contract}, BootnodeRegistryTransactor: BootnodeRegistryTransactor{contract: contract}, BootnodeRegistryFilterer: BootnodeRegistryFilterer{contract: contract}}, nil
+}
+
+// NewBootnodeRegistryCaller creates a new read-only instance of BootnodeRegistry, bound to a specific deployed contract.
+func NewBootnodeRegistryCaller(address common.Address, caller bind.ContractCaller) (*BootnodeRegistryCaller, error) {
+	contract, err := bindBootnodeRegistry(address, caller, nil, nil)
+	if err != nil {
+		return nil, err
+	}
+	return &BootnodeRegistryCaller{contract: contract}, nil
+}
+
+// NewBootnodeRegistryTransactor creates a new write-only instance of BootnodeRegistry, bound to a specific deployed contract.
+func NewBootnodeRegistryTransactor(address common.Address, transactor bind.ContractTransactor) (*BootnodeRegistryTransactor, error) {
+	contract, err := bindBootnodeRegistry(address, nil, transactor, nil)
+	if err != nil {
+		return nil, err
+	}
+	return &BootnodeRegistryTransactor{contract: contract}, nil
+}
+
+// NewBootnodeRegistryFilterer creates a new log filterer instance of BootnodeRegistry, bound to a specific deployed contract.
+func NewBootnodeRegistryFilterer(address common.Address, filterer bind.ContractFilterer) (*BootnodeRegistryFilterer, error) {
+	contract, err := bindBootnodeRegistry(address, nil, nil, filterer)
+	if err != nil {
+		return nil, err
+	}
+	return &BootnodeRegistryFilterer{contract: contract}, nil
+}
+
+// bindBootnodeRegistry binds a generic wrapper to an already deployed contract.
+func bindBootnodeRegistry(address common.Address, caller bind.ContractCaller, transactor bind.ContractTransactor, filterer bind.ContractFilterer) (*bind.BoundContract, error) {
+	parsed, err := BootnodeRegistryMetaData.GetAbi()
+	if err != nil {
+		return nil, err
+	}
+	return bind.NewBoundContract(address, *parsed, caller, transactor, filterer), nil
+}
+
+// Call invokes the (constant) contract method with params as input values and
+// sets the output to result. The result type might be a single field for simple
+// returns, a slice of interfaces for anonymous returns and a struct for named
+// returns.
+func (_BootnodeRegistry *BootnodeRegistryRaw) Call(opts *bind.CallOpts, result *[]interface{}, method string, params ...interface{}) error {
+	return _BootnodeRegistry.Contract.BootnodeRegistryCaller.contract.Call(opts, result, method, params...)
+}
+
+// Transfer initiates a plain transaction to move funds to the contract, calling
+// its default method if one is available.
+func (_BootnodeRegistry *BootnodeRegistryRaw) Transfer(opts *bind.TransactOpts) (*types.Transaction, error) {
+	return _BootnodeRegistry.Contract.BootnodeRegistryTransactor.contract.Transfer(opts)
+}
+
+// Transact invokes the (paid) contract method with params as input values.
+func (_BootnodeRegistry *BootnodeRegistryRaw) Transact(opts *bind.TransactOpts, method string, params ...interface{}) (*types.Transaction, error) {
+	return _BootnodeRegistry.Contract.BootnodeRegistryTransactor.contract.Transact(opts, method, params...)
+}
+
+// Call invokes the (constant) contract method with params as input values and
+// sets the output to result. The result type might be a single field for simple
+// returns, a slice of interfaces for anonymous returns and a struct for named
+// returns.
+func (_BootnodeRegistry *BootnodeRegistryCallerRaw) Call(opts *bind.CallOpts, result *[]interface{}, method string, params ...interface{}) error {
+	return _BootnodeRegistry.Contract.contract.Call(opts, result, method, params...)
+}
+
+// Transfer initiates a plain transaction to move funds to the contract, calling
+// its default method if one is available.
+func (_BootnodeRegistry *BootnodeRegistryTransactorRaw) Transfer(opts *bind.TransactOpts) (*types.Transaction, error) {
+	return _BootnodeRegistry.Contract.contract.Transfer(opts)
+}
+
+// Transact invokes the (paid) contract method with params as input values.
+func (_BootnodeRegistry *BootnodeRegistryTransactorRaw) Transact(opts *bind.TransactOpts, method string, params ...interface{}) (*types.Transaction, error) {
+	return _BootnodeRegistry.Contract.contract.Transact(opts, method, params...)
+}
+
+// GetIPAddresses is a free data retrieval call binding the contract method 0xd42c014a.
+//
+// Solidity: function getIPAddresses() view returns(string[])
+func (_BootnodeRegistry *BootnodeRegistryCaller) GetIPAddresses(opts *bind.CallOpts) ([]string, error) {
+	var out []interface{}
+	err := _BootnodeRegistry.contract.Call(opts, &out, "getIPAddresses")
+
+	if err != nil {
+		return *new([]string), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new([]string)).(*[]string)
+
+	return out0, err
+
+}
+
+// GetIPAddresses is a free data retrieval call binding the contract method 0xd42c014a.
+//
+// Solidity: function getIPAddresses() view returns(string[])
+func (_BootnodeRegistry *BootnodeRegistrySession) GetIPAddresses() ([]string, error) {
+	return _BootnodeRegistry.Contract.GetIPAddresses(&_BootnodeRegistry.CallOpts)
+}
+
+// GetIPAddresses is a free data retrieval call binding the contract method 0xd42c014a.
+//
+// Solidity: function getIPAddresses() view returns(string[])
+func (_BootnodeRegistry *BootnodeRegistryCallerSession) GetIPAddresses() ([]string, error) {
+	return _BootnodeRegistry.Contract.GetIPAddresses(&_BootnodeRegistry.CallOpts)
+}
+
+// IsAuthorizedUpdater is a free data retrieval call binding the contract method 0xb865bccc.
+//
+// Solidity: function isAuthorizedUpdater(address _updater) view returns(bool)
+func (_BootnodeRegistry *BootnodeRegistryCaller) IsAuthorizedUpdater(opts *bind.CallOpts, _updater common.Address) (bool, error) {
+	var out []interface{}
+	err := _BootnodeRegistry.contract.Call(opts, &out, "isAuthorizedUpdater", _updater)
+
+	if err != nil {
+		return *new(bool), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(bool)).(*bool)
+
+	return out0, err
+
+}
+
+// IsAuthorizedUpdater is a free data retrieval call binding the contract method 0xb865bccc.
+//
+// Solidity: function isAuthorizedUpdater(address _updater) view returns(bool)
+func (_BootnodeRegistry *BootnodeRegistrySession) IsAuthorizedUpdater(_updater common.Address) (bool, error) {
+	return _BootnodeRegistry.Contract.IsAuthorizedUpdater(&_BootnodeRegistry.CallOpts, _updater)
+}
+
+// IsAuthorizedUpdater is a free data retrieval call binding the contract method 0xb865bccc.
+//
+// Solidity: function isAuthorizedUpdater(address _updater) view returns(bool)
+func (_BootnodeRegistry *BootnodeRegistryCallerSession) IsAuthorizedUpdater(_updater common.Address) (bool, error) {
+	return _BootnodeRegistry.Contract.IsAuthorizedUpdater(&_BootnodeRegistry.CallOpts, _updater)
+}
+
+// Owner is a free data retrieval call binding the contract method 0x8da5cb5b.
+//
+// Solidity: function owner() view returns(address)
+func (_BootnodeRegistry *BootnodeRegistryCaller) Owner(opts *bind.CallOpts) (common.Address, error) {
+	var out []interface{}
+	err := _BootnodeRegistry.contract.Call(opts, &out, "owner")
+
+	if err != nil {
+		return *new(common.Address), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(common.Address)).(*common.Address)
+
+	return out0, err
+
+}
+
+// Owner is a free data retrieval call binding the contract method 0x8da5cb5b.
+//
+// Solidity: function owner() view returns(address)
+func (_BootnodeRegistry *BootnodeRegistrySession) Owner() (common.Address, error) {
+	return _BootnodeRegistry.Contract.Owner(&_BootnodeRegistry.CallOpts)
+}
+
+// Owner is a free data retrieval call binding the contract method 0x8da5cb5b.
+//
+// Solidity: function owner() view returns(address)
+func (_BootnodeRegistry *BootnodeRegistryCallerSession) Owner() (common.Address, error) {
+	return _BootnodeRegistry.Contract.Owner(&_BootnodeRegistry.CallOpts)
+}
+
+// AddAuthorizedUpdater is a paid mutator transaction binding the contract method 0x8c9b9fdc.
+//
+// Solidity: function addAuthorizedUpdater(address _updater) returns()
+func (_BootnodeRegistry *BootnodeRegistryTransactor) AddAuthorizedUpdater(opts *bind.TransactOpts, _updater common.Address) (*types.Transaction, error) {
+	return _BootnodeRegistry.contract.Transact(opts, "addAuthorizedUpdater", _updater)
+}
+
+// AddAuthorizedUpdater is a paid mutator transaction binding the contract method 0x8c9b9fdc.
+//
+// Solidity: function addAuthorizedUpdater(address _updater) returns()
+func (_BootnodeRegistry *BootnodeRegistrySession) AddAuthorizedUpdater(_updater common.Address) (*types.Transaction, error) {
+	return _BootnodeRegistry.Contract.AddAuthorizedUpdater(&_BootnodeRegistry.TransactOpts, _updater)
+}
+
+// AddAuthorizedUpdater is a paid mutator transaction binding the contract method 0x8c9b9fdc.
+//
+// Solidity: function addAuthorizedUpdater(address _updater) returns()
+func (_BootnodeRegistry *BootnodeRegistryTransactorSession) AddAuthorizedUpdater(_updater common.Address) (*types.Transaction, error) {
+	return _BootnodeRegistry.Contract.AddAuthorizedUpdater(&_BootnodeRegistry.TransactOpts, _updater)
+}
+
+// AddIPAddress is a paid mutator transaction binding the contract method 0x90139fa0.
+//
+// Solidity: function addIPAddress(string _ipAddress) returns()
+func (_BootnodeRegistry *BootnodeRegistryTransactor) AddIPAddress(opts *bind.TransactOpts, _ipAddress string) (*types.Transaction, error) {
+	return _BootnodeRegistry.contract.Transact(opts, "addIPAddress", _ipAddress)
+}
+
+// AddIPAddress is a paid mutator transaction binding the contract method 0x90139fa0.
+//
+// Solidity: function addIPAddress(string _ipAddress) returns()
+func (_BootnodeRegistry *BootnodeRegistrySession) AddIPAddress(_ipAddress string) (*types.Transaction, error) {
+	return _BootnodeRegistry.Contract.AddIPAddress(&_BootnodeRegistry.TransactOpts, _ipAddress)
+}
+
+// AddIPAddress is a paid mutator transaction binding the contract method 0x90139fa0.
+//
+// Solidity: function addIPAddress(string _ipAddress) returns()
+func (_BootnodeRegistry *BootnodeRegistryTransactorSession) AddIPAddress(_ipAddress string) (*types.Transaction, error) {
+	return _BootnodeRegistry.Contract.AddIPAddress(&_BootnodeRegistry.TransactOpts, _ipAddress)
+}
+
+// RemoveAuthorizedUpdater is a paid mutator transaction binding the contract method 0x603cda09.
+//
+// Solidity: function removeAuthorizedUpdater(address _updater) returns()
+func (_BootnodeRegistry *BootnodeRegistryTransactor) RemoveAuthorizedUpdater(opts *bind.TransactOpts, _updater common.Address) (*types.Transaction, error) {
+	return _BootnodeRegistry.contract.Transact(opts, "removeAuthorizedUpdater", _updater)
+}
+
+// RemoveAuthorizedUpdater is a paid mutator transaction binding the contract method 0x603cda09.
+//
+// Solidity: function removeAuthorizedUpdater(address _updater) returns()
+func (_BootnodeRegistry *BootnodeRegistrySession) RemoveAuthorizedUpdater(_updater common.Address) (*types.Transaction, error) {
+	return _BootnodeRegistry.Contract.RemoveAuthorizedUpdater(&_BootnodeRegistry.TransactOpts, _updater)
+}
+
+// RemoveAuthorizedUpdater is a paid mutator transaction binding the contract method 0x603cda09.
+//
+// Solidity: function removeAuthorizedUpdater(address _updater) returns()
+func (_BootnodeRegistry *BootnodeRegistryTransactorSession) RemoveAuthorizedUpdater(_updater common.Address) (*types.Transaction, error) {
+	return _BootnodeRegistry.Contract.RemoveAuthorizedUpdater(&_BootnodeRegistry.TransactOpts, _updater)
+}
+
+// RemoveIPAddress is a paid mutator transaction binding the contract method 0xba14bc71.
+//
+// Solidity: function removeIPAddress(uint256 index) returns()
+func (_BootnodeRegistry *BootnodeRegistryTransactor) RemoveIPAddress(opts *bind.TransactOpts, index *big.Int) (*types.Transaction, error) {
+	return _BootnodeRegistry.contract.Transact(opts, "removeIPAddress", index)
+}
+
+// RemoveIPAddress is a paid mutator transaction binding the contract method 0xba14bc71.
+//
+// Solidity: function removeIPAddress(uint256 index) returns()
+func (_BootnodeRegistry *BootnodeRegistrySession) RemoveIPAddress(index *big.Int) (*types.Transaction, error) {
+	return _BootnodeRegistry.Contract.RemoveIPAddress(&_BootnodeRegistry.TransactOpts, index)
+}
+
+// RemoveIPAddress is a paid mutator transaction binding the contract method 0xba14bc71.
+//
+// Solidity: function removeIPAddress(uint256 index) returns()
+func (_BootnodeRegistry *BootnodeRegistryTransactorSession) RemoveIPAddress(index *big.Int) (*types.Transaction, error) {
+	return _BootnodeRegistry.Contract.RemoveIPAddress(&_BootnodeRegistry.TransactOpts, index)
+}
+
+// RenounceOwnership is a paid mutator transaction binding the contract method 0x715018a6.
+//
+// Solidity: function renounceOwnership() returns()
+func (_BootnodeRegistry *BootnodeRegistryTransactor) RenounceOwnership(opts *bind.TransactOpts) (*types.Transaction, error) {
+	return _BootnodeRegistry.contract.Transact(opts, "renounceOwnership")
+}
+
+// RenounceOwnership is a paid mutator transaction binding the contract method 0x715018a6.
+//
+// Solidity: function renounceOwnership() returns()
+func (_BootnodeRegistry *BootnodeRegistrySession) RenounceOwnership() (*types.Transaction, error) {
+	return _BootnodeRegistry.Contract.RenounceOwnership(&_BootnodeRegistry.TransactOpts)
+}
+
+// RenounceOwnership is a paid mutator transaction binding the contract method 0x715018a6.
+//
+// Solidity: function renounceOwnership() returns()
+func (_BootnodeRegistry *BootnodeRegistryTransactorSession) RenounceOwnership() (*types.Transaction, error) {
+	return _BootnodeRegistry.Contract.RenounceOwnership(&_BootnodeRegistry.TransactOpts)
+}
+
+// TransferOwnership is a paid mutator transaction binding the contract method 0xf2fde38b.
+//
+// Solidity: function transferOwnership(address newOwner) returns()
+func (_BootnodeRegistry *BootnodeRegistryTransactor) TransferOwnership(opts *bind.TransactOpts, newOwner common.Address) (*types.Transaction, error) {
+	return _BootnodeRegistry.contract.Transact(opts, "transferOwnership", newOwner)
+}
+
+// TransferOwnership is a paid mutator transaction binding the contract method 0xf2fde38b.
+//
+// Solidity: function transferOwnership(address newOwner) returns()
+func (_BootnodeRegistry *BootnodeRegistrySession) TransferOwnership(newOwner common.Address) (*types.Transaction, error) {
+	return _BootnodeRegistry.Contract.TransferOwnership(&_BootnodeRegistry.TransactOpts, newOwner)
+}
+
+// TransferOwnership is a paid mutator transaction binding the contract method 0xf2fde38b.
+//
+// Solidity: function transferOwnership(address newOwner) returns()
+func (_BootnodeRegistry *BootnodeRegistryTransactorSession) TransferOwnership(newOwner common.Address) (*types.Transaction, error) {
+	return _BootnodeRegistry.Contract.TransferOwnership(&_BootnodeRegistry.TransactOpts, newOwner)
+}
+
+// BootnodeRegistryIPAddedIterator is returned from FilterIPAdded and is used to iterate over the raw logs and unpacked data for IPAdded events raised by the BootnodeRegistry contract.
+type BootnodeRegistryIPAddedIterator struct {
+	Event *BootnodeRegistryIPAdded // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *BootnodeRegistryIPAddedIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(BootnodeRegistryIPAdded)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(BootnodeRegistryIPAdded)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *BootnodeRegistryIPAddedIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *BootnodeRegistryIPAddedIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// BootnodeRegistryIPAdded represents a IPAdded event raised by the BootnodeRegistry contract.
+type BootnodeRegistryIPAdded struct {
+	IpAddress string
+	Raw       types.Log // Blockchain specific contextual infos
+}
+
+// FilterIPAdded is a free log retrieval operation binding the contract event 0xe7f7a48f1891a089b5b0418c215a3fdc894029f208c5b5930473161f39ae988b.
+//
+// Solidity: event IPAdded(string ipAddress)
+func (_BootnodeRegistry *BootnodeRegistryFilterer) FilterIPAdded(opts *bind.FilterOpts) (*BootnodeRegistryIPAddedIterator, error) {
+
+	logs, sub, err := _BootnodeRegistry.contract.FilterLogs(opts, "IPAdded")
+	if err != nil {
+		return nil, err
+	}
+	return &BootnodeRegistryIPAddedIterator{contract: _BootnodeRegistry.contract, event: "IPAdded", logs: logs, sub: sub}, nil
+}
+
+// WatchIPAdded is a free log subscription operation binding the contract event 0xe7f7a48f1891a089b5b0418c215a3fdc894029f208c5b5930473161f39ae988b.
+//
+// Solidity: event IPAdded(string ipAddress)
+func (_BootnodeRegistry *BootnodeRegistryFilterer) WatchIPAdded(opts *bind.WatchOpts, sink chan<- *BootnodeRegistryIPAdded) (event.Subscription, error) {
+
+	logs, sub, err := _BootnodeRegistry.contract.WatchLogs(opts, "IPAdded")
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(BootnodeRegistryIPAdded)
+				if err := _BootnodeRegistry.contract.UnpackLog(event, "IPAdded", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseIPAdded is a log parse operation binding the contract event 0xe7f7a48f1891a089b5b0418c215a3fdc894029f208c5b5930473161f39ae988b.
+//
+// Solidity: event IPAdded(string ipAddress)
+func (_BootnodeRegistry *BootnodeRegistryFilterer) ParseIPAdded(log types.Log) (*BootnodeRegistryIPAdded, error) {
+	event := new(BootnodeRegistryIPAdded)
+	if err := _BootnodeRegistry.contract.UnpackLog(event, "IPAdded", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// BootnodeRegistryIPRemovedIterator is returned from FilterIPRemoved and is used to iterate over the raw logs and unpacked data for IPRemoved events raised by the BootnodeRegistry contract.
+type BootnodeRegistryIPRemovedIterator struct {
+	Event *BootnodeRegistryIPRemoved // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *BootnodeRegistryIPRemovedIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(BootnodeRegistryIPRemoved)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(BootnodeRegistryIPRemoved)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *BootnodeRegistryIPRemovedIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *BootnodeRegistryIPRemovedIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// BootnodeRegistryIPRemoved represents a IPRemoved event raised by the BootnodeRegistry contract.
+type BootnodeRegistryIPRemoved struct {
+	IpAddress string
+	Raw       types.Log // Blockchain specific contextual infos
+}
+
+// FilterIPRemoved is a free log retrieval operation binding the contract event 0x45fe66c64cad3093171b605f5ffe092b5333c407560ee34f49a9096c6b312c4f.
+//
+// Solidity: event IPRemoved(string ipAddress)
+func (_BootnodeRegistry *BootnodeRegistryFilterer) FilterIPRemoved(opts *bind.FilterOpts) (*BootnodeRegistryIPRemovedIterator, error) {
+
+	logs, sub, err := _BootnodeRegistry.contract.FilterLogs(opts, "IPRemoved")
+	if err != nil {
+		return nil, err
+	}
+	return &BootnodeRegistryIPRemovedIterator{contract: _BootnodeRegistry.contract, event: "IPRemoved", logs: logs, sub: sub}, nil
+}
+
+// WatchIPRemoved is a free log subscription operation binding the contract event 0x45fe66c64cad3093171b605f5ffe092b5333c407560ee34f49a9096c6b312c4f.
+//
+// Solidity: event IPRemoved(string ipAddress)
+func (_BootnodeRegistry *BootnodeRegistryFilterer) WatchIPRemoved(opts *bind.WatchOpts, sink chan<- *BootnodeRegistryIPRemoved) (event.Subscription, error) {
+
+	logs, sub, err := _BootnodeRegistry.contract.WatchLogs(opts, "IPRemoved")
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(BootnodeRegistryIPRemoved)
+				if err := _BootnodeRegistry.contract.UnpackLog(event, "IPRemoved", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseIPRemoved is a log parse operation binding the contract event 0x45fe66c64cad3093171b605f5ffe092b5333c407560ee34f49a9096c6b312c4f.
+//
+// Solidity: event IPRemoved(string ipAddress)
+func (_BootnodeRegistry *BootnodeRegistryFilterer) ParseIPRemoved(log types.Log) (*BootnodeRegistryIPRemoved, error) {
+	event := new(BootnodeRegistryIPRemoved)
+	if err := _BootnodeRegistry.contract.UnpackLog(event, "IPRemoved", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// BootnodeRegistryOwnershipTransferredIterator is returned from FilterOwnershipTransferred and is used to iterate over the raw logs and unpacked data for OwnershipTransferred events raised by the BootnodeRegistry contract.
+type BootnodeRegistryOwnershipTransferredIterator struct {
+	Event *BootnodeRegistryOwnershipTransferred // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *BootnodeRegistryOwnershipTransferredIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(BootnodeRegistryOwnershipTransferred)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(BootnodeRegistryOwnershipTransferred)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *BootnodeRegistryOwnershipTransferredIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *BootnodeRegistryOwnershipTransferredIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// BootnodeRegistryOwnershipTransferred represents a OwnershipTransferred event raised by the BootnodeRegistry contract.
+type BootnodeRegistryOwnershipTransferred struct {
+	PreviousOwner common.Address
+	NewOwner      common.Address
+	Raw           types.Log // Blockchain specific contextual infos
+}
+
+// FilterOwnershipTransferred is a free log retrieval operation binding the contract event 0x8be0079c531659141344cd1fd0a4f28419497f9722a3daafe3b4186f6b6457e0.
+//
+// Solidity: event OwnershipTransferred(address indexed previousOwner, address indexed newOwner)
+func (_BootnodeRegistry *BootnodeRegistryFilterer) FilterOwnershipTransferred(opts *bind.FilterOpts, previousOwner []common.Address, newOwner []common.Address) (*BootnodeRegistryOwnershipTransferredIterator, error) {
+
+	var previousOwnerRule []interface{}
+	for _, previousOwnerItem := range previousOwner {
+		previousOwnerRule = append(previousOwnerRule, previousOwnerItem)
+	}
+	var newOwnerRule []interface{}
+	for _, newOwnerItem := range newOwner {
+		newOwnerRule = append(newOwnerRule, newOwnerItem)
+	}
+
+	logs, sub, err := _BootnodeRegistry.contract.FilterLogs(opts, "OwnershipTransferred", previousOwnerRule, newOwnerRule)
+	if err != nil {
+		return nil, err
+	}
+	return &BootnodeRegistryOwnershipTransferredIterator{contract: _BootnodeRegistry.contract, event: "OwnershipTransferred", logs: logs, sub: sub}, nil
+}
+
+// WatchOwnershipTransferred is a free log subscription operation binding the contract event 0x8be0079c531659141344cd1fd0a4f28419497f9722a3daafe3b4186f6b6457e0.
+//
+// Solidity: event OwnershipTransferred(address indexed previousOwner, address indexed newOwner)
+func (_BootnodeRegistry *BootnodeRegistryFilterer) WatchOwnershipTransferred(opts *bind.WatchOpts, sink chan<- *BootnodeRegistryOwnershipTransferred, previousOwner []common.Address, newOwner []common.Address) (event.Subscription, error) {
+
+	var previousOwnerRule []interface{}
+	for _, previousOwnerItem := range previousOwner {
+		previousOwnerRule = append(previousOwnerRule, previousOwnerItem)
+	}
+	var newOwnerRule []interface{}
+	for _, newOwnerItem := range newOwner {
+		newOwnerRule = append(newOwnerRule, newOwnerItem)
+	}
+
+	logs, sub, err := _BootnodeRegistry.contract.WatchLogs(opts, "OwnershipTransferred", previousOwnerRule, newOwnerRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(BootnodeRegistryOwnershipTransferred)
+				if err := _BootnodeRegistry.contract.UnpackLog(event, "OwnershipTransferred", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseOwnershipTransferred is a log parse operation binding the contract event 0x8be0079c531659141344cd1fd0a4f28419497f9722a3daafe3b4186f6b6457e0.
+//
+// Solidity: event OwnershipTransferred(address indexed previousOwner, address indexed newOwner)
+func (_BootnodeRegistry *BootnodeRegistryFilterer) ParseOwnershipTransferred(log types.Log) (*BootnodeRegistryOwnershipTransferred, error) {
+	event := new(BootnodeRegistryOwnershipTransferred)
+	if err := _BootnodeRegistry.contract.UnpackLog(event, "OwnershipTransferred", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// BootnodeRegistryUpdaterAddedIterator is returned from FilterUpdaterAdded and is used to iterate over the raw logs and unpacked data for UpdaterAdded events raised by the BootnodeRegistry contract.
+type BootnodeRegistryUpdaterAddedIterator struct {
+	Event *BootnodeRegistryUpdaterAdded // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *BootnodeRegistryUpdaterAddedIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(BootnodeRegistryUpdaterAdded)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(BootnodeRegistryUpdaterAdded)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *BootnodeRegistryUpdaterAddedIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *BootnodeRegistryUpdaterAddedIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// BootnodeRegistryUpdaterAdded represents a UpdaterAdded event raised by the BootnodeRegistry contract.
+type BootnodeRegistryUpdaterAdded struct {
+	Updater common.Address
+	Raw     types.Log // Blockchain specific contextual infos
+}
+
+// FilterUpdaterAdded is a free log retrieval operation binding the contract event 0x23a38f89c31ff6329bf86f3863cfa2ad8fc1462c40dbf907dbbebb8f9cb237ec.
+//
+// Solidity: event UpdaterAdded(address updater)
+func (_BootnodeRegistry *BootnodeRegistryFilterer) FilterUpdaterAdded(opts *bind.FilterOpts) (*BootnodeRegistryUpdaterAddedIterator, error) {
+
+	logs, sub, err := _BootnodeRegistry.contract.FilterLogs(opts, "UpdaterAdded")
+	if err != nil {
+		return nil, err
+	}
+	return &BootnodeRegistryUpdaterAddedIterator{contract: _BootnodeRegistry.contract, event: "UpdaterAdded", logs: logs, sub: sub}, nil
+}
+
+// WatchUpdaterAdded is a free log subscription operation binding the contract event 0x23a38f89c31ff6329bf86f3863cfa2ad8fc1462c40dbf907dbbebb8f9cb237ec.
+//
+// Solidity: event UpdaterAdded(address updater)
+func (_BootnodeRegistry *BootnodeRegistryFilterer) WatchUpdaterAdded(opts *bind.WatchOpts, sink chan<- *BootnodeRegistryUpdaterAdded) (event.Subscription, error) {
+
+	logs, sub, err := _BootnodeRegistry.contract.WatchLogs(opts, "UpdaterAdded")
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(BootnodeRegistryUpdaterAdded)
+				if err := _BootnodeRegistry.contract.UnpackLog(event, "UpdaterAdded", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseUpdaterAdded is a log parse operation binding the contract event 0x23a38f89c31ff6329bf86f3863cfa2ad8fc1462c40dbf907dbbebb8f9cb237ec.
+//
+// Solidity: event UpdaterAdded(address updater)
+func (_BootnodeRegistry *BootnodeRegistryFilterer) ParseUpdaterAdded(log types.Log) (*BootnodeRegistryUpdaterAdded, error) {
+	event := new(BootnodeRegistryUpdaterAdded)
+	if err := _BootnodeRegistry.contract.UnpackLog(event, "UpdaterAdded", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// BootnodeRegistryUpdaterRemovedIterator is returned from FilterUpdaterRemoved and is used to iterate over the raw logs and unpacked data for UpdaterRemoved events raised by the BootnodeRegistry contract.
+type BootnodeRegistryUpdaterRemovedIterator struct {
+	Event *BootnodeRegistryUpdaterRemoved // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *BootnodeRegistryUpdaterRemovedIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(BootnodeRegistryUpdaterRemoved)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(BootnodeRegistryUpdaterRemoved)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *BootnodeRegistryUpdaterRemovedIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *BootnodeRegistryUpdaterRemovedIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// BootnodeRegistryUpdaterRemoved represents a UpdaterRemoved event raised by the BootnodeRegistry contract.
+type BootnodeRegistryUpdaterRemoved struct {
+	Updater common.Address
+	Raw     types.Log // Blockchain specific contextual infos
+}
+
+// FilterUpdaterRemoved is a free log retrieval operation binding the contract event 0x209d819a9ec655e89f2b2b9d65c8a78879b45a8f20d1941d69c5fe6dc21bcb62.
+//
+// Solidity: event UpdaterRemoved(address updater)
+func (_BootnodeRegistry *BootnodeRegistryFilterer) FilterUpdaterRemoved(opts *bind.FilterOpts) (*BootnodeRegistryUpdaterRemovedIterator, error) {
+
+	logs, sub, err := _BootnodeRegistry.contract.FilterLogs(opts, "UpdaterRemoved")
+	if err != nil {
+		return nil, err
+	}
+	return &BootnodeRegistryUpdaterRemovedIterator{contract: _BootnodeRegistry.contract, event: "UpdaterRemoved", logs: logs, sub: sub}, nil
+}
+
+// WatchUpdaterRemoved is a free log subscription operation binding the contract event 0x209d819a9ec655e89f2b2b9d65c8a78879b45a8f20d1941d69c5fe6dc21bcb62.
+//
+// Solidity: event UpdaterRemoved(address updater)
+func (_BootnodeRegistry *BootnodeRegistryFilterer) WatchUpdaterRemoved(opts *bind.WatchOpts, sink chan<- *BootnodeRegistryUpdaterRemoved) (event.Subscription, error) {
+
+	logs, sub, err := _BootnodeRegistry.contract.WatchLogs(opts, "UpdaterRemoved")
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(BootnodeRegistryUpdaterRemoved)
+				if err := _BootnodeRegistry.contract.UnpackLog(event, "UpdaterRemoved", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseUpdaterRemoved is a log parse operation binding the contract event 0x209d819a9ec655e89f2b2b9d65c8a78879b45a8f20d1941d69c5fe6dc21bcb62.
+//
+// Solidity: event UpdaterRemoved(address updater)
+func (_BootnodeRegistry *BootnodeRegistryFilterer) ParseUpdaterRemoved(log types.Log) (*BootnodeRegistryUpdaterRemoved, error) {
+	event := new(BootnodeRegistryUpdaterRemoved)
+	if err := _BootnodeRegistry.contract.UnpackLog(event, "UpdaterRemoved", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}

--- a/l1/eth_subscriber.go
+++ b/l1/eth_subscriber.go
@@ -50,6 +50,18 @@ func (s *EthSubscriber) WatchLogStateUpdate(ctx context.Context, sink chan<- *co
 	return s.filterer.WatchLogStateUpdate(&bind.WatchOpts{Context: ctx}, sink)
 }
 
+func (s *EthSubscriber) WatchIPAdded(ctx context.Context, sink chan<- *contract.BootnodeRegistryIPAdded) (event.Subscription, error) {
+	return s.bootnodeRegistryFilterer.WatchIPAdded(&bind.WatchOpts{Context: ctx}, sink)
+}
+
+func (s *EthSubscriber) WatchIPRemoved(ctx context.Context, sink chan<- *contract.BootnodeRegistryIPRemoved) (event.Subscription, error) {
+	return s.bootnodeRegistryFilterer.WatchIPRemoved(&bind.WatchOpts{Context: ctx}, sink)
+}
+
+func (s *EthSubscriber) GetIPAddresses(ctx context.Context, ip common.Address) ([]string, error) {
+	return s.bootnodeRegistry.GetIPAddresses(&bind.CallOpts{Context: ctx})
+}
+
 func (s *EthSubscriber) ChainID(ctx context.Context) (*big.Int, error) {
 	reqTimer := time.Now()
 	chainID, err := s.ethClient.ChainID(ctx)

--- a/l1/l1.go
+++ b/l1/l1.go
@@ -10,17 +10,22 @@ import (
 	"github.com/NethermindEth/juno/core"
 	"github.com/NethermindEth/juno/core/felt"
 	"github.com/NethermindEth/juno/l1/contract"
+	"github.com/NethermindEth/juno/p2p"
 	"github.com/NethermindEth/juno/service"
 	"github.com/NethermindEth/juno/utils"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/event"
+	"golang.org/x/sync/errgroup"
 )
 
 //go:generate mockgen -destination=../mocks/mock_subscriber.go -package=mocks github.com/NethermindEth/juno/l1 Subscriber
 type Subscriber interface {
 	FinalisedHeight(ctx context.Context) (uint64, error)
 	WatchLogStateUpdate(ctx context.Context, sink chan<- *contract.StarknetLogStateUpdate) (event.Subscription, error)
+	WatchIPAdded(ctx context.Context, sink chan<- *contract.BootnodeRegistryIPAdded) (event.Subscription, error)
+	WatchIPRemoved(ctx context.Context, sink chan<- *contract.BootnodeRegistryIPRemoved) (event.Subscription, error)
+	GetIPAddresses(ctx context.Context, ip common.Address) ([]string, error)
 	ChainID(ctx context.Context) (*big.Int, error)
 	TransactionReceipt(ctx context.Context, txHash common.Hash) (*types.Receipt, error)
 

--- a/l1/l1_pkg_test.go
+++ b/l1/l1_pkg_test.go
@@ -514,7 +514,7 @@ func TestMakeSubscribtionsToBootnodes(t *testing.T) {
 		}).
 		Times(1)
 
-	require.NoError(t, client.makeSubscribtionsToBootnodes(ctx, 1))
+	require.ErrorIs(t, client.makeSubscriptionsToBootnodes(ctx, 1), context.DeadlineExceeded)
 
 	expectedAddressesToAdd := make(map[string]struct{}, len(addressesToAdd)+len(storedAddresses))
 	for _, addr := range addressesToAdd {
@@ -662,7 +662,7 @@ func TestUnreliableSubscriptionToBootnodes(t *testing.T) {
 
 			ctx, cancel := context.WithTimeout(context.Background(), tc.timeOut)
 			defer cancel()
-			err := client.makeSubscribtionsToBootnodes(ctx, 1)
+			err := client.makeSubscriptionsToBootnodes(ctx, 1)
 			require.ErrorIs(t, err, tc.expectedErr)
 		})
 	}

--- a/l1/l1_pkg_test.go
+++ b/l1/l1_pkg_test.go
@@ -13,7 +13,9 @@ import (
 	"github.com/NethermindEth/juno/db/pebble"
 	"github.com/NethermindEth/juno/l1/contract"
 	"github.com/NethermindEth/juno/mocks"
+	"github.com/NethermindEth/juno/p2p"
 	"github.com/NethermindEth/juno/utils"
+	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -338,7 +340,7 @@ func TestClient(t *testing.T) {
 			network := utils.Mainnet
 			chain := blockchain.New(pebble.NewMemTest(t), &network, nil)
 
-			client := NewClient(nil, chain, nopLog).WithResubscribeDelay(0).WithPollFinalisedInterval(time.Nanosecond)
+			client := NewClient(nil, chain, nopLog, nil).WithResubscribeDelay(0).WithPollFinalisedInterval(time.Nanosecond)
 
 			// We loop over each block and check that the state agrees with our expectations.
 			for _, block := range tt.blocks {
@@ -398,7 +400,7 @@ func TestUnreliableSubscription(t *testing.T) {
 	nopLog := utils.NewNopZapLogger()
 	network := utils.Mainnet
 	chain := blockchain.New(pebble.NewMemTest(t), &network, nil)
-	client := NewClient(nil, chain, nopLog).WithResubscribeDelay(0).WithPollFinalisedInterval(time.Nanosecond)
+	client := NewClient(nil, chain, nopLog, nil).WithResubscribeDelay(0).WithPollFinalisedInterval(time.Nanosecond)
 
 	err := errors.New("test err")
 	for _, block := range longSequenceOfBlocks {
@@ -464,5 +466,204 @@ func TestUnreliableSubscription(t *testing.T) {
 			}
 			assert.Equal(t, want, got)
 		}
+	}
+}
+
+func TestMakeSubscribtionsToBootnodes(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	nopLog := utils.NewNopZapLogger()
+	network := utils.Mainnet
+	address := common.HexToAddress("0x1234")
+	network.BootnodeRegistry = address
+	eventsChan := make(chan p2p.BootnodeRegistryEvent, 10)
+	chain := blockchain.New(pebble.NewMemTest(t), &network, nil)
+	client := NewClient(nil, chain, nopLog, eventsChan).WithResubscribeDelay(0).WithPollFinalisedInterval(time.Nanosecond)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 500*time.Millisecond)
+	defer cancel()
+
+	storedAddresses := []string{"0x1", "0x2", "0x3"}
+	addressesToAdd := []string{"0x4", "0x5", "0x6"}
+	addressToRemove := []string{"0x2", "0x5"}
+
+	subscriber := mocks.NewMockSubscriber(ctrl)
+	client.l1 = subscriber
+
+	subscriber.EXPECT().GetIPAddresses(gomock.Any(), address).Return(addressesToAdd[:2], nil).Times(1)
+	subscriber.EXPECT().WatchIPAdded(gomock.Any(), gomock.Any()).
+		DoAndReturn(func(_ context.Context, sink chan<- *contract.BootnodeRegistryIPAdded) (*fakeSubscription, error) {
+			go func() {
+				for _, addr := range addressesToAdd {
+					sink <- &contract.BootnodeRegistryIPAdded{IpAddress: addr}
+				}
+			}()
+			return newFakeSubscription(), nil
+		}).
+		Times(1)
+
+	subscriber.EXPECT().WatchIPRemoved(gomock.Any(), gomock.Any()).
+		DoAndReturn(func(_ context.Context, sink chan<- *contract.BootnodeRegistryIPRemoved) (*fakeSubscription, error) {
+			go func() {
+				for _, addr := range addressToRemove {
+					sink <- &contract.BootnodeRegistryIPRemoved{IpAddress: addr}
+				}
+			}()
+			return newFakeSubscription(), nil
+		}).
+		Times(1)
+
+	require.NoError(t, client.makeSubscribtionsToBootnodes(ctx, 1))
+
+	expectedAddressesToAdd := make(map[string]struct{}, len(addressesToAdd)+len(storedAddresses))
+	for _, addr := range addressesToAdd {
+		expectedAddressesToAdd[addr] = struct{}{}
+	}
+	for _, addr := range storedAddresses {
+		expectedAddressesToAdd[addr] = struct{}{}
+	}
+	expectedAddressesToRemove := make(map[string]struct{}, len(addressToRemove))
+	for _, addr := range addressToRemove {
+		expectedAddressesToRemove[addr] = struct{}{}
+	}
+	select {
+	case event := <-eventsChan:
+		switch event.EventType {
+		case p2p.Add:
+			assert.Contains(t, expectedAddressesToAdd, event.Address)
+			delete(expectedAddressesToAdd, event.Address)
+		case p2p.Remove:
+			assert.Contains(t, expectedAddressesToRemove, event.Address)
+			delete(expectedAddressesToRemove, event.Address)
+		}
+	case <-time.After(100 * time.Millisecond):
+		t.Fatal("Expected IP address addition event")
+	}
+}
+
+func TestUnreliableSubscriptionToBootnodes(t *testing.T) {
+	t.Parallel()
+	address := common.HexToAddress("0x1234")
+	network := utils.Mainnet
+	network.BootnodeRegistry = address
+	chain := blockchain.New(pebble.NewMemTest(t), &network, nil)
+	nopLog := utils.NewNopZapLogger()
+	err := errors.New("test err")
+
+	testCases := []struct {
+		name        string
+		setupMock   func(subscriber *mocks.MockSubscriber)
+		timeOut     time.Duration
+		expectedErr error
+	}{
+		{
+			name: "GetIPAddresses error",
+			setupMock: func(subscriber *mocks.MockSubscriber) {
+				subscriber.EXPECT().GetIPAddresses(gomock.Any(), address).Return(nil, err).Times(1)
+			},
+			timeOut:     50 * time.Millisecond,
+			expectedErr: err,
+		},
+		{
+			name: "WatchIPAdded error",
+			setupMock: func(subscriber *mocks.MockSubscriber) {
+				subscriber.EXPECT().GetIPAddresses(gomock.Any(), address).Return(nil, nil).Times(1)
+				subscriber.EXPECT().WatchIPAdded(gomock.Any(), gomock.Any()).Return(nil, err).Times(1)
+				subscriber.EXPECT().WatchIPRemoved(gomock.Any(), gomock.Any()).Return(newFakeSubscription(), nil).Times(1)
+				subscriber.EXPECT().WatchIPAdded(gomock.Any(), gomock.Any()).Return(newFakeSubscription(), nil).Times(1)
+			},
+			timeOut:     time.Millisecond,
+			expectedErr: context.DeadlineExceeded,
+		},
+		{
+			name: "WatchIPRemoved error",
+			setupMock: func(subscriber *mocks.MockSubscriber) {
+				subscriber.EXPECT().GetIPAddresses(gomock.Any(), address).Return(nil, nil).Times(1)
+				subscriber.EXPECT().WatchIPAdded(gomock.Any(), gomock.Any()).Return(newFakeSubscription(), nil).Times(1)
+				subscriber.EXPECT().WatchIPRemoved(gomock.Any(), gomock.Any()).Return(nil, err).Times(1)
+				subscriber.EXPECT().WatchIPRemoved(gomock.Any(), gomock.Any()).Return(newFakeSubscription(), nil).Times(1)
+			},
+			timeOut:     50 * time.Millisecond,
+			expectedErr: context.DeadlineExceeded,
+		},
+		{
+			name: "Addition subscription error",
+			setupMock: func(subscriber *mocks.MockSubscriber) {
+				subscriber.EXPECT().GetIPAddresses(gomock.Any(), address).Return(nil, nil).Times(1)
+				subscriber.EXPECT().WatchIPAdded(gomock.Any(), gomock.Any()).Return(newFakeSubscription(err), nil).Times(1)
+				subscriber.EXPECT().WatchIPRemoved(gomock.Any(), gomock.Any()).Return(newFakeSubscription(), nil).Times(1)
+				subscriber.EXPECT().WatchIPAdded(gomock.Any(), gomock.Any()).Return(newFakeSubscription(), nil).Times(1)
+			},
+			timeOut:     50 * time.Millisecond,
+			expectedErr: context.DeadlineExceeded,
+		},
+		{
+			name: "Removal subscription error",
+			setupMock: func(subscriber *mocks.MockSubscriber) {
+				subscriber.EXPECT().GetIPAddresses(gomock.Any(), address).Return(nil, nil).Times(1)
+				subscriber.EXPECT().WatchIPAdded(gomock.Any(), gomock.Any()).Return(newFakeSubscription(), nil).Times(1)
+				subscriber.EXPECT().WatchIPRemoved(gomock.Any(), gomock.Any()).Return(newFakeSubscription(err), nil).Times(1)
+				subscriber.EXPECT().WatchIPRemoved(gomock.Any(), gomock.Any()).Return(newFakeSubscription(), nil).Times(1)
+			},
+			timeOut:     50 * time.Millisecond,
+			expectedErr: context.DeadlineExceeded,
+		},
+		{
+			name: "Addition subscription expires",
+			setupMock: func(subscriber *mocks.MockSubscriber) {
+				subscriber.EXPECT().GetIPAddresses(gomock.Any(), address).DoAndReturn(
+					func(_ context.Context, _ common.Address) ([]string, error) {
+						time.Sleep(100 * time.Millisecond)
+						return nil, nil
+					},
+				).Times(1)
+			},
+			expectedErr: context.DeadlineExceeded,
+			timeOut:     50 * time.Millisecond,
+		},
+		{
+			name: "Removal subscription expires",
+			setupMock: func(subscriber *mocks.MockSubscriber) {
+				subscriber.EXPECT().GetIPAddresses(gomock.Any(), address).Return(nil, nil).Times(1)
+				subscriber.EXPECT().WatchIPAdded(gomock.Any(), gomock.Any()).DoAndReturn(
+					func(_ context.Context, sink chan<- *contract.BootnodeRegistryIPAdded) (*fakeSubscription, error) {
+						time.Sleep(100 * time.Millisecond)
+						return newFakeSubscription(), nil
+					},
+				).Times(1)
+			},
+			timeOut:     50 * time.Millisecond,
+			expectedErr: context.DeadlineExceeded,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+
+			eventsChan := make(chan p2p.BootnodeRegistryEvent, 10)
+			client := Client{
+				l1:               nil,
+				l2Chain:          chain,
+				log:              nopLog,
+				network:          chain.Network(),
+				resubscribeDelay: 0,
+				nonFinalisedLogs: make(map[uint64]*contract.StarknetLogStateUpdate, 0),
+				listener:         SelectiveListener{},
+				eventsToP2P:      eventsChan,
+			}
+
+			subscriber := mocks.NewMockSubscriber(ctrl)
+			client.l1 = subscriber
+			tc.setupMock(subscriber)
+
+			ctx, cancel := context.WithTimeout(context.Background(), tc.timeOut)
+			defer cancel()
+			err := client.makeSubscribtionsToBootnodes(ctx, 1)
+			require.ErrorIs(t, err, tc.expectedErr)
+		})
 	}
 }

--- a/l1/l1_test.go
+++ b/l1/l1_test.go
@@ -171,7 +171,7 @@ func TestEventListener(t *testing.T) {
 		})
 
 	ctx, cancel := context.WithTimeout(context.Background(), 500*time.Millisecond)
-	require.NoError(t, client.Run(ctx))
+	require.ErrorIs(t, client.Run(ctx), context.DeadlineExceeded)
 	cancel()
 
 	require.Equal(t, &core.L1Head{

--- a/mocks/mock_event_filterer.go
+++ b/mocks/mock_event_filterer.go
@@ -21,6 +21,7 @@ import (
 type MockEventFilterer struct {
 	ctrl     *gomock.Controller
 	recorder *MockEventFiltererMockRecorder
+	isgomock struct{}
 }
 
 // MockEventFiltererMockRecorder is the mock recorder for MockEventFilterer.
@@ -55,9 +56,9 @@ func (mr *MockEventFiltererMockRecorder) Close() *gomock.Call {
 }
 
 // Events mocks base method.
-func (m *MockEventFilterer) Events(arg0 *blockchain.ContinuationToken, arg1 uint64) ([]*blockchain.FilteredEvent, *blockchain.ContinuationToken, error) {
+func (m *MockEventFilterer) Events(cToken *blockchain.ContinuationToken, chunkSize uint64) ([]*blockchain.FilteredEvent, *blockchain.ContinuationToken, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Events", arg0, arg1)
+	ret := m.ctrl.Call(m, "Events", cToken, chunkSize)
 	ret0, _ := ret[0].([]*blockchain.FilteredEvent)
 	ret1, _ := ret[1].(*blockchain.ContinuationToken)
 	ret2, _ := ret[2].(error)
@@ -65,49 +66,49 @@ func (m *MockEventFilterer) Events(arg0 *blockchain.ContinuationToken, arg1 uint
 }
 
 // Events indicates an expected call of Events.
-func (mr *MockEventFiltererMockRecorder) Events(arg0, arg1 any) *gomock.Call {
+func (mr *MockEventFiltererMockRecorder) Events(cToken, chunkSize any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Events", reflect.TypeOf((*MockEventFilterer)(nil).Events), arg0, arg1)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Events", reflect.TypeOf((*MockEventFilterer)(nil).Events), cToken, chunkSize)
 }
 
 // SetRangeEndBlockByHash mocks base method.
-func (m *MockEventFilterer) SetRangeEndBlockByHash(arg0 blockchain.EventFilterRange, arg1 *felt.Felt) error {
+func (m *MockEventFilterer) SetRangeEndBlockByHash(filterRange blockchain.EventFilterRange, blockHash *felt.Felt) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "SetRangeEndBlockByHash", arg0, arg1)
+	ret := m.ctrl.Call(m, "SetRangeEndBlockByHash", filterRange, blockHash)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // SetRangeEndBlockByHash indicates an expected call of SetRangeEndBlockByHash.
-func (mr *MockEventFiltererMockRecorder) SetRangeEndBlockByHash(arg0, arg1 any) *gomock.Call {
+func (mr *MockEventFiltererMockRecorder) SetRangeEndBlockByHash(filterRange, blockHash any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetRangeEndBlockByHash", reflect.TypeOf((*MockEventFilterer)(nil).SetRangeEndBlockByHash), arg0, arg1)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetRangeEndBlockByHash", reflect.TypeOf((*MockEventFilterer)(nil).SetRangeEndBlockByHash), filterRange, blockHash)
 }
 
 // SetRangeEndBlockByNumber mocks base method.
-func (m *MockEventFilterer) SetRangeEndBlockByNumber(arg0 blockchain.EventFilterRange, arg1 uint64) error {
+func (m *MockEventFilterer) SetRangeEndBlockByNumber(filterRange blockchain.EventFilterRange, blockNumber uint64) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "SetRangeEndBlockByNumber", arg0, arg1)
+	ret := m.ctrl.Call(m, "SetRangeEndBlockByNumber", filterRange, blockNumber)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // SetRangeEndBlockByNumber indicates an expected call of SetRangeEndBlockByNumber.
-func (mr *MockEventFiltererMockRecorder) SetRangeEndBlockByNumber(arg0, arg1 any) *gomock.Call {
+func (mr *MockEventFiltererMockRecorder) SetRangeEndBlockByNumber(filterRange, blockNumber any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetRangeEndBlockByNumber", reflect.TypeOf((*MockEventFilterer)(nil).SetRangeEndBlockByNumber), arg0, arg1)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetRangeEndBlockByNumber", reflect.TypeOf((*MockEventFilterer)(nil).SetRangeEndBlockByNumber), filterRange, blockNumber)
 }
 
 // WithLimit mocks base method.
-func (m *MockEventFilterer) WithLimit(arg0 uint) *blockchain.EventFilter {
+func (m *MockEventFilterer) WithLimit(limit uint) *blockchain.EventFilter {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "WithLimit", arg0)
+	ret := m.ctrl.Call(m, "WithLimit", limit)
 	ret0, _ := ret[0].(*blockchain.EventFilter)
 	return ret0
 }
 
 // WithLimit indicates an expected call of WithLimit.
-func (mr *MockEventFiltererMockRecorder) WithLimit(arg0 any) *gomock.Call {
+func (mr *MockEventFiltererMockRecorder) WithLimit(limit any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WithLimit", reflect.TypeOf((*MockEventFilterer)(nil).WithLimit), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WithLimit", reflect.TypeOf((*MockEventFilterer)(nil).WithLimit), limit)
 }

--- a/mocks/mock_gateway_handler.go
+++ b/mocks/mock_gateway_handler.go
@@ -21,6 +21,7 @@ import (
 type MockGateway struct {
 	ctrl     *gomock.Controller
 	recorder *MockGatewayMockRecorder
+	isgomock struct{}
 }
 
 // MockGatewayMockRecorder is the mock recorder for MockGateway.

--- a/mocks/mock_plugin.go
+++ b/mocks/mock_plugin.go
@@ -22,6 +22,7 @@ import (
 type MockJunoPlugin struct {
 	ctrl     *gomock.Controller
 	recorder *MockJunoPluginMockRecorder
+	isgomock struct{}
 }
 
 // MockJunoPluginMockRecorder is the mock recorder for MockJunoPlugin.
@@ -56,31 +57,31 @@ func (mr *MockJunoPluginMockRecorder) Init() *gomock.Call {
 }
 
 // NewBlock mocks base method.
-func (m *MockJunoPlugin) NewBlock(arg0 *core.Block, arg1 *core.StateUpdate, arg2 map[felt.Felt]core.Class) error {
+func (m *MockJunoPlugin) NewBlock(block *core.Block, stateUpdate *core.StateUpdate, newClasses map[felt.Felt]core.Class) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "NewBlock", arg0, arg1, arg2)
+	ret := m.ctrl.Call(m, "NewBlock", block, stateUpdate, newClasses)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // NewBlock indicates an expected call of NewBlock.
-func (mr *MockJunoPluginMockRecorder) NewBlock(arg0, arg1, arg2 any) *gomock.Call {
+func (mr *MockJunoPluginMockRecorder) NewBlock(block, stateUpdate, newClasses any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NewBlock", reflect.TypeOf((*MockJunoPlugin)(nil).NewBlock), arg0, arg1, arg2)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NewBlock", reflect.TypeOf((*MockJunoPlugin)(nil).NewBlock), block, stateUpdate, newClasses)
 }
 
 // RevertBlock mocks base method.
-func (m *MockJunoPlugin) RevertBlock(arg0, arg1 *plugin.BlockAndStateUpdate, arg2 *core.StateDiff) error {
+func (m *MockJunoPlugin) RevertBlock(from, to *plugin.BlockAndStateUpdate, reverseStateDiff *core.StateDiff) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "RevertBlock", arg0, arg1, arg2)
+	ret := m.ctrl.Call(m, "RevertBlock", from, to, reverseStateDiff)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // RevertBlock indicates an expected call of RevertBlock.
-func (mr *MockJunoPluginMockRecorder) RevertBlock(arg0, arg1, arg2 any) *gomock.Call {
+func (mr *MockJunoPluginMockRecorder) RevertBlock(from, to, reverseStateDiff any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RevertBlock", reflect.TypeOf((*MockJunoPlugin)(nil).RevertBlock), arg0, arg1, arg2)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RevertBlock", reflect.TypeOf((*MockJunoPlugin)(nil).RevertBlock), from, to, reverseStateDiff)
 }
 
 // Shutdown mocks base method.

--- a/mocks/mock_starknetdata.go
+++ b/mocks/mock_starknetdata.go
@@ -22,6 +22,7 @@ import (
 type MockStarknetData struct {
 	ctrl     *gomock.Controller
 	recorder *MockStarknetDataMockRecorder
+	isgomock struct{}
 }
 
 // MockStarknetDataMockRecorder is the mock recorder for MockStarknetData.
@@ -42,99 +43,99 @@ func (m *MockStarknetData) EXPECT() *MockStarknetDataMockRecorder {
 }
 
 // BlockByNumber mocks base method.
-func (m *MockStarknetData) BlockByNumber(arg0 context.Context, arg1 uint64) (*core.Block, error) {
+func (m *MockStarknetData) BlockByNumber(ctx context.Context, blockNumber uint64) (*core.Block, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "BlockByNumber", arg0, arg1)
+	ret := m.ctrl.Call(m, "BlockByNumber", ctx, blockNumber)
 	ret0, _ := ret[0].(*core.Block)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // BlockByNumber indicates an expected call of BlockByNumber.
-func (mr *MockStarknetDataMockRecorder) BlockByNumber(arg0, arg1 any) *gomock.Call {
+func (mr *MockStarknetDataMockRecorder) BlockByNumber(ctx, blockNumber any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BlockByNumber", reflect.TypeOf((*MockStarknetData)(nil).BlockByNumber), arg0, arg1)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BlockByNumber", reflect.TypeOf((*MockStarknetData)(nil).BlockByNumber), ctx, blockNumber)
 }
 
 // BlockLatest mocks base method.
-func (m *MockStarknetData) BlockLatest(arg0 context.Context) (*core.Block, error) {
+func (m *MockStarknetData) BlockLatest(ctx context.Context) (*core.Block, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "BlockLatest", arg0)
+	ret := m.ctrl.Call(m, "BlockLatest", ctx)
 	ret0, _ := ret[0].(*core.Block)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // BlockLatest indicates an expected call of BlockLatest.
-func (mr *MockStarknetDataMockRecorder) BlockLatest(arg0 any) *gomock.Call {
+func (mr *MockStarknetDataMockRecorder) BlockLatest(ctx any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BlockLatest", reflect.TypeOf((*MockStarknetData)(nil).BlockLatest), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BlockLatest", reflect.TypeOf((*MockStarknetData)(nil).BlockLatest), ctx)
 }
 
 // BlockPending mocks base method.
-func (m *MockStarknetData) BlockPending(arg0 context.Context) (*core.Block, error) {
+func (m *MockStarknetData) BlockPending(ctx context.Context) (*core.Block, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "BlockPending", arg0)
+	ret := m.ctrl.Call(m, "BlockPending", ctx)
 	ret0, _ := ret[0].(*core.Block)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // BlockPending indicates an expected call of BlockPending.
-func (mr *MockStarknetDataMockRecorder) BlockPending(arg0 any) *gomock.Call {
+func (mr *MockStarknetDataMockRecorder) BlockPending(ctx any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BlockPending", reflect.TypeOf((*MockStarknetData)(nil).BlockPending), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BlockPending", reflect.TypeOf((*MockStarknetData)(nil).BlockPending), ctx)
 }
 
 // Class mocks base method.
-func (m *MockStarknetData) Class(arg0 context.Context, arg1 *felt.Felt) (core.Class, error) {
+func (m *MockStarknetData) Class(ctx context.Context, classHash *felt.Felt) (core.Class, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Class", arg0, arg1)
+	ret := m.ctrl.Call(m, "Class", ctx, classHash)
 	ret0, _ := ret[0].(core.Class)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // Class indicates an expected call of Class.
-func (mr *MockStarknetDataMockRecorder) Class(arg0, arg1 any) *gomock.Call {
+func (mr *MockStarknetDataMockRecorder) Class(ctx, classHash any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Class", reflect.TypeOf((*MockStarknetData)(nil).Class), arg0, arg1)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Class", reflect.TypeOf((*MockStarknetData)(nil).Class), ctx, classHash)
 }
 
 // StateUpdate mocks base method.
-func (m *MockStarknetData) StateUpdate(arg0 context.Context, arg1 uint64) (*core.StateUpdate, error) {
+func (m *MockStarknetData) StateUpdate(ctx context.Context, blockNumber uint64) (*core.StateUpdate, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "StateUpdate", arg0, arg1)
+	ret := m.ctrl.Call(m, "StateUpdate", ctx, blockNumber)
 	ret0, _ := ret[0].(*core.StateUpdate)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // StateUpdate indicates an expected call of StateUpdate.
-func (mr *MockStarknetDataMockRecorder) StateUpdate(arg0, arg1 any) *gomock.Call {
+func (mr *MockStarknetDataMockRecorder) StateUpdate(ctx, blockNumber any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StateUpdate", reflect.TypeOf((*MockStarknetData)(nil).StateUpdate), arg0, arg1)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StateUpdate", reflect.TypeOf((*MockStarknetData)(nil).StateUpdate), ctx, blockNumber)
 }
 
 // StateUpdatePending mocks base method.
-func (m *MockStarknetData) StateUpdatePending(arg0 context.Context) (*core.StateUpdate, error) {
+func (m *MockStarknetData) StateUpdatePending(ctx context.Context) (*core.StateUpdate, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "StateUpdatePending", arg0)
+	ret := m.ctrl.Call(m, "StateUpdatePending", ctx)
 	ret0, _ := ret[0].(*core.StateUpdate)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // StateUpdatePending indicates an expected call of StateUpdatePending.
-func (mr *MockStarknetDataMockRecorder) StateUpdatePending(arg0 any) *gomock.Call {
+func (mr *MockStarknetDataMockRecorder) StateUpdatePending(ctx any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StateUpdatePending", reflect.TypeOf((*MockStarknetData)(nil).StateUpdatePending), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StateUpdatePending", reflect.TypeOf((*MockStarknetData)(nil).StateUpdatePending), ctx)
 }
 
 // StateUpdatePendingWithBlock mocks base method.
-func (m *MockStarknetData) StateUpdatePendingWithBlock(arg0 context.Context) (*core.StateUpdate, *core.Block, error) {
+func (m *MockStarknetData) StateUpdatePendingWithBlock(ctx context.Context) (*core.StateUpdate, *core.Block, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "StateUpdatePendingWithBlock", arg0)
+	ret := m.ctrl.Call(m, "StateUpdatePendingWithBlock", ctx)
 	ret0, _ := ret[0].(*core.StateUpdate)
 	ret1, _ := ret[1].(*core.Block)
 	ret2, _ := ret[2].(error)
@@ -142,15 +143,15 @@ func (m *MockStarknetData) StateUpdatePendingWithBlock(arg0 context.Context) (*c
 }
 
 // StateUpdatePendingWithBlock indicates an expected call of StateUpdatePendingWithBlock.
-func (mr *MockStarknetDataMockRecorder) StateUpdatePendingWithBlock(arg0 any) *gomock.Call {
+func (mr *MockStarknetDataMockRecorder) StateUpdatePendingWithBlock(ctx any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StateUpdatePendingWithBlock", reflect.TypeOf((*MockStarknetData)(nil).StateUpdatePendingWithBlock), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StateUpdatePendingWithBlock", reflect.TypeOf((*MockStarknetData)(nil).StateUpdatePendingWithBlock), ctx)
 }
 
 // StateUpdateWithBlock mocks base method.
-func (m *MockStarknetData) StateUpdateWithBlock(arg0 context.Context, arg1 uint64) (*core.StateUpdate, *core.Block, error) {
+func (m *MockStarknetData) StateUpdateWithBlock(ctx context.Context, blockNumber uint64) (*core.StateUpdate, *core.Block, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "StateUpdateWithBlock", arg0, arg1)
+	ret := m.ctrl.Call(m, "StateUpdateWithBlock", ctx, blockNumber)
 	ret0, _ := ret[0].(*core.StateUpdate)
 	ret1, _ := ret[1].(*core.Block)
 	ret2, _ := ret[2].(error)
@@ -158,22 +159,22 @@ func (m *MockStarknetData) StateUpdateWithBlock(arg0 context.Context, arg1 uint6
 }
 
 // StateUpdateWithBlock indicates an expected call of StateUpdateWithBlock.
-func (mr *MockStarknetDataMockRecorder) StateUpdateWithBlock(arg0, arg1 any) *gomock.Call {
+func (mr *MockStarknetDataMockRecorder) StateUpdateWithBlock(ctx, blockNumber any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StateUpdateWithBlock", reflect.TypeOf((*MockStarknetData)(nil).StateUpdateWithBlock), arg0, arg1)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StateUpdateWithBlock", reflect.TypeOf((*MockStarknetData)(nil).StateUpdateWithBlock), ctx, blockNumber)
 }
 
 // Transaction mocks base method.
-func (m *MockStarknetData) Transaction(arg0 context.Context, arg1 *felt.Felt) (core.Transaction, error) {
+func (m *MockStarknetData) Transaction(ctx context.Context, transactionHash *felt.Felt) (core.Transaction, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Transaction", arg0, arg1)
+	ret := m.ctrl.Call(m, "Transaction", ctx, transactionHash)
 	ret0, _ := ret[0].(core.Transaction)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // Transaction indicates an expected call of Transaction.
-func (mr *MockStarknetDataMockRecorder) Transaction(arg0, arg1 any) *gomock.Call {
+func (mr *MockStarknetDataMockRecorder) Transaction(ctx, transactionHash any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Transaction", reflect.TypeOf((*MockStarknetData)(nil).Transaction), arg0, arg1)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Transaction", reflect.TypeOf((*MockStarknetData)(nil).Transaction), ctx, transactionHash)
 }

--- a/mocks/mock_state.go
+++ b/mocks/mock_state.go
@@ -22,6 +22,7 @@ import (
 type MockStateHistoryReader struct {
 	ctrl     *gomock.Controller
 	recorder *MockStateHistoryReaderMockRecorder
+	isgomock struct{}
 }
 
 // MockStateHistoryReaderMockRecorder is the mock recorder for MockStateHistoryReader.
@@ -42,18 +43,18 @@ func (m *MockStateHistoryReader) EXPECT() *MockStateHistoryReaderMockRecorder {
 }
 
 // Class mocks base method.
-func (m *MockStateHistoryReader) Class(arg0 *felt.Felt) (*core.DeclaredClass, error) {
+func (m *MockStateHistoryReader) Class(classHash *felt.Felt) (*core.DeclaredClass, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Class", arg0)
+	ret := m.ctrl.Call(m, "Class", classHash)
 	ret0, _ := ret[0].(*core.DeclaredClass)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // Class indicates an expected call of Class.
-func (mr *MockStateHistoryReaderMockRecorder) Class(arg0 any) *gomock.Call {
+func (mr *MockStateHistoryReaderMockRecorder) Class(classHash any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Class", reflect.TypeOf((*MockStateHistoryReader)(nil).Class), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Class", reflect.TypeOf((*MockStateHistoryReader)(nil).Class), classHash)
 }
 
 // ClassTrie mocks base method.
@@ -72,108 +73,108 @@ func (mr *MockStateHistoryReaderMockRecorder) ClassTrie() *gomock.Call {
 }
 
 // ContractClassHash mocks base method.
-func (m *MockStateHistoryReader) ContractClassHash(arg0 *felt.Felt) (*felt.Felt, error) {
+func (m *MockStateHistoryReader) ContractClassHash(addr *felt.Felt) (*felt.Felt, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ContractClassHash", arg0)
+	ret := m.ctrl.Call(m, "ContractClassHash", addr)
 	ret0, _ := ret[0].(*felt.Felt)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // ContractClassHash indicates an expected call of ContractClassHash.
-func (mr *MockStateHistoryReaderMockRecorder) ContractClassHash(arg0 any) *gomock.Call {
+func (mr *MockStateHistoryReaderMockRecorder) ContractClassHash(addr any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ContractClassHash", reflect.TypeOf((*MockStateHistoryReader)(nil).ContractClassHash), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ContractClassHash", reflect.TypeOf((*MockStateHistoryReader)(nil).ContractClassHash), addr)
 }
 
 // ContractClassHashAt mocks base method.
-func (m *MockStateHistoryReader) ContractClassHashAt(arg0 *felt.Felt, arg1 uint64) (*felt.Felt, error) {
+func (m *MockStateHistoryReader) ContractClassHashAt(addr *felt.Felt, blockNumber uint64) (*felt.Felt, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ContractClassHashAt", arg0, arg1)
+	ret := m.ctrl.Call(m, "ContractClassHashAt", addr, blockNumber)
 	ret0, _ := ret[0].(*felt.Felt)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // ContractClassHashAt indicates an expected call of ContractClassHashAt.
-func (mr *MockStateHistoryReaderMockRecorder) ContractClassHashAt(arg0, arg1 any) *gomock.Call {
+func (mr *MockStateHistoryReaderMockRecorder) ContractClassHashAt(addr, blockNumber any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ContractClassHashAt", reflect.TypeOf((*MockStateHistoryReader)(nil).ContractClassHashAt), arg0, arg1)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ContractClassHashAt", reflect.TypeOf((*MockStateHistoryReader)(nil).ContractClassHashAt), addr, blockNumber)
 }
 
 // ContractIsAlreadyDeployedAt mocks base method.
-func (m *MockStateHistoryReader) ContractIsAlreadyDeployedAt(arg0 *felt.Felt, arg1 uint64) (bool, error) {
+func (m *MockStateHistoryReader) ContractIsAlreadyDeployedAt(addr *felt.Felt, blockNumber uint64) (bool, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ContractIsAlreadyDeployedAt", arg0, arg1)
+	ret := m.ctrl.Call(m, "ContractIsAlreadyDeployedAt", addr, blockNumber)
 	ret0, _ := ret[0].(bool)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // ContractIsAlreadyDeployedAt indicates an expected call of ContractIsAlreadyDeployedAt.
-func (mr *MockStateHistoryReaderMockRecorder) ContractIsAlreadyDeployedAt(arg0, arg1 any) *gomock.Call {
+func (mr *MockStateHistoryReaderMockRecorder) ContractIsAlreadyDeployedAt(addr, blockNumber any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ContractIsAlreadyDeployedAt", reflect.TypeOf((*MockStateHistoryReader)(nil).ContractIsAlreadyDeployedAt), arg0, arg1)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ContractIsAlreadyDeployedAt", reflect.TypeOf((*MockStateHistoryReader)(nil).ContractIsAlreadyDeployedAt), addr, blockNumber)
 }
 
 // ContractNonce mocks base method.
-func (m *MockStateHistoryReader) ContractNonce(arg0 *felt.Felt) (*felt.Felt, error) {
+func (m *MockStateHistoryReader) ContractNonce(addr *felt.Felt) (*felt.Felt, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ContractNonce", arg0)
+	ret := m.ctrl.Call(m, "ContractNonce", addr)
 	ret0, _ := ret[0].(*felt.Felt)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // ContractNonce indicates an expected call of ContractNonce.
-func (mr *MockStateHistoryReaderMockRecorder) ContractNonce(arg0 any) *gomock.Call {
+func (mr *MockStateHistoryReaderMockRecorder) ContractNonce(addr any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ContractNonce", reflect.TypeOf((*MockStateHistoryReader)(nil).ContractNonce), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ContractNonce", reflect.TypeOf((*MockStateHistoryReader)(nil).ContractNonce), addr)
 }
 
 // ContractNonceAt mocks base method.
-func (m *MockStateHistoryReader) ContractNonceAt(arg0 *felt.Felt, arg1 uint64) (*felt.Felt, error) {
+func (m *MockStateHistoryReader) ContractNonceAt(addr *felt.Felt, blockNumber uint64) (*felt.Felt, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ContractNonceAt", arg0, arg1)
+	ret := m.ctrl.Call(m, "ContractNonceAt", addr, blockNumber)
 	ret0, _ := ret[0].(*felt.Felt)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // ContractNonceAt indicates an expected call of ContractNonceAt.
-func (mr *MockStateHistoryReaderMockRecorder) ContractNonceAt(arg0, arg1 any) *gomock.Call {
+func (mr *MockStateHistoryReaderMockRecorder) ContractNonceAt(addr, blockNumber any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ContractNonceAt", reflect.TypeOf((*MockStateHistoryReader)(nil).ContractNonceAt), arg0, arg1)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ContractNonceAt", reflect.TypeOf((*MockStateHistoryReader)(nil).ContractNonceAt), addr, blockNumber)
 }
 
 // ContractStorage mocks base method.
-func (m *MockStateHistoryReader) ContractStorage(arg0, arg1 *felt.Felt) (*felt.Felt, error) {
+func (m *MockStateHistoryReader) ContractStorage(addr, key *felt.Felt) (*felt.Felt, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ContractStorage", arg0, arg1)
+	ret := m.ctrl.Call(m, "ContractStorage", addr, key)
 	ret0, _ := ret[0].(*felt.Felt)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // ContractStorage indicates an expected call of ContractStorage.
-func (mr *MockStateHistoryReaderMockRecorder) ContractStorage(arg0, arg1 any) *gomock.Call {
+func (mr *MockStateHistoryReaderMockRecorder) ContractStorage(addr, key any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ContractStorage", reflect.TypeOf((*MockStateHistoryReader)(nil).ContractStorage), arg0, arg1)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ContractStorage", reflect.TypeOf((*MockStateHistoryReader)(nil).ContractStorage), addr, key)
 }
 
 // ContractStorageAt mocks base method.
-func (m *MockStateHistoryReader) ContractStorageAt(arg0, arg1 *felt.Felt, arg2 uint64) (*felt.Felt, error) {
+func (m *MockStateHistoryReader) ContractStorageAt(addr, key *felt.Felt, blockNumber uint64) (*felt.Felt, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ContractStorageAt", arg0, arg1, arg2)
+	ret := m.ctrl.Call(m, "ContractStorageAt", addr, key, blockNumber)
 	ret0, _ := ret[0].(*felt.Felt)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // ContractStorageAt indicates an expected call of ContractStorageAt.
-func (mr *MockStateHistoryReaderMockRecorder) ContractStorageAt(arg0, arg1, arg2 any) *gomock.Call {
+func (mr *MockStateHistoryReaderMockRecorder) ContractStorageAt(addr, key, blockNumber any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ContractStorageAt", reflect.TypeOf((*MockStateHistoryReader)(nil).ContractStorageAt), arg0, arg1, arg2)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ContractStorageAt", reflect.TypeOf((*MockStateHistoryReader)(nil).ContractStorageAt), addr, key, blockNumber)
 }
 
 // ContractStorageTrie mocks base method.

--- a/mocks/mock_subscriber.go
+++ b/mocks/mock_subscriber.go
@@ -25,6 +25,7 @@ import (
 type MockSubscriber struct {
 	ctrl     *gomock.Controller
 	recorder *MockSubscriberMockRecorder
+	isgomock struct{}
 }
 
 // MockSubscriberMockRecorder is the mock recorder for MockSubscriber.
@@ -45,18 +46,18 @@ func (m *MockSubscriber) EXPECT() *MockSubscriberMockRecorder {
 }
 
 // ChainID mocks base method.
-func (m *MockSubscriber) ChainID(arg0 context.Context) (*big.Int, error) {
+func (m *MockSubscriber) ChainID(ctx context.Context) (*big.Int, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ChainID", arg0)
+	ret := m.ctrl.Call(m, "ChainID", ctx)
 	ret0, _ := ret[0].(*big.Int)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // ChainID indicates an expected call of ChainID.
-func (mr *MockSubscriberMockRecorder) ChainID(arg0 any) *gomock.Call {
+func (mr *MockSubscriberMockRecorder) ChainID(ctx any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ChainID", reflect.TypeOf((*MockSubscriber)(nil).ChainID), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ChainID", reflect.TypeOf((*MockSubscriber)(nil).ChainID), ctx)
 }
 
 // Close mocks base method.
@@ -72,46 +73,91 @@ func (mr *MockSubscriberMockRecorder) Close() *gomock.Call {
 }
 
 // FinalisedHeight mocks base method.
-func (m *MockSubscriber) FinalisedHeight(arg0 context.Context) (uint64, error) {
+func (m *MockSubscriber) FinalisedHeight(ctx context.Context) (uint64, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "FinalisedHeight", arg0)
+	ret := m.ctrl.Call(m, "FinalisedHeight", ctx)
 	ret0, _ := ret[0].(uint64)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // FinalisedHeight indicates an expected call of FinalisedHeight.
-func (mr *MockSubscriberMockRecorder) FinalisedHeight(arg0 any) *gomock.Call {
+func (mr *MockSubscriberMockRecorder) FinalisedHeight(ctx any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FinalisedHeight", reflect.TypeOf((*MockSubscriber)(nil).FinalisedHeight), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FinalisedHeight", reflect.TypeOf((*MockSubscriber)(nil).FinalisedHeight), ctx)
+}
+
+// GetIPAddresses mocks base method.
+func (m *MockSubscriber) GetIPAddresses(ctx context.Context, ip common.Address) ([]string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetIPAddresses", ctx, ip)
+	ret0, _ := ret[0].([]string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetIPAddresses indicates an expected call of GetIPAddresses.
+func (mr *MockSubscriberMockRecorder) GetIPAddresses(ctx, ip any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetIPAddresses", reflect.TypeOf((*MockSubscriber)(nil).GetIPAddresses), ctx, ip)
 }
 
 // TransactionReceipt mocks base method.
-func (m *MockSubscriber) TransactionReceipt(arg0 context.Context, arg1 common.Hash) (*types.Receipt, error) {
+func (m *MockSubscriber) TransactionReceipt(ctx context.Context, txHash common.Hash) (*types.Receipt, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "TransactionReceipt", arg0, arg1)
+	ret := m.ctrl.Call(m, "TransactionReceipt", ctx, txHash)
 	ret0, _ := ret[0].(*types.Receipt)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // TransactionReceipt indicates an expected call of TransactionReceipt.
-func (mr *MockSubscriberMockRecorder) TransactionReceipt(arg0, arg1 any) *gomock.Call {
+func (mr *MockSubscriberMockRecorder) TransactionReceipt(ctx, txHash any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "TransactionReceipt", reflect.TypeOf((*MockSubscriber)(nil).TransactionReceipt), arg0, arg1)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "TransactionReceipt", reflect.TypeOf((*MockSubscriber)(nil).TransactionReceipt), ctx, txHash)
+}
+
+// WatchIPAdded mocks base method.
+func (m *MockSubscriber) WatchIPAdded(ctx context.Context, sink chan<- *contract.BootnodeRegistryIPAdded) (event.Subscription, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "WatchIPAdded", ctx, sink)
+	ret0, _ := ret[0].(event.Subscription)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// WatchIPAdded indicates an expected call of WatchIPAdded.
+func (mr *MockSubscriberMockRecorder) WatchIPAdded(ctx, sink any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WatchIPAdded", reflect.TypeOf((*MockSubscriber)(nil).WatchIPAdded), ctx, sink)
+}
+
+// WatchIPRemoved mocks base method.
+func (m *MockSubscriber) WatchIPRemoved(ctx context.Context, sink chan<- *contract.BootnodeRegistryIPRemoved) (event.Subscription, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "WatchIPRemoved", ctx, sink)
+	ret0, _ := ret[0].(event.Subscription)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// WatchIPRemoved indicates an expected call of WatchIPRemoved.
+func (mr *MockSubscriberMockRecorder) WatchIPRemoved(ctx, sink any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WatchIPRemoved", reflect.TypeOf((*MockSubscriber)(nil).WatchIPRemoved), ctx, sink)
 }
 
 // WatchLogStateUpdate mocks base method.
-func (m *MockSubscriber) WatchLogStateUpdate(arg0 context.Context, arg1 chan<- *contract.StarknetLogStateUpdate) (event.Subscription, error) {
+func (m *MockSubscriber) WatchLogStateUpdate(ctx context.Context, sink chan<- *contract.StarknetLogStateUpdate) (event.Subscription, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "WatchLogStateUpdate", arg0, arg1)
+	ret := m.ctrl.Call(m, "WatchLogStateUpdate", ctx, sink)
 	ret0, _ := ret[0].(event.Subscription)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // WatchLogStateUpdate indicates an expected call of WatchLogStateUpdate.
-func (mr *MockSubscriberMockRecorder) WatchLogStateUpdate(arg0, arg1 any) *gomock.Call {
+func (mr *MockSubscriberMockRecorder) WatchLogStateUpdate(ctx, sink any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WatchLogStateUpdate", reflect.TypeOf((*MockSubscriber)(nil).WatchLogStateUpdate), arg0, arg1)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WatchLogStateUpdate", reflect.TypeOf((*MockSubscriber)(nil).WatchLogStateUpdate), ctx, sink)
 }

--- a/node/node_test.go
+++ b/node/node_test.go
@@ -110,7 +110,7 @@ func TestNodeWithL1Verification(t *testing.T) {
 		EthNode:               "ws://" + listener.Addr().String(),
 		DatabasePath:          t.TempDir(),
 		DisableL1Verification: false,
-	}, "v0.1")
+	}, "v0.1", utils.NewLogLevel(utils.INFO))
 	require.NoError(t, err)
 }
 
@@ -140,7 +140,7 @@ func TestNodeWithL1VerificationError(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			_, err := node.New(tt.cfg, "v0.1")
+			_, err := node.New(tt.cfg, "v0.1", utils.NewLogLevel(utils.INFO))
 			require.ErrorContains(t, err, tt.err)
 		})
 	}

--- a/p2p/p2p_pkg_test.go
+++ b/p2p/p2p_pkg_test.go
@@ -1,0 +1,53 @@
+package p2p
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/NethermindEth/juno/db/pebble"
+	"github.com/NethermindEth/juno/utils"
+	"github.com/libp2p/go-libp2p/core/peer"
+	mocknet "github.com/libp2p/go-libp2p/p2p/net/mock"
+	"github.com/stretchr/testify/require"
+)
+
+func TestListenForL1Events(t *testing.T) {
+	eventChan := make(chan BootnodeRegistryEvent, 8)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer func() {
+		cancel()
+		close(eventChan)
+	}()
+
+	net, err := mocknet.FullMeshLinked(2)
+	require.NoError(t, err)
+	peerHosts := net.Hosts()
+	require.Len(t, peerHosts, 2)
+	testDB := pebble.NewMemTest(t)
+
+	peerA, err := NewWithHost(peerHosts[0], "", false, nil, &utils.Integration, utils.NewNopZapLogger(), testDB, eventChan)
+	require.NoError(t, err)
+
+	go peerA.listenForL1Events(ctx)
+
+	peerB, err := NewWithHost(peerHosts[1], "", false, nil, &utils.Integration, utils.NewNopZapLogger(), testDB, nil)
+	require.NoError(t, err)
+
+	addr, err := peerB.ListenAddrs()
+	require.NoError(t, err)
+	addrStr := addr[0].String()
+
+	eventChan <- BootnodeRegistryEvent{Add, addrStr}
+	time.Sleep(100 * time.Millisecond)
+	expectedPeers := map[peer.ID]struct{}{
+		peerHosts[0].ID(): {},
+		peerHosts[1].ID(): {},
+	}
+
+	for _, peer := range peerA.host.Peerstore().Peers() {
+		require.Contains(t, expectedPeers, peer)
+	}
+
+	// TODO: test remove event, find a way to remove peer from peerstore
+}

--- a/p2p/p2p_test.go
+++ b/p2p/p2p_test.go
@@ -24,6 +24,7 @@ func TestInvalidKey(t *testing.T) {
 		&utils.Integration,
 		utils.NewNopZapLogger(),
 		nil,
+		nil,
 	)
 
 	require.Error(t, err)
@@ -61,6 +62,7 @@ func TestLoadAndPersistPeers(t *testing.T) {
 		&utils.Integration,
 		utils.NewNopZapLogger(),
 		testDB,
+		nil,
 	)
 	require.NoError(t, err)
 }

--- a/utils/network.go
+++ b/utils/network.go
@@ -22,6 +22,7 @@ type Network struct {
 	L1ChainID           *big.Int           `json:"l1_chain_id" validate:"required"`
 	L2ChainID           string             `json:"l2_chain_id" validate:"required"`
 	CoreContractAddress common.Address     `json:"core_contract_address" validate:"required"`
+	BootnodeRegistry    common.Address     `json:"ip_address_registry"`
 	BlockHashMetaInfo   *BlockHashMetaInfo `json:"block_hash_meta_info"`
 }
 
@@ -107,6 +108,7 @@ var (
 			First07Block:             0,
 			FallBackSequencerAddress: fallBackSequencerAddress,
 		},
+		BootnodeRegistry: common.HexToAddress("0xa2499F2a3Fb071fd99f921038d043eF31B446883"),
 	}
 	SepoliaIntegration = Network{
 		Name:       "sepolia-integration",


### PR DESCRIPTION
This pull request introduces significant changes to the `l1` package, primarily focusing on integrating the IP Address Registry functionality. The most important changes include adding the IP Address Registry ABI, updating the `EthSubscriber` to handle IP address events, and modifying the `Client` to subscribe to these events and forward them to the P2P layer.

### IP Address Registry Integration:

* [`l1/abi/ip_address_registry.json`](diffhunk://#diff-9a0f51c7ab77a11006ee230d16a75ae09a3217db364385f1f5c379ea02c073a8R1-R217): Added the ABI for the IP Address Registry contract, defining functions, errors, and events related to IP address management.
* [`l1/eth_subscriber.go`](diffhunk://#diff-33d45c810a23e4517685e6a1c1080a1bc281ce34e77dee7b4c1357eed882d1edR11): Updated the `EthSubscriber` struct to include the IP Address Registry and its filterer. Added methods to watch for IP address additions and removals, and to get the list of IP addresses. [[1]](diffhunk://#diff-33d45c810a23e4517685e6a1c1080a1bc281ce34e77dee7b4c1357eed882d1edR11) [[2]](diffhunk://#diff-33d45c810a23e4517685e6a1c1080a1bc281ce34e77dee7b4c1357eed882d1edR25-R31) [[3]](diffhunk://#diff-33d45c810a23e4517685e6a1c1080a1bc281ce34e77dee7b4c1357eed882d1edL37-R85)
* [`l1/l1.go`](diffhunk://#diff-7f7fd9a26e7cb24ff29bbaa5130bd597f6ec2c15bec9414dfec4863850ca8570R1): Added methods to the `Client` to subscribe to IP address events and forward them to the P2P layer. Modified the `Client` constructor to accept a channel for forwarding these events. [[1]](diffhunk://#diff-7f7fd9a26e7cb24ff29bbaa5130bd597f6ec2c15bec9414dfec4863850ca8570R1) [[2]](diffhunk://#diff-7f7fd9a26e7cb24ff29bbaa5130bd597f6ec2c15bec9414dfec4863850ca8570R14-R29) [[3]](diffhunk://#diff-7f7fd9a26e7cb24ff29bbaa5130bd597f6ec2c15bec9414dfec4863850ca8570R45-R50) [[4]](diffhunk://#diff-7f7fd9a26e7cb24ff29bbaa5130bd597f6ec2c15bec9414dfec4863850ca8570R60) [[5]](diffhunk://#diff-7f7fd9a26e7cb24ff29bbaa5130bd597f6ec2c15bec9414dfec4863850ca8570R96-R131) [[6]](diffhunk://#diff-7f7fd9a26e7cb24ff29bbaa5130bd597f6ec2c15bec9414dfec4863850ca8570L112-R169) [[7]](diffhunk://#diff-7f7fd9a26e7cb24ff29bbaa5130bd597f6ec2c15bec9414dfec4863850ca8570R181) [[8]](diffhunk://#diff-7f7fd9a26e7cb24ff29bbaa5130bd597f6ec2c15bec9414dfec4863850ca8570R230-R295)