### PR TITLE
refactor: using slices.Contains to simplify the code

### DIFF
--- a/utils/slices.go
+++ b/utils/slices.go
@@ -32,10 +32,5 @@ func All[T any](slice []T, f func(T) bool) bool {
 }
 
 func AnyOf[T comparable](e T, values ...T) bool {
-	for _, v := range values {
-		if e == v {
-			return true
-		}
-	}
-	return false
+	return slices.Contains(values, e)
 }


### PR DESCRIPTION
This is a [new function](https://pkg.go.dev/slices@go1.21.0#Contains) added in the go1.21 standard library, which can make the code more concise and easy to read.