### PR TITLE
fix: Reverted INVOKE tx returns a non-nil ExecuteInvocation in trace

### DIFF
--- a/clients/feeder/testdata/sepolia/block/18.json
+++ b/clients/feeder/testdata/sepolia/block/18.json
@@ -1,0 +1,737 @@
+{
+    "block_hash": "0x5beb56c7d9a9fc066e695c3fc467f45532cace83d9979db4ccfd6b77ca476af",
+    "parent_block_hash": "0x641077df21f3d3167e62ddf3feea236e2644e427940673114a30f2eb5c445c6",
+    "block_number": 18,
+    "state_root": "0x4c7f8d53ff361055ca6b224bff96bae036e1694c7d0efd0bef5fc633eef720d",
+    "transaction_commitment": "0x5eba4f898340f70f68337edb05f13b2c613e4523d61de7baec8e3d273d84afb",
+    "event_commitment": "0xc37d5155b6d4aed16b99f2d9247886e8b691e0c07d7909ab7166dac17191b3",
+    "status": "ACCEPTED_ON_L1",
+    "l1_da_mode": "CALLDATA",
+    "l1_gas_price": {
+        "price_in_wei": "0x41e2d195",
+        "price_in_fri": "0x0"
+    },
+    "l1_data_gas_price": {
+        "price_in_wei": "0x1",
+        "price_in_fri": "0x1"
+    },
+    "l2_gas_price": {
+        "price_in_wei": "0x1",
+        "price_in_fri": "0x1"
+    },
+    "transactions": [
+        {
+            "transaction_hash": "0x3744af1511b472fa4dac94feefc944ec785c4a380e9b925ea408d4954729453",
+            "version": "0x2",
+            "max_fee": "0x58ece00bd5f",
+            "signature": [
+                "0x25db5938ed86d666ddfdbfe08fdaa1cdcec72911c979304f47851c76afc30ab",
+                "0x1c8db05f7fe7aa3d549044c7128b62c9b0f69cdc97f6752ea33a875b6458e8b"
+            ],
+            "nonce": "0x1",
+            "class_hash": "0x16342ade8a7cc8296920731bc34b5a6530f5ee1dc1bfd3cc83cb3f519d6530a",
+            "compiled_class_hash": "0x7d50adbdf0ac129ba351f21b026e5ccf1741a318c13240e50795f1b7ecde94d",
+            "sender_address": "0x70503f026c7af73cfd2b007fe650e8c310256e9674ac4e42797c291edca5e84",
+            "type": "DECLARE"
+        },
+        {
+            "transaction_hash": "0x4093daac10408c08333a2030be765fe0ff1b78cfd81835d2253b2ecd06c2b35",
+            "version": "0x1",
+            "max_fee": "0x691405d069e",
+            "signature": [
+                "0x441e8ca731aa93ad0cf7b3ecd5d998230c2a71a96bacb41b2ad98dfc1c0a6f0",
+                "0x6567123b1434f4d779ebb305cf96281c81be6b3f9396fc756d914957859e75"
+            ],
+            "nonce": "0x2",
+            "sender_address": "0x70503f026c7af73cfd2b007fe650e8c310256e9674ac4e42797c291edca5e84",
+            "calldata": [
+                "0x1",
+                "0x41a78e741e5af2fec34b695679bc6891742439f7afb8484ecd7766661ad02bf",
+                "0x1987cbd17808b9a23693d4de7e246a443cfe37e6e7fbaeabd7d7e6532b07c3d",
+                "0x4",
+                "0x16342ade8a7cc8296920731bc34b5a6530f5ee1dc1bfd3cc83cb3f519d6530a",
+                "0x4ceeaa6aca0882e5dfd686a72db97a79bb8e6b0a6b8732785253da8440e712e",
+                "0x1",
+                "0x0"
+            ],
+            "type": "INVOKE_FUNCTION"
+        },
+        {
+            "transaction_hash": "0x6be72382daa1946a1ca961dadc907117a29014a05a3453c5b44e87cd7ac719a",
+            "version": "0x1",
+            "max_fee": "0x38d7ea4c68000",
+            "signature": [
+                "0x7fe0ff3d16520f8926fb60fe831a55c462556056dc46b4d5d1e82b7aa73fdbb",
+                "0x2586eac9fb4eccddc95f37717ddff5e07eaa4163783e7a3f2e33613ef77aec5"
+            ],
+            "nonce": "0x3",
+            "sender_address": "0x70503f026c7af73cfd2b007fe650e8c310256e9674ac4e42797c291edca5e84",
+            "calldata": [
+                "0x1",
+                "0x7c687d151607710a7ec82ca5ab0ff2c48f52abd3b4a2773938a0cfef723fe6a",
+                "0x10b7e63d3ca05c9baffd985d3e1c3858d4dbf0759f066be0eaddc5d71c2cab5",
+                "0x1",
+                "0x64"
+            ],
+            "type": "INVOKE_FUNCTION"
+        },
+        {
+            "transaction_hash": "0x2f00c7f28df2197196440747f97baa63d0851e3b0cfc2efedb6a88a7ef78cb1",
+            "version": "0x1",
+            "max_fee": "0x38d7ea4c68000",
+            "signature": [
+                "0x3dac4eaeeea2f0958bb4cb896e582ee2be6d3be5490f8c49dd73c95ba06ac18",
+                "0x26b8df6e1c84d804211dbd56b0b816a9ea795d25dfc4e8cfbebe397378438d2"
+            ],
+            "nonce": "0x4",
+            "sender_address": "0x70503f026c7af73cfd2b007fe650e8c310256e9674ac4e42797c291edca5e84",
+            "calldata": [
+                "0x1",
+                "0x7c687d151607710a7ec82ca5ab0ff2c48f52abd3b4a2773938a0cfef723fe6a",
+                "0x10b7e63d3ca05c9baffd985d3e1c3858d4dbf0759f066be0eaddc5d71c2cab5",
+                "0x1",
+                "0xa"
+            ],
+            "type": "INVOKE_FUNCTION"
+        },
+        {
+            "transaction_hash": "0x3ad3bcc36ce7fd7c8181fb827c6e39f39fc68a40f7107f77d43215ff4b8cfd9",
+            "version": "0x1",
+            "max_fee": "0x38d7ea4c68000",
+            "signature": [
+                "0x73042f7943ccf61bc9d2dff12b3d9c445fa96787ee6747efb83f1d7e72c2bd9",
+                "0x46a5b31417b6c8b96f8df52d01dd25eab42b42e9eb97e9ef345af4d25a47955"
+            ],
+            "nonce": "0x5",
+            "sender_address": "0x70503f026c7af73cfd2b007fe650e8c310256e9674ac4e42797c291edca5e84",
+            "calldata": [
+                "0x1",
+                "0x41a78e741e5af2fec34b695679bc6891742439f7afb8484ecd7766661ad02bf",
+                "0x1987cbd17808b9a23693d4de7e246a443cfe37e6e7fbaeabd7d7e6532b07c3d",
+                "0x4",
+                "0x16342ade8a7cc8296920731bc34b5a6530f5ee1dc1bfd3cc83cb3f519d6530a",
+                "0x710aa12bbab801c046773f3ceed2ea7cb50a24838ef55d584b4221ff955e2c9",
+                "0x1",
+                "0x0"
+            ],
+            "type": "INVOKE_FUNCTION"
+        },
+        {
+            "transaction_hash": "0x6657f07f42b04a450677d818ffe105d4f45c68b6122f97395af5f2017028853",
+            "version": "0x2",
+            "max_fee": "0x5965180d023",
+            "signature": [
+                "0x3be14892e277ff4568f9f87d919699e594c780b47202ba4c3c41884b602de2c",
+                "0x16f1558dcf161cd3a1adc47e6d34bd36bb540fd842d29a47e6ac8e7401fbc38"
+            ],
+            "nonce": "0x6",
+            "class_hash": "0x2cbe2e8145b35db6fbb61a8697385f81f16b8fb294b2d88ec7400bfc7edcbda",
+            "compiled_class_hash": "0x73654e9daf19a4e04f88aaa9aec71606a92d4065ed0241a7e3c97b6a091a14b",
+            "sender_address": "0x70503f026c7af73cfd2b007fe650e8c310256e9674ac4e42797c291edca5e84",
+            "type": "DECLARE"
+        },
+        {
+            "transaction_hash": "0x27a335af75e13127335cc4fd19a815c89920a33378b14573d6b813ae942bb93",
+            "version": "0x1",
+            "max_fee": "0x691a33140fe",
+            "signature": [
+                "0x34644638bb4f22fafa606207d3117e6284645d465dc3936d449e4aeb9d3caea",
+                "0x69ed84935cf28e03a5a88366b525529fa7ee6a51795827cdcd44c8d7c80316b"
+            ],
+            "nonce": "0x7",
+            "sender_address": "0x70503f026c7af73cfd2b007fe650e8c310256e9674ac4e42797c291edca5e84",
+            "calldata": [
+                "0x1",
+                "0x41a78e741e5af2fec34b695679bc6891742439f7afb8484ecd7766661ad02bf",
+                "0x1987cbd17808b9a23693d4de7e246a443cfe37e6e7fbaeabd7d7e6532b07c3d",
+                "0x4",
+                "0x2cbe2e8145b35db6fbb61a8697385f81f16b8fb294b2d88ec7400bfc7edcbda",
+                "0x48aa72e665e92626c1f71546bae3630a10ed131b4260e1c6a33d1f2208bd2cf",
+                "0x1",
+                "0x0"
+            ],
+            "type": "INVOKE_FUNCTION"
+        },
+        {
+            "transaction_hash": "0x147298203237faa45ecea2c15c93576064559ec36d065273519d4e363845784",
+            "version": "0x2",
+            "max_fee": "0x5965180d023",
+            "signature": [
+                "0x1bc34579026b5ab66ac85f72cc43ca567850707df911801763478824662230d",
+                "0x30c15b5302af57bbdc47d07b454f779c70d31a0dbdc06315605dc6e89c86761"
+            ],
+            "nonce": "0x8",
+            "class_hash": "0x348f560344334951bcbccd27aff05a9f6bedeaefc36315fe20e842163adae3d",
+            "compiled_class_hash": "0x16c9c943c6d33f6e285f7268e394c914a3a78b8165566b40daea85f90c01a6b",
+            "sender_address": "0x70503f026c7af73cfd2b007fe650e8c310256e9674ac4e42797c291edca5e84",
+            "type": "DECLARE"
+        },
+        {
+            "transaction_hash": "0x741c8e45a306bb5a88c0c56150bc063b9976f94d947b42589e1683ce08b2d7f",
+            "version": "0x1",
+            "max_fee": "0x691405d069e",
+            "signature": [
+                "0x7ca46c95542250ef892937a315962248964669258a2f7f7067cbfe5ca87d94",
+                "0x7cea6c9fe582a294427a44b834f53a90d590fa713c52639af65d9f441c0a54d"
+            ],
+            "nonce": "0x9",
+            "sender_address": "0x70503f026c7af73cfd2b007fe650e8c310256e9674ac4e42797c291edca5e84",
+            "calldata": [
+                "0x1",
+                "0x41a78e741e5af2fec34b695679bc6891742439f7afb8484ecd7766661ad02bf",
+                "0x1987cbd17808b9a23693d4de7e246a443cfe37e6e7fbaeabd7d7e6532b07c3d",
+                "0x4",
+                "0x348f560344334951bcbccd27aff05a9f6bedeaefc36315fe20e842163adae3d",
+                "0x67b93aa39a05b7a3f5125f6ffde049894517961eeaf662efd58ded5eca34bc6",
+                "0x1",
+                "0x0"
+            ],
+            "type": "INVOKE_FUNCTION"
+        },
+        {
+            "transaction_hash": "0x49ad61002cff7597291c5004d8ab9c4bc9e2ba9f35d9d202f5bf48de801faf5",
+            "version": "0x1",
+            "max_fee": "0x691a33140fe",
+            "signature": [
+                "0x5fabc46404d4d67b7781647e42b500c920a5d2693a85d0796fbf2af3d883dea",
+                "0x7937e5a14fedc673100f8fbc5805eb0e6d6717ee08bb6798269f23ff14b0144"
+            ],
+            "nonce": "0xa",
+            "sender_address": "0x70503f026c7af73cfd2b007fe650e8c310256e9674ac4e42797c291edca5e84",
+            "calldata": [
+                "0x1",
+                "0x41a78e741e5af2fec34b695679bc6891742439f7afb8484ecd7766661ad02bf",
+                "0x1987cbd17808b9a23693d4de7e246a443cfe37e6e7fbaeabd7d7e6532b07c3d",
+                "0x4",
+                "0x2cbe2e8145b35db6fbb61a8697385f81f16b8fb294b2d88ec7400bfc7edcbda",
+                "0x79bc1b65eecf7c7072c525668db7e06e39c6c321ab3e32f77df0cae4740d07f",
+                "0x1",
+                "0x0"
+            ],
+            "type": "INVOKE_FUNCTION"
+        },
+        {
+            "transaction_hash": "0x4cc8c57cfd5f2396d87554de709988146317505e432bd0b3036bdadcdb0d051",
+            "version": "0x1",
+            "max_fee": "0x778e1c5d672",
+            "signature": [
+                "0x68648c6977feff1a2c63308c68f037a38baca2992e93200d9bd34b5906b9806",
+                "0x624af118a42dbb074568f9c990a59dbf9c287c6be557d3dd49921dbaea61dca"
+            ],
+            "nonce": "0xb",
+            "sender_address": "0x70503f026c7af73cfd2b007fe650e8c310256e9674ac4e42797c291edca5e84",
+            "calldata": [
+                "0x1",
+                "0x45283160abd44efff6bf2b3ad40e556bfbcf623ce36ad395cf72b96678c2dab",
+                "0x362398bec32bc0ebb411203221a35a0301193a96f317ebe5e40be9f60d15320",
+                "0x1",
+                "0x64"
+            ],
+            "type": "INVOKE_FUNCTION"
+        },
+        {
+            "transaction_hash": "0x15c2858c6e5129547473db62415f4069916798e2f462f95eed3a1a802c9ec14",
+            "version": "0x1",
+            "max_fee": "0x778e1c5d672",
+            "signature": [
+                "0x75d1779c928448abd6ed363ac77dab0d7ebd4249cdee7c8b213b18bd9083b90",
+                "0x6c4f65131033fc6c20add31c202d43e88e584e423bc0a71beeb1917bd34edea"
+            ],
+            "nonce": "0xc",
+            "sender_address": "0x70503f026c7af73cfd2b007fe650e8c310256e9674ac4e42797c291edca5e84",
+            "calldata": [
+                "0x1",
+                "0x45283160abd44efff6bf2b3ad40e556bfbcf623ce36ad395cf72b96678c2dab",
+                "0x362398bec32bc0ebb411203221a35a0301193a96f317ebe5e40be9f60d15320",
+                "0x1",
+                "0x64"
+            ],
+            "type": "INVOKE_FUNCTION"
+        },
+        {
+            "transaction_hash": "0x552b84ae3b01fe925c3a8d58204882d343364e8f20369657c2295fae0b0745",
+            "version": "0x1",
+            "max_fee": "0x779449a10d2",
+            "signature": [
+                "0x2c00804c90efb85e1a41a518f4c200014d8a02f14ffae8ae0a657de7cddae42",
+                "0x71661a5475ba8b3e974c28680db7d230c35c312bd99dc3affad6005cd78ee1e"
+            ],
+            "nonce": "0xd",
+            "sender_address": "0x70503f026c7af73cfd2b007fe650e8c310256e9674ac4e42797c291edca5e84",
+            "calldata": [
+                "0x1",
+                "0x45283160abd44efff6bf2b3ad40e556bfbcf623ce36ad395cf72b96678c2dab",
+                "0x20cbe051691c714b9bcc3f3a599bbd419b5b1c0b239544efddd99e94217317b",
+                "0x1",
+                "0xff"
+            ],
+            "type": "INVOKE_FUNCTION"
+        }
+    ],
+    "timestamp": 1701093162,
+    "sequencer_address": "0x1176a1bd84444c89232ec27754698e5d2e7e1a7f1539f12027f28b23ec9f3d8",
+    "transaction_receipts": [
+        {
+            "execution_status": "SUCCEEDED",
+            "transaction_index": 0,
+            "transaction_hash": "0x3744af1511b472fa4dac94feefc944ec785c4a380e9b925ea408d4954729453",
+            "l2_to_l1_messages": [],
+            "events": [
+                {
+                    "from_address": "0x49d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7",
+                    "keys": [
+                        "0x99cd8bde557814842a3121e8ddfd433a539b8c9f14bf31ebf108d12e6196e9"
+                    ],
+                    "data": [
+                        "0x70503f026c7af73cfd2b007fe650e8c310256e9674ac4e42797c291edca5e84",
+                        "0x1176a1bd84444c89232ec27754698e5d2e7e1a7f1539f12027f28b23ec9f3d8",
+                        "0x3b98bab356d",
+                        "0x0"
+                    ]
+                }
+            ],
+            "execution_resources": {
+                "n_steps": 3298,
+                "builtin_instance_counter": {
+                    "ec_op_builtin": 3,
+                    "pedersen_builtin": 15,
+                    "range_check_builtin": 73
+                },
+                "n_memory_holes": 0
+            },
+            "actual_fee": "0x3b98bab356d"
+        },
+        {
+            "execution_status": "SUCCEEDED",
+            "transaction_index": 1,
+            "transaction_hash": "0x4093daac10408c08333a2030be765fe0ff1b78cfd81835d2253b2ecd06c2b35",
+            "l2_to_l1_messages": [],
+            "events": [
+                {
+                    "from_address": "0x41a78e741e5af2fec34b695679bc6891742439f7afb8484ecd7766661ad02bf",
+                    "keys": [
+                        "0x26b160f10156dea0639bec90696772c640b9706a47f5b8c52ea1abe5858b34d"
+                    ],
+                    "data": [
+                        "0x7c687d151607710a7ec82ca5ab0ff2c48f52abd3b4a2773938a0cfef723fe6a",
+                        "0x70503f026c7af73cfd2b007fe650e8c310256e9674ac4e42797c291edca5e84",
+                        "0x1",
+                        "0x16342ade8a7cc8296920731bc34b5a6530f5ee1dc1bfd3cc83cb3f519d6530a",
+                        "0x0",
+                        "0x4ceeaa6aca0882e5dfd686a72db97a79bb8e6b0a6b8732785253da8440e712e"
+                    ]
+                },
+                {
+                    "from_address": "0x49d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7",
+                    "keys": [
+                        "0x99cd8bde557814842a3121e8ddfd433a539b8c9f14bf31ebf108d12e6196e9"
+                    ],
+                    "data": [
+                        "0x70503f026c7af73cfd2b007fe650e8c310256e9674ac4e42797c291edca5e84",
+                        "0x1176a1bd84444c89232ec27754698e5d2e7e1a7f1539f12027f28b23ec9f3d8",
+                        "0x460d59359bf",
+                        "0x0"
+                    ]
+                }
+            ],
+            "execution_resources": {
+                "n_steps": 7091,
+                "builtin_instance_counter": {
+                    "pedersen_builtin": 24,
+                    "range_check_builtin": 157,
+                    "ec_op_builtin": 3
+                },
+                "n_memory_holes": 0
+            },
+            "actual_fee": "0x460d59359bf"
+        },
+        {
+            "execution_status": "SUCCEEDED",
+            "transaction_index": 2,
+            "transaction_hash": "0x6be72382daa1946a1ca961dadc907117a29014a05a3453c5b44e87cd7ac719a",
+            "l2_to_l1_messages": [],
+            "events": [
+                {
+                    "from_address": "0x49d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7",
+                    "keys": [
+                        "0x99cd8bde557814842a3121e8ddfd433a539b8c9f14bf31ebf108d12e6196e9"
+                    ],
+                    "data": [
+                        "0x70503f026c7af73cfd2b007fe650e8c310256e9674ac4e42797c291edca5e84",
+                        "0x1176a1bd84444c89232ec27754698e5d2e7e1a7f1539f12027f28b23ec9f3d8",
+                        "0x4faff4bbd62",
+                        "0x0"
+                    ]
+                }
+            ],
+            "execution_resources": {
+                "n_steps": 5781,
+                "builtin_instance_counter": {
+                    "ec_op_builtin": 3,
+                    "pedersen_builtin": 16,
+                    "range_check_builtin": 134
+                },
+                "n_memory_holes": 0
+            },
+            "actual_fee": "0x4faff4bbd62"
+        },
+        {
+            "revert_error": "Error in the called contract (0x070503f026c7af73cfd2b007fe650e8c310256e9674ac4e42797c291edca5e84):\nError at pc=0:4288:\nGot an exception while executing a hint: Custom Hint Error: Execution failed. Failure reason: \"Fatal\".\nCairo traceback (most recent call last):\nUnknown location (pc=0:67)\nUnknown location (pc=0:1997)\nUnknown location (pc=0:2729)\nUnknown location (pc=0:3577)\n",
+            "execution_status": "REVERTED",
+            "transaction_index": 3,
+            "transaction_hash": "0x2f00c7f28df2197196440747f97baa63d0851e3b0cfc2efedb6a88a7ef78cb1",
+            "l2_to_l1_messages": [],
+            "events": [
+                {
+                    "from_address": "0x49d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7",
+                    "keys": [
+                        "0x99cd8bde557814842a3121e8ddfd433a539b8c9f14bf31ebf108d12e6196e9"
+                    ],
+                    "data": [
+                        "0x70503f026c7af73cfd2b007fe650e8c310256e9674ac4e42797c291edca5e84",
+                        "0x1176a1bd84444c89232ec27754698e5d2e7e1a7f1539f12027f28b23ec9f3d8",
+                        "0x2847291f968",
+                        "0x0"
+                    ]
+                }
+            ],
+            "execution_resources": {
+                "n_steps": 5537,
+                "builtin_instance_counter": {
+                    "range_check_builtin": 120,
+                    "ec_op_builtin": 3,
+                    "pedersen_builtin": 16
+                },
+                "n_memory_holes": 0
+            },
+            "actual_fee": "0x2847291f968"
+        },
+        {
+            "execution_status": "SUCCEEDED",
+            "transaction_index": 4,
+            "transaction_hash": "0x3ad3bcc36ce7fd7c8181fb827c6e39f39fc68a40f7107f77d43215ff4b8cfd9",
+            "l2_to_l1_messages": [],
+            "events": [
+                {
+                    "from_address": "0x41a78e741e5af2fec34b695679bc6891742439f7afb8484ecd7766661ad02bf",
+                    "keys": [
+                        "0x26b160f10156dea0639bec90696772c640b9706a47f5b8c52ea1abe5858b34d"
+                    ],
+                    "data": [
+                        "0x254df9ff3e3c3e6b078232b69716a10449077a3988ff883520494515d94c631",
+                        "0x70503f026c7af73cfd2b007fe650e8c310256e9674ac4e42797c291edca5e84",
+                        "0x1",
+                        "0x16342ade8a7cc8296920731bc34b5a6530f5ee1dc1bfd3cc83cb3f519d6530a",
+                        "0x0",
+                        "0x710aa12bbab801c046773f3ceed2ea7cb50a24838ef55d584b4221ff955e2c9"
+                    ]
+                },
+                {
+                    "from_address": "0x49d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7",
+                    "keys": [
+                        "0x99cd8bde557814842a3121e8ddfd433a539b8c9f14bf31ebf108d12e6196e9"
+                    ],
+                    "data": [
+                        "0x70503f026c7af73cfd2b007fe650e8c310256e9674ac4e42797c291edca5e84",
+                        "0x1176a1bd84444c89232ec27754698e5d2e7e1a7f1539f12027f28b23ec9f3d8",
+                        "0x460d59359bf",
+                        "0x0"
+                    ]
+                }
+            ],
+            "execution_resources": {
+                "n_steps": 7091,
+                "builtin_instance_counter": {
+                    "pedersen_builtin": 24,
+                    "range_check_builtin": 157,
+                    "ec_op_builtin": 3
+                },
+                "n_memory_holes": 0
+            },
+            "actual_fee": "0x460d59359bf"
+        },
+        {
+            "execution_status": "SUCCEEDED",
+            "transaction_index": 5,
+            "transaction_hash": "0x6657f07f42b04a450677d818ffe105d4f45c68b6122f97395af5f2017028853",
+            "l2_to_l1_messages": [],
+            "events": [
+                {
+                    "from_address": "0x49d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7",
+                    "keys": [
+                        "0x99cd8bde557814842a3121e8ddfd433a539b8c9f14bf31ebf108d12e6196e9"
+                    ],
+                    "data": [
+                        "0x70503f026c7af73cfd2b007fe650e8c310256e9674ac4e42797c291edca5e84",
+                        "0x1176a1bd84444c89232ec27754698e5d2e7e1a7f1539f12027f28b23ec9f3d8",
+                        "0x3b98bab356d",
+                        "0x0"
+                    ]
+                }
+            ],
+            "execution_resources": {
+                "n_steps": 3298,
+                "builtin_instance_counter": {
+                    "pedersen_builtin": 15,
+                    "range_check_builtin": 73,
+                    "ec_op_builtin": 3
+                },
+                "n_memory_holes": 0
+            },
+            "actual_fee": "0x3b98bab356d"
+        },
+        {
+            "execution_status": "SUCCEEDED",
+            "transaction_index": 6,
+            "transaction_hash": "0x27a335af75e13127335cc4fd19a815c89920a33378b14573d6b813ae942bb93",
+            "l2_to_l1_messages": [],
+            "events": [
+                {
+                    "from_address": "0x41a78e741e5af2fec34b695679bc6891742439f7afb8484ecd7766661ad02bf",
+                    "keys": [
+                        "0x26b160f10156dea0639bec90696772c640b9706a47f5b8c52ea1abe5858b34d"
+                    ],
+                    "data": [
+                        "0x45283160abd44efff6bf2b3ad40e556bfbcf623ce36ad395cf72b96678c2dab",
+                        "0x70503f026c7af73cfd2b007fe650e8c310256e9674ac4e42797c291edca5e84",
+                        "0x1",
+                        "0x2cbe2e8145b35db6fbb61a8697385f81f16b8fb294b2d88ec7400bfc7edcbda",
+                        "0x0",
+                        "0x48aa72e665e92626c1f71546bae3630a10ed131b4260e1c6a33d1f2208bd2cf"
+                    ]
+                },
+                {
+                    "from_address": "0x49d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7",
+                    "keys": [
+                        "0x99cd8bde557814842a3121e8ddfd433a539b8c9f14bf31ebf108d12e6196e9"
+                    ],
+                    "data": [
+                        "0x70503f026c7af73cfd2b007fe650e8c310256e9674ac4e42797c291edca5e84",
+                        "0x1176a1bd84444c89232ec27754698e5d2e7e1a7f1539f12027f28b23ec9f3d8",
+                        "0x46117762b54",
+                        "0x0"
+                    ]
+                }
+            ],
+            "execution_resources": {
+                "n_steps": 7116,
+                "builtin_instance_counter": {
+                    "range_check_builtin": 159,
+                    "ec_op_builtin": 3,
+                    "pedersen_builtin": 24
+                },
+                "n_memory_holes": 0
+            },
+            "actual_fee": "0x46117762b54"
+        },
+        {
+            "execution_status": "SUCCEEDED",
+            "transaction_index": 7,
+            "transaction_hash": "0x147298203237faa45ecea2c15c93576064559ec36d065273519d4e363845784",
+            "l2_to_l1_messages": [],
+            "events": [
+                {
+                    "from_address": "0x49d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7",
+                    "keys": [
+                        "0x99cd8bde557814842a3121e8ddfd433a539b8c9f14bf31ebf108d12e6196e9"
+                    ],
+                    "data": [
+                        "0x70503f026c7af73cfd2b007fe650e8c310256e9674ac4e42797c291edca5e84",
+                        "0x1176a1bd84444c89232ec27754698e5d2e7e1a7f1539f12027f28b23ec9f3d8",
+                        "0x3b98bab356d",
+                        "0x0"
+                    ]
+                }
+            ],
+            "execution_resources": {
+                "n_steps": 3298,
+                "builtin_instance_counter": {
+                    "ec_op_builtin": 3,
+                    "range_check_builtin": 73,
+                    "pedersen_builtin": 15
+                },
+                "n_memory_holes": 0
+            },
+            "actual_fee": "0x3b98bab356d"
+        },
+        {
+            "execution_status": "SUCCEEDED",
+            "transaction_index": 8,
+            "transaction_hash": "0x741c8e45a306bb5a88c0c56150bc063b9976f94d947b42589e1683ce08b2d7f",
+            "l2_to_l1_messages": [],
+            "events": [
+                {
+                    "from_address": "0x41a78e741e5af2fec34b695679bc6891742439f7afb8484ecd7766661ad02bf",
+                    "keys": [
+                        "0x26b160f10156dea0639bec90696772c640b9706a47f5b8c52ea1abe5858b34d"
+                    ],
+                    "data": [
+                        "0x9459c8cb7424a2946e6bcf7bc204e349a2865f84f2ae75586ada2897d74c4e",
+                        "0x70503f026c7af73cfd2b007fe650e8c310256e9674ac4e42797c291edca5e84",
+                        "0x1",
+                        "0x348f560344334951bcbccd27aff05a9f6bedeaefc36315fe20e842163adae3d",
+                        "0x0",
+                        "0x67b93aa39a05b7a3f5125f6ffde049894517961eeaf662efd58ded5eca34bc6"
+                    ]
+                },
+                {
+                    "from_address": "0x49d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7",
+                    "keys": [
+                        "0x99cd8bde557814842a3121e8ddfd433a539b8c9f14bf31ebf108d12e6196e9"
+                    ],
+                    "data": [
+                        "0x70503f026c7af73cfd2b007fe650e8c310256e9674ac4e42797c291edca5e84",
+                        "0x1176a1bd84444c89232ec27754698e5d2e7e1a7f1539f12027f28b23ec9f3d8",
+                        "0x460d59359bf",
+                        "0x0"
+                    ]
+                }
+            ],
+            "execution_resources": {
+                "n_steps": 7091,
+                "builtin_instance_counter": {
+                    "pedersen_builtin": 24,
+                    "ec_op_builtin": 3,
+                    "range_check_builtin": 157
+                },
+                "n_memory_holes": 0
+            },
+            "actual_fee": "0x460d59359bf"
+        },
+        {
+            "execution_status": "SUCCEEDED",
+            "transaction_index": 9,
+            "transaction_hash": "0x49ad61002cff7597291c5004d8ab9c4bc9e2ba9f35d9d202f5bf48de801faf5",
+            "l2_to_l1_messages": [],
+            "events": [
+                {
+                    "from_address": "0x41a78e741e5af2fec34b695679bc6891742439f7afb8484ecd7766661ad02bf",
+                    "keys": [
+                        "0x26b160f10156dea0639bec90696772c640b9706a47f5b8c52ea1abe5858b34d"
+                    ],
+                    "data": [
+                        "0x4b41f0be8d60cce826dc46185b8934f86b4e5d848555c069f04aaa55f978117",
+                        "0x70503f026c7af73cfd2b007fe650e8c310256e9674ac4e42797c291edca5e84",
+                        "0x1",
+                        "0x2cbe2e8145b35db6fbb61a8697385f81f16b8fb294b2d88ec7400bfc7edcbda",
+                        "0x0",
+                        "0x79bc1b65eecf7c7072c525668db7e06e39c6c321ab3e32f77df0cae4740d07f"
+                    ]
+                },
+                {
+                    "from_address": "0x49d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7",
+                    "keys": [
+                        "0x99cd8bde557814842a3121e8ddfd433a539b8c9f14bf31ebf108d12e6196e9"
+                    ],
+                    "data": [
+                        "0x70503f026c7af73cfd2b007fe650e8c310256e9674ac4e42797c291edca5e84",
+                        "0x1176a1bd84444c89232ec27754698e5d2e7e1a7f1539f12027f28b23ec9f3d8",
+                        "0x46117762b54",
+                        "0x0"
+                    ]
+                }
+            ],
+            "execution_resources": {
+                "n_steps": 7116,
+                "builtin_instance_counter": {
+                    "pedersen_builtin": 24,
+                    "ec_op_builtin": 3,
+                    "range_check_builtin": 159
+                },
+                "n_memory_holes": 0
+            },
+            "actual_fee": "0x46117762b54"
+        },
+        {
+            "execution_status": "SUCCEEDED",
+            "transaction_index": 10,
+            "transaction_hash": "0x4cc8c57cfd5f2396d87554de709988146317505e432bd0b3036bdadcdb0d051",
+            "l2_to_l1_messages": [],
+            "events": [
+                {
+                    "from_address": "0x49d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7",
+                    "keys": [
+                        "0x99cd8bde557814842a3121e8ddfd433a539b8c9f14bf31ebf108d12e6196e9"
+                    ],
+                    "data": [
+                        "0x70503f026c7af73cfd2b007fe650e8c310256e9674ac4e42797c291edca5e84",
+                        "0x1176a1bd84444c89232ec27754698e5d2e7e1a7f1539f12027f28b23ec9f3d8",
+                        "0x4fb412e8ef7",
+                        "0x0"
+                    ]
+                }
+            ],
+            "execution_resources": {
+                "n_steps": 5844,
+                "builtin_instance_counter": {
+                    "ec_op_builtin": 3,
+                    "range_check_builtin": 132,
+                    "pedersen_builtin": 16
+                },
+                "n_memory_holes": 0
+            },
+            "actual_fee": "0x4fb412e8ef7"
+        },
+        {
+            "execution_status": "SUCCEEDED",
+            "transaction_index": 11,
+            "transaction_hash": "0x15c2858c6e5129547473db62415f4069916798e2f462f95eed3a1a802c9ec14",
+            "l2_to_l1_messages": [],
+            "events": [
+                {
+                    "from_address": "0x49d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7",
+                    "keys": [
+                        "0x99cd8bde557814842a3121e8ddfd433a539b8c9f14bf31ebf108d12e6196e9"
+                    ],
+                    "data": [
+                        "0x70503f026c7af73cfd2b007fe650e8c310256e9674ac4e42797c291edca5e84",
+                        "0x1176a1bd84444c89232ec27754698e5d2e7e1a7f1539f12027f28b23ec9f3d8",
+                        "0x4fb412e8ef7",
+                        "0x0"
+                    ]
+                }
+            ],
+            "execution_resources": {
+                "n_steps": 5844,
+                "builtin_instance_counter": {
+                    "range_check_builtin": 132,
+                    "pedersen_builtin": 16,
+                    "ec_op_builtin": 3
+                },
+                "n_memory_holes": 0
+            },
+            "actual_fee": "0x4fb412e8ef7"
+        },
+        {
+            "execution_status": "SUCCEEDED",
+            "transaction_index": 12,
+            "transaction_hash": "0x552b84ae3b01fe925c3a8d58204882d343364e8f20369657c2295fae0b0745",
+            "l2_to_l1_messages": [],
+            "events": [
+                {
+                    "from_address": "0x49d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7",
+                    "keys": [
+                        "0x99cd8bde557814842a3121e8ddfd433a539b8c9f14bf31ebf108d12e6196e9"
+                    ],
+                    "data": [
+                        "0x70503f026c7af73cfd2b007fe650e8c310256e9674ac4e42797c291edca5e84",
+                        "0x1176a1bd84444c89232ec27754698e5d2e7e1a7f1539f12027f28b23ec9f3d8",
+                        "0x4fb8311608c",
+                        "0x0"
+                    ]
+                }
+            ],
+            "execution_resources": {
+                "n_steps": 5929,
+                "builtin_instance_counter": {
+                    "ec_op_builtin": 3,
+                    "range_check_builtin": 137,
+                    "pedersen_builtin": 16
+                },
+                "n_memory_holes": 0
+            },
+            "actual_fee": "0x4fb8311608c"
+        }
+    ],
+    "starknet_version": "0.12.3"
+}

--- a/clients/feeder/testdata/sepolia/signature/18.json
+++ b/clients/feeder/testdata/sepolia/signature/18.json
@@ -1,0 +1,7 @@
+{
+    "block_hash": "0x5beb56c7d9a9fc066e695c3fc467f45532cace83d9979db4ccfd6b77ca476af",
+    "signature": [
+        "0x703ada3cac29cdc1e97e034c3f739c1b4cb2bb0df3434f94980035cee6307bb",
+        "0x1549f1497161a04ad0c30a43d49424871727e2e1abf49ea363119e8b90113a4"
+    ]
+}

--- a/clients/feeder/testdata/sepolia/traces/0x5beb56c7d9a9fc066e695c3fc467f45532cace83d9979db4ccfd6b77ca476af.json
+++ b/clients/feeder/testdata/sepolia/traces/0x5beb56c7d9a9fc066e695c3fc467f45532cace83d9979db4ccfd6b77ca476af.json
@@ -1,0 +1,2119 @@
+{
+    "traces": [
+        {
+            "validate_invocation": {
+                "caller_address": "0x0",
+                "contract_address": "0x70503f026c7af73cfd2b007fe650e8c310256e9674ac4e42797c291edca5e84",
+                "calldata": [
+                    "0x16342ade8a7cc8296920731bc34b5a6530f5ee1dc1bfd3cc83cb3f519d6530a"
+                ],
+                "call_type": "CALL",
+                "class_hash": "0x903752516de5c04fe91600ca6891e325278b2dfc54880ae11a809abb364844",
+                "selector": "0x289da278a8dc833409cabfdad1581e8e7d40e42dcaed693fa4008dcdb4963b3",
+                "entry_point_type": "EXTERNAL",
+                "result": [
+                    "0x56414c4944"
+                ],
+                "failed": false,
+                "execution_resources": {
+                    "n_steps": 510,
+                    "builtin_instance_counter": {
+                        "ec_op_builtin": 3,
+                        "range_check_builtin": 10
+                    },
+                    "n_memory_holes": 4
+                },
+                "internal_calls": [],
+                "events": [],
+                "messages": []
+            },
+            "fee_transfer_invocation": {
+                "caller_address": "0x70503f026c7af73cfd2b007fe650e8c310256e9674ac4e42797c291edca5e84",
+                "contract_address": "0x49d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7",
+                "calldata": [
+                    "0x1176a1bd84444c89232ec27754698e5d2e7e1a7f1539f12027f28b23ec9f3d8",
+                    "0x3b98bab356d",
+                    "0x0"
+                ],
+                "call_type": "CALL",
+                "class_hash": "0xd0e183745e9dae3e4e78a8ffedcce0903fc4900beace4e0abf192d4c202da3",
+                "selector": "0x83afd3f4caedc6eebf44246fe54e38c95e3179a5ec9ea81740eca5b482d12e",
+                "entry_point_type": "EXTERNAL",
+                "result": [
+                    "0x1"
+                ],
+                "failed": false,
+                "execution_resources": {
+                    "n_steps": 589,
+                    "builtin_instance_counter": {
+                        "pedersen_builtin": 4,
+                        "range_check_builtin": 21
+                    },
+                    "n_memory_holes": 57
+                },
+                "internal_calls": [
+                    {
+                        "caller_address": "0x70503f026c7af73cfd2b007fe650e8c310256e9674ac4e42797c291edca5e84",
+                        "contract_address": "0x49d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7",
+                        "calldata": [
+                            "0x1176a1bd84444c89232ec27754698e5d2e7e1a7f1539f12027f28b23ec9f3d8",
+                            "0x3b98bab356d",
+                            "0x0"
+                        ],
+                        "call_type": "DELEGATE",
+                        "class_hash": "0x1b661756bf7d16210fc611626e1af4569baa1781ffc964bd018f4585ae241c1",
+                        "selector": "0x83afd3f4caedc6eebf44246fe54e38c95e3179a5ec9ea81740eca5b482d12e",
+                        "entry_point_type": "EXTERNAL",
+                        "result": [
+                            "0x1"
+                        ],
+                        "failed": false,
+                        "execution_resources": {
+                            "n_steps": 529,
+                            "builtin_instance_counter": {
+                                "range_check_builtin": 21,
+                                "pedersen_builtin": 4
+                            },
+                            "n_memory_holes": 57
+                        },
+                        "internal_calls": [],
+                        "events": [
+                            {
+                                "order": 0,
+                                "keys": [
+                                    "0x99cd8bde557814842a3121e8ddfd433a539b8c9f14bf31ebf108d12e6196e9"
+                                ],
+                                "data": [
+                                    "0x70503f026c7af73cfd2b007fe650e8c310256e9674ac4e42797c291edca5e84",
+                                    "0x1176a1bd84444c89232ec27754698e5d2e7e1a7f1539f12027f28b23ec9f3d8",
+                                    "0x3b98bab356d",
+                                    "0x0"
+                                ]
+                            }
+                        ],
+                        "messages": []
+                    }
+                ],
+                "events": [],
+                "messages": []
+            },
+            "signature": [
+                "0x25db5938ed86d666ddfdbfe08fdaa1cdcec72911c979304f47851c76afc30ab",
+                "0x1c8db05f7fe7aa3d549044c7128b62c9b0f69cdc97f6752ea33a875b6458e8b"
+            ],
+            "transaction_hash": "0x3744af1511b472fa4dac94feefc944ec785c4a380e9b925ea408d4954729453"
+        },
+        {
+            "validate_invocation": {
+                "caller_address": "0x0",
+                "contract_address": "0x70503f026c7af73cfd2b007fe650e8c310256e9674ac4e42797c291edca5e84",
+                "calldata": [
+                    "0x1",
+                    "0x41a78e741e5af2fec34b695679bc6891742439f7afb8484ecd7766661ad02bf",
+                    "0x1987cbd17808b9a23693d4de7e246a443cfe37e6e7fbaeabd7d7e6532b07c3d",
+                    "0x4",
+                    "0x16342ade8a7cc8296920731bc34b5a6530f5ee1dc1bfd3cc83cb3f519d6530a",
+                    "0x4ceeaa6aca0882e5dfd686a72db97a79bb8e6b0a6b8732785253da8440e712e",
+                    "0x1",
+                    "0x0"
+                ],
+                "call_type": "CALL",
+                "class_hash": "0x903752516de5c04fe91600ca6891e325278b2dfc54880ae11a809abb364844",
+                "selector": "0x162da33a4585851fe8d3af3c2a9c60b557814e221e0d4f30ff0b2189d9c7775",
+                "entry_point_type": "EXTERNAL",
+                "result": [
+                    "0x56414c4944"
+                ],
+                "failed": false,
+                "execution_resources": {
+                    "n_steps": 895,
+                    "builtin_instance_counter": {
+                        "ec_op_builtin": 3,
+                        "range_check_builtin": 20
+                    },
+                    "n_memory_holes": 5
+                },
+                "internal_calls": [],
+                "events": [],
+                "messages": []
+            },
+            "function_invocation": {
+                "caller_address": "0x0",
+                "contract_address": "0x70503f026c7af73cfd2b007fe650e8c310256e9674ac4e42797c291edca5e84",
+                "calldata": [
+                    "0x1",
+                    "0x41a78e741e5af2fec34b695679bc6891742439f7afb8484ecd7766661ad02bf",
+                    "0x1987cbd17808b9a23693d4de7e246a443cfe37e6e7fbaeabd7d7e6532b07c3d",
+                    "0x4",
+                    "0x16342ade8a7cc8296920731bc34b5a6530f5ee1dc1bfd3cc83cb3f519d6530a",
+                    "0x4ceeaa6aca0882e5dfd686a72db97a79bb8e6b0a6b8732785253da8440e712e",
+                    "0x1",
+                    "0x0"
+                ],
+                "call_type": "CALL",
+                "class_hash": "0x903752516de5c04fe91600ca6891e325278b2dfc54880ae11a809abb364844",
+                "selector": "0x15d40a3d6ca2ac30f4031e42be28da9b056fef9bb7357ac5e85627ee876e5ad",
+                "entry_point_type": "EXTERNAL",
+                "result": [
+                    "0x1",
+                    "0x1",
+                    "0x7c687d151607710a7ec82ca5ab0ff2c48f52abd3b4a2773938a0cfef723fe6a"
+                ],
+                "failed": false,
+                "execution_resources": {
+                    "n_steps": 987,
+                    "builtin_instance_counter": {
+                        "pedersen_builtin": 1,
+                        "range_check_builtin": 20
+                    },
+                    "n_memory_holes": 5
+                },
+                "internal_calls": [
+                    {
+                        "caller_address": "0x70503f026c7af73cfd2b007fe650e8c310256e9674ac4e42797c291edca5e84",
+                        "contract_address": "0x41a78e741e5af2fec34b695679bc6891742439f7afb8484ecd7766661ad02bf",
+                        "calldata": [
+                            "0x16342ade8a7cc8296920731bc34b5a6530f5ee1dc1bfd3cc83cb3f519d6530a",
+                            "0x4ceeaa6aca0882e5dfd686a72db97a79bb8e6b0a6b8732785253da8440e712e",
+                            "0x1",
+                            "0x0"
+                        ],
+                        "call_type": "CALL",
+                        "class_hash": "0x7b3e05f48f0c69e4a65ce5e076a66271a527aff2c34ce1083ec6e1526997a69",
+                        "selector": "0x1987cbd17808b9a23693d4de7e246a443cfe37e6e7fbaeabd7d7e6532b07c3d",
+                        "entry_point_type": "EXTERNAL",
+                        "result": [
+                            "0x7c687d151607710a7ec82ca5ab0ff2c48f52abd3b4a2773938a0cfef723fe6a"
+                        ],
+                        "failed": false,
+                        "execution_resources": {
+                            "n_steps": 135,
+                            "builtin_instance_counter": {
+                                "range_check_builtin": 2,
+                                "pedersen_builtin": 1
+                            },
+                            "n_memory_holes": 2
+                        },
+                        "internal_calls": [
+                            {
+                                "caller_address": "0x41a78e741e5af2fec34b695679bc6891742439f7afb8484ecd7766661ad02bf",
+                                "contract_address": "0x7c687d151607710a7ec82ca5ab0ff2c48f52abd3b4a2773938a0cfef723fe6a",
+                                "calldata": [],
+                                "call_type": "CALL",
+                                "class_hash": "0x16342ade8a7cc8296920731bc34b5a6530f5ee1dc1bfd3cc83cb3f519d6530a",
+                                "selector": "0x28ffe4ff0f226a9107253e17a904099aa4f63a02a5621de0576e5aa71bc5194",
+                                "entry_point_type": "CONSTRUCTOR",
+                                "result": [],
+                                "failed": false,
+                                "execution_resources": {
+                                    "n_steps": 0,
+                                    "builtin_instance_counter": {},
+                                    "n_memory_holes": 0
+                                },
+                                "internal_calls": [],
+                                "events": [],
+                                "messages": []
+                            }
+                        ],
+                        "events": [
+                            {
+                                "order": 0,
+                                "keys": [
+                                    "0x26b160f10156dea0639bec90696772c640b9706a47f5b8c52ea1abe5858b34d"
+                                ],
+                                "data": [
+                                    "0x7c687d151607710a7ec82ca5ab0ff2c48f52abd3b4a2773938a0cfef723fe6a",
+                                    "0x70503f026c7af73cfd2b007fe650e8c310256e9674ac4e42797c291edca5e84",
+                                    "0x1",
+                                    "0x16342ade8a7cc8296920731bc34b5a6530f5ee1dc1bfd3cc83cb3f519d6530a",
+                                    "0x0",
+                                    "0x4ceeaa6aca0882e5dfd686a72db97a79bb8e6b0a6b8732785253da8440e712e"
+                                ]
+                            }
+                        ],
+                        "messages": []
+                    }
+                ],
+                "events": [],
+                "messages": []
+            },
+            "fee_transfer_invocation": {
+                "caller_address": "0x70503f026c7af73cfd2b007fe650e8c310256e9674ac4e42797c291edca5e84",
+                "contract_address": "0x49d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7",
+                "calldata": [
+                    "0x1176a1bd84444c89232ec27754698e5d2e7e1a7f1539f12027f28b23ec9f3d8",
+                    "0x460d59359bf",
+                    "0x0"
+                ],
+                "call_type": "CALL",
+                "class_hash": "0xd0e183745e9dae3e4e78a8ffedcce0903fc4900beace4e0abf192d4c202da3",
+                "selector": "0x83afd3f4caedc6eebf44246fe54e38c95e3179a5ec9ea81740eca5b482d12e",
+                "entry_point_type": "EXTERNAL",
+                "result": [
+                    "0x1"
+                ],
+                "failed": false,
+                "execution_resources": {
+                    "n_steps": 589,
+                    "builtin_instance_counter": {
+                        "pedersen_builtin": 4,
+                        "range_check_builtin": 21
+                    },
+                    "n_memory_holes": 57
+                },
+                "internal_calls": [
+                    {
+                        "caller_address": "0x70503f026c7af73cfd2b007fe650e8c310256e9674ac4e42797c291edca5e84",
+                        "contract_address": "0x49d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7",
+                        "calldata": [
+                            "0x1176a1bd84444c89232ec27754698e5d2e7e1a7f1539f12027f28b23ec9f3d8",
+                            "0x460d59359bf",
+                            "0x0"
+                        ],
+                        "call_type": "DELEGATE",
+                        "class_hash": "0x1b661756bf7d16210fc611626e1af4569baa1781ffc964bd018f4585ae241c1",
+                        "selector": "0x83afd3f4caedc6eebf44246fe54e38c95e3179a5ec9ea81740eca5b482d12e",
+                        "entry_point_type": "EXTERNAL",
+                        "result": [
+                            "0x1"
+                        ],
+                        "failed": false,
+                        "execution_resources": {
+                            "n_steps": 529,
+                            "builtin_instance_counter": {
+                                "range_check_builtin": 21,
+                                "pedersen_builtin": 4
+                            },
+                            "n_memory_holes": 57
+                        },
+                        "internal_calls": [],
+                        "events": [
+                            {
+                                "order": 0,
+                                "keys": [
+                                    "0x99cd8bde557814842a3121e8ddfd433a539b8c9f14bf31ebf108d12e6196e9"
+                                ],
+                                "data": [
+                                    "0x70503f026c7af73cfd2b007fe650e8c310256e9674ac4e42797c291edca5e84",
+                                    "0x1176a1bd84444c89232ec27754698e5d2e7e1a7f1539f12027f28b23ec9f3d8",
+                                    "0x460d59359bf",
+                                    "0x0"
+                                ]
+                            }
+                        ],
+                        "messages": []
+                    }
+                ],
+                "events": [],
+                "messages": []
+            },
+            "signature": [
+                "0x441e8ca731aa93ad0cf7b3ecd5d998230c2a71a96bacb41b2ad98dfc1c0a6f0",
+                "0x6567123b1434f4d779ebb305cf96281c81be6b3f9396fc756d914957859e75"
+            ],
+            "transaction_hash": "0x4093daac10408c08333a2030be765fe0ff1b78cfd81835d2253b2ecd06c2b35"
+        },
+        {
+            "validate_invocation": {
+                "caller_address": "0x0",
+                "contract_address": "0x70503f026c7af73cfd2b007fe650e8c310256e9674ac4e42797c291edca5e84",
+                "calldata": [
+                    "0x1",
+                    "0x7c687d151607710a7ec82ca5ab0ff2c48f52abd3b4a2773938a0cfef723fe6a",
+                    "0x10b7e63d3ca05c9baffd985d3e1c3858d4dbf0759f066be0eaddc5d71c2cab5",
+                    "0x1",
+                    "0x64"
+                ],
+                "call_type": "CALL",
+                "class_hash": "0x903752516de5c04fe91600ca6891e325278b2dfc54880ae11a809abb364844",
+                "selector": "0x162da33a4585851fe8d3af3c2a9c60b557814e221e0d4f30ff0b2189d9c7775",
+                "entry_point_type": "EXTERNAL",
+                "result": [
+                    "0x56414c4944"
+                ],
+                "failed": false,
+                "execution_resources": {
+                    "n_steps": 754,
+                    "builtin_instance_counter": {
+                        "range_check_builtin": 17,
+                        "ec_op_builtin": 3
+                    },
+                    "n_memory_holes": 5
+                },
+                "internal_calls": [],
+                "events": [],
+                "messages": []
+            },
+            "function_invocation": {
+                "caller_address": "0x0",
+                "contract_address": "0x70503f026c7af73cfd2b007fe650e8c310256e9674ac4e42797c291edca5e84",
+                "calldata": [
+                    "0x1",
+                    "0x7c687d151607710a7ec82ca5ab0ff2c48f52abd3b4a2773938a0cfef723fe6a",
+                    "0x10b7e63d3ca05c9baffd985d3e1c3858d4dbf0759f066be0eaddc5d71c2cab5",
+                    "0x1",
+                    "0x64"
+                ],
+                "call_type": "CALL",
+                "class_hash": "0x903752516de5c04fe91600ca6891e325278b2dfc54880ae11a809abb364844",
+                "selector": "0x15d40a3d6ca2ac30f4031e42be28da9b056fef9bb7357ac5e85627ee876e5ad",
+                "entry_point_type": "EXTERNAL",
+                "result": [
+                    "0x1",
+                    "0x0"
+                ],
+                "failed": false,
+                "execution_resources": {
+                    "n_steps": 764,
+                    "builtin_instance_counter": {
+                        "range_check_builtin": 18
+                    },
+                    "n_memory_holes": 8
+                },
+                "internal_calls": [
+                    {
+                        "caller_address": "0x70503f026c7af73cfd2b007fe650e8c310256e9674ac4e42797c291edca5e84",
+                        "contract_address": "0x7c687d151607710a7ec82ca5ab0ff2c48f52abd3b4a2773938a0cfef723fe6a",
+                        "calldata": [
+                            "0x64"
+                        ],
+                        "call_type": "CALL",
+                        "class_hash": "0x16342ade8a7cc8296920731bc34b5a6530f5ee1dc1bfd3cc83cb3f519d6530a",
+                        "selector": "0x10b7e63d3ca05c9baffd985d3e1c3858d4dbf0759f066be0eaddc5d71c2cab5",
+                        "entry_point_type": "EXTERNAL",
+                        "result": [],
+                        "failed": false,
+                        "execution_resources": {
+                            "n_steps": 96,
+                            "builtin_instance_counter": {
+                                "range_check_builtin": 4
+                            },
+                            "n_memory_holes": 5
+                        },
+                        "internal_calls": [],
+                        "events": [],
+                        "messages": []
+                    }
+                ],
+                "events": [],
+                "messages": []
+            },
+            "fee_transfer_invocation": {
+                "caller_address": "0x70503f026c7af73cfd2b007fe650e8c310256e9674ac4e42797c291edca5e84",
+                "contract_address": "0x49d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7",
+                "calldata": [
+                    "0x1176a1bd84444c89232ec27754698e5d2e7e1a7f1539f12027f28b23ec9f3d8",
+                    "0x4faff4bbd62",
+                    "0x0"
+                ],
+                "call_type": "CALL",
+                "class_hash": "0xd0e183745e9dae3e4e78a8ffedcce0903fc4900beace4e0abf192d4c202da3",
+                "selector": "0x83afd3f4caedc6eebf44246fe54e38c95e3179a5ec9ea81740eca5b482d12e",
+                "entry_point_type": "EXTERNAL",
+                "result": [
+                    "0x1"
+                ],
+                "failed": false,
+                "execution_resources": {
+                    "n_steps": 589,
+                    "builtin_instance_counter": {
+                        "pedersen_builtin": 4,
+                        "range_check_builtin": 21
+                    },
+                    "n_memory_holes": 57
+                },
+                "internal_calls": [
+                    {
+                        "caller_address": "0x70503f026c7af73cfd2b007fe650e8c310256e9674ac4e42797c291edca5e84",
+                        "contract_address": "0x49d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7",
+                        "calldata": [
+                            "0x1176a1bd84444c89232ec27754698e5d2e7e1a7f1539f12027f28b23ec9f3d8",
+                            "0x4faff4bbd62",
+                            "0x0"
+                        ],
+                        "call_type": "DELEGATE",
+                        "class_hash": "0x1b661756bf7d16210fc611626e1af4569baa1781ffc964bd018f4585ae241c1",
+                        "selector": "0x83afd3f4caedc6eebf44246fe54e38c95e3179a5ec9ea81740eca5b482d12e",
+                        "entry_point_type": "EXTERNAL",
+                        "result": [
+                            "0x1"
+                        ],
+                        "failed": false,
+                        "execution_resources": {
+                            "n_steps": 529,
+                            "builtin_instance_counter": {
+                                "pedersen_builtin": 4,
+                                "range_check_builtin": 21
+                            },
+                            "n_memory_holes": 57
+                        },
+                        "internal_calls": [],
+                        "events": [
+                            {
+                                "order": 0,
+                                "keys": [
+                                    "0x99cd8bde557814842a3121e8ddfd433a539b8c9f14bf31ebf108d12e6196e9"
+                                ],
+                                "data": [
+                                    "0x70503f026c7af73cfd2b007fe650e8c310256e9674ac4e42797c291edca5e84",
+                                    "0x1176a1bd84444c89232ec27754698e5d2e7e1a7f1539f12027f28b23ec9f3d8",
+                                    "0x4faff4bbd62",
+                                    "0x0"
+                                ]
+                            }
+                        ],
+                        "messages": []
+                    }
+                ],
+                "events": [],
+                "messages": []
+            },
+            "signature": [
+                "0x7fe0ff3d16520f8926fb60fe831a55c462556056dc46b4d5d1e82b7aa73fdbb",
+                "0x2586eac9fb4eccddc95f37717ddff5e07eaa4163783e7a3f2e33613ef77aec5"
+            ],
+            "transaction_hash": "0x6be72382daa1946a1ca961dadc907117a29014a05a3453c5b44e87cd7ac719a"
+        },
+        {
+            "revert_error": "Error in the called contract (0x070503f026c7af73cfd2b007fe650e8c310256e9674ac4e42797c291edca5e84):\nError at pc=0:4288:\nGot an exception while executing a hint: Custom Hint Error: Execution failed. Failure reason: 'Fatal'.\nCairo traceback (most recent call last):\nUnknown location (pc=0:67)\nUnknown location (pc=0:1997)\nUnknown location (pc=0:2729)\nUnknown location (pc=0:3577)\n",
+            "validate_invocation": {
+                "caller_address": "0x0",
+                "contract_address": "0x70503f026c7af73cfd2b007fe650e8c310256e9674ac4e42797c291edca5e84",
+                "calldata": [
+                    "0x1",
+                    "0x7c687d151607710a7ec82ca5ab0ff2c48f52abd3b4a2773938a0cfef723fe6a",
+                    "0x10b7e63d3ca05c9baffd985d3e1c3858d4dbf0759f066be0eaddc5d71c2cab5",
+                    "0x1",
+                    "0xa"
+                ],
+                "call_type": "CALL",
+                "class_hash": "0x903752516de5c04fe91600ca6891e325278b2dfc54880ae11a809abb364844",
+                "selector": "0x162da33a4585851fe8d3af3c2a9c60b557814e221e0d4f30ff0b2189d9c7775",
+                "entry_point_type": "EXTERNAL",
+                "result": [
+                    "0x56414c4944"
+                ],
+                "failed": false,
+                "execution_resources": {
+                    "n_steps": 754,
+                    "builtin_instance_counter": {
+                        "range_check_builtin": 17,
+                        "ec_op_builtin": 3
+                    },
+                    "n_memory_holes": 5
+                },
+                "internal_calls": [],
+                "events": [],
+                "messages": []
+            },
+            "fee_transfer_invocation": {
+                "caller_address": "0x70503f026c7af73cfd2b007fe650e8c310256e9674ac4e42797c291edca5e84",
+                "contract_address": "0x49d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7",
+                "calldata": [
+                    "0x1176a1bd84444c89232ec27754698e5d2e7e1a7f1539f12027f28b23ec9f3d8",
+                    "0x2847291f968",
+                    "0x0"
+                ],
+                "call_type": "CALL",
+                "class_hash": "0xd0e183745e9dae3e4e78a8ffedcce0903fc4900beace4e0abf192d4c202da3",
+                "selector": "0x83afd3f4caedc6eebf44246fe54e38c95e3179a5ec9ea81740eca5b482d12e",
+                "entry_point_type": "EXTERNAL",
+                "result": [
+                    "0x1"
+                ],
+                "failed": false,
+                "execution_resources": {
+                    "n_steps": 589,
+                    "builtin_instance_counter": {
+                        "range_check_builtin": 21,
+                        "pedersen_builtin": 4
+                    },
+                    "n_memory_holes": 57
+                },
+                "internal_calls": [
+                    {
+                        "caller_address": "0x70503f026c7af73cfd2b007fe650e8c310256e9674ac4e42797c291edca5e84",
+                        "contract_address": "0x49d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7",
+                        "calldata": [
+                            "0x1176a1bd84444c89232ec27754698e5d2e7e1a7f1539f12027f28b23ec9f3d8",
+                            "0x2847291f968",
+                            "0x0"
+                        ],
+                        "call_type": "DELEGATE",
+                        "class_hash": "0x1b661756bf7d16210fc611626e1af4569baa1781ffc964bd018f4585ae241c1",
+                        "selector": "0x83afd3f4caedc6eebf44246fe54e38c95e3179a5ec9ea81740eca5b482d12e",
+                        "entry_point_type": "EXTERNAL",
+                        "result": [
+                            "0x1"
+                        ],
+                        "failed": false,
+                        "execution_resources": {
+                            "n_steps": 529,
+                            "builtin_instance_counter": {
+                                "range_check_builtin": 21,
+                                "pedersen_builtin": 4
+                            },
+                            "n_memory_holes": 57
+                        },
+                        "internal_calls": [],
+                        "events": [
+                            {
+                                "order": 0,
+                                "keys": [
+                                    "0x99cd8bde557814842a3121e8ddfd433a539b8c9f14bf31ebf108d12e6196e9"
+                                ],
+                                "data": [
+                                    "0x70503f026c7af73cfd2b007fe650e8c310256e9674ac4e42797c291edca5e84",
+                                    "0x1176a1bd84444c89232ec27754698e5d2e7e1a7f1539f12027f28b23ec9f3d8",
+                                    "0x2847291f968",
+                                    "0x0"
+                                ]
+                            }
+                        ],
+                        "messages": []
+                    }
+                ],
+                "events": [],
+                "messages": []
+            },
+            "signature": [
+                "0x3dac4eaeeea2f0958bb4cb896e582ee2be6d3be5490f8c49dd73c95ba06ac18",
+                "0x26b8df6e1c84d804211dbd56b0b816a9ea795d25dfc4e8cfbebe397378438d2"
+            ],
+            "transaction_hash": "0x2f00c7f28df2197196440747f97baa63d0851e3b0cfc2efedb6a88a7ef78cb1"
+        },
+        {
+            "validate_invocation": {
+                "caller_address": "0x0",
+                "contract_address": "0x70503f026c7af73cfd2b007fe650e8c310256e9674ac4e42797c291edca5e84",
+                "calldata": [
+                    "0x1",
+                    "0x41a78e741e5af2fec34b695679bc6891742439f7afb8484ecd7766661ad02bf",
+                    "0x1987cbd17808b9a23693d4de7e246a443cfe37e6e7fbaeabd7d7e6532b07c3d",
+                    "0x4",
+                    "0x16342ade8a7cc8296920731bc34b5a6530f5ee1dc1bfd3cc83cb3f519d6530a",
+                    "0x710aa12bbab801c046773f3ceed2ea7cb50a24838ef55d584b4221ff955e2c9",
+                    "0x1",
+                    "0x0"
+                ],
+                "call_type": "CALL",
+                "class_hash": "0x903752516de5c04fe91600ca6891e325278b2dfc54880ae11a809abb364844",
+                "selector": "0x162da33a4585851fe8d3af3c2a9c60b557814e221e0d4f30ff0b2189d9c7775",
+                "entry_point_type": "EXTERNAL",
+                "result": [
+                    "0x56414c4944"
+                ],
+                "failed": false,
+                "execution_resources": {
+                    "n_steps": 895,
+                    "builtin_instance_counter": {
+                        "ec_op_builtin": 3,
+                        "range_check_builtin": 20
+                    },
+                    "n_memory_holes": 5
+                },
+                "internal_calls": [],
+                "events": [],
+                "messages": []
+            },
+            "function_invocation": {
+                "caller_address": "0x0",
+                "contract_address": "0x70503f026c7af73cfd2b007fe650e8c310256e9674ac4e42797c291edca5e84",
+                "calldata": [
+                    "0x1",
+                    "0x41a78e741e5af2fec34b695679bc6891742439f7afb8484ecd7766661ad02bf",
+                    "0x1987cbd17808b9a23693d4de7e246a443cfe37e6e7fbaeabd7d7e6532b07c3d",
+                    "0x4",
+                    "0x16342ade8a7cc8296920731bc34b5a6530f5ee1dc1bfd3cc83cb3f519d6530a",
+                    "0x710aa12bbab801c046773f3ceed2ea7cb50a24838ef55d584b4221ff955e2c9",
+                    "0x1",
+                    "0x0"
+                ],
+                "call_type": "CALL",
+                "class_hash": "0x903752516de5c04fe91600ca6891e325278b2dfc54880ae11a809abb364844",
+                "selector": "0x15d40a3d6ca2ac30f4031e42be28da9b056fef9bb7357ac5e85627ee876e5ad",
+                "entry_point_type": "EXTERNAL",
+                "result": [
+                    "0x1",
+                    "0x1",
+                    "0x254df9ff3e3c3e6b078232b69716a10449077a3988ff883520494515d94c631"
+                ],
+                "failed": false,
+                "execution_resources": {
+                    "n_steps": 987,
+                    "builtin_instance_counter": {
+                        "pedersen_builtin": 1,
+                        "range_check_builtin": 20
+                    },
+                    "n_memory_holes": 5
+                },
+                "internal_calls": [
+                    {
+                        "caller_address": "0x70503f026c7af73cfd2b007fe650e8c310256e9674ac4e42797c291edca5e84",
+                        "contract_address": "0x41a78e741e5af2fec34b695679bc6891742439f7afb8484ecd7766661ad02bf",
+                        "calldata": [
+                            "0x16342ade8a7cc8296920731bc34b5a6530f5ee1dc1bfd3cc83cb3f519d6530a",
+                            "0x710aa12bbab801c046773f3ceed2ea7cb50a24838ef55d584b4221ff955e2c9",
+                            "0x1",
+                            "0x0"
+                        ],
+                        "call_type": "CALL",
+                        "class_hash": "0x7b3e05f48f0c69e4a65ce5e076a66271a527aff2c34ce1083ec6e1526997a69",
+                        "selector": "0x1987cbd17808b9a23693d4de7e246a443cfe37e6e7fbaeabd7d7e6532b07c3d",
+                        "entry_point_type": "EXTERNAL",
+                        "result": [
+                            "0x254df9ff3e3c3e6b078232b69716a10449077a3988ff883520494515d94c631"
+                        ],
+                        "failed": false,
+                        "execution_resources": {
+                            "n_steps": 135,
+                            "builtin_instance_counter": {
+                                "pedersen_builtin": 1,
+                                "range_check_builtin": 2
+                            },
+                            "n_memory_holes": 2
+                        },
+                        "internal_calls": [
+                            {
+                                "caller_address": "0x41a78e741e5af2fec34b695679bc6891742439f7afb8484ecd7766661ad02bf",
+                                "contract_address": "0x254df9ff3e3c3e6b078232b69716a10449077a3988ff883520494515d94c631",
+                                "calldata": [],
+                                "call_type": "CALL",
+                                "class_hash": "0x16342ade8a7cc8296920731bc34b5a6530f5ee1dc1bfd3cc83cb3f519d6530a",
+                                "selector": "0x28ffe4ff0f226a9107253e17a904099aa4f63a02a5621de0576e5aa71bc5194",
+                                "entry_point_type": "CONSTRUCTOR",
+                                "result": [],
+                                "failed": false,
+                                "execution_resources": {
+                                    "n_steps": 0,
+                                    "builtin_instance_counter": {},
+                                    "n_memory_holes": 0
+                                },
+                                "internal_calls": [],
+                                "events": [],
+                                "messages": []
+                            }
+                        ],
+                        "events": [
+                            {
+                                "order": 0,
+                                "keys": [
+                                    "0x26b160f10156dea0639bec90696772c640b9706a47f5b8c52ea1abe5858b34d"
+                                ],
+                                "data": [
+                                    "0x254df9ff3e3c3e6b078232b69716a10449077a3988ff883520494515d94c631",
+                                    "0x70503f026c7af73cfd2b007fe650e8c310256e9674ac4e42797c291edca5e84",
+                                    "0x1",
+                                    "0x16342ade8a7cc8296920731bc34b5a6530f5ee1dc1bfd3cc83cb3f519d6530a",
+                                    "0x0",
+                                    "0x710aa12bbab801c046773f3ceed2ea7cb50a24838ef55d584b4221ff955e2c9"
+                                ]
+                            }
+                        ],
+                        "messages": []
+                    }
+                ],
+                "events": [],
+                "messages": []
+            },
+            "fee_transfer_invocation": {
+                "caller_address": "0x70503f026c7af73cfd2b007fe650e8c310256e9674ac4e42797c291edca5e84",
+                "contract_address": "0x49d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7",
+                "calldata": [
+                    "0x1176a1bd84444c89232ec27754698e5d2e7e1a7f1539f12027f28b23ec9f3d8",
+                    "0x460d59359bf",
+                    "0x0"
+                ],
+                "call_type": "CALL",
+                "class_hash": "0xd0e183745e9dae3e4e78a8ffedcce0903fc4900beace4e0abf192d4c202da3",
+                "selector": "0x83afd3f4caedc6eebf44246fe54e38c95e3179a5ec9ea81740eca5b482d12e",
+                "entry_point_type": "EXTERNAL",
+                "result": [
+                    "0x1"
+                ],
+                "failed": false,
+                "execution_resources": {
+                    "n_steps": 589,
+                    "builtin_instance_counter": {
+                        "range_check_builtin": 21,
+                        "pedersen_builtin": 4
+                    },
+                    "n_memory_holes": 57
+                },
+                "internal_calls": [
+                    {
+                        "caller_address": "0x70503f026c7af73cfd2b007fe650e8c310256e9674ac4e42797c291edca5e84",
+                        "contract_address": "0x49d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7",
+                        "calldata": [
+                            "0x1176a1bd84444c89232ec27754698e5d2e7e1a7f1539f12027f28b23ec9f3d8",
+                            "0x460d59359bf",
+                            "0x0"
+                        ],
+                        "call_type": "DELEGATE",
+                        "class_hash": "0x1b661756bf7d16210fc611626e1af4569baa1781ffc964bd018f4585ae241c1",
+                        "selector": "0x83afd3f4caedc6eebf44246fe54e38c95e3179a5ec9ea81740eca5b482d12e",
+                        "entry_point_type": "EXTERNAL",
+                        "result": [
+                            "0x1"
+                        ],
+                        "failed": false,
+                        "execution_resources": {
+                            "n_steps": 529,
+                            "builtin_instance_counter": {
+                                "pedersen_builtin": 4,
+                                "range_check_builtin": 21
+                            },
+                            "n_memory_holes": 57
+                        },
+                        "internal_calls": [],
+                        "events": [
+                            {
+                                "order": 0,
+                                "keys": [
+                                    "0x99cd8bde557814842a3121e8ddfd433a539b8c9f14bf31ebf108d12e6196e9"
+                                ],
+                                "data": [
+                                    "0x70503f026c7af73cfd2b007fe650e8c310256e9674ac4e42797c291edca5e84",
+                                    "0x1176a1bd84444c89232ec27754698e5d2e7e1a7f1539f12027f28b23ec9f3d8",
+                                    "0x460d59359bf",
+                                    "0x0"
+                                ]
+                            }
+                        ],
+                        "messages": []
+                    }
+                ],
+                "events": [],
+                "messages": []
+            },
+            "signature": [
+                "0x73042f7943ccf61bc9d2dff12b3d9c445fa96787ee6747efb83f1d7e72c2bd9",
+                "0x46a5b31417b6c8b96f8df52d01dd25eab42b42e9eb97e9ef345af4d25a47955"
+            ],
+            "transaction_hash": "0x3ad3bcc36ce7fd7c8181fb827c6e39f39fc68a40f7107f77d43215ff4b8cfd9"
+        },
+        {
+            "validate_invocation": {
+                "caller_address": "0x0",
+                "contract_address": "0x70503f026c7af73cfd2b007fe650e8c310256e9674ac4e42797c291edca5e84",
+                "calldata": [
+                    "0x2cbe2e8145b35db6fbb61a8697385f81f16b8fb294b2d88ec7400bfc7edcbda"
+                ],
+                "call_type": "CALL",
+                "class_hash": "0x903752516de5c04fe91600ca6891e325278b2dfc54880ae11a809abb364844",
+                "selector": "0x289da278a8dc833409cabfdad1581e8e7d40e42dcaed693fa4008dcdb4963b3",
+                "entry_point_type": "EXTERNAL",
+                "result": [
+                    "0x56414c4944"
+                ],
+                "failed": false,
+                "execution_resources": {
+                    "n_steps": 510,
+                    "builtin_instance_counter": {
+                        "ec_op_builtin": 3,
+                        "range_check_builtin": 10
+                    },
+                    "n_memory_holes": 4
+                },
+                "internal_calls": [],
+                "events": [],
+                "messages": []
+            },
+            "fee_transfer_invocation": {
+                "caller_address": "0x70503f026c7af73cfd2b007fe650e8c310256e9674ac4e42797c291edca5e84",
+                "contract_address": "0x49d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7",
+                "calldata": [
+                    "0x1176a1bd84444c89232ec27754698e5d2e7e1a7f1539f12027f28b23ec9f3d8",
+                    "0x3b98bab356d",
+                    "0x0"
+                ],
+                "call_type": "CALL",
+                "class_hash": "0xd0e183745e9dae3e4e78a8ffedcce0903fc4900beace4e0abf192d4c202da3",
+                "selector": "0x83afd3f4caedc6eebf44246fe54e38c95e3179a5ec9ea81740eca5b482d12e",
+                "entry_point_type": "EXTERNAL",
+                "result": [
+                    "0x1"
+                ],
+                "failed": false,
+                "execution_resources": {
+                    "n_steps": 589,
+                    "builtin_instance_counter": {
+                        "pedersen_builtin": 4,
+                        "range_check_builtin": 21
+                    },
+                    "n_memory_holes": 57
+                },
+                "internal_calls": [
+                    {
+                        "caller_address": "0x70503f026c7af73cfd2b007fe650e8c310256e9674ac4e42797c291edca5e84",
+                        "contract_address": "0x49d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7",
+                        "calldata": [
+                            "0x1176a1bd84444c89232ec27754698e5d2e7e1a7f1539f12027f28b23ec9f3d8",
+                            "0x3b98bab356d",
+                            "0x0"
+                        ],
+                        "call_type": "DELEGATE",
+                        "class_hash": "0x1b661756bf7d16210fc611626e1af4569baa1781ffc964bd018f4585ae241c1",
+                        "selector": "0x83afd3f4caedc6eebf44246fe54e38c95e3179a5ec9ea81740eca5b482d12e",
+                        "entry_point_type": "EXTERNAL",
+                        "result": [
+                            "0x1"
+                        ],
+                        "failed": false,
+                        "execution_resources": {
+                            "n_steps": 529,
+                            "builtin_instance_counter": {
+                                "range_check_builtin": 21,
+                                "pedersen_builtin": 4
+                            },
+                            "n_memory_holes": 57
+                        },
+                        "internal_calls": [],
+                        "events": [
+                            {
+                                "order": 0,
+                                "keys": [
+                                    "0x99cd8bde557814842a3121e8ddfd433a539b8c9f14bf31ebf108d12e6196e9"
+                                ],
+                                "data": [
+                                    "0x70503f026c7af73cfd2b007fe650e8c310256e9674ac4e42797c291edca5e84",
+                                    "0x1176a1bd84444c89232ec27754698e5d2e7e1a7f1539f12027f28b23ec9f3d8",
+                                    "0x3b98bab356d",
+                                    "0x0"
+                                ]
+                            }
+                        ],
+                        "messages": []
+                    }
+                ],
+                "events": [],
+                "messages": []
+            },
+            "signature": [
+                "0x3be14892e277ff4568f9f87d919699e594c780b47202ba4c3c41884b602de2c",
+                "0x16f1558dcf161cd3a1adc47e6d34bd36bb540fd842d29a47e6ac8e7401fbc38"
+            ],
+            "transaction_hash": "0x6657f07f42b04a450677d818ffe105d4f45c68b6122f97395af5f2017028853"
+        },
+        {
+            "validate_invocation": {
+                "caller_address": "0x0",
+                "contract_address": "0x70503f026c7af73cfd2b007fe650e8c310256e9674ac4e42797c291edca5e84",
+                "calldata": [
+                    "0x1",
+                    "0x41a78e741e5af2fec34b695679bc6891742439f7afb8484ecd7766661ad02bf",
+                    "0x1987cbd17808b9a23693d4de7e246a443cfe37e6e7fbaeabd7d7e6532b07c3d",
+                    "0x4",
+                    "0x2cbe2e8145b35db6fbb61a8697385f81f16b8fb294b2d88ec7400bfc7edcbda",
+                    "0x48aa72e665e92626c1f71546bae3630a10ed131b4260e1c6a33d1f2208bd2cf",
+                    "0x1",
+                    "0x0"
+                ],
+                "call_type": "CALL",
+                "class_hash": "0x903752516de5c04fe91600ca6891e325278b2dfc54880ae11a809abb364844",
+                "selector": "0x162da33a4585851fe8d3af3c2a9c60b557814e221e0d4f30ff0b2189d9c7775",
+                "entry_point_type": "EXTERNAL",
+                "result": [
+                    "0x56414c4944"
+                ],
+                "failed": false,
+                "execution_resources": {
+                    "n_steps": 895,
+                    "builtin_instance_counter": {
+                        "ec_op_builtin": 3,
+                        "range_check_builtin": 20
+                    },
+                    "n_memory_holes": 5
+                },
+                "internal_calls": [],
+                "events": [],
+                "messages": []
+            },
+            "function_invocation": {
+                "caller_address": "0x0",
+                "contract_address": "0x70503f026c7af73cfd2b007fe650e8c310256e9674ac4e42797c291edca5e84",
+                "calldata": [
+                    "0x1",
+                    "0x41a78e741e5af2fec34b695679bc6891742439f7afb8484ecd7766661ad02bf",
+                    "0x1987cbd17808b9a23693d4de7e246a443cfe37e6e7fbaeabd7d7e6532b07c3d",
+                    "0x4",
+                    "0x2cbe2e8145b35db6fbb61a8697385f81f16b8fb294b2d88ec7400bfc7edcbda",
+                    "0x48aa72e665e92626c1f71546bae3630a10ed131b4260e1c6a33d1f2208bd2cf",
+                    "0x1",
+                    "0x0"
+                ],
+                "call_type": "CALL",
+                "class_hash": "0x903752516de5c04fe91600ca6891e325278b2dfc54880ae11a809abb364844",
+                "selector": "0x15d40a3d6ca2ac30f4031e42be28da9b056fef9bb7357ac5e85627ee876e5ad",
+                "entry_point_type": "EXTERNAL",
+                "result": [
+                    "0x1",
+                    "0x1",
+                    "0x45283160abd44efff6bf2b3ad40e556bfbcf623ce36ad395cf72b96678c2dab"
+                ],
+                "failed": false,
+                "execution_resources": {
+                    "n_steps": 1012,
+                    "builtin_instance_counter": {
+                        "range_check_builtin": 22,
+                        "pedersen_builtin": 1
+                    },
+                    "n_memory_holes": 5
+                },
+                "internal_calls": [
+                    {
+                        "caller_address": "0x70503f026c7af73cfd2b007fe650e8c310256e9674ac4e42797c291edca5e84",
+                        "contract_address": "0x41a78e741e5af2fec34b695679bc6891742439f7afb8484ecd7766661ad02bf",
+                        "calldata": [
+                            "0x2cbe2e8145b35db6fbb61a8697385f81f16b8fb294b2d88ec7400bfc7edcbda",
+                            "0x48aa72e665e92626c1f71546bae3630a10ed131b4260e1c6a33d1f2208bd2cf",
+                            "0x1",
+                            "0x0"
+                        ],
+                        "call_type": "CALL",
+                        "class_hash": "0x7b3e05f48f0c69e4a65ce5e076a66271a527aff2c34ce1083ec6e1526997a69",
+                        "selector": "0x1987cbd17808b9a23693d4de7e246a443cfe37e6e7fbaeabd7d7e6532b07c3d",
+                        "entry_point_type": "EXTERNAL",
+                        "result": [
+                            "0x45283160abd44efff6bf2b3ad40e556bfbcf623ce36ad395cf72b96678c2dab"
+                        ],
+                        "failed": false,
+                        "execution_resources": {
+                            "n_steps": 160,
+                            "builtin_instance_counter": {
+                                "pedersen_builtin": 1,
+                                "range_check_builtin": 4
+                            },
+                            "n_memory_holes": 2
+                        },
+                        "internal_calls": [
+                            {
+                                "caller_address": "0x41a78e741e5af2fec34b695679bc6891742439f7afb8484ecd7766661ad02bf",
+                                "contract_address": "0x45283160abd44efff6bf2b3ad40e556bfbcf623ce36ad395cf72b96678c2dab",
+                                "calldata": [],
+                                "call_type": "CALL",
+                                "class_hash": "0x2cbe2e8145b35db6fbb61a8697385f81f16b8fb294b2d88ec7400bfc7edcbda",
+                                "selector": "0x28ffe4ff0f226a9107253e17a904099aa4f63a02a5621de0576e5aa71bc5194",
+                                "entry_point_type": "CONSTRUCTOR",
+                                "result": [],
+                                "failed": false,
+                                "execution_resources": {
+                                    "n_steps": 25,
+                                    "builtin_instance_counter": {
+                                        "range_check_builtin": 2
+                                    },
+                                    "n_memory_holes": 0
+                                },
+                                "internal_calls": [],
+                                "events": [],
+                                "messages": []
+                            }
+                        ],
+                        "events": [
+                            {
+                                "order": 0,
+                                "keys": [
+                                    "0x26b160f10156dea0639bec90696772c640b9706a47f5b8c52ea1abe5858b34d"
+                                ],
+                                "data": [
+                                    "0x45283160abd44efff6bf2b3ad40e556bfbcf623ce36ad395cf72b96678c2dab",
+                                    "0x70503f026c7af73cfd2b007fe650e8c310256e9674ac4e42797c291edca5e84",
+                                    "0x1",
+                                    "0x2cbe2e8145b35db6fbb61a8697385f81f16b8fb294b2d88ec7400bfc7edcbda",
+                                    "0x0",
+                                    "0x48aa72e665e92626c1f71546bae3630a10ed131b4260e1c6a33d1f2208bd2cf"
+                                ]
+                            }
+                        ],
+                        "messages": []
+                    }
+                ],
+                "events": [],
+                "messages": []
+            },
+            "fee_transfer_invocation": {
+                "caller_address": "0x70503f026c7af73cfd2b007fe650e8c310256e9674ac4e42797c291edca5e84",
+                "contract_address": "0x49d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7",
+                "calldata": [
+                    "0x1176a1bd84444c89232ec27754698e5d2e7e1a7f1539f12027f28b23ec9f3d8",
+                    "0x46117762b54",
+                    "0x0"
+                ],
+                "call_type": "CALL",
+                "class_hash": "0xd0e183745e9dae3e4e78a8ffedcce0903fc4900beace4e0abf192d4c202da3",
+                "selector": "0x83afd3f4caedc6eebf44246fe54e38c95e3179a5ec9ea81740eca5b482d12e",
+                "entry_point_type": "EXTERNAL",
+                "result": [
+                    "0x1"
+                ],
+                "failed": false,
+                "execution_resources": {
+                    "n_steps": 589,
+                    "builtin_instance_counter": {
+                        "pedersen_builtin": 4,
+                        "range_check_builtin": 21
+                    },
+                    "n_memory_holes": 57
+                },
+                "internal_calls": [
+                    {
+                        "caller_address": "0x70503f026c7af73cfd2b007fe650e8c310256e9674ac4e42797c291edca5e84",
+                        "contract_address": "0x49d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7",
+                        "calldata": [
+                            "0x1176a1bd84444c89232ec27754698e5d2e7e1a7f1539f12027f28b23ec9f3d8",
+                            "0x46117762b54",
+                            "0x0"
+                        ],
+                        "call_type": "DELEGATE",
+                        "class_hash": "0x1b661756bf7d16210fc611626e1af4569baa1781ffc964bd018f4585ae241c1",
+                        "selector": "0x83afd3f4caedc6eebf44246fe54e38c95e3179a5ec9ea81740eca5b482d12e",
+                        "entry_point_type": "EXTERNAL",
+                        "result": [
+                            "0x1"
+                        ],
+                        "failed": false,
+                        "execution_resources": {
+                            "n_steps": 529,
+                            "builtin_instance_counter": {
+                                "range_check_builtin": 21,
+                                "pedersen_builtin": 4
+                            },
+                            "n_memory_holes": 57
+                        },
+                        "internal_calls": [],
+                        "events": [
+                            {
+                                "order": 0,
+                                "keys": [
+                                    "0x99cd8bde557814842a3121e8ddfd433a539b8c9f14bf31ebf108d12e6196e9"
+                                ],
+                                "data": [
+                                    "0x70503f026c7af73cfd2b007fe650e8c310256e9674ac4e42797c291edca5e84",
+                                    "0x1176a1bd84444c89232ec27754698e5d2e7e1a7f1539f12027f28b23ec9f3d8",
+                                    "0x46117762b54",
+                                    "0x0"
+                                ]
+                            }
+                        ],
+                        "messages": []
+                    }
+                ],
+                "events": [],
+                "messages": []
+            },
+            "signature": [
+                "0x34644638bb4f22fafa606207d3117e6284645d465dc3936d449e4aeb9d3caea",
+                "0x69ed84935cf28e03a5a88366b525529fa7ee6a51795827cdcd44c8d7c80316b"
+            ],
+            "transaction_hash": "0x27a335af75e13127335cc4fd19a815c89920a33378b14573d6b813ae942bb93"
+        },
+        {
+            "validate_invocation": {
+                "caller_address": "0x0",
+                "contract_address": "0x70503f026c7af73cfd2b007fe650e8c310256e9674ac4e42797c291edca5e84",
+                "calldata": [
+                    "0x348f560344334951bcbccd27aff05a9f6bedeaefc36315fe20e842163adae3d"
+                ],
+                "call_type": "CALL",
+                "class_hash": "0x903752516de5c04fe91600ca6891e325278b2dfc54880ae11a809abb364844",
+                "selector": "0x289da278a8dc833409cabfdad1581e8e7d40e42dcaed693fa4008dcdb4963b3",
+                "entry_point_type": "EXTERNAL",
+                "result": [
+                    "0x56414c4944"
+                ],
+                "failed": false,
+                "execution_resources": {
+                    "n_steps": 510,
+                    "builtin_instance_counter": {
+                        "ec_op_builtin": 3,
+                        "range_check_builtin": 10
+                    },
+                    "n_memory_holes": 4
+                },
+                "internal_calls": [],
+                "events": [],
+                "messages": []
+            },
+            "fee_transfer_invocation": {
+                "caller_address": "0x70503f026c7af73cfd2b007fe650e8c310256e9674ac4e42797c291edca5e84",
+                "contract_address": "0x49d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7",
+                "calldata": [
+                    "0x1176a1bd84444c89232ec27754698e5d2e7e1a7f1539f12027f28b23ec9f3d8",
+                    "0x3b98bab356d",
+                    "0x0"
+                ],
+                "call_type": "CALL",
+                "class_hash": "0xd0e183745e9dae3e4e78a8ffedcce0903fc4900beace4e0abf192d4c202da3",
+                "selector": "0x83afd3f4caedc6eebf44246fe54e38c95e3179a5ec9ea81740eca5b482d12e",
+                "entry_point_type": "EXTERNAL",
+                "result": [
+                    "0x1"
+                ],
+                "failed": false,
+                "execution_resources": {
+                    "n_steps": 589,
+                    "builtin_instance_counter": {
+                        "pedersen_builtin": 4,
+                        "range_check_builtin": 21
+                    },
+                    "n_memory_holes": 57
+                },
+                "internal_calls": [
+                    {
+                        "caller_address": "0x70503f026c7af73cfd2b007fe650e8c310256e9674ac4e42797c291edca5e84",
+                        "contract_address": "0x49d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7",
+                        "calldata": [
+                            "0x1176a1bd84444c89232ec27754698e5d2e7e1a7f1539f12027f28b23ec9f3d8",
+                            "0x3b98bab356d",
+                            "0x0"
+                        ],
+                        "call_type": "DELEGATE",
+                        "class_hash": "0x1b661756bf7d16210fc611626e1af4569baa1781ffc964bd018f4585ae241c1",
+                        "selector": "0x83afd3f4caedc6eebf44246fe54e38c95e3179a5ec9ea81740eca5b482d12e",
+                        "entry_point_type": "EXTERNAL",
+                        "result": [
+                            "0x1"
+                        ],
+                        "failed": false,
+                        "execution_resources": {
+                            "n_steps": 529,
+                            "builtin_instance_counter": {
+                                "range_check_builtin": 21,
+                                "pedersen_builtin": 4
+                            },
+                            "n_memory_holes": 57
+                        },
+                        "internal_calls": [],
+                        "events": [
+                            {
+                                "order": 0,
+                                "keys": [
+                                    "0x99cd8bde557814842a3121e8ddfd433a539b8c9f14bf31ebf108d12e6196e9"
+                                ],
+                                "data": [
+                                    "0x70503f026c7af73cfd2b007fe650e8c310256e9674ac4e42797c291edca5e84",
+                                    "0x1176a1bd84444c89232ec27754698e5d2e7e1a7f1539f12027f28b23ec9f3d8",
+                                    "0x3b98bab356d",
+                                    "0x0"
+                                ]
+                            }
+                        ],
+                        "messages": []
+                    }
+                ],
+                "events": [],
+                "messages": []
+            },
+            "signature": [
+                "0x1bc34579026b5ab66ac85f72cc43ca567850707df911801763478824662230d",
+                "0x30c15b5302af57bbdc47d07b454f779c70d31a0dbdc06315605dc6e89c86761"
+            ],
+            "transaction_hash": "0x147298203237faa45ecea2c15c93576064559ec36d065273519d4e363845784"
+        },
+        {
+            "validate_invocation": {
+                "caller_address": "0x0",
+                "contract_address": "0x70503f026c7af73cfd2b007fe650e8c310256e9674ac4e42797c291edca5e84",
+                "calldata": [
+                    "0x1",
+                    "0x41a78e741e5af2fec34b695679bc6891742439f7afb8484ecd7766661ad02bf",
+                    "0x1987cbd17808b9a23693d4de7e246a443cfe37e6e7fbaeabd7d7e6532b07c3d",
+                    "0x4",
+                    "0x348f560344334951bcbccd27aff05a9f6bedeaefc36315fe20e842163adae3d",
+                    "0x67b93aa39a05b7a3f5125f6ffde049894517961eeaf662efd58ded5eca34bc6",
+                    "0x1",
+                    "0x0"
+                ],
+                "call_type": "CALL",
+                "class_hash": "0x903752516de5c04fe91600ca6891e325278b2dfc54880ae11a809abb364844",
+                "selector": "0x162da33a4585851fe8d3af3c2a9c60b557814e221e0d4f30ff0b2189d9c7775",
+                "entry_point_type": "EXTERNAL",
+                "result": [
+                    "0x56414c4944"
+                ],
+                "failed": false,
+                "execution_resources": {
+                    "n_steps": 895,
+                    "builtin_instance_counter": {
+                        "range_check_builtin": 20,
+                        "ec_op_builtin": 3
+                    },
+                    "n_memory_holes": 5
+                },
+                "internal_calls": [],
+                "events": [],
+                "messages": []
+            },
+            "function_invocation": {
+                "caller_address": "0x0",
+                "contract_address": "0x70503f026c7af73cfd2b007fe650e8c310256e9674ac4e42797c291edca5e84",
+                "calldata": [
+                    "0x1",
+                    "0x41a78e741e5af2fec34b695679bc6891742439f7afb8484ecd7766661ad02bf",
+                    "0x1987cbd17808b9a23693d4de7e246a443cfe37e6e7fbaeabd7d7e6532b07c3d",
+                    "0x4",
+                    "0x348f560344334951bcbccd27aff05a9f6bedeaefc36315fe20e842163adae3d",
+                    "0x67b93aa39a05b7a3f5125f6ffde049894517961eeaf662efd58ded5eca34bc6",
+                    "0x1",
+                    "0x0"
+                ],
+                "call_type": "CALL",
+                "class_hash": "0x903752516de5c04fe91600ca6891e325278b2dfc54880ae11a809abb364844",
+                "selector": "0x15d40a3d6ca2ac30f4031e42be28da9b056fef9bb7357ac5e85627ee876e5ad",
+                "entry_point_type": "EXTERNAL",
+                "result": [
+                    "0x1",
+                    "0x1",
+                    "0x9459c8cb7424a2946e6bcf7bc204e349a2865f84f2ae75586ada2897d74c4e"
+                ],
+                "failed": false,
+                "execution_resources": {
+                    "n_steps": 987,
+                    "builtin_instance_counter": {
+                        "pedersen_builtin": 1,
+                        "range_check_builtin": 20
+                    },
+                    "n_memory_holes": 5
+                },
+                "internal_calls": [
+                    {
+                        "caller_address": "0x70503f026c7af73cfd2b007fe650e8c310256e9674ac4e42797c291edca5e84",
+                        "contract_address": "0x41a78e741e5af2fec34b695679bc6891742439f7afb8484ecd7766661ad02bf",
+                        "calldata": [
+                            "0x348f560344334951bcbccd27aff05a9f6bedeaefc36315fe20e842163adae3d",
+                            "0x67b93aa39a05b7a3f5125f6ffde049894517961eeaf662efd58ded5eca34bc6",
+                            "0x1",
+                            "0x0"
+                        ],
+                        "call_type": "CALL",
+                        "class_hash": "0x7b3e05f48f0c69e4a65ce5e076a66271a527aff2c34ce1083ec6e1526997a69",
+                        "selector": "0x1987cbd17808b9a23693d4de7e246a443cfe37e6e7fbaeabd7d7e6532b07c3d",
+                        "entry_point_type": "EXTERNAL",
+                        "result": [
+                            "0x9459c8cb7424a2946e6bcf7bc204e349a2865f84f2ae75586ada2897d74c4e"
+                        ],
+                        "failed": false,
+                        "execution_resources": {
+                            "n_steps": 135,
+                            "builtin_instance_counter": {
+                                "range_check_builtin": 2,
+                                "pedersen_builtin": 1
+                            },
+                            "n_memory_holes": 2
+                        },
+                        "internal_calls": [
+                            {
+                                "caller_address": "0x41a78e741e5af2fec34b695679bc6891742439f7afb8484ecd7766661ad02bf",
+                                "contract_address": "0x9459c8cb7424a2946e6bcf7bc204e349a2865f84f2ae75586ada2897d74c4e",
+                                "calldata": [],
+                                "call_type": "CALL",
+                                "class_hash": "0x348f560344334951bcbccd27aff05a9f6bedeaefc36315fe20e842163adae3d",
+                                "selector": "0x28ffe4ff0f226a9107253e17a904099aa4f63a02a5621de0576e5aa71bc5194",
+                                "entry_point_type": "CONSTRUCTOR",
+                                "result": [],
+                                "failed": false,
+                                "execution_resources": {
+                                    "n_steps": 0,
+                                    "builtin_instance_counter": {},
+                                    "n_memory_holes": 0
+                                },
+                                "internal_calls": [],
+                                "events": [],
+                                "messages": []
+                            }
+                        ],
+                        "events": [
+                            {
+                                "order": 0,
+                                "keys": [
+                                    "0x26b160f10156dea0639bec90696772c640b9706a47f5b8c52ea1abe5858b34d"
+                                ],
+                                "data": [
+                                    "0x9459c8cb7424a2946e6bcf7bc204e349a2865f84f2ae75586ada2897d74c4e",
+                                    "0x70503f026c7af73cfd2b007fe650e8c310256e9674ac4e42797c291edca5e84",
+                                    "0x1",
+                                    "0x348f560344334951bcbccd27aff05a9f6bedeaefc36315fe20e842163adae3d",
+                                    "0x0",
+                                    "0x67b93aa39a05b7a3f5125f6ffde049894517961eeaf662efd58ded5eca34bc6"
+                                ]
+                            }
+                        ],
+                        "messages": []
+                    }
+                ],
+                "events": [],
+                "messages": []
+            },
+            "fee_transfer_invocation": {
+                "caller_address": "0x70503f026c7af73cfd2b007fe650e8c310256e9674ac4e42797c291edca5e84",
+                "contract_address": "0x49d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7",
+                "calldata": [
+                    "0x1176a1bd84444c89232ec27754698e5d2e7e1a7f1539f12027f28b23ec9f3d8",
+                    "0x460d59359bf",
+                    "0x0"
+                ],
+                "call_type": "CALL",
+                "class_hash": "0xd0e183745e9dae3e4e78a8ffedcce0903fc4900beace4e0abf192d4c202da3",
+                "selector": "0x83afd3f4caedc6eebf44246fe54e38c95e3179a5ec9ea81740eca5b482d12e",
+                "entry_point_type": "EXTERNAL",
+                "result": [
+                    "0x1"
+                ],
+                "failed": false,
+                "execution_resources": {
+                    "n_steps": 589,
+                    "builtin_instance_counter": {
+                        "range_check_builtin": 21,
+                        "pedersen_builtin": 4
+                    },
+                    "n_memory_holes": 57
+                },
+                "internal_calls": [
+                    {
+                        "caller_address": "0x70503f026c7af73cfd2b007fe650e8c310256e9674ac4e42797c291edca5e84",
+                        "contract_address": "0x49d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7",
+                        "calldata": [
+                            "0x1176a1bd84444c89232ec27754698e5d2e7e1a7f1539f12027f28b23ec9f3d8",
+                            "0x460d59359bf",
+                            "0x0"
+                        ],
+                        "call_type": "DELEGATE",
+                        "class_hash": "0x1b661756bf7d16210fc611626e1af4569baa1781ffc964bd018f4585ae241c1",
+                        "selector": "0x83afd3f4caedc6eebf44246fe54e38c95e3179a5ec9ea81740eca5b482d12e",
+                        "entry_point_type": "EXTERNAL",
+                        "result": [
+                            "0x1"
+                        ],
+                        "failed": false,
+                        "execution_resources": {
+                            "n_steps": 529,
+                            "builtin_instance_counter": {
+                                "range_check_builtin": 21,
+                                "pedersen_builtin": 4
+                            },
+                            "n_memory_holes": 57
+                        },
+                        "internal_calls": [],
+                        "events": [
+                            {
+                                "order": 0,
+                                "keys": [
+                                    "0x99cd8bde557814842a3121e8ddfd433a539b8c9f14bf31ebf108d12e6196e9"
+                                ],
+                                "data": [
+                                    "0x70503f026c7af73cfd2b007fe650e8c310256e9674ac4e42797c291edca5e84",
+                                    "0x1176a1bd84444c89232ec27754698e5d2e7e1a7f1539f12027f28b23ec9f3d8",
+                                    "0x460d59359bf",
+                                    "0x0"
+                                ]
+                            }
+                        ],
+                        "messages": []
+                    }
+                ],
+                "events": [],
+                "messages": []
+            },
+            "signature": [
+                "0x7ca46c95542250ef892937a315962248964669258a2f7f7067cbfe5ca87d94",
+                "0x7cea6c9fe582a294427a44b834f53a90d590fa713c52639af65d9f441c0a54d"
+            ],
+            "transaction_hash": "0x741c8e45a306bb5a88c0c56150bc063b9976f94d947b42589e1683ce08b2d7f"
+        },
+        {
+            "validate_invocation": {
+                "caller_address": "0x0",
+                "contract_address": "0x70503f026c7af73cfd2b007fe650e8c310256e9674ac4e42797c291edca5e84",
+                "calldata": [
+                    "0x1",
+                    "0x41a78e741e5af2fec34b695679bc6891742439f7afb8484ecd7766661ad02bf",
+                    "0x1987cbd17808b9a23693d4de7e246a443cfe37e6e7fbaeabd7d7e6532b07c3d",
+                    "0x4",
+                    "0x2cbe2e8145b35db6fbb61a8697385f81f16b8fb294b2d88ec7400bfc7edcbda",
+                    "0x79bc1b65eecf7c7072c525668db7e06e39c6c321ab3e32f77df0cae4740d07f",
+                    "0x1",
+                    "0x0"
+                ],
+                "call_type": "CALL",
+                "class_hash": "0x903752516de5c04fe91600ca6891e325278b2dfc54880ae11a809abb364844",
+                "selector": "0x162da33a4585851fe8d3af3c2a9c60b557814e221e0d4f30ff0b2189d9c7775",
+                "entry_point_type": "EXTERNAL",
+                "result": [
+                    "0x56414c4944"
+                ],
+                "failed": false,
+                "execution_resources": {
+                    "n_steps": 895,
+                    "builtin_instance_counter": {
+                        "ec_op_builtin": 3,
+                        "range_check_builtin": 20
+                    },
+                    "n_memory_holes": 5
+                },
+                "internal_calls": [],
+                "events": [],
+                "messages": []
+            },
+            "function_invocation": {
+                "caller_address": "0x0",
+                "contract_address": "0x70503f026c7af73cfd2b007fe650e8c310256e9674ac4e42797c291edca5e84",
+                "calldata": [
+                    "0x1",
+                    "0x41a78e741e5af2fec34b695679bc6891742439f7afb8484ecd7766661ad02bf",
+                    "0x1987cbd17808b9a23693d4de7e246a443cfe37e6e7fbaeabd7d7e6532b07c3d",
+                    "0x4",
+                    "0x2cbe2e8145b35db6fbb61a8697385f81f16b8fb294b2d88ec7400bfc7edcbda",
+                    "0x79bc1b65eecf7c7072c525668db7e06e39c6c321ab3e32f77df0cae4740d07f",
+                    "0x1",
+                    "0x0"
+                ],
+                "call_type": "CALL",
+                "class_hash": "0x903752516de5c04fe91600ca6891e325278b2dfc54880ae11a809abb364844",
+                "selector": "0x15d40a3d6ca2ac30f4031e42be28da9b056fef9bb7357ac5e85627ee876e5ad",
+                "entry_point_type": "EXTERNAL",
+                "result": [
+                    "0x1",
+                    "0x1",
+                    "0x4b41f0be8d60cce826dc46185b8934f86b4e5d848555c069f04aaa55f978117"
+                ],
+                "failed": false,
+                "execution_resources": {
+                    "n_steps": 1012,
+                    "builtin_instance_counter": {
+                        "range_check_builtin": 22,
+                        "pedersen_builtin": 1
+                    },
+                    "n_memory_holes": 5
+                },
+                "internal_calls": [
+                    {
+                        "caller_address": "0x70503f026c7af73cfd2b007fe650e8c310256e9674ac4e42797c291edca5e84",
+                        "contract_address": "0x41a78e741e5af2fec34b695679bc6891742439f7afb8484ecd7766661ad02bf",
+                        "calldata": [
+                            "0x2cbe2e8145b35db6fbb61a8697385f81f16b8fb294b2d88ec7400bfc7edcbda",
+                            "0x79bc1b65eecf7c7072c525668db7e06e39c6c321ab3e32f77df0cae4740d07f",
+                            "0x1",
+                            "0x0"
+                        ],
+                        "call_type": "CALL",
+                        "class_hash": "0x7b3e05f48f0c69e4a65ce5e076a66271a527aff2c34ce1083ec6e1526997a69",
+                        "selector": "0x1987cbd17808b9a23693d4de7e246a443cfe37e6e7fbaeabd7d7e6532b07c3d",
+                        "entry_point_type": "EXTERNAL",
+                        "result": [
+                            "0x4b41f0be8d60cce826dc46185b8934f86b4e5d848555c069f04aaa55f978117"
+                        ],
+                        "failed": false,
+                        "execution_resources": {
+                            "n_steps": 160,
+                            "builtin_instance_counter": {
+                                "range_check_builtin": 4,
+                                "pedersen_builtin": 1
+                            },
+                            "n_memory_holes": 2
+                        },
+                        "internal_calls": [
+                            {
+                                "caller_address": "0x41a78e741e5af2fec34b695679bc6891742439f7afb8484ecd7766661ad02bf",
+                                "contract_address": "0x4b41f0be8d60cce826dc46185b8934f86b4e5d848555c069f04aaa55f978117",
+                                "calldata": [],
+                                "call_type": "CALL",
+                                "class_hash": "0x2cbe2e8145b35db6fbb61a8697385f81f16b8fb294b2d88ec7400bfc7edcbda",
+                                "selector": "0x28ffe4ff0f226a9107253e17a904099aa4f63a02a5621de0576e5aa71bc5194",
+                                "entry_point_type": "CONSTRUCTOR",
+                                "result": [],
+                                "failed": false,
+                                "execution_resources": {
+                                    "n_steps": 25,
+                                    "builtin_instance_counter": {
+                                        "range_check_builtin": 2
+                                    },
+                                    "n_memory_holes": 0
+                                },
+                                "internal_calls": [],
+                                "events": [],
+                                "messages": []
+                            }
+                        ],
+                        "events": [
+                            {
+                                "order": 0,
+                                "keys": [
+                                    "0x26b160f10156dea0639bec90696772c640b9706a47f5b8c52ea1abe5858b34d"
+                                ],
+                                "data": [
+                                    "0x4b41f0be8d60cce826dc46185b8934f86b4e5d848555c069f04aaa55f978117",
+                                    "0x70503f026c7af73cfd2b007fe650e8c310256e9674ac4e42797c291edca5e84",
+                                    "0x1",
+                                    "0x2cbe2e8145b35db6fbb61a8697385f81f16b8fb294b2d88ec7400bfc7edcbda",
+                                    "0x0",
+                                    "0x79bc1b65eecf7c7072c525668db7e06e39c6c321ab3e32f77df0cae4740d07f"
+                                ]
+                            }
+                        ],
+                        "messages": []
+                    }
+                ],
+                "events": [],
+                "messages": []
+            },
+            "fee_transfer_invocation": {
+                "caller_address": "0x70503f026c7af73cfd2b007fe650e8c310256e9674ac4e42797c291edca5e84",
+                "contract_address": "0x49d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7",
+                "calldata": [
+                    "0x1176a1bd84444c89232ec27754698e5d2e7e1a7f1539f12027f28b23ec9f3d8",
+                    "0x46117762b54",
+                    "0x0"
+                ],
+                "call_type": "CALL",
+                "class_hash": "0xd0e183745e9dae3e4e78a8ffedcce0903fc4900beace4e0abf192d4c202da3",
+                "selector": "0x83afd3f4caedc6eebf44246fe54e38c95e3179a5ec9ea81740eca5b482d12e",
+                "entry_point_type": "EXTERNAL",
+                "result": [
+                    "0x1"
+                ],
+                "failed": false,
+                "execution_resources": {
+                    "n_steps": 589,
+                    "builtin_instance_counter": {
+                        "pedersen_builtin": 4,
+                        "range_check_builtin": 21
+                    },
+                    "n_memory_holes": 57
+                },
+                "internal_calls": [
+                    {
+                        "caller_address": "0x70503f026c7af73cfd2b007fe650e8c310256e9674ac4e42797c291edca5e84",
+                        "contract_address": "0x49d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7",
+                        "calldata": [
+                            "0x1176a1bd84444c89232ec27754698e5d2e7e1a7f1539f12027f28b23ec9f3d8",
+                            "0x46117762b54",
+                            "0x0"
+                        ],
+                        "call_type": "DELEGATE",
+                        "class_hash": "0x1b661756bf7d16210fc611626e1af4569baa1781ffc964bd018f4585ae241c1",
+                        "selector": "0x83afd3f4caedc6eebf44246fe54e38c95e3179a5ec9ea81740eca5b482d12e",
+                        "entry_point_type": "EXTERNAL",
+                        "result": [
+                            "0x1"
+                        ],
+                        "failed": false,
+                        "execution_resources": {
+                            "n_steps": 529,
+                            "builtin_instance_counter": {
+                                "range_check_builtin": 21,
+                                "pedersen_builtin": 4
+                            },
+                            "n_memory_holes": 57
+                        },
+                        "internal_calls": [],
+                        "events": [
+                            {
+                                "order": 0,
+                                "keys": [
+                                    "0x99cd8bde557814842a3121e8ddfd433a539b8c9f14bf31ebf108d12e6196e9"
+                                ],
+                                "data": [
+                                    "0x70503f026c7af73cfd2b007fe650e8c310256e9674ac4e42797c291edca5e84",
+                                    "0x1176a1bd84444c89232ec27754698e5d2e7e1a7f1539f12027f28b23ec9f3d8",
+                                    "0x46117762b54",
+                                    "0x0"
+                                ]
+                            }
+                        ],
+                        "messages": []
+                    }
+                ],
+                "events": [],
+                "messages": []
+            },
+            "signature": [
+                "0x5fabc46404d4d67b7781647e42b500c920a5d2693a85d0796fbf2af3d883dea",
+                "0x7937e5a14fedc673100f8fbc5805eb0e6d6717ee08bb6798269f23ff14b0144"
+            ],
+            "transaction_hash": "0x49ad61002cff7597291c5004d8ab9c4bc9e2ba9f35d9d202f5bf48de801faf5"
+        },
+        {
+            "validate_invocation": {
+                "caller_address": "0x0",
+                "contract_address": "0x70503f026c7af73cfd2b007fe650e8c310256e9674ac4e42797c291edca5e84",
+                "calldata": [
+                    "0x1",
+                    "0x45283160abd44efff6bf2b3ad40e556bfbcf623ce36ad395cf72b96678c2dab",
+                    "0x362398bec32bc0ebb411203221a35a0301193a96f317ebe5e40be9f60d15320",
+                    "0x1",
+                    "0x64"
+                ],
+                "call_type": "CALL",
+                "class_hash": "0x903752516de5c04fe91600ca6891e325278b2dfc54880ae11a809abb364844",
+                "selector": "0x162da33a4585851fe8d3af3c2a9c60b557814e221e0d4f30ff0b2189d9c7775",
+                "entry_point_type": "EXTERNAL",
+                "result": [
+                    "0x56414c4944"
+                ],
+                "failed": false,
+                "execution_resources": {
+                    "n_steps": 754,
+                    "builtin_instance_counter": {
+                        "ec_op_builtin": 3,
+                        "range_check_builtin": 17
+                    },
+                    "n_memory_holes": 5
+                },
+                "internal_calls": [],
+                "events": [],
+                "messages": []
+            },
+            "function_invocation": {
+                "caller_address": "0x0",
+                "contract_address": "0x70503f026c7af73cfd2b007fe650e8c310256e9674ac4e42797c291edca5e84",
+                "calldata": [
+                    "0x1",
+                    "0x45283160abd44efff6bf2b3ad40e556bfbcf623ce36ad395cf72b96678c2dab",
+                    "0x362398bec32bc0ebb411203221a35a0301193a96f317ebe5e40be9f60d15320",
+                    "0x1",
+                    "0x64"
+                ],
+                "call_type": "CALL",
+                "class_hash": "0x903752516de5c04fe91600ca6891e325278b2dfc54880ae11a809abb364844",
+                "selector": "0x15d40a3d6ca2ac30f4031e42be28da9b056fef9bb7357ac5e85627ee876e5ad",
+                "entry_point_type": "EXTERNAL",
+                "result": [
+                    "0x1",
+                    "0x0"
+                ],
+                "failed": false,
+                "execution_resources": {
+                    "n_steps": 788,
+                    "builtin_instance_counter": {
+                        "range_check_builtin": 16
+                    },
+                    "n_memory_holes": 3
+                },
+                "internal_calls": [
+                    {
+                        "caller_address": "0x70503f026c7af73cfd2b007fe650e8c310256e9674ac4e42797c291edca5e84",
+                        "contract_address": "0x45283160abd44efff6bf2b3ad40e556bfbcf623ce36ad395cf72b96678c2dab",
+                        "calldata": [
+                            "0x64"
+                        ],
+                        "call_type": "CALL",
+                        "class_hash": "0x2cbe2e8145b35db6fbb61a8697385f81f16b8fb294b2d88ec7400bfc7edcbda",
+                        "selector": "0x362398bec32bc0ebb411203221a35a0301193a96f317ebe5e40be9f60d15320",
+                        "entry_point_type": "EXTERNAL",
+                        "result": [],
+                        "failed": false,
+                        "execution_resources": {
+                            "n_steps": 120,
+                            "builtin_instance_counter": {
+                                "range_check_builtin": 2
+                            },
+                            "n_memory_holes": 0
+                        },
+                        "internal_calls": [],
+                        "events": [],
+                        "messages": []
+                    }
+                ],
+                "events": [],
+                "messages": []
+            },
+            "fee_transfer_invocation": {
+                "caller_address": "0x70503f026c7af73cfd2b007fe650e8c310256e9674ac4e42797c291edca5e84",
+                "contract_address": "0x49d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7",
+                "calldata": [
+                    "0x1176a1bd84444c89232ec27754698e5d2e7e1a7f1539f12027f28b23ec9f3d8",
+                    "0x4fb412e8ef7",
+                    "0x0"
+                ],
+                "call_type": "CALL",
+                "class_hash": "0xd0e183745e9dae3e4e78a8ffedcce0903fc4900beace4e0abf192d4c202da3",
+                "selector": "0x83afd3f4caedc6eebf44246fe54e38c95e3179a5ec9ea81740eca5b482d12e",
+                "entry_point_type": "EXTERNAL",
+                "result": [
+                    "0x1"
+                ],
+                "failed": false,
+                "execution_resources": {
+                    "n_steps": 589,
+                    "builtin_instance_counter": {
+                        "pedersen_builtin": 4,
+                        "range_check_builtin": 21
+                    },
+                    "n_memory_holes": 57
+                },
+                "internal_calls": [
+                    {
+                        "caller_address": "0x70503f026c7af73cfd2b007fe650e8c310256e9674ac4e42797c291edca5e84",
+                        "contract_address": "0x49d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7",
+                        "calldata": [
+                            "0x1176a1bd84444c89232ec27754698e5d2e7e1a7f1539f12027f28b23ec9f3d8",
+                            "0x4fb412e8ef7",
+                            "0x0"
+                        ],
+                        "call_type": "DELEGATE",
+                        "class_hash": "0x1b661756bf7d16210fc611626e1af4569baa1781ffc964bd018f4585ae241c1",
+                        "selector": "0x83afd3f4caedc6eebf44246fe54e38c95e3179a5ec9ea81740eca5b482d12e",
+                        "entry_point_type": "EXTERNAL",
+                        "result": [
+                            "0x1"
+                        ],
+                        "failed": false,
+                        "execution_resources": {
+                            "n_steps": 529,
+                            "builtin_instance_counter": {
+                                "range_check_builtin": 21,
+                                "pedersen_builtin": 4
+                            },
+                            "n_memory_holes": 57
+                        },
+                        "internal_calls": [],
+                        "events": [
+                            {
+                                "order": 0,
+                                "keys": [
+                                    "0x99cd8bde557814842a3121e8ddfd433a539b8c9f14bf31ebf108d12e6196e9"
+                                ],
+                                "data": [
+                                    "0x70503f026c7af73cfd2b007fe650e8c310256e9674ac4e42797c291edca5e84",
+                                    "0x1176a1bd84444c89232ec27754698e5d2e7e1a7f1539f12027f28b23ec9f3d8",
+                                    "0x4fb412e8ef7",
+                                    "0x0"
+                                ]
+                            }
+                        ],
+                        "messages": []
+                    }
+                ],
+                "events": [],
+                "messages": []
+            },
+            "signature": [
+                "0x68648c6977feff1a2c63308c68f037a38baca2992e93200d9bd34b5906b9806",
+                "0x624af118a42dbb074568f9c990a59dbf9c287c6be557d3dd49921dbaea61dca"
+            ],
+            "transaction_hash": "0x4cc8c57cfd5f2396d87554de709988146317505e432bd0b3036bdadcdb0d051"
+        },
+        {
+            "validate_invocation": {
+                "caller_address": "0x0",
+                "contract_address": "0x70503f026c7af73cfd2b007fe650e8c310256e9674ac4e42797c291edca5e84",
+                "calldata": [
+                    "0x1",
+                    "0x45283160abd44efff6bf2b3ad40e556bfbcf623ce36ad395cf72b96678c2dab",
+                    "0x362398bec32bc0ebb411203221a35a0301193a96f317ebe5e40be9f60d15320",
+                    "0x1",
+                    "0x64"
+                ],
+                "call_type": "CALL",
+                "class_hash": "0x903752516de5c04fe91600ca6891e325278b2dfc54880ae11a809abb364844",
+                "selector": "0x162da33a4585851fe8d3af3c2a9c60b557814e221e0d4f30ff0b2189d9c7775",
+                "entry_point_type": "EXTERNAL",
+                "result": [
+                    "0x56414c4944"
+                ],
+                "failed": false,
+                "execution_resources": {
+                    "n_steps": 754,
+                    "builtin_instance_counter": {
+                        "ec_op_builtin": 3,
+                        "range_check_builtin": 17
+                    },
+                    "n_memory_holes": 5
+                },
+                "internal_calls": [],
+                "events": [],
+                "messages": []
+            },
+            "function_invocation": {
+                "caller_address": "0x0",
+                "contract_address": "0x70503f026c7af73cfd2b007fe650e8c310256e9674ac4e42797c291edca5e84",
+                "calldata": [
+                    "0x1",
+                    "0x45283160abd44efff6bf2b3ad40e556bfbcf623ce36ad395cf72b96678c2dab",
+                    "0x362398bec32bc0ebb411203221a35a0301193a96f317ebe5e40be9f60d15320",
+                    "0x1",
+                    "0x64"
+                ],
+                "call_type": "CALL",
+                "class_hash": "0x903752516de5c04fe91600ca6891e325278b2dfc54880ae11a809abb364844",
+                "selector": "0x15d40a3d6ca2ac30f4031e42be28da9b056fef9bb7357ac5e85627ee876e5ad",
+                "entry_point_type": "EXTERNAL",
+                "result": [
+                    "0x1",
+                    "0x0"
+                ],
+                "failed": false,
+                "execution_resources": {
+                    "n_steps": 788,
+                    "builtin_instance_counter": {
+                        "range_check_builtin": 16
+                    },
+                    "n_memory_holes": 3
+                },
+                "internal_calls": [
+                    {
+                        "caller_address": "0x70503f026c7af73cfd2b007fe650e8c310256e9674ac4e42797c291edca5e84",
+                        "contract_address": "0x45283160abd44efff6bf2b3ad40e556bfbcf623ce36ad395cf72b96678c2dab",
+                        "calldata": [
+                            "0x64"
+                        ],
+                        "call_type": "CALL",
+                        "class_hash": "0x2cbe2e8145b35db6fbb61a8697385f81f16b8fb294b2d88ec7400bfc7edcbda",
+                        "selector": "0x362398bec32bc0ebb411203221a35a0301193a96f317ebe5e40be9f60d15320",
+                        "entry_point_type": "EXTERNAL",
+                        "result": [],
+                        "failed": false,
+                        "execution_resources": {
+                            "n_steps": 120,
+                            "builtin_instance_counter": {
+                                "range_check_builtin": 2
+                            },
+                            "n_memory_holes": 0
+                        },
+                        "internal_calls": [],
+                        "events": [],
+                        "messages": []
+                    }
+                ],
+                "events": [],
+                "messages": []
+            },
+            "fee_transfer_invocation": {
+                "caller_address": "0x70503f026c7af73cfd2b007fe650e8c310256e9674ac4e42797c291edca5e84",
+                "contract_address": "0x49d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7",
+                "calldata": [
+                    "0x1176a1bd84444c89232ec27754698e5d2e7e1a7f1539f12027f28b23ec9f3d8",
+                    "0x4fb412e8ef7",
+                    "0x0"
+                ],
+                "call_type": "CALL",
+                "class_hash": "0xd0e183745e9dae3e4e78a8ffedcce0903fc4900beace4e0abf192d4c202da3",
+                "selector": "0x83afd3f4caedc6eebf44246fe54e38c95e3179a5ec9ea81740eca5b482d12e",
+                "entry_point_type": "EXTERNAL",
+                "result": [
+                    "0x1"
+                ],
+                "failed": false,
+                "execution_resources": {
+                    "n_steps": 589,
+                    "builtin_instance_counter": {
+                        "range_check_builtin": 21,
+                        "pedersen_builtin": 4
+                    },
+                    "n_memory_holes": 57
+                },
+                "internal_calls": [
+                    {
+                        "caller_address": "0x70503f026c7af73cfd2b007fe650e8c310256e9674ac4e42797c291edca5e84",
+                        "contract_address": "0x49d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7",
+                        "calldata": [
+                            "0x1176a1bd84444c89232ec27754698e5d2e7e1a7f1539f12027f28b23ec9f3d8",
+                            "0x4fb412e8ef7",
+                            "0x0"
+                        ],
+                        "call_type": "DELEGATE",
+                        "class_hash": "0x1b661756bf7d16210fc611626e1af4569baa1781ffc964bd018f4585ae241c1",
+                        "selector": "0x83afd3f4caedc6eebf44246fe54e38c95e3179a5ec9ea81740eca5b482d12e",
+                        "entry_point_type": "EXTERNAL",
+                        "result": [
+                            "0x1"
+                        ],
+                        "failed": false,
+                        "execution_resources": {
+                            "n_steps": 529,
+                            "builtin_instance_counter": {
+                                "range_check_builtin": 21,
+                                "pedersen_builtin": 4
+                            },
+                            "n_memory_holes": 57
+                        },
+                        "internal_calls": [],
+                        "events": [
+                            {
+                                "order": 0,
+                                "keys": [
+                                    "0x99cd8bde557814842a3121e8ddfd433a539b8c9f14bf31ebf108d12e6196e9"
+                                ],
+                                "data": [
+                                    "0x70503f026c7af73cfd2b007fe650e8c310256e9674ac4e42797c291edca5e84",
+                                    "0x1176a1bd84444c89232ec27754698e5d2e7e1a7f1539f12027f28b23ec9f3d8",
+                                    "0x4fb412e8ef7",
+                                    "0x0"
+                                ]
+                            }
+                        ],
+                        "messages": []
+                    }
+                ],
+                "events": [],
+                "messages": []
+            },
+            "signature": [
+                "0x75d1779c928448abd6ed363ac77dab0d7ebd4249cdee7c8b213b18bd9083b90",
+                "0x6c4f65131033fc6c20add31c202d43e88e584e423bc0a71beeb1917bd34edea"
+            ],
+            "transaction_hash": "0x15c2858c6e5129547473db62415f4069916798e2f462f95eed3a1a802c9ec14"
+        },
+        {
+            "validate_invocation": {
+                "caller_address": "0x0",
+                "contract_address": "0x70503f026c7af73cfd2b007fe650e8c310256e9674ac4e42797c291edca5e84",
+                "calldata": [
+                    "0x1",
+                    "0x45283160abd44efff6bf2b3ad40e556bfbcf623ce36ad395cf72b96678c2dab",
+                    "0x20cbe051691c714b9bcc3f3a599bbd419b5b1c0b239544efddd99e94217317b",
+                    "0x1",
+                    "0xff"
+                ],
+                "call_type": "CALL",
+                "class_hash": "0x903752516de5c04fe91600ca6891e325278b2dfc54880ae11a809abb364844",
+                "selector": "0x162da33a4585851fe8d3af3c2a9c60b557814e221e0d4f30ff0b2189d9c7775",
+                "entry_point_type": "EXTERNAL",
+                "result": [
+                    "0x56414c4944"
+                ],
+                "failed": false,
+                "execution_resources": {
+                    "n_steps": 754,
+                    "builtin_instance_counter": {
+                        "ec_op_builtin": 3,
+                        "range_check_builtin": 17
+                    },
+                    "n_memory_holes": 5
+                },
+                "internal_calls": [],
+                "events": [],
+                "messages": []
+            },
+            "function_invocation": {
+                "caller_address": "0x0",
+                "contract_address": "0x70503f026c7af73cfd2b007fe650e8c310256e9674ac4e42797c291edca5e84",
+                "calldata": [
+                    "0x1",
+                    "0x45283160abd44efff6bf2b3ad40e556bfbcf623ce36ad395cf72b96678c2dab",
+                    "0x20cbe051691c714b9bcc3f3a599bbd419b5b1c0b239544efddd99e94217317b",
+                    "0x1",
+                    "0xff"
+                ],
+                "call_type": "CALL",
+                "class_hash": "0x903752516de5c04fe91600ca6891e325278b2dfc54880ae11a809abb364844",
+                "selector": "0x15d40a3d6ca2ac30f4031e42be28da9b056fef9bb7357ac5e85627ee876e5ad",
+                "entry_point_type": "EXTERNAL",
+                "result": [
+                    "0x1",
+                    "0x0"
+                ],
+                "failed": false,
+                "execution_resources": {
+                    "n_steps": 860,
+                    "builtin_instance_counter": {
+                        "range_check_builtin": 21
+                    },
+                    "n_memory_holes": 16
+                },
+                "internal_calls": [
+                    {
+                        "caller_address": "0x70503f026c7af73cfd2b007fe650e8c310256e9674ac4e42797c291edca5e84",
+                        "contract_address": "0x45283160abd44efff6bf2b3ad40e556bfbcf623ce36ad395cf72b96678c2dab",
+                        "calldata": [
+                            "0xff"
+                        ],
+                        "call_type": "CALL",
+                        "class_hash": "0x2cbe2e8145b35db6fbb61a8697385f81f16b8fb294b2d88ec7400bfc7edcbda",
+                        "selector": "0x20cbe051691c714b9bcc3f3a599bbd419b5b1c0b239544efddd99e94217317b",
+                        "entry_point_type": "EXTERNAL",
+                        "result": [],
+                        "failed": false,
+                        "execution_resources": {
+                            "n_steps": 192,
+                            "builtin_instance_counter": {
+                                "range_check_builtin": 7
+                            },
+                            "n_memory_holes": 13
+                        },
+                        "internal_calls": [],
+                        "events": [],
+                        "messages": []
+                    }
+                ],
+                "events": [],
+                "messages": []
+            },
+            "fee_transfer_invocation": {
+                "caller_address": "0x70503f026c7af73cfd2b007fe650e8c310256e9674ac4e42797c291edca5e84",
+                "contract_address": "0x49d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7",
+                "calldata": [
+                    "0x1176a1bd84444c89232ec27754698e5d2e7e1a7f1539f12027f28b23ec9f3d8",
+                    "0x4fb8311608c",
+                    "0x0"
+                ],
+                "call_type": "CALL",
+                "class_hash": "0xd0e183745e9dae3e4e78a8ffedcce0903fc4900beace4e0abf192d4c202da3",
+                "selector": "0x83afd3f4caedc6eebf44246fe54e38c95e3179a5ec9ea81740eca5b482d12e",
+                "entry_point_type": "EXTERNAL",
+                "result": [
+                    "0x1"
+                ],
+                "failed": false,
+                "execution_resources": {
+                    "n_steps": 589,
+                    "builtin_instance_counter": {
+                        "range_check_builtin": 21,
+                        "pedersen_builtin": 4
+                    },
+                    "n_memory_holes": 57
+                },
+                "internal_calls": [
+                    {
+                        "caller_address": "0x70503f026c7af73cfd2b007fe650e8c310256e9674ac4e42797c291edca5e84",
+                        "contract_address": "0x49d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7",
+                        "calldata": [
+                            "0x1176a1bd84444c89232ec27754698e5d2e7e1a7f1539f12027f28b23ec9f3d8",
+                            "0x4fb8311608c",
+                            "0x0"
+                        ],
+                        "call_type": "DELEGATE",
+                        "class_hash": "0x1b661756bf7d16210fc611626e1af4569baa1781ffc964bd018f4585ae241c1",
+                        "selector": "0x83afd3f4caedc6eebf44246fe54e38c95e3179a5ec9ea81740eca5b482d12e",
+                        "entry_point_type": "EXTERNAL",
+                        "result": [
+                            "0x1"
+                        ],
+                        "failed": false,
+                        "execution_resources": {
+                            "n_steps": 529,
+                            "builtin_instance_counter": {
+                                "pedersen_builtin": 4,
+                                "range_check_builtin": 21
+                            },
+                            "n_memory_holes": 57
+                        },
+                        "internal_calls": [],
+                        "events": [
+                            {
+                                "order": 0,
+                                "keys": [
+                                    "0x99cd8bde557814842a3121e8ddfd433a539b8c9f14bf31ebf108d12e6196e9"
+                                ],
+                                "data": [
+                                    "0x70503f026c7af73cfd2b007fe650e8c310256e9674ac4e42797c291edca5e84",
+                                    "0x1176a1bd84444c89232ec27754698e5d2e7e1a7f1539f12027f28b23ec9f3d8",
+                                    "0x4fb8311608c",
+                                    "0x0"
+                                ]
+                            }
+                        ],
+                        "messages": []
+                    }
+                ],
+                "events": [],
+                "messages": []
+            },
+            "signature": [
+                "0x2c00804c90efb85e1a41a518f4c200014d8a02f14ffae8ae0a657de7cddae42",
+                "0x71661a5475ba8b3e974c28680db7d230c35c312bd99dc3affad6005cd78ee1e"
+            ],
+            "transaction_hash": "0x552b84ae3b01fe925c3a8d58204882d343364e8f20369657c2295fae0b0745"
+        }
+    ]
+}

--- a/rpc/v6/adapters.go
+++ b/rpc/v6/adapters.go
@@ -245,22 +245,23 @@ func AdaptFeederBlockTrace(block *BlockWithTxs, blockTrace *starknet.BlockTrace)
 			trace.ValidateInvocation = utils.HeapPtr(AdaptFeederFunctionInvocation(val))
 		}
 
+		var fnInvocation *FunctionInvocation
 		if fct := feederTrace.FunctionInvocation; fct != nil {
-			fnInvocation := utils.HeapPtr(AdaptFeederFunctionInvocation(fct))
+			fnInvocation = utils.HeapPtr(AdaptFeederFunctionInvocation(fct))
+		}
 
-			switch block.Transactions[index].Type {
-			case TxnDeploy, TxnDeployAccount:
-				trace.ConstructorInvocation = fnInvocation
-			case TxnInvoke:
-				trace.ExecuteInvocation = new(ExecuteInvocation)
-				if feederTrace.RevertError != "" {
-					trace.ExecuteInvocation.RevertReason = feederTrace.RevertError
-				} else {
-					trace.ExecuteInvocation.FunctionInvocation = fnInvocation
-				}
-			case TxnL1Handler:
-				trace.FunctionInvocation = fnInvocation
+		switch trace.Type {
+		case TxnDeploy, TxnDeployAccount:
+			trace.ConstructorInvocation = fnInvocation
+		case TxnInvoke:
+			trace.ExecuteInvocation = new(ExecuteInvocation)
+			if feederTrace.RevertError != "" {
+				trace.ExecuteInvocation.RevertReason = feederTrace.RevertError
+			} else {
+				trace.ExecuteInvocation.FunctionInvocation = fnInvocation
 			}
+		case TxnL1Handler:
+			trace.FunctionInvocation = fnInvocation
 		}
 
 		adaptedTraces[index] = TracedBlockTransaction{

--- a/rpc/v6/trace_test.go
+++ b/rpc/v6/trace_test.go
@@ -410,7 +410,7 @@ func TestTraceTransaction(t *testing.T) {
 				CallType:       "CALL",
 				Result:         []felt.Felt{*utils.HexToFelt(t, "0x1")},
 				Calls: []rpc.FunctionInvocation{
-					rpc.FunctionInvocation{
+					{
 						ContractAddress:    *utils.HexToFelt(t, "0x49d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7"),
 						EntryPointSelector: utils.HexToFelt(t, "0x83afd3f4caedc6eebf44246fe54e38c95e3179a5ec9ea81740eca5b482d12e"),
 						Calldata: []felt.Felt{
@@ -425,7 +425,7 @@ func TestTraceTransaction(t *testing.T) {
 						Result:         []felt.Felt{*utils.HexToFelt(t, "0x1")},
 						Calls:          []rpc.FunctionInvocation{},
 						Events: []rpc.OrderedEvent{
-							rpc.OrderedEvent{
+							{
 								Order: 0,
 								Keys:  []*felt.Felt{utils.HexToFelt(t, "0x99cd8bde557814842a3121e8ddfd433a539b8c9f14bf31ebf108d12e6196e9")},
 								Data: []*felt.Felt{

--- a/rpc/v6/trace_test.go
+++ b/rpc/v6/trace_test.go
@@ -204,7 +204,7 @@ func TestFunctionInvocationMarshalling(t *testing.T) {
 	})
 }
 
-func TestTraceTransactionV0_6(t *testing.T) {
+func TestTraceTransaction(t *testing.T) {
 	mockCtrl := gomock.NewController(t)
 	t.Cleanup(mockCtrl.Finish)
 
@@ -343,6 +343,126 @@ func TestTraceTransactionV0_6(t *testing.T) {
 		trace, err := handler.TraceTransaction(context.Background(), *hash)
 		require.Nil(t, err)
 		assert.Equal(t, rpc.AdaptVMTransactionTrace(vmTrace), *trace)
+	})
+
+	t.Run("reverted INVOKE tx from feeder", func(t *testing.T) {
+		n := &utils.Sepolia
+
+		handler := rpc.New(mockReader, mockSyncReader, mockVM, "", n, utils.NewNopZapLogger())
+
+		client := feeder.NewTestClient(t, n)
+		handler.WithFeeder(client)
+		gateway := adaptfeeder.New(client)
+
+		// Tx at index 3 in the block
+		revertedTxHash := utils.HexToFelt(t, "0x2f00c7f28df2197196440747f97baa63d0851e3b0cfc2efedb6a88a7ef78cb1")
+
+		blockNumber := uint64(18)
+		blockHash := utils.HexToFelt(t, "0x5beb56c7d9a9fc066e695c3fc467f45532cace83d9979db4ccfd6b77ca476af")
+
+		mockReader.EXPECT().Receipt(revertedTxHash).Return(nil, blockHash, blockNumber, nil)
+		mockReader.EXPECT().BlockByHash(blockHash).DoAndReturn(func(_ *felt.Felt) (block *core.Block, err error) {
+			return gateway.BlockByNumber(context.Background(), blockNumber)
+		}).Times(2)
+
+		mockReader.EXPECT().L1Head().Return(&core.L1Head{
+			BlockNumber: 19, // Doesn't really matter for this test
+		}, nil)
+
+		expectedRevertedTrace := rpc.TransactionTrace{
+			Type: rpc.TxnInvoke,
+			ValidateInvocation: &rpc.FunctionInvocation{
+				ContractAddress:    *utils.HexToFelt(t, "0x70503f026c7af73cfd2b007fe650e8c310256e9674ac4e42797c291edca5e84"),
+				EntryPointSelector: utils.HexToFelt(t, "0x162da33a4585851fe8d3af3c2a9c60b557814e221e0d4f30ff0b2189d9c7775"),
+				Calldata: []felt.Felt{
+					*utils.HexToFelt(t, "0x1"),
+					*utils.HexToFelt(t, "0x7c687d151607710a7ec82ca5ab0ff2c48f52abd3b4a2773938a0cfef723fe6a"),
+					*utils.HexToFelt(t, "0x10b7e63d3ca05c9baffd985d3e1c3858d4dbf0759f066be0eaddc5d71c2cab5"),
+					*utils.HexToFelt(t, "0x1"),
+					*utils.HexToFelt(t, "0xa"),
+				},
+				CallerAddress:  *utils.HexToFelt(t, "0x0"),
+				ClassHash:      utils.HexToFelt(t, "0x903752516de5c04fe91600ca6891e325278b2dfc54880ae11a809abb364844"),
+				EntryPointType: "EXTERNAL",
+				CallType:       "CALL",
+				Result:         []felt.Felt{*utils.HexToFelt(t, "0x56414c4944")},
+				Calls:          []rpc.FunctionInvocation{},
+				Events:         []rpc.OrderedEvent{},
+				Messages:       []rpc.OrderedL2toL1Message{},
+				ExecutionResources: &rpc.ComputationResources{
+					Steps:       754,
+					MemoryHoles: 5,
+					RangeCheck:  17,
+					EcOp:        3,
+				},
+			},
+			FeeTransferInvocation: &rpc.FunctionInvocation{
+				ContractAddress:    *utils.HexToFelt(t, "0x49d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7"),
+				EntryPointSelector: utils.HexToFelt(t, "0x83afd3f4caedc6eebf44246fe54e38c95e3179a5ec9ea81740eca5b482d12e"),
+				Calldata: []felt.Felt{
+					*utils.HexToFelt(t, "0x1176a1bd84444c89232ec27754698e5d2e7e1a7f1539f12027f28b23ec9f3d8"),
+					*utils.HexToFelt(t, "0x2847291f968"),
+					*utils.HexToFelt(t, "0x0"),
+				},
+				CallerAddress:  *utils.HexToFelt(t, "0x70503f026c7af73cfd2b007fe650e8c310256e9674ac4e42797c291edca5e84"),
+				ClassHash:      utils.HexToFelt(t, "0xd0e183745e9dae3e4e78a8ffedcce0903fc4900beace4e0abf192d4c202da3"),
+				EntryPointType: "EXTERNAL",
+				CallType:       "CALL",
+				Result:         []felt.Felt{*utils.HexToFelt(t, "0x1")},
+				Calls: []rpc.FunctionInvocation{
+					rpc.FunctionInvocation{
+						ContractAddress:    *utils.HexToFelt(t, "0x49d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7"),
+						EntryPointSelector: utils.HexToFelt(t, "0x83afd3f4caedc6eebf44246fe54e38c95e3179a5ec9ea81740eca5b482d12e"),
+						Calldata: []felt.Felt{
+							*utils.HexToFelt(t, "0x1176a1bd84444c89232ec27754698e5d2e7e1a7f1539f12027f28b23ec9f3d8"),
+							*utils.HexToFelt(t, "0x2847291f968"),
+							*utils.HexToFelt(t, "0x0"),
+						},
+						CallerAddress:  *utils.HexToFelt(t, "0x70503f026c7af73cfd2b007fe650e8c310256e9674ac4e42797c291edca5e84"),
+						ClassHash:      utils.HexToFelt(t, "0x1b661756bf7d16210fc611626e1af4569baa1781ffc964bd018f4585ae241c1"),
+						EntryPointType: "EXTERNAL",
+						CallType:       "DELEGATE",
+						Result:         []felt.Felt{*utils.HexToFelt(t, "0x1")},
+						Calls:          []rpc.FunctionInvocation{},
+						Events: []rpc.OrderedEvent{
+							rpc.OrderedEvent{
+								Order: 0,
+								Keys:  []*felt.Felt{utils.HexToFelt(t, "0x99cd8bde557814842a3121e8ddfd433a539b8c9f14bf31ebf108d12e6196e9")},
+								Data: []*felt.Felt{
+									utils.HexToFelt(t, "0x70503f026c7af73cfd2b007fe650e8c310256e9674ac4e42797c291edca5e84"),
+									utils.HexToFelt(t, "0x1176a1bd84444c89232ec27754698e5d2e7e1a7f1539f12027f28b23ec9f3d8"),
+									utils.HexToFelt(t, "0x2847291f968"),
+									utils.HexToFelt(t, "0x0"),
+								},
+							},
+						},
+						Messages: []rpc.OrderedL2toL1Message{},
+						ExecutionResources: &rpc.ComputationResources{
+							Steps:       529,
+							MemoryHoles: 57,
+							Pedersen:    4,
+							RangeCheck:  21,
+						},
+					},
+				},
+				Events:   []rpc.OrderedEvent{},
+				Messages: []rpc.OrderedL2toL1Message{},
+				ExecutionResources: &rpc.ComputationResources{
+					Steps:       589,
+					MemoryHoles: 57,
+					Pedersen:    4,
+					RangeCheck:  21,
+				},
+			},
+			ExecuteInvocation: &rpc.ExecuteInvocation{
+				RevertReason: "Error in the called contract (0x070503f026c7af73cfd2b007fe650e8c310256e9674ac4e42797c291edca5e84):\nError at pc=0:4288:\nGot an exception while executing a hint: Custom Hint Error: Execution failed. Failure reason: 'Fatal'.\nCairo traceback (most recent call last):\nUnknown location (pc=0:67)\nUnknown location (pc=0:1997)\nUnknown location (pc=0:2729)\nUnknown location (pc=0:3577)\n",
+			},
+		}
+
+		trace, err := handler.TraceTransaction(context.Background(), *revertedTxHash)
+
+		require.Nil(t, err)
+		assert.Equal(t, expectedRevertedTrace, *trace)
 	})
 }
 
@@ -870,8 +990,8 @@ func TestAdaptFeederBlockTrace(t *testing.T) {
 					TransactionHash:       *new(felt.Felt).SetUint64(1),
 					FeeTransferInvocation: &starknet.FunctionInvocation{},
 					ValidateInvocation:    &starknet.FunctionInvocation{},
-					FunctionInvocation:    &starknet.FunctionInvocation{},
-					RevertError:           "some error",
+					// When revert error, feeder trace has no FunctionInvocation only RevertError is set
+					RevertError: "some error",
 				},
 			},
 		}

--- a/rpc/v7/adapters.go
+++ b/rpc/v7/adapters.go
@@ -122,22 +122,23 @@ func AdaptFeederBlockTrace(block *BlockWithTxs, blockTrace *starknet.BlockTrace)
 			trace.ValidateInvocation = utils.HeapPtr(rpcv6.AdaptFeederFunctionInvocation(val))
 		}
 
+		var fnInvocation *rpcv6.FunctionInvocation
 		if fct := feederTrace.FunctionInvocation; fct != nil {
-			fnInvocation := utils.HeapPtr(rpcv6.AdaptFeederFunctionInvocation(fct))
+			fnInvocation = utils.HeapPtr(rpcv6.AdaptFeederFunctionInvocation(fct))
+		}
 
-			switch block.Transactions[index].Type {
-			case TxnDeploy, TxnDeployAccount:
-				trace.ConstructorInvocation = fnInvocation
-			case TxnInvoke:
-				trace.ExecuteInvocation = new(rpcv6.ExecuteInvocation)
-				if feederTrace.RevertError != "" {
-					trace.ExecuteInvocation.RevertReason = feederTrace.RevertError
-				} else {
-					trace.ExecuteInvocation.FunctionInvocation = fnInvocation
-				}
-			case TxnL1Handler:
-				trace.FunctionInvocation = fnInvocation
+		switch trace.Type {
+		case TxnDeploy, TxnDeployAccount:
+			trace.ConstructorInvocation = fnInvocation
+		case TxnInvoke:
+			trace.ExecuteInvocation = new(rpcv6.ExecuteInvocation)
+			if feederTrace.RevertError != "" {
+				trace.ExecuteInvocation.RevertReason = feederTrace.RevertError
+			} else {
+				trace.ExecuteInvocation.FunctionInvocation = fnInvocation
 			}
+		case TxnL1Handler:
+			trace.FunctionInvocation = fnInvocation
 		}
 
 		adaptedTraces[index] = TracedBlockTransaction{

--- a/rpc/v7/trace_test.go
+++ b/rpc/v7/trace_test.go
@@ -514,7 +514,7 @@ func TestTraceTransaction(t *testing.T) {
 				CallType:       "CALL",
 				Result:         []felt.Felt{*utils.HexToFelt(t, "0x1")},
 				Calls: []rpcv6.FunctionInvocation{
-					rpcv6.FunctionInvocation{
+					{
 						ContractAddress:    *utils.HexToFelt(t, "0x49d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7"),
 						EntryPointSelector: utils.HexToFelt(t, "0x83afd3f4caedc6eebf44246fe54e38c95e3179a5ec9ea81740eca5b482d12e"),
 						Calldata: []felt.Felt{
@@ -529,7 +529,7 @@ func TestTraceTransaction(t *testing.T) {
 						Result:         []felt.Felt{*utils.HexToFelt(t, "0x1")},
 						Calls:          []rpcv6.FunctionInvocation{},
 						Events: []rpcv6.OrderedEvent{
-							rpcv6.OrderedEvent{
+							{
 								Order: 0,
 								Keys:  []*felt.Felt{utils.HexToFelt(t, "0x99cd8bde557814842a3121e8ddfd433a539b8c9f14bf31ebf108d12e6196e9")},
 								Data: []*felt.Felt{

--- a/rpc/v7/trace_test.go
+++ b/rpc/v7/trace_test.go
@@ -448,6 +448,137 @@ func TestTraceTransaction(t *testing.T) {
 		}
 		assert.Equal(t, rpcv7.AdaptVMTransactionTrace(vmTrace), *trace)
 	})
+
+	t.Run("reverted INVOKE tx from feeder", func(t *testing.T) {
+		n := &utils.Sepolia
+
+		handler := rpcv7.New(mockReader, mockSyncReader, mockVM, "", n, utils.NewNopZapLogger())
+
+		client := feeder.NewTestClient(t, n)
+		handler.WithFeeder(client)
+		gateway := adaptfeeder.New(client)
+
+		// Tx at index 3 in the block
+		revertedTxHash := utils.HexToFelt(t, "0x2f00c7f28df2197196440747f97baa63d0851e3b0cfc2efedb6a88a7ef78cb1")
+
+		blockNumber := uint64(18)
+		blockHash := utils.HexToFelt(t, "0x5beb56c7d9a9fc066e695c3fc467f45532cace83d9979db4ccfd6b77ca476af")
+
+		mockReader.EXPECT().Receipt(revertedTxHash).Return(nil, blockHash, blockNumber, nil)
+		mockReader.EXPECT().BlockByHash(blockHash).DoAndReturn(func(_ *felt.Felt) (block *core.Block, err error) {
+			return gateway.BlockByNumber(context.Background(), blockNumber)
+		}).Times(2)
+
+		mockReader.EXPECT().L1Head().Return(&core.L1Head{
+			BlockNumber: 19, // Doesn't really matter for this test
+		}, nil)
+
+		expectedRevertedTrace := rpcv7.TransactionTrace{
+			Type: rpcv7.TxnInvoke,
+			ValidateInvocation: &rpcv6.FunctionInvocation{
+				ContractAddress:    *utils.HexToFelt(t, "0x70503f026c7af73cfd2b007fe650e8c310256e9674ac4e42797c291edca5e84"),
+				EntryPointSelector: utils.HexToFelt(t, "0x162da33a4585851fe8d3af3c2a9c60b557814e221e0d4f30ff0b2189d9c7775"),
+				Calldata: []felt.Felt{
+					*utils.HexToFelt(t, "0x1"),
+					*utils.HexToFelt(t, "0x7c687d151607710a7ec82ca5ab0ff2c48f52abd3b4a2773938a0cfef723fe6a"),
+					*utils.HexToFelt(t, "0x10b7e63d3ca05c9baffd985d3e1c3858d4dbf0759f066be0eaddc5d71c2cab5"),
+					*utils.HexToFelt(t, "0x1"),
+					*utils.HexToFelt(t, "0xa"),
+				},
+				CallerAddress:  *utils.HexToFelt(t, "0x0"),
+				ClassHash:      utils.HexToFelt(t, "0x903752516de5c04fe91600ca6891e325278b2dfc54880ae11a809abb364844"),
+				EntryPointType: "EXTERNAL",
+				CallType:       "CALL",
+				Result:         []felt.Felt{*utils.HexToFelt(t, "0x56414c4944")},
+				Calls:          []rpcv6.FunctionInvocation{},
+				Events:         []rpcv6.OrderedEvent{},
+				Messages:       []rpcv6.OrderedL2toL1Message{},
+				ExecutionResources: &rpcv6.ComputationResources{
+					Steps:       754,
+					MemoryHoles: 5,
+					RangeCheck:  17,
+					EcOp:        3,
+				},
+			},
+			FeeTransferInvocation: &rpcv6.FunctionInvocation{
+				ContractAddress:    *utils.HexToFelt(t, "0x49d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7"),
+				EntryPointSelector: utils.HexToFelt(t, "0x83afd3f4caedc6eebf44246fe54e38c95e3179a5ec9ea81740eca5b482d12e"),
+				Calldata: []felt.Felt{
+					*utils.HexToFelt(t, "0x1176a1bd84444c89232ec27754698e5d2e7e1a7f1539f12027f28b23ec9f3d8"),
+					*utils.HexToFelt(t, "0x2847291f968"),
+					*utils.HexToFelt(t, "0x0"),
+				},
+				CallerAddress:  *utils.HexToFelt(t, "0x70503f026c7af73cfd2b007fe650e8c310256e9674ac4e42797c291edca5e84"),
+				ClassHash:      utils.HexToFelt(t, "0xd0e183745e9dae3e4e78a8ffedcce0903fc4900beace4e0abf192d4c202da3"),
+				EntryPointType: "EXTERNAL",
+				CallType:       "CALL",
+				Result:         []felt.Felt{*utils.HexToFelt(t, "0x1")},
+				Calls: []rpcv6.FunctionInvocation{
+					rpcv6.FunctionInvocation{
+						ContractAddress:    *utils.HexToFelt(t, "0x49d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7"),
+						EntryPointSelector: utils.HexToFelt(t, "0x83afd3f4caedc6eebf44246fe54e38c95e3179a5ec9ea81740eca5b482d12e"),
+						Calldata: []felt.Felt{
+							*utils.HexToFelt(t, "0x1176a1bd84444c89232ec27754698e5d2e7e1a7f1539f12027f28b23ec9f3d8"),
+							*utils.HexToFelt(t, "0x2847291f968"),
+							*utils.HexToFelt(t, "0x0"),
+						},
+						CallerAddress:  *utils.HexToFelt(t, "0x70503f026c7af73cfd2b007fe650e8c310256e9674ac4e42797c291edca5e84"),
+						ClassHash:      utils.HexToFelt(t, "0x1b661756bf7d16210fc611626e1af4569baa1781ffc964bd018f4585ae241c1"),
+						EntryPointType: "EXTERNAL",
+						CallType:       "DELEGATE",
+						Result:         []felt.Felt{*utils.HexToFelt(t, "0x1")},
+						Calls:          []rpcv6.FunctionInvocation{},
+						Events: []rpcv6.OrderedEvent{
+							rpcv6.OrderedEvent{
+								Order: 0,
+								Keys:  []*felt.Felt{utils.HexToFelt(t, "0x99cd8bde557814842a3121e8ddfd433a539b8c9f14bf31ebf108d12e6196e9")},
+								Data: []*felt.Felt{
+									utils.HexToFelt(t, "0x70503f026c7af73cfd2b007fe650e8c310256e9674ac4e42797c291edca5e84"),
+									utils.HexToFelt(t, "0x1176a1bd84444c89232ec27754698e5d2e7e1a7f1539f12027f28b23ec9f3d8"),
+									utils.HexToFelt(t, "0x2847291f968"),
+									utils.HexToFelt(t, "0x0"),
+								},
+							},
+						},
+						Messages: []rpcv6.OrderedL2toL1Message{},
+						ExecutionResources: &rpcv6.ComputationResources{
+							Steps:       529,
+							MemoryHoles: 57,
+							Pedersen:    4,
+							RangeCheck:  21,
+						},
+					},
+				},
+				Events:   []rpcv6.OrderedEvent{},
+				Messages: []rpcv6.OrderedL2toL1Message{},
+				ExecutionResources: &rpcv6.ComputationResources{
+					Steps:       589,
+					MemoryHoles: 57,
+					Pedersen:    4,
+					RangeCheck:  21,
+				},
+			},
+			ExecuteInvocation: &rpcv6.ExecuteInvocation{
+				RevertReason: "Error in the called contract (0x070503f026c7af73cfd2b007fe650e8c310256e9674ac4e42797c291edca5e84):\nError at pc=0:4288:\nGot an exception while executing a hint: Custom Hint Error: Execution failed. Failure reason: 'Fatal'.\nCairo traceback (most recent call last):\nUnknown location (pc=0:67)\nUnknown location (pc=0:1997)\nUnknown location (pc=0:2729)\nUnknown location (pc=0:3577)\n",
+			},
+			ExecutionResources: &rpcv7.ExecutionResources{
+				ComputationResources: rpcv7.ComputationResources{
+					Steps:       1343,
+					MemoryHoles: 62,
+					Pedersen:    4,
+					RangeCheck:  38,
+					EcOp:        3,
+				},
+				DataAvailability: &rpcv7.DataAvailability{},
+			},
+		}
+
+		trace, httpHeader, err := handler.TraceTransaction(context.Background(), *revertedTxHash)
+
+		require.Nil(t, err)
+		assert.Equal(t, httpHeader.Get(rpcv7.ExecutionStepsHeader), "0")
+		assert.Equal(t, expectedRevertedTrace, *trace)
+	})
 }
 
 func TestTraceBlockTransactions(t *testing.T) {
@@ -1056,8 +1187,8 @@ func TestAdaptFeederBlockTrace(t *testing.T) {
 					TransactionHash:       *new(felt.Felt).SetUint64(1),
 					FeeTransferInvocation: &starknet.FunctionInvocation{},
 					ValidateInvocation:    &starknet.FunctionInvocation{},
-					FunctionInvocation:    &starknet.FunctionInvocation{},
-					RevertError:           "some error",
+					// When revert error, feeder trace has no FunctionInvocation only RevertError is set
+					RevertError: "some error",
 				},
 			},
 		}


### PR DESCRIPTION
Fixes #2616

_Bug explanation_
The `FunctionInvocation` field in the returned trace from the feeder is set to nil when the tx gets reverted

(I added some feeder testdata with a block containing a reverted tx, hence the new files!)