### PR TITLE
Fix `ResourceBounds` encoding

### DIFF
--- a/rpc/transaction.go
+++ b/rpc/transaction.go
@@ -164,6 +164,7 @@ type Resource uint32
 const (
 	ResourceL1Gas Resource = iota + 1
 	ResourceL2Gas
+	ResourceL1DataGas
 )
 
 func (r Resource) MarshalText() ([]byte, error) {
@@ -172,6 +173,8 @@ func (r Resource) MarshalText() ([]byte, error) {
 		return []byte("l1_gas"), nil
 	case ResourceL2Gas:
 		return []byte("l2_gas"), nil
+	case ResourceL1DataGas:
+		return []byte("l1_data_gas"), nil
 	default:
 		return nil, fmt.Errorf("unknown Resource %v", r)
 	}
@@ -183,6 +186,8 @@ func (r *Resource) UnmarshalJSON(data []byte) error {
 		*r = ResourceL1Gas
 	case `"l2_gas"`:
 		*r = ResourceL2Gas
+	case `"l1_data_gas"`:
+		*r = ResourceL1DataGas
 	default:
 		return fmt.Errorf("unknown Resource: %q", string(data))
 	}

--- a/rpc/transaction_test.go
+++ b/rpc/transaction_test.go
@@ -1365,3 +1365,54 @@ func TestTransactionStatus(t *testing.T) {
 		})
 	}
 }
+
+func TestResourceMarshalText(t *testing.T) {
+	tests := []struct {
+		resource rpc.Resource
+		text     string
+		hasError bool
+	}{
+		{rpc.ResourceL1Gas, "l1_gas", false},
+		{rpc.ResourceL2Gas, "l2_gas", false},
+		{rpc.ResourceL1DataGas, "l1_data_gas", false},
+		{rpc.Resource(999), "error", true},
+	}
+
+	for _, test := range tests {
+		t.Run(test.text, func(t *testing.T) {
+			b, err := test.resource.MarshalText()
+			if test.hasError {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, test.text, string(b))
+		})
+	}
+}
+
+func TestResourceUnmarshalText(t *testing.T) {
+	tests := []struct {
+		resource rpc.Resource
+		text     string
+		hasError bool
+	}{
+		{rpc.ResourceL1Gas, `"l1_gas"`, false},
+		{rpc.ResourceL2Gas, `"l2_gas"`, false},
+		{rpc.ResourceL1DataGas, `"l1_data_gas"`, false},
+		{rpc.Resource(999), "error", true},
+	}
+
+	for _, test := range tests {
+		t.Run(test.text, func(t *testing.T) {
+			var r rpc.Resource
+			err := r.UnmarshalText([]byte(test.text))
+			if test.hasError {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, test.resource, r)
+		})
+	}
+}

--- a/starknet/transaction.go
+++ b/starknet/transaction.go
@@ -137,6 +137,8 @@ func (r Resource) MarshalText() ([]byte, error) {
 		return []byte("L1_GAS"), nil
 	case ResourceL2Gas:
 		return []byte("L2_GAS"), nil
+	case ResourceL1DataGas:
+		return []byte("L1_DATA_GAS"), nil
 	default:
 		return nil, errors.New("unknown resource")
 	}

--- a/starknet/transaction_test.go
+++ b/starknet/transaction_test.go
@@ -43,3 +43,54 @@ func TestUnmarshalFinalityStatus(t *testing.T) {
 
 	require.ErrorContains(t, json.Unmarshal([]byte(`"ABC"`), fs), "unknown FinalityStatus")
 }
+
+func TestResourceMarshalText(t *testing.T) {
+	tests := []struct {
+		resource starknet.Resource
+		text     string
+		hasError bool
+	}{
+		{starknet.ResourceL1Gas, "L1_GAS", false},
+		{starknet.ResourceL2Gas, "L2_GAS", false},
+		{starknet.ResourceL1DataGas, "L1_DATA_GAS", false},
+		{starknet.Resource(999), "error", true},
+	}
+
+	for _, test := range tests {
+		t.Run(test.text, func(t *testing.T) {
+			b, err := test.resource.MarshalText()
+			if test.hasError {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, test.text, string(b))
+		})
+	}
+}
+
+func TestResourceUnmarshalText(t *testing.T) {
+	tests := []struct {
+		resource starknet.Resource
+		text     string
+		hasError bool
+	}{
+		{starknet.ResourceL1Gas, "L1_GAS", false},
+		{starknet.ResourceL2Gas, "L2_GAS", false},
+		{starknet.ResourceL1DataGas, "L1_DATA_GAS", false},
+		{starknet.Resource(999), "error", true},
+	}
+
+	for _, test := range tests {
+		t.Run(test.text, func(t *testing.T) {
+			var r starknet.Resource
+			err := r.UnmarshalText([]byte(test.text))
+			if test.hasError {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, test.resource, r)
+		})
+	}
+}


### PR DESCRIPTION
This pull request includes updates to the `Resource` type in the `rpc/transaction.go` and `starknet/transaction.go` files to support a new resource type, `ResourceL1DataGas`.

Enhancements to resource handling:

* [`rpc/transaction.go`](diffhunk://#diff-14aba5c63ad044ac1e8a62d96fed2cd132ad5e4935fc555a935a40c14f5cb0f7R167): Added `ResourceL1DataGas` to the `Resource` type and updated the `MarshalText` and `UnmarshalJSON` methods to handle this new resource. [[1]](diffhunk://#diff-14aba5c63ad044ac1e8a62d96fed2cd132ad5e4935fc555a935a40c14f5cb0f7R167) [[2]](diffhunk://#diff-14aba5c63ad044ac1e8a62d96fed2cd132ad5e4935fc555a935a40c14f5cb0f7R176-R177) [[3]](diffhunk://#diff-14aba5c63ad044ac1e8a62d96fed2cd132ad5e4935fc555a935a40c14f5cb0f7R189-R190)
* [`starknet/transaction.go`](diffhunk://#diff-f71e03f1230241344a665d7de14e132f82293acc9be434c549be267af62461ceR140-R141): Updated the `MarshalText` method to handle the new `ResourceL1DataGas` resource.