### PR TITLE
feat(onboarding): Add rpc endpoint juno_getBlockWithTxnHashesAndReceipts

### DIFF
--- a/rpc/block.go
+++ b/rpc/block.go
@@ -154,6 +154,13 @@ type BlockWithReceipts struct {
 	Transactions []TransactionWithReceipt `json:"transactions"`
 }
 
+type BlockWithTxHashesAndReceipts struct {
+	Status BlockStatus `json:"status,omitempty"`
+	BlockHeader
+	TxnHashes    []*felt.Felt             `json:"transactions_hashes"`
+	Transactions []TransactionWithReceipt `json:"transactions_with_receipts"`
+}
+
 /****************************************************
 		Block Handlers
 *****************************************************/
@@ -205,7 +212,7 @@ func (h *Handler) BlockWithTxHashes(id BlockID) (*BlockWithTxHashes, *jsonrpc.Er
 
 	return &BlockWithTxHashes{
 		Status:      status,
-		BlockHeader: adaptBlockHeader(block.Header),
+		BlockHeader: AdaptBlockHeader(block.Header),
 		TxnHashes:   txnHashes,
 	}, nil
 }
@@ -254,8 +261,31 @@ func (h *Handler) BlockWithReceipts(id BlockID) (*BlockWithReceipts, *jsonrpc.Er
 
 	return &BlockWithReceipts{
 		Status:       blockStatus,
-		BlockHeader:  adaptBlockHeader(block.Header),
+		BlockHeader:  AdaptBlockHeader(block.Header),
 		Transactions: txsWithReceipts,
+	}, nil
+}
+
+func (h *Handler) BlockWithTxHashesAndReceipts(id BlockID) (*BlockWithTxHashesAndReceipts, *jsonrpc.Error) {
+	// Get tx receipts
+	block, err := h.BlockWithReceipts(id)
+	if err != nil {
+		return nil, err
+	}
+
+	// Get tx hashes
+	txnHashes := make([]*felt.Felt, len(block.Transactions))
+	for index, txn := range block.Transactions {
+		// Get hash from Receipt and not Transaction as `starknet_getBlockWithReceipts`'s
+		// array of txs does not contain hash
+		txnHashes[index] = txn.Receipt.Hash
+	}
+
+	return &BlockWithTxHashesAndReceipts{
+		Status:       block.Status,
+		BlockHeader:  block.BlockHeader,
+		Transactions: block.Transactions,
+		TxnHashes:    txnHashes,
 	}, nil
 }
 
@@ -281,7 +311,7 @@ func (h *Handler) BlockWithTxs(id BlockID) (*BlockWithTxs, *jsonrpc.Error) {
 
 	return &BlockWithTxs{
 		Status:       status,
-		BlockHeader:  adaptBlockHeader(block.Header),
+		BlockHeader:  AdaptBlockHeader(block.Header),
 		Transactions: txs,
 	}, nil
 }
@@ -302,7 +332,7 @@ func (h *Handler) blockStatus(id BlockID, block *core.Block) (BlockStatus, *json
 	return status, nil
 }
 
-func adaptBlockHeader(header *core.Header) BlockHeader {
+func AdaptBlockHeader(header *core.Header) BlockHeader {
 	var blockNumber *uint64
 	// if header.Hash == nil it's a pending block
 	if header.Hash != nil {

--- a/rpc/block_test.go
+++ b/rpc/block_test.go
@@ -734,7 +734,7 @@ func TestBlockWithTxHashesAndReceipts(t *testing.T) {
 
 		// Assert transaction hashes
 		assert.Equal(t, len(latestBlock.Transactions), len(b.TxnHashes))
-		for i := 0; i < len(latestBlock.Transactions); i++ {
+		for i := range latestBlock.Transactions {
 			assert.Equal(t, latestBlock.Transactions[i].Hash(), b.TxnHashes[i])
 		}
 

--- a/rpc/handlers.go
+++ b/rpc/handlers.go
@@ -404,6 +404,11 @@ func (h *Handler) Methods() ([]jsonrpc.Method, string) { //nolint: funlen
 			Params:  []jsonrpc.Parameter{{Name: "transaction_hash"}},
 			Handler: h.GetMessageStatus,
 		},
+		{
+			Name:    "juno_getBlockWithTxnHashesAndReceipts",
+			Params:  []jsonrpc.Parameter{{Name: "block_id"}},
+			Handler: h.BlockWithTxHashesAndReceipts,
+		},
 	}, "/v0_8"
 }
 

--- a/rpc/subscriptions.go
+++ b/rpc/subscriptions.go
@@ -686,7 +686,7 @@ func (h *Handler) sendHeader(w jsonrpc.Conn, header *core.Header, id uint64) err
 		Method:  "starknet_subscriptionNewHeads",
 		Params: map[string]any{
 			"subscription_id": id,
-			"result":          adaptBlockHeader(header),
+			"result":          AdaptBlockHeader(header),
 		},
 	})
 	if err != nil {


### PR DESCRIPTION
Onboarding implementation task 1: endpoint `juno_getBlockWithTxnHashesAndReceipts`

Note: I saw other helper function whose visibility was public, so, I changed the visibility of `adaptBlockHeader` to be able to use it in the tests. Let me know if it's something we don't want to do, I'll revert it and change my test.

I set it as draft just to make sure it doesn't get merged.
