### PR TITLE
Add bound options to `txn.NewIterator`

### DIFF
--- a/blockchain/blockchain.go
+++ b/blockchain/blockchain.go
@@ -506,20 +506,16 @@ func BlockByNumber(txn db.Transaction, number uint64) (*core.Block, error) {
 }
 
 func TransactionsByBlockNumber(txn db.Transaction, number uint64) ([]core.Transaction, error) {
-	iterator, err := txn.NewIterator()
+	numBytes := core.MarshalBlockNumber(number)
+	prefix := db.TransactionsByBlockNumberAndIndex.Key(numBytes)
+
+	iterator, err := txn.NewIterator(prefix, true)
 	if err != nil {
 		return nil, err
 	}
 
 	var txs []core.Transaction
-	numBytes := core.MarshalBlockNumber(number)
-
-	prefix := db.TransactionsByBlockNumberAndIndex.Key(numBytes)
-	for iterator.Seek(prefix); iterator.Valid(); iterator.Next() {
-		if !bytes.HasPrefix(iterator.Key(), prefix) {
-			break
-		}
-
+	for iterator.First(); iterator.Valid(); iterator.Next() {
 		val, vErr := iterator.Value()
 		if vErr != nil {
 			return nil, utils.RunAndWrapOnError(iterator.Close, vErr)
@@ -541,16 +537,17 @@ func TransactionsByBlockNumber(txn db.Transaction, number uint64) ([]core.Transa
 }
 
 func receiptsByBlockNumber(txn db.Transaction, number uint64) ([]*core.TransactionReceipt, error) {
-	iterator, err := txn.NewIterator()
+	numBytes := core.MarshalBlockNumber(number)
+	prefix := db.ReceiptsByBlockNumberAndIndex.Key(numBytes)
+
+	iterator, err := txn.NewIterator(prefix, true)
 	if err != nil {
 		return nil, err
 	}
 
 	var receipts []*core.TransactionReceipt
-	numBytes := core.MarshalBlockNumber(number)
 
-	prefix := db.ReceiptsByBlockNumberAndIndex.Key(numBytes)
-	for iterator.Seek(prefix); iterator.Valid(); iterator.Next() {
+	for iterator.First(); iterator.Valid(); iterator.Next() {
 		if !bytes.HasPrefix(iterator.Key(), prefix) {
 			break
 		}

--- a/blockchain/blockchain_test.go
+++ b/blockchain/blockchain_test.go
@@ -654,7 +654,7 @@ func TestRevert(t *testing.T) {
 
 	t.Run("empty blockchain should mean empty db", func(t *testing.T) {
 		require.NoError(t, testdb.View(func(txn db.Transaction) error {
-			it, err := txn.NewIterator()
+			it, err := txn.NewIterator(nil, false)
 			if err != nil {
 				return err
 			}

--- a/core/history.go
+++ b/core/history.go
@@ -29,7 +29,7 @@ func (h *history) deleteLog(key []byte, height uint64) error {
 }
 
 func (h *history) valueAt(key []byte, height uint64) ([]byte, error) {
-	it, err := h.txn.NewIterator()
+	it, err := h.txn.NewIterator(nil, false)
 	if err != nil {
 		return nil, err
 	}

--- a/core/state_test.go
+++ b/core/state_test.go
@@ -556,7 +556,7 @@ func TestRevert(t *testing.T) {
 
 	t.Run("empty state should mean empty db", func(t *testing.T) {
 		require.NoError(t, testDB.View(func(txn db.Transaction) error {
-			it, err := txn.NewIterator()
+			it, err := txn.NewIterator(nil, false)
 			if err != nil {
 				return err
 			}

--- a/db/buffered_transaction.go
+++ b/db/buffered_transaction.go
@@ -79,6 +79,6 @@ func (t *BufferedTransaction) Impl() any {
 }
 
 // NewIterator : see db.Transaction.NewIterator
-func (t *BufferedTransaction) NewIterator() (Iterator, error) {
+func (t *BufferedTransaction) NewIterator(_ []byte, _ bool) (Iterator, error) {
 	return nil, errors.New("buffered transactions dont support iterators")
 }

--- a/db/db.go
+++ b/db/db.go
@@ -42,6 +42,9 @@ type Iterator interface {
 	// Valid returns true if the iterator is positioned at a valid key/value pair.
 	Valid() bool
 
+	// First moves the iterator to the first key/value pair.
+	First() bool
+
 	// Next moves the iterator to the next key/value pair. It returns whether the
 	// iterator is valid after the call. Once invalid, the iterator remains
 	// invalid.
@@ -63,7 +66,7 @@ type Iterator interface {
 // the transaction is committed.
 type Transaction interface {
 	// NewIterator returns an iterator over the database's key/value pairs.
-	NewIterator() (Iterator, error)
+	NewIterator(lowerBound []byte, withUpperBound bool) (Iterator, error)
 	// Discard discards all the changes done to the database with this transaction
 	Discard() error
 	// Commit flushes all the changes pending on this transaction to the database, making the changes visible to other

--- a/db/memory_transaction.go
+++ b/db/memory_transaction.go
@@ -14,7 +14,7 @@ func NewMemTransaction() Transaction {
 	return &memTransaction{storage: make(map[string][]byte)}
 }
 
-func (t *memTransaction) NewIterator() (Iterator, error) {
+func (t *memTransaction) NewIterator(_ []byte, _ bool) (Iterator, error) {
 	return nil, errors.New("not implemented")
 }
 

--- a/db/pebble/batch.go
+++ b/db/pebble/batch.go
@@ -88,7 +88,7 @@ func (b *batch) Get(key []byte, cb func([]byte) error) error {
 }
 
 // NewIterator : see db.Transaction.NewIterator
-func (b *batch) NewIterator() (db.Iterator, error) {
+func (b *batch) NewIterator(lowerBound []byte, withUpperBound bool) (db.Iterator, error) {
 	var iter *pebble.Iterator
 	var err error
 
@@ -96,7 +96,12 @@ func (b *batch) NewIterator() (db.Iterator, error) {
 		return nil, ErrDiscardedTransaction
 	}
 
-	iter, err = b.batch.NewIter(nil)
+	iterOpt := &pebble.IterOptions{LowerBound: lowerBound}
+	if withUpperBound {
+		iterOpt.UpperBound = upperBound(lowerBound)
+	}
+
+	iter, err = b.batch.NewIter(iterOpt)
 	if err != nil {
 		return nil, err
 	}

--- a/db/pebble/db.go
+++ b/db/pebble/db.go
@@ -164,6 +164,14 @@ func CalculatePrefixSize(ctx context.Context, pDB *DB, prefix []byte, withUpperB
 	return item, utils.RunAndWrapOnError(it.Close, err)
 }
 
+// Calculates the next possible prefix after the given prefix bytes.
+// It's used to establish an upper boundary for prefix-based database scans.
+// Examples:
+//
+//	[1]     	  -> [2]
+//	[1, 255, 255] -> [2]
+//	[1, 2, 255]   -> [1, 3]
+//	[255, 255]    -> nil
 func upperBound(prefix []byte) []byte {
 	var ub []byte
 

--- a/db/pebble/db_test.go
+++ b/db/pebble/db_test.go
@@ -289,52 +289,56 @@ func TestSeek(t *testing.T) {
 
 func TestPrefixSearch(t *testing.T) {
 	type entry struct {
-		key   uint64
-		value []byte
+		prefix []byte
+		key    uint64
+		value  []byte
 	}
 
 	data := []entry{
-		{11, []byte("c")},
-		{12, []byte("a")},
-		{13, []byte("e")},
-		{22, []byte("d")},
-		{23, []byte("b")},
-		{123, []byte("f")},
+		{[]byte{11}, 1, []byte("c")},
+		{[]byte{11}, 2, []byte("a")},
+		{[]byte{11}, 3, []byte("e")},
+		{[]byte{12}, 4, []byte("d")},
+		{[]byte{23}, 5, []byte("b")},
+		{[]byte{123}, 6, []byte("f")},
+		{[]byte{0}, 7, []byte("g")},
 	}
 
 	testDB := pebble.NewMemTest(t)
 
 	require.NoError(t, testDB.Update(func(txn db.Transaction) error {
 		for _, d := range data {
-			numBytes := make([]byte, 8)
-			binary.BigEndian.PutUint64(numBytes, d.key)
-			require.NoError(t, txn.Set(numBytes, d.value))
+			keyBytes := make([]byte, 8)
+			binary.BigEndian.PutUint64(keyBytes, d.key)
+			var dbKey []byte
+			dbKey = append(dbKey, d.prefix...)
+			dbKey = append(dbKey, keyBytes...)
+			require.NoError(t, txn.Set(dbKey, d.value))
 		}
 		return nil
 	}))
 
 	require.NoError(t, testDB.View(func(txn db.Transaction) error {
-		iter, err := txn.NewIterator(nil, false)
+		targetPrefix := []byte{11}
+		iter, err := txn.NewIterator(targetPrefix, true)
 		require.NoError(t, err)
 		t.Cleanup(func() {
 			require.NoError(t, iter.Close())
 		})
 
-		prefixBytes := make([]byte, 8)
-		binary.BigEndian.PutUint64(prefixBytes, 1)
-
 		var entries []entry
-		for iter.Seek(prefixBytes); iter.Valid(); iter.Next() {
-			key := binary.BigEndian.Uint64(iter.Key())
-			if key >= 20 {
-				break
-			}
+		for iter.First(); iter.Valid(); iter.Next() {
+			key := iter.Key()
+			key = key[len(targetPrefix):]
+			keyUint64 := binary.BigEndian.Uint64(key)
+
 			v, err := iter.Value()
 			require.NoError(t, err)
-			entries = append(entries, entry{key, v})
+
+			entries = append(entries, entry{targetPrefix, keyUint64, v})
 		}
 
-		expectedKeys := []uint64{11, 12, 13}
+		expectedKeys := []uint64{1, 2, 3}
 
 		assert.Equal(t, len(expectedKeys), len(entries))
 
@@ -344,6 +348,39 @@ func TestPrefixSearch(t *testing.T) {
 
 		return nil
 	}))
+}
+
+func TestFirst(t *testing.T) {
+	testDB := pebble.NewMemTest(t)
+
+	txn, err := testDB.NewTransaction(true)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		require.NoError(t, txn.Discard())
+	})
+	require.NoError(t, txn.Set([]byte{0}, []byte{0}))
+	require.NoError(t, txn.Set([]byte{1}, []byte{1}))
+	require.NoError(t, txn.Set([]byte{2}, []byte{2}))
+
+	t.Run("First() on new iterator", func(t *testing.T) {
+		iter, err := txn.NewIterator(nil, false)
+		require.NoError(t, err)
+		assert.Equal(t, true, iter.First())
+		assert.Equal(t, []byte{0}, iter.Key())
+		require.NoError(t, iter.Close())
+	})
+
+	t.Run("First() after multiple Next()", func(t *testing.T) {
+		iter, err := txn.NewIterator(nil, false)
+		require.NoError(t, err)
+		assert.Equal(t, true, iter.Next())
+		assert.Equal(t, []byte{0}, iter.Key())
+		assert.Equal(t, true, iter.Next())
+		assert.Equal(t, []byte{1}, iter.Key())
+		assert.Equal(t, true, iter.First())
+		assert.Equal(t, []byte{0}, iter.Key())
+		require.NoError(t, iter.Close())
+	})
 }
 
 func TestNext(t *testing.T) {

--- a/db/pebble/db_test.go
+++ b/db/pebble/db_test.go
@@ -261,7 +261,7 @@ func TestSeek(t *testing.T) {
 	require.NoError(t, txn.Set([]byte{3}, []byte{3}))
 
 	t.Run("seeks to the next key in lexicographical order", func(t *testing.T) {
-		iter, err := txn.NewIterator()
+		iter, err := txn.NewIterator(nil, false)
 		require.NoError(t, err)
 		t.Cleanup(func() {
 			require.NoError(t, iter.Close())
@@ -275,7 +275,7 @@ func TestSeek(t *testing.T) {
 	})
 
 	t.Run("key returns nil when seeking nonexistent data", func(t *testing.T) {
-		iter, err := txn.NewIterator()
+		iter, err := txn.NewIterator(nil, false)
 		require.NoError(t, err)
 
 		t.Cleanup(func() {
@@ -314,7 +314,7 @@ func TestPrefixSearch(t *testing.T) {
 	}))
 
 	require.NoError(t, testDB.View(func(txn db.Transaction) error {
-		iter, err := txn.NewIterator()
+		iter, err := txn.NewIterator(nil, false)
 		require.NoError(t, err)
 		t.Cleanup(func() {
 			require.NoError(t, iter.Close())
@@ -359,7 +359,7 @@ func TestNext(t *testing.T) {
 	require.NoError(t, txn.Set([]byte{2}, []byte{2}))
 
 	t.Run("Next() on new iterator", func(t *testing.T) {
-		it, err := txn.NewIterator()
+		it, err := txn.NewIterator(nil, false)
 		require.NoError(t, err)
 
 		t.Run("new iterator should be invalid", func(t *testing.T) {
@@ -374,7 +374,7 @@ func TestNext(t *testing.T) {
 	})
 
 	t.Run("Next() should work as expected after a Seek()", func(t *testing.T) {
-		it, err := txn.NewIterator()
+		it, err := txn.NewIterator(nil, false)
 		require.NoError(t, err)
 
 		require.True(t, it.Seek([]byte{0}))

--- a/db/pebble/iterator.go
+++ b/db/pebble/iterator.go
@@ -39,6 +39,11 @@ func (i *iterator) Value() ([]byte, error) {
 	return buf, nil
 }
 
+func (i *iterator) First() bool {
+	i.positioned = true
+	return i.iter.First()
+}
+
 // Next : see db.Transaction.Iterator.Next
 func (i *iterator) Next() bool {
 	if !i.positioned {

--- a/db/pebble/snapshot.go
+++ b/db/pebble/snapshot.go
@@ -58,7 +58,7 @@ func (s *snapshot) Get(key []byte, cb func([]byte) error) error {
 }
 
 // NewIterator : see db.Transaction.NewIterator
-func (s *snapshot) NewIterator() (db.Iterator, error) {
+func (s *snapshot) NewIterator(lowerBound []byte, withUpperBound bool) (db.Iterator, error) {
 	var iter *pebble.Iterator
 	var err error
 
@@ -66,7 +66,12 @@ func (s *snapshot) NewIterator() (db.Iterator, error) {
 		return nil, ErrDiscardedTransaction
 	}
 
-	iter, err = s.snapshot.NewIter(nil)
+	iterOpt := &pebble.IterOptions{LowerBound: lowerBound}
+	if withUpperBound {
+		iterOpt.UpperBound = upperBound(lowerBound)
+	}
+
+	iter, err = s.snapshot.NewIter(iterOpt)
 	if err != nil {
 		return nil, err
 	}

--- a/db/remote/db_test.go
+++ b/db/remote/db_test.go
@@ -63,7 +63,7 @@ func TestRemote(t *testing.T) {
 
 	t.Run("iterate", func(t *testing.T) {
 		err := remoteDB.View(func(txn db.Transaction) error {
-			it, err := txn.NewIterator()
+			it, err := txn.NewIterator(nil, false)
 			if err != nil {
 				return err
 			}
@@ -85,7 +85,7 @@ func TestRemote(t *testing.T) {
 
 	t.Run("seek", func(t *testing.T) {
 		err := remoteDB.View(func(txn db.Transaction) error {
-			it, err := txn.NewIterator()
+			it, err := txn.NewIterator(nil, false)
 			if err != nil {
 				return err
 			}

--- a/db/remote/iterator.go
+++ b/db/remote/iterator.go
@@ -52,6 +52,13 @@ func (i *iterator) Value() ([]byte, error) {
 	return i.currentV, nil
 }
 
+func (i *iterator) First() bool {
+	if err := i.doOpAndUpdate(gen.Op_FIRST, nil); err != nil {
+		i.log.Debugw("Error", "op", gen.Op_FIRST, "err", err)
+	}
+	return len(i.currentK) > 0 || len(i.currentV) > 0
+}
+
 func (i *iterator) Next() bool {
 	if err := i.doOpAndUpdate(gen.Op_NEXT, nil); err != nil {
 		i.log.Debugw("Error", "op", gen.Op_NEXT, "err", err)

--- a/db/remote/transaction.go
+++ b/db/remote/transaction.go
@@ -16,7 +16,7 @@ type transaction struct {
 	log    utils.SimpleLogger
 }
 
-func (t *transaction) NewIterator() (db.Iterator, error) {
+func (t *transaction) NewIterator(_ []byte, _ bool) (db.Iterator, error) {
 	err := t.client.Send(&gen.Cursor{
 		Op: gen.Op_OPEN,
 	})

--- a/db/sync_transaction.go
+++ b/db/sync_transaction.go
@@ -61,6 +61,6 @@ func (t *SyncTransaction) Impl() any {
 }
 
 // NewIterator : see db.Transaction.NewIterator
-func (t *SyncTransaction) NewIterator() (Iterator, error) {
+func (t *SyncTransaction) NewIterator(_ []byte, _ bool) (Iterator, error) {
 	return nil, errors.New("sync transactions dont support iterators")
 }

--- a/grpc/tx.go
+++ b/grpc/tx.go
@@ -23,7 +23,7 @@ func newTx(dbTx db.Transaction) *tx {
 }
 
 func (t *tx) newCursor() (uint32, error) {
-	it, err := t.dbTx.NewIterator()
+	it, err := t.dbTx.NewIterator(nil, false)
 	if err != nil {
 		return 0, err
 	}

--- a/migration/bucket_migrator.go
+++ b/migration/bucket_migrator.go
@@ -78,7 +78,7 @@ func (m *BucketMigrator) Before(_ []byte) error {
 
 func (m *BucketMigrator) Migrate(ctx context.Context, txn db.Transaction, network *utils.Network, log utils.SimpleLogger) ([]byte, error) {
 	remainingInBatch := m.batchSize
-	iterator, err := txn.NewIterator()
+	iterator, err := txn.NewIterator(nil, false)
 	if err != nil {
 		return nil, err
 	}

--- a/migration/migration.go
+++ b/migration/migration.go
@@ -183,7 +183,7 @@ func updateSchemaMetadata(txn db.Transaction, schema schemaMetadata) error {
 
 // migration0000 makes sure the targetDB is empty
 func migration0000(txn db.Transaction, _ *utils.Network) error {
-	it, err := txn.NewIterator()
+	it, err := txn.NewIterator(nil, false)
 	if err != nil {
 		return err
 	}
@@ -202,7 +202,7 @@ func migration0000(txn db.Transaction, _ *utils.Network) error {
 //
 // This enables us to remove the db.ContractRootKey prefix.
 func relocateContractStorageRootKeys(txn db.Transaction, _ *utils.Network) error {
-	it, err := txn.NewIterator()
+	it, err := txn.NewIterator(nil, false)
 	if err != nil {
 		return err
 	}
@@ -429,7 +429,7 @@ func (m *changeTrieNodeEncoding) Migrate(_ context.Context, txn db.Transaction, 
 		return nil
 	}
 
-	iterator, err := txn.NewIterator()
+	iterator, err := txn.NewIterator(nil, false)
 	if err != nil {
 		return nil, err
 	}

--- a/migration/migration_pkg_test.go
+++ b/migration/migration_pkg_test.go
@@ -572,7 +572,7 @@ func TestChangeStateDiffStructEmptyDB(t *testing.T) {
 		require.Nil(t, intermediateState)
 
 		// DB is still empty.
-		iter, err := txn.NewIterator()
+		iter, err := txn.NewIterator(nil, false)
 		defer func() {
 			require.NoError(t, iter.Close())
 		}()
@@ -654,7 +654,7 @@ func TestChangeStateDiffStruct(t *testing.T) {
 	// - Both state diffs have been updated.
 	// - There are no extraneous entries in the DB.
 	require.NoError(t, testdb.View(func(txn db.Transaction) error {
-		iter, err := txn.NewIterator()
+		iter, err := txn.NewIterator(nil, false)
 		require.NoError(t, err)
 		defer func() {
 			require.NoError(t, iter.Close())

--- a/p2p/p2p.go
+++ b/p2p/p2p.go
@@ -353,15 +353,14 @@ func loadPeers(database db.DB) ([]peer.AddrInfo, error) {
 	var peers []peer.AddrInfo
 
 	err := database.View(func(txn db.Transaction) error {
-		it, err := txn.NewIterator()
+		it, err := txn.NewIterator(db.Peer.Key(), true)
 		if err != nil {
 			return fmt.Errorf("create iterator: %w", err)
 		}
 		defer it.Close()
 
-		prefix := db.Peer.Key()
-		for it.Seek(prefix); it.Valid(); it.Next() {
-			peerIDBytes := it.Key()[len(prefix):]
+		for it.First(); it.Valid(); it.Next() {
+			peerIDBytes := it.Key()
 			peerID, err := peer.IDFromBytes(peerIDBytes)
 			if err != nil {
 				return fmt.Errorf("decode peer ID: %w", err)


### PR DESCRIPTION
The old pattern is as follows:

```
for iterator.Seek(prefix); iterator.Valid(); iterator.Next() {
  if !bytes.HasPrefix(iterator.Key(), prefix) {
	break
  }
}
```

The prefix check is redundant because PebbleDB offers a built-in iterator with prefix match. Hence we simply add the bound options in the `NewIterator` method and create PebbleDB's iterator options accordingly.