### PR TITLE
Move starknet_getStorageProof method from RPC v0.7 to v0.8

### DIFF
--- a/rpc/handlers.go
+++ b/rpc/handlers.go
@@ -277,6 +277,16 @@ func (h *Handler) Methods() ([]jsonrpc.Method, string) { //nolint: funlen
 			Handler: h.StorageAt,
 		},
 		{
+			Name: "starknet_getStorageProof",
+			Params: []jsonrpc.Parameter{
+				{Name: "block_id"},
+				{Name: "class_hashes", Optional: true},
+				{Name: "contract_addresses", Optional: true},
+				{Name: "contracts_storage_keys", Optional: true},
+			},
+			Handler: h.StorageProof,
+		},
+		{
 			Name:    "starknet_getClassHashAt",
 			Params:  []jsonrpc.Parameter{{Name: "block_id"}, {Name: "contract_address"}},
 			Handler: h.ClassHashAt,
@@ -459,16 +469,6 @@ func (h *Handler) MethodsV0_7() ([]jsonrpc.Method, string) { //nolint: funlen
 			Name:    "starknet_getStorageAt",
 			Params:  []jsonrpc.Parameter{{Name: "contract_address"}, {Name: "key"}, {Name: "block_id"}},
 			Handler: h.StorageAt,
-		},
-		{
-			Name: "starknet_getStorageProof",
-			Params: []jsonrpc.Parameter{
-				{Name: "block_id"},
-				{Name: "class_hashes", Optional: true},
-				{Name: "contract_addresses", Optional: true},
-				{Name: "contracts_storage_keys", Optional: true},
-			},
-			Handler: h.StorageProof,
 		},
 		{
 			Name:    "starknet_getClassHashAt",


### PR DESCRIPTION
According to the Starknet spec, starknet_getStorageProof should be part of RPC v0.8 and does not exist in v0.7. This PR moves the method to the correct version for spec compliance.