### PR TITLE
Create general variables to gain performance

### DIFF
--- a/core/block.go
+++ b/core/block.go
@@ -55,6 +55,12 @@ const (
 	Blob
 )
 
+var (
+	starknetBlockHash0 = new(felt.Felt).SetBytes([]byte("STARKNET_BLOCK_HASH0"))
+	starknetBlockHash1 = new(felt.Felt).SetBytes([]byte("STARKNET_BLOCK_HASH1"))
+	starknetGasPrices0 = new(felt.Felt).SetBytes([]byte("STARKNET_GAS_PRICES0"))
+)
+
 type GasPrice struct {
 	PriceInWei *felt.Felt
 	PriceInFri *felt.Felt
@@ -226,7 +232,7 @@ func post0134Hash(b *Block, stateDiff *StateDiff) (*felt.Felt, *BlockCommitments
 	)
 
 	return crypto.PoseidonArray(
-			new(felt.Felt).SetBytes([]byte("STARKNET_BLOCK_HASH1")),
+			starknetBlockHash1,
 			new(felt.Felt).SetUint64(b.Number),    // block number
 			b.GlobalStateRoot,                     // global state root
 			b.SequencerAddress,                    // sequencer address
@@ -284,7 +290,7 @@ func post0132Hash(b *Block, stateDiff *StateDiff) (*felt.Felt, *BlockCommitments
 	concatCounts := concatCounts(b.TransactionCount, b.EventCount, sdLength, b.L1DAMode)
 
 	return crypto.PoseidonArray(
-			new(felt.Felt).SetBytes([]byte("STARKNET_BLOCK_HASH0")),
+			starknetBlockHash0,
 			new(felt.Felt).SetUint64(b.Number),    // block number
 			b.GlobalStateRoot,                     // global state root
 			b.SequencerAddress,                    // sequencer address
@@ -398,7 +404,7 @@ func concatCounts(txCount, eventCount, stateDiffLen uint64, l1Mode L1DAMode) *fe
 
 func gasPricesHash(gasPrices, dataGasPrices, l2GasPrices GasPrice) *felt.Felt {
 	return crypto.PoseidonArray(
-		new(felt.Felt).SetBytes([]byte("STARKNET_GAS_PRICES0")),
+		starknetGasPrices0,
 		// gas prices
 		gasPrices.PriceInWei,
 		gasPrices.PriceInFri,

--- a/core/state_update.go
+++ b/core/state_update.go
@@ -39,10 +39,12 @@ func (d *StateDiff) Length() uint64 {
 	return uint64(length)
 }
 
+var starknetStateDiff0 = new(felt.Felt).SetBytes([]byte("STARKNET_STATE_DIFF0"))
+
 func (d *StateDiff) Hash() *felt.Felt {
 	digest := new(crypto.PoseidonDigest)
 
-	digest.Update(new(felt.Felt).SetBytes([]byte("STARKNET_STATE_DIFF0")))
+	digest.Update(starknetStateDiff0)
 
 	// updated_contracts = deployedContracts + replacedClasses
 	// Digest: [number_of_updated_contracts, address_0, class_hash_0, address_1, class_hash_1, ...].


### PR DESCRIPTION
This pull request includes changes to the `core/block.go` and `core/state_update.go` files to improve the performance by defining reusable constants for specific `felt.Felt` values.

* Defined reusable variables `starknetBlockHash0`, `starknetBlockHash1`, and `starknetGasPrices0` to replace inline `felt.Felt` values in `core/block.go`.
* Updated the `post0134Hash` function to use the `starknetBlockHash1` variable instead of inline `felt.Felt` value in `core/block.go`.
* Updated the `post0132Hash` function to use the `starknetBlockHash0` variable instead of inline `felt.Felt` value in `core/block.go`.
* Updated the `gasPricesHash` function to use the `starknetGasPrices0` variable instead of inline `felt.Felt` value in `core/block.go`.
* Defined a reusable variable `starknetStateDiff0` and updated the `Hash` function to use this variable instead of inline `felt.Felt` value in `core/state_update.go`.