### PR TITLE
fix(rpc): failed json marshalling in starknet_call rpc v6-7

### DIFF
--- a/rpc/rpccore/rpccore.go
+++ b/rpc/rpccore/rpccore.go
@@ -18,6 +18,7 @@ const (
 	ThrottledVMErr                = "VM throughput limit reached"
 	MaxBlocksBack                 = 1024
 	EntrypointNotFoundFelt string = "0x454e545259504f494e545f4e4f545f464f554e44"
+	ExecutionFailed               = `"execution failed"`
 )
 
 //go:generate mockgen -destination=../mocks/mock_gateway_handler.go -package=mocks github.com/NethermindEth/juno/rpc Gateway

--- a/rpc/rpccore/rpccore.go
+++ b/rpc/rpccore/rpccore.go
@@ -18,7 +18,6 @@ const (
 	ThrottledVMErr                = "VM throughput limit reached"
 	MaxBlocksBack                 = 1024
 	EntrypointNotFoundFelt string = "0x454e545259504f494e545f4e4f545f464f554e44"
-	ExecutionFailed               = `"execution failed"`
 )
 
 //go:generate mockgen -destination=../mocks/mock_gateway_handler.go -package=mocks github.com/NethermindEth/juno/rpc Gateway

--- a/rpc/v6/trace.go
+++ b/rpc/v6/trace.go
@@ -304,7 +304,7 @@ func (h *Handler) Call(funcCall *FunctionCall, id *BlockID) ([]*felt.Felt, *json
 	if res.ExecutionFailed {
 		var strErr string
 		if len(res.Result) != 0 && res.Result[0].String() == rpccore.EntrypointNotFoundFelt {
-			strErr = `"execution failed"`
+			strErr = rpccore.ExecutionFailed
 		} else {
 			strErr = `"` + utils.FeltArrToString(res.Result) + `"`
 		}

--- a/rpc/v6/trace.go
+++ b/rpc/v6/trace.go
@@ -303,10 +303,12 @@ func (h *Handler) Call(funcCall *FunctionCall, id *BlockID) ([]*felt.Felt, *json
 	}
 	if res.ExecutionFailed {
 		var strErr string
-		if len(res.Result) != 0 && res.Result[0].String() == rpccore.EntrypointNotFoundFelt {
-			strErr = rpccore.ExecutionFailed
-		} else {
-			strErr = `"` + utils.FeltArrToString(res.Result) + `"`
+		if len(res.Result) != 0 {
+			if res.Result[0].String() == rpccore.EntrypointNotFoundFelt {
+				strErr = rpccore.ExecutionFailed
+			} else {
+				strErr = `"` + utils.FeltArrToString(res.Result) + `"`
+			}
 		}
 		return nil, MakeContractError(json.RawMessage(strErr))
 	}

--- a/rpc/v6/trace.go
+++ b/rpc/v6/trace.go
@@ -302,14 +302,17 @@ func (h *Handler) Call(funcCall *FunctionCall, id *BlockID) ([]*felt.Felt, *json
 		return nil, MakeContractError(json.RawMessage(err.Error()))
 	}
 	if res.ExecutionFailed {
+		// the blockifier 0.13.4 update requires us to check if the execution failed,
+		// and if so, return ErrEntrypointNotFound if res.Result[0]==EntrypointNotFoundFelt,
+		// otherwise we should wrap the result in ErrContractError
 		var strErr string
 		if len(res.Result) != 0 {
 			if res.Result[0].String() == rpccore.EntrypointNotFoundFelt {
-				strErr = rpccore.ExecutionFailed
-			} else {
-				strErr = `"` + utils.FeltArrToString(res.Result) + `"`
+				return nil, rpccore.ErrEntrypointNotFound
 			}
+			strErr = `"` + utils.FeltArrToString(res.Result) + `"`
 		}
+		// Todo: There is currently no standardised way to format these error messages
 		return nil, MakeContractError(json.RawMessage(strErr))
 	}
 	return res.Result, nil

--- a/rpc/v6/trace.go
+++ b/rpc/v6/trace.go
@@ -302,7 +302,13 @@ func (h *Handler) Call(funcCall *FunctionCall, id *BlockID) ([]*felt.Felt, *json
 		return nil, MakeContractError(json.RawMessage(err.Error()))
 	}
 	if res.ExecutionFailed {
-		return nil, MakeContractError(json.RawMessage(utils.FeltArrToString(res.Result)))
+		var strErr string
+		if len(res.Result) != 0 && res.Result[0].String() == rpccore.EntrypointNotFoundFelt {
+			strErr = `"execution failed"`
+		} else {
+			strErr = `"` + utils.FeltArrToString(res.Result) + `"`
+		}
+		return nil, MakeContractError(json.RawMessage(strErr))
 	}
 	return res.Result, nil
 }

--- a/rpc/v6/trace.go
+++ b/rpc/v6/trace.go
@@ -308,9 +308,11 @@ func (h *Handler) Call(funcCall *FunctionCall, id *BlockID) ([]*felt.Felt, *json
 		var strErr string
 		if len(res.Result) != 0 {
 			if res.Result[0].String() == rpccore.EntrypointNotFoundFelt {
-				return nil, rpccore.ErrEntrypointNotFound
+				strErr = rpccore.ErrEntrypointNotFound.Message
+			} else {
+				strErr = utils.FeltArrToString(res.Result)
 			}
-			strErr = `"` + utils.FeltArrToString(res.Result) + `"`
+			strErr = `"` + strErr + `"`
 		}
 		// Todo: There is currently no standardised way to format these error messages
 		return nil, MakeContractError(json.RawMessage(strErr))

--- a/rpc/v6/trace_test.go
+++ b/rpc/v6/trace_test.go
@@ -1005,7 +1005,10 @@ func TestCall(t *testing.T) {
 			Result:          []*felt.Felt{utils.HexToFelt(t, rpccore.EntrypointNotFoundFelt)},
 			ExecutionFailed: true,
 		}
-		expectedErr := rpccore.ErrEntrypointNotFound
+		expectedErr := rpccore.ErrContractError
+		expectedErr.Data = rpc.ContractErrorData{
+			RevertError: json.RawMessage(`"` + rpccore.ErrEntrypointNotFound.Message + `"`),
+		}
 
 		headsHeader := &core.Header{
 			Number:    9,

--- a/rpc/v6/trace_test.go
+++ b/rpc/v6/trace_test.go
@@ -1075,4 +1075,44 @@ func TestCall(t *testing.T) {
 		require.Nil(t, res)
 		require.Equal(t, expectedErr, rpcErr)
 	})
+
+	t.Run("execution failed with execution failure and empty result", func(t *testing.T) {
+		handler = handler.WithCallMaxSteps(1337)
+
+		contractAddr := new(felt.Felt).SetUint64(1)
+		selector := new(felt.Felt).SetUint64(2)
+		classHash := new(felt.Felt).SetUint64(3)
+		calldata := []felt.Felt{*new(felt.Felt).SetUint64(4)}
+		expectedRes := vm.CallResult{
+			ExecutionFailed: true,
+		}
+		expectedErr := rpc.MakeContractError(json.RawMessage(""))
+
+		headsHeader := &core.Header{
+			Number:    9,
+			Timestamp: 101,
+		}
+
+		cairoClass := core.Cairo1Class{
+			Program: []*felt.Felt{
+				new(felt.Felt).SetUint64(3),
+				new(felt.Felt),
+				new(felt.Felt),
+			},
+		}
+		mockReader.EXPECT().HeadState().Return(mockState, nopCloser, nil)
+		mockReader.EXPECT().HeadsHeader().Return(headsHeader, nil)
+		mockState.EXPECT().ContractClassHash(contractAddr).Return(classHash, nil)
+		mockState.EXPECT().Class(classHash).Return(&core.DeclaredClass{Class: &cairoClass}, nil)
+		mockReader.EXPECT().Network().Return(n)
+		mockVM.EXPECT().Call(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(expectedRes, nil)
+
+		res, rpcErr := handler.Call(&rpc.FunctionCall{
+			ContractAddress:    *contractAddr,
+			EntryPointSelector: *selector,
+			Calldata:           calldata,
+		}, &rpc.BlockID{Latest: true})
+		require.Nil(t, res)
+		require.Equal(t, expectedErr, rpcErr)
+	})
 }

--- a/rpc/v6/trace_test.go
+++ b/rpc/v6/trace_test.go
@@ -1005,7 +1005,7 @@ func TestCall(t *testing.T) {
 			Result:          []*felt.Felt{utils.HexToFelt(t, rpccore.EntrypointNotFoundFelt)},
 			ExecutionFailed: true,
 		}
-		expectedErr := rpc.MakeContractError(json.RawMessage(rpccore.ExecutionFailed))
+		expectedErr := rpccore.ErrEntrypointNotFound
 
 		headsHeader := &core.Header{
 			Number:    9,

--- a/rpc/v6/trace_test.go
+++ b/rpc/v6/trace_test.go
@@ -1005,7 +1005,7 @@ func TestCall(t *testing.T) {
 			Result:          []*felt.Felt{utils.HexToFelt(t, rpccore.EntrypointNotFoundFelt)},
 			ExecutionFailed: true,
 		}
-		expectedErr := rpc.MakeContractError(json.RawMessage(rpccore.EntrypointNotFoundFelt))
+		expectedErr := rpc.MakeContractError(json.RawMessage(rpccore.ExecutionFailed))
 
 		headsHeader := &core.Header{
 			Number:    9,
@@ -1032,6 +1032,6 @@ func TestCall(t *testing.T) {
 			Calldata:           calldata,
 		}, &rpc.BlockID{Latest: true})
 		require.Nil(t, res)
-		require.Equal(t, rpcErr, expectedErr)
+		require.Equal(t, expectedErr, rpcErr)
 	})
 }

--- a/rpc/v6/trace_test.go
+++ b/rpc/v6/trace_test.go
@@ -1034,4 +1034,45 @@ func TestCall(t *testing.T) {
 		require.Nil(t, res)
 		require.Equal(t, expectedErr, rpcErr)
 	})
+
+	t.Run("execution failed with execution failure", func(t *testing.T) {
+		handler = handler.WithCallMaxSteps(1337)
+
+		contractAddr := new(felt.Felt).SetUint64(1)
+		selector := new(felt.Felt).SetUint64(2)
+		classHash := new(felt.Felt).SetUint64(3)
+		calldata := []felt.Felt{*new(felt.Felt).SetUint64(4)}
+		expectedRes := vm.CallResult{
+			Result:          []*felt.Felt{utils.HexToFelt(t, "0xdeadbeef")},
+			ExecutionFailed: true,
+		}
+		expectedErr := rpc.MakeContractError(json.RawMessage(`"0xdeadbeef"`))
+
+		headsHeader := &core.Header{
+			Number:    9,
+			Timestamp: 101,
+		}
+
+		cairoClass := core.Cairo1Class{
+			Program: []*felt.Felt{
+				new(felt.Felt).SetUint64(3),
+				new(felt.Felt),
+				new(felt.Felt),
+			},
+		}
+		mockReader.EXPECT().HeadState().Return(mockState, nopCloser, nil)
+		mockReader.EXPECT().HeadsHeader().Return(headsHeader, nil)
+		mockState.EXPECT().ContractClassHash(contractAddr).Return(classHash, nil)
+		mockState.EXPECT().Class(classHash).Return(&core.DeclaredClass{Class: &cairoClass}, nil)
+		mockReader.EXPECT().Network().Return(n)
+		mockVM.EXPECT().Call(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(expectedRes, nil)
+
+		res, rpcErr := handler.Call(&rpc.FunctionCall{
+			ContractAddress:    *contractAddr,
+			EntryPointSelector: *selector,
+			Calldata:           calldata,
+		}, &rpc.BlockID{Latest: true})
+		require.Nil(t, res)
+		require.Equal(t, expectedErr, rpcErr)
+	})
 }

--- a/rpc/v7/trace.go
+++ b/rpc/v7/trace.go
@@ -437,9 +437,11 @@ func (h *Handler) Call(funcCall FunctionCall, id BlockID) ([]*felt.Felt, *jsonrp
 		var strErr string
 		if len(res.Result) != 0 {
 			if res.Result[0].String() == rpccore.EntrypointNotFoundFelt {
-				return nil, rpccore.ErrEntrypointNotFound
+				strErr = rpccore.ErrEntrypointNotFound.Message
+			} else {
+				strErr = utils.FeltArrToString(res.Result)
 			}
-			strErr = `"` + utils.FeltArrToString(res.Result) + `"`
+			strErr = `"` + strErr + `"`
 		}
 		// Todo: There is currently no standardised way to format these error messages
 		return nil, MakeContractError(json.RawMessage(strErr))

--- a/rpc/v7/trace.go
+++ b/rpc/v7/trace.go
@@ -433,7 +433,7 @@ func (h *Handler) Call(funcCall FunctionCall, id BlockID) ([]*felt.Felt, *jsonrp
 	if res.ExecutionFailed {
 		var strErr string
 		if len(res.Result) != 0 && res.Result[0].String() == rpccore.EntrypointNotFoundFelt {
-			strErr = `"execution failed"`
+			strErr = rpccore.ExecutionFailed
 		} else {
 			strErr = `"` + utils.FeltArrToString(res.Result) + `"`
 		}

--- a/rpc/v7/trace.go
+++ b/rpc/v7/trace.go
@@ -431,7 +431,13 @@ func (h *Handler) Call(funcCall FunctionCall, id BlockID) ([]*felt.Felt, *jsonrp
 		return nil, MakeContractError(json.RawMessage(err.Error()))
 	}
 	if res.ExecutionFailed {
-		return nil, MakeContractError(json.RawMessage(utils.FeltArrToString(res.Result)))
+		var strErr string
+		if len(res.Result) != 0 && res.Result[0].String() == rpccore.EntrypointNotFoundFelt {
+			strErr = `"execution failed"`
+		} else {
+			strErr = `"` + utils.FeltArrToString(res.Result) + `"`
+		}
+		return nil, MakeContractError(json.RawMessage(strErr))
 	}
 	return res.Result, nil
 }

--- a/rpc/v7/trace.go
+++ b/rpc/v7/trace.go
@@ -432,10 +432,12 @@ func (h *Handler) Call(funcCall FunctionCall, id BlockID) ([]*felt.Felt, *jsonrp
 	}
 	if res.ExecutionFailed {
 		var strErr string
-		if len(res.Result) != 0 && res.Result[0].String() == rpccore.EntrypointNotFoundFelt {
-			strErr = rpccore.ExecutionFailed
-		} else {
-			strErr = `"` + utils.FeltArrToString(res.Result) + `"`
+		if len(res.Result) != 0 {
+			if res.Result[0].String() == rpccore.EntrypointNotFoundFelt {
+				strErr = rpccore.ExecutionFailed
+			} else {
+				strErr = `"` + utils.FeltArrToString(res.Result) + `"`
+			}
 		}
 		return nil, MakeContractError(json.RawMessage(strErr))
 	}

--- a/rpc/v7/trace_test.go
+++ b/rpc/v7/trace_test.go
@@ -601,7 +601,7 @@ func TestCall(t *testing.T) {
 			Result:          []*felt.Felt{utils.HexToFelt(t, rpccore.EntrypointNotFoundFelt)},
 			ExecutionFailed: true,
 		}
-		expectedErr := rpcv7.MakeContractError(json.RawMessage(rpccore.ExecutionFailed))
+		expectedErr := rpccore.ErrEntrypointNotFound
 
 		headsHeader := &core.Header{
 			Number:    9,

--- a/rpc/v7/trace_test.go
+++ b/rpc/v7/trace_test.go
@@ -635,4 +635,45 @@ func TestCall(t *testing.T) {
 		require.Nil(t, res)
 		require.Equal(t, rpcErr, expectedErr)
 	})
+
+	t.Run("execution failed with execution failure", func(t *testing.T) {
+		handler = handler.WithCallMaxSteps(1337)
+
+		contractAddr := new(felt.Felt).SetUint64(1)
+		selector := new(felt.Felt).SetUint64(2)
+		classHash := new(felt.Felt).SetUint64(3)
+		calldata := []felt.Felt{*new(felt.Felt).SetUint64(4)}
+		expectedRes := vm.CallResult{
+			Result:          []*felt.Felt{utils.HexToFelt(t, "0xdeadbeef")},
+			ExecutionFailed: true,
+		}
+		expectedErr := rpcv7.MakeContractError(json.RawMessage(`"0xdeadbeef"`))
+
+		headsHeader := &core.Header{
+			Number:    9,
+			Timestamp: 101,
+		}
+
+		cairoClass := core.Cairo1Class{
+			Program: []*felt.Felt{
+				new(felt.Felt).SetUint64(3),
+				new(felt.Felt),
+				new(felt.Felt),
+			},
+		}
+		mockReader.EXPECT().HeadState().Return(mockState, nopCloser, nil)
+		mockReader.EXPECT().HeadsHeader().Return(headsHeader, nil)
+		mockState.EXPECT().ContractClassHash(contractAddr).Return(classHash, nil)
+		mockState.EXPECT().Class(classHash).Return(&core.DeclaredClass{Class: &cairoClass}, nil)
+		mockReader.EXPECT().Network().Return(n)
+		mockVM.EXPECT().Call(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(expectedRes, nil)
+
+		res, rpcErr := handler.Call(rpcv7.FunctionCall{
+			ContractAddress:    *contractAddr,
+			EntryPointSelector: *selector,
+			Calldata:           calldata,
+		}, rpcv7.BlockID{Latest: true})
+		require.Nil(t, res)
+		require.Equal(t, expectedErr, rpcErr)
+	})
 }

--- a/rpc/v7/trace_test.go
+++ b/rpc/v7/trace_test.go
@@ -601,7 +601,10 @@ func TestCall(t *testing.T) {
 			Result:          []*felt.Felt{utils.HexToFelt(t, rpccore.EntrypointNotFoundFelt)},
 			ExecutionFailed: true,
 		}
-		expectedErr := rpccore.ErrEntrypointNotFound
+		expectedErr := rpccore.ErrContractError
+		expectedErr.Data = rpcv7.ContractErrorData{
+			RevertError: json.RawMessage(`"` + rpccore.ErrEntrypointNotFound.Message + `"`),
+		}
 
 		headsHeader := &core.Header{
 			Number:    9,

--- a/rpc/v7/trace_test.go
+++ b/rpc/v7/trace_test.go
@@ -601,7 +601,7 @@ func TestCall(t *testing.T) {
 			Result:          []*felt.Felt{utils.HexToFelt(t, rpccore.EntrypointNotFoundFelt)},
 			ExecutionFailed: true,
 		}
-		expectedErr := rpcv7.MakeContractError(json.RawMessage(rpccore.EntrypointNotFoundFelt))
+		expectedErr := rpcv7.MakeContractError(json.RawMessage(rpccore.ExecutionFailed))
 
 		headsHeader := &core.Header{
 			Number:    9,

--- a/rpc/v7/trace_test.go
+++ b/rpc/v7/trace_test.go
@@ -676,4 +676,44 @@ func TestCall(t *testing.T) {
 		require.Nil(t, res)
 		require.Equal(t, expectedErr, rpcErr)
 	})
+
+	t.Run("execution failed with execution failure and empty result", func(t *testing.T) {
+		handler = handler.WithCallMaxSteps(1337)
+
+		contractAddr := new(felt.Felt).SetUint64(1)
+		selector := new(felt.Felt).SetUint64(2)
+		classHash := new(felt.Felt).SetUint64(3)
+		calldata := []felt.Felt{*new(felt.Felt).SetUint64(4)}
+		expectedRes := vm.CallResult{
+			ExecutionFailed: true,
+		}
+		expectedErr := rpcv7.MakeContractError(json.RawMessage(""))
+
+		headsHeader := &core.Header{
+			Number:    9,
+			Timestamp: 101,
+		}
+
+		cairoClass := core.Cairo1Class{
+			Program: []*felt.Felt{
+				new(felt.Felt).SetUint64(3),
+				new(felt.Felt),
+				new(felt.Felt),
+			},
+		}
+		mockReader.EXPECT().HeadState().Return(mockState, nopCloser, nil)
+		mockReader.EXPECT().HeadsHeader().Return(headsHeader, nil)
+		mockState.EXPECT().ContractClassHash(contractAddr).Return(classHash, nil)
+		mockState.EXPECT().Class(classHash).Return(&core.DeclaredClass{Class: &cairoClass}, nil)
+		mockReader.EXPECT().Network().Return(n)
+		mockVM.EXPECT().Call(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(expectedRes, nil)
+
+		res, rpcErr := handler.Call(rpcv7.FunctionCall{
+			ContractAddress:    *contractAddr,
+			EntryPointSelector: *selector,
+			Calldata:           calldata,
+		}, rpcv7.BlockID{Latest: true})
+		require.Nil(t, res)
+		require.Equal(t, expectedErr, rpcErr)
+	})
 }

--- a/rpc/v8/trace.go
+++ b/rpc/v8/trace.go
@@ -419,11 +419,15 @@ func (h *Handler) Call(funcCall FunctionCall, id BlockID) ([]*felt.Felt, *jsonrp
 		// the blockifier 0.13.4 update requires us to check if the execution failed,
 		// and if so, return ErrEntrypointNotFound if res.Result[0]==EntrypointNotFoundFelt,
 		// otherwise we should wrap the result in ErrContractError
-		if len(res.Result) != 0 && res.Result[0].String() == rpccore.EntrypointNotFoundFelt {
-			return nil, rpccore.ErrEntrypointNotFound
+		var strErr string
+		if len(res.Result) != 0 {
+			if res.Result[0].String() == rpccore.EntrypointNotFoundFelt {
+				return nil, rpccore.ErrEntrypointNotFound
+			}
+			strErr = `"` + utils.FeltArrToString(res.Result) + `"`
 		}
 		// Todo: There is currently no standardised way to format these error messages
-		return nil, MakeContractError(json.RawMessage(utils.FeltArrToString(res.Result)))
+		return nil, MakeContractError(json.RawMessage(strErr))
 	}
 	return res.Result, nil
 }


### PR DESCRIPTION
Fixes #2599
[CI/CD](https://github.com/NethermindEth/juno/actions/runs/13634961985)

Since we started using `json.RawMessage` in [this](https://github.com/NethermindEth/juno/pull/2523) PR, and `blockifier` returns `0x454e545259504f494e545f4e4f545f464f554e44` in the case of `ENTRYPOINT_NOT_FOUND`, we should handle this case explicitly.