### PR TITLE
Fix simulate transaction

### DIFF
--- a/vm/rust/src/execution.rs
+++ b/vm/rust/src/execution.rs
@@ -2,6 +2,7 @@ use crate::juno_state_reader::JunoStateReader;
 use blockifier::execution::contract_class::TrackedResource;
 use blockifier::fee::fee_checks::FeeCheckError;
 use blockifier::state::state_api::{StateReader, StateResult, UpdatableState};
+use blockifier::transaction::objects::HasRelatedFeeType;
 use blockifier::transaction::transaction_execution::Transaction;
 use blockifier::transaction::transactions::ExecutableTransaction;
 use blockifier::{
@@ -12,8 +13,13 @@ use blockifier::{
 use starknet_api::core::ClassHash;
 use starknet_api::executable_transaction::AccountTransaction;
 use starknet_api::execution_resources::GasAmount;
-use starknet_api::transaction::fields::{GasVectorComputationMode, ValidResourceBounds};
-use starknet_api::transaction::{DeclareTransaction, DeployAccountTransaction, InvokeTransaction};
+use starknet_api::transaction::fields::{
+    AllResourceBounds, GasVectorComputationMode, ValidResourceBounds,
+};
+use starknet_api::transaction::{
+    DeclareTransaction, DeclareTransactionV3, DeployAccountTransaction, DeployAccountTransactionV3,
+    InvokeTransaction, InvokeTransactionV3,
+};
 
 pub fn execute_transaction(
     txn: &mut Transaction,

--- a/vm/rust/src/execution.rs
+++ b/vm/rust/src/execution.rs
@@ -106,7 +106,7 @@ fn get_gas_vector_computation_mode<S>(
 where
     S: UpdatableState,
 {
-    let original_tx = transaction.clone();
+    let mut original_tx = transaction.clone();
     let initial_gas_limit = extract_l2_gas_limit(transaction);
 
     // Simulate transaction execution with maximum possible gas to get actual gas usage.
@@ -197,7 +197,7 @@ where
 
     if original_charge_fee {
         if let Transaction::Account(_) = transaction {
-            set_l2_gas_limit(transaction, l2_gas_limit);
+            set_l2_gas_limit(&mut original_tx, l2_gas_limit);
             return original_tx.execute(state, block_context);
         }
     }


### PR DESCRIPTION
This PR fixes an issue that arose after #2473, transaction simulation fails due to `charge_fee` and `validate` flags