### PR TITLE
Fix concurrent RPC handlers

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -33,6 +33,7 @@ require (
 	go.uber.org/mock v0.5.0
 	go.uber.org/zap v1.27.0
 	golang.org/x/crypto v0.32.0
+	golang.org/x/sync v0.10.0
 	google.golang.org/grpc v1.70.0
 	google.golang.org/protobuf v1.36.5
 	gopkg.in/yaml.v3 v3.0.1
@@ -191,7 +192,6 @@ require (
 	golang.org/x/exp v0.0.0-20241217172543-b2144cdd0a67 // indirect
 	golang.org/x/mod v0.22.0 // indirect
 	golang.org/x/net v0.34.0 // indirect
-	golang.org/x/sync v0.10.0 // indirect
 	golang.org/x/sys v0.29.0 // indirect
 	golang.org/x/text v0.21.0 // indirect
 	golang.org/x/tools v0.29.0 // indirect

--- a/rpc/handlers_test.go
+++ b/rpc/handlers_test.go
@@ -1,0 +1,47 @@
+package rpc
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/NethermindEth/juno/blockchain"
+	"github.com/NethermindEth/juno/core"
+	"github.com/NethermindEth/juno/feed"
+	"github.com/NethermindEth/juno/mocks"
+	"github.com/NethermindEth/juno/rpc/v6"
+	"github.com/NethermindEth/juno/rpc/v7"
+	"github.com/NethermindEth/juno/rpc/v8"
+	"github.com/NethermindEth/juno/sync"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+)
+
+func TestRun(t *testing.T) {
+	mockCtrl := gomock.NewController(t)
+	t.Cleanup(mockCtrl.Finish)
+
+	l1Sub := feed.New[*core.L1Head]()
+	headerSub := feed.New[*core.Header]()
+	reorgSub := feed.New[*sync.ReorgBlockRange]()
+	pendingSub := feed.New[*core.Block]()
+
+	mockBcReader := mocks.NewMockReader(mockCtrl)
+	mockSyncReader := mocks.NewMockSyncReader(mockCtrl)
+	mockBcReader.EXPECT().SubscribeL1Head().Return(blockchain.L1HeadSubscription{Subscription: l1Sub.Subscribe()}).AnyTimes()
+	mockSyncReader.EXPECT().SubscribeNewHeads().Return(sync.HeaderSubscription{Subscription: headerSub.Subscribe()}).AnyTimes()
+	mockSyncReader.EXPECT().SubscribeReorg().Return(sync.ReorgSubscription{Subscription: reorgSub.Subscribe()}).AnyTimes()
+	mockSyncReader.EXPECT().SubscribePending().Return(sync.PendingSubscription{Subscription: pendingSub.Subscribe()}).AnyTimes()
+
+	handler := &Handler{
+		rpcv6Handler: rpcv6.New(mockBcReader, mockSyncReader, nil, "", nil, nil),
+		rpcv7Handler: rpcv7.New(mockBcReader, mockSyncReader, nil, "", nil, nil),
+		rpcv8Handler: rpcv8.New(mockBcReader, mockSyncReader, nil, "", nil),
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+	t.Cleanup(cancel)
+
+	err := handler.Run(ctx)
+	require.NoError(t, err)
+}


### PR DESCRIPTION
`rpcv6Handler.Run()` blocks the rest of the RPC handlers from running, they should be running concurrently in goroutines.

Fixes #2450 