### PR TITLE
fix(ci): Remove dev_deploy_test dependency from promote_to_staging job

### DIFF
--- a/.github/workflows/ci-cd-pipeline.yml
+++ b/.github/workflows/ci-cd-pipeline.yml
@@ -41,7 +41,7 @@ jobs:
       TEST_ACCOUNT_PRIVATE_KEY: ${{ secrets.TEST_ACCOUNT_PRIVATE_KEY }}
 
   promote_to_staging:
-    needs: [build, dev_deploy_test]
+    needs: [build]
     runs-on: ubuntu-latest
     environment:
       name: Staging


### PR DESCRIPTION
This change allows staging deployments to be **manually approved** immediately after build completion, without need for dev tests to pass. The manual approval gate via environment protection rules remains in place, ensuring controlled promotion to staging.