### PR TITLE
refactor: Use pointer for optional block number in FilteredEvent

### DIFF
--- a/rpc/v6/events.go
+++ b/rpc/v6/events.go
@@ -99,7 +99,7 @@ func (h *Handler) Events(args EventsArg) (*EventsChunk, *jsonrpc.Error) {
 	for _, fEvent := range filteredEvents {
 		var blockNumber *uint64
 		if fEvent.BlockHash != nil {
-			blockNumber = &(fEvent.BlockNumber)
+			blockNumber = fEvent.BlockNumber
 		}
 		emittedEvents = append(emittedEvents, &EmittedEvent{
 			BlockNumber:     blockNumber,

--- a/rpc/v8/subscriptions.go
+++ b/rpc/v8/subscriptions.go
@@ -163,7 +163,7 @@ func (h *Handler) SubscribeEvents(ctx context.Context, fromAddr *felt.Felt, keys
 						for _, e := range r.Events {
 							fe := blockchain.FilteredEvent{
 								Event:           e,
-								BlockNumber:     header.Number,
+								BlockNumber:     &block.Number,
 								BlockHash:       header.Hash,
 								TransactionHash: block.Transactions[i].Hash(),
 							}
@@ -397,7 +397,7 @@ func sendEvents(ctx context.Context, w jsonrpc.Conn, events []*blockchain.Filter
 			}
 
 			emittedEvent := &EmittedEvent{
-				BlockNumber:     &event.BlockNumber, // This always be filled as subscribeEvents cannot be called on pending block
+				BlockNumber:     event.BlockNumber, // This always be filled as subscribeEvents cannot be called on pending block
 				BlockHash:       event.BlockHash,
 				TransactionHash: event.TransactionHash,
 				Event: &Event{

--- a/rpc/v8/subscriptions_test.go
+++ b/rpc/v8/subscriptions_test.go
@@ -124,16 +124,17 @@ func TestSubscribeEvents(t *testing.T) {
 	fromAddr := new(felt.Felt).SetBytes([]byte("some address"))
 	keys := [][]felt.Felt{{*new(felt.Felt).SetBytes([]byte("key1"))}}
 
+	b2BlockNumber := b1.Number + 1
 	filteredEvents := []*blockchain.FilteredEvent{
 		{
 			Event:           b1.Receipts[0].Events[0],
-			BlockNumber:     b1.Number,
+			BlockNumber:     &b1.Number,
 			BlockHash:       new(felt.Felt).SetBytes([]byte("b1")),
 			TransactionHash: b1.Transactions[0].Hash(),
 		},
 		{
 			Event:           b1.Receipts[1].Events[0],
-			BlockNumber:     b1.Number + 1,
+			BlockNumber:     &b2BlockNumber,
 			BlockHash:       new(felt.Felt).SetBytes([]byte("b2")),
 			TransactionHash: b1.Transactions[1].Hash(),
 		},
@@ -148,7 +149,7 @@ func TestSubscribeEvents(t *testing.T) {
 				Data: e.Data,
 			},
 			BlockHash:       e.BlockHash,
-			BlockNumber:     &e.BlockNumber,
+			BlockNumber:     e.BlockNumber,
 			TransactionHash: e.TransactionHash,
 		})
 	}
@@ -333,7 +334,7 @@ func TestSubscribeEvents(t *testing.T) {
 		mockEventFilterer.EXPECT().SetRangeEndBlockByNumber(gomock.Any(), gomock.Any()).Return(nil).MaxTimes(2)
 		mockEventFilterer.EXPECT().Events(gomock.Any(), gomock.Any()).Return([]*blockchain.FilteredEvent{filteredEvents[1]}, nil, nil)
 
-		pendingFeed.Send(&core.Block{Header: &core.Header{Number: b1.Number + 1}})
+		pendingFeed.Send(&core.Block{Header: &core.Header{}})
 
 		resp, err = marshalSubEventsResp(emittedEvents[1], id)
 		require.NoError(t, err)
@@ -349,7 +350,7 @@ func TestSubscribeEvents(t *testing.T) {
 		mockEventFilterer.EXPECT().Events(gomock.Any(), gomock.Any()).Return([]*blockchain.
 			FilteredEvent{filteredEvents[1], filteredEvents[0]}, nil, nil)
 
-		pendingFeed.Send(&core.Block{Header: &core.Header{Number: b1.Number + 1}})
+		pendingFeed.Send(&core.Block{Header: &core.Header{}})
 
 		resp, err = marshalSubEventsResp(emittedEvents[0], id)
 		require.NoError(t, err)


### PR DESCRIPTION
Pending transaction events are expected not to have block number, hence `EmittedEvent` should have nil block number in that case, which requires `FilteredEvent` to accept nil block number too.