### PR TITLE
refactor: Reuse rpcv6 starknet_getNonce endpoint for v7 and v8

### DIFF
--- a/rpc/handlers.go
+++ b/rpc/handlers.go
@@ -143,7 +143,7 @@ func (h *Handler) MethodsV0_8() ([]jsonrpc.Method, string) { //nolint: funlen
 		{
 			Name:    "starknet_getNonce",
 			Params:  []jsonrpc.Parameter{{Name: "block_id"}, {Name: "contract_address"}},
-			Handler: h.rpcv8Handler.Nonce,
+			Handler: h.rpcv6Handler.Nonce,
 		},
 		{
 			Name:    "starknet_getStorageAt",
@@ -347,7 +347,7 @@ func (h *Handler) MethodsV0_7() ([]jsonrpc.Method, string) { //nolint: funlen
 		{
 			Name:    "starknet_getNonce",
 			Params:  []jsonrpc.Parameter{{Name: "block_id"}, {Name: "contract_address"}},
-			Handler: h.rpcv7Handler.Nonce,
+			Handler: h.rpcv6Handler.Nonce,
 		},
 		{
 			Name:    "starknet_getStorageAt",

--- a/rpc/v7/storage.go
+++ b/rpc/v7/storage.go
@@ -13,25 +13,6 @@ import (
 		Contract Handlers
 *****************************************************/
 
-// Nonce returns the nonce associated with the given address in the given block number
-//
-// It follows the specification defined here:
-// https://github.com/starkware-libs/starknet-specs/blob/a789ccc3432c57777beceaa53a34a7ae2f25fda0/api/starknet_api_openrpc.json#L633
-func (h *Handler) Nonce(id BlockID, address felt.Felt) (*felt.Felt, *jsonrpc.Error) {
-	stateReader, stateCloser, rpcErr := h.stateByBlockID(&id)
-	if rpcErr != nil {
-		return nil, rpcErr
-	}
-	defer h.callAndLogErr(stateCloser, "Error closing state reader in getNonce")
-
-	nonce, err := stateReader.ContractNonce(&address)
-	if err != nil {
-		return nil, rpccore.ErrContractNotFound
-	}
-
-	return nonce, nil
-}
-
 // StorageAt gets the value of the storage at the given address and key.
 //
 // It follows the specification defined here:

--- a/rpc/v7/storage_test.go
+++ b/rpc/v7/storage_test.go
@@ -1,7 +1,6 @@
 package rpcv7_test
 
 import (
-	"errors"
 	"testing"
 
 	"github.com/NethermindEth/juno/core/felt"
@@ -14,79 +13,6 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
 )
-
-func TestNonce(t *testing.T) {
-	mockCtrl := gomock.NewController(t)
-	t.Cleanup(mockCtrl.Finish)
-
-	mockReader := mocks.NewMockReader(mockCtrl)
-	log := utils.NewNopZapLogger()
-	handler := rpcv7.New(mockReader, nil, nil, "", utils.Ptr(utils.Mainnet), log)
-
-	t.Run("empty blockchain", func(t *testing.T) {
-		mockReader.EXPECT().HeadState().Return(nil, nil, db.ErrKeyNotFound)
-
-		nonce, rpcErr := handler.Nonce(rpcv7.BlockID{Latest: true}, felt.Zero)
-		require.Nil(t, nonce)
-		assert.Equal(t, rpccore.ErrBlockNotFound, rpcErr)
-	})
-
-	t.Run("non-existent block hash", func(t *testing.T) {
-		mockReader.EXPECT().StateAtBlockHash(&felt.Zero).Return(nil, nil, db.ErrKeyNotFound)
-
-		nonce, rpcErr := handler.Nonce(rpcv7.BlockID{Hash: &felt.Zero}, felt.Zero)
-		require.Nil(t, nonce)
-		assert.Equal(t, rpccore.ErrBlockNotFound, rpcErr)
-	})
-
-	t.Run("non-existent block number", func(t *testing.T) {
-		mockReader.EXPECT().StateAtBlockNumber(uint64(0)).Return(nil, nil, db.ErrKeyNotFound)
-
-		nonce, rpcErr := handler.Nonce(rpcv7.BlockID{Number: 0}, felt.Zero)
-		require.Nil(t, nonce)
-		assert.Equal(t, rpccore.ErrBlockNotFound, rpcErr)
-	})
-
-	mockState := mocks.NewMockStateHistoryReader(mockCtrl)
-
-	t.Run("non-existent contract", func(t *testing.T) {
-		mockReader.EXPECT().HeadState().Return(mockState, nopCloser, nil)
-		mockState.EXPECT().ContractNonce(&felt.Zero).Return(nil, errors.New("non-existent contract"))
-
-		nonce, rpcErr := handler.Nonce(rpcv7.BlockID{Latest: true}, felt.Zero)
-		require.Nil(t, nonce)
-		assert.Equal(t, rpccore.ErrContractNotFound, rpcErr)
-	})
-
-	expectedNonce := new(felt.Felt).SetUint64(1)
-
-	t.Run("blockID - latest", func(t *testing.T) {
-		mockReader.EXPECT().HeadState().Return(mockState, nopCloser, nil)
-		mockState.EXPECT().ContractNonce(&felt.Zero).Return(expectedNonce, nil)
-
-		nonce, rpcErr := handler.Nonce(rpcv7.BlockID{Latest: true}, felt.Zero)
-		require.Nil(t, rpcErr)
-		assert.Equal(t, expectedNonce, nonce)
-	})
-
-	t.Run("blockID - hash", func(t *testing.T) {
-		mockReader.EXPECT().StateAtBlockHash(&felt.Zero).Return(mockState, nopCloser, nil)
-		mockState.EXPECT().ContractNonce(&felt.Zero).Return(expectedNonce, nil)
-
-		nonce, rpcErr := handler.Nonce(rpcv7.BlockID{Hash: &felt.Zero}, felt.Zero)
-		require.Nil(t, rpcErr)
-		assert.Equal(t, expectedNonce, nonce)
-	})
-
-	t.Run("blockID - number", func(t *testing.T) {
-		mockReader.EXPECT().StateAtBlockNumber(uint64(0)).Return(mockState, nopCloser, nil)
-		mockState.EXPECT().ContractNonce(&felt.Zero).Return(expectedNonce, nil)
-
-		nonce, rpcErr := handler.Nonce(rpcv7.BlockID{Number: 0}, felt.Zero)
-		require.Nil(t, rpcErr)
-		assert.Equal(t, expectedNonce, nonce)
-	})
-}
 
 func TestStorageAt(t *testing.T) {
 	mockCtrl := gomock.NewController(t)

--- a/rpc/v8/handlers.go
+++ b/rpc/v8/handlers.go
@@ -196,11 +196,6 @@ func (h *Handler) methods() ([]jsonrpc.Method, string) { //nolint: funlen
 			Handler: h.Syncing,
 		},
 		{
-			Name:    "starknet_getNonce",
-			Params:  []jsonrpc.Parameter{{Name: "block_id"}, {Name: "contract_address"}},
-			Handler: h.Nonce,
-		},
-		{
 			Name:    "starknet_getStorageAt",
 			Params:  []jsonrpc.Parameter{{Name: "contract_address"}, {Name: "key"}, {Name: "block_id"}},
 			Handler: h.StorageAt,

--- a/rpc/v8/storage.go
+++ b/rpc/v8/storage.go
@@ -21,25 +21,6 @@ const (
 		Contract Handlers
 *****************************************************/
 
-// Nonce returns the nonce associated with the given address in the given block number
-//
-// It follows the specification defined here:
-// https://github.com/starkware-libs/starknet-specs/blob/a789ccc3432c57777beceaa53a34a7ae2f25fda0/api/starknet_api_openrpc.json#L633
-func (h *Handler) Nonce(id BlockID, address felt.Felt) (*felt.Felt, *jsonrpc.Error) {
-	stateReader, stateCloser, rpcErr := h.stateByBlockID(&id)
-	if rpcErr != nil {
-		return nil, rpcErr
-	}
-	defer h.callAndLogErr(stateCloser, "Error closing state reader in getNonce")
-
-	nonce, err := stateReader.ContractNonce(&address)
-	if err != nil {
-		return nil, rpccore.ErrContractNotFound
-	}
-
-	return nonce, nil
-}
-
 // StorageAt gets the value of the storage at the given address and key.
 //
 // It follows the specification defined here:

--- a/rpc/v8/storage_test.go
+++ b/rpc/v8/storage_test.go
@@ -2,7 +2,6 @@ package rpcv8_test
 
 import (
 	"context"
-	"errors"
 	"testing"
 	"time"
 
@@ -25,79 +24,6 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
 )
-
-func TestNonce(t *testing.T) {
-	mockCtrl := gomock.NewController(t)
-	t.Cleanup(mockCtrl.Finish)
-
-	mockReader := mocks.NewMockReader(mockCtrl)
-	log := utils.NewNopZapLogger()
-	handler := rpc.New(mockReader, nil, nil, "", log)
-
-	t.Run("empty blockchain", func(t *testing.T) {
-		mockReader.EXPECT().HeadState().Return(nil, nil, db.ErrKeyNotFound)
-
-		nonce, rpcErr := handler.Nonce(rpc.BlockID{Latest: true}, felt.Zero)
-		require.Nil(t, nonce)
-		assert.Equal(t, rpccore.ErrBlockNotFound, rpcErr)
-	})
-
-	t.Run("non-existent block hash", func(t *testing.T) {
-		mockReader.EXPECT().StateAtBlockHash(&felt.Zero).Return(nil, nil, db.ErrKeyNotFound)
-
-		nonce, rpcErr := handler.Nonce(rpc.BlockID{Hash: &felt.Zero}, felt.Zero)
-		require.Nil(t, nonce)
-		assert.Equal(t, rpccore.ErrBlockNotFound, rpcErr)
-	})
-
-	t.Run("non-existent block number", func(t *testing.T) {
-		mockReader.EXPECT().StateAtBlockNumber(uint64(0)).Return(nil, nil, db.ErrKeyNotFound)
-
-		nonce, rpcErr := handler.Nonce(rpc.BlockID{Number: 0}, felt.Zero)
-		require.Nil(t, nonce)
-		assert.Equal(t, rpccore.ErrBlockNotFound, rpcErr)
-	})
-
-	mockState := mocks.NewMockStateHistoryReader(mockCtrl)
-
-	t.Run("non-existent contract", func(t *testing.T) {
-		mockReader.EXPECT().HeadState().Return(mockState, nopCloser, nil)
-		mockState.EXPECT().ContractNonce(&felt.Zero).Return(nil, errors.New("non-existent contract"))
-
-		nonce, rpcErr := handler.Nonce(rpc.BlockID{Latest: true}, felt.Zero)
-		require.Nil(t, nonce)
-		assert.Equal(t, rpccore.ErrContractNotFound, rpcErr)
-	})
-
-	expectedNonce := new(felt.Felt).SetUint64(1)
-
-	t.Run("blockID - latest", func(t *testing.T) {
-		mockReader.EXPECT().HeadState().Return(mockState, nopCloser, nil)
-		mockState.EXPECT().ContractNonce(&felt.Zero).Return(expectedNonce, nil)
-
-		nonce, rpcErr := handler.Nonce(rpc.BlockID{Latest: true}, felt.Zero)
-		require.Nil(t, rpcErr)
-		assert.Equal(t, expectedNonce, nonce)
-	})
-
-	t.Run("blockID - hash", func(t *testing.T) {
-		mockReader.EXPECT().StateAtBlockHash(&felt.Zero).Return(mockState, nopCloser, nil)
-		mockState.EXPECT().ContractNonce(&felt.Zero).Return(expectedNonce, nil)
-
-		nonce, rpcErr := handler.Nonce(rpc.BlockID{Hash: &felt.Zero}, felt.Zero)
-		require.Nil(t, rpcErr)
-		assert.Equal(t, expectedNonce, nonce)
-	})
-
-	t.Run("blockID - number", func(t *testing.T) {
-		mockReader.EXPECT().StateAtBlockNumber(uint64(0)).Return(mockState, nopCloser, nil)
-		mockState.EXPECT().ContractNonce(&felt.Zero).Return(expectedNonce, nil)
-
-		nonce, rpcErr := handler.Nonce(rpc.BlockID{Number: 0}, felt.Zero)
-		require.Nil(t, rpcErr)
-		assert.Equal(t, expectedNonce, nonce)
-	})
-}
 
 func TestStorageAt(t *testing.T) {
 	mockCtrl := gomock.NewController(t)


### PR DESCRIPTION
rpc pkg clean up according to issue #2437

- v7: Reuse v6 handler
- v8: Reuse v6 handler