### PR TITLE
Fix missing L1 client error log

### DIFF
--- a/rpc/v8/l1.go
+++ b/rpc/v8/l1.go
@@ -2,7 +2,6 @@ package rpcv8
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"math/big"
 
@@ -83,7 +82,7 @@ func (h *Handler) GetMessageStatus(ctx context.Context, l1TxnHash *common.Hash) 
 
 func (h *Handler) messageToL2Logs(ctx context.Context, txHash *common.Hash) ([]*common.Hash, *jsonrpc.Error) {
 	if h.l1Client == nil {
-		return nil, jsonrpc.Err(jsonrpc.InternalError, errors.New("11 client not found, cannot serve starknet_getMessage"))
+		return nil, jsonrpc.Err(jsonrpc.InternalError, "11 client not found")
 	}
 
 	receipt, err := h.l1Client.TransactionReceipt(ctx, *txHash)

--- a/rpc/v8/l1_test.go
+++ b/rpc/v8/l1_test.go
@@ -97,4 +97,11 @@ func TestGetMessageStatus(t *testing.T) {
 			require.Equal(t, test.msgs, msgStatuses)
 		})
 	}
+
+	t.Run("l1 client not found", func(t *testing.T) {
+		handler := rpc.New(nil, nil, nil, "", nil).WithL1Client(nil)
+		msgStatuses, rpcErr := handler.GetMessageStatus(context.Background(), &common.Hash{})
+		require.Nil(t, msgStatuses)
+		require.NotNil(t, rpcErr)
+	})
 }


### PR DESCRIPTION
Expected Behaviour
```
{"jsonrpc":"2.0","error":{"code":-32603,"message":"Internal error","data":"11 client not found"},"id":1}                                      
```

Actual Behaviour
```
{"jsonrpc":"2.0","error":{"code":-32603,"message":"Internal error","data":{}},"id":1}
```