### PR TITLE
test(cmd): safer and simpler cmd test env

### DIFF
--- a/cmd/juno/juno_test.go
+++ b/cmd/juno/juno_test.go
@@ -7,7 +7,6 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
-	"strings"
 	"testing"
 	"time"
 
@@ -665,8 +664,6 @@ network: sepolia
 		},
 	}
 
-	junoEnv := unsetJunoPrefixedEnv(t)
-
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
 			if tc.cfgFile {
@@ -678,7 +675,7 @@ network: sepolia
 
 			if len(tc.env) > 0 {
 				for i := range len(tc.env) / 2 {
-					require.NoError(t, os.Setenv(tc.env[2*i], tc.env[2*i+1]))
+					t.Setenv(tc.env[2*i], tc.env[2*i+1])
 				}
 			}
 
@@ -694,14 +691,8 @@ network: sepolia
 			require.NoError(t, err)
 
 			assert.Equal(t, tc.expectedConfig, config)
-			if len(tc.env) > 0 {
-				for i := range len(tc.env) / 2 {
-					require.NoError(t, os.Unsetenv(tc.env[2*i]))
-				}
-			}
 		})
 	}
-	setJunoPrefixedEnv(t, junoEnv)
 }
 
 func TestGenP2PKeyPair(t *testing.T) {
@@ -725,30 +716,4 @@ func tempCfgFile(t *testing.T, cfg string) string {
 	require.NoError(t, f.Sync())
 
 	return f.Name()
-}
-
-func unsetJunoPrefixedEnv(t *testing.T) map[string]string {
-	t.Helper()
-
-	const prefix = "JUNO_"
-	junoEnv := make(map[string]string)
-
-	for _, e := range os.Environ() {
-		pair := strings.Split(e, "=")
-		k, v := pair[0], pair[1]
-
-		if strings.HasPrefix(k, prefix) {
-			junoEnv[k] = v
-
-			require.NoError(t, os.Unsetenv(k))
-		}
-	}
-	return junoEnv
-}
-
-func setJunoPrefixedEnv(t *testing.T, env map[string]string) {
-	t.Helper()
-	for k, v := range env {
-		require.NoError(t, os.Setenv(k, v))
-	}
 }


### PR DESCRIPTION
This change replaces manual environment variable handling with `t.Setenv`, which simplifies the logic and ensures proper cleanup.

`t.Setenv` automatically restores the previous value (or removes it if it didn’t exist) using `t.Cleanup`, making the tests more robust, even in case of a crash.

Also makes my linter happy since its been screaming for some time for usage of `os.setenv` in tests.

Ref: [t.Setenv](https://github.com/golang/go/blob/b38b0c0088039b03117b87eee61583ac4153f2b7/src/testing/testing.go#L1327)
