### PR TITLE
Skip tests BlockWithReceipts due to invalid test asserts

### DIFF
--- a/.github/workflows/starknet-go-tests.yml
+++ b/.github/workflows/starknet-go-tests.yml
@@ -31,6 +31,6 @@ jobs:
         run: go mod download
 
       - name: Test RPC on testnet
-        run: cd rpc && go test -timeout 1200s -v -env testnet .
+        run: cd rpc && go test -skip 'TestBlockWithReceipts'  -timeout 1200s -v -env testnet .
         env:
           INTEGRATION_BASE: ${{ secrets.TEST_RPC_URL }}

--- a/.github/workflows/starknet-rs-tests.yml
+++ b/.github/workflows/starknet-rs-tests.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Run jsonrpc tests
         run: |
           cd starknet-providers && cargo test jsonrpc
-          cd ../starknet-accounts && cargo test jsonrpc -- --skip can_declare_cairo0_contract_with_jsonrpc
+          cd ../starknet-accounts && cargo test jsonrpc -- --skip can_declare_cairo0_contract_with_jsonrpc --skip jsonrpc_get_block_with_receipts
         env:
           STARKNET_RPC: ${{ secrets.STARKNET_RPC }}
           RUST_BACKTRACE: full


### PR DESCRIPTION
The tests are incorrect because they expect transaction_hash in the transaction object, while the spec only requires it in the receipt. Skipping them for now in our pipeline, and will unskip them once the framework fixes the tests.