### PR TITLE
clean: Reuse rpcv6 BlockStatus type for v7 and v8

### DIFF
--- a/rpc/v7/block.go
+++ b/rpc/v7/block.go
@@ -9,32 +9,8 @@ import (
 	"github.com/NethermindEth/juno/core/felt"
 	"github.com/NethermindEth/juno/jsonrpc"
 	"github.com/NethermindEth/juno/rpc/rpccore"
+	rpcv6 "github.com/NethermindEth/juno/rpc/v6"
 )
-
-// https://github.com/starkware-libs/starknet-specs/blob/fbf8710c2d2dcdb70a95776f257d080392ad0816/api/starknet_api_openrpc.json#L2353-L2363
-type BlockStatus uint8
-
-const (
-	BlockPending BlockStatus = iota
-	BlockAcceptedL2
-	BlockAcceptedL1
-	BlockRejected
-)
-
-func (s BlockStatus) MarshalText() ([]byte, error) {
-	switch s {
-	case BlockPending:
-		return []byte("PENDING"), nil
-	case BlockAcceptedL2:
-		return []byte("ACCEPTED_ON_L2"), nil
-	case BlockAcceptedL1:
-		return []byte("ACCEPTED_ON_L1"), nil
-	case BlockRejected:
-		return []byte("REJECTED"), nil
-	default:
-		return nil, fmt.Errorf("unknown block status %v", s)
-	}
-}
 
 type L1DAMode uint8
 
@@ -131,14 +107,14 @@ type BlockHeader struct {
 
 // https://github.com/starkware-libs/starknet-specs/blob/a789ccc3432c57777beceaa53a34a7ae2f25fda0/api/starknet_api_openrpc.json#L1131
 type BlockWithTxs struct {
-	Status BlockStatus `json:"status,omitempty"`
+	Status rpcv6.BlockStatus `json:"status,omitempty"`
 	BlockHeader
 	Transactions []*Transaction `json:"transactions"`
 }
 
 // https://github.com/starkware-libs/starknet-specs/blob/a789ccc3432c57777beceaa53a34a7ae2f25fda0/api/starknet_api_openrpc.json#L1109
 type BlockWithTxHashes struct {
-	Status BlockStatus `json:"status,omitempty"`
+	Status rpcv6.BlockStatus `json:"status,omitempty"`
 	BlockHeader
 	TxnHashes []*felt.Felt `json:"transactions"`
 }
@@ -149,7 +125,7 @@ type TransactionWithReceipt struct {
 }
 
 type BlockWithReceipts struct {
-	Status BlockStatus `json:"status,omitempty"`
+	Status rpcv6.BlockStatus `json:"status,omitempty"`
 	BlockHeader
 	Transactions []TransactionWithReceipt `json:"transactions"`
 }
@@ -235,7 +211,7 @@ func (h *Handler) BlockWithReceipts(id BlockID) (*BlockWithReceipts, *jsonrpc.Er
 	}
 
 	finalityStatus := TxnAcceptedOnL2
-	if blockStatus == BlockAcceptedL1 {
+	if blockStatus == rpcv6.BlockAcceptedL1 {
 		finalityStatus = TxnAcceptedOnL1
 	}
 
@@ -286,17 +262,17 @@ func (h *Handler) BlockWithTxs(id BlockID) (*BlockWithTxs, *jsonrpc.Error) {
 	}, nil
 }
 
-func (h *Handler) blockStatus(id BlockID, block *core.Block) (BlockStatus, *jsonrpc.Error) {
+func (h *Handler) blockStatus(id BlockID, block *core.Block) (rpcv6.BlockStatus, *jsonrpc.Error) {
 	l1H, jsonErr := h.l1Head()
 	if jsonErr != nil {
 		return 0, jsonErr
 	}
 
-	status := BlockAcceptedL2
+	status := rpcv6.BlockAcceptedL2
 	if id.Pending {
-		status = BlockPending
+		status = rpcv6.BlockPending
 	} else if isL1Verified(block.Number, l1H) {
-		status = BlockAcceptedL1
+		status = rpcv6.BlockAcceptedL1
 	}
 
 	return status, nil

--- a/rpc/v7/block_test.go
+++ b/rpc/v7/block_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/NethermindEth/juno/db/pebble"
 	"github.com/NethermindEth/juno/mocks"
 	"github.com/NethermindEth/juno/rpc/rpccore"
+	rpcv6 "github.com/NethermindEth/juno/rpc/v6"
 	rpcv7 "github.com/NethermindEth/juno/rpc/v7"
 	adaptfeeder "github.com/NethermindEth/juno/starknetdata/feeder"
 	"github.com/NethermindEth/juno/sync"
@@ -290,7 +291,7 @@ func TestBlockWithTxHashes(t *testing.T) {
 			assert.Equal(t, latestBlock.Number, *b.Number)
 		} else {
 			assert.Nil(t, b.Number)
-			assert.Equal(t, rpcv7.BlockPending, b.Status)
+			assert.Equal(t, rpcv6.BlockPending, b.Status)
 		}
 		checkBlock(t, b)
 	}
@@ -336,7 +337,7 @@ func TestBlockWithTxHashes(t *testing.T) {
 		block, rpcErr := handler.BlockWithTxHashes(rpcv7.BlockID{Number: latestBlockNumber})
 		require.Nil(t, rpcErr)
 
-		assert.Equal(t, rpcv7.BlockAcceptedL1, block.Status)
+		assert.Equal(t, rpcv6.BlockAcceptedL1, block.Status)
 		checkBlock(t, block)
 	})
 
@@ -542,7 +543,7 @@ func TestBlockWithTxHashesV013(t *testing.T) {
 			SequencerAddress: coreBlock.SequencerAddress,
 			Timestamp:        coreBlock.Timestamp,
 		},
-		Status: rpcv7.BlockAcceptedL2,
+		Status: rpcv6.BlockAcceptedL2,
 		Transactions: []*rpcv7.Transaction{
 			{
 				Hash:               tx.Hash(),
@@ -635,7 +636,7 @@ func TestBlockWithReceipts(t *testing.T) {
 
 		assert.Nil(t, rpcErr)
 		assert.Equal(t, &rpcv7.BlockWithReceipts{
-			Status: rpcv7.BlockPending,
+			Status: rpcv6.BlockPending,
 			BlockHeader: rpcv7.BlockHeader{
 				Hash:             header.Hash,
 				ParentHash:       header.ParentHash,
@@ -680,7 +681,7 @@ func TestBlockWithReceipts(t *testing.T) {
 
 		assert.Nil(t, rpcErr)
 		assert.Equal(t, &rpcv7.BlockWithReceipts{
-			Status: rpcv7.BlockAcceptedL1,
+			Status: rpcv6.BlockAcceptedL1,
 			BlockHeader: rpcv7.BlockHeader{
 				Hash:             header.Hash,
 				ParentHash:       header.ParentHash,

--- a/rpc/v8/block_test.go
+++ b/rpc/v8/block_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/NethermindEth/juno/db/pebble"
 	"github.com/NethermindEth/juno/mocks"
 	"github.com/NethermindEth/juno/rpc/rpccore"
+	rpcv6 "github.com/NethermindEth/juno/rpc/v6"
 	rpcv8 "github.com/NethermindEth/juno/rpc/v8"
 	adaptfeeder "github.com/NethermindEth/juno/starknetdata/feeder"
 	"github.com/NethermindEth/juno/sync"
@@ -290,7 +291,7 @@ func TestBlockWithTxHashes(t *testing.T) {
 			assert.Equal(t, latestBlock.Number, *b.Number)
 		} else {
 			assert.Nil(t, b.Number)
-			assert.Equal(t, rpcv8.BlockPending, b.Status)
+			assert.Equal(t, rpcv6.BlockPending, b.Status)
 		}
 		checkBlock(t, b)
 	}
@@ -336,7 +337,7 @@ func TestBlockWithTxHashes(t *testing.T) {
 		block, rpcErr := handler.BlockWithTxHashes(rpcv8.BlockID{Number: latestBlockNumber})
 		require.Nil(t, rpcErr)
 
-		assert.Equal(t, rpcv8.BlockAcceptedL1, block.Status)
+		assert.Equal(t, rpcv6.BlockAcceptedL1, block.Status)
 		checkBlock(t, block)
 	})
 
@@ -546,7 +547,7 @@ func TestBlockWithTxHashesV013(t *testing.T) {
 			SequencerAddress: coreBlock.SequencerAddress,
 			Timestamp:        coreBlock.Timestamp,
 		},
-		Status: rpcv8.BlockAcceptedL2,
+		Status: rpcv6.BlockAcceptedL2,
 		Transactions: []*rpcv8.Transaction{
 			{
 				Hash:               tx.Hash(),
@@ -639,7 +640,7 @@ func TestBlockWithReceipts(t *testing.T) {
 
 		assert.Nil(t, rpcErr)
 		assert.Equal(t, &rpcv8.BlockWithReceipts{
-			Status: rpcv8.BlockPending,
+			Status: rpcv6.BlockPending,
 			BlockHeader: rpcv8.BlockHeader{
 				Hash:             header.Hash,
 				ParentHash:       header.ParentHash,
@@ -685,7 +686,7 @@ func TestBlockWithReceipts(t *testing.T) {
 
 		assert.Nil(t, rpcErr)
 		assert.Equal(t, &rpcv8.BlockWithReceipts{
-			Status: rpcv8.BlockAcceptedL1,
+			Status: rpcv6.BlockAcceptedL1,
 			BlockHeader: rpcv8.BlockHeader{
 				Hash:             header.Hash,
 				ParentHash:       header.ParentHash,


### PR DESCRIPTION
Reuse existing rpcv6 `BlockStatus` type for rpcv7 and v8 (useful for PR `BlockWithTxHashes`)