### PR TITLE
fix: Fix starknet_getStorageAt handler in edge cases

### DIFF
--- a/rpc/v6/contract.go
+++ b/rpc/v6/contract.go
@@ -1,7 +1,10 @@
 package rpcv6
 
 import (
+	"errors"
+
 	"github.com/NethermindEth/juno/core/felt"
+	"github.com/NethermindEth/juno/db"
 	"github.com/NethermindEth/juno/jsonrpc"
 	rpccore "github.com/NethermindEth/juno/rpc/rpccore"
 )
@@ -29,7 +32,7 @@ func (h *Handler) Nonce(id BlockID, address felt.Felt) (*felt.Felt, *jsonrpc.Err
 	return nonce, nil
 }
 
-// StorageAt gets the value of the storage at the given address and key.
+// StorageAt gets the value of the storage at the given address and key for a given block.
 //
 // It follows the specification defined here:
 // https://github.com/starkware-libs/starknet-specs/blob/a789ccc3432c57777beceaa53a34a7ae2f25fda0/api/starknet_api_openrpc.json#L110
@@ -40,9 +43,22 @@ func (h *Handler) StorageAt(address, key felt.Felt, id BlockID) (*felt.Felt, *js
 	}
 	defer h.callAndLogErr(stateCloser, "Error closing state reader in getStorageAt")
 
+	// Check if the contract exists because if it doesn't, the call to `ContractStorage` below
+	// will just return a zero-valued felt with a nil error (not an `ErrContractNotFound` error)
+	_, err := stateReader.ContractClassHash(&address)
+	if err != nil {
+		if errors.Is(err, db.ErrKeyNotFound) {
+			return nil, rpccore.ErrContractNotFound
+		}
+		h.log.Errorw("Failed to get contract class hash", "err", err)
+		return nil, rpccore.ErrInternal
+	}
+
+	// Check if key exists in existing contract
+	// If it doesn't, it will return a zero-valued felt with a nil error
 	value, err := stateReader.ContractStorage(&address, &key)
 	if err != nil {
-		return nil, rpccore.ErrContractNotFound
+		return nil, rpccore.ErrInternal
 	}
 
 	return value, nil

--- a/rpc/v6/contract_test.go
+++ b/rpc/v6/contract_test.go
@@ -101,24 +101,24 @@ func TestStorageAt(t *testing.T) {
 	t.Run("empty blockchain", func(t *testing.T) {
 		mockReader.EXPECT().HeadState().Return(nil, nil, db.ErrKeyNotFound)
 
-		storage, rpcErr := handler.StorageAt(felt.Zero, felt.Zero, rpc.BlockID{Latest: true})
-		require.Nil(t, storage)
+		storageValue, rpcErr := handler.StorageAt(felt.Zero, felt.Zero, rpc.BlockID{Latest: true})
+		require.Nil(t, storageValue)
 		assert.Equal(t, rpccore.ErrBlockNotFound, rpcErr)
 	})
 
 	t.Run("non-existent block hash", func(t *testing.T) {
 		mockReader.EXPECT().StateAtBlockHash(&felt.Zero).Return(nil, nil, db.ErrKeyNotFound)
 
-		storage, rpcErr := handler.StorageAt(felt.Zero, felt.Zero, rpc.BlockID{Hash: &felt.Zero})
-		require.Nil(t, storage)
+		storageValue, rpcErr := handler.StorageAt(felt.Zero, felt.Zero, rpc.BlockID{Hash: &felt.Zero})
+		require.Nil(t, storageValue)
 		assert.Equal(t, rpccore.ErrBlockNotFound, rpcErr)
 	})
 
 	t.Run("non-existent block number", func(t *testing.T) {
 		mockReader.EXPECT().StateAtBlockNumber(uint64(0)).Return(nil, nil, db.ErrKeyNotFound)
 
-		storage, rpcErr := handler.StorageAt(felt.Zero, felt.Zero, rpc.BlockID{Number: 0})
-		require.Nil(t, storage)
+		storageValue, rpcErr := handler.StorageAt(felt.Zero, felt.Zero, rpc.BlockID{Number: 0})
+		require.Nil(t, storageValue)
 		assert.Equal(t, rpccore.ErrBlockNotFound, rpcErr)
 	})
 
@@ -128,8 +128,8 @@ func TestStorageAt(t *testing.T) {
 		mockReader.EXPECT().HeadState().Return(mockState, nopCloser, nil)
 		mockState.EXPECT().ContractClassHash(gomock.Any()).Return(nil, db.ErrKeyNotFound)
 
-		storage, rpcErr := handler.StorageAt(felt.Zero, felt.Zero, rpc.BlockID{Latest: true})
-		require.Nil(t, storage)
+		storageValue, rpcErr := handler.StorageAt(felt.Zero, felt.Zero, rpc.BlockID{Latest: true})
+		require.Nil(t, storageValue)
 		assert.Equal(t, rpccore.ErrContractNotFound, rpcErr)
 	})
 
@@ -137,8 +137,8 @@ func TestStorageAt(t *testing.T) {
 		mockReader.EXPECT().HeadState().Return(mockState, nopCloser, nil)
 		mockState.EXPECT().ContractClassHash(gomock.Any()).Return(nil, errors.New("some internal error"))
 
-		storage, rpcErr := handler.StorageAt(felt.Zero, felt.Zero, rpc.BlockID{Latest: true})
-		require.Nil(t, storage)
+		storageValue, rpcErr := handler.StorageAt(felt.Zero, felt.Zero, rpc.BlockID{Latest: true})
+		require.Nil(t, storageValue)
 		assert.Equal(t, rpccore.ErrInternal, rpcErr)
 	})
 
@@ -147,8 +147,8 @@ func TestStorageAt(t *testing.T) {
 		mockState.EXPECT().ContractClassHash(gomock.Any()).Return(nil, nil)
 		mockState.EXPECT().ContractStorage(gomock.Any(), gomock.Any()).Return(&felt.Zero, nil)
 
-		storage, rpcErr := handler.StorageAt(felt.Zero, felt.Zero, rpc.BlockID{Latest: true})
-		require.Equal(t, storage, &felt.Zero)
+		storageValue, rpcErr := handler.StorageAt(felt.Zero, felt.Zero, rpc.BlockID{Latest: true})
+		require.Equal(t, storageValue, &felt.Zero)
 		assert.Nil(t, rpcErr)
 	})
 
@@ -157,8 +157,8 @@ func TestStorageAt(t *testing.T) {
 		mockState.EXPECT().ContractClassHash(gomock.Any()).Return(nil, nil)
 		mockState.EXPECT().ContractStorage(gomock.Any(), gomock.Any()).Return(nil, errors.New("some internal error"))
 
-		storage, rpcErr := handler.StorageAt(felt.Zero, felt.Zero, rpc.BlockID{Latest: true})
-		require.Nil(t, storage)
+		storageValue, rpcErr := handler.StorageAt(felt.Zero, felt.Zero, rpc.BlockID{Latest: true})
+		require.Nil(t, storageValue)
 		assert.Equal(t, rpccore.ErrInternal, rpcErr)
 	})
 
@@ -169,9 +169,9 @@ func TestStorageAt(t *testing.T) {
 		mockState.EXPECT().ContractClassHash(gomock.Any()).Return(nil, nil)
 		mockState.EXPECT().ContractStorage(gomock.Any(), gomock.Any()).Return(expectedStorage, nil)
 
-		storage, rpcErr := handler.StorageAt(felt.Zero, felt.Zero, rpc.BlockID{Latest: true})
+		storageValue, rpcErr := handler.StorageAt(felt.Zero, felt.Zero, rpc.BlockID{Latest: true})
 		require.Nil(t, rpcErr)
-		assert.Equal(t, expectedStorage, storage)
+		assert.Equal(t, expectedStorage, storageValue)
 	})
 
 	t.Run("blockID - hash", func(t *testing.T) {
@@ -179,9 +179,9 @@ func TestStorageAt(t *testing.T) {
 		mockState.EXPECT().ContractClassHash(gomock.Any()).Return(nil, nil)
 		mockState.EXPECT().ContractStorage(gomock.Any(), gomock.Any()).Return(expectedStorage, nil)
 
-		storage, rpcErr := handler.StorageAt(felt.Zero, felt.Zero, rpc.BlockID{Hash: &felt.Zero})
+		storageValue, rpcErr := handler.StorageAt(felt.Zero, felt.Zero, rpc.BlockID{Hash: &felt.Zero})
 		require.Nil(t, rpcErr)
-		assert.Equal(t, expectedStorage, storage)
+		assert.Equal(t, expectedStorage, storageValue)
 	})
 
 	t.Run("blockID - number", func(t *testing.T) {
@@ -189,8 +189,8 @@ func TestStorageAt(t *testing.T) {
 		mockState.EXPECT().ContractClassHash(gomock.Any()).Return(nil, nil)
 		mockState.EXPECT().ContractStorage(gomock.Any(), gomock.Any()).Return(expectedStorage, nil)
 
-		storage, rpcErr := handler.StorageAt(felt.Zero, felt.Zero, rpc.BlockID{Number: 0})
+		storageValue, rpcErr := handler.StorageAt(felt.Zero, felt.Zero, rpc.BlockID{Number: 0})
 		require.Nil(t, rpcErr)
-		assert.Equal(t, expectedStorage, storage)
+		assert.Equal(t, expectedStorage, storageValue)
 	})
 }

--- a/rpc/v7/storage.go
+++ b/rpc/v7/storage.go
@@ -56,7 +56,7 @@ func (h *Handler) StorageAt(address, key felt.Felt, id BlockID) (*felt.Felt, *js
 
 	value, err := stateReader.ContractStorage(&address, &key)
 	if err != nil {
-		return nil, rpccore.ErrContractNotFound
+		return nil, rpccore.ErrInternal
 	}
 
 	return value, nil

--- a/rpc/v7/storage_test.go
+++ b/rpc/v7/storage_test.go
@@ -99,24 +99,24 @@ func TestStorageAt(t *testing.T) {
 	t.Run("empty blockchain", func(t *testing.T) {
 		mockReader.EXPECT().HeadState().Return(nil, nil, db.ErrKeyNotFound)
 
-		storage, rpcErr := handler.StorageAt(felt.Zero, felt.Zero, rpcv7.BlockID{Latest: true})
-		require.Nil(t, storage)
+		storageValue, rpcErr := handler.StorageAt(felt.Zero, felt.Zero, rpcv7.BlockID{Latest: true})
+		require.Nil(t, storageValue)
 		assert.Equal(t, rpccore.ErrBlockNotFound, rpcErr)
 	})
 
 	t.Run("non-existent block hash", func(t *testing.T) {
 		mockReader.EXPECT().StateAtBlockHash(&felt.Zero).Return(nil, nil, db.ErrKeyNotFound)
 
-		storage, rpcErr := handler.StorageAt(felt.Zero, felt.Zero, rpcv7.BlockID{Hash: &felt.Zero})
-		require.Nil(t, storage)
+		storageValue, rpcErr := handler.StorageAt(felt.Zero, felt.Zero, rpcv7.BlockID{Hash: &felt.Zero})
+		require.Nil(t, storageValue)
 		assert.Equal(t, rpccore.ErrBlockNotFound, rpcErr)
 	})
 
 	t.Run("non-existent block number", func(t *testing.T) {
 		mockReader.EXPECT().StateAtBlockNumber(uint64(0)).Return(nil, nil, db.ErrKeyNotFound)
 
-		storage, rpcErr := handler.StorageAt(felt.Zero, felt.Zero, rpcv7.BlockID{Number: 0})
-		require.Nil(t, storage)
+		storageValue, rpcErr := handler.StorageAt(felt.Zero, felt.Zero, rpcv7.BlockID{Number: 0})
+		require.Nil(t, storageValue)
 		assert.Equal(t, rpccore.ErrBlockNotFound, rpcErr)
 	})
 
@@ -126,8 +126,8 @@ func TestStorageAt(t *testing.T) {
 		mockReader.EXPECT().HeadState().Return(mockState, nopCloser, nil)
 		mockState.EXPECT().ContractClassHash(gomock.Any()).Return(nil, db.ErrKeyNotFound)
 
-		storage, rpcErr := handler.StorageAt(felt.Zero, felt.Zero, rpcv7.BlockID{Latest: true})
-		require.Nil(t, storage)
+		storageValue, rpcErr := handler.StorageAt(felt.Zero, felt.Zero, rpcv7.BlockID{Latest: true})
+		require.Nil(t, storageValue)
 		assert.Equal(t, rpccore.ErrContractNotFound, rpcErr)
 	})
 
@@ -136,8 +136,8 @@ func TestStorageAt(t *testing.T) {
 		mockState.EXPECT().ContractClassHash(&felt.Zero).Return(nil, nil)
 		mockState.EXPECT().ContractStorage(gomock.Any(), gomock.Any()).Return(&felt.Zero, nil)
 
-		storage, rpcErr := handler.StorageAt(felt.Zero, felt.Zero, rpcv7.BlockID{Latest: true})
-		require.Equal(t, storage, &felt.Zero)
+		storageValue, rpcErr := handler.StorageAt(felt.Zero, felt.Zero, rpcv7.BlockID{Latest: true})
+		require.Equal(t, storageValue, &felt.Zero)
 		assert.Nil(t, rpcErr)
 	})
 
@@ -146,8 +146,8 @@ func TestStorageAt(t *testing.T) {
 		mockState.EXPECT().ContractClassHash(&felt.Zero).Return(nil, nil)
 		mockState.EXPECT().ContractStorage(gomock.Any(), gomock.Any()).Return(nil, errors.New("some internal error"))
 
-		storage, rpcErr := handler.StorageAt(felt.Zero, felt.Zero, rpcv7.BlockID{Latest: true})
-		require.Nil(t, storage)
+		storageValue, rpcErr := handler.StorageAt(felt.Zero, felt.Zero, rpcv7.BlockID{Latest: true})
+		require.Nil(t, storageValue)
 		assert.Equal(t, rpccore.ErrInternal, rpcErr)
 	})
 
@@ -158,9 +158,9 @@ func TestStorageAt(t *testing.T) {
 		mockState.EXPECT().ContractClassHash(&felt.Zero).Return(nil, nil)
 		mockState.EXPECT().ContractStorage(gomock.Any(), gomock.Any()).Return(expectedStorage, nil)
 
-		storage, rpcErr := handler.StorageAt(felt.Zero, felt.Zero, rpcv7.BlockID{Latest: true})
+		storageValue, rpcErr := handler.StorageAt(felt.Zero, felt.Zero, rpcv7.BlockID{Latest: true})
 		require.Nil(t, rpcErr)
-		assert.Equal(t, expectedStorage, storage)
+		assert.Equal(t, expectedStorage, storageValue)
 	})
 
 	t.Run("blockID - hash", func(t *testing.T) {
@@ -168,9 +168,9 @@ func TestStorageAt(t *testing.T) {
 		mockState.EXPECT().ContractClassHash(&felt.Zero).Return(nil, nil)
 		mockState.EXPECT().ContractStorage(gomock.Any(), gomock.Any()).Return(expectedStorage, nil)
 
-		storage, rpcErr := handler.StorageAt(felt.Zero, felt.Zero, rpcv7.BlockID{Hash: &felt.Zero})
+		storageValue, rpcErr := handler.StorageAt(felt.Zero, felt.Zero, rpcv7.BlockID{Hash: &felt.Zero})
 		require.Nil(t, rpcErr)
-		assert.Equal(t, expectedStorage, storage)
+		assert.Equal(t, expectedStorage, storageValue)
 	})
 
 	t.Run("blockID - number", func(t *testing.T) {
@@ -178,8 +178,8 @@ func TestStorageAt(t *testing.T) {
 		mockState.EXPECT().ContractClassHash(&felt.Zero).Return(nil, nil)
 		mockState.EXPECT().ContractStorage(gomock.Any(), gomock.Any()).Return(expectedStorage, nil)
 
-		storage, rpcErr := handler.StorageAt(felt.Zero, felt.Zero, rpcv7.BlockID{Number: 0})
+		storageValue, rpcErr := handler.StorageAt(felt.Zero, felt.Zero, rpcv7.BlockID{Number: 0})
 		require.Nil(t, rpcErr)
-		assert.Equal(t, expectedStorage, storage)
+		assert.Equal(t, expectedStorage, storageValue)
 	})
 }

--- a/rpc/v8/storage.go
+++ b/rpc/v8/storage.go
@@ -64,7 +64,7 @@ func (h *Handler) StorageAt(address, key felt.Felt, id BlockID) (*felt.Felt, *js
 
 	value, err := stateReader.ContractStorage(&address, &key)
 	if err != nil {
-		return nil, rpccore.ErrContractNotFound
+		return nil, rpccore.ErrInternal
 	}
 
 	return value, nil

--- a/rpc/v8/storage_test.go
+++ b/rpc/v8/storage_test.go
@@ -110,24 +110,24 @@ func TestStorageAt(t *testing.T) {
 	t.Run("empty blockchain", func(t *testing.T) {
 		mockReader.EXPECT().HeadState().Return(nil, nil, db.ErrKeyNotFound)
 
-		storage, rpcErr := handler.StorageAt(felt.Zero, felt.Zero, rpc.BlockID{Latest: true})
-		require.Nil(t, storage)
+		storageValue, rpcErr := handler.StorageAt(felt.Zero, felt.Zero, rpc.BlockID{Latest: true})
+		require.Nil(t, storageValue)
 		assert.Equal(t, rpccore.ErrBlockNotFound, rpcErr)
 	})
 
 	t.Run("non-existent block hash", func(t *testing.T) {
 		mockReader.EXPECT().StateAtBlockHash(&felt.Zero).Return(nil, nil, db.ErrKeyNotFound)
 
-		storage, rpcErr := handler.StorageAt(felt.Zero, felt.Zero, rpc.BlockID{Hash: &felt.Zero})
-		require.Nil(t, storage)
+		storageValue, rpcErr := handler.StorageAt(felt.Zero, felt.Zero, rpc.BlockID{Hash: &felt.Zero})
+		require.Nil(t, storageValue)
 		assert.Equal(t, rpccore.ErrBlockNotFound, rpcErr)
 	})
 
 	t.Run("non-existent block number", func(t *testing.T) {
 		mockReader.EXPECT().StateAtBlockNumber(uint64(0)).Return(nil, nil, db.ErrKeyNotFound)
 
-		storage, rpcErr := handler.StorageAt(felt.Zero, felt.Zero, rpc.BlockID{Number: 0})
-		require.Nil(t, storage)
+		storageValue, rpcErr := handler.StorageAt(felt.Zero, felt.Zero, rpc.BlockID{Number: 0})
+		require.Nil(t, storageValue)
 		assert.Equal(t, rpccore.ErrBlockNotFound, rpcErr)
 	})
 
@@ -137,8 +137,8 @@ func TestStorageAt(t *testing.T) {
 		mockReader.EXPECT().HeadState().Return(mockState, nopCloser, nil)
 		mockState.EXPECT().ContractClassHash(gomock.Any()).Return(nil, db.ErrKeyNotFound)
 
-		storage, rpcErr := handler.StorageAt(felt.Zero, felt.Zero, rpc.BlockID{Latest: true})
-		require.Nil(t, storage)
+		storageValue, rpcErr := handler.StorageAt(felt.Zero, felt.Zero, rpc.BlockID{Latest: true})
+		require.Nil(t, storageValue)
 		assert.Equal(t, rpccore.ErrContractNotFound, rpcErr)
 	})
 
@@ -147,8 +147,8 @@ func TestStorageAt(t *testing.T) {
 		mockState.EXPECT().ContractClassHash(&felt.Zero).Return(nil, nil)
 		mockState.EXPECT().ContractStorage(gomock.Any(), gomock.Any()).Return(&felt.Zero, nil)
 
-		storage, rpcErr := handler.StorageAt(felt.Zero, felt.Zero, rpc.BlockID{Latest: true})
-		assert.Equal(t, &felt.Zero, storage)
+		storageValue, rpcErr := handler.StorageAt(felt.Zero, felt.Zero, rpc.BlockID{Latest: true})
+		assert.Equal(t, &felt.Zero, storageValue)
 		require.Nil(t, rpcErr)
 	})
 
@@ -157,8 +157,8 @@ func TestStorageAt(t *testing.T) {
 		mockState.EXPECT().ContractClassHash(&felt.Zero).Return(nil, nil)
 		mockState.EXPECT().ContractStorage(gomock.Any(), gomock.Any()).Return(nil, errors.New("some internal error"))
 
-		storage, rpcErr := handler.StorageAt(felt.Zero, felt.Zero, rpc.BlockID{Latest: true})
-		assert.Nil(t, storage)
+		storageValue, rpcErr := handler.StorageAt(felt.Zero, felt.Zero, rpc.BlockID{Latest: true})
+		assert.Nil(t, storageValue)
 		assert.Equal(t, rpccore.ErrInternal, rpcErr)
 	})
 
@@ -169,9 +169,9 @@ func TestStorageAt(t *testing.T) {
 		mockState.EXPECT().ContractClassHash(&felt.Zero).Return(nil, nil)
 		mockState.EXPECT().ContractStorage(gomock.Any(), gomock.Any()).Return(expectedStorage, nil)
 
-		storage, rpcErr := handler.StorageAt(felt.Zero, felt.Zero, rpc.BlockID{Latest: true})
+		storageValue, rpcErr := handler.StorageAt(felt.Zero, felt.Zero, rpc.BlockID{Latest: true})
 		require.Nil(t, rpcErr)
-		assert.Equal(t, expectedStorage, storage)
+		assert.Equal(t, expectedStorage, storageValue)
 	})
 
 	t.Run("blockID - hash", func(t *testing.T) {
@@ -179,9 +179,9 @@ func TestStorageAt(t *testing.T) {
 		mockState.EXPECT().ContractClassHash(&felt.Zero).Return(nil, nil)
 		mockState.EXPECT().ContractStorage(gomock.Any(), gomock.Any()).Return(expectedStorage, nil)
 
-		storage, rpcErr := handler.StorageAt(felt.Zero, felt.Zero, rpc.BlockID{Hash: &felt.Zero})
+		storageValue, rpcErr := handler.StorageAt(felt.Zero, felt.Zero, rpc.BlockID{Hash: &felt.Zero})
 		require.Nil(t, rpcErr)
-		assert.Equal(t, expectedStorage, storage)
+		assert.Equal(t, expectedStorage, storageValue)
 	})
 
 	t.Run("blockID - number", func(t *testing.T) {
@@ -189,9 +189,9 @@ func TestStorageAt(t *testing.T) {
 		mockState.EXPECT().ContractClassHash(&felt.Zero).Return(nil, nil)
 		mockState.EXPECT().ContractStorage(gomock.Any(), gomock.Any()).Return(expectedStorage, nil)
 
-		storage, rpcErr := handler.StorageAt(felt.Zero, felt.Zero, rpc.BlockID{Number: 0})
+		storageValue, rpcErr := handler.StorageAt(felt.Zero, felt.Zero, rpc.BlockID{Number: 0})
 		require.Nil(t, rpcErr)
-		assert.Equal(t, expectedStorage, storage)
+		assert.Equal(t, expectedStorage, storageValue)
 	})
 }
 


### PR DESCRIPTION
The specs for get_StorageAt is the same for v6, v7 and v8: https://github.com/starkware-libs/starknet-specs/blob/v0.6.0/api/starknet_api_openrpc.json#L136

The possible errors are:
- ErrBlockNotFound
- ErrContractNotFound

## Modifications

1. In our v6, when the contract did not exist, it returned a zero-valued field (as if the contract existed but not the key). I added a check for contract existence.

2. In our v6, v7, v8, when an error is returned when trying to retrieve the value of a key (call to `ContractStorage`), we used to return `ErrContractNotFound`. But this check is now done before (thanks to point 1), and this call can actually never return `ErrContractNotFound` error, so, I changed to return an `ErrInternal` instead.

## Question

This bug was not seen before because in the tests, we can "cheat" by mocking calls to return whatever value we want. Shouldn't we use something like `NewMemTest` ? I've seen this used elsewhere, and I believe using this avoids mocking calls and subsequently allows to get the actual returned value that will be returned in practice too. But this would require setting up tests a bit more I guess (for example, adding a contract with a storage key to test key existence than just mocking a call, etc.).  What do you think ?