### PR TITLE
fix(tests): replace utils.Ptr with utils.HeapPtr in events_test.go

### DIFF
--- a/rpc/v6/events_test.go
+++ b/rpc/v6/events_test.go
@@ -230,7 +230,7 @@ func TestEvents(t *testing.T) {
 
 func TestUnsubscribe(t *testing.T) {
 	log := utils.NewNopZapLogger()
-	n := utils.Ptr(utils.Sepolia)
+	n := utils.HeapPtr(utils.Sepolia)
 
 	t.Run("error when no connection in context", func(t *testing.T) {
 		mockCtrl := gomock.NewController(t)


### PR DESCRIPTION
Fix failing unit tests: https://github.com/NethermindEth/juno/actions/runs/13649230324/job/38153859132#step:10:338
```
Error: rpc/v6/events_test.go:233:13: undefined: utils.Ptr
```