### PR TITLE
fix(rpc): failed fee estimation due to absence of l1_data_gas

### DIFF
--- a/adapters/sn2core/sn2core.go
+++ b/adapters/sn2core/sn2core.go
@@ -199,6 +199,21 @@ func adaptResourceBounds(rb *map[starknet.Resource]starknet.ResourceBounds) map[
 			MaxPricePerUnit: bounds.MaxPricePerUnit,
 		}
 	}
+
+	// Ensures that the L1DataGas resource is always present if L2Gas is non-zero.
+	// In RPC v8, L1Gas, L2Gas and L1DataGas are part of the spec and required.
+	// In RPC v6 and v7, only L1Gas and L2Gas are part of the spec and required.
+	// Blockifier will throw an error if L1DataGas is absent and L2Gas is non-zero.
+	// To avoid that, if L2Gas is non-zero, we set the L1DataGas resource to zero.
+	if l2Gas, ok := coreBounds[core.ResourceL2Gas]; ok && !l2Gas.IsZero() {
+		if _, ok := coreBounds[core.ResourceL1DataGas]; !ok {
+			coreBounds[core.ResourceL1DataGas] = core.ResourceBounds{
+				MaxAmount:       0,
+				MaxPricePerUnit: &felt.Zero,
+			}
+		}
+	}
+
 	return coreBounds
 }
 

--- a/core/transaction.go
+++ b/core/transaction.go
@@ -74,6 +74,10 @@ func (rb ResourceBounds) Bytes(resource Resource) []byte {
 	)
 }
 
+func (rb ResourceBounds) IsZero() bool {
+	return rb.MaxAmount == 0 && (rb.MaxPricePerUnit == nil || rb.MaxPricePerUnit.IsZero())
+}
+
 type Event struct {
 	Data []*felt.Felt
 	From *felt.Felt

--- a/rpc/v7/simulation_test.go
+++ b/rpc/v7/simulation_test.go
@@ -69,34 +69,6 @@ func TestSimulateTransactions(t *testing.T) {
 		assert.Equal(t, httpHeader.Get(rpcv7.ExecutionStepsHeader), "123")
 	})
 
-	t.Run("ok with l2gas present", func(t *testing.T) {
-		stepsUsed := uint64(123)
-		mockVM.EXPECT().Execute([]core.Transaction{}, nil, []*felt.Felt{}, &vm.BlockInfo{
-			Header: headsHeader,
-		}, mockState, n, false, true, false, false).
-			Return(vm.ExecutionResults{
-				OverallFees:      []*felt.Felt{},
-				DataAvailability: []core.DataAvailability{},
-				Traces:           []vm.TransactionTrace{},
-				NumSteps:         stepsUsed,
-			}, nil)
-
-		txn := rpcv7.BroadcastedTransaction{
-			Transaction: rpcv7.Transaction{
-				ResourceBounds: &map[rpcv7.Resource]rpcv7.ResourceBounds{
-					rpcv7.Resource(core.ResourceL2Gas): {
-						MaxAmount:       new(felt.Felt).SetUint64(100),
-						MaxPricePerUnit: new(felt.Felt).SetUint64(100),
-					},
-				},
-			},
-		}
-
-		_, httpHeader, err := handler.SimulateTransactions(rpcv7.BlockID{Latest: true}, []rpcv7.BroadcastedTransaction{txn}, []rpcv7.SimulationFlag{rpcv7.SkipValidateFlag})
-		require.Nil(t, err)
-		assert.Equal(t, httpHeader.Get(rpcv7.ExecutionStepsHeader), "123")
-	})
-
 	t.Run("transaction execution error", func(t *testing.T) {
 		t.Run("v0_7, v0_8", func(t *testing.T) { //nolint:dupl
 			mockVM.EXPECT().Execute([]core.Transaction{}, nil, []*felt.Felt{}, &vm.BlockInfo{

--- a/rpc/v7/simulation_test.go
+++ b/rpc/v7/simulation_test.go
@@ -69,6 +69,34 @@ func TestSimulateTransactions(t *testing.T) {
 		assert.Equal(t, httpHeader.Get(rpcv7.ExecutionStepsHeader), "123")
 	})
 
+	t.Run("ok with l2gas present", func(t *testing.T) {
+		stepsUsed := uint64(123)
+		mockVM.EXPECT().Execute([]core.Transaction{}, nil, []*felt.Felt{}, &vm.BlockInfo{
+			Header: headsHeader,
+		}, mockState, n, false, true, false, false).
+			Return(vm.ExecutionResults{
+				OverallFees:      []*felt.Felt{},
+				DataAvailability: []core.DataAvailability{},
+				Traces:           []vm.TransactionTrace{},
+				NumSteps:         stepsUsed,
+			}, nil)
+
+		txn := rpcv7.BroadcastedTransaction{
+			Transaction: rpcv7.Transaction{
+				ResourceBounds: &map[rpcv7.Resource]rpcv7.ResourceBounds{
+					rpcv7.Resource(core.ResourceL2Gas): {
+						MaxAmount:       new(felt.Felt).SetUint64(100),
+						MaxPricePerUnit: new(felt.Felt).SetUint64(100),
+					},
+				},
+			},
+		}
+
+		_, httpHeader, err := handler.SimulateTransactions(rpcv7.BlockID{Latest: true}, []rpcv7.BroadcastedTransaction{txn}, []rpcv7.SimulationFlag{rpcv7.SkipValidateFlag})
+		require.Nil(t, err)
+		assert.Equal(t, httpHeader.Get(rpcv7.ExecutionStepsHeader), "123")
+	})
+
 	t.Run("transaction execution error", func(t *testing.T) {
 		t.Run("v0_7, v0_8", func(t *testing.T) { //nolint:dupl
 			mockVM.EXPECT().Execute([]core.Transaction{}, nil, []*felt.Felt{}, &vm.BlockInfo{

--- a/starknetdata/feeder/feeder_test.go
+++ b/starknetdata/feeder/feeder_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/NethermindEth/juno/clients/feeder"
 	"github.com/NethermindEth/juno/core"
 	"github.com/NethermindEth/juno/core/felt"
+	"github.com/NethermindEth/juno/starknet"
 	adaptfeeder "github.com/NethermindEth/juno/starknetdata/feeder"
 	"github.com/NethermindEth/juno/utils"
 	"github.com/stretchr/testify/assert"
@@ -175,6 +176,25 @@ func TestTransaction(t *testing.T) {
 		l1HandlerTx, ok := txn.(*core.L1HandlerTransaction)
 		require.True(t, ok)
 		assert.Equal(t, sn2core.AdaptL1HandlerTransaction(responseTx), l1HandlerTx)
+	})
+
+	t.Run("tx with non-zero l2 gas should have l1 data gas", func(t *testing.T) {
+		hash := utils.HexToFelt(t, "0x7e3a229febf47c6edfd96582d9476dd91a58a5ba3df4553ae448a14a2f132d9")
+		response, err := clientGoerli.Transaction(ctx, hash)
+		require.NoError(t, err)
+		responseTx := response.Transaction
+		responseTx.ResourceBounds = utils.Ptr(map[starknet.Resource]starknet.ResourceBounds{
+			starknet.ResourceL2Gas: {
+				MaxAmount:       new(felt.Felt).SetUint64(100),
+				MaxPricePerUnit: new(felt.Felt).SetUint64(100),
+			},
+		})
+
+		adaptTx := sn2core.AdaptInvokeTransaction(responseTx)
+
+		require.NotNil(t, adaptTx.ResourceBounds[core.ResourceL1DataGas])
+		require.Equal(t, uint64(0), adaptTx.ResourceBounds[core.ResourceL1DataGas].MaxAmount)
+		require.Equal(t, &felt.Zero, adaptTx.ResourceBounds[core.ResourceL1DataGas].MaxPricePerUnit)
 	})
 }
 

--- a/starknetdata/feeder/feeder_test.go
+++ b/starknetdata/feeder/feeder_test.go
@@ -183,7 +183,7 @@ func TestTransaction(t *testing.T) {
 		response, err := clientGoerli.Transaction(ctx, hash)
 		require.NoError(t, err)
 		responseTx := response.Transaction
-		responseTx.ResourceBounds = utils.Ptr(map[starknet.Resource]starknet.ResourceBounds{
+		responseTx.ResourceBounds = utils.HeapPtr(map[starknet.Resource]starknet.ResourceBounds{
 			starknet.ResourceL2Gas: {
 				MaxAmount:       new(felt.Felt).SetUint64(100),
 				MaxPricePerUnit: new(felt.Felt).SetUint64(100),


### PR DESCRIPTION
Fixes https://github.com/NethermindEth/juno/issues/2577

- In RPC v8, L1Gas, L2Gas and L1DataGas are part of the spec and required.
- In RPC v6 and v7, only L1Gas and L2Gas are part of the spec and required.
- Blockifier will throw an error if L1DataGas is absent and L2Gas is non-zero.
- To avoid that, if L2Gas is non-zero, we set the L1DataGas resource to zero.