### PR TITLE
Fix typos

### DIFF
--- a/db/db.go
+++ b/db/db.go
@@ -108,7 +108,7 @@ func discardTxnOnPanic(txn Transaction) {
 	p := recover()
 	if p != nil {
 		if err := txn.Discard(); err != nil {
-			fmt.Fprintf(os.Stderr, "failed discarding panicing txn err: %s", err)
+			fmt.Fprintf(os.Stderr, "failed discarding panicking txn err: %s", err)
 		}
 		panic(p)
 	}

--- a/vm/rust/src/juno_state_reader.rs
+++ b/vm/rust/src/juno_state_reader.rs
@@ -139,7 +139,7 @@ impl StateReader for JunoStateReader {
             // About the changes in the second attempt at making class cache behave as expected;
             //
             // The initial assumption here was that `self.height` uniquely identifies and strictly orders the underlying state
-            // instances. The first assumption doesn't necessarily hold, because we can pass different state instaces with the
+            // instances. The first assumption doesn't necessarily hold, because we can pass different state instances with the
             // same height. This most commonly happens with call/estimate/simulate and trace flows. Trace flow calls the VM
             // for block number N with the state at the beginning of the block, while call/estimate/simulate flows call the VM
             // with the same block number but with the state at the end of that block. That is why, we cannot use classes from cache


### PR DESCRIPTION
## Description
This pull request fixes minor typos in the following files:

1. `db/db.go`: Corrected "panicing" to "panicking" for improved clarity.
2. `vm/rust/src/juno_state_reader.rs`: Corrected "instaces" to "instances" for accurate spelling.

## Motivation and Context
Clear and professional code and documentation improve maintainability and readability. These fixes address small errors to align with the project's high standards.

## How Has This Been Tested?
No functional changes were introduced. The files were reviewed post-edits to ensure correctness.

## Types of Changes
- Typo fixes in source code and comments.

## Checklist:
- [x] I have reviewed the changes for accuracy and consistency.
- [x] My changes do not introduce any breaking changes.
- [x] I have followed the contributing guidelines.
- [x] My pull request targets the correct branch.

## Additional Notes
I am excited about the opportunity to contribute to this project and am happy to take on further tasks. Please let me know if there's anything more I can assist wi
