### PR TITLE
rpc sub pending txns returns txn/hash one at a time

### DIFF
--- a/rpc/v8/subscriptions.go
+++ b/rpc/v8/subscriptions.go
@@ -523,7 +523,7 @@ func (h *Handler) processPendingTxs(ctx context.Context, getDetails bool, sender
 			return
 		case pendingBlock := <-pendingSub.Recv():
 			filteredTxs := h.filterTxs(pendingBlock.Transactions, getDetails, senderAddr)
-			for filteredTxn := range filteredTxs {
+			for _, filteredTxn := range filteredTxs {
 				if err := h.sendPendingTxs(w, filteredTxn, id); err != nil {
 					h.log.Warnw("Error sending pending transactions", "err", err)
 					return
@@ -533,27 +533,15 @@ func (h *Handler) processPendingTxs(ctx context.Context, getDetails bool, sender
 	}
 }
 
-// filterTxs filters the transactions based on the getDetails flag.
-// If getDetails is true, response will contain the transaction details.
-// If getDetails is false, response will only contain the transaction hashes.
 func (h *Handler) filterTxs(pendingTxs []core.Transaction, getDetails bool, senderAddr []felt.Felt) []any {
-	result := make([]any, len(pendingTxs))
 	if getDetails {
-		txs := h.filterTxDetails(pendingTxs, senderAddr)
-		for i, txn := range txs {
-			result[i] = txn
-		}
-	} else {
-		hashes := h.filterTxHashes(pendingTxs, senderAddr)
-		for i, hash := range hashes {
-			result[i] = hash
-		}
+		return h.filterTxDetails(pendingTxs, senderAddr)
 	}
-	return result
+	return h.filterTxHashes(pendingTxs, senderAddr)
 }
 
-func (h *Handler) filterTxDetails(pendingTxs []core.Transaction, senderAddr []felt.Felt) []*Transaction {
-	filteredTxs := make([]*Transaction, 0, len(pendingTxs))
+func (h *Handler) filterTxDetails(pendingTxs []core.Transaction, senderAddr []felt.Felt) []any {
+	filteredTxs := make([]any, 0, len(pendingTxs))
 	for _, txn := range pendingTxs {
 		if h.filterTxBySender(txn, senderAddr) {
 			filteredTxs = append(filteredTxs, AdaptTransaction(txn))
@@ -562,8 +550,8 @@ func (h *Handler) filterTxDetails(pendingTxs []core.Transaction, senderAddr []fe
 	return filteredTxs
 }
 
-func (h *Handler) filterTxHashes(pendingTxs []core.Transaction, senderAddr []felt.Felt) []felt.Felt {
-	filteredTxHashes := make([]felt.Felt, 0, len(pendingTxs))
+func (h *Handler) filterTxHashes(pendingTxs []core.Transaction, senderAddr []felt.Felt) []any {
+	filteredTxHashes := make([]any, 0, len(pendingTxs))
 	for _, txn := range pendingTxs {
 		if h.filterTxBySender(txn, senderAddr) {
 			filteredTxHashes = append(filteredTxHashes, *txn.Hash())


### PR DESCRIPTION
looks like there is also small issue with starknet_subscribePendingTransactions . For simple subscription like:
```
{
	"jsonrpc":"2.0",
	"method":"starknet_subscribePendingTransactions",
	"id":1
}
```
We get events with list of txn hashes:
```
{
    "jsonrpc": "2.0",
    "method": "starknet_subscriptionPendingTransactions",
    "params": {
        "result": [
            "0x27edae45913bd7a795f880e097952f701508a0db6e526d7d429322cca0b1d46",
            "0xd1546be050876c40d4bce245042148c6228e64d4e919f882c83d5ced6a7204",
            "0x5e7a0a1c092b718c29adfe0310b562f7e4eef525718b23efc5c0ed29dbc2010",
            "0x1d35b11c6a8972f0553ba2e9c56a2473fc2604f9a31df23494ace06ddf92554",
            "0x7175c433facb2d43d715cd6ebe0368189518e0067cf40d2a92c8b402c658dbe"
        ],
        "subscription_id": 17314660468562213818
    }
}
```
While [according to the spec](https://github.com/starkware-libs/starknet-specs/blob/436e6307bab3938339e4bf469f14dee79b50802d/api/starknet_ws_api.json#L224) result should be single new transaction, no array.

This PR should make the subscription return the txn/hash one at a time