### PR TITLE
fix: errors.New use error 

### DIFF
--- a/jsonrpc/server.go
+++ b/jsonrpc/server.go
@@ -560,7 +560,7 @@ func (s *Server) buildArguments(ctx context.Context, params any, method Method) 
 				// optional parameter
 				v = reflect.New(handlerType.In(i + addContext)).Elem()
 			} else {
-				return nil, errors.New("missing non-optional param: " + configuredParam.Name)
+				return nil, fmt.Errorf("missing non-optional param: " + configuredParam.Name)
 			}
 
 			args = append(args, v)


### PR DESCRIPTION
fix: It is recommended to use the fmt.Errorf method with parameters instead of the errors.New method without parameters.