### PR TITLE
Use flattened format for subscribe responses

### DIFF
--- a/rpc/v8/events.go
+++ b/rpc/v8/events.go
@@ -12,9 +12,7 @@ type EventsArg struct {
 	ResultPageRequest
 }
 
-type SubscriptionID struct {
-	ID uint64 `json:"subscription_id"`
-}
+type SubscriptionID uint64
 
 type EventFilter struct {
 	FromBlock *BlockID      `json:"from_block"`


### PR DESCRIPTION
Previous response:
```
{"jsonrpc":"2.0","result":{"subscription_id":4600765286302481922},"id":1}
```

New response:
```
{"jsonrpc":"2.0","result":4600765286302481922, "id":1}
```