### PR TITLE
typo fix plugin.go

### DIFF
--- a/plugin/plugin.go
+++ b/plugin/plugin.go
@@ -36,7 +36,7 @@ func Load(pluginPath string) (JunoPlugin, error) {
 
 	pluginInstance, ok := symPlugin.(JunoPlugin)
 	if !ok {
-		return nil, fmt.Errorf("the plugin does not staisfy the required interface")
+		return nil, fmt.Errorf("the plugin does not satisfy the required interface")
 	}
 
 	return pluginInstance, pluginInstance.Init()


### PR DESCRIPTION
### Title
`typo fix plugin.go`

### Description
This pull request fixes a typo in the `plugin/plugin.go` file:
- Corrected "staisfy" to "satisfy" in the error message for improved clarity and professionalism.

### Details of Changes
- Replaced the misspelled word "staisfy" with "satisfy" in the `Load` function's error message.

### Checklist
- [x] The typo has been corrected.
- [x] Changes were reviewed for accuracy.
- [x] Documentation and code readability remain consistent with the repository's standards.

### Additional Notes
This change is minor and does not affect the functionality of the code. It ensures that error messages are clear and professional.
