### PR TITLE
chore: update Starknet SDK test workflows

### DIFF
--- a/.github/workflows/starknet-go-tests.yml
+++ b/.github/workflows/starknet-go-tests.yml
@@ -2,12 +2,6 @@ name: starknet-go tests
 
 on:
   workflow_call:
-    inputs:
-      ref:
-        description: 'The branch, tag or SHA to checkout'
-        required: false
-        default: '1ede19210c10f1f1f9c3cb49a42f737cd90eda5e'
-        type: string
     secrets:
       TEST_RPC_URL:
         required: true
@@ -20,7 +14,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: NethermindEth/starknet.go
-          ref: ${{ inputs.ref }}
+          ref: v0.7.3
 
       - name: Setup Go
         uses: actions/setup-go@v5
@@ -31,6 +25,6 @@ jobs:
         run: go mod download
 
       - name: Test RPC on testnet
-        run: cd rpc && go test -skip 'TestBlockWithReceipts'  -timeout 1200s -v -env testnet .
+        run: cd rpc && go test -timeout 1200s -v -env testnet .
         env:
           INTEGRATION_BASE: ${{ secrets.TEST_RPC_URL }}

--- a/.github/workflows/starknet-js-tests.yml
+++ b/.github/workflows/starknet-js-tests.yml
@@ -18,7 +18,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: starknet-io/starknet.js
-          ref: v6.14.1
+          ref: v6.23.1
   
       - name: Setup Node.js
         uses: actions/setup-node@v4
@@ -34,3 +34,4 @@ jobs:
           TEST_RPC_URL: ${{ secrets.TEST_RPC_URL }}
           TEST_ACCOUNT_ADDRESS: ${{ secrets.TEST_ACCOUNT_ADDRESS }}
           TEST_ACCOUNT_PRIVATE_KEY: ${{ secrets.TEST_ACCOUNT_PRIVATE_KEY }}
+          TX_VERSION: "v3"

--- a/.github/workflows/starknet-rs-tests.yml
+++ b/.github/workflows/starknet-rs-tests.yml
@@ -14,7 +14,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: xJonathanLEI/starknet-rs
-          ref: starknet/v0.12.0
+          ref: starknet/v0.13.0
 
       - name: Setup Rust
         uses: actions-rs/toolchain@v1
@@ -25,7 +25,7 @@ jobs:
 
       - name: Run jsonrpc tests
         run: |
-          cd starknet-providers && cargo test jsonrpc -- --skip jsonrpc_get_block_with_receipts
+          cd starknet-providers && cargo test jsonrpc
           cd ../starknet-accounts && cargo test jsonrpc -- --skip can_declare_cairo0_contract_with_jsonrpc
         env:
           STARKNET_RPC: ${{ secrets.STARKNET_RPC }}


### PR DESCRIPTION
Fixes issue #2556

- starknet-go-tests.yml:
  - Remove hardcoded commit reference in favor of using v0.7.3 tag
  - Remove skipped test 'TestBlockWithReceipts'
- starknet-js-tests.yml:
  - Update starknet.js version from v6.14.1 to v6.23.1
- starknet-rs-tests.yml:
  - Update starknet-rs version from v0.12.0 to v0.13.0
  - Remove skipped test 'jsonrpc_get_block_with_receipts'

These updates ensure compatibility with the latest SDK versions and enable previously skipped tests, improving test coverage.