### PR TITLE
Reuse v6 BlockNumber rpc handler for v7 and v8

### DIFF
--- a/rpc/handlers.go
+++ b/rpc/handlers.go
@@ -97,7 +97,7 @@ func (h *Handler) MethodsV0_8() ([]jsonrpc.Method, string) { //nolint: funlen
 		},
 		{
 			Name:    "starknet_blockNumber",
-			Handler: h.rpcv8Handler.BlockNumber,
+			Handler: h.rpcv6Handler.BlockNumber,
 		},
 		{
 			Name:    "starknet_blockHashAndNumber",
@@ -301,7 +301,7 @@ func (h *Handler) MethodsV0_7() ([]jsonrpc.Method, string) { //nolint: funlen
 		},
 		{
 			Name:    "starknet_blockNumber",
-			Handler: h.rpcv7Handler.BlockNumber,
+			Handler: h.rpcv6Handler.BlockNumber,
 		},
 		{
 			Name:    "starknet_blockHashAndNumber",

--- a/rpc/v7/block.go
+++ b/rpc/v7/block.go
@@ -158,19 +158,6 @@ type BlockWithReceipts struct {
 		Block Handlers
 *****************************************************/
 
-// BlockNumber returns the latest synced block number.
-//
-// It follows the specification defined here:
-// https://github.com/starkware-libs/starknet-specs/blob/a789ccc3432c57777beceaa53a34a7ae2f25fda0/api/starknet_api_openrpc.json#L500
-func (h *Handler) BlockNumber() (uint64, *jsonrpc.Error) {
-	num, err := h.bcReader.Height()
-	if err != nil {
-		return 0, rpccore.ErrNoBlock
-	}
-
-	return num, nil
-}
-
 // BlockHashAndNumber returns the block hash and number of the latest synced block.
 //
 // It follows the specification defined here:

--- a/rpc/v7/block_test.go
+++ b/rpc/v7/block_test.go
@@ -90,32 +90,6 @@ func TestBlockId(t *testing.T) {
 	}
 }
 
-func TestBlockNumber(t *testing.T) {
-	mockCtrl := gomock.NewController(t)
-	t.Cleanup(mockCtrl.Finish)
-
-	mockReader := mocks.NewMockReader(mockCtrl)
-	handler := rpcv7.New(mockReader, nil, nil, "", utils.Ptr(utils.Mainnet), nil)
-
-	t.Run("empty blockchain", func(t *testing.T) {
-		expectedHeight := uint64(0)
-		mockReader.EXPECT().Height().Return(expectedHeight, errors.New("empty blockchain"))
-
-		num, err := handler.BlockNumber()
-		assert.Equal(t, expectedHeight, num)
-		assert.Equal(t, rpccore.ErrNoBlock, err)
-	})
-
-	t.Run("blockchain height is 21", func(t *testing.T) {
-		expectedHeight := uint64(21)
-		mockReader.EXPECT().Height().Return(expectedHeight, nil)
-
-		num, err := handler.BlockNumber()
-		require.Nil(t, err)
-		assert.Equal(t, expectedHeight, num)
-	})
-}
-
 func TestBlockHashAndNumber(t *testing.T) {
 	mockCtrl := gomock.NewController(t)
 	t.Cleanup(mockCtrl.Finish)

--- a/rpc/v8/block.go
+++ b/rpc/v8/block.go
@@ -159,19 +159,6 @@ type BlockWithReceipts struct {
 		Block Handlers
 *****************************************************/
 
-// BlockNumber returns the latest synced block number.
-//
-// It follows the specification defined here:
-// https://github.com/starkware-libs/starknet-specs/blob/a789ccc3432c57777beceaa53a34a7ae2f25fda0/api/starknet_api_openrpc.json#L500
-func (h *Handler) BlockNumber() (uint64, *jsonrpc.Error) {
-	num, err := h.bcReader.Height()
-	if err != nil {
-		return 0, rpccore.ErrNoBlock
-	}
-
-	return num, nil
-}
-
 // BlockHashAndNumber returns the block hash and number of the latest synced block.
 //
 // It follows the specification defined here:

--- a/rpc/v8/block_test.go
+++ b/rpc/v8/block_test.go
@@ -90,32 +90,6 @@ func TestBlockId(t *testing.T) {
 	}
 }
 
-func TestBlockNumber(t *testing.T) {
-	mockCtrl := gomock.NewController(t)
-	t.Cleanup(mockCtrl.Finish)
-
-	mockReader := mocks.NewMockReader(mockCtrl)
-	handler := rpcv8.New(mockReader, nil, nil, "", nil)
-
-	t.Run("empty blockchain", func(t *testing.T) {
-		expectedHeight := uint64(0)
-		mockReader.EXPECT().Height().Return(expectedHeight, errors.New("empty blockchain"))
-
-		num, err := handler.BlockNumber()
-		assert.Equal(t, expectedHeight, num)
-		assert.Equal(t, rpccore.ErrNoBlock, err)
-	})
-
-	t.Run("blockchain height is 21", func(t *testing.T) {
-		expectedHeight := uint64(21)
-		mockReader.EXPECT().Height().Return(expectedHeight, nil)
-
-		num, err := handler.BlockNumber()
-		require.Nil(t, err)
-		assert.Equal(t, expectedHeight, num)
-	})
-}
-
 func TestBlockHashAndNumber(t *testing.T) {
 	mockCtrl := gomock.NewController(t)
 	t.Cleanup(mockCtrl.Finish)

--- a/rpc/v8/handlers.go
+++ b/rpc/v8/handlers.go
@@ -157,10 +157,6 @@ func (h *Handler) methods() ([]jsonrpc.Method, string) { //nolint: funlen
 			Handler: h.ChainID,
 		},
 		{
-			Name:    "starknet_blockNumber",
-			Handler: h.BlockNumber,
-		},
-		{
 			Name:    "starknet_blockHashAndNumber",
 			Handler: h.BlockHashAndNumber,
 		},


### PR DESCRIPTION
Clean endpoint according to #2437 