### PR TITLE
Revert removing transaction_hash from getBlockWithReceipts in v0.7

### DIFF
--- a/rpc/v7/block.go
+++ b/rpc/v7/block.go
@@ -136,10 +136,8 @@ func (h *Handler) BlockWithReceipts(id BlockID) (*BlockWithReceipts, *jsonrpc.Er
 	for index, txn := range block.Transactions {
 		r := block.Receipts[index]
 
-		t := AdaptTransaction(txn)
-		t.Hash = nil
 		txsWithReceipts[index] = TransactionWithReceipt{
-			Transaction: t,
+			Transaction: AdaptTransaction(txn),
 			// block_hash, block_number are optional in BlockWithReceipts response
 			Receipt: AdaptReceipt(r, txn, finalityStatus, nil, 0),
 		}

--- a/rpc/v7/block_test.go
+++ b/rpc/v7/block_test.go
@@ -488,7 +488,6 @@ func TestBlockWithReceipts(t *testing.T) {
 		for i, tx := range block0.Transactions {
 			receipt := block0.Receipts[i]
 			adaptedTx := rpcv7.AdaptTransaction(tx)
-			adaptedTx.Hash = nil
 
 			txsWithReceipt = append(txsWithReceipt, rpcv7.TransactionWithReceipt{
 				Transaction: adaptedTx,
@@ -533,7 +532,6 @@ func TestBlockWithReceipts(t *testing.T) {
 		for i, tx := range block1.Transactions {
 			receipt := block1.Receipts[i]
 			adaptedTx := rpcv7.AdaptTransaction(tx)
-			adaptedTx.Hash = nil
 
 			transactions = append(transactions, rpcv7.TransactionWithReceipt{
 				Transaction: adaptedTx,


### PR DESCRIPTION
In Juno v0.13.0, `transaction_hash` was removed from transactions returned by `starknet_getBlockWithReceipts`, aligning with the StarkNet JSON-RPC specification. However, this change caused issues for clients relying on the previous behavior.