### PR TITLE
remove block_id from starknet_subscribeTransactionStatus

### DIFF
--- a/rpc/handlers.go
+++ b/rpc/handlers.go
@@ -366,7 +366,7 @@ func (h *Handler) Methods() ([]jsonrpc.Method, string) { //nolint: funlen
 		},
 		{
 			Name:    "starknet_subscribeTransactionStatus",
-			Params:  []jsonrpc.Parameter{{Name: "transaction_hash"}, {Name: "block_id", Optional: true}},
+			Params:  []jsonrpc.Parameter{{Name: "transaction_hash"}},
 			Handler: h.SubscribeTransactionStatus,
 		},
 		{

--- a/rpc/subscriptions.go
+++ b/rpc/subscriptions.go
@@ -108,20 +108,12 @@ func (h *Handler) SubscribeEvents(ctx context.Context, fromAddr *felt.Felt, keys
 // The optional block_id parameter is ignored, as status changes are not stored and historical data cannot be sent.
 //
 //nolint:gocyclo,funlen
-func (h *Handler) SubscribeTransactionStatus(ctx context.Context, txHash felt.Felt, blockID *BlockID) (*SubscriptionID,
+func (h *Handler) SubscribeTransactionStatus(ctx context.Context, txHash felt.Felt) (*SubscriptionID,
 	*jsonrpc.Error,
 ) {
 	w, ok := jsonrpc.ConnFromContext(ctx)
 	if !ok {
 		return nil, jsonrpc.Err(jsonrpc.MethodNotFound, nil)
-	}
-
-	// resolveBlockRange is only used to make sure that the requested block id is not older than 1024 block and check
-	// if the requested block is found. The range is inconsequential since we assume the provided transaction hash
-	// of a transaction is included in the block range: latest/pending - 1024.
-	_, _, rpcErr := h.resolveBlockRange(blockID)
-	if rpcErr != nil {
-		return nil, rpcErr
 	}
 
 	// If the error is transaction not found that means the transaction has not been submitted to the feeder gateway,

--- a/rpc/subscriptions_test.go
+++ b/rpc/subscriptions_test.go
@@ -341,7 +341,6 @@ func TestSubscribeTxnStatus(t *testing.T) {
 		mockSyncer := mocks.NewMockSyncReader(mockCtrl)
 		handler := New(mockChain, mockSyncer, nil, "", log)
 
-		mockChain.EXPECT().HeadsHeader().Return(&core.Header{Number: 1}, nil)
 		mockChain.EXPECT().TransactionByHash(txHash).Return(nil, db.ErrKeyNotFound).AnyTimes()
 		mockSyncer.EXPECT().PendingBlock().Return(nil).AnyTimes()
 
@@ -355,45 +354,6 @@ func TestSubscribeTxnStatus(t *testing.T) {
 		id, rpcErr := handler.SubscribeTransactionStatus(subCtx, *txHash)
 		assert.Nil(t, id)
 		assert.Equal(t, ErrTxnHashNotFound, rpcErr)
-	})
-
-	t.Run("Return error if block is too far back", func(t *testing.T) {
-		mockCtrl := gomock.NewController(t)
-		t.Cleanup(mockCtrl.Finish)
-
-		mockChain := mocks.NewMockReader(mockCtrl)
-		mockSyncer := mocks.NewMockSyncReader(mockCtrl)
-		handler := New(mockChain, mockSyncer, nil, "", log)
-
-		blockID := &BlockID{Number: 0}
-
-		serverConn, _ := net.Pipe()
-		t.Cleanup(func() {
-			require.NoError(t, serverConn.Close())
-		})
-
-		subCtx := context.WithValue(context.Background(), jsonrpc.ConnKey{}, &fakeConn{w: serverConn})
-
-		// Note the end of the window doesn't need to be tested because if requested block number is more than the
-		// head, a block not found error will be returned. This behaviour has been tested in various other tests, and we
-		// don't need to test it here again.
-		t.Run("head is 1024", func(t *testing.T) {
-			mockChain.EXPECT().HeadsHeader().Return(&core.Header{Number: 1024}, nil)
-			mockChain.EXPECT().BlockHeaderByNumber(blockID.Number).Return(&core.Header{Number: 0}, nil)
-
-			id, rpcErr := handler.SubscribeTransactionStatus(subCtx, *txHash)
-			assert.Zero(t, id)
-			assert.Equal(t, ErrTooManyBlocksBack, rpcErr)
-		})
-
-		t.Run("head is more than 1024", func(t *testing.T) {
-			mockChain.EXPECT().HeadsHeader().Return(&core.Header{Number: 2024}, nil)
-			mockChain.EXPECT().BlockHeaderByNumber(blockID.Number).Return(&core.Header{Number: 0}, nil)
-
-			id, rpcErr := handler.SubscribeTransactionStatus(subCtx, *txHash)
-			assert.Zero(t, id)
-			assert.Equal(t, ErrTooManyBlocksBack, rpcErr)
-		})
 	})
 
 	t.Run("Transaction status is final", func(t *testing.T) {
@@ -416,7 +376,6 @@ func TestSubscribeTxnStatus(t *testing.T) {
 			txHash, err := new(felt.Felt).SetString("0x1111")
 			require.NoError(t, err)
 
-			mockChain.EXPECT().HeadsHeader().Return(&core.Header{Number: 1}, nil)
 			mockChain.EXPECT().TransactionByHash(txHash).Return(nil, db.ErrKeyNotFound)
 			mockSyncer.EXPECT().PendingBlock().Return(nil)
 
@@ -447,7 +406,6 @@ func TestSubscribeTxnStatus(t *testing.T) {
 			txHash, err := new(felt.Felt).SetString("0x1010")
 			require.NoError(t, err)
 
-			mockChain.EXPECT().HeadsHeader().Return(&core.Header{Number: 1}, nil)
 			mockChain.EXPECT().TransactionByHash(txHash).Return(nil, db.ErrKeyNotFound)
 			mockSyncer.EXPECT().PendingBlock().Return(nil)
 
@@ -496,7 +454,6 @@ func TestSubscribeTxnStatus(t *testing.T) {
 		txHash, err := new(felt.Felt).SetString("0x1001")
 		require.NoError(t, err)
 
-		mockChain.EXPECT().HeadsHeader().Return(&core.Header{Number: block.Number}, nil)
 		mockChain.EXPECT().TransactionByHash(txHash).Return(nil, db.ErrKeyNotFound)
 		mockSyncer.EXPECT().PendingBlock().Return(nil)
 

--- a/rpc/subscriptions_test.go
+++ b/rpc/subscriptions_test.go
@@ -352,7 +352,7 @@ func TestSubscribeTxnStatus(t *testing.T) {
 
 		subCtx := context.WithValue(context.Background(), jsonrpc.ConnKey{}, &fakeConn{w: serverConn})
 
-		id, rpcErr := handler.SubscribeTransactionStatus(subCtx, *txHash, nil)
+		id, rpcErr := handler.SubscribeTransactionStatus(subCtx, *txHash)
 		assert.Nil(t, id)
 		assert.Equal(t, ErrTxnHashNotFound, rpcErr)
 	})
@@ -381,7 +381,7 @@ func TestSubscribeTxnStatus(t *testing.T) {
 			mockChain.EXPECT().HeadsHeader().Return(&core.Header{Number: 1024}, nil)
 			mockChain.EXPECT().BlockHeaderByNumber(blockID.Number).Return(&core.Header{Number: 0}, nil)
 
-			id, rpcErr := handler.SubscribeTransactionStatus(subCtx, *txHash, blockID)
+			id, rpcErr := handler.SubscribeTransactionStatus(subCtx, *txHash)
 			assert.Zero(t, id)
 			assert.Equal(t, ErrTooManyBlocksBack, rpcErr)
 		})
@@ -390,7 +390,7 @@ func TestSubscribeTxnStatus(t *testing.T) {
 			mockChain.EXPECT().HeadsHeader().Return(&core.Header{Number: 2024}, nil)
 			mockChain.EXPECT().BlockHeaderByNumber(blockID.Number).Return(&core.Header{Number: 0}, nil)
 
-			id, rpcErr := handler.SubscribeTransactionStatus(subCtx, *txHash, blockID)
+			id, rpcErr := handler.SubscribeTransactionStatus(subCtx, *txHash)
 			assert.Zero(t, id)
 			assert.Equal(t, ErrTooManyBlocksBack, rpcErr)
 		})
@@ -422,7 +422,7 @@ func TestSubscribeTxnStatus(t *testing.T) {
 
 			ctx, cancel := context.WithCancel(context.Background())
 			subCtx := context.WithValue(ctx, jsonrpc.ConnKey{}, &fakeConn{w: serverConn})
-			id, rpcErr := handler.SubscribeTransactionStatus(subCtx, *txHash, nil)
+			id, rpcErr := handler.SubscribeTransactionStatus(subCtx, *txHash)
 			require.Nil(t, rpcErr)
 
 			b, err := TxnStatusRejected.MarshalText()
@@ -453,7 +453,7 @@ func TestSubscribeTxnStatus(t *testing.T) {
 
 			ctx, cancel := context.WithCancel(context.Background())
 			subCtx := context.WithValue(ctx, jsonrpc.ConnKey{}, &fakeConn{w: serverConn})
-			id, rpcErr := handler.SubscribeTransactionStatus(subCtx, *txHash, nil)
+			id, rpcErr := handler.SubscribeTransactionStatus(subCtx, *txHash)
 			require.Nil(t, rpcErr)
 
 			b, err := TxnStatusAcceptedOnL1.MarshalText()
@@ -502,7 +502,7 @@ func TestSubscribeTxnStatus(t *testing.T) {
 
 		ctx, cancel := context.WithCancel(context.Background())
 		subCtx := context.WithValue(ctx, jsonrpc.ConnKey{}, &fakeConn{w: serverConn})
-		id, rpcErr := handler.SubscribeTransactionStatus(subCtx, *txHash, nil)
+		id, rpcErr := handler.SubscribeTransactionStatus(subCtx, *txHash)
 		require.Nil(t, rpcErr)
 
 		b, err := TxnStatusReceived.MarshalText()


### PR DESCRIPTION
This PR removes the `BlockID` parameter from `starknet_subscribeTransactionStatus` method

spec: https://github.com/starkware-libs/starknet-specs/blob/v0.8.0-rc2/api/starknet_ws_api.json#L134