### PR TITLE
fix: RPC v0.8 now doesn't support broadcasted transaction less than v3

### DIFF
--- a/node/node.go
+++ b/node/node.go
@@ -214,12 +214,12 @@ func New(cfg *Config, version string, logLevel *utils.LogLevel) (*Node, error) {
 	if err = jsonrpcServerV08.RegisterMethods(methodsV08...); err != nil {
 		return nil, err
 	}
-	jsonrpcServerV07 := jsonrpc.NewServer(maxGoroutines, log).WithValidator(validator.Validator())
+	jsonrpcServerV07 := jsonrpc.NewServer(maxGoroutines, log)
 	methodsV07, pathV07 := rpcHandler.MethodsV0_7()
 	if err = jsonrpcServerV07.RegisterMethods(methodsV07...); err != nil {
 		return nil, err
 	}
-	jsonrpcServerV06 := jsonrpc.NewServer(maxGoroutines, log).WithValidator(validator.Validator())
+	jsonrpcServerV06 := jsonrpc.NewServer(maxGoroutines, log)
 	methodsV06, pathV06 := rpcHandler.MethodsV0_6()
 	if err = jsonrpcServerV06.RegisterMethods(methodsV06...); err != nil {
 		return nil, err

--- a/rpc/v8/transaction.go
+++ b/rpc/v8/transaction.go
@@ -212,7 +212,7 @@ type ResourceBounds struct {
 type Transaction struct {
 	Hash                  *felt.Felt                   `json:"transaction_hash,omitempty"`
 	Type                  TransactionType              `json:"type" validate:"required"`
-	Version               *felt.Felt                   `json:"version,omitempty" validate:"required,version_min_0x3"`
+	Version               *felt.Felt                   `json:"version,omitempty" validate:"required,version_0x3"`
 	Nonce                 *felt.Felt                   `json:"nonce,omitempty" validate:"required"`
 	MaxFee                *felt.Felt                   `json:"max_fee,omitempty"`
 	ContractAddress       *felt.Felt                   `json:"contract_address,omitempty"`

--- a/rpc/v8/transaction.go
+++ b/rpc/v8/transaction.go
@@ -212,24 +212,24 @@ type ResourceBounds struct {
 type Transaction struct {
 	Hash                  *felt.Felt                   `json:"transaction_hash,omitempty"`
 	Type                  TransactionType              `json:"type" validate:"required"`
-	Version               *felt.Felt                   `json:"version,omitempty" validate:"required"`
-	Nonce                 *felt.Felt                   `json:"nonce,omitempty" validate:"required_unless=Version 0x0"`
-	MaxFee                *felt.Felt                   `json:"max_fee,omitempty" validate:"required_if=Version 0x0,required_if=Version 0x1,required_if=Version 0x2"`
+	Version               *felt.Felt                   `json:"version,omitempty" validate:"required,version_min_0x3"`
+	Nonce                 *felt.Felt                   `json:"nonce,omitempty" validate:"required"`
+	MaxFee                *felt.Felt                   `json:"max_fee,omitempty"`
 	ContractAddress       *felt.Felt                   `json:"contract_address,omitempty"`
 	ContractAddressSalt   *felt.Felt                   `json:"contract_address_salt,omitempty" validate:"required_if=Type DEPLOY,required_if=Type DEPLOY_ACCOUNT"`
 	ClassHash             *felt.Felt                   `json:"class_hash,omitempty" validate:"required_if=Type DEPLOY,required_if=Type DEPLOY_ACCOUNT"`
 	ConstructorCallData   *[]*felt.Felt                `json:"constructor_calldata,omitempty" validate:"required_if=Type DEPLOY,required_if=Type DEPLOY_ACCOUNT"`
-	SenderAddress         *felt.Felt                   `json:"sender_address,omitempty" validate:"required_if=Type DECLARE,required_if=Type INVOKE Version 0x1,required_if=Type INVOKE Version 0x3"`
+	SenderAddress         *felt.Felt                   `json:"sender_address,omitempty" validate:"required_if=Type DECLARE,required_if=Type INVOKE"`
 	Signature             *[]*felt.Felt                `json:"signature,omitempty" validate:"required"`
 	CallData              *[]*felt.Felt                `json:"calldata,omitempty" validate:"required_if=Type INVOKE"`
-	EntryPointSelector    *felt.Felt                   `json:"entry_point_selector,omitempty" validate:"required_if=Type INVOKE Version 0x0"`
-	CompiledClassHash     *felt.Felt                   `json:"compiled_class_hash,omitempty" validate:"required_if=Type DECLARE Version 0x2"`
+	EntryPointSelector    *felt.Felt                   `json:"entry_point_selector,omitempty"`
+	CompiledClassHash     *felt.Felt                   `json:"compiled_class_hash,omitempty"`
 	ResourceBounds        *map[Resource]ResourceBounds `json:"resource_bounds,omitempty" validate:"resource_bounds_required"`
-	Tip                   *felt.Felt                   `json:"tip,omitempty" validate:"required_if=Version 0x3"`
-	PaymasterData         *[]*felt.Felt                `json:"paymaster_data,omitempty" validate:"required_if=Version 0x3"`
-	AccountDeploymentData *[]*felt.Felt                `json:"account_deployment_data,omitempty" validate:"required_if=Type INVOKE Version 0x3,required_if=Type DECLARE Version 0x3"`
-	NonceDAMode           *DataAvailabilityMode        `json:"nonce_data_availability_mode,omitempty" validate:"required_if=Version 0x3"`
-	FeeDAMode             *DataAvailabilityMode        `json:"fee_data_availability_mode,omitempty" validate:"required_if=Version 0x3"`
+	Tip                   *felt.Felt                   `json:"tip,omitempty" validate:"required"`
+	PaymasterData         *[]*felt.Felt                `json:"paymaster_data,omitempty" validate:"required"`
+	AccountDeploymentData *[]*felt.Felt                `json:"account_deployment_data,omitempty" validate:"required_if=Type INVOKE,required_if=Type DECLARE"`
+	NonceDAMode           *DataAvailabilityMode        `json:"nonce_data_availability_mode,omitempty" validate:"required"`
+	FeeDAMode             *DataAvailabilityMode        `json:"fee_data_availability_mode,omitempty" validate:"required"`
 }
 
 type TransactionStatus struct {

--- a/rpc/v8/transaction_test.go
+++ b/rpc/v8/transaction_test.go
@@ -1491,6 +1491,20 @@ func TestResourceBoundsValidation(t *testing.T) {
 		"fee_data_availability_mode": "L1",
 		"account_deployment_data": []
 	}`
+	invokeV1 := `{
+		"type": "INVOKE",
+		"sender_address": "0x4a7876e03402cf253efdb3b17c760ee7349c7ec2876059b83ec2c92ca451e16",
+		"calldata": [
+			"0x1",
+			"0x3745ab04a431fc02871a139be6b93d9260b0ff3e779ad9c8b377183b23109f1",
+			"0x6a26462a114fa5e0c0e6b9cd8442c79e1ad560232e65427e16de301eb99b89",
+			"0x0"
+		],
+		"max_fee": "0x0",
+		"version": "0x100000000000000000000000000000001",
+		"signature": [],
+		"nonce": "0x34f6"
+	}`
 
 	tests := []struct {
 		name    string
@@ -1506,6 +1520,11 @@ func TestResourceBoundsValidation(t *testing.T) {
 			name:    "valid v3 - resource_bounds fully populated",
 			txnJSON: validInvokeV3,
 			wantErr: false,
+		},
+		{
+			name:    "valid v1",
+			txnJSON: invokeV1,
+			wantErr: true,
 		},
 	}
 

--- a/validator/validator.go
+++ b/validator/validator.go
@@ -18,20 +18,13 @@ var (
 
 func validateResourceBounds(fl validator.FieldLevel) bool {
 	req, ok := fl.Parent().Interface().(rpcv8.Transaction)
-	if !ok {
-		return false
-	}
-
-	return req.ResourceBounds != nil && len(*req.ResourceBounds) == 3
+	return ok && req.ResourceBounds != nil && len(*req.ResourceBounds) == 3
 }
 
 // Custom validation function for version
 func validateVersion(fl validator.FieldLevel) bool {
 	version, ok := fl.Field().Interface().(string)
-	if !ok {
-		return false
-	}
-	return version == "0x3" || version == "0x100000000000000000000000000000003"
+	return ok && (version == "0x3" || version == "0x100000000000000000000000000000003")
 }
 
 // Validator returns a singleton that can be used to validate various objects

--- a/validator/validator.go
+++ b/validator/validator.go
@@ -22,12 +22,16 @@ func validateResourceBounds(fl validator.FieldLevel) bool {
 		return false
 	}
 
-	version := req.Version.String()
-	if (version == "0x3" || version == "0x100000000000000000000000000000003") &&
-		(req.ResourceBounds == nil || len(*req.ResourceBounds) != 3) {
+	return req.ResourceBounds != nil && len(*req.ResourceBounds) == 3
+}
+
+// Custom validation function for version
+func validateVersion(fl validator.FieldLevel) bool {
+	version, ok := fl.Field().Interface().(string)
+	if !ok {
 		return false
 	}
-	return true
+	return version == "0x3" || version == "0x100000000000000000000000000000003"
 }
 
 // Validator returns a singleton that can be used to validate various objects
@@ -36,6 +40,10 @@ func Validator() *validator.Validate {
 		v = validator.New()
 
 		if err := v.RegisterValidation("resource_bounds_required", validateResourceBounds); err != nil {
+			panic("failed to register validation: " + err.Error())
+		}
+
+		if err := v.RegisterValidation("version_min_0x3", validateVersion); err != nil {
 			panic("failed to register validation: " + err.Error())
 		}
 

--- a/validator/validator.go
+++ b/validator/validator.go
@@ -43,7 +43,7 @@ func Validator() *validator.Validate {
 			panic("failed to register validation: " + err.Error())
 		}
 
-		if err := v.RegisterValidation("version_min_0x3", validateVersion); err != nil {
+		if err := v.RegisterValidation("version_0x3", validateVersion); err != nil {
 			panic("failed to register validation: " + err.Error())
 		}
 

--- a/validator/validator.go
+++ b/validator/validator.go
@@ -22,7 +22,7 @@ func validateResourceBounds(fl validator.FieldLevel) bool {
 }
 
 // Custom validation function for version
-func validateVersion(fl validator.FieldLevel) bool {
+func validateVersion03(fl validator.FieldLevel) bool {
 	version, ok := fl.Field().Interface().(string)
 	return ok && (version == "0x3" || version == "0x100000000000000000000000000000003")
 }
@@ -36,7 +36,7 @@ func Validator() *validator.Validate {
 			panic("failed to register validation: " + err.Error())
 		}
 
-		if err := v.RegisterValidation("version_0x3", validateVersion); err != nil {
+		if err := v.RegisterValidation("version_0x3", validateVersion03); err != nil {
 			panic("failed to register validation: " + err.Error())
 		}
 


### PR DESCRIPTION
This pull request includes several changes to fix the validation logic. The most important changes include removing redundant validator calls, updating validation rules for transaction fields, and adding a new custom validation function for versions.