### PR TITLE
Fix: ErrPendingBlockNotFound condition omission

### DIFF
--- a/rpc/v6/helpers.go
+++ b/rpc/v6/helpers.go
@@ -165,7 +165,7 @@ func (h *Handler) stateByBlockID(id *BlockID) (core.StateReader, blockchain.Stat
 	}
 
 	if err != nil {
-		if errors.Is(err, db.ErrKeyNotFound) {
+		if errors.Is(err, db.ErrKeyNotFound) || errors.Is(err, sync.ErrPendingBlockNotFound) {
 			return nil, nil, rpccore.ErrBlockNotFound
 		}
 		return nil, nil, rpccore.ErrInternal.CloneWithData(err)


### PR DESCRIPTION
Just a quick small fix PR to add a condition in the case that we don't have the pending block. In that case, `h.syncReader.PendingState()` will return `ErrPendingBlockNotFound`, not `db.ErrKeyNotFound`, so we should handle that by returning `ErrBlockNotFound` not an internal error.