### PR TITLE
Added custom type for Deployed contracts throughout the repo wherever necessary

### DIFF
--- a/adapters/p2p2core/state.go
+++ b/adapters/p2p2core/state.go
@@ -33,7 +33,7 @@ func AdaptStateDiff(reader core.StateReader, contractDiffs []*gen.ContractDiff, 
 
 	var deployedContracts, replacedClasses []addrToClassHash
 	// addr -> {key -> value, ...}
-	storageDiffs := make(map[felt.Felt]map[felt.Felt]*felt.Felt)
+	storageDiffs := make(core.StorageDiff)
 	nonces := make(map[felt.Felt]*felt.Felt)
 	for _, diff := range contractDiffs {
 		address := AdaptAddress(diff.Address)

--- a/adapters/sn2core/sn2core.go
+++ b/adapters/sn2core/sn2core.go
@@ -369,7 +369,7 @@ func AdaptStateUpdate(response *starknet.StateUpdate) (*core.StateUpdate, error)
 		stateDiff.Nonces[*addr] = nonce
 	}
 
-	stateDiff.StorageDiffs = make(map[felt.Felt]map[felt.Felt]*felt.Felt, len(response.StateDiff.StorageDiffs))
+	stateDiff.StorageDiffs = make(core.StorageDiff, len(response.StateDiff.StorageDiffs))
 	for addrStr, diffs := range response.StateDiff.StorageDiffs {
 		addr, err := new(felt.Felt).SetString(addrStr)
 		if err != nil {

--- a/adapters/sn2core/sn2core.go
+++ b/adapters/sn2core/sn2core.go
@@ -369,7 +369,7 @@ func AdaptStateUpdate(response *starknet.StateUpdate) (*core.StateUpdate, error)
 		stateDiff.Nonces[*addr] = nonce
 	}
 
-	stateDiff.StorageDiffs = make(core.StorageDiff, len(response.StateDiff.StorageDiffs))
+	stateDiff.StorageDiffs = make(map[felt.Felt]map[felt.Felt]*felt.Felt, len(response.StateDiff.StorageDiffs))
 	for addrStr, diffs := range response.StateDiff.StorageDiffs {
 		addr, err := new(felt.Felt).SetString(addrStr)
 		if err != nil {

--- a/core/state.go
+++ b/core/state.go
@@ -389,7 +389,7 @@ func (s *State) updateStorageBuffered(contractAddr *felt.Felt, updateDiff map[fe
 
 // updateContractStorages applies the diff set to the Trie of the
 // contract at the given address in the given Txn context.
-func (s *State) updateContractStorages(stateTrie *trie.Trie, diffs map[felt.Felt]map[felt.Felt]*felt.Felt,
+func (s *State) updateContractStorages(stateTrie *trie.Trie, diffs StorageDiff,
 	blockNumber uint64, logChanges bool,
 ) error {
 	type bufferedTransactionWithAddress struct {
@@ -689,7 +689,7 @@ func (s *State) GetReverseStateDiff(blockNumber uint64, diff *StateDiff) (*State
 	reversed := *diff
 
 	// storage diffs
-	reversed.StorageDiffs = make(map[felt.Felt]map[felt.Felt]*felt.Felt, len(diff.StorageDiffs))
+	reversed.StorageDiffs = make(StorageDiff, len(diff.StorageDiffs))
 	for addr, storageDiffs := range diff.StorageDiffs {
 		reversedDiffs := make(map[felt.Felt]*felt.Felt, len(storageDiffs))
 		for key := range storageDiffs {

--- a/core/state_test.go
+++ b/core/state_test.go
@@ -114,7 +114,7 @@ func TestUpdate(t *testing.T) {
 		OldRoot: su3.NewRoot,
 		NewRoot: utils.HexToFelt(t, "0x68ac0196d9b6276b8d86f9e92bca0ed9f854d06ded5b7f0b8bc0eeaa4377d9e"),
 		StateDiff: &core.StateDiff{
-			StorageDiffs: map[felt.Felt]map[felt.Felt]*felt.Felt{*scAddr: {*scKey: scValue}},
+			StorageDiffs: core.StorageDiff{*scAddr: {*scKey: scValue}},
 		},
 	}
 
@@ -143,7 +143,7 @@ func TestUpdate(t *testing.T) {
 			OldRoot: su4.NewRoot,
 			NewRoot: utils.HexToFelt(t, "0x68ac0196d9b6276b8d86f9e92bca0ed9f854d06ded5b7f0b8bc0eeaa4377d9e"),
 			StateDiff: &core.StateDiff{
-				StorageDiffs: map[felt.Felt]map[felt.Felt]*felt.Felt{*scAddr2: {*scKey: scValue}},
+				StorageDiffs: core.StorageDiff{*scAddr2: {*scKey: scValue}},
 			},
 		}
 		assert.ErrorIs(t, state.Update(5, su5, nil), core.ErrContractNotDeployed)
@@ -292,7 +292,7 @@ func TestStateHistory(t *testing.T) {
 		NewRoot: utils.HexToFelt(t, "0xac747e0ea7497dad7407ecf2baf24b1598b0b40943207fc9af8ded09a64f1c"),
 		OldRoot: su0.NewRoot,
 		StateDiff: &core.StateDiff{
-			StorageDiffs: map[felt.Felt]map[felt.Felt]*felt.Felt{
+			StorageDiffs: core.StorageDiff{
 				*contractAddr: {
 					*changedLoc: utils.HexToFelt(t, "0x44"),
 				},
@@ -560,7 +560,7 @@ func TestRevertGenesisStateDiff(t *testing.T) {
 		NewRoot:   utils.HexToFelt(t, "0xa89ee2d272016fd3708435efda2ce766692231f8c162e27065ce1607d5a9e8"),
 		OldRoot:   new(felt.Felt),
 		StateDiff: &core.StateDiff{
-			StorageDiffs: map[felt.Felt]map[felt.Felt]*felt.Felt{
+			StorageDiffs: core.StorageDiff{
 				*addr: {
 					*key: value,
 				},

--- a/core/state_update.go
+++ b/core/state_update.go
@@ -15,13 +15,15 @@ type StateUpdate struct {
 	StateDiff *StateDiff
 }
 
+type StorageDiff map[felt.Felt]map[felt.Felt]*felt.Felt
+
 type StateDiff struct {
-	StorageDiffs      map[felt.Felt]map[felt.Felt]*felt.Felt // addr -> {key -> value, ...}
-	Nonces            map[felt.Felt]*felt.Felt               // addr -> nonce
-	DeployedContracts map[felt.Felt]*felt.Felt               // addr -> class hash
-	DeclaredV0Classes []*felt.Felt                           // class hashes
-	DeclaredV1Classes map[felt.Felt]*felt.Felt               // class hash -> compiled class hash
-	ReplacedClasses   map[felt.Felt]*felt.Felt               // addr -> class hash
+	StorageDiffs      StorageDiff              // addr -> {key -> value, ...}
+	Nonces            map[felt.Felt]*felt.Felt // addr -> nonce
+	DeployedContracts map[felt.Felt]*felt.Felt // addr -> class hash
+	DeclaredV0Classes []*felt.Felt             // class hashes
+	DeclaredV1Classes map[felt.Felt]*felt.Felt // class hash -> compiled class hash
+	ReplacedClasses   map[felt.Felt]*felt.Felt // addr -> class hash
 }
 
 func (d *StateDiff) Length() uint64 {
@@ -173,7 +175,7 @@ func deprecatedDeclaredClassesDigest(declaredV0Classes []*felt.Felt, digest *cry
 	digest.Update(declaredV0Classes...)
 }
 
-func storageDiffDigest(storageDiffs map[felt.Felt]map[felt.Felt]*felt.Felt, digest *crypto.PoseidonDigest) {
+func storageDiffDigest(storageDiffs StorageDiff, digest *crypto.PoseidonDigest) {
 	numOfStorageDiffs := uint64(len(storageDiffs))
 	digest.Update(new(felt.Felt).SetUint64(numOfStorageDiffs))
 

--- a/migration/migration.go
+++ b/migration/migration.go
@@ -633,7 +633,7 @@ func changeStateDiffStruct(txn db.Transaction, key, value []byte, _ *utils.Netwo
 		return fmt.Errorf("unmarshal: %v", err)
 	}
 
-	storageDiffs := make(map[felt.Felt]map[felt.Felt]*felt.Felt, len(old.StateDiff.StorageDiffs))
+	storageDiffs := make(core.StorageDiff, len(old.StateDiff.StorageDiffs))
 	for addr, diff := range old.StateDiff.StorageDiffs {
 		newStorageDiffs := make(map[felt.Felt]*felt.Felt, len(diff))
 		for _, kv := range diff {

--- a/migration/migration_pkg_test.go
+++ b/migration/migration_pkg_test.go
@@ -671,7 +671,7 @@ func TestChangeStateDiffStruct(t *testing.T) {
 					NewRoot:   utils.HexToFelt(t, "0x1"),
 					OldRoot:   utils.HexToFelt(t, "0x2"),
 					StateDiff: &core.StateDiff{
-						StorageDiffs: map[felt.Felt]map[felt.Felt]*felt.Felt{
+						StorageDiffs: core.StorageDiff{
 							*utils.HexToFelt(t, "0x3"): {
 								*utils.HexToFelt(t, "0x4"): utils.HexToFelt(t, "0x5"),
 							},
@@ -700,7 +700,7 @@ func TestChangeStateDiffStruct(t *testing.T) {
 					NewRoot:   utils.HexToFelt(t, "0x16"),
 					OldRoot:   utils.HexToFelt(t, "0x17"),
 					StateDiff: &core.StateDiff{
-						StorageDiffs: map[felt.Felt]map[felt.Felt]*felt.Felt{
+						StorageDiffs: core.StorageDiff{
 							*utils.HexToFelt(t, "0x18"): {
 								*utils.HexToFelt(t, "0x19"): utils.HexToFelt(t, "0x20"),
 							},

--- a/sync/pending_test.go
+++ b/sync/pending_test.go
@@ -46,7 +46,7 @@ func TestPendingState(t *testing.T) {
 				Nonces: map[felt.Felt]*felt.Felt{
 					*deployedAddr: new(felt.Felt).SetUint64(44),
 				},
-				StorageDiffs: map[felt.Felt]map[felt.Felt]*felt.Felt{
+				StorageDiffs: core.StorageDiff{
 					*deployedAddr: {
 						*new(felt.Felt).SetUint64(44): new(felt.Felt).SetUint64(37),
 					},

--- a/sync/sync.go
+++ b/sync/sync.go
@@ -710,7 +710,7 @@ func (s *Synchronizer) storeEmptyPending(latestHeader *core.Header) error {
 
 func makeStateDiffForEmptyBlock(bc blockchain.Reader, blockNumber uint64) (*core.StateDiff, error) {
 	stateDiff := &core.StateDiff{
-		StorageDiffs:      make(map[felt.Felt]map[felt.Felt]*felt.Felt),
+		StorageDiffs:      make(core.StorageDiff),
 		Nonces:            make(map[felt.Felt]*felt.Felt),
 		DeployedContracts: make(map[felt.Felt]*felt.Felt),
 		DeclaredV0Classes: make([]*felt.Felt, 0),

--- a/vm/vm_test.go
+++ b/vm/vm_test.go
@@ -58,7 +58,7 @@ func TestV0Call(t *testing.T) {
 		OldRoot: utils.HexToFelt(t, "0x3d452fbb3c3a32fe85b1a3fbbcdec316d5fc940cefc028ee808ad25a15991c8"),
 		NewRoot: utils.HexToFelt(t, "0x4a948783e8786ba9d8edaf42de972213bd2deb1b50c49e36647f1fef844890f"),
 		StateDiff: &core.StateDiff{
-			StorageDiffs: map[felt.Felt]map[felt.Felt]*felt.Felt{
+			StorageDiffs: core.StorageDiff{
 				*contractAddr: {
 					*utils.HexToFelt(t, "0x206f38f7e4f15e87567361213c28f235cccdaa1d7fd34c9db1dfe9489c6a091"): new(felt.Felt).SetUint64(1337),
 				},
@@ -124,7 +124,7 @@ func TestV1Call(t *testing.T) {
 		OldRoot: utils.HexToFelt(t, "0x2650cef46c190ec6bb7dc21a5a36781132e7c883b27175e625031149d4f1a84"),
 		NewRoot: utils.HexToFelt(t, "0x7a9da0a7471a8d5118d3eefb8c26a6acbe204eb1eaa934606f4757a595fe552"),
 		StateDiff: &core.StateDiff{
-			StorageDiffs: map[felt.Felt]map[felt.Felt]*felt.Felt{
+			StorageDiffs: core.StorageDiff{
 				*contractAddr: {
 					*storageLocation: new(felt.Felt).SetUint64(37),
 				},


### PR DESCRIPTION
Fixes #2396 

This PR introduces the structure `type StorageDiff map[felt.Felt]map[felt.Felt]*felt.Felt` for refactoring `StorageDiff` initially as `map[felt.Felt]map[felt.Felt]*felt.Felt`.

It integrates the new struct throughout the repo wherever needed.