### PR TITLE
Reduce number of allocations in p2p

### DIFF
--- a/p2p/sync/client.go
+++ b/p2p/sync/client.go
@@ -82,9 +82,9 @@ func requestAndReceiveStream[ReqT proto.Message, ResT proto.Message](ctx context
 			}
 		}()
 
+		var zero ResT
+		res := zero.ProtoReflect().New().Interface()
 		for {
-			var zero ResT
-			res := zero.ProtoReflect().New().Interface()
 			if err := receiveInto(stream, res); err != nil {
 				if !errors.Is(err, io.EOF) {
 					log.Debugw("Error while reading from stream", "err", err)
@@ -96,6 +96,8 @@ func requestAndReceiveStream[ReqT proto.Message, ResT proto.Message](ctx context
 			if !yield(res.(ResT)) {
 				break
 			}
+
+			proto.Reset(res)
 		}
 	}, nil
 }


### PR DESCRIPTION
TL;DR: instead of allocating response message on every iteration we allocate it once before iterations and reset it once we done with it after each iteration

Yesterday, I was watching a video about generics and thought that this function (particularly the reflection part) could be rewritten. Unfortunately, after 10 minutes of trial and error, I didn't succeed, but at least I found a way to reduce allocations and reflection calls.