### PR TITLE
fix: errors.New use error

### DIFF
--- a/core/felt/felt.go
+++ b/core/felt/felt.go
@@ -88,12 +88,12 @@ func (z *Felt) SetString(number string) (*Felt, error) {
 
 	if _, ok := vv.SetString(number, 0); !ok {
 		if _, ok := vv.SetString(number, Base16); !ok {
-			return z, errors.New("can't parse into a big.Int: " + number)
+			return z, fmt.Errorf("can't parse into a big.Int: " + number)
 		}
 	}
 
 	if vv.BitLen() > fp.Bits {
-		return z, errors.New("can't fit in felt: " + number)
+		return z, fmt.Errorf("can't fit in felt: " + number)
 	}
 
 	var bytes [32]byte


### PR DESCRIPTION
fix: It is recommended to use the fmt.Errorf method with parameters instead of the errors.New method without parameters.