### PR TITLE
Prevent panic in TransactionByHash for non-existent transactions

### DIFF
--- a/rpc/transaction.go
+++ b/rpc/transaction.go
@@ -440,7 +440,12 @@ func (h *Handler) TransactionByHash(hash felt.Felt) (*Transaction, *jsonrpc.Erro
 		for _, t := range pendingB.Transactions {
 			if hash.Equal(t.Hash()) {
 				txn = t
+				break
 			}
+		}
+
+		if txn == nil {
+			return nil, ErrTxnHashNotFound
 		}
 	}
 	return AdaptTransaction(txn), nil


### PR DESCRIPTION
Fixes an issue where the code could panic when attempting to adapt a nil transaction in the pending block. This ensures the function gracefully handles non-existent transactions by returning ErrTxnHashNotFound.