### PR TITLE
refactor: rename `Ptr` utility to `HeapPtr`

### DIFF
--- a/adapters/core2p2p/receipt.go
+++ b/adapters/core2p2p/receipt.go
@@ -63,12 +63,12 @@ func AdaptReceipt(r *core.TransactionReceipt, txn core.Transaction) *gen.Receipt
 }
 
 func receiptCommon(r *core.TransactionReceipt) *gen.Receipt_Common {
-	var revertReason string
+	var revertReason *string
 	if r.RevertReason != "" {
-		revertReason = r.RevertReason
+		revertReason = &r.RevertReason
 	} else if r.Reverted {
 		// in some cases receipt marked as reverted may contain empty string in revert_reason
-		revertReason = ""
+		revertReason = utils.HeapPtr("")
 	}
 
 	return &gen.Receipt_Common{
@@ -76,7 +76,7 @@ func receiptCommon(r *core.TransactionReceipt) *gen.Receipt_Common {
 		PriceUnit:          adaptPriceUnit(r.FeeUnit),
 		MessagesSent:       utils.Map(r.L2ToL1Message, AdaptMessageToL1),
 		ExecutionResources: AdaptExecutionResources(r.ExecutionResources),
-		RevertReason:       &revertReason,
+		RevertReason:       revertReason,
 	}
 }
 

--- a/adapters/core2p2p/receipt.go
+++ b/adapters/core2p2p/receipt.go
@@ -63,12 +63,12 @@ func AdaptReceipt(r *core.TransactionReceipt, txn core.Transaction) *gen.Receipt
 }
 
 func receiptCommon(r *core.TransactionReceipt) *gen.Receipt_Common {
-	var revertReason *string
+	var revertReason string
 	if r.RevertReason != "" {
-		revertReason = &r.RevertReason
+		revertReason = r.RevertReason
 	} else if r.Reverted {
 		// in some cases receipt marked as reverted may contain empty string in revert_reason
-		revertReason = utils.Ptr("")
+		revertReason = ""
 	}
 
 	return &gen.Receipt_Common{
@@ -76,7 +76,7 @@ func receiptCommon(r *core.TransactionReceipt) *gen.Receipt_Common {
 		PriceUnit:          adaptPriceUnit(r.FeeUnit),
 		MessagesSent:       utils.Map(r.L2ToL1Message, AdaptMessageToL1),
 		ExecutionResources: AdaptExecutionResources(r.ExecutionResources),
-		RevertReason:       revertReason,
+		RevertReason:       &revertReason,
 	}
 }
 

--- a/adapters/p2p2core/receipt_test.go
+++ b/adapters/p2p2core/receipt_test.go
@@ -34,7 +34,7 @@ func TestAdaptReceipt(t *testing.T) {
 				Type: &gen.Receipt_L1Handler_{
 					L1Handler: &gen.Receipt_L1Handler{
 						Common: &gen.Receipt_Common{
-							RevertReason: utils.Ptr(reason),
+							RevertReason: &reason,
 						},
 					},
 				},

--- a/clients/feeder/feeder_test.go
+++ b/clients/feeder/feeder_test.go
@@ -54,8 +54,8 @@ func TestDeclareTransactionUnmarshal(t *testing.T) {
 				utils.HexToFelt(t, "0x429d142a17223b4f2acde0f5ecb9ad453e188b245003c86fab5c109bad58fc3"),
 			},
 			Nonce:       new(felt.Felt).SetUint64(1),
-			NonceDAMode: utils.Ptr(starknet.DAModeL1),
-			FeeDAMode:   utils.Ptr(starknet.DAModeL1),
+			NonceDAMode: utils.HeapPtr(starknet.DAModeL1),
+			FeeDAMode:   utils.HeapPtr(starknet.DAModeL1),
 			ResourceBounds: &map[starknet.Resource]starknet.ResourceBounds{
 				starknet.ResourceL1Gas: {
 					MaxAmount:       utils.HexToFelt(t, "0x186a0"),
@@ -112,8 +112,8 @@ func TestInvokeTransactionUnmarshal(t *testing.T) {
 				utils.HexToFelt(t, "0x6bef4745194c9447fdc8dd3aec4fc738ab0a560b0d2c7bf62fbf58aef3abfc5"),
 			},
 			Nonce:       utils.HexToFelt(t, "0xe97"),
-			NonceDAMode: utils.Ptr(starknet.DAModeL1),
-			FeeDAMode:   utils.Ptr(starknet.DAModeL1),
+			NonceDAMode: utils.HeapPtr(starknet.DAModeL1),
+			FeeDAMode:   utils.HeapPtr(starknet.DAModeL1),
 			ResourceBounds: &map[starknet.Resource]starknet.ResourceBounds{
 				starknet.ResourceL1Gas: {
 					MaxAmount:       utils.HexToFelt(t, "0x186a0"),
@@ -216,8 +216,8 @@ func TestDeployAccountTransactionUnmarshal(t *testing.T) {
 				utils.HexToFelt(t, "0x4daebba599f860daee8f6e100601d98873052e1c61530c630cc4375c6bd48e3"),
 			},
 			Nonce:       new(felt.Felt),
-			NonceDAMode: utils.Ptr(starknet.DAModeL1),
-			FeeDAMode:   utils.Ptr(starknet.DAModeL1),
+			NonceDAMode: utils.HeapPtr(starknet.DAModeL1),
+			FeeDAMode:   utils.HeapPtr(starknet.DAModeL1),
 			ResourceBounds: &map[starknet.Resource]starknet.ResourceBounds{
 				starknet.ResourceL1Gas: {
 					MaxAmount:       utils.HexToFelt(t, "0x186a0"),

--- a/p2p/p2p.go
+++ b/p2p/p2p.go
@@ -184,8 +184,9 @@ func privateKey(privKeyStr string) (crypto.PrivKey, error) {
 		return nil, err
 	}
 
+	keyType := pb.KeyType_Ed25519
 	privKeyBytesPB, err := proto.Marshal(&pb.PrivateKey{
-		Type: utils.Ptr(pb.KeyType_Ed25519),
+		Type: &keyType,
 		Data: privKeyBytes,
 	})
 	if err != nil {

--- a/rpc/v6/block_test.go
+++ b/rpc/v6/block_test.go
@@ -95,7 +95,7 @@ func TestBlockNumber(t *testing.T) {
 	t.Cleanup(mockCtrl.Finish)
 
 	mockReader := mocks.NewMockReader(mockCtrl)
-	handler := rpc.New(mockReader, nil, nil, "", utils.Ptr(utils.Mainnet), nil)
+	handler := rpc.New(mockReader, nil, nil, "", &utils.Mainnet, nil)
 
 	t.Run("empty blockchain", func(t *testing.T) {
 		expectedHeight := uint64(0)
@@ -120,7 +120,7 @@ func TestBlockHashAndNumber(t *testing.T) {
 	mockCtrl := gomock.NewController(t)
 	t.Cleanup(mockCtrl.Finish)
 
-	n := utils.Ptr(utils.Mainnet)
+	n := &utils.Mainnet
 	mockReader := mocks.NewMockReader(mockCtrl)
 	handler := rpc.New(mockReader, nil, nil, "", n, nil)
 
@@ -153,7 +153,7 @@ func TestBlockTransactionCount(t *testing.T) {
 	mockCtrl := gomock.NewController(t)
 	t.Cleanup(mockCtrl.Finish)
 	mockSyncReader := mocks.NewMockSyncReader(mockCtrl)
-	n := utils.Ptr(utils.Sepolia)
+	n := utils.HeapPtr(utils.Sepolia)
 	mockReader := mocks.NewMockReader(mockCtrl)
 	handler := rpc.New(mockReader, mockSyncReader, nil, "", n, nil)
 
@@ -253,7 +253,7 @@ func TestBlockWithTxHashes(t *testing.T) {
 	for description, id := range errTests {
 		t.Run(description, func(t *testing.T) {
 			log := utils.NewNopZapLogger()
-			n := utils.Ptr(utils.Mainnet)
+			n := &utils.Mainnet
 			chain := blockchain.New(pebble.NewMemTest(t), n)
 			if description == "pending" { //nolint:goconst
 				mockSyncReader = mocks.NewMockSyncReader(mockCtrl)
@@ -267,7 +267,7 @@ func TestBlockWithTxHashes(t *testing.T) {
 		})
 	}
 
-	n := utils.Ptr(utils.Sepolia)
+	n := &utils.Sepolia
 	handler := rpc.New(mockReader, mockSyncReader, nil, "", n, nil)
 
 	client := feeder.NewTestClient(t, n)
@@ -376,7 +376,7 @@ func TestBlockWithTxs(t *testing.T) {
 	for description, id := range errTests { //nolint:dupl
 		t.Run(description, func(t *testing.T) {
 			log := utils.NewNopZapLogger()
-			n := utils.Ptr(utils.Mainnet)
+			n := &utils.Mainnet
 			chain := blockchain.New(pebble.NewMemTest(t), n)
 			if description == "pending" {
 				mockSyncReader = mocks.NewMockSyncReader(mockCtrl)
@@ -390,7 +390,7 @@ func TestBlockWithTxs(t *testing.T) {
 		})
 	}
 
-	n := utils.Ptr(utils.Mainnet)
+	n := &utils.Mainnet
 	handler := rpc.New(mockReader, mockSyncReader, nil, "", n, nil)
 
 	client := feeder.NewTestClient(t, n)
@@ -505,7 +505,7 @@ func TestBlockWithTxs(t *testing.T) {
 }
 
 func TestBlockWithTxHashesV013(t *testing.T) {
-	n := utils.Ptr(utils.SepoliaIntegration)
+	n := &utils.SepoliaIntegration
 	mockCtrl := gomock.NewController(t)
 	t.Cleanup(mockCtrl.Finish)
 	mockReader := mocks.NewMockReader(mockCtrl)
@@ -564,8 +564,8 @@ func TestBlockWithTxHashesV013(t *testing.T) {
 				Tip:                   new(felt.Felt).SetUint64(tx.Tip),
 				PaymasterData:         &tx.PaymasterData,
 				AccountDeploymentData: &tx.AccountDeploymentData,
-				NonceDAMode:           utils.Ptr(rpc.DataAvailabilityMode(tx.NonceDAMode)),
-				FeeDAMode:             utils.Ptr(rpc.DataAvailabilityMode(tx.FeeDAMode)),
+				NonceDAMode:           utils.HeapPtr(rpc.DataAvailabilityMode(tx.NonceDAMode)),
+				FeeDAMode:             utils.HeapPtr(rpc.DataAvailabilityMode(tx.FeeDAMode)),
 			},
 		},
 	}, got)
@@ -576,7 +576,7 @@ func TestBlockWithReceipts(t *testing.T) {
 	t.Cleanup(mockCtrl.Finish)
 	mockSyncReader := mocks.NewMockSyncReader(mockCtrl)
 
-	n := utils.Ptr(utils.Mainnet)
+	n := &utils.Mainnet
 	mockReader := mocks.NewMockReader(mockCtrl)
 	handler := rpc.New(mockReader, mockSyncReader, nil, "", n, nil)
 
@@ -694,7 +694,7 @@ func TestRpcBlockAdaptation(t *testing.T) {
 	mockCtrl := gomock.NewController(t)
 	t.Cleanup(mockCtrl.Finish)
 
-	n := utils.Ptr(utils.Sepolia)
+	n := &utils.Sepolia
 	mockReader := mocks.NewMockReader(mockCtrl)
 	handler := rpc.New(mockReader, nil, nil, "", n, nil)
 

--- a/rpc/v6/chain_test.go
+++ b/rpc/v6/chain_test.go
@@ -20,7 +20,7 @@ func TestChainId(t *testing.T) {
 			t.Cleanup(mockCtrl.Finish)
 
 			mockReader := mocks.NewMockReader(mockCtrl)
-			mockReader.EXPECT().Network().Return(n)
+			mockReader.EXPECT().Network().Return(&n)
 			handler := rpc.New(mockReader, nil, nil, "", &n, nil)
 
 			cID, err := handler.ChainID()

--- a/rpc/v6/chain_test.go
+++ b/rpc/v6/chain_test.go
@@ -12,8 +12,8 @@ import (
 )
 
 func TestChainId(t *testing.T) {
-	for _, n := range []*utils.Network{
-		utils.Ptr(utils.Mainnet), utils.Ptr(utils.Sepolia), utils.Ptr(utils.SepoliaIntegration),
+	for _, n := range []utils.Network{
+		utils.Mainnet, utils.Sepolia, utils.SepoliaIntegration,
 	} {
 		t.Run(n.String(), func(t *testing.T) {
 			mockCtrl := gomock.NewController(t)
@@ -21,7 +21,7 @@ func TestChainId(t *testing.T) {
 
 			mockReader := mocks.NewMockReader(mockCtrl)
 			mockReader.EXPECT().Network().Return(n)
-			handler := rpc.New(mockReader, nil, nil, "", n, nil)
+			handler := rpc.New(mockReader, nil, nil, "", &n, nil)
 
 			cID, err := handler.ChainID()
 			require.Nil(t, err)

--- a/rpc/v6/class_test.go
+++ b/rpc/v6/class_test.go
@@ -20,7 +20,7 @@ import (
 )
 
 func TestClass(t *testing.T) {
-	n := utils.Ptr(utils.Integration)
+	n := &utils.Integration
 	integrationClient := feeder.NewTestClient(t, n)
 	integGw := adaptfeeder.New(integrationClient)
 
@@ -95,7 +95,7 @@ func TestClass(t *testing.T) {
 }
 
 func TestClassAt(t *testing.T) {
-	n := utils.Ptr(utils.Integration)
+	n := &utils.Integration
 	integrationClient := feeder.NewTestClient(t, n)
 	integGw := adaptfeeder.New(integrationClient)
 
@@ -151,7 +151,7 @@ func TestClassHashAt(t *testing.T) {
 	mockCtrl := gomock.NewController(t)
 	t.Cleanup(mockCtrl.Finish)
 
-	n := utils.Ptr(utils.Mainnet)
+	n := &utils.Mainnet
 	mockReader := mocks.NewMockReader(mockCtrl)
 	log := utils.NewNopZapLogger()
 	handler := rpc.New(mockReader, nil, nil, "", n, log)

--- a/rpc/v6/contract_test.go
+++ b/rpc/v6/contract_test.go
@@ -19,7 +19,7 @@ func TestNonce(t *testing.T) {
 	mockCtrl := gomock.NewController(t)
 	t.Cleanup(mockCtrl.Finish)
 
-	n := utils.Ptr(utils.Mainnet)
+	n := &utils.Mainnet
 	mockReader := mocks.NewMockReader(mockCtrl)
 	log := utils.NewNopZapLogger()
 	handler := rpc.New(mockReader, nil, nil, "", n, log)
@@ -93,7 +93,7 @@ func TestStorageAt(t *testing.T) {
 	mockCtrl := gomock.NewController(t)
 	t.Cleanup(mockCtrl.Finish)
 
-	n := utils.Ptr(utils.Mainnet)
+	n := &utils.Mainnet
 	mockReader := mocks.NewMockReader(mockCtrl)
 	log := utils.NewNopZapLogger()
 	handler := rpc.New(mockReader, nil, nil, "", n, log)

--- a/rpc/v6/estimate_fee_test.go
+++ b/rpc/v6/estimate_fee_test.go
@@ -22,7 +22,7 @@ func TestEstimateMessageFee(t *testing.T) {
 	mockCtrl := gomock.NewController(t)
 	t.Cleanup(mockCtrl.Finish)
 
-	n := utils.Ptr(utils.Mainnet)
+	n := &utils.Mainnet
 	mockReader := mocks.NewMockReader(mockCtrl)
 	mockReader.EXPECT().Network().Return(n).AnyTimes()
 	mockVM := mocks.NewMockVM(mockCtrl)

--- a/rpc/v6/events_test.go
+++ b/rpc/v6/events_test.go
@@ -23,7 +23,7 @@ func TestEvents(t *testing.T) {
 		return pendingB
 	}
 	testDB := pebble.NewMemTest(t)
-	n := utils.Ptr(utils.Sepolia)
+	n := &utils.Sepolia
 	chain := blockchain.New(testDB, n)
 	chain = chain.WithPendingBlockFn(pendingBlockFn)
 

--- a/rpc/v6/handlers_test.go
+++ b/rpc/v6/handlers_test.go
@@ -20,14 +20,14 @@ func nopCloser() error { return nil }
 func TestVersion(t *testing.T) {
 	const version = "1.2.3-rc1"
 
-	handler := rpc.New(nil, nil, nil, version, utils.Ptr(utils.Mainnet), nil)
+	handler := rpc.New(nil, nil, nil, version, &utils.Mainnet, nil)
 	ver, err := handler.Version()
 	require.Nil(t, err)
 	assert.Equal(t, version, ver)
 }
 
 func TestSpecVersion(t *testing.T) {
-	handler := rpc.New(nil, nil, nil, "", utils.Ptr(utils.Mainnet), nil)
+	handler := rpc.New(nil, nil, nil, "", &utils.Mainnet, nil)
 	legacyVersion, rpcErr := handler.SpecVersion()
 	require.Nil(t, rpcErr)
 	require.Equal(t, "0.6.0", legacyVersion)
@@ -42,7 +42,7 @@ func TestThrottledVMError(t *testing.T) {
 	mockSyncReader := mocks.NewMockSyncReader(mockCtrl)
 
 	throttledVM := node.NewThrottledVM(mockVM, 0, 0)
-	handler := rpc.New(mockReader, mockSyncReader, throttledVM, "", utils.Ptr(utils.Mainnet), nil)
+	handler := rpc.New(mockReader, mockSyncReader, throttledVM, "", &utils.Mainnet, nil)
 	mockState := mocks.NewMockStateHistoryReader(mockCtrl)
 
 	throttledErr := "VM throughput limit reached"

--- a/rpc/v6/simulation.go
+++ b/rpc/v6/simulation.go
@@ -135,7 +135,7 @@ func (h *Handler) simulateTransactions(id BlockID, transactions []BroadcastedTra
 			GasConsumed: gasConsumed,
 			GasPrice:    gasPrice,
 			OverallFee:  overallFee,
-			Unit:        utils.Ptr(feeUnit),
+			Unit:        &feeUnit,
 		}
 
 		if !v0_6Response {

--- a/rpc/v6/simulation_test.go
+++ b/rpc/v6/simulation_test.go
@@ -20,7 +20,7 @@ func TestSimulateTransactions(t *testing.T) {
 	mockCtrl := gomock.NewController(t)
 	defer mockCtrl.Finish()
 
-	n := utils.Ptr(utils.Mainnet)
+	n := &utils.Mainnet
 
 	mockReader := mocks.NewMockReader(mockCtrl)
 	mockReader.EXPECT().Network().Return(n).AnyTimes()

--- a/rpc/v6/state_update_test.go
+++ b/rpc/v6/state_update_test.go
@@ -31,7 +31,7 @@ func TestStateUpdate(t *testing.T) {
 	t.Cleanup(mockCtrl.Finish)
 	var mockSyncReader *mocks.MockSyncReader
 
-	n := utils.Ptr(utils.Mainnet)
+	n := &utils.Mainnet
 	for description, id := range errTests {
 		t.Run(description, func(t *testing.T) {
 			chain := blockchain.New(pebble.NewMemTest(t), n)

--- a/rpc/v6/sync_test.go
+++ b/rpc/v6/sync_test.go
@@ -17,7 +17,7 @@ func TestSyncing(t *testing.T) {
 	mockCtrl := gomock.NewController(t)
 	t.Cleanup(mockCtrl.Finish)
 
-	n := utils.Ptr(utils.Mainnet)
+	n := &utils.Mainnet
 	synchronizer := mocks.NewMockSyncReader(mockCtrl)
 	mockReader := mocks.NewMockReader(mockCtrl)
 	handler := rpc.New(mockReader, synchronizer, nil, "", n, nil)

--- a/rpc/v6/trace.go
+++ b/rpc/v6/trace.go
@@ -93,15 +93,15 @@ func adaptFunctionInvocation(snFnInvocation *starknet.FunctionInvocation) *vm.Fu
 		snEvent := &snFnInvocation.Events[index]
 		fnInvocation.Events = append(fnInvocation.Events, vm.OrderedEvent{
 			Order: snEvent.Order,
-			Keys:  utils.Map(snEvent.Keys, utils.Ptr[felt.Felt]),
-			Data:  utils.Map(snEvent.Data, utils.Ptr[felt.Felt]),
+			Keys:  utils.Map(snEvent.Keys, utils.HeapPtr[felt.Felt]),
+			Data:  utils.Map(snEvent.Data, utils.HeapPtr[felt.Felt]),
 		})
 	}
 	for index := range snFnInvocation.Messages {
 		snMessage := &snFnInvocation.Messages[index]
 		fnInvocation.Messages = append(fnInvocation.Messages, vm.OrderedL2toL1Message{
 			Order:   snMessage.Order,
-			Payload: utils.Map(snMessage.Payload, utils.Ptr[felt.Felt]),
+			Payload: utils.Map(snMessage.Payload, utils.HeapPtr[felt.Felt]),
 			To:      snMessage.ToAddr,
 		})
 	}

--- a/rpc/v6/trace_test.go
+++ b/rpc/v6/trace_test.go
@@ -27,7 +27,7 @@ import (
 func TestTraceFallback(t *testing.T) {
 	mockCtrl := gomock.NewController(t)
 	t.Cleanup(mockCtrl.Finish)
-	n := utils.Ptr(utils.Integration)
+	n := &utils.Integration
 	client := feeder.NewTestClient(t, n)
 	mockReader := mocks.NewMockReader(mockCtrl)
 	gateway := adaptfeeder.New(client)
@@ -82,7 +82,7 @@ func TestTraceTransactionV0_6(t *testing.T) {
 	mockReader := mocks.NewMockReader(mockCtrl)
 	mockReader.EXPECT().Network().Return(&utils.Mainnet).AnyTimes()
 	mockVM := mocks.NewMockVM(mockCtrl)
-	handler := rpc.New(mockReader, mockSyncReader, mockVM, "", utils.Ptr(utils.Mainnet), utils.NewNopZapLogger())
+	handler := rpc.New(mockReader, mockSyncReader, mockVM, "", &utils.Mainnet, utils.NewNopZapLogger())
 
 	t.Run("not found", func(t *testing.T) {
 		hash := utils.HexToFelt(t, "0xBBBB")
@@ -224,7 +224,7 @@ func TestTraceBlockTransactions(t *testing.T) {
 	for description, id := range errTests {
 		t.Run(description, func(t *testing.T) {
 			log := utils.NewNopZapLogger()
-			n := utils.Ptr(utils.Mainnet)
+			n := &utils.Mainnet
 			chain := blockchain.New(pebble.NewMemTest(t), n)
 			handler := rpc.New(chain, nil, nil, "", n, log)
 
@@ -236,7 +236,7 @@ func TestTraceBlockTransactions(t *testing.T) {
 
 	mockCtrl := gomock.NewController(t)
 	t.Cleanup(mockCtrl.Finish)
-	n := utils.Ptr(utils.Mainnet)
+	n := &utils.Mainnet
 
 	mockReader := mocks.NewMockReader(mockCtrl)
 	mockReader.EXPECT().Network().Return(n).AnyTimes()
@@ -389,7 +389,7 @@ func TestCall(t *testing.T) {
 	mockCtrl := gomock.NewController(t)
 	t.Cleanup(mockCtrl.Finish)
 
-	n := utils.Ptr(utils.Mainnet)
+	n := utils.HeapPtr(utils.Mainnet)
 	mockReader := mocks.NewMockReader(mockCtrl)
 	mockVM := mocks.NewMockVM(mockCtrl)
 	handler := rpc.New(mockReader, nil, mockVM, "", n, utils.NewNopZapLogger())

--- a/rpc/v6/transaction.go
+++ b/rpc/v6/transaction.go
@@ -393,7 +393,7 @@ func adaptToFeederDAMode(mode *DataAvailabilityMode) *starknet.DataAvailabilityM
 	if mode == nil {
 		return nil
 	}
-	return utils.Ptr(starknet.DataAvailabilityMode(*mode))
+	return utils.HeapPtr(starknet.DataAvailabilityMode(*mode))
 }
 
 func adaptRPCTxToFeederTx(rpcTx *Transaction) *starknet.Transaction {
@@ -769,7 +769,7 @@ func adaptInvokeTransaction(t *core.InvokeTransaction) *Transaction {
 		Hash:               t.Hash(),
 		MaxFee:             t.MaxFee,
 		Version:            t.Version.AsFelt(),
-		Signature:          utils.Ptr(t.Signature()),
+		Signature:          utils.HeapPtr(t.Signature()),
 		Nonce:              t.Nonce,
 		CallData:           &t.CallData,
 		ContractAddress:    t.ContractAddress,
@@ -778,12 +778,12 @@ func adaptInvokeTransaction(t *core.InvokeTransaction) *Transaction {
 	}
 
 	if tx.Version.Uint64() == 3 {
-		tx.ResourceBounds = utils.Ptr(adaptResourceBounds(t.ResourceBounds))
+		tx.ResourceBounds = utils.HeapPtr(adaptResourceBounds(t.ResourceBounds))
 		tx.Tip = new(felt.Felt).SetUint64(t.Tip)
 		tx.PaymasterData = &t.PaymasterData
 		tx.AccountDeploymentData = &t.AccountDeploymentData
-		tx.NonceDAMode = utils.Ptr(DataAvailabilityMode(t.NonceDAMode))
-		tx.FeeDAMode = utils.Ptr(DataAvailabilityMode(t.FeeDAMode))
+		tx.NonceDAMode = utils.HeapPtr(DataAvailabilityMode(t.NonceDAMode))
+		tx.FeeDAMode = utils.HeapPtr(DataAvailabilityMode(t.FeeDAMode))
 	}
 	return tx
 }
@@ -795,7 +795,7 @@ func adaptDeclareTransaction(t *core.DeclareTransaction) *Transaction {
 		Type:              TxnDeclare,
 		MaxFee:            t.MaxFee,
 		Version:           t.Version.AsFelt(),
-		Signature:         utils.Ptr(t.Signature()),
+		Signature:         utils.HeapPtr(t.Signature()),
 		Nonce:             t.Nonce,
 		ClassHash:         t.ClassHash,
 		SenderAddress:     t.SenderAddress,
@@ -803,12 +803,12 @@ func adaptDeclareTransaction(t *core.DeclareTransaction) *Transaction {
 	}
 
 	if tx.Version.Uint64() == 3 {
-		tx.ResourceBounds = utils.Ptr(adaptResourceBounds(t.ResourceBounds))
+		tx.ResourceBounds = utils.HeapPtr(adaptResourceBounds(t.ResourceBounds))
 		tx.Tip = new(felt.Felt).SetUint64(t.Tip)
 		tx.PaymasterData = &t.PaymasterData
 		tx.AccountDeploymentData = &t.AccountDeploymentData
-		tx.NonceDAMode = utils.Ptr(DataAvailabilityMode(t.NonceDAMode))
-		tx.FeeDAMode = utils.Ptr(DataAvailabilityMode(t.FeeDAMode))
+		tx.NonceDAMode = utils.HeapPtr(DataAvailabilityMode(t.NonceDAMode))
+		tx.FeeDAMode = utils.HeapPtr(DataAvailabilityMode(t.FeeDAMode))
 	}
 
 	return tx
@@ -819,7 +819,7 @@ func adaptDeployAccountTrandaction(t *core.DeployAccountTransaction) *Transactio
 		Hash:                t.Hash(),
 		MaxFee:              t.MaxFee,
 		Version:             t.Version.AsFelt(),
-		Signature:           utils.Ptr(t.Signature()),
+		Signature:           utils.HeapPtr(t.Signature()),
 		Nonce:               t.Nonce,
 		Type:                TxnDeployAccount,
 		ContractAddressSalt: t.ContractAddressSalt,
@@ -828,11 +828,11 @@ func adaptDeployAccountTrandaction(t *core.DeployAccountTransaction) *Transactio
 	}
 
 	if tx.Version.Uint64() == 3 {
-		tx.ResourceBounds = utils.Ptr(adaptResourceBounds(t.ResourceBounds))
+		tx.ResourceBounds = utils.HeapPtr(adaptResourceBounds(t.ResourceBounds))
 		tx.Tip = new(felt.Felt).SetUint64(t.Tip)
 		tx.PaymasterData = &t.PaymasterData
-		tx.NonceDAMode = utils.Ptr(DataAvailabilityMode(t.NonceDAMode))
-		tx.FeeDAMode = utils.Ptr(DataAvailabilityMode(t.FeeDAMode))
+		tx.NonceDAMode = utils.HeapPtr(DataAvailabilityMode(t.NonceDAMode))
+		tx.FeeDAMode = utils.HeapPtr(DataAvailabilityMode(t.FeeDAMode))
 	}
 
 	return tx

--- a/rpc/v6/transaction_test.go
+++ b/rpc/v6/transaction_test.go
@@ -28,7 +28,7 @@ func TestTransactionByHashNotFound(t *testing.T) {
 	t.Cleanup(mockCtrl.Finish)
 	mockReader := mocks.NewMockReader(mockCtrl)
 
-	n := utils.Ptr(utils.Mainnet)
+	n := utils.HeapPtr(utils.Mainnet)
 	txHash := new(felt.Felt).SetBytes([]byte("random hash"))
 	mockReader.EXPECT().TransactionByHash(txHash).Return(nil, errors.New("tx not found"))
 
@@ -47,7 +47,7 @@ func TestTransactionByHash(t *testing.T) {
 	}{
 		"DECLARE v1": {
 			hash:    "0x1b4d9f09276629d496af1af8ff00173c11ff146affacb1b5c858d7aa89001ae",
-			network: utils.Ptr(utils.Mainnet),
+			network: &utils.Mainnet,
 			expected: `{
 			"type": "DECLARE",
 			"transaction_hash": "0x1b4d9f09276629d496af1af8ff00173c11ff146affacb1b5c858d7aa89001ae",
@@ -65,7 +65,7 @@ func TestTransactionByHash(t *testing.T) {
 
 		"DECLARE v0": {
 			hash:    "0x222f8902d1eeea76fa2642a90e2411bfd71cffb299b3a299029e1937fab3fe4",
-			network: utils.Ptr(utils.Mainnet),
+			network: &utils.Mainnet,
 			expected: `{
 				"transaction_hash": "0x222f8902d1eeea76fa2642a90e2411bfd71cffb299b3a299029e1937fab3fe4",
 				"type": "DECLARE",
@@ -79,7 +79,7 @@ func TestTransactionByHash(t *testing.T) {
 
 		"L1 Handler v0 with nonce": {
 			hash:    "0x537eacfd3c49166eec905daff61ff7feef9c133a049ea2135cb94eec840a4a8",
-			network: utils.Ptr(utils.Mainnet),
+			network: &utils.Mainnet,
 			expected: `{
        "type": "L1_HANDLER",
        "transaction_hash": "0x537eacfd3c49166eec905daff61ff7feef9c133a049ea2135cb94eec840a4a8",
@@ -98,7 +98,7 @@ func TestTransactionByHash(t *testing.T) {
 		},
 		"L1 Handler v0 without nonce": {
 			hash:    "0x5d50b7020f7cf8033fd7d913e489f47edf74fbf3c8ada85be512c7baa6a2eab",
-			network: utils.Ptr(utils.Mainnet),
+			network: &utils.Mainnet,
 			expected: `{
 				"type": "L1_HANDLER",
 				"transaction_hash":  "0x5d50b7020f7cf8033fd7d913e489f47edf74fbf3c8ada85be512c7baa6a2eab",
@@ -117,7 +117,7 @@ func TestTransactionByHash(t *testing.T) {
 
 		"Invoke v1": {
 			hash:    "0x2897e3cec3e24e4d341df26b8cf1ab84ea1c01a051021836b36c6639145b497",
-			network: utils.Ptr(utils.Mainnet),
+			network: &utils.Mainnet,
 			expected: `{
        "type": "INVOKE",
        "transaction_hash": "0x2897e3cec3e24e4d341df26b8cf1ab84ea1c01a051021836b36c6639145b497",
@@ -153,7 +153,7 @@ func TestTransactionByHash(t *testing.T) {
 
 		"DEPLOY v0": {
 			hash:    "0x6486c6303dba2f364c684a2e9609211c5b8e417e767f37b527cda51e776e6f0",
-			network: utils.Ptr(utils.Mainnet),
+			network: &utils.Mainnet,
 			expected: `{
        "type": "DEPLOY",
        "transaction_hash": "0x6486c6303dba2f364c684a2e9609211c5b8e417e767f37b527cda51e776e6f0",
@@ -172,7 +172,7 @@ func TestTransactionByHash(t *testing.T) {
 
 		"DEPLOY ACCOUNT v1": {
 			hash:    "0xd61fc89f4d1dc4dc90a014957d655d38abffd47ecea8e3fa762e3160f155f2",
-			network: utils.Ptr(utils.Mainnet),
+			network: &utils.Mainnet,
 			expected: `{
        "type": "DEPLOY_ACCOUNT",
        "transaction_hash": "0xd61fc89f4d1dc4dc90a014957d655d38abffd47ecea8e3fa762e3160f155f2",
@@ -193,7 +193,7 @@ func TestTransactionByHash(t *testing.T) {
 
 		"INVOKE v0": {
 			hash:    "0xf1d99fb97509e0dfc425ddc2a8c5398b74231658ca58b6f8da92f39cb739e",
-			network: utils.Ptr(utils.Mainnet),
+			network: &utils.Mainnet,
 			expected: `{
        "type": "INVOKE",
        "transaction_hash": "0xf1d99fb97509e0dfc425ddc2a8c5398b74231658ca58b6f8da92f39cb739e",
@@ -212,7 +212,7 @@ func TestTransactionByHash(t *testing.T) {
 		},
 		"DECLARE v3": {
 			hash:    "0x41d1f5206ef58a443e7d3d1ca073171ec25fa75313394318fc83a074a6631c3",
-			network: utils.Ptr(utils.Integration),
+			network: &utils.Integration,
 			expected: `{
 		"transaction_hash": "0x41d1f5206ef58a443e7d3d1ca073171ec25fa75313394318fc83a074a6631c3",
 		"type": "DECLARE",
@@ -241,7 +241,7 @@ func TestTransactionByHash(t *testing.T) {
 		},
 		"INVOKE v3": {
 			hash:    "0x49728601e0bb2f48ce506b0cbd9c0e2a9e50d95858aa41463f46386dca489fd",
-			network: utils.Ptr(utils.Integration),
+			network: &utils.Integration,
 			expected: `{
 				"type": "INVOKE",
 				"transaction_hash": "0x49728601e0bb2f48ce506b0cbd9c0e2a9e50d95858aa41463f46386dca489fd",
@@ -285,7 +285,7 @@ func TestTransactionByHash(t *testing.T) {
 		},
 		"DEPLOY ACCOUNT v3": {
 			hash:    "0x29fd7881f14380842414cdfdd8d6c0b1f2174f8916edcfeb1ede1eb26ac3ef0",
-			network: utils.Ptr(utils.Integration),
+			network: &utils.Integration,
 			expected: `{
 				"transaction_hash": "0x29fd7881f14380842414cdfdd8d6c0b1f2174f8916edcfeb1ede1eb26ac3ef0",
 				"version": "0x3",
@@ -351,7 +351,7 @@ func TestTransactionByBlockIdAndIndex(t *testing.T) {
 
 	mockSyncReader := mocks.NewMockSyncReader(mockCtrl)
 
-	n := utils.Ptr(utils.Mainnet)
+	n := &utils.Mainnet
 	mockReader := mocks.NewMockReader(mockCtrl)
 	client := feeder.NewTestClient(t, n)
 	mainnetGw := adaptfeeder.New(client)
@@ -499,7 +499,7 @@ func TestLegacyTransactionReceiptByHash(t *testing.T) {
 	mockCtrl := gomock.NewController(t)
 	t.Cleanup(mockCtrl.Finish)
 
-	n := utils.Ptr(utils.Mainnet)
+	n := &utils.Mainnet
 	mockReader := mocks.NewMockReader(mockCtrl)
 	handler := rpc.New(mockReader, nil, nil, "", n, nil)
 
@@ -816,8 +816,8 @@ func TestAdaptTransaction(t *testing.T) {
 			CallData:              new([]*felt.Felt),
 			PaymasterData:         new([]*felt.Felt),
 			AccountDeploymentData: new([]*felt.Felt),
-			NonceDAMode:           utils.Ptr(rpc.DAModeL1),
-			FeeDAMode:             utils.Ptr(rpc.DAModeL1),
+			NonceDAMode:           utils.HeapPtr(rpc.DAModeL1),
+			FeeDAMode:             utils.HeapPtr(rpc.DAModeL1),
 		}
 
 		require.Equal(t, expectedTx, tx)
@@ -825,7 +825,7 @@ func TestAdaptTransaction(t *testing.T) {
 }
 
 func TestAddTransaction(t *testing.T) {
-	n := utils.Ptr(utils.Integration)
+	n := &utils.Integration
 	gw := adaptfeeder.New(feeder.NewTestClient(t, n))
 	txWithoutClass := func(hash string) rpc.BroadcastedTransaction {
 		tx, err := gw.Transaction(context.Background(), utils.HexToFelt(t, hash))
@@ -1118,13 +1118,13 @@ func TestTransactionStatus(t *testing.T) {
 		notFoundTxHash    *felt.Felt
 	}{
 		{
-			network:           utils.Ptr(utils.Mainnet),
+			network:           &utils.Mainnet,
 			verifiedTxHash:    utils.HexToFelt(t, "0xf1d99fb97509e0dfc425ddc2a8c5398b74231658ca58b6f8da92f39cb739e"),
 			nonVerifiedTxHash: utils.HexToFelt(t, "0x6c40890743aa220b10e5ee68cef694c5c23cc2defd0dbdf5546e687f9982ab1"),
 			notFoundTxHash:    utils.HexToFelt(t, "0x8c96a2b3d73294667e489bf8904c6aa7c334e38e24ad5a721c7e04439ff9"),
 		},
 		{
-			network:           utils.Ptr(utils.Integration),
+			network:           &utils.Integration,
 			verifiedTxHash:    utils.HexToFelt(t, "0x5e91283c1c04c3f88e4a98070df71227fb44dea04ce349c7eb379f85a10d1c3"),
 			nonVerifiedTxHash: utils.HexToFelt(t, "0x45d9c2c8e01bacae6dec3438874576a4a1ce65f1d4247f4e9748f0e7216838"),
 			notFoundTxHash:    utils.HexToFelt(t, "0xd7747f3d0ce84b3a19b05b987a782beac22c54e66773303e94ea78cc3c15"),

--- a/rpc/v7/block_test.go
+++ b/rpc/v7/block_test.go
@@ -107,7 +107,7 @@ func TestBlockWithTxHashes(t *testing.T) {
 	for description, id := range errTests { //nolint:dupl
 		t.Run(description, func(t *testing.T) {
 			log := utils.NewNopZapLogger()
-			n := utils.Ptr(utils.Mainnet)
+			n := &utils.Mainnet
 			chain := blockchain.New(pebble.NewMemTest(t), n)
 
 			if description == "pending" { //nolint:goconst
@@ -123,7 +123,7 @@ func TestBlockWithTxHashes(t *testing.T) {
 		})
 	}
 
-	n := utils.Ptr(utils.Sepolia)
+	n := &utils.Sepolia
 	handler := rpcv7.New(mockReader, mockSyncReader, nil, "", n, nil)
 
 	client := feeder.NewTestClient(t, n)
@@ -234,7 +234,7 @@ func TestBlockWithTxs(t *testing.T) {
 	for description, id := range errTests { //nolint:dupl
 		t.Run(description, func(t *testing.T) {
 			log := utils.NewNopZapLogger()
-			n := utils.Ptr(utils.Mainnet)
+			n := &utils.Mainnet
 			chain := blockchain.New(pebble.NewMemTest(t), n)
 
 			if description == "pending" {
@@ -250,7 +250,7 @@ func TestBlockWithTxs(t *testing.T) {
 		})
 	}
 
-	n := utils.Ptr(utils.Mainnet)
+	n := &utils.Mainnet
 	handler := rpcv7.New(mockReader, mockSyncReader, nil, "", n, nil)
 
 	client := feeder.NewTestClient(t, n)
@@ -367,7 +367,7 @@ func TestBlockWithTxs(t *testing.T) {
 }
 
 func TestBlockWithTxHashesV013(t *testing.T) {
-	n := utils.Ptr(utils.SepoliaIntegration)
+	n := &utils.SepoliaIntegration
 	mockCtrl := gomock.NewController(t)
 	t.Cleanup(mockCtrl.Finish)
 	mockReader := mocks.NewMockReader(mockCtrl)
@@ -393,7 +393,7 @@ func TestBlockWithTxHashesV013(t *testing.T) {
 			NewRoot:         coreBlock.GlobalStateRoot,
 			Number:          &coreBlock.Number,
 			ParentHash:      coreBlock.ParentHash,
-			L1DAMode:        utils.Ptr(rpcv6.Blob),
+			L1DAMode:        utils.HeapPtr(rpcv6.Blob),
 			L1GasPrice: &rpcv6.ResourcePrice{
 				InFri: utils.HexToFelt(t, "0x17882b6aa74"),
 				InWei: utils.HexToFelt(t, "0x3b9aca10"),
@@ -431,8 +431,8 @@ func TestBlockWithTxHashesV013(t *testing.T) {
 				Tip:                   new(felt.Felt).SetUint64(tx.Tip),
 				PaymasterData:         &tx.PaymasterData,
 				AccountDeploymentData: &tx.AccountDeploymentData,
-				NonceDAMode:           utils.Ptr(rpcv7.DataAvailabilityMode(tx.NonceDAMode)),
-				FeeDAMode:             utils.Ptr(rpcv7.DataAvailabilityMode(tx.FeeDAMode)),
+				NonceDAMode:           utils.HeapPtr(rpcv7.DataAvailabilityMode(tx.NonceDAMode)),
+				FeeDAMode:             utils.HeapPtr(rpcv7.DataAvailabilityMode(tx.FeeDAMode)),
 			},
 		},
 	}, got)
@@ -442,7 +442,7 @@ func TestBlockWithReceipts(t *testing.T) {
 	mockCtrl := gomock.NewController(t)
 	t.Cleanup(mockCtrl.Finish)
 
-	n := utils.Ptr(utils.Mainnet)
+	n := &utils.Mainnet
 	mockReader := mocks.NewMockReader(mockCtrl)
 	mockSyncReader := mocks.NewMockSyncReader(mockCtrl)
 	handler := rpcv7.New(mockReader, mockSyncReader, nil, "", n, nil)
@@ -563,7 +563,7 @@ func TestRpcBlockAdaptation(t *testing.T) {
 	mockCtrl := gomock.NewController(t)
 	t.Cleanup(mockCtrl.Finish)
 
-	n := utils.Ptr(utils.Sepolia)
+	n := &utils.Sepolia
 	mockReader := mocks.NewMockReader(mockCtrl)
 	handler := rpcv7.New(mockReader, nil, nil, "", n, nil)
 

--- a/rpc/v7/estimate_fee_test.go
+++ b/rpc/v7/estimate_fee_test.go
@@ -21,7 +21,7 @@ func TestEstimateFee(t *testing.T) {
 	mockCtrl := gomock.NewController(t)
 	defer mockCtrl.Finish()
 
-	n := utils.Ptr(utils.Mainnet)
+	n := &utils.Mainnet
 
 	mockReader := mocks.NewMockReader(mockCtrl)
 	mockReader.EXPECT().Network().Return(n).AnyTimes()

--- a/rpc/v7/handlers_test.go
+++ b/rpc/v7/handlers_test.go
@@ -20,14 +20,14 @@ func nopCloser() error { return nil }
 func TestVersion(t *testing.T) {
 	const version = "1.2.3-rc1"
 
-	handler := rpcv7.New(nil, nil, nil, version, utils.Ptr(utils.Mainnet), nil)
+	handler := rpcv7.New(nil, nil, nil, version, &utils.Mainnet, nil)
 	ver, err := handler.Version()
 	require.Nil(t, err)
 	assert.Equal(t, version, ver)
 }
 
 func TestSpecVersion(t *testing.T) {
-	handler := rpcv7.New(nil, nil, nil, "", utils.Ptr(utils.Mainnet), nil)
+	handler := rpcv7.New(nil, nil, nil, "", &utils.Mainnet, nil)
 	version, rpcErr := handler.SpecVersion()
 	require.Nil(t, rpcErr)
 	require.Equal(t, "0.7.1", version)
@@ -42,7 +42,7 @@ func TestThrottledVMError(t *testing.T) {
 	mockVM := mocks.NewMockVM(mockCtrl)
 
 	throttledVM := node.NewThrottledVM(mockVM, 0, 0)
-	handler := rpcv7.New(mockReader, mockSyncReader, throttledVM, "", utils.Ptr(utils.Mainnet), nil)
+	handler := rpcv7.New(mockReader, mockSyncReader, throttledVM, "", &utils.Mainnet, nil)
 	mockState := mocks.NewMockStateHistoryReader(mockCtrl)
 
 	throttledErr := "VM throughput limit reached"

--- a/rpc/v7/simulation.go
+++ b/rpc/v7/simulation.go
@@ -161,7 +161,7 @@ func (h *Handler) simulateTransactions(id BlockID, transactions []BroadcastedTra
 			DataGasConsumed: daGasL1DataGas,
 			DataGasPrice:    dataGasPrice,
 			OverallFee:      overallFee,
-			Unit:            utils.Ptr(feeUnit),
+			Unit:            &feeUnit,
 		}
 
 		trace := traces[i]

--- a/rpc/v7/simulation_test.go
+++ b/rpc/v7/simulation_test.go
@@ -21,7 +21,7 @@ func TestSimulateTransactions(t *testing.T) {
 	mockCtrl := gomock.NewController(t)
 	defer mockCtrl.Finish()
 
-	n := utils.Ptr(utils.Mainnet)
+	n := &utils.Mainnet
 
 	mockReader := mocks.NewMockReader(mockCtrl)
 	mockReader.EXPECT().Network().Return(n).AnyTimes()

--- a/rpc/v7/storage_test.go
+++ b/rpc/v7/storage_test.go
@@ -21,7 +21,7 @@ func TestStorageAt(t *testing.T) {
 
 	mockReader := mocks.NewMockReader(mockCtrl)
 	log := utils.NewNopZapLogger()
-	handler := rpcv7.New(mockReader, nil, nil, "", utils.Ptr(utils.Mainnet), log)
+	handler := rpcv7.New(mockReader, nil, nil, "", &utils.Mainnet, log)
 
 	t.Run("empty blockchain", func(t *testing.T) {
 		mockReader.EXPECT().HeadState().Return(nil, nil, db.ErrKeyNotFound)

--- a/rpc/v7/trace.go
+++ b/rpc/v7/trace.go
@@ -93,15 +93,15 @@ func adaptFunctionInvocation(snFnInvocation *starknet.FunctionInvocation) *vm.Fu
 		snEvent := &snFnInvocation.Events[index]
 		fnInvocation.Events = append(fnInvocation.Events, vm.OrderedEvent{
 			Order: snEvent.Order,
-			Keys:  utils.Map(snEvent.Keys, utils.Ptr[felt.Felt]),
-			Data:  utils.Map(snEvent.Data, utils.Ptr[felt.Felt]),
+			Keys:  utils.Map(snEvent.Keys, utils.HeapPtr[felt.Felt]),
+			Data:  utils.Map(snEvent.Data, utils.HeapPtr[felt.Felt]),
 		})
 	}
 	for index := range snFnInvocation.Messages {
 		snMessage := &snFnInvocation.Messages[index]
 		fnInvocation.Messages = append(fnInvocation.Messages, vm.OrderedL2toL1Message{
 			Order:   snMessage.Order,
-			Payload: utils.Map(snMessage.Payload, utils.Ptr[felt.Felt]),
+			Payload: utils.Map(snMessage.Payload, utils.HeapPtr[felt.Felt]),
 			To:      snMessage.ToAddr,
 		})
 	}

--- a/rpc/v7/trace_test.go
+++ b/rpc/v7/trace_test.go
@@ -28,7 +28,7 @@ import (
 func TestTraceFallback(t *testing.T) {
 	mockCtrl := gomock.NewController(t)
 	t.Cleanup(mockCtrl.Finish)
-	n := utils.Ptr(utils.Integration)
+	n := &utils.Integration
 	client := feeder.NewTestClient(t, n)
 	mockReader := mocks.NewMockReader(mockCtrl)
 	gateway := adaptfeeder.New(client)
@@ -84,7 +84,7 @@ func TestTraceTransaction(t *testing.T) {
 	mockSyncReader := mocks.NewMockSyncReader(mockCtrl)
 	mockReader.EXPECT().Network().Return(&utils.Mainnet).AnyTimes()
 	mockVM := mocks.NewMockVM(mockCtrl)
-	handler := rpcv7.New(mockReader, mockSyncReader, mockVM, "", utils.Ptr(utils.Mainnet), utils.NewNopZapLogger())
+	handler := rpcv7.New(mockReader, mockSyncReader, mockVM, "", utils.HeapPtr(utils.Mainnet), utils.NewNopZapLogger())
 
 	t.Run("not found", func(t *testing.T) {
 		t.Run("key not found", func(t *testing.T) {
@@ -310,7 +310,7 @@ func TestTraceBlockTransactions(t *testing.T) {
 	for description, id := range errTests {
 		t.Run(description, func(t *testing.T) {
 			log := utils.NewNopZapLogger()
-			n := utils.Ptr(utils.Mainnet)
+			n := &utils.Mainnet
 			chain := blockchain.New(pebble.NewMemTest(t), n)
 			handler := rpcv7.New(chain, nil, nil, "", n, log)
 
@@ -333,7 +333,7 @@ func TestTraceBlockTransactions(t *testing.T) {
 
 	mockCtrl := gomock.NewController(t)
 	t.Cleanup(mockCtrl.Finish)
-	n := utils.Ptr(utils.Mainnet)
+	n := &utils.Mainnet
 
 	mockReader := mocks.NewMockReader(mockCtrl)
 	mockSyncReader := mocks.NewMockSyncReader(mockCtrl)
@@ -498,7 +498,7 @@ func TestCall(t *testing.T) {
 	mockCtrl := gomock.NewController(t)
 	t.Cleanup(mockCtrl.Finish)
 
-	n := utils.Ptr(utils.Mainnet)
+	n := &utils.Mainnet
 	mockReader := mocks.NewMockReader(mockCtrl)
 	mockVM := mocks.NewMockVM(mockCtrl)
 	handler := rpcv7.New(mockReader, nil, mockVM, "", n, utils.NewNopZapLogger())

--- a/rpc/v7/transaction.go
+++ b/rpc/v7/transaction.go
@@ -395,7 +395,7 @@ func adaptToFeederDAMode(mode *DataAvailabilityMode) *starknet.DataAvailabilityM
 	if mode == nil {
 		return nil
 	}
-	return utils.Ptr(starknet.DataAvailabilityMode(*mode))
+	return utils.HeapPtr(starknet.DataAvailabilityMode(*mode))
 }
 
 func adaptRPCTxToFeederTx(rpcTx *Transaction) *starknet.Transaction {
@@ -860,7 +860,7 @@ func adaptInvokeTransaction(t *core.InvokeTransaction) *Transaction {
 		Hash:               t.Hash(),
 		MaxFee:             t.MaxFee,
 		Version:            t.Version.AsFelt(),
-		Signature:          utils.Ptr(t.Signature()),
+		Signature:          utils.HeapPtr(t.Signature()),
 		Nonce:              t.Nonce,
 		CallData:           &t.CallData,
 		ContractAddress:    t.ContractAddress,
@@ -869,12 +869,12 @@ func adaptInvokeTransaction(t *core.InvokeTransaction) *Transaction {
 	}
 
 	if tx.Version.Uint64() == 3 {
-		tx.ResourceBounds = utils.Ptr(adaptResourceBounds(t.ResourceBounds))
+		tx.ResourceBounds = utils.HeapPtr(adaptResourceBounds(t.ResourceBounds))
 		tx.Tip = new(felt.Felt).SetUint64(t.Tip)
 		tx.PaymasterData = &t.PaymasterData
 		tx.AccountDeploymentData = &t.AccountDeploymentData
-		tx.NonceDAMode = utils.Ptr(DataAvailabilityMode(t.NonceDAMode))
-		tx.FeeDAMode = utils.Ptr(DataAvailabilityMode(t.FeeDAMode))
+		tx.NonceDAMode = utils.HeapPtr(DataAvailabilityMode(t.NonceDAMode))
+		tx.FeeDAMode = utils.HeapPtr(DataAvailabilityMode(t.FeeDAMode))
 	}
 	return tx
 }
@@ -886,7 +886,7 @@ func adaptDeclareTransaction(t *core.DeclareTransaction) *Transaction {
 		Type:              TxnDeclare,
 		MaxFee:            t.MaxFee,
 		Version:           t.Version.AsFelt(),
-		Signature:         utils.Ptr(t.Signature()),
+		Signature:         utils.HeapPtr(t.Signature()),
 		Nonce:             t.Nonce,
 		ClassHash:         t.ClassHash,
 		SenderAddress:     t.SenderAddress,
@@ -894,12 +894,12 @@ func adaptDeclareTransaction(t *core.DeclareTransaction) *Transaction {
 	}
 
 	if tx.Version.Uint64() == 3 {
-		tx.ResourceBounds = utils.Ptr(adaptResourceBounds(t.ResourceBounds))
+		tx.ResourceBounds = utils.HeapPtr(adaptResourceBounds(t.ResourceBounds))
 		tx.Tip = new(felt.Felt).SetUint64(t.Tip)
 		tx.PaymasterData = &t.PaymasterData
 		tx.AccountDeploymentData = &t.AccountDeploymentData
-		tx.NonceDAMode = utils.Ptr(DataAvailabilityMode(t.NonceDAMode))
-		tx.FeeDAMode = utils.Ptr(DataAvailabilityMode(t.FeeDAMode))
+		tx.NonceDAMode = utils.HeapPtr(DataAvailabilityMode(t.NonceDAMode))
+		tx.FeeDAMode = utils.HeapPtr(DataAvailabilityMode(t.FeeDAMode))
 	}
 
 	return tx
@@ -910,7 +910,7 @@ func adaptDeployAccountTransaction(t *core.DeployAccountTransaction) *Transactio
 		Hash:                t.Hash(),
 		MaxFee:              t.MaxFee,
 		Version:             t.Version.AsFelt(),
-		Signature:           utils.Ptr(t.Signature()),
+		Signature:           utils.HeapPtr(t.Signature()),
 		Nonce:               t.Nonce,
 		Type:                TxnDeployAccount,
 		ContractAddressSalt: t.ContractAddressSalt,
@@ -919,11 +919,11 @@ func adaptDeployAccountTransaction(t *core.DeployAccountTransaction) *Transactio
 	}
 
 	if tx.Version.Uint64() == 3 {
-		tx.ResourceBounds = utils.Ptr(adaptResourceBounds(t.ResourceBounds))
+		tx.ResourceBounds = utils.HeapPtr(adaptResourceBounds(t.ResourceBounds))
 		tx.Tip = new(felt.Felt).SetUint64(t.Tip)
 		tx.PaymasterData = &t.PaymasterData
-		tx.NonceDAMode = utils.Ptr(DataAvailabilityMode(t.NonceDAMode))
-		tx.FeeDAMode = utils.Ptr(DataAvailabilityMode(t.FeeDAMode))
+		tx.NonceDAMode = utils.HeapPtr(DataAvailabilityMode(t.NonceDAMode))
+		tx.FeeDAMode = utils.HeapPtr(DataAvailabilityMode(t.FeeDAMode))
 	}
 
 	return tx

--- a/rpc/v7/transaction_test.go
+++ b/rpc/v7/transaction_test.go
@@ -48,7 +48,7 @@ func TestTransactionByHash(t *testing.T) {
 	}{
 		"DECLARE v1": {
 			hash:    "0x1b4d9f09276629d496af1af8ff00173c11ff146affacb1b5c858d7aa89001ae",
-			network: utils.Ptr(utils.Mainnet),
+			network: &utils.Mainnet,
 			expected: `{
 			"type": "DECLARE",
 			"transaction_hash": "0x1b4d9f09276629d496af1af8ff00173c11ff146affacb1b5c858d7aa89001ae",
@@ -66,7 +66,7 @@ func TestTransactionByHash(t *testing.T) {
 
 		"DECLARE v0": {
 			hash:    "0x222f8902d1eeea76fa2642a90e2411bfd71cffb299b3a299029e1937fab3fe4",
-			network: utils.Ptr(utils.Mainnet),
+			network: &utils.Mainnet,
 			expected: `{
 				"transaction_hash": "0x222f8902d1eeea76fa2642a90e2411bfd71cffb299b3a299029e1937fab3fe4",
 				"type": "DECLARE",
@@ -80,7 +80,7 @@ func TestTransactionByHash(t *testing.T) {
 
 		"L1 Handler v0 with nonce": {
 			hash:    "0x537eacfd3c49166eec905daff61ff7feef9c133a049ea2135cb94eec840a4a8",
-			network: utils.Ptr(utils.Mainnet),
+			network: &utils.Mainnet,
 			expected: `{
        "type": "L1_HANDLER",
        "transaction_hash": "0x537eacfd3c49166eec905daff61ff7feef9c133a049ea2135cb94eec840a4a8",
@@ -99,7 +99,7 @@ func TestTransactionByHash(t *testing.T) {
 		},
 		"L1 Handler v0 without nonce": {
 			hash:    "0x5d50b7020f7cf8033fd7d913e489f47edf74fbf3c8ada85be512c7baa6a2eab",
-			network: utils.Ptr(utils.Mainnet),
+			network: &utils.Mainnet,
 			expected: `{
 				"type": "L1_HANDLER",
 				"transaction_hash":  "0x5d50b7020f7cf8033fd7d913e489f47edf74fbf3c8ada85be512c7baa6a2eab",
@@ -118,7 +118,7 @@ func TestTransactionByHash(t *testing.T) {
 
 		"Invoke v1": {
 			hash:    "0x2897e3cec3e24e4d341df26b8cf1ab84ea1c01a051021836b36c6639145b497",
-			network: utils.Ptr(utils.Mainnet),
+			network: &utils.Mainnet,
 			expected: `{
        "type": "INVOKE",
        "transaction_hash": "0x2897e3cec3e24e4d341df26b8cf1ab84ea1c01a051021836b36c6639145b497",
@@ -154,7 +154,7 @@ func TestTransactionByHash(t *testing.T) {
 
 		"DEPLOY v0": {
 			hash:    "0x6486c6303dba2f364c684a2e9609211c5b8e417e767f37b527cda51e776e6f0",
-			network: utils.Ptr(utils.Mainnet),
+			network: &utils.Mainnet,
 			expected: `{
        "type": "DEPLOY",
        "transaction_hash": "0x6486c6303dba2f364c684a2e9609211c5b8e417e767f37b527cda51e776e6f0",
@@ -173,7 +173,7 @@ func TestTransactionByHash(t *testing.T) {
 
 		"DEPLOY ACCOUNT v1": {
 			hash:    "0xd61fc89f4d1dc4dc90a014957d655d38abffd47ecea8e3fa762e3160f155f2",
-			network: utils.Ptr(utils.Mainnet),
+			network: &utils.Mainnet,
 			expected: `{
        "type": "DEPLOY_ACCOUNT",
        "transaction_hash": "0xd61fc89f4d1dc4dc90a014957d655d38abffd47ecea8e3fa762e3160f155f2",
@@ -194,7 +194,7 @@ func TestTransactionByHash(t *testing.T) {
 
 		"INVOKE v0": {
 			hash:    "0xf1d99fb97509e0dfc425ddc2a8c5398b74231658ca58b6f8da92f39cb739e",
-			network: utils.Ptr(utils.Mainnet),
+			network: &utils.Mainnet,
 			expected: `{
        "type": "INVOKE",
        "transaction_hash": "0xf1d99fb97509e0dfc425ddc2a8c5398b74231658ca58b6f8da92f39cb739e",
@@ -213,7 +213,7 @@ func TestTransactionByHash(t *testing.T) {
 		},
 		"DECLARE v3": {
 			hash:    "0x41d1f5206ef58a443e7d3d1ca073171ec25fa75313394318fc83a074a6631c3",
-			network: utils.Ptr(utils.Integration),
+			network: &utils.Integration,
 			expected: `{
 		"transaction_hash": "0x41d1f5206ef58a443e7d3d1ca073171ec25fa75313394318fc83a074a6631c3",
 		"type": "DECLARE",
@@ -242,7 +242,7 @@ func TestTransactionByHash(t *testing.T) {
 		},
 		"INVOKE v3": {
 			hash:    "0x49728601e0bb2f48ce506b0cbd9c0e2a9e50d95858aa41463f46386dca489fd",
-			network: utils.Ptr(utils.Integration),
+			network: &utils.Integration,
 			expected: `{
 				"type": "INVOKE",
 				"transaction_hash": "0x49728601e0bb2f48ce506b0cbd9c0e2a9e50d95858aa41463f46386dca489fd",
@@ -286,7 +286,7 @@ func TestTransactionByHash(t *testing.T) {
 		},
 		"DEPLOY ACCOUNT v3": {
 			hash:    "0x29fd7881f14380842414cdfdd8d6c0b1f2174f8916edcfeb1ede1eb26ac3ef0",
-			network: utils.Ptr(utils.Integration),
+			network: &utils.Integration,
 			expected: `{
 				"transaction_hash": "0x29fd7881f14380842414cdfdd8d6c0b1f2174f8916edcfeb1ede1eb26ac3ef0",
 				"version": "0x3",
@@ -349,7 +349,7 @@ func TestTransactionByHash(t *testing.T) {
 func TestTransactionByBlockIdAndIndex(t *testing.T) {
 	mockCtrl := gomock.NewController(t)
 	t.Cleanup(mockCtrl.Finish)
-	n := utils.Ptr(utils.Mainnet)
+	n := &utils.Mainnet
 	mockReader := mocks.NewMockReader(mockCtrl)
 	client := feeder.NewTestClient(t, n)
 	mainnetGw := adaptfeeder.New(client)
@@ -499,7 +499,7 @@ func TestTransactionReceiptByHash(t *testing.T) {
 	mockCtrl := gomock.NewController(t)
 	t.Cleanup(mockCtrl.Finish)
 
-	n := utils.Ptr(utils.Mainnet)
+	n := &utils.Mainnet
 	mockReader := mocks.NewMockReader(mockCtrl)
 	mockSyncer := mocks.NewMockSyncReader(mockCtrl)
 	handler := rpc.New(mockReader, mockSyncer, nil, "", n, nil)
@@ -764,7 +764,7 @@ func TestLegacyTransactionReceiptByHash(t *testing.T) {
 	mockCtrl := gomock.NewController(t)
 	t.Cleanup(mockCtrl.Finish)
 
-	n := utils.Ptr(utils.Mainnet)
+	n := &utils.Mainnet
 	mockReader := mocks.NewMockReader(mockCtrl)
 	handler := rpc.New(mockReader, nil, nil, "", n, nil)
 
@@ -1081,8 +1081,8 @@ func TestAdaptTransaction(t *testing.T) {
 			CallData:              new([]*felt.Felt),
 			PaymasterData:         new([]*felt.Felt),
 			AccountDeploymentData: new([]*felt.Felt),
-			NonceDAMode:           utils.Ptr(rpc.DAModeL1),
-			FeeDAMode:             utils.Ptr(rpc.DAModeL1),
+			NonceDAMode:           utils.HeapPtr(rpc.DAModeL1),
+			FeeDAMode:             utils.HeapPtr(rpc.DAModeL1),
 		}
 
 		require.Equal(t, expectedTx, tx)
@@ -1090,7 +1090,7 @@ func TestAdaptTransaction(t *testing.T) {
 }
 
 func TestAddTransaction(t *testing.T) {
-	n := utils.Ptr(utils.Integration)
+	n := &utils.Integration
 	gw := adaptfeeder.New(feeder.NewTestClient(t, n))
 	txWithoutClass := func(hash string) rpc.BroadcastedTransaction {
 		tx, err := gw.Transaction(context.Background(), utils.HexToFelt(t, hash))
@@ -1383,13 +1383,13 @@ func TestTransactionStatus(t *testing.T) {
 		notFoundTxHash    *felt.Felt
 	}{
 		{
-			network:           utils.Ptr(utils.Mainnet),
+			network:           &utils.Mainnet,
 			verifiedTxHash:    utils.HexToFelt(t, "0xf1d99fb97509e0dfc425ddc2a8c5398b74231658ca58b6f8da92f39cb739e"),
 			nonVerifiedTxHash: utils.HexToFelt(t, "0x6c40890743aa220b10e5ee68cef694c5c23cc2defd0dbdf5546e687f9982ab1"),
 			notFoundTxHash:    utils.HexToFelt(t, "0x8c96a2b3d73294667e489bf8904c6aa7c334e38e24ad5a721c7e04439ff9"),
 		},
 		{
-			network:           utils.Ptr(utils.Integration),
+			network:           &utils.Integration,
 			verifiedTxHash:    utils.HexToFelt(t, "0x5e91283c1c04c3f88e4a98070df71227fb44dea04ce349c7eb379f85a10d1c3"),
 			nonVerifiedTxHash: utils.HexToFelt(t, "0x45d9c2c8e01bacae6dec3438874576a4a1ce65f1d4247f4e9748f0e7216838"),
 			notFoundTxHash:    utils.HexToFelt(t, "0xd7747f3d0ce84b3a19b05b987a782beac22c54e66773303e94ea78cc3c15"),

--- a/rpc/v8/block_test.go
+++ b/rpc/v8/block_test.go
@@ -107,7 +107,7 @@ func TestBlockWithTxHashes(t *testing.T) {
 	for description, id := range errTests { //nolint:dupl
 		t.Run(description, func(t *testing.T) {
 			log := utils.NewNopZapLogger()
-			n := utils.Ptr(utils.Mainnet)
+			n := &utils.Mainnet
 			chain := blockchain.New(pebble.NewMemTest(t), n)
 
 			if description == "pending" { //nolint:goconst
@@ -123,7 +123,7 @@ func TestBlockWithTxHashes(t *testing.T) {
 		})
 	}
 
-	n := utils.Ptr(utils.Sepolia)
+	n := &utils.Sepolia
 	handler := rpcv8.New(mockReader, mockSyncReader, nil, "", nil)
 
 	client := feeder.NewTestClient(t, n)
@@ -234,7 +234,7 @@ func TestBlockWithTxs(t *testing.T) {
 	for description, id := range errTests { //nolint:dupl
 		t.Run(description, func(t *testing.T) {
 			log := utils.NewNopZapLogger()
-			n := utils.Ptr(utils.Mainnet)
+			n := &utils.Mainnet
 			chain := blockchain.New(pebble.NewMemTest(t), n)
 
 			if description == "pending" {
@@ -250,7 +250,7 @@ func TestBlockWithTxs(t *testing.T) {
 		})
 	}
 
-	n := utils.Ptr(utils.Mainnet)
+	n := &utils.Mainnet
 	handler := rpcv8.New(mockReader, mockSyncReader, nil, "", nil)
 
 	client := feeder.NewTestClient(t, n)
@@ -367,7 +367,7 @@ func TestBlockWithTxs(t *testing.T) {
 }
 
 func TestBlockWithTxHashesV013(t *testing.T) {
-	n := utils.Ptr(utils.SepoliaIntegration)
+	n := utils.HeapPtr(utils.SepoliaIntegration)
 	mockCtrl := gomock.NewController(t)
 	t.Cleanup(mockCtrl.Finish)
 	mockReader := mocks.NewMockReader(mockCtrl)
@@ -394,7 +394,7 @@ func TestBlockWithTxHashesV013(t *testing.T) {
 				NewRoot:         coreBlock.GlobalStateRoot,
 				Number:          &coreBlock.Number,
 				ParentHash:      coreBlock.ParentHash,
-				L1DAMode:        utils.Ptr(rpcv6.Blob),
+				L1DAMode:        utils.HeapPtr(rpcv6.Blob),
 				L1GasPrice: &rpcv6.ResourcePrice{
 					InFri: utils.HexToFelt(t, "0x17882b6aa74"),
 					InWei: utils.HexToFelt(t, "0x3b9aca10"),
@@ -437,8 +437,8 @@ func TestBlockWithTxHashesV013(t *testing.T) {
 				Tip:                   new(felt.Felt).SetUint64(tx.Tip),
 				PaymasterData:         &tx.PaymasterData,
 				AccountDeploymentData: &tx.AccountDeploymentData,
-				NonceDAMode:           utils.Ptr(rpcv8.DataAvailabilityMode(tx.NonceDAMode)),
-				FeeDAMode:             utils.Ptr(rpcv8.DataAvailabilityMode(tx.FeeDAMode)),
+				NonceDAMode:           utils.HeapPtr(rpcv8.DataAvailabilityMode(tx.NonceDAMode)),
+				FeeDAMode:             utils.HeapPtr(rpcv8.DataAvailabilityMode(tx.FeeDAMode)),
 			},
 		},
 	}, got)
@@ -448,7 +448,7 @@ func TestBlockWithReceipts(t *testing.T) {
 	mockCtrl := gomock.NewController(t)
 	t.Cleanup(mockCtrl.Finish)
 
-	n := utils.Ptr(utils.Mainnet)
+	n := utils.HeapPtr(utils.Mainnet)
 	mockReader := mocks.NewMockReader(mockCtrl)
 	mockSyncReader := mocks.NewMockSyncReader(mockCtrl)
 	handler := rpcv8.New(mockReader, mockSyncReader, nil, "", nil)
@@ -577,7 +577,7 @@ func TestRpcBlockAdaptation(t *testing.T) {
 	mockCtrl := gomock.NewController(t)
 	t.Cleanup(mockCtrl.Finish)
 
-	n := utils.Ptr(utils.Sepolia)
+	n := utils.HeapPtr(utils.Sepolia)
 	mockReader := mocks.NewMockReader(mockCtrl)
 	handler := rpcv8.New(mockReader, nil, nil, "", nil)
 

--- a/rpc/v8/estimate_fee_test.go
+++ b/rpc/v8/estimate_fee_test.go
@@ -21,7 +21,7 @@ func TestEstimateFee(t *testing.T) {
 	mockCtrl := gomock.NewController(t)
 	defer mockCtrl.Finish()
 
-	n := utils.Ptr(utils.Mainnet)
+	n := &utils.Mainnet
 
 	mockReader := mocks.NewMockReader(mockCtrl)
 	mockReader.EXPECT().Network().Return(n).AnyTimes()

--- a/rpc/v8/simulation.go
+++ b/rpc/v8/simulation.go
@@ -212,7 +212,7 @@ func createSimulatedTransactions(
 				L1DataGasConsumed: new(felt.Felt).SetUint64(gasConsumed[i].L1DataGas),
 				L1DataGasPrice:    l1DataGasPrice,
 				OverallFee:        overallFee,
-				Unit:              utils.Ptr(feeUnit),
+				Unit:              &feeUnit,
 			},
 		}
 	}

--- a/rpc/v8/simulation_pkg_test.go
+++ b/rpc/v8/simulation_pkg_test.go
@@ -75,7 +75,7 @@ func TestCreateSimulatedTransactions(t *testing.T) {
 				L1DataGasConsumed: new(felt.Felt).SetUint64(50),
 				L1DataGasPrice:    new(felt.Felt).SetUint64(5),
 				OverallFee:        new(felt.Felt).SetUint64(10),
-				Unit:              utils.Ptr(WEI),
+				Unit:              utils.HeapPtr(WEI),
 			},
 		},
 		{
@@ -98,7 +98,7 @@ func TestCreateSimulatedTransactions(t *testing.T) {
 				L1DataGasConsumed: new(felt.Felt).SetUint64(70),
 				L1DataGasPrice:    new(felt.Felt).SetUint64(6),
 				OverallFee:        new(felt.Felt).SetUint64(20),
-				Unit:              utils.Ptr(FRI),
+				Unit:              utils.HeapPtr(FRI),
 			},
 		},
 	}

--- a/rpc/v8/simulation_test.go
+++ b/rpc/v8/simulation_test.go
@@ -20,7 +20,7 @@ import (
 
 func TestSimulateTransactions(t *testing.T) {
 	t.Parallel()
-	n := utils.Ptr(utils.Mainnet)
+	n := &utils.Mainnet
 	headsHeader := &core.Header{
 		SequencerAddress: n.BlockHashMetaInfo.FallBackSequencerAddress,
 		L1GasPriceETH:    &felt.Zero,

--- a/rpc/v8/subscriptions_test.go
+++ b/rpc/v8/subscriptions_test.go
@@ -114,7 +114,7 @@ func TestSubscribeEvents(t *testing.T) {
 		})
 	})
 
-	n := utils.Ptr(utils.Sepolia)
+	n := &utils.Sepolia
 	client := feeder.NewTestClient(t, n)
 	gw := adaptfeeder.New(client)
 
@@ -1008,7 +1008,7 @@ func subMsg(method string) string {
 func testHeadBlock(t *testing.T) *core.Block {
 	t.Helper()
 
-	n := utils.Ptr(utils.Sepolia)
+	n := utils.HeapPtr(utils.Sepolia)
 	client := feeder.NewTestClient(t, n)
 	gw := adaptfeeder.New(client)
 

--- a/rpc/v8/trace.go
+++ b/rpc/v8/trace.go
@@ -93,15 +93,15 @@ func adaptFunctionInvocation(snFnInvocation *starknet.FunctionInvocation) *vm.Fu
 		snEvent := &snFnInvocation.Events[index]
 		fnInvocation.Events = append(fnInvocation.Events, vm.OrderedEvent{
 			Order: snEvent.Order,
-			Keys:  utils.Map(snEvent.Keys, utils.Ptr[felt.Felt]),
-			Data:  utils.Map(snEvent.Data, utils.Ptr[felt.Felt]),
+			Keys:  utils.Map(snEvent.Keys, utils.HeapPtr[felt.Felt]),
+			Data:  utils.Map(snEvent.Data, utils.HeapPtr[felt.Felt]),
 		})
 	}
 	for index := range snFnInvocation.Messages {
 		snMessage := &snFnInvocation.Messages[index]
 		fnInvocation.Messages = append(fnInvocation.Messages, vm.OrderedL2toL1Message{
 			Order:   snMessage.Order,
-			Payload: utils.Map(snMessage.Payload, utils.Ptr[felt.Felt]),
+			Payload: utils.Map(snMessage.Payload, utils.HeapPtr[felt.Felt]),
 			To:      snMessage.ToAddr,
 		})
 	}

--- a/rpc/v8/trace_test.go
+++ b/rpc/v8/trace_test.go
@@ -28,7 +28,7 @@ import (
 func TestTraceFallback(t *testing.T) {
 	mockCtrl := gomock.NewController(t)
 	t.Cleanup(mockCtrl.Finish)
-	n := utils.Ptr(utils.Integration)
+	n := &utils.Integration
 	client := feeder.NewTestClient(t, n)
 	mockReader := mocks.NewMockReader(mockCtrl)
 	gateway := adaptfeeder.New(client)
@@ -319,7 +319,7 @@ func TestTraceBlockTransactions(t *testing.T) {
 	for description, id := range errTests {
 		t.Run(description, func(t *testing.T) {
 			log := utils.NewNopZapLogger()
-			n := utils.Ptr(utils.Mainnet)
+			n := &utils.Mainnet
 			chain := blockchain.New(pebble.NewMemTest(t), n)
 			handler := rpc.New(chain, nil, nil, "", log)
 
@@ -342,7 +342,7 @@ func TestTraceBlockTransactions(t *testing.T) {
 
 	mockCtrl := gomock.NewController(t)
 	t.Cleanup(mockCtrl.Finish)
-	n := utils.Ptr(utils.Mainnet)
+	n := &utils.Mainnet
 
 	mockReader := mocks.NewMockReader(mockCtrl)
 	mockSyncReader := mocks.NewMockSyncReader(mockCtrl)
@@ -511,7 +511,7 @@ func TestCall(t *testing.T) {
 	mockCtrl := gomock.NewController(t)
 	t.Cleanup(mockCtrl.Finish)
 
-	n := utils.Ptr(utils.Mainnet)
+	n := &utils.Mainnet
 	mockReader := mocks.NewMockReader(mockCtrl)
 	mockVM := mocks.NewMockVM(mockCtrl)
 	handler := rpc.New(mockReader, nil, mockVM, "", utils.NewNopZapLogger())

--- a/rpc/v8/transaction.go
+++ b/rpc/v8/transaction.go
@@ -393,7 +393,7 @@ func adaptToFeederDAMode(mode *DataAvailabilityMode) *starknet.DataAvailabilityM
 	if mode == nil {
 		return nil
 	}
-	return utils.Ptr(starknet.DataAvailabilityMode(*mode))
+	return utils.HeapPtr(starknet.DataAvailabilityMode(*mode))
 }
 
 func adaptRPCTxToFeederTx(rpcTx *Transaction) *starknet.Transaction {
@@ -858,7 +858,7 @@ func adaptInvokeTransaction(t *core.InvokeTransaction) *Transaction {
 		Hash:               t.Hash(),
 		MaxFee:             t.MaxFee,
 		Version:            t.Version.AsFelt(),
-		Signature:          utils.Ptr(t.Signature()),
+		Signature:          utils.HeapPtr(t.Signature()),
 		Nonce:              t.Nonce,
 		CallData:           &t.CallData,
 		ContractAddress:    t.ContractAddress,
@@ -867,12 +867,12 @@ func adaptInvokeTransaction(t *core.InvokeTransaction) *Transaction {
 	}
 
 	if tx.Version.Uint64() == 3 {
-		tx.ResourceBounds = utils.Ptr(adaptResourceBounds(t.ResourceBounds))
+		tx.ResourceBounds = utils.HeapPtr(adaptResourceBounds(t.ResourceBounds))
 		tx.Tip = new(felt.Felt).SetUint64(t.Tip)
 		tx.PaymasterData = &t.PaymasterData
 		tx.AccountDeploymentData = &t.AccountDeploymentData
-		tx.NonceDAMode = utils.Ptr(DataAvailabilityMode(t.NonceDAMode))
-		tx.FeeDAMode = utils.Ptr(DataAvailabilityMode(t.FeeDAMode))
+		tx.NonceDAMode = utils.HeapPtr(DataAvailabilityMode(t.NonceDAMode))
+		tx.FeeDAMode = utils.HeapPtr(DataAvailabilityMode(t.FeeDAMode))
 	}
 	return tx
 }
@@ -884,7 +884,7 @@ func adaptDeclareTransaction(t *core.DeclareTransaction) *Transaction {
 		Type:              TxnDeclare,
 		MaxFee:            t.MaxFee,
 		Version:           t.Version.AsFelt(),
-		Signature:         utils.Ptr(t.Signature()),
+		Signature:         utils.HeapPtr(t.Signature()),
 		Nonce:             t.Nonce,
 		ClassHash:         t.ClassHash,
 		SenderAddress:     t.SenderAddress,
@@ -892,12 +892,12 @@ func adaptDeclareTransaction(t *core.DeclareTransaction) *Transaction {
 	}
 
 	if tx.Version.Uint64() == 3 {
-		tx.ResourceBounds = utils.Ptr(adaptResourceBounds(t.ResourceBounds))
+		tx.ResourceBounds = utils.HeapPtr(adaptResourceBounds(t.ResourceBounds))
 		tx.Tip = new(felt.Felt).SetUint64(t.Tip)
 		tx.PaymasterData = &t.PaymasterData
 		tx.AccountDeploymentData = &t.AccountDeploymentData
-		tx.NonceDAMode = utils.Ptr(DataAvailabilityMode(t.NonceDAMode))
-		tx.FeeDAMode = utils.Ptr(DataAvailabilityMode(t.FeeDAMode))
+		tx.NonceDAMode = utils.HeapPtr(DataAvailabilityMode(t.NonceDAMode))
+		tx.FeeDAMode = utils.HeapPtr(DataAvailabilityMode(t.FeeDAMode))
 	}
 
 	return tx
@@ -908,7 +908,7 @@ func adaptDeployAccountTrandaction(t *core.DeployAccountTransaction) *Transactio
 		Hash:                t.Hash(),
 		MaxFee:              t.MaxFee,
 		Version:             t.Version.AsFelt(),
-		Signature:           utils.Ptr(t.Signature()),
+		Signature:           utils.HeapPtr(t.Signature()),
 		Nonce:               t.Nonce,
 		Type:                TxnDeployAccount,
 		ContractAddressSalt: t.ContractAddressSalt,
@@ -917,11 +917,11 @@ func adaptDeployAccountTrandaction(t *core.DeployAccountTransaction) *Transactio
 	}
 
 	if tx.Version.Uint64() == 3 {
-		tx.ResourceBounds = utils.Ptr(adaptResourceBounds(t.ResourceBounds))
+		tx.ResourceBounds = utils.HeapPtr(adaptResourceBounds(t.ResourceBounds))
 		tx.Tip = new(felt.Felt).SetUint64(t.Tip)
 		tx.PaymasterData = &t.PaymasterData
-		tx.NonceDAMode = utils.Ptr(DataAvailabilityMode(t.NonceDAMode))
-		tx.FeeDAMode = utils.Ptr(DataAvailabilityMode(t.FeeDAMode))
+		tx.NonceDAMode = utils.HeapPtr(DataAvailabilityMode(t.NonceDAMode))
+		tx.FeeDAMode = utils.HeapPtr(DataAvailabilityMode(t.FeeDAMode))
 	}
 
 	return tx

--- a/rpc/v8/transaction_test.go
+++ b/rpc/v8/transaction_test.go
@@ -76,7 +76,7 @@ func TestTransactionByHash(t *testing.T) {
 	}{
 		"DECLARE v1": {
 			hash:    "0x1b4d9f09276629d496af1af8ff00173c11ff146affacb1b5c858d7aa89001ae",
-			network: utils.Ptr(utils.Mainnet),
+			network: &utils.Mainnet,
 			expected: `{
 			"type": "DECLARE",
 			"transaction_hash": "0x1b4d9f09276629d496af1af8ff00173c11ff146affacb1b5c858d7aa89001ae",
@@ -94,7 +94,7 @@ func TestTransactionByHash(t *testing.T) {
 
 		"DECLARE v0": {
 			hash:    "0x222f8902d1eeea76fa2642a90e2411bfd71cffb299b3a299029e1937fab3fe4",
-			network: utils.Ptr(utils.Mainnet),
+			network: &utils.Mainnet,
 			expected: `{
 				"transaction_hash": "0x222f8902d1eeea76fa2642a90e2411bfd71cffb299b3a299029e1937fab3fe4",
 				"type": "DECLARE",
@@ -108,7 +108,7 @@ func TestTransactionByHash(t *testing.T) {
 
 		"L1 Handler v0 with nonce": {
 			hash:    "0x537eacfd3c49166eec905daff61ff7feef9c133a049ea2135cb94eec840a4a8",
-			network: utils.Ptr(utils.Mainnet),
+			network: &utils.Mainnet,
 			expected: `{
        "type": "L1_HANDLER",
        "transaction_hash": "0x537eacfd3c49166eec905daff61ff7feef9c133a049ea2135cb94eec840a4a8",
@@ -127,7 +127,7 @@ func TestTransactionByHash(t *testing.T) {
 		},
 		"L1 Handler v0 without nonce": {
 			hash:    "0x5d50b7020f7cf8033fd7d913e489f47edf74fbf3c8ada85be512c7baa6a2eab",
-			network: utils.Ptr(utils.Mainnet),
+			network: &utils.Mainnet,
 			expected: `{
 				"type": "L1_HANDLER",
 				"transaction_hash":  "0x5d50b7020f7cf8033fd7d913e489f47edf74fbf3c8ada85be512c7baa6a2eab",
@@ -146,7 +146,7 @@ func TestTransactionByHash(t *testing.T) {
 
 		"Invoke v1": {
 			hash:    "0x2897e3cec3e24e4d341df26b8cf1ab84ea1c01a051021836b36c6639145b497",
-			network: utils.Ptr(utils.Mainnet),
+			network: &utils.Mainnet,
 			expected: `{
        "type": "INVOKE",
        "transaction_hash": "0x2897e3cec3e24e4d341df26b8cf1ab84ea1c01a051021836b36c6639145b497",
@@ -182,7 +182,7 @@ func TestTransactionByHash(t *testing.T) {
 
 		"DEPLOY v0": {
 			hash:    "0x6486c6303dba2f364c684a2e9609211c5b8e417e767f37b527cda51e776e6f0",
-			network: utils.Ptr(utils.Mainnet),
+			network: &utils.Mainnet,
 			expected: `{
        "type": "DEPLOY",
        "transaction_hash": "0x6486c6303dba2f364c684a2e9609211c5b8e417e767f37b527cda51e776e6f0",
@@ -201,7 +201,7 @@ func TestTransactionByHash(t *testing.T) {
 
 		"DEPLOY ACCOUNT v1": {
 			hash:    "0xd61fc89f4d1dc4dc90a014957d655d38abffd47ecea8e3fa762e3160f155f2",
-			network: utils.Ptr(utils.Mainnet),
+			network: &utils.Mainnet,
 			expected: `{
        "type": "DEPLOY_ACCOUNT",
        "transaction_hash": "0xd61fc89f4d1dc4dc90a014957d655d38abffd47ecea8e3fa762e3160f155f2",
@@ -222,7 +222,7 @@ func TestTransactionByHash(t *testing.T) {
 
 		"INVOKE v0": {
 			hash:    "0xf1d99fb97509e0dfc425ddc2a8c5398b74231658ca58b6f8da92f39cb739e",
-			network: utils.Ptr(utils.Mainnet),
+			network: &utils.Mainnet,
 			expected: `{
        "type": "INVOKE",
        "transaction_hash": "0xf1d99fb97509e0dfc425ddc2a8c5398b74231658ca58b6f8da92f39cb739e",
@@ -241,7 +241,7 @@ func TestTransactionByHash(t *testing.T) {
 		},
 		"DECLARE v3": {
 			hash:    "0x41d1f5206ef58a443e7d3d1ca073171ec25fa75313394318fc83a074a6631c3",
-			network: utils.Ptr(utils.Integration),
+			network: &utils.Integration,
 			expected: `{
 		"transaction_hash": "0x41d1f5206ef58a443e7d3d1ca073171ec25fa75313394318fc83a074a6631c3",
 		"type": "DECLARE",
@@ -270,7 +270,7 @@ func TestTransactionByHash(t *testing.T) {
 		},
 		"INVOKE v3": {
 			hash:    "0x49728601e0bb2f48ce506b0cbd9c0e2a9e50d95858aa41463f46386dca489fd",
-			network: utils.Ptr(utils.Integration),
+			network: &utils.Integration,
 			expected: `{
 				"type": "INVOKE",
 				"transaction_hash": "0x49728601e0bb2f48ce506b0cbd9c0e2a9e50d95858aa41463f46386dca489fd",
@@ -314,7 +314,7 @@ func TestTransactionByHash(t *testing.T) {
 		},
 		"DEPLOY ACCOUNT v3": {
 			hash:    "0x29fd7881f14380842414cdfdd8d6c0b1f2174f8916edcfeb1ede1eb26ac3ef0",
-			network: utils.Ptr(utils.Integration),
+			network: &utils.Integration,
 			expected: `{
 				"transaction_hash": "0x29fd7881f14380842414cdfdd8d6c0b1f2174f8916edcfeb1ede1eb26ac3ef0",
 				"version": "0x3",
@@ -377,7 +377,7 @@ func TestTransactionByHash(t *testing.T) {
 func TestTransactionByBlockIdAndIndex(t *testing.T) {
 	mockCtrl := gomock.NewController(t)
 	t.Cleanup(mockCtrl.Finish)
-	n := utils.Ptr(utils.Mainnet)
+	n := &utils.Mainnet
 	mockReader := mocks.NewMockReader(mockCtrl)
 	mockSyncReader := mocks.NewMockSyncReader(mockCtrl)
 	client := feeder.NewTestClient(t, n)
@@ -525,7 +525,7 @@ func TestTransactionReceiptByHash(t *testing.T) {
 	mockCtrl := gomock.NewController(t)
 	t.Cleanup(mockCtrl.Finish)
 
-	n := utils.Ptr(utils.Mainnet)
+	n := &utils.Mainnet
 	mockReader := mocks.NewMockReader(mockCtrl)
 	mockSyncReader := mocks.NewMockSyncReader(mockCtrl)
 	handler := rpc.New(mockReader, mockSyncReader, nil, "", nil)
@@ -832,7 +832,7 @@ func TestTransactionReceiptByHash(t *testing.T) {
 			}
 		}`
 
-		netClient := feeder.NewTestClient(t, utils.Ptr(utils.SepoliaIntegration))
+		netClient := feeder.NewTestClient(t, &utils.SepoliaIntegration)
 		netGW := adaptfeeder.New(netClient)
 
 		block, err := netGW.BlockByNumber(context.Background(), 35748)
@@ -894,7 +894,7 @@ func TestAddTransactionUnmarshal(t *testing.T) {
 }
 
 func TestAddTransaction(t *testing.T) {
-	n := utils.Ptr(utils.Integration)
+	n := &utils.Integration
 	gw := adaptfeeder.New(feeder.NewTestClient(t, n))
 	txWithoutClass := func(hash string) rpc.BroadcastedTransaction {
 		tx, err := gw.Transaction(context.Background(), utils.HexToFelt(t, hash))
@@ -1203,13 +1203,13 @@ func TestTransactionStatus(t *testing.T) {
 		notFoundTxHash    *felt.Felt
 	}{
 		{
-			network:           utils.Ptr(utils.Mainnet),
+			network:           &utils.Mainnet,
 			verifiedTxHash:    utils.HexToFelt(t, "0xf1d99fb97509e0dfc425ddc2a8c5398b74231658ca58b6f8da92f39cb739e"),
 			nonVerifiedTxHash: utils.HexToFelt(t, "0x6c40890743aa220b10e5ee68cef694c5c23cc2defd0dbdf5546e687f9982ab1"),
 			notFoundTxHash:    utils.HexToFelt(t, "0x8c96a2b3d73294667e489bf8904c6aa7c334e38e24ad5a721c7e04439ff9"),
 		},
 		{
-			network:           utils.Ptr(utils.Integration),
+			network:           &utils.Integration,
 			verifiedTxHash:    utils.HexToFelt(t, "0x5e91283c1c04c3f88e4a98070df71227fb44dea04ce349c7eb379f85a10d1c3"),
 			nonVerifiedTxHash: utils.HexToFelt(t, "0x45d9c2c8e01bacae6dec3438874576a4a1ce65f1d4247f4e9748f0e7216838"),
 			notFoundTxHash:    utils.HexToFelt(t, "0xd7747f3d0ce84b3a19b05b987a782beac22c54e66773303e94ea78cc3c15"),

--- a/utils/ptr.go
+++ b/utils/ptr.go
@@ -1,6 +1,8 @@
 package utils
 
-func Ptr[T any](v T) *T {
+// This function allocates a value into the heap and returns
+// a pointer to it
+func HeapPtr[T any](v T) *T {
 	return &v
 }
 

--- a/vm/transaction.go
+++ b/vm/transaction.go
@@ -123,7 +123,7 @@ func adaptTransaction(txn core.Transaction) *Transaction {
 		tx = &Transaction{
 			MaxFee:            t.MaxFee,
 			Version:           t.Version.AsFelt(),
-			Signature:         utils.Ptr(t.Signature()),
+			Signature:         utils.HeapPtr(t.Signature()),
 			Nonce:             t.Nonce,
 			ClassHash:         t.ClassHash,
 			SenderAddress:     t.SenderAddress,
@@ -131,18 +131,18 @@ func adaptTransaction(txn core.Transaction) *Transaction {
 		}
 
 		if tx.Version.Uint64() == 3 {
-			tx.ResourceBounds = utils.Ptr(adaptResourceBounds(t.ResourceBounds))
+			tx.ResourceBounds = utils.HeapPtr(adaptResourceBounds(t.ResourceBounds))
 			tx.Tip = new(felt.Felt).SetUint64(t.Tip)
 			tx.PaymasterData = &t.PaymasterData
 			tx.AccountDeploymentData = &t.AccountDeploymentData
-			tx.NonceDAMode = utils.Ptr(DataAvailabilityMode(t.NonceDAMode))
-			tx.FeeDAMode = utils.Ptr(DataAvailabilityMode(t.FeeDAMode))
+			tx.NonceDAMode = utils.HeapPtr(DataAvailabilityMode(t.NonceDAMode))
+			tx.FeeDAMode = utils.HeapPtr(DataAvailabilityMode(t.FeeDAMode))
 		}
 	case *core.InvokeTransaction:
 		tx = &Transaction{
 			MaxFee:             t.MaxFee,
 			Version:            t.Version.AsFelt(),
-			Signature:          utils.Ptr(t.Signature()),
+			Signature:          utils.HeapPtr(t.Signature()),
 			Nonce:              t.Nonce,
 			CallData:           &t.CallData,
 			ContractAddress:    t.ContractAddress,
@@ -151,12 +151,12 @@ func adaptTransaction(txn core.Transaction) *Transaction {
 		}
 
 		if t.Version.Is(3) {
-			tx.ResourceBounds = utils.Ptr(adaptResourceBounds(t.ResourceBounds))
+			tx.ResourceBounds = utils.HeapPtr(adaptResourceBounds(t.ResourceBounds))
 			tx.Tip = new(felt.Felt).SetUint64(t.Tip)
 			tx.PaymasterData = &t.PaymasterData
 			tx.AccountDeploymentData = &t.AccountDeploymentData
-			tx.NonceDAMode = utils.Ptr(DataAvailabilityMode(t.NonceDAMode))
-			tx.FeeDAMode = utils.Ptr(DataAvailabilityMode(t.FeeDAMode))
+			tx.NonceDAMode = utils.HeapPtr(DataAvailabilityMode(t.NonceDAMode))
+			tx.FeeDAMode = utils.HeapPtr(DataAvailabilityMode(t.FeeDAMode))
 		}
 	case *core.DeployTransaction:
 		return &Transaction{
@@ -178,7 +178,7 @@ func adaptTransaction(txn core.Transaction) *Transaction {
 		tx = &Transaction{
 			MaxFee:              t.MaxFee,
 			Version:             t.Version.AsFelt(),
-			Signature:           utils.Ptr(t.Signature()),
+			Signature:           utils.HeapPtr(t.Signature()),
 			Nonce:               t.Nonce,
 			ContractAddressSalt: t.ContractAddressSalt,
 			ConstructorCallData: &t.ConstructorCallData,
@@ -186,11 +186,11 @@ func adaptTransaction(txn core.Transaction) *Transaction {
 		}
 
 		if tx.Version.Uint64() == 3 {
-			tx.ResourceBounds = utils.Ptr(adaptResourceBounds(t.ResourceBounds))
+			tx.ResourceBounds = utils.HeapPtr(adaptResourceBounds(t.ResourceBounds))
 			tx.Tip = new(felt.Felt).SetUint64(t.Tip)
 			tx.PaymasterData = &t.PaymasterData
-			tx.NonceDAMode = utils.Ptr(DataAvailabilityMode(t.NonceDAMode))
-			tx.FeeDAMode = utils.Ptr(DataAvailabilityMode(t.FeeDAMode))
+			tx.NonceDAMode = utils.HeapPtr(DataAvailabilityMode(t.NonceDAMode))
+			tx.FeeDAMode = utils.HeapPtr(DataAvailabilityMode(t.FeeDAMode))
 		}
 	default:
 		panic(fmt.Sprintf("unknown txn type in core2sn.AdaptTransaction: %T", t))


### PR DESCRIPTION
Changed it so that everyone in the future is aware that using `Ptr` has the inherent cost of a heap allocation