### PR TITLE
Add linters

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -112,6 +112,9 @@ linters:
     - exhaustruct
     - usetesting
     - nilnesserr
+    - prealloc
+    - makezero
+    - intrange
 
   # don't enable:
   # - asciicheck

--- a/blockchain/blockchain.go
+++ b/blockchain/blockchain.go
@@ -916,7 +916,7 @@ func removeTxsAndReceipts(txn db.Transaction, blockNumber, numTxs uint64) error 
 		Number: blockNumber,
 	}
 	// remove txs and receipts
-	for i := uint64(0); i < numTxs; i++ {
+	for i := range numTxs {
 		blockIDAndIndex.Index = i
 		reorgedTxn, err := transactionByBlockNumberAndIndex(txn, &blockIDAndIndex)
 		if err != nil {

--- a/blockchain/blockchain_test.go
+++ b/blockchain/blockchain_test.go
@@ -331,7 +331,7 @@ func TestTransactionAndReceipt(t *testing.T) {
 	client := feeder.NewTestClient(t, &utils.Mainnet)
 	gw := adaptfeeder.New(client)
 
-	for i := uint64(0); i < 3; i++ {
+	for i := range uint64(3) {
 		b, err := gw.BlockByNumber(context.Background(), i)
 		require.NoError(t, err)
 
@@ -363,7 +363,7 @@ func TestTransactionAndReceipt(t *testing.T) {
 	})
 
 	t.Run("GetTransactionByHash and GetGetTransactionByBlockNumberAndIndex return same transaction", func(t *testing.T) {
-		for i := uint64(0); i < 3; i++ {
+		for i := range uint64(3) {
 			t.Run(fmt.Sprintf("mainnet block %v", i), func(t *testing.T) {
 				block, err := gw.BlockByNumber(context.Background(), i)
 				require.NoError(t, err)
@@ -382,7 +382,7 @@ func TestTransactionAndReceipt(t *testing.T) {
 	})
 
 	t.Run("GetReceipt returns expected receipt", func(t *testing.T) {
-		for i := uint64(0); i < 3; i++ {
+		for i := range uint64(3) {
 			t.Run(fmt.Sprintf("mainnet block %v", i), func(t *testing.T) {
 				block, err := gw.BlockByNumber(context.Background(), i)
 				require.NoError(t, err)
@@ -399,7 +399,7 @@ func TestTransactionAndReceipt(t *testing.T) {
 	})
 
 	t.Run("BlockCommitments returns expected values", func(t *testing.T) {
-		for i := uint64(0); i < 3; i++ {
+		for i := range uint64(3) {
 			t.Run(fmt.Sprintf("mainnet block %v", i), func(t *testing.T) {
 				commitments, err := chain.BlockCommitmentsByNumber(i)
 				require.NoError(t, err)
@@ -425,7 +425,7 @@ func TestState(t *testing.T) {
 	})
 
 	var existingBlockHash *felt.Felt
-	for i := uint64(0); i < 2; i++ {
+	for i := range uint64(2) {
 		block, err := gw.BlockByNumber(context.Background(), i)
 		require.NoError(t, err)
 		su, err := gw.StateUpdate(context.Background(), i)
@@ -546,7 +546,7 @@ func TestEvents(t *testing.T) {
 				var accEvents []*blockchain.FilteredEvent
 				var lastToken *blockchain.ContinuationToken
 				var gotEvents []*blockchain.FilteredEvent
-				for i := 0; i < len(allEvents)+1; i++ {
+				for range len(allEvents) + 1 {
 					gotEvents, lastToken, err = filter.Events(lastToken, chunkSize)
 					require.NoError(t, err)
 					accEvents = append(accEvents, gotEvents...)
@@ -603,7 +603,7 @@ func TestRevert(t *testing.T) {
 	client := feeder.NewTestClient(t, &utils.Mainnet)
 	gw := adaptfeeder.New(client)
 
-	for i := uint64(0); i < 3; i++ {
+	for i := range uint64(3) {
 		b, err := gw.BlockByNumber(context.Background(), i)
 		require.NoError(t, err)
 

--- a/clients/feeder/feeder.go
+++ b/clients/feeder/feeder.go
@@ -232,7 +232,7 @@ func (c *Client) get(ctx context.Context, queryURL string) (io.ReadCloser, error
 	var res *http.Response
 	var err error
 	wait := time.Duration(0)
-	for i := 0; i <= c.maxRetries; i++ {
+	for range c.maxRetries + 1 {
 		select {
 		case <-ctx.Done():
 			return nil, ctx.Err()

--- a/cmd/juno/dbcmd.go
+++ b/cmd/juno/dbcmd.go
@@ -200,11 +200,10 @@ func dbSize(cmd *cobra.Command, args []string) error {
 
 		withHistoryCount    uint
 		withoutHistoryCount uint
-
-		items [][]string
 	)
 
 	buckets := db.BucketValues()
+	items := make([][]string, 0, len(buckets)+3)
 	for _, b := range buckets {
 		fmt.Fprintf(cmd.OutOrStdout(), "Calculating size of %s, remaining buckets: %d\n", b, len(db.BucketValues())-int(b)-1)
 		bucketItem, err := pebble.CalculatePrefixSize(cmd.Context(), pebbleDB.(*pebble.DB), []byte{byte(b)}, true)

--- a/cmd/juno/juno_test.go
+++ b/cmd/juno/juno_test.go
@@ -677,7 +677,7 @@ network: sepolia
 			require.True(t, len(tc.env)%2 == 0, "The number of env variables should be an even number")
 
 			if len(tc.env) > 0 {
-				for i := 0; i < len(tc.env)/2; i++ {
+				for i := range len(tc.env) / 2 {
 					require.NoError(t, os.Setenv(tc.env[2*i], tc.env[2*i+1]))
 				}
 			}
@@ -695,7 +695,7 @@ network: sepolia
 
 			assert.Equal(t, tc.expectedConfig, config)
 			if len(tc.env) > 0 {
-				for i := 0; i < len(tc.env)/2; i++ {
+				for i := range len(tc.env) / 2 {
 					require.NoError(t, os.Unsetenv(tc.env[2*i]))
 				}
 			}

--- a/core/crypto/ecdsa_test.go
+++ b/core/crypto/ecdsa_test.go
@@ -70,7 +70,7 @@ func BenchmarkVerify(b *testing.B) {
 	var verified bool
 	var err error
 	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		verified, err = publicKey.Verify(&signature, msg)
 		require.NoError(b, err)
 	}

--- a/core/crypto/pedersen_hash_test.go
+++ b/core/crypto/pedersen_hash_test.go
@@ -133,7 +133,7 @@ func BenchmarkPedersenArray(b *testing.B) {
 			randomFeltSls := genRandomFeltSls(b, i)
 			var f *felt.Felt
 			b.ResetTimer()
-			for n := 0; n < b.N; n++ {
+			for n := range b.N {
 				f = crypto.PedersenArray(randomFeltSls[n]...)
 			}
 			benchHashR = f
@@ -145,15 +145,15 @@ func BenchmarkPedersen(b *testing.B) {
 	randFelts := genRandomFeltPairs(b)
 	var f *felt.Felt
 	b.ResetTimer()
-	for n := 0; n < b.N; n++ {
+	for n := range b.N {
 		f = crypto.Pedersen(randFelts[n][0], randFelts[n][1])
 	}
 	benchHashR = f
 }
 
 func genRandomFeltSls(b *testing.B, n int) [][]*felt.Felt {
-	var randomFeltSls [][]*felt.Felt
-	for j := 0; j < b.N; j++ {
+	randomFeltSls := make([][]*felt.Felt, 0, b.N)
+	for range b.N {
 		randomFeltSls = append(randomFeltSls, genRandomFelts(b, n))
 	}
 	return randomFeltSls
@@ -161,8 +161,8 @@ func genRandomFeltSls(b *testing.B, n int) [][]*felt.Felt {
 
 func genRandomFelts(b *testing.B, n int) []*felt.Felt {
 	b.Helper()
-	var felts []*felt.Felt
-	for i := 0; i < n; i++ {
+	felts := make([]*felt.Felt, 0, n)
+	for range n {
 		f, err := new(felt.Felt).SetRandom()
 		require.NoError(b, err)
 		felts = append(felts, f)
@@ -174,7 +174,7 @@ func genRandomFeltPairs(b *testing.B) [][2]*felt.Felt {
 	b.Helper()
 	var err error
 	randFelts := make([][2]*felt.Felt, b.N)
-	for i := 0; i < b.N; i++ {
+	for i := range b.N {
 		randFelts[i][0], err = new(felt.Felt).SetRandom()
 		require.NoError(b, err)
 		randFelts[i][1], err = new(felt.Felt).SetRandom()

--- a/core/crypto/poseidon_hash.go
+++ b/core/crypto/poseidon_hash.go
@@ -45,7 +45,7 @@ func round(state []felt.Felt, full bool, index int) {
 func HadesPermutation(state []felt.Felt) {
 	initialiseRoundKeys.Do(setRoundKeys)
 	totalRounds := fullRounds + partialRounds
-	for i := 0; i < totalRounds; i++ {
+	for i := range totalRounds {
 		full := (i < fullRounds/2) || (totalRounds-i <= fullRounds/2)
 		round(state, full, i)
 	}
@@ -74,7 +74,7 @@ var one = new(felt.Felt).SetUint64(1)
 func PoseidonArray(elems ...*felt.Felt) *felt.Felt {
 	state := []felt.Felt{{}, {}, {}}
 
-	for i := 0; i < len(elems)/2; i++ {
+	for i := range len(elems) / 2 {
 		state[0].Add(&state[0], elems[2*i])
 		state[1].Add(&state[1], elems[2*i+1])
 		HadesPermutation(state)

--- a/core/crypto/poseidon_hash_test.go
+++ b/core/crypto/poseidon_hash_test.go
@@ -63,7 +63,7 @@ func BenchmarkPoseidonArray(b *testing.B) {
 			randomFeltSls := genRandomFeltSls(b, i)
 			var f *felt.Felt
 			b.ResetTimer()
-			for n := 0; n < b.N; n++ {
+			for n := range b.N {
 				f = crypto.PoseidonArray(randomFeltSls[n]...)
 			}
 			benchHashR = f
@@ -76,7 +76,7 @@ func BenchmarkPoseidon(b *testing.B) {
 
 	var f *felt.Felt
 	b.ResetTimer()
-	for n := 0; n < b.N; n++ {
+	for n := range b.N {
 		f = crypto.Poseidon(randFelts[n][0], randFelts[n][1])
 	}
 	benchHashR = f

--- a/core/receipt_test.go
+++ b/core/receipt_test.go
@@ -95,7 +95,7 @@ func BenchmarkReceiptCommitment(b *testing.B) {
 	var f *felt.Felt
 	var err error
 	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		f, err = receiptCommitment(receipts)
 		require.NoError(b, err)
 	}

--- a/core/state_update_test.go
+++ b/core/state_update_test.go
@@ -86,7 +86,7 @@ func BenchmarkStateDiffHash(b *testing.B) {
 	require.NoError(b, err)
 
 	b.ResetTimer()
-	for n := 0; n < b.N; n++ {
+	for range b.N {
 		su.StateDiff.Hash()
 	}
 }

--- a/core/trie/proof.go
+++ b/core/trie/proof.go
@@ -205,7 +205,7 @@ func VerifyRangeProof(root, first *felt.Felt, keys, values []*felt.Felt, proof *
 	}
 
 	// Ensure all keys are monotonically increasing and values contain no deletions
-	for i := 0; i < len(keys); i++ {
+	for i := range keys {
 		if i < len(keys)-1 && keys[i].Cmp(keys[i+1]) > 0 {
 			return false, errors.New("keys are not monotonic increasing")
 		}

--- a/core/trie/proof_test.go
+++ b/core/trie/proof_test.go
@@ -204,7 +204,7 @@ func TestRangeProof(t *testing.T) {
 	root, err := tr.Root()
 	require.NoError(t, err)
 
-	for i := 0; i < 100; i++ {
+	for range 100 {
 		start := rand.Intn(n)
 		end := rand.Intn(n-start) + start + 1
 
@@ -233,7 +233,7 @@ func TestRangeProofWithNonExistentProof(t *testing.T) {
 	root, err := tr.Root()
 	require.NoError(t, err)
 
-	for i := 0; i < 100; i++ {
+	for range 100 {
 		start := rand.Intn(n)
 		end := rand.Intn(n-start) + start + 1
 
@@ -403,7 +403,7 @@ func TestSingleSideRangeProof(t *testing.T) {
 
 		keys := make([]*felt.Felt, i+1)
 		values := make([]*felt.Felt, i+1)
-		for j := 0; j < i+1; j++ {
+		for j := range i + 1 {
 			keys[j] = records[j].key
 			values[j] = records[j].value
 		}
@@ -531,7 +531,7 @@ func TestBadRangeProof(t *testing.T) {
 	root, err := tr.Root()
 	require.NoError(t, err)
 
-	for i := 0; i < 100; i++ {
+	for range 100 {
 		start := rand.Intn(len(records))
 		end := rand.Intn(len(records)-start) + start + 1
 
@@ -584,7 +584,7 @@ func TestBadRangeProof(t *testing.T) {
 func BenchmarkProve(b *testing.B) {
 	tr, records := randomTrie(b, 1000)
 	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for i := range b.N {
 		proof := trie.NewProofNodeSet()
 		key := records[i%len(records)].key
 		if err := tr.Prove(key, proof); err != nil {
@@ -598,7 +598,7 @@ func BenchmarkVerifyProof(b *testing.B) {
 	root, err := tr.Root()
 	require.NoError(b, err)
 
-	var proofs []*trie.ProofNodeSet
+	proofs := make([]*trie.ProofNodeSet, 0, len(records))
 	for _, record := range records {
 		proof := trie.NewProofNodeSet()
 		if err := tr.Prove(record.key, proof); err != nil {
@@ -608,7 +608,7 @@ func BenchmarkVerifyProof(b *testing.B) {
 	}
 
 	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for i := range b.N {
 		index := i % len(records)
 		if _, err := trie.VerifyProof(root, records[index].key, proofs[index], crypto.Pedersen); err != nil {
 			b.Fatal(err)
@@ -636,7 +636,7 @@ func BenchmarkVerifyRangeProof(b *testing.B) {
 	}
 
 	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		_, err := trie.VerifyRangeProof(root, keys[0], keys, values, proof)
 		require.NoError(b, err)
 	}
@@ -784,7 +784,7 @@ func randomTrie(t testing.TB, n int) (*trie.Trie, []*keyValue) {
 	require.NoError(t, err)
 
 	records := make([]*keyValue, n)
-	for i := 0; i < n; i++ {
+	for i := range n {
 		key := new(felt.Felt).SetUint64(uint64(rrand.Uint32() + 1))
 		records[i] = &keyValue{key: key, value: key}
 		_, err := tempTrie.Put(key, key)

--- a/core/trie/trie_test.go
+++ b/core/trie/trie_test.go
@@ -164,7 +164,7 @@ func TestPutZero(t *testing.T) {
 		var keys []*felt.Felt
 
 		// put random 64 keys and record roots
-		for i := 0; i < 64; i++ {
+		for range 64 {
 			key, value := new(felt.Felt), new(felt.Felt)
 
 			_, err = key.SetRandom()
@@ -238,7 +238,7 @@ func TestTrie(t *testing.T) {
 		var keys []*felt.Felt
 
 		// put random 64 keys and record roots
-		for i := 0; i < 64; i++ {
+		for range 64 {
 			key, value := new(felt.Felt), new(felt.Felt)
 
 			_, err = key.SetRandom()
@@ -433,7 +433,7 @@ var benchTriePutR *felt.Felt
 
 func BenchmarkTriePut(b *testing.B) {
 	keys := make([]*felt.Felt, 0, b.N)
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		rnd, err := new(felt.Felt).SetRandom()
 		require.NoError(b, err)
 		keys = append(keys, rnd)
@@ -444,7 +444,7 @@ func BenchmarkTriePut(b *testing.B) {
 		var f *felt.Felt
 		var err error
 		b.ResetTimer()
-		for i := 0; i < b.N; i++ {
+		for i := range b.N {
 			f, err = t.Put(keys[i], one)
 			if err != nil {
 				return err

--- a/db/pebble/db_test.go
+++ b/db/pebble/db_test.go
@@ -342,7 +342,7 @@ func TestPrefixSearch(t *testing.T) {
 
 		assert.Equal(t, len(expectedKeys), len(entries))
 
-		for i := 0; i < len(entries); i++ {
+		for i := range entries {
 			assert.Contains(t, expectedKeys, entries[i].key)
 		}
 

--- a/jsonrpc/server.go
+++ b/jsonrpc/server.go
@@ -620,7 +620,7 @@ func (s *Server) validateParam(param reflect.Value) error {
 			return err
 		}
 	case kind == reflect.Slice || kind == reflect.Array:
-		for i := 0; i < param.Len(); i++ {
+		for i := range param.Len() {
 			if err := s.validateParam(param.Index(i)); err != nil {
 				return err
 			}

--- a/jsonrpc/server_test.go
+++ b/jsonrpc/server_test.go
@@ -562,7 +562,7 @@ func BenchmarkHandle(b *testing.B) {
 	var header http.Header
 	var err error
 	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		_, header, err = server.HandleReader(context.Background(), strings.NewReader(request))
 		require.NoError(b, err)
 		require.NotNil(b, header)

--- a/migration/migration_pkg_test.go
+++ b/migration/migration_pkg_test.go
@@ -52,7 +52,7 @@ func TestRelocateContractStorageRootKeys(t *testing.T) {
 	numberOfContracts := 5
 
 	// Populate the database with entries in the old location.
-	for i := 0; i < numberOfContracts; i++ {
+	for i := range numberOfContracts {
 		exampleBytes := new(felt.Felt).SetUint64(uint64(i)).Bytes()
 		// Use exampleBytes for the key suffix (the contract address) and the value.
 		err := txn.Set(db.Peer.Key(exampleBytes[:]), exampleBytes[:])
@@ -63,7 +63,7 @@ func TestRelocateContractStorageRootKeys(t *testing.T) {
 
 	// Each root-key entry should have been moved to its new location
 	// and the old entry should not exist.
-	for i := 0; i < numberOfContracts; i++ {
+	for i := range numberOfContracts {
 		exampleBytes := new(felt.Felt).SetUint64(uint64(i)).Bytes()
 
 		// New entry exists.
@@ -85,7 +85,7 @@ func TestRecalculateBloomFilters(t *testing.T) {
 	client := feeder.NewTestClient(t, &utils.Mainnet)
 	gw := adaptfeeder.New(client)
 
-	for i := uint64(0); i < 3; i++ {
+	for i := range uint64(3) {
 		b, err := gw.BlockByNumber(context.Background(), i)
 		require.NoError(t, err)
 		su, err := gw.StateUpdate(context.Background(), i)
@@ -99,7 +99,7 @@ func TestRecalculateBloomFilters(t *testing.T) {
 		return recalculateBloomFilters(txn, &utils.Mainnet)
 	}))
 
-	for i := uint64(0); i < 3; i++ {
+	for i := range uint64(3) {
 		b, err := chain.BlockByNumber(i)
 		require.NoError(t, err)
 		assert.Equal(t, core.EventsBloom(b.Receipts), b.EventsBloom)
@@ -193,7 +193,7 @@ func TestCalculateBlockCommitments(t *testing.T) {
 	client := feeder.NewTestClient(t, &utils.Mainnet)
 	gw := adaptfeeder.New(client)
 
-	for i := uint64(0); i < 3; i++ {
+	for i := range uint64(3) {
 		b, err := gw.BlockByNumber(context.Background(), i)
 		require.NoError(t, err)
 		su, err := gw.StateUpdate(context.Background(), i)
@@ -204,7 +204,7 @@ func TestCalculateBlockCommitments(t *testing.T) {
 	require.NoError(t, testdb.Update(func(txn db.Transaction) error {
 		return calculateBlockCommitments(txn, &utils.Mainnet)
 	}))
-	for i := uint64(0); i < 3; i++ {
+	for i := range uint64(3) {
 		b, err := chain.BlockCommitmentsByNumber(i)
 		require.NoError(t, err)
 		assert.NotNil(t, b.TransactionCommitment)
@@ -217,7 +217,7 @@ func TestL1HandlerTxns(t *testing.T) {
 	client := feeder.NewTestClient(t, &utils.Sepolia)
 	gw := adaptfeeder.New(client)
 
-	for i := uint64(0); i <= 6; i++ { // First l1 handler txn is in block 6
+	for i := range uint64(7) { // First l1 handler txn is in block 6
 		b, err := gw.BlockByNumber(context.Background(), i)
 		require.NoError(t, err)
 		su, err := gw.StateUpdate(context.Background(), i)

--- a/p2p/hashstorage/hash_storage.go
+++ b/p2p/hashstorage/hash_storage.go
@@ -16,7 +16,7 @@ var SepoliaBlockHashesMap = make(map[uint64]*felt.Felt, first0132SepoliaBlock)
 //nolint:gochecknoinits
 func init() {
 	var offset uint64
-	for i := uint64(0); i < first0132SepoliaBlock; i++ {
+	for i := range uint64(first0132SepoliaBlock) {
 		offset = i * 32
 		SepoliaBlockHashesMap[i] = new(felt.Felt).SetBytes(sepoliaBlockHashes[offset : offset+32])
 	}

--- a/rpc/block_test.go
+++ b/rpc/block_test.go
@@ -278,7 +278,7 @@ func TestBlockWithTxHashes(t *testing.T) {
 		assert.Equal(t, latestBlock.SequencerAddress, b.SequencerAddress)
 		assert.Equal(t, latestBlock.Timestamp, b.Timestamp)
 		assert.Equal(t, len(latestBlock.Transactions), len(b.TxnHashes))
-		for i := 0; i < len(latestBlock.Transactions); i++ {
+		for i := range latestBlock.Transactions {
 			assert.Equal(t, latestBlock.Transactions[i].Hash(), b.TxnHashes[i])
 		}
 	}

--- a/rpc/compiled_casm.go
+++ b/rpc/compiled_casm.go
@@ -78,7 +78,7 @@ func adaptCairo0Class(class *core.Cairo0Class) (*CasmCompiledContractClass, erro
 		return nil, err
 	}
 
-	var bytecode []*felt.Felt
+	bytecode := make([]*felt.Felt, 0, len(cairo0.Data))
 	for _, str := range cairo0.Data {
 		f, err := new(felt.Felt).SetString(str)
 		if err != nil {
@@ -92,7 +92,7 @@ func adaptCairo0Class(class *core.Cairo0Class) (*CasmCompiledContractClass, erro
 		return nil, err
 	}
 
-	var hints [][2]any // slice of 2-element tuples where first value is pc, and second value is slice of hints
+	hints := make([][2]any, 0, len(classHints)) // slice of 2-element tuples where first value is pc, and second value is slice of hints
 	for pc, hintItems := range utils.SortedMap(classHints) {
 		hints = append(hints, [2]any{pc, hintItems})
 	}

--- a/rpc/events_test.go
+++ b/rpc/events_test.go
@@ -111,7 +111,7 @@ func TestEvents(t *testing.T) {
 			var accEvents []*rpc.EmittedEvent
 			args.ChunkSize = 1
 
-			for i := 0; i < len(allEvents)+1; i++ {
+			for range len(allEvents) + 1 {
 				events, err := handler.Events(args)
 				require.Nil(t, err)
 				accEvents = append(accEvents, events.Events...)

--- a/rpc/l1.go
+++ b/rpc/l1.go
@@ -90,7 +90,7 @@ func (h *Handler) messageToL2Logs(ctx context.Context, txHash *common.Hash) ([]*
 		return nil, ErrTxnHashNotFound
 	}
 
-	var messageHashes []*common.Hash
+	messageHashes := make([]*common.Hash, 0, len(receipt.Logs))
 	for _, vLog := range receipt.Logs {
 		if common.HexToHash(vLog.Topics[0].Hex()).Cmp(logMsgToL2SigHash) != 0 {
 			continue

--- a/rpc/subscriptions_test.go
+++ b/rpc/subscriptions_test.go
@@ -162,7 +162,7 @@ func TestSubscribeEvents(t *testing.T) {
 		},
 	}
 
-	var emittedEvents []*EmittedEvent
+	emittedEvents := make([]*EmittedEvent, 0, len(filteredEvents))
 	for _, e := range filteredEvents {
 		emittedEvents = append(emittedEvents, &EmittedEvent{
 			Event: &Event{

--- a/utils/maps_test.go
+++ b/utils/maps_test.go
@@ -10,7 +10,7 @@ import (
 func TestSortedMap(t *testing.T) {
 	m := map[int]string{3: "three", 1: "one", 4: "four", 2: "two", 0: "zero"}
 
-	var keys []int
+	keys := make([]int, 0, len(m))
 	for k, v := range SortedMap(m) {
 		keys = append(keys, k)
 		assert.Equal(t, m[k], v)

--- a/utils/orderedset_test.go
+++ b/utils/orderedset_test.go
@@ -62,7 +62,7 @@ func TestOrderedSet(t *testing.T) {
 		var wg sync.WaitGroup
 
 		// Concurrent writes
-		for i := 0; i < 100; i++ {
+		for i := range 100 {
 			wg.Add(1)
 			go func(n int) {
 				defer wg.Done()
@@ -71,7 +71,7 @@ func TestOrderedSet(t *testing.T) {
 		}
 
 		// Concurrent reads
-		for i := 0; i < 50; i++ {
+		for range 50 {
 			wg.Add(1)
 			go func() {
 				defer wg.Done()
@@ -105,14 +105,14 @@ func TestOrderedSet(t *testing.T) {
 		n := 10000
 
 		// Insert elements
-		for i := 0; i < n; i++ {
+		for i := range n {
 			set.Put(i, i*2)
 		}
 
 		assert.Equal(t, n, set.Size())
 
 		// Verify all elements
-		for i := 0; i < n; i++ {
+		for i := range n {
 			val, exists := set.Get(i)
 			assert.True(t, exists)
 			assert.Equal(t, i*2, val)
@@ -121,7 +121,7 @@ func TestOrderedSet(t *testing.T) {
 		// Verify order
 		keys := set.Keys()
 		values := set.List()
-		for i := 0; i < n; i++ {
+		for i := range n {
 			assert.Equal(t, i, keys[i])
 			assert.Equal(t, i*2, values[i])
 		}

--- a/vm/trace_test.go
+++ b/vm/trace_test.go
@@ -24,7 +24,7 @@ func TestRevertReason(t *testing.T) {
 func TestAllEvents(t *testing.T) {
 	numEvents := uint64(10)
 	events := make([]vm.OrderedEvent, 0, numEvents)
-	for i := uint64(0); i < numEvents; i++ {
+	for i := range numEvents {
 		events = append(events, vm.OrderedEvent{Order: i})
 	}
 	tests := map[string]*vm.TransactionTrace{
@@ -83,7 +83,7 @@ func TestAllEvents(t *testing.T) {
 func TestAllMessages(t *testing.T) {
 	nummessages := uint64(10)
 	messages := make([]vm.OrderedL2toL1Message, 0, nummessages)
-	for i := uint64(0); i < nummessages; i++ {
+	for i := range nummessages {
 		messages = append(messages, vm.OrderedL2toL1Message{Order: i})
 	}
 	tests := map[string]*vm.TransactionTrace{


### PR DESCRIPTION
This pull request includes multiple changes aimed at improving the codebase by optimizing loops and adding new linters. The most significant changes include replacing traditional `for` loops with `range` loops, adding new linters to the configuration, and optimizing array initialization.

### Loop Optimization:

* [`blockchain/blockchain.go`](diffhunk://#diff-37b6e7ed4f299b87b357b54376123393b34ee0699fc035f25bc0621627dcc6baL919-R919): Modified `removeTxsAndReceipts` function to use `range` in the loop.
* [`blockchain/blockchain_test.go`](diffhunk://#diff-29f3c6e8d6136889adad56f05676a458cb547cd95bdc57ba71a6c2be0353123eL334-R334): Updated multiple test functions to use `range` loops instead of traditional loops. [[1]](diffhunk://#diff-29f3c6e8d6136889adad56f05676a458cb547cd95bdc57ba71a6c2be0353123eL334-R334) [[2]](diffhunk://#diff-29f3c6e8d6136889adad56f05676a458cb547cd95bdc57ba71a6c2be0353123eL366-R366) [[3]](diffhunk://#diff-29f3c6e8d6136889adad56f05676a458cb547cd95bdc57ba71a6c2be0353123eL385-R385) [[4]](diffhunk://#diff-29f3c6e8d6136889adad56f05676a458cb547cd95bdc57ba71a6c2be0353123eL402-R402) [[5]](diffhunk://#diff-29f3c6e8d6136889adad56f05676a458cb547cd95bdc57ba71a6c2be0353123eL428-R428) [[6]](diffhunk://#diff-29f3c6e8d6136889adad56f05676a458cb547cd95bdc57ba71a6c2be0353123eL549-R549) [[7]](diffhunk://#diff-29f3c6e8d6136889adad56f05676a458cb547cd95bdc57ba71a6c2be0353123eL606-R606)
* [`clients/feeder/feeder.go`](diffhunk://#diff-c7875a0a587f470324a6e4dc7813f735ddbad1e0d6ddad99bd6003a557885761L235-R235): Changed the retry loop in `get` function to use `range` for better readability.
* [`cmd/juno/juno_test.go`](diffhunk://#diff-607f63031911efee85ffef1e3a01f8b97580261ced2087e1c214866da86ff86eL650-R650): Updated environment variable handling loops to use `range`. [[1]](diffhunk://#diff-607f63031911efee85ffef1e3a01f8b97580261ced2087e1c214866da86ff86eL650-R650) [[2]](diffhunk://#diff-607f63031911efee85ffef1e3a01f8b97580261ced2087e1c214866da86ff86eL668-R668)
* `core/crypto/ecdsa_test.go`, `core/crypto/pedersen_hash_test.go`, `core/crypto/poseidon_hash_test.go`: Replaced loops in benchmark functions with `range`. [[1]](diffhunk://#diff-330620e47cf713d1802c93ef31ae10e0b52e9422bf4cbef8332503f95a4a1560L73-R73) [[2]](diffhunk://#diff-fe39021987fc6486d7e3af276e9986625ed1771b1999ba570f71bca39b8a14b9L136-R136) [[3]](diffhunk://#diff-fe39021987fc6486d7e3af276e9986625ed1771b1999ba570f71bca39b8a14b9L148-R165) [[4]](diffhunk://#diff-03b541e6685fd2a10beed4345c511e2a663feb5d18e5e9636ca1d43acf30af9cL48-R48) [[5]](diffhunk://#diff-03b541e6685fd2a10beed4345c511e2a663feb5d18e5e9636ca1d43acf30af9cL77-R77) [[6]](diffhunk://#diff-be4d61b39745b225bea50a335e79cb5389d34f0b18ffd9decaaa81f962cc9cb7L66-R66) [[7]](diffhunk://#diff-be4d61b39745b225bea50a335e79cb5389d34f0b18ffd9decaaa81f962cc9cb7L79-R79) [[8]](diffhunk://#diff-48a9b5c7983968f567ea5810f0bf47370c5d99ad3faa5983bf9653a1f81755e9L98-R98) [[9]](diffhunk://#diff-05c0ce2065703e2147be11cb771109191f9d15e0469499ea724d8e35036a84bdL89-R89)

### Linter Configuration:

* [`.golangci.yaml`](diffhunk://#diff-9917ddc9f1c3304218f7269265b746d997c5c0615478177b5fceecd33ef47cb5R115-R117): Added new linters `prealloc`, `makezero`, and `intrange` to the configuration.

### Array Initialization:

* [`cmd/juno/dbcmd.go`](diffhunk://#diff-ea52e3c121c000a4ed66d27ff35d2a09593b9f20ed2bf038c6a37ce7bfc676a1L203-R206): Optimized array initialization in `dbSize` function.
* [`core/trie/proof_test.go`](diffhunk://#diff-33acf8ac78476ffb3a59b91a6622e799fba85523285f14ac3a6db34bddb7fbfdL534-R534): Updated array initialization in multiple test functions for better performance. [[1]](diffhunk://#diff-33acf8ac78476ffb3a59b91a6622e799fba85523285f14ac3a6db34bddb7fbfdL534-R534) [[2]](diffhunk://#diff-33acf8ac78476ffb3a59b91a6622e799fba85523285f14ac3a6db34bddb7fbfdL601-R601) [[3]](diffhunk://#diff-33acf8ac78476ffb3a59b91a6622e799fba85523285f14ac3a6db34bddb7fbfdL611-R611) [[4]](diffhunk://#diff-33acf8ac78476ffb3a59b91a6622e799fba85523285f14ac3a6db34bddb7fbfdL639-R639) [[5]](diffhunk://#diff-33acf8ac78476ffb3a59b91a6622e799fba85523285f14ac3a6db34bddb7fbfdL787-R787)
* [`core/trie/trie_test.go`](diffhunk://#diff-eb1136f09e3388f45c868c2cb7f330934f685ade824a1cada8944805048720d3L436-R436): Improved array initialization in benchmark functions. [[1]](diffhunk://#diff-eb1136f09e3388f45c868c2cb7f330934f685ade824a1cada8944805048720d3L436-R436) [[2]](diffhunk://#diff-eb1136f09e3388f45c868c2cb7f330934f685ade824a1cada8944805048720d3L447-R447)