### PR TITLE
Bump golangci-lint and add linters

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -111,6 +111,7 @@ linters:
     - gci
     - exhaustruct
     - usetesting
+    - nilnesserr
 
   # don't enable:
   # - asciicheck

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -110,6 +110,7 @@ linters:
     - tparallel
     - gci
     - exhaustruct
+    - usetesting
 
   # don't enable:
   # - asciicheck

--- a/Makefile
+++ b/Makefile
@@ -94,7 +94,7 @@ install-mockgen:
 	go install go.uber.org/mock/mockgen@latest
 
 install-golangci-lint:
-	@which golangci-lint || go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.62.2
+	@which golangci-lint || go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.63.4
 
 lint: install-golangci-lint ## Run linter
 	golangci-lint run

--- a/vm/vm.go
+++ b/vm/vm.go
@@ -341,7 +341,7 @@ func (v *vm) Execute(txns []core.Transaction, declaredClasses []core.Class, paid
 	return context.actualFees, context.daGas, traces, context.executionSteps, nil
 }
 
-func marshalTxnsAndDeclaredClasses(txns []core.Transaction, declaredClasses []core.Class) (json.RawMessage, json.RawMessage, error) { //nolint:lll
+func marshalTxnsAndDeclaredClasses(txns []core.Transaction, declaredClasses []core.Class) (json.RawMessage, json.RawMessage, error) {
 	txnJSONs := make([]json.RawMessage, 0, len(txns))
 	for _, txn := range txns {
 		txnJSON, err := marshalTxn(txn)

--- a/vm/vm_test.go
+++ b/vm/vm_test.go
@@ -224,7 +224,7 @@ func TestSetVersionedConstants(t *testing.T) {
 		assert.NoError(t, err)
 	})
 	t.Run("not valid json", func(t *testing.T) {
-		fd, err := os.CreateTemp("", "versioned_constants_test*")
+		fd, err := os.CreateTemp(t.TempDir(), "versioned_constants_test*")
 		require.NoError(t, err)
 		defer os.Remove(fd.Name())
 


### PR DESCRIPTION
The most important changes include adding new linters, updating the `golangci-lint` version, and making minor adjustments to the codebase.

### Code Quality Improvements:

* Add [nilnesserr](https://github.com/alingse/nilnesserr). This linter reports that it returns a nil value error after checking some error not nil. Example:
```go
err := do()
if err != nil {
     return err
}
err2 := do2()
if err2 != nil {
    return err
}
```
* Add [UseTesting linter](https://github.com/ldez/usetesting). This linter detects functions that can be replaced by methods from the testing package. Example:
```diff
- fd, err := os.CreateTemp("", "versioned_constants_test*")
+ fd, err := os.CreateTemp(t.TempDir(), "versioned_constants_test*")
```

### Tooling Updates:

* [`Makefile`](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L97-R97): Updated `golangci-lint` to version `v1.63.4`.

### Codebase Adjustments:

* [`vm/vm.go`](diffhunk://#diff-c087fa7dffa5d472e6b7b59eb8f8bafd4208832487a1429e0fcfc38a9fe05167L344-R344): Removed the `//nolint:lll` directive from the `marshalTxnsAndDeclaredClasses` function signature.
* [`vm/vm_test.go`](diffhunk://#diff-11f0bc114469cd5519c577c6688384edf8786c307023e008682ffa72dacd8e07L227-R227): Changed the temporary directory creation for the "not valid json" test case to use `t.TempDir()` for better test isolation.