### PR TITLE
Web socket updates

### DIFF
--- a/jsonrpc/websocket.go
+++ b/jsonrpc/websocket.go
@@ -78,9 +78,7 @@ func (ws *Websocket) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Ensure we decrease the connection count when the connection closes
-	defer func() {
-		ws.connCount.Add(-1)
-	}()
+	defer ws.connCount.Add(-1)
 
 	// TODO include connection information, such as the remote address, in the logs.
 

--- a/jsonrpc/websocket.go
+++ b/jsonrpc/websocket.go
@@ -5,21 +5,29 @@ import (
 	"io"
 	"net/http"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/NethermindEth/juno/utils"
 	"github.com/coder/websocket"
 )
 
-const closeReasonMaxBytes = 125
+const (
+	closeReasonMaxBytes = 125
+	maxConns            = 2048 // TODO: an arbitrary default number, should be revisited after monitoring
+)
 
 type Websocket struct {
 	rpc        *Server
 	log        utils.SimpleLogger
 	connParams *WebsocketConnParams
 	listener   NewRequestListener
+	shutdown   <-chan struct{}
 
-	shutdown <-chan struct{}
+	// Add connection tracking
+	connCount int
+	maxConns  int
+	connMu    sync.RWMutex
 }
 
 func NewWebsocket(rpc *Server, shutdown <-chan struct{}, log utils.SimpleLogger) *Websocket {
@@ -29,8 +37,15 @@ func NewWebsocket(rpc *Server, shutdown <-chan struct{}, log utils.SimpleLogger)
 		connParams: DefaultWebsocketConnParams(),
 		listener:   &SelectiveListener{},
 		shutdown:   shutdown,
+		maxConns:   maxConns,
 	}
 
+	return ws
+}
+
+// WithMaxConnections sets the maximum number of concurrent websocket connections
+func (ws *Websocket) WithMaxConnections(max int) *Websocket {
+	ws.maxConns = max
 	return ws
 }
 
@@ -49,11 +64,29 @@ func (ws *Websocket) WithListener(listener NewRequestListener) *Websocket {
 // ServeHTTP processes an HTTP request and upgrades it to a websocket connection.
 // The connection's entire "lifetime" is spent in this function.
 func (ws *Websocket) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	// Check connection limit
+	ws.connMu.Lock()
+	if ws.connCount >= ws.maxConns {
+		ws.connMu.Unlock()
+		ws.log.Warnw("Max websocket connections reached", "maxConns", ws.maxConns)
+		http.Error(w, "Too many connections", http.StatusServiceUnavailable)
+		return
+	}
+	ws.connCount++
+	ws.connMu.Unlock()
+
 	conn, err := websocket.Accept(w, r, nil /* TODO: options */)
 	if err != nil {
 		ws.log.Errorw("Failed to upgrade connection", "err", err)
 		return
 	}
+
+	// Ensure we decrease the connection count when the connection closes
+	defer func() {
+		ws.connMu.Lock()
+		ws.connCount--
+		ws.connMu.Unlock()
+	}()
 
 	// TODO include connection information, such as the remote address, in the logs.
 

--- a/jsonrpc/websocket.go
+++ b/jsonrpc/websocket.go
@@ -44,8 +44,8 @@ func NewWebsocket(rpc *Server, shutdown <-chan struct{}, log utils.SimpleLogger)
 }
 
 // WithMaxConnections sets the maximum number of concurrent websocket connections
-func (ws *Websocket) WithMaxConnections(max int) *Websocket {
-	ws.maxConns = max
+func (ws *Websocket) WithMaxConnections(maxConns int) *Websocket {
+	ws.maxConns = maxConns
 	return ws
 }
 

--- a/jsonrpc/websocket_test.go
+++ b/jsonrpc/websocket_test.go
@@ -102,19 +102,19 @@ func TestWebsocketConnectionLimit(t *testing.T) {
 	defer httpSrv.Close()
 
 	// First connection should succeed
-	conn1, resp1, err := websocket.Dial(context.Background(), httpSrv.URL, nil)
+	conn1, resp1, err := websocket.Dial(context.Background(), httpSrv.URL, nil) //nolint:bodyclose
 	require.NoError(t, err)
 	require.Equal(t, http.StatusSwitchingProtocols, resp1.StatusCode)
 	defer conn1.Close(websocket.StatusNormalClosure, "")
 
 	// Second connection should succeed
-	conn2, resp2, err := websocket.Dial(context.Background(), httpSrv.URL, nil)
+	conn2, resp2, err := websocket.Dial(context.Background(), httpSrv.URL, nil) //nolint:bodyclose
 	require.NoError(t, err)
 	require.Equal(t, http.StatusSwitchingProtocols, resp2.StatusCode)
 	defer conn2.Close(websocket.StatusNormalClosure, "")
 
 	// Third connection should fail with 503 Service Unavailable
-	_, resp3, err := websocket.Dial(context.Background(), httpSrv.URL, nil)
+	_, resp3, err := websocket.Dial(context.Background(), httpSrv.URL, nil) //nolint:bodyclose
 	require.Error(t, err)
 	require.Equal(t, http.StatusServiceUnavailable, resp3.StatusCode)
 
@@ -122,7 +122,7 @@ func TestWebsocketConnectionLimit(t *testing.T) {
 	require.NoError(t, conn1.Close(websocket.StatusNormalClosure, ""))
 	time.Sleep(10 * time.Millisecond) // Give the server time to clean up
 
-	conn4, resp4, err := websocket.Dial(context.Background(), httpSrv.URL, nil)
+	conn4, resp4, err := websocket.Dial(context.Background(), httpSrv.URL, nil) //nolint:bodyclose
 	require.NoError(t, err)
 	require.Equal(t, http.StatusSwitchingProtocols, resp4.StatusCode)
 	require.NoError(t, conn4.Close(websocket.StatusNormalClosure, ""))

--- a/jsonrpc/websocket_test.go
+++ b/jsonrpc/websocket_test.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 
 	"github.com/NethermindEth/juno/jsonrpc"
 	"github.com/NethermindEth/juno/utils"
@@ -92,4 +93,37 @@ func TestSendFromHandler(t *testing.T) {
 	require.Equal(t, msg, string(resp1))
 
 	require.NoError(t, conn.Close(websocket.StatusNormalClosure, ""))
+}
+
+func TestWebsocketConnectionLimit(t *testing.T) {
+	rpc := jsonrpc.NewServer(1, utils.NewNopZapLogger())
+	ws := jsonrpc.NewWebsocket(rpc, nil, utils.NewNopZapLogger()).WithMaxConnections(2)
+	httpSrv := httptest.NewServer(ws)
+	defer httpSrv.Close()
+
+	// First connection should succeed
+	conn1, resp1, err := websocket.Dial(context.Background(), httpSrv.URL, nil)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusSwitchingProtocols, resp1.StatusCode)
+	defer conn1.Close(websocket.StatusNormalClosure, "")
+
+	// Second connection should succeed
+	conn2, resp2, err := websocket.Dial(context.Background(), httpSrv.URL, nil)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusSwitchingProtocols, resp2.StatusCode)
+	defer conn2.Close(websocket.StatusNormalClosure, "")
+
+	// Third connection should fail with 503 Service Unavailable
+	_, resp3, err := websocket.Dial(context.Background(), httpSrv.URL, nil)
+	require.Error(t, err)
+	require.Equal(t, http.StatusServiceUnavailable, resp3.StatusCode)
+
+	// Close one connection and try again - should succeed
+	require.NoError(t, conn1.Close(websocket.StatusNormalClosure, ""))
+	time.Sleep(10 * time.Millisecond) // Give the server time to clean up
+
+	conn4, resp4, err := websocket.Dial(context.Background(), httpSrv.URL, nil)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusSwitchingProtocols, resp4.StatusCode)
+	require.NoError(t, conn4.Close(websocket.StatusNormalClosure, ""))
 }

--- a/mocks/mock_synchronizer.go
+++ b/mocks/mock_synchronizer.go
@@ -128,6 +128,20 @@ func (mr *MockSyncReaderMockRecorder) SubscribeNewHeads() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SubscribeNewHeads", reflect.TypeOf((*MockSyncReader)(nil).SubscribeNewHeads))
 }
 
+// SubscribePending mocks base method.
+func (m *MockSyncReader) SubscribePending() sync.PendingSubscription {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "SubscribePending")
+	ret0, _ := ret[0].(sync.PendingSubscription)
+	return ret0
+}
+
+// SubscribePending indicates an expected call of SubscribePending.
+func (mr *MockSyncReaderMockRecorder) SubscribePending() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SubscribePending", reflect.TypeOf((*MockSyncReader)(nil).SubscribePending))
+}
+
 // SubscribePendingTxs mocks base method.
 func (m *MockSyncReader) SubscribePendingTxs() sync.PendingTxSubscription {
 	m.ctrl.T.Helper()

--- a/mocks/mock_synchronizer.go
+++ b/mocks/mock_synchronizer.go
@@ -142,20 +142,6 @@ func (mr *MockSyncReaderMockRecorder) SubscribePending() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SubscribePending", reflect.TypeOf((*MockSyncReader)(nil).SubscribePending))
 }
 
-// SubscribePendingTxs mocks base method.
-func (m *MockSyncReader) SubscribePendingTxs() sync.PendingTxSubscription {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "SubscribePendingTxs")
-	ret0, _ := ret[0].(sync.PendingTxSubscription)
-	return ret0
-}
-
-// SubscribePendingTxs indicates an expected call of SubscribePendingTxs.
-func (mr *MockSyncReaderMockRecorder) SubscribePendingTxs() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SubscribePendingTxs", reflect.TypeOf((*MockSyncReader)(nil).SubscribePendingTxs))
-}
-
 // SubscribeReorg mocks base method.
 func (m *MockSyncReader) SubscribeReorg() sync.ReorgSubscription {
 	m.ctrl.T.Helper()

--- a/rpc/block.go
+++ b/rpc/block.go
@@ -67,6 +67,22 @@ type BlockID struct {
 	Number  uint64
 }
 
+func (b *BlockID) IsLatest() bool {
+	return b.Latest
+}
+
+func (b *BlockID) IsPending() bool {
+	return b.Pending
+}
+
+func (b *BlockID) GetHash() *felt.Felt {
+	return b.Hash
+}
+
+func (b *BlockID) GetNumber() uint64 {
+	return b.Number
+}
+
 func (b *BlockID) UnmarshalJSON(data []byte) error {
 	if string(data) == `"latest"` {
 		b.Latest = true

--- a/rpc/handlers.go
+++ b/rpc/handlers.go
@@ -96,7 +96,6 @@ type Handler struct {
 	version      string
 	newHeads     *feed.Feed[*core.Header]
 	reorgs       *feed.Feed[*sync.ReorgBlockRange]
-	pendingTxs   *feed.Feed[[]core.Transaction]
 	pendingBlock *feed.Feed[*core.Block]
 	l1Heads      *feed.Feed[*core.L1Head]
 
@@ -182,18 +181,15 @@ func (h *Handler) WithGateway(gatewayClient Gateway) *Handler {
 func (h *Handler) Run(ctx context.Context) error {
 	newHeadsSub := h.syncReader.SubscribeNewHeads().Subscription
 	reorgsSub := h.syncReader.SubscribeReorg().Subscription
-	pendingTxsSub := h.syncReader.SubscribePendingTxs().Subscription
 	l1HeadsSub := h.bcReader.SubscribeL1Head().Subscription
 	pendingBlock := h.syncReader.SubscribePending().Subscription
 	defer newHeadsSub.Unsubscribe()
 	defer reorgsSub.Unsubscribe()
-	defer pendingTxsSub.Unsubscribe()
 	defer l1HeadsSub.Unsubscribe()
 	defer pendingBlock.Unsubscribe()
 
 	feed.Tee(newHeadsSub, h.newHeads)
 	feed.Tee(reorgsSub, h.reorgs)
-	feed.Tee(pendingTxsSub, h.pendingTxs)
 	feed.Tee(l1HeadsSub, h.l1Heads)
 	feed.Tee(pendingBlock, h.pendingBlock)
 

--- a/rpc/handlers.go
+++ b/rpc/handlers.go
@@ -134,11 +134,11 @@ func New(bcReader blockchain.Reader, syncReader sync.Reader, virtualMachine vm.V
 			}
 			return n
 		},
-		version:    version,
-		newHeads:   feed.New[*core.Header](),
-		reorgs:     feed.New[*sync.ReorgBlockRange](),
-		pendingTxs: feed.New[[]core.Transaction](),
-		l1Heads:    feed.New[*core.L1Head](),
+		version:      version,
+		newHeads:     feed.New[*core.Header](),
+		reorgs:       feed.New[*sync.ReorgBlockRange](),
+		pendingBlock: feed.New[*core.Block](),
+		l1Heads:      feed.New[*core.L1Head](),
 
 		blockTraceCache: lru.NewCache[traceCacheKey, []TracedBlockTransaction](traceCacheSize),
 		filterLimit:     math.MaxUint,

--- a/rpc/handlers.go
+++ b/rpc/handlers.go
@@ -70,7 +70,6 @@ var (
 	ErrInvalidSubscriptionID           = &jsonrpc.Error{Code: 66, Message: "Invalid subscription id"}
 	ErrTooManyAddressesInFilter        = &jsonrpc.Error{Code: 67, Message: "Too many addresses in filter sender_address filter"}
 	ErrTooManyBlocksBack               = &jsonrpc.Error{Code: 68, Message: fmt.Sprintf("Cannot go back more than %v blocks", maxBlocksBack)}
-	ErrCallOnPending                   = &jsonrpc.Error{Code: 69, Message: "This method does not support being called on the pending block"}
 )
 
 const (

--- a/rpc/helpers.go
+++ b/rpc/helpers.go
@@ -60,22 +60,34 @@ func (h *Handler) blockByID(id *BlockID) (*core.Block, *jsonrpc.Error) {
 	return block, nil
 }
 
-func (h *Handler) blockHeaderByID(id *BlockID) (*core.Header, *jsonrpc.Error) {
+func (h *Handler) blockHeaderByID(id blockID) (*core.Header, *jsonrpc.Error) {
 	var header *core.Header
 	var err error
-	switch {
-	case id.Latest:
-		header, err = h.bcReader.HeadsHeader()
-	case id.Hash != nil:
-		header, err = h.bcReader.BlockHeaderByHash(id.Hash)
-	case id.Pending:
-		var pending *sync.Pending
-		pending, err = h.syncReader.Pending()
-		if err == nil {
-			header = pending.Block.Header
+	switch id := id.(type) {
+	case *BlockID:
+		switch {
+		case id.Latest:
+			header, err = h.bcReader.HeadsHeader()
+		case id.Hash != nil:
+			header, err = h.bcReader.BlockHeaderByHash(id.Hash)
+		case id.Pending:
+			var pending *sync.Pending
+			pending, err = h.syncReader.Pending()
+			if err == nil {
+				header = pending.Block.Header
+			}
+		default:
+			header, err = h.bcReader.BlockHeaderByNumber(id.Number)
 		}
-	default:
-		header, err = h.bcReader.BlockHeaderByNumber(id.Number)
+	case *SubscriptionBlockID:
+		switch {
+		case id.Latest:
+			header, err = h.bcReader.HeadsHeader()
+		case id.Hash != nil:
+			header, err = h.bcReader.BlockHeaderByHash(id.Hash)
+		default:
+			header, err = h.bcReader.BlockHeaderByNumber(id.Number)
+		}
 	}
 
 	if err != nil {

--- a/rpc/helpers.go
+++ b/rpc/helpers.go
@@ -60,34 +60,23 @@ func (h *Handler) blockByID(id *BlockID) (*core.Block, *jsonrpc.Error) {
 	return block, nil
 }
 
-func (h *Handler) blockHeaderByID(id blockID) (*core.Header, *jsonrpc.Error) {
+func (h *Handler) blockHeaderByID(id BlockIdentifier) (*core.Header, *jsonrpc.Error) {
 	var header *core.Header
 	var err error
-	switch id := id.(type) {
-	case *BlockID:
-		switch {
-		case id.Latest:
-			header, err = h.bcReader.HeadsHeader()
-		case id.Hash != nil:
-			header, err = h.bcReader.BlockHeaderByHash(id.Hash)
-		case id.Pending:
-			var pending *sync.Pending
-			pending, err = h.syncReader.Pending()
-			if err == nil {
-				header = pending.Block.Header
-			}
-		default:
-			header, err = h.bcReader.BlockHeaderByNumber(id.Number)
+
+	switch {
+	case id.IsLatest():
+		header, err = h.bcReader.HeadsHeader()
+	case id.GetHash() != nil:
+		header, err = h.bcReader.BlockHeaderByHash(id.GetHash())
+	case id.IsPending():
+		var pending *sync.Pending
+		pending, err = h.syncReader.Pending()
+		if err == nil {
+			header = pending.Block.Header
 		}
-	case *SubscriptionBlockID:
-		switch {
-		case id.Latest:
-			header, err = h.bcReader.HeadsHeader()
-		case id.Hash != nil:
-			header, err = h.bcReader.BlockHeaderByHash(id.Hash)
-		default:
-			header, err = h.bcReader.BlockHeaderByNumber(id.Number)
-		}
+	default:
+		header, err = h.bcReader.BlockHeaderByNumber(id.GetNumber())
 	}
 
 	if err != nil {

--- a/rpc/subscriptions.go
+++ b/rpc/subscriptions.go
@@ -47,10 +47,6 @@ func (h *Handler) SubscribeEvents(ctx context.Context, fromAddr *felt.Felt, keys
 		return nil, ErrTooManyKeysInFilter
 	}
 
-	if blockID != nil && blockID.Pending {
-		return nil, ErrCallOnPending
-	}
-
 	requestedHeader, headHeader, rpcErr := h.resolveBlockRange(blockID)
 	if rpcErr != nil {
 		return nil, rpcErr
@@ -365,10 +361,6 @@ func (h *Handler) SubscribeNewHeads(ctx context.Context, blockID *BlockID) (*Sub
 	w, ok := jsonrpc.ConnFromContext(ctx)
 	if !ok {
 		return nil, jsonrpc.Err(jsonrpc.MethodNotFound, nil)
-	}
-
-	if blockID != nil && blockID.Pending {
-		return nil, ErrCallOnPending
 	}
 
 	startHeader, latestHeader, rpcErr := h.resolveBlockRange(blockID)

--- a/rpc/subscriptions.go
+++ b/rpc/subscriptions.go
@@ -152,19 +152,19 @@ func (h *Handler) SubscribeEvents(ctx context.Context, fromAddr *felt.Felt, keys
 					// trying to resend the event should be of no consequences and the map can be safely emptied.
 					h.processEvents(subscriptionCtx, w, id, header.Number, header.Number, fromAddr, keys, eventsPreviouslySent)
 
-					b, err := h.bcReader.BlockByNumber(header.Number)
+					block, err := h.bcReader.BlockByNumber(header.Number)
 					if err != nil {
 						h.log.Warnw("Error retrieving block", "block number", header.Number, "err", err)
 						return
 					}
 
-					for i, r := range b.Receipts {
+					for i, r := range block.Receipts {
 						for _, e := range r.Events {
 							fe := blockchain.FilteredEvent{
 								Event:           e,
 								BlockNumber:     header.Number,
 								BlockHash:       header.Hash,
-								TransactionHash: b.Transactions[i].Hash(),
+								TransactionHash: block.Transactions[i].Hash(),
 							}
 
 							delete(eventsPreviouslySent, fe)

--- a/rpc/subscriptions_test.go
+++ b/rpc/subscriptions_test.go
@@ -83,7 +83,7 @@ func TestSubscribeEvents(t *testing.T) {
 
 		keys := make([][]felt.Felt, 1)
 		fromAddr := new(felt.Felt).SetBytes([]byte("from_address"))
-		blockID := &BlockID{Number: 0}
+		blockID := &SubscriptionBlockID{Number: 0}
 
 		serverConn, _ := net.Pipe()
 		t.Cleanup(func() {
@@ -178,7 +178,7 @@ func TestSubscribeEvents(t *testing.T) {
 
 		ctx, cancel := context.WithCancel(context.Background())
 		subCtx := context.WithValue(ctx, jsonrpc.ConnKey{}, &fakeConn{w: serverConn})
-		id, rpcErr := handler.SubscribeEvents(subCtx, fromAddr, keys, &BlockID{Number: b1.Number})
+		id, rpcErr := handler.SubscribeEvents(subCtx, fromAddr, keys, &SubscriptionBlockID{Number: b1.Number})
 		require.Nil(t, rpcErr)
 
 		var marshalledResponses [][]byte
@@ -226,7 +226,7 @@ func TestSubscribeEvents(t *testing.T) {
 
 		ctx, cancel := context.WithCancel(context.Background())
 		subCtx := context.WithValue(ctx, jsonrpc.ConnKey{}, &fakeConn{w: serverConn})
-		id, rpcErr := handler.SubscribeEvents(subCtx, fromAddr, keys, &BlockID{Number: b1.Number})
+		id, rpcErr := handler.SubscribeEvents(subCtx, fromAddr, keys, &SubscriptionBlockID{Number: b1.Number})
 		require.Nil(t, rpcErr)
 
 		var marshalledResponses [][]byte
@@ -549,7 +549,7 @@ func TestSubscribeNewHeads(t *testing.T) {
 		mockSyncer := mocks.NewMockSyncReader(mockCtrl)
 		handler := New(mockChain, mockSyncer, nil, "", log)
 
-		blockID := &BlockID{Number: 0}
+		blockID := &SubscriptionBlockID{Number: 0}
 
 		serverConn, _ := net.Pipe()
 		t.Cleanup(func() {

--- a/rpc/subscriptions_test.go
+++ b/rpc/subscriptions_test.go
@@ -7,7 +7,6 @@ import (
 	"io"
 	"net"
 	"net/http/httptest"
-	"reflect"
 	"testing"
 	"time"
 
@@ -1132,56 +1131,4 @@ func marshalSubEventsResp(e *EmittedEvent, id uint64) ([]byte, error) {
 			"result":          e,
 		},
 	})
-}
-
-func TestEventEquality(t *testing.T) {
-	e1 := &Event{
-		From: new(felt.Felt).SetUint64(1),
-		Keys: []*felt.Felt{new(felt.Felt).SetUint64(2), new(felt.Felt).SetUint64(3)},
-		Data: []*felt.Felt{new(felt.Felt).SetUint64(4), new(felt.Felt).SetUint64(3)},
-	}
-
-	e2 := &Event{
-		From: new(felt.Felt).SetUint64(1),
-		Keys: []*felt.Felt{new(felt.Felt).SetUint64(2), new(felt.Felt).SetUint64(3)},
-		Data: []*felt.Felt{new(felt.Felt).SetUint64(4), new(felt.Felt).SetUint64(3)},
-	}
-
-	assert.True(t, reflect.DeepEqual(e1, e2))
-
-	e3 := &core.Event{
-		From: new(felt.Felt).SetUint64(1),
-		Keys: []*felt.Felt{new(felt.Felt).SetUint64(2), new(felt.Felt).SetUint64(3)},
-		Data: []*felt.Felt{new(felt.Felt).SetUint64(4), new(felt.Felt).SetUint64(3)},
-	}
-
-	e4 := &core.Event{
-		From: new(felt.Felt).SetUint64(1),
-		Keys: []*felt.Felt{new(felt.Felt).SetUint64(2), new(felt.Felt).SetUint64(3)},
-		Data: []*felt.Felt{new(felt.Felt).SetUint64(4), new(felt.Felt).SetUint64(3)},
-	}
-
-	assert.True(t, reflect.DeepEqual(e3, e4))
-
-	bn1 := uint64(10)
-	ee1 := EmittedEvent{
-		Event:           e1,
-		BlockNumber:     &bn1,
-		BlockHash:       new(felt.Felt).SetBytes([]byte("b hash")),
-		TransactionHash: new(felt.Felt).SetBytes([]byte("tx hash")),
-	}
-
-	bn2 := uint64(10)
-	ee2 := EmittedEvent{
-		Event:           e2,
-		BlockNumber:     &bn2,
-		BlockHash:       new(felt.Felt).SetBytes([]byte("b hash")),
-		TransactionHash: new(felt.Felt).SetBytes([]byte("tx hash")),
-	}
-
-	assert.True(t, reflect.DeepEqual(ee1, ee2))
-	// assert.True(t, *ee1.Event.Data == *ee2.Event.Data)
-	assert.True(t, *ee1.BlockNumber == *ee2.BlockNumber)
-	assert.True(t, *ee1.BlockHash == *ee2.BlockHash)
-	assert.True(t, *ee1.TransactionHash == *ee2.TransactionHash)
 }

--- a/rpc/subscriptions_test.go
+++ b/rpc/subscriptions_test.go
@@ -163,7 +163,7 @@ func TestSubscribeEvents(t *testing.T) {
 
 		mockChain.EXPECT().HeadsHeader().Return(&core.Header{Number: b1.Number}, nil)
 		mockChain.EXPECT().BlockHeaderByNumber(b1.Number).Return(b1.Header, nil)
-		mockChain.EXPECT().EventFilter(fromAddr, keys).Return(mockEventFilterer, nil)
+		mockChain.EXPECT().EventFilter(gomock.Any(), gomock.Any()).Return(mockEventFilterer, nil)
 
 		mockEventFilterer.EXPECT().SetRangeEndBlockByNumber(gomock.Any(), gomock.Any()).Return(nil).MaxTimes(2)
 		mockEventFilterer.EXPECT().Events(gomock.Any(), gomock.Any()).Return(filteredEvents, nil, nil)
@@ -207,7 +207,7 @@ func TestSubscribeEvents(t *testing.T) {
 
 		mockChain.EXPECT().HeadsHeader().Return(&core.Header{Number: b1.Number}, nil)
 		mockChain.EXPECT().BlockHeaderByNumber(b1.Number).Return(b1.Header, nil)
-		mockChain.EXPECT().EventFilter(fromAddr, keys).Return(mockEventFilterer, nil)
+		mockChain.EXPECT().EventFilter(gomock.Any(), gomock.Any()).Return(mockEventFilterer, nil)
 
 		cToken := new(blockchain.ContinuationToken)
 		mockEventFilterer.EXPECT().SetRangeEndBlockByNumber(gomock.Any(), gomock.Any()).Return(nil).MaxTimes(2)
@@ -257,7 +257,7 @@ func TestSubscribeEvents(t *testing.T) {
 		handler.pendingBlock = pendingFeed
 
 		mockChain.EXPECT().HeadsHeader().Return(&core.Header{Number: b1.Number}, nil)
-		mockChain.EXPECT().EventFilter(fromAddr, keys).Return(mockEventFilterer, nil)
+		mockChain.EXPECT().EventFilter(gomock.Any(), gomock.Any()).Return(mockEventFilterer, nil)
 
 		mockEventFilterer.EXPECT().SetRangeEndBlockByNumber(gomock.Any(), gomock.Any()).Return(nil).MaxTimes(2)
 		mockEventFilterer.EXPECT().Events(gomock.Any(), gomock.Any()).Return([]*blockchain.FilteredEvent{filteredEvents[0]}, nil, nil)
@@ -283,7 +283,7 @@ func TestSubscribeEvents(t *testing.T) {
 		assert.Equal(t, string(resp), string(got))
 
 		// Pending block events, due to the use of mocks events which were sent before are resent.
-		mockChain.EXPECT().EventFilter(fromAddr, keys).Return(mockEventFilterer, nil)
+		mockChain.EXPECT().EventFilter(gomock.Any(), gomock.Any()).Return(mockEventFilterer, nil)
 
 		mockEventFilterer.EXPECT().SetRangeEndBlockByNumber(gomock.Any(), gomock.Any()).Return(nil).MaxTimes(2)
 		mockEventFilterer.EXPECT().Events(gomock.Any(), gomock.Any()).Return([]*blockchain.FilteredEvent{filteredEvents[1]}, nil, nil)
@@ -298,7 +298,7 @@ func TestSubscribeEvents(t *testing.T) {
 		require.NoError(t, err)
 		assert.Equal(t, string(resp), string(got))
 
-		mockChain.EXPECT().EventFilter(fromAddr, keys).Return(mockEventFilterer, nil)
+		mockChain.EXPECT().EventFilter(gomock.Any(), gomock.Any()).Return(mockEventFilterer, nil)
 
 		mockEventFilterer.EXPECT().SetRangeEndBlockByNumber(gomock.Any(), gomock.Any()).Return(nil).MaxTimes(2)
 		mockEventFilterer.EXPECT().Events(gomock.Any(), gomock.Any()).Return([]*blockchain.

--- a/rpc/subscriptions_test.go
+++ b/rpc/subscriptions_test.go
@@ -862,12 +862,14 @@ func TestSubscribePendingTxs(t *testing.T) {
 		hash4 := new(felt.Felt).SetUint64(4)
 		hash5 := new(felt.Felt).SetUint64(5)
 
-		syncer.pendingTxs.Send([]core.Transaction{
-			&core.InvokeTransaction{TransactionHash: hash1, SenderAddress: addr1},
-			&core.DeclareTransaction{TransactionHash: hash2, SenderAddress: addr2},
-			&core.DeployTransaction{TransactionHash: hash3},
-			&core.DeployAccountTransaction{DeployTransaction: core.DeployTransaction{TransactionHash: hash4}},
-			&core.L1HandlerTransaction{TransactionHash: hash5},
+		syncer.pending.Send(&core.Block{
+			Transactions: []core.Transaction{
+				&core.InvokeTransaction{TransactionHash: hash1, SenderAddress: addr1},
+				&core.DeclareTransaction{TransactionHash: hash2, SenderAddress: addr2},
+				&core.DeployTransaction{TransactionHash: hash3},
+				&core.DeployAccountTransaction{DeployTransaction: core.DeployTransaction{TransactionHash: hash4}},
+				&core.L1HandlerTransaction{TransactionHash: hash5},
+			},
 		})
 
 		want := `{"jsonrpc":"2.0","method":"starknet_subscriptionPendingTransactions","params":{"result":["0x1","0x2","0x3","0x4","0x5"],"subscription_id":%d}}`
@@ -902,14 +904,16 @@ func TestSubscribePendingTxs(t *testing.T) {
 		hash7 := new(felt.Felt).SetUint64(7)
 		addr7 := new(felt.Felt).SetUint64(77)
 
-		syncer.pendingTxs.Send([]core.Transaction{
-			&core.InvokeTransaction{TransactionHash: hash1, SenderAddress: addr1},
-			&core.DeclareTransaction{TransactionHash: hash2, SenderAddress: addr2},
-			&core.DeployTransaction{TransactionHash: hash3},
-			&core.DeployAccountTransaction{DeployTransaction: core.DeployTransaction{TransactionHash: hash4}},
-			&core.L1HandlerTransaction{TransactionHash: hash5},
-			&core.InvokeTransaction{TransactionHash: hash6, SenderAddress: addr6},
-			&core.DeclareTransaction{TransactionHash: hash7, SenderAddress: addr7},
+		syncer.pending.Send(&core.Block{
+			Transactions: []core.Transaction{
+				&core.InvokeTransaction{TransactionHash: hash1, SenderAddress: addr1},
+				&core.DeclareTransaction{TransactionHash: hash2, SenderAddress: addr2},
+				&core.DeployTransaction{TransactionHash: hash3},
+				&core.DeployAccountTransaction{DeployTransaction: core.DeployTransaction{TransactionHash: hash4}},
+				&core.L1HandlerTransaction{TransactionHash: hash5},
+				&core.InvokeTransaction{TransactionHash: hash6, SenderAddress: addr6},
+				&core.DeclareTransaction{TransactionHash: hash7, SenderAddress: addr7},
+			},
 		})
 
 		want := `{"jsonrpc":"2.0","method":"starknet_subscriptionPendingTransactions","params":{"result":["0x1","0x2"],"subscription_id":%d}}`
@@ -928,21 +932,23 @@ func TestSubscribePendingTxs(t *testing.T) {
 		got := sendWsMessage(t, ctx, conn, subMsg)
 		require.Equal(t, subResp(id), got)
 
-		syncer.pendingTxs.Send([]core.Transaction{
-			&core.InvokeTransaction{
-				TransactionHash:       new(felt.Felt).SetUint64(1),
-				CallData:              []*felt.Felt{new(felt.Felt).SetUint64(2)},
-				TransactionSignature:  []*felt.Felt{new(felt.Felt).SetUint64(3)},
-				MaxFee:                new(felt.Felt).SetUint64(4),
-				ContractAddress:       new(felt.Felt).SetUint64(5),
-				Version:               new(core.TransactionVersion).SetUint64(3),
-				EntryPointSelector:    new(felt.Felt).SetUint64(6),
-				Nonce:                 new(felt.Felt).SetUint64(7),
-				SenderAddress:         new(felt.Felt).SetUint64(8),
-				ResourceBounds:        map[core.Resource]core.ResourceBounds{},
-				Tip:                   9,
-				PaymasterData:         []*felt.Felt{new(felt.Felt).SetUint64(10)},
-				AccountDeploymentData: []*felt.Felt{new(felt.Felt).SetUint64(11)},
+		syncer.pending.Send(&core.Block{
+			Transactions: []core.Transaction{
+				&core.InvokeTransaction{
+					TransactionHash:       new(felt.Felt).SetUint64(1),
+					CallData:              []*felt.Felt{new(felt.Felt).SetUint64(2)},
+					TransactionSignature:  []*felt.Felt{new(felt.Felt).SetUint64(3)},
+					MaxFee:                new(felt.Felt).SetUint64(4),
+					ContractAddress:       new(felt.Felt).SetUint64(5),
+					Version:               new(core.TransactionVersion).SetUint64(3),
+					EntryPointSelector:    new(felt.Felt).SetUint64(6),
+					Nonce:                 new(felt.Felt).SetUint64(7),
+					SenderAddress:         new(felt.Felt).SetUint64(8),
+					ResourceBounds:        map[core.Resource]core.ResourceBounds{},
+					Tip:                   9,
+					PaymasterData:         []*felt.Felt{new(felt.Felt).SetUint64(10)},
+					AccountDeploymentData: []*felt.Felt{new(felt.Felt).SetUint64(11)},
+				},
 			},
 		})
 

--- a/rpc/subscriptions_test.go
+++ b/rpc/subscriptions_test.go
@@ -510,6 +510,7 @@ type fakeSyncer struct {
 	newHeads   *feed.Feed[*core.Header]
 	reorgs     *feed.Feed[*sync.ReorgBlockRange]
 	pendingTxs *feed.Feed[[]core.Transaction]
+	pending    *feed.Feed[*core.Block]
 }
 
 func newFakeSyncer() *fakeSyncer {
@@ -517,6 +518,7 @@ func newFakeSyncer() *fakeSyncer {
 		newHeads:   feed.New[*core.Header](),
 		reorgs:     feed.New[*sync.ReorgBlockRange](),
 		pendingTxs: feed.New[[]core.Transaction](),
+		pending:    feed.New[*core.Block](),
 	}
 }
 
@@ -530,6 +532,10 @@ func (fs *fakeSyncer) SubscribeReorg() sync.ReorgSubscription {
 
 func (fs *fakeSyncer) SubscribePendingTxs() sync.PendingTxSubscription {
 	return sync.PendingTxSubscription{Subscription: fs.pendingTxs.Subscribe()}
+}
+
+func (fs *fakeSyncer) SubscribePending() sync.PendingSubscription {
+	return sync.PendingSubscription{Subscription: fs.pending.Subscribe()}
 }
 
 func (fs *fakeSyncer) StartingBlockNumber() (uint64, error) {

--- a/rpc/subscriptions_test.go
+++ b/rpc/subscriptions_test.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"net"
 	"net/http/httptest"
+	"reflect"
 	"testing"
 	"time"
 
@@ -1131,4 +1132,56 @@ func marshalSubEventsResp(e *EmittedEvent, id uint64) ([]byte, error) {
 			"result":          e,
 		},
 	})
+}
+
+func TestEventEquality(t *testing.T) {
+	e1 := &Event{
+		From: new(felt.Felt).SetUint64(1),
+		Keys: []*felt.Felt{new(felt.Felt).SetUint64(2), new(felt.Felt).SetUint64(3)},
+		Data: []*felt.Felt{new(felt.Felt).SetUint64(4), new(felt.Felt).SetUint64(3)},
+	}
+
+	e2 := &Event{
+		From: new(felt.Felt).SetUint64(1),
+		Keys: []*felt.Felt{new(felt.Felt).SetUint64(2), new(felt.Felt).SetUint64(3)},
+		Data: []*felt.Felt{new(felt.Felt).SetUint64(4), new(felt.Felt).SetUint64(3)},
+	}
+
+	assert.True(t, reflect.DeepEqual(e1, e2))
+
+	e3 := &core.Event{
+		From: new(felt.Felt).SetUint64(1),
+		Keys: []*felt.Felt{new(felt.Felt).SetUint64(2), new(felt.Felt).SetUint64(3)},
+		Data: []*felt.Felt{new(felt.Felt).SetUint64(4), new(felt.Felt).SetUint64(3)},
+	}
+
+	e4 := &core.Event{
+		From: new(felt.Felt).SetUint64(1),
+		Keys: []*felt.Felt{new(felt.Felt).SetUint64(2), new(felt.Felt).SetUint64(3)},
+		Data: []*felt.Felt{new(felt.Felt).SetUint64(4), new(felt.Felt).SetUint64(3)},
+	}
+
+	assert.True(t, reflect.DeepEqual(e3, e4))
+
+	bn1 := uint64(10)
+	ee1 := EmittedEvent{
+		Event:           e1,
+		BlockNumber:     &bn1,
+		BlockHash:       new(felt.Felt).SetBytes([]byte("b hash")),
+		TransactionHash: new(felt.Felt).SetBytes([]byte("tx hash")),
+	}
+
+	bn2 := uint64(10)
+	ee2 := EmittedEvent{
+		Event:           e2,
+		BlockNumber:     &bn2,
+		BlockHash:       new(felt.Felt).SetBytes([]byte("b hash")),
+		TransactionHash: new(felt.Felt).SetBytes([]byte("tx hash")),
+	}
+
+	assert.True(t, reflect.DeepEqual(ee1, ee2))
+	// assert.True(t, *ee1.Event.Data == *ee2.Event.Data)
+	assert.True(t, *ee1.BlockNumber == *ee2.BlockNumber)
+	assert.True(t, *ee1.BlockHash == *ee2.BlockHash)
+	assert.True(t, *ee1.TransactionHash == *ee2.TransactionHash)
 }

--- a/rpc/subscriptions_test.go
+++ b/rpc/subscriptions_test.go
@@ -207,7 +207,7 @@ func TestSubscribeEvents(t *testing.T) {
 
 		mockChain.EXPECT().HeadsHeader().Return(&core.Header{Number: b1.Number}, nil)
 		mockChain.EXPECT().BlockHeaderByNumber(b1.Number).Return(b1.Header, nil)
-		mockChain.EXPECT().EventFilter(gomock.Any(), gomock.Any()).Return(mockEventFilterer, nil)
+		mockChain.EXPECT().EventFilter(fromAddr, keys).Return(mockEventFilterer, nil)
 
 		mockEventFilterer.EXPECT().SetRangeEndBlockByNumber(gomock.Any(), gomock.Any()).Return(nil).MaxTimes(2)
 		mockEventFilterer.EXPECT().Events(gomock.Any(), gomock.Any()).Return(filteredEvents, nil, nil)
@@ -251,7 +251,7 @@ func TestSubscribeEvents(t *testing.T) {
 
 		mockChain.EXPECT().HeadsHeader().Return(&core.Header{Number: b1.Number}, nil)
 		mockChain.EXPECT().BlockHeaderByNumber(b1.Number).Return(b1.Header, nil)
-		mockChain.EXPECT().EventFilter(gomock.Any(), gomock.Any()).Return(mockEventFilterer, nil)
+		mockChain.EXPECT().EventFilter(fromAddr, keys).Return(mockEventFilterer, nil)
 
 		cToken := new(blockchain.ContinuationToken)
 		mockEventFilterer.EXPECT().SetRangeEndBlockByNumber(gomock.Any(), gomock.Any()).Return(nil).MaxTimes(2)
@@ -301,7 +301,7 @@ func TestSubscribeEvents(t *testing.T) {
 		handler.pendingBlock = pendingFeed
 
 		mockChain.EXPECT().HeadsHeader().Return(&core.Header{Number: b1.Number}, nil)
-		mockChain.EXPECT().EventFilter(gomock.Any(), gomock.Any()).Return(mockEventFilterer, nil)
+		mockChain.EXPECT().EventFilter(fromAddr, keys).Return(mockEventFilterer, nil)
 
 		mockEventFilterer.EXPECT().SetRangeEndBlockByNumber(gomock.Any(), gomock.Any()).Return(nil).MaxTimes(2)
 		mockEventFilterer.EXPECT().Events(gomock.Any(), gomock.Any()).Return([]*blockchain.FilteredEvent{filteredEvents[0]}, nil, nil)
@@ -327,7 +327,7 @@ func TestSubscribeEvents(t *testing.T) {
 		assert.Equal(t, string(resp), string(got))
 
 		// Pending block events, due to the use of mocks events which were sent before are resent.
-		mockChain.EXPECT().EventFilter(gomock.Any(), gomock.Any()).Return(mockEventFilterer, nil)
+		mockChain.EXPECT().EventFilter(fromAddr, keys).Return(mockEventFilterer, nil)
 
 		mockEventFilterer.EXPECT().SetRangeEndBlockByNumber(gomock.Any(), gomock.Any()).Return(nil).MaxTimes(2)
 		mockEventFilterer.EXPECT().Events(gomock.Any(), gomock.Any()).Return([]*blockchain.FilteredEvent{filteredEvents[1]}, nil, nil)
@@ -342,7 +342,7 @@ func TestSubscribeEvents(t *testing.T) {
 		require.NoError(t, err)
 		assert.Equal(t, string(resp), string(got))
 
-		mockChain.EXPECT().EventFilter(gomock.Any(), gomock.Any()).Return(mockEventFilterer, nil)
+		mockChain.EXPECT().EventFilter(fromAddr, keys).Return(mockEventFilterer, nil)
 
 		mockEventFilterer.EXPECT().SetRangeEndBlockByNumber(gomock.Any(), gomock.Any()).Return(nil).MaxTimes(2)
 		mockEventFilterer.EXPECT().Events(gomock.Any(), gomock.Any()).Return([]*blockchain.

--- a/rpc/subscriptions_test.go
+++ b/rpc/subscriptions_test.go
@@ -507,18 +507,16 @@ func TestSubscribeTxnStatus(t *testing.T) {
 }
 
 type fakeSyncer struct {
-	newHeads   *feed.Feed[*core.Header]
-	reorgs     *feed.Feed[*sync.ReorgBlockRange]
-	pendingTxs *feed.Feed[[]core.Transaction]
-	pending    *feed.Feed[*core.Block]
+	newHeads *feed.Feed[*core.Header]
+	reorgs   *feed.Feed[*sync.ReorgBlockRange]
+	pending  *feed.Feed[*core.Block]
 }
 
 func newFakeSyncer() *fakeSyncer {
 	return &fakeSyncer{
-		newHeads:   feed.New[*core.Header](),
-		reorgs:     feed.New[*sync.ReorgBlockRange](),
-		pendingTxs: feed.New[[]core.Transaction](),
-		pending:    feed.New[*core.Block](),
+		newHeads: feed.New[*core.Header](),
+		reorgs:   feed.New[*sync.ReorgBlockRange](),
+		pending:  feed.New[*core.Block](),
 	}
 }
 
@@ -528,10 +526,6 @@ func (fs *fakeSyncer) SubscribeNewHeads() sync.HeaderSubscription {
 
 func (fs *fakeSyncer) SubscribeReorg() sync.ReorgSubscription {
 	return sync.ReorgSubscription{Subscription: fs.reorgs.Subscribe()}
-}
-
-func (fs *fakeSyncer) SubscribePendingTxs() sync.PendingTxSubscription {
-	return sync.PendingTxSubscription{Subscription: fs.pendingTxs.Subscribe()}
 }
 
 func (fs *fakeSyncer) SubscribePending() sync.PendingSubscription {

--- a/rpc/subscriptions_test.go
+++ b/rpc/subscriptions_test.go
@@ -436,9 +436,9 @@ func TestSubscribeTxnStatus(t *testing.T) {
 		mockSyncer := mocks.NewMockSyncReader(mockCtrl)
 		handler := New(mockChain, mockSyncer, nil, "", log)
 		handler.WithFeeder(client)
-		l2Feed := feed.New[*core.Header]()
+		pendingFeed := feed.New[*core.Block]()
 		l1Feed := feed.New[*core.L1Head]()
-		handler.newHeads = l2Feed
+		handler.pendingBlock = pendingFeed
 		handler.l1Heads = l1Feed
 
 		block, err := gw.BlockByNumber(context.Background(), 38748)
@@ -475,7 +475,7 @@ func TestSubscribeTxnStatus(t *testing.T) {
 		mockChain.EXPECT().Receipt(txHash).Return(block.Receipts[0], block.Hash, block.Number, nil)
 		mockChain.EXPECT().L1Head().Return(nil, db.ErrKeyNotFound)
 
-		l2Feed.Send(&core.Header{Number: block.Number + 1})
+		pendingFeed.Send(&core.Block{Header: &core.Header{Number: block.Number + 1}})
 
 		b, err = TxnStatusAcceptedOnL2.MarshalText()
 		require.NoError(t, err)

--- a/rpc/subscriptions_test.go
+++ b/rpc/subscriptions_test.go
@@ -72,30 +72,6 @@ func TestSubscribeEvents(t *testing.T) {
 		assert.Equal(t, ErrTooManyKeysInFilter, rpcErr)
 	})
 
-	t.Run("Return error if called on pending block", func(t *testing.T) {
-		mockCtrl := gomock.NewController(t)
-		t.Cleanup(mockCtrl.Finish)
-
-		mockChain := mocks.NewMockReader(mockCtrl)
-		mockSyncer := mocks.NewMockSyncReader(mockCtrl)
-		handler := New(mockChain, mockSyncer, nil, "", log)
-
-		keys := make([][]felt.Felt, 1)
-		fromAddr := new(felt.Felt).SetBytes([]byte("from_address"))
-		blockID := &BlockID{Pending: true}
-
-		serverConn, _ := net.Pipe()
-		t.Cleanup(func() {
-			require.NoError(t, serverConn.Close())
-		})
-
-		subCtx := context.WithValue(context.Background(), jsonrpc.ConnKey{}, &fakeConn{w: serverConn})
-
-		id, rpcErr := handler.SubscribeEvents(subCtx, fromAddr, keys, blockID)
-		assert.Zero(t, id)
-		assert.Equal(t, ErrCallOnPending, rpcErr)
-	})
-
 	t.Run("Return error if block is too far back", func(t *testing.T) {
 		mockCtrl := gomock.NewController(t)
 		t.Cleanup(mockCtrl.Finish)
@@ -563,26 +539,6 @@ func (fs *fakeSyncer) PendingState() (core.StateReader, func() error, error) { r
 
 func TestSubscribeNewHeads(t *testing.T) {
 	log := utils.NewNopZapLogger()
-
-	t.Run("Return error if called on pending block", func(t *testing.T) {
-		mockCtrl := gomock.NewController(t)
-		t.Cleanup(mockCtrl.Finish)
-
-		mockChain := mocks.NewMockReader(mockCtrl)
-		mockSyncer := mocks.NewMockSyncReader(mockCtrl)
-		handler := New(mockChain, mockSyncer, nil, "", log)
-
-		serverConn, _ := net.Pipe()
-		t.Cleanup(func() {
-			require.NoError(t, serverConn.Close())
-		})
-
-		subCtx := context.WithValue(context.Background(), jsonrpc.ConnKey{}, &fakeConn{w: serverConn})
-
-		id, rpcErr := handler.SubscribeNewHeads(subCtx, &BlockID{Pending: true})
-		assert.Zero(t, id)
-		assert.Equal(t, ErrCallOnPending, rpcErr)
-	})
 
 	t.Run("Return error if block is too far back", func(t *testing.T) {
 		mockCtrl := gomock.NewController(t)

--- a/sync/sync.go
+++ b/sync/sync.go
@@ -70,7 +70,6 @@ type Reader interface {
 	HighestBlockHeader() *core.Header
 	SubscribeNewHeads() HeaderSubscription
 	SubscribeReorg() ReorgSubscription
-	SubscribePendingTxs() PendingTxSubscription
 	SubscribePending() PendingSubscription
 
 	Pending() (*Pending, error)
@@ -95,10 +94,6 @@ func (n *NoopSynchronizer) SubscribeNewHeads() HeaderSubscription {
 
 func (n *NoopSynchronizer) SubscribeReorg() ReorgSubscription {
 	return ReorgSubscription{feed.New[*ReorgBlockRange]().Subscribe()}
-}
-
-func (n *NoopSynchronizer) SubscribePendingTxs() PendingTxSubscription {
-	return PendingTxSubscription{feed.New[[]core.Transaction]().Subscribe()}
 }
 
 func (n *NoopSynchronizer) SubscribePending() PendingSubscription {
@@ -127,7 +122,6 @@ type Synchronizer struct {
 	highestBlockHeader  atomic.Pointer[core.Header]
 	newHeads            *feed.Feed[*core.Header]
 	reorgFeed           *feed.Feed[*ReorgBlockRange]
-	pendingTxsFeed      *feed.Feed[[]core.Transaction]
 	pendingFeed         *feed.Feed[*core.Block]
 
 	log      utils.SimpleLogger
@@ -151,7 +145,7 @@ func New(bc *blockchain.Blockchain, starkNetData starknetdata.StarknetData, log 
 		log:                 log,
 		newHeads:            feed.New[*core.Header](),
 		reorgFeed:           feed.New[*ReorgBlockRange](),
-		pendingTxsFeed:      feed.New[[]core.Transaction](),
+		pendingFeed:         feed.New[*core.Block](),
 		pendingPollInterval: pendingPollInterval,
 		listener:            &SelectiveListener{},
 		readOnlyBlockchain:  readOnlyBlockchain,
@@ -603,10 +597,6 @@ func (s *Synchronizer) SubscribeReorg() ReorgSubscription {
 	return ReorgSubscription{s.reorgFeed.Subscribe()}
 }
 
-func (s *Synchronizer) SubscribePendingTxs() PendingTxSubscription {
-	return PendingTxSubscription{s.pendingTxsFeed.Subscribe()}
-}
-
 func (s *Synchronizer) SubscribePending() PendingSubscription {
 	return PendingSubscription{s.pendingFeed.Subscribe()}
 }
@@ -641,7 +631,7 @@ func (s *Synchronizer) StorePending(p *Pending) error {
 	s.pending.Store(p)
 
 	// send the pending transactions to the feed
-	s.pendingTxsFeed.Send(p.Block.Transactions)
+	s.pendingFeed.Send(p.Block)
 
 	return nil
 }

--- a/sync/sync.go
+++ b/sync/sync.go
@@ -46,6 +46,10 @@ type PendingTxSubscription struct {
 	*feed.Subscription[[]core.Transaction]
 }
 
+type PendingSubscription struct {
+	*feed.Subscription[*core.Block]
+}
+
 // ReorgBlockRange represents data about reorganised blocks, starting and ending block number and hash
 type ReorgBlockRange struct {
 	// StartBlockHash is the hash of the first known block of the orphaned chain
@@ -67,6 +71,7 @@ type Reader interface {
 	SubscribeNewHeads() HeaderSubscription
 	SubscribeReorg() ReorgSubscription
 	SubscribePendingTxs() PendingTxSubscription
+	SubscribePending() PendingSubscription
 
 	Pending() (*Pending, error)
 	PendingBlock() *core.Block
@@ -96,6 +101,10 @@ func (n *NoopSynchronizer) SubscribePendingTxs() PendingTxSubscription {
 	return PendingTxSubscription{feed.New[[]core.Transaction]().Subscribe()}
 }
 
+func (n *NoopSynchronizer) SubscribePending() PendingSubscription {
+	return PendingSubscription{feed.New[*core.Block]().Subscribe()}
+}
+
 func (n *NoopSynchronizer) PendingBlock() *core.Block {
 	return nil
 }
@@ -119,6 +128,7 @@ type Synchronizer struct {
 	newHeads            *feed.Feed[*core.Header]
 	reorgFeed           *feed.Feed[*ReorgBlockRange]
 	pendingTxsFeed      *feed.Feed[[]core.Transaction]
+	pendingFeed         *feed.Feed[*core.Block]
 
 	log      utils.SimpleLogger
 	listener EventListener
@@ -595,6 +605,10 @@ func (s *Synchronizer) SubscribeReorg() ReorgSubscription {
 
 func (s *Synchronizer) SubscribePendingTxs() PendingTxSubscription {
 	return PendingTxSubscription{s.pendingTxsFeed.Subscribe()}
+}
+
+func (s *Synchronizer) SubscribePending() PendingSubscription {
+	return PendingSubscription{s.pendingFeed.Subscribe()}
 }
 
 // StorePending stores a pending block given that it is for the next height

--- a/sync/sync.go
+++ b/sync/sync.go
@@ -630,7 +630,6 @@ func (s *Synchronizer) StorePending(p *Pending) error {
 	}
 	s.pending.Store(p)
 
-	// send the pending transactions to the feed
 	s.pendingFeed.Send(p.Block)
 
 	return nil

--- a/sync/sync_test.go
+++ b/sync/sync_test.go
@@ -286,7 +286,7 @@ func TestSubscribeNewHeads(t *testing.T) {
 	sub.Unsubscribe()
 }
 
-func TestSubscribePendingTxs(t *testing.T) {
+func TestSubscribePending(t *testing.T) {
 	t.Parallel()
 
 	client := feeder.NewTestClient(t, &utils.Mainnet)
@@ -298,15 +298,15 @@ func TestSubscribePendingTxs(t *testing.T) {
 	synchronizer := sync.New(bc, gw, log, time.Millisecond*100, false, testDB)
 	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
 
-	sub := synchronizer.SubscribePendingTxs()
+	sub := synchronizer.SubscribePending()
 
 	require.NoError(t, synchronizer.Run(ctx))
 	cancel()
 
 	pending, err := synchronizer.Pending()
 	require.NoError(t, err)
-	pendingTxs, ok := <-sub.Recv()
+	pendingBlock, ok := <-sub.Recv()
 	require.True(t, ok)
-	require.Equal(t, pending.Block.Transactions, pendingTxs)
+	require.Equal(t, pending.Block, pendingBlock)
 	sub.Unsubscribe()
 }


### PR DESCRIPTION
This PR introduces the most recent changes to websocket specs, please see each commit.

Todo:
- Fix sending of pending events. Currently, only when a new block is added the latest events are sent, however, there cannot be any duplicates and we need to make sure that the events are sent once the pending block is updated.
- Add subscription block id, so users cannot call ws subscription with `blockID = pending`.
- Add max websocket connections