### PR TITLE
fix: Distinguish between ErrTxnHashNotFound and ErrInternal

### DIFF
--- a/rpc/v6/transaction.go
+++ b/rpc/v6/transaction.go
@@ -11,6 +11,7 @@ import (
 	"github.com/NethermindEth/juno/clients/gateway"
 	"github.com/NethermindEth/juno/core"
 	"github.com/NethermindEth/juno/core/felt"
+	"github.com/NethermindEth/juno/db"
 	"github.com/NethermindEth/juno/jsonrpc"
 	rpccore "github.com/NethermindEth/juno/rpc/rpccore"
 	"github.com/NethermindEth/juno/starknet"
@@ -427,6 +428,10 @@ func adaptRPCTxToFeederTx(rpcTx *Transaction) *starknet.Transaction {
 func (h *Handler) TransactionByHash(hash felt.Felt) (*Transaction, *jsonrpc.Error) {
 	txn, err := h.bcReader.TransactionByHash(&hash)
 	if err != nil {
+		if !errors.Is(err, db.ErrKeyNotFound) {
+			return nil, rpccore.ErrInternal.CloneWithData(err)
+		}
+
 		return nil, rpccore.ErrTxnHashNotFound
 	}
 	return AdaptTransaction(txn), nil


### PR DESCRIPTION
rpc pkg cleanup according to issue #2437

- **for v6:** I think it could be nice to add this condition to distinguish between ErrTxnHashNotFound and ErrInternal.

- **for v7:** We cannot refactor as the logic is different from v6

- **for v8:** The logic + data structures are the same with v7. So theoretically, we could refactor by reusing v7's handler. But some v8 tests use this v8 handler to compare and test other handlers. For example, it is used to test `TestBlockWithTxs` by comparing the returned txs. So, we cannot really remove the handler.