### PR TITLE
Refactor: Reuse v6 starknet_getClassAt handler for v7 and v8

### DIFF
--- a/rpc/handlers.go
+++ b/rpc/handlers.go
@@ -173,7 +173,7 @@ func (h *Handler) MethodsV0_8() ([]jsonrpc.Method, string) { //nolint: funlen
 		{
 			Name:    "starknet_getClassAt",
 			Params:  []jsonrpc.Parameter{{Name: "block_id"}, {Name: "contract_address"}},
-			Handler: h.rpcv8Handler.ClassAt,
+			Handler: h.rpcv6Handler.ClassAt,
 		},
 		{
 			Name:    "starknet_addInvokeTransaction",
@@ -367,7 +367,7 @@ func (h *Handler) MethodsV0_7() ([]jsonrpc.Method, string) { //nolint: funlen
 		{
 			Name:    "starknet_getClassAt",
 			Params:  []jsonrpc.Parameter{{Name: "block_id"}, {Name: "contract_address"}},
-			Handler: h.rpcv7Handler.ClassAt,
+			Handler: h.rpcv6Handler.ClassAt,
 		},
 		{
 			Name:    "starknet_addInvokeTransaction",

--- a/rpc/v7/class.go
+++ b/rpc/v7/class.go
@@ -146,18 +146,6 @@ func (h *Handler) Class(id BlockID, classHash felt.Felt) (*Class, *jsonrpc.Error
 	return rpcClass, nil
 }
 
-// ClassAt gets the contract class definition in the given block instantiated by the given contract address
-//
-// It follows the specification defined here:
-// https://github.com/starkware-libs/starknet-specs/blob/master/api/starknet_api_openrpc.json#L329
-func (h *Handler) ClassAt(id BlockID, address felt.Felt) (*Class, *jsonrpc.Error) {
-	classHash, err := h.ClassHashAt(id, address)
-	if err != nil {
-		return nil, err
-	}
-	return h.Class(id, *classHash)
-}
-
 // ClassHashAt gets the class hash for the contract deployed at the given address in the given block.
 //
 // It follows the specification defined here:

--- a/rpc/v8/class.go
+++ b/rpc/v8/class.go
@@ -146,18 +146,6 @@ func (h *Handler) Class(id BlockID, classHash felt.Felt) (*Class, *jsonrpc.Error
 	return rpcClass, nil
 }
 
-// ClassAt gets the contract class definition in the given block instantiated by the given contract address
-//
-// It follows the specification defined here:
-// https://github.com/starkware-libs/starknet-specs/blob/master/api/starknet_api_openrpc.json#L329
-func (h *Handler) ClassAt(id BlockID, address felt.Felt) (*Class, *jsonrpc.Error) {
-	classHash, err := h.ClassHashAt(id, address)
-	if err != nil {
-		return nil, err
-	}
-	return h.Class(id, *classHash)
-}
-
 // ClassHashAt gets the class hash for the contract deployed at the given address in the given block.
 //
 // It follows the specification defined here:

--- a/rpc/v8/class_test.go
+++ b/rpc/v8/class_test.go
@@ -94,59 +94,6 @@ func TestClass(t *testing.T) {
 	})
 }
 
-func TestClassAt(t *testing.T) {
-	n := utils.Ptr(utils.Integration)
-	integrationClient := feeder.NewTestClient(t, n)
-	integGw := adaptfeeder.New(integrationClient)
-
-	mockCtrl := gomock.NewController(t)
-	t.Cleanup(mockCtrl.Finish)
-
-	mockReader := mocks.NewMockReader(mockCtrl)
-	mockState := mocks.NewMockStateHistoryReader(mockCtrl)
-
-	cairo0ContractAddress, _ := new(felt.Felt).SetRandom()
-	cairo0ClassHash := utils.HexToFelt(t, "0x4631b6b3fa31e140524b7d21ba784cea223e618bffe60b5bbdca44a8b45be04")
-	mockState.EXPECT().ContractClassHash(cairo0ContractAddress).Return(cairo0ClassHash, nil)
-
-	cairo1ContractAddress, _ := new(felt.Felt).SetRandom()
-	cairo1ClassHash := utils.HexToFelt(t, "0x1cd2edfb485241c4403254d550de0a097fa76743cd30696f714a491a454bad5")
-	mockState.EXPECT().ContractClassHash(cairo1ContractAddress).Return(cairo1ClassHash, nil)
-
-	mockState.EXPECT().Class(gomock.Any()).DoAndReturn(func(classHash *felt.Felt) (*core.DeclaredClass, error) {
-		class, err := integGw.Class(context.Background(), classHash)
-		return &core.DeclaredClass{Class: class, At: 0}, err
-	}).AnyTimes()
-	mockReader.EXPECT().HeadState().Return(mockState, func() error {
-		return nil
-	}, nil).AnyTimes()
-	mockReader.EXPECT().HeadsHeader().Return(new(core.Header), nil).AnyTimes()
-	handler := rpc.New(mockReader, nil, nil, "", utils.NewNopZapLogger())
-
-	latest := rpc.BlockID{Latest: true}
-
-	t.Run("sierra class", func(t *testing.T) {
-		coreClass, err := integGw.Class(context.Background(), cairo1ClassHash)
-		require.NoError(t, err)
-
-		class, rpcErr := handler.ClassAt(latest, *cairo1ContractAddress)
-		require.Nil(t, rpcErr)
-		cairo1Class := coreClass.(*core.Cairo1Class)
-		assertEqualCairo1Class(t, cairo1Class, class)
-	})
-
-	t.Run("casm class", func(t *testing.T) {
-		coreClass, err := integGw.Class(context.Background(), cairo0ClassHash)
-		require.NoError(t, err)
-
-		class, rpcErr := handler.ClassAt(latest, *cairo0ContractAddress)
-		require.Nil(t, rpcErr)
-
-		cairo0Class := coreClass.(*core.Cairo0Class)
-		assertEqualCairo0Class(t, cairo0Class, class)
-	})
-}
-
 func TestClassHashAt(t *testing.T) {
 	mockCtrl := gomock.NewController(t)
 	t.Cleanup(mockCtrl.Finish)

--- a/rpc/v8/handlers.go
+++ b/rpc/v8/handlers.go
@@ -216,11 +216,6 @@ func (h *Handler) methods() ([]jsonrpc.Method, string) { //nolint: funlen
 			Handler: h.Class,
 		},
 		{
-			Name:    "starknet_getClassAt",
-			Params:  []jsonrpc.Parameter{{Name: "block_id"}, {Name: "contract_address"}},
-			Handler: h.ClassAt,
-		},
-		{
 			Name:    "starknet_addInvokeTransaction",
 			Params:  []jsonrpc.Parameter{{Name: "invoke_transaction"}},
 			Handler: h.AddTransaction,


### PR DESCRIPTION
RPC pkg cleanup according to issue #2437 

Reuse starknet_getClassAt v6 handler for both v7 and v8