### PR TITLE
Rename unsubscribe id parameter to match spec

### DIFF
--- a/rpc/v8/handlers.go
+++ b/rpc/v8/handlers.go
@@ -313,7 +313,7 @@ func (h *Handler) methods() ([]jsonrpc.Method, string) { //nolint: funlen
 		},
 		{
 			Name:    "starknet_unsubscribe",
-			Params:  []jsonrpc.Parameter{{Name: "id"}},
+			Params:  []jsonrpc.Parameter{{Name: "subscription_id"}},
 			Handler: h.Unsubscribe,
 		},
 		{


### PR DESCRIPTION
Change the parameter name from `id` to `subscription_id` in the starknet_unsubscribe ws method to align with the Starknet specification - [see here](https://github.com/starkware-libs/starknet-specs/blob/436e6307bab3938339e4bf469f14dee79b50802d/api/starknet_ws_api.json#L260)