### PR TITLE
Fix positional optional params

### DIFF
--- a/jsonrpc/server.go
+++ b/jsonrpc/server.go
@@ -116,9 +116,9 @@ type Method struct {
 	// Set upon successful registration.
 	needsContext bool
 
-	// The number of optional parameters in the method.
+	// The number of required parameters in the method.
 	// Set upon successful registration.
-	optionalCount int
+	requiredParamCount int
 }
 
 type Server struct {
@@ -202,13 +202,13 @@ func (s *Server) registerMethod(method Method) error {
 		return errors.New("second return value must be a http.Header for 3 tuple handler")
 	}
 
-	optionalCount := 0
+	requiredParamCount := 0
 	for _, param := range method.Params {
-		if param.Optional {
-			optionalCount++
+		if !param.Optional {
+			requiredParamCount++
 		}
 	}
-	method.optionalCount = optionalCount
+	method.requiredParamCount = requiredParamCount
 
 	// The method is valid. Mutate the appropriate fields and register on the server.
 	s.methods[method.Name] = method
@@ -547,8 +547,7 @@ func (s *Server) buildArguments(ctx context.Context, params any, method Method) 
 		paramsList := params.([]any)
 
 		// Ensure that the number of provided parameters is between required and total parameters
-		requiredParams := len(method.Params) - method.optionalCount
-		if len(paramsList) < requiredParams || len(paramsList) > len(method.Params) {
+		if len(paramsList) < method.requiredParamCount || len(paramsList) > len(method.Params) {
 			return nil, errors.New("missing/unexpected params in list")
 		}
 

--- a/jsonrpc/server_test.go
+++ b/jsonrpc/server_test.go
@@ -181,6 +181,18 @@ func TestHandle(t *testing.T) {
 				return 0, nil
 			},
 		},
+		{
+			Name: "multipleOptionalParams",
+			Params: []jsonrpc.Parameter{
+				{Name: "param1"},
+				{Name: "param2"},
+				{Name: "param3", Optional: true},
+				{Name: "param4", Optional: true},
+			},
+			Handler: func(param1 *int, param2 []int, param3 *int, param4 []int) (int, *jsonrpc.Error) {
+				return 0, nil
+			},
+		},
 	}
 
 	listener := CountingEventListener{}
@@ -217,10 +229,6 @@ func TestHandle(t *testing.T) {
 		"no params": {
 			req: `{"jsonrpc" : "2.0", "method" : "method", "id" : 5}`,
 			res: `{"jsonrpc":"2.0","error":{"code":-32602,"message":"Invalid Params","data":"missing non-optional param field"},"id":5}`,
-		},
-		"missing param(s)": {
-			req: `{"jsonrpc" : "2.0", "method" : "method", "params" : [3, false] , "id" : 3}`,
-			res: `{"jsonrpc":"2.0","error":{"code":-32602,"message":"Invalid Params","data":"missing/unexpected params in list"},"id":3}`,
 		},
 		"too many params": {
 			req: `{"jsonrpc" : "2.0", "method" : "method", "params" : [3, false, "error message", "too many"] , "id" : 3}`,
@@ -488,6 +496,14 @@ func TestHandle(t *testing.T) {
 		},
 		"null optional param": {
 			req: `{"jsonrpc": "2.0", "method": "singleOptionalParam", "id": 1}`,
+			res: `{"jsonrpc":"2.0","result":0,"id":1}`,
+		},
+		"empty multiple optional params": {
+			req: `{"jsonrpc": "2.0", "method": "multipleOptionalParams", "params": {"param1": 1, "param2": [2, 3]}, "id": 1}`,
+			res: `{"jsonrpc":"2.0","result":0,"id":1}`,
+		},
+		"empty multiple optional positional params": {
+			req: `{"jsonrpc": "2.0", "method": "multipleOptionalParams", "params": [1, [2, 3]], "id": 1}`,
 			res: `{"jsonrpc":"2.0","result":0,"id":1}`,
 		},
 	}


### PR DESCRIPTION
This PR fixes optional parameters in positional format.

How to reproduce:
```
{
    "jsonrpc": "2.0",
    "method": "starknet_getStorageProof",
    "params": [
        "latest"
    ],
    "id": 0
}
```

Expected behaviour:
- Return a valid output

Actual behaviour:
```
"error": {
    "code": -32602,
    "message": "Invalid Params",
    "data": "missing/unexpected params in list"
}
``` 