### PR TITLE
Fix Typos

### DIFF
--- a/core/felt/felt.go
+++ b/core/felt/felt.go
@@ -26,9 +26,9 @@ const (
 )
 
 const (
-	Limbs = fp.Limbs // number of 64 bits words needed to represent a Element
-	Bits  = fp.Bits  // number of bits needed to represent a Element
-	Bytes = fp.Bytes // number of bytes needed to represent a Element
+	Limbs = fp.Limbs // number of 64 bits words needed to represent an Element
+	Bits  = fp.Bits  // number of bits needed to represent an Element
+	Bytes = fp.Bytes // number of bytes needed to represent an Element
 )
 
 // Zero felt constant

--- a/sync/sync.go
+++ b/sync/sync.go
@@ -149,7 +149,7 @@ func New(bc *blockchain.Blockchain, starkNetData starknetdata.StarknetData, log 
 	return s
 }
 
-// WithPlugin registers an plugin
+// WithPlugin registers a plugin
 func (s *Synchronizer) WithPlugin(plugin junoplugin.JunoPlugin) *Synchronizer {
 	s.plugin = plugin
 	return s


### PR DESCRIPTION
This pull request resolves minor typographical errors in the `felt.go` and `sync.go` files. These corrections improve the readability and accuracy of comments without affecting the functionality of the code.

### Summary of Changes
1. **`felt.go`**
   - Corrected article usage in constant descriptions (e.g., "a Element" → "an Element").
   - Improved consistency in comment formatting.

2. **`sync.go`**
   - Fixed a typo in the comment describing the `WithPlugin` function ("an plugin" → "a plugin").
