### PR TITLE
fix: restore exact version pinning for Starknet dependencies

### DIFF
--- a/vm/rust/Cargo.toml
+++ b/vm/rust/Cargo.toml
@@ -8,11 +8,11 @@ edition = "2021"
 [dependencies]
 serde = "1.0.208"
 serde_json = { version = "1.0.125", features = ["raw_value"] }
-blockifier = "0.14.0-rc.1"
+blockifier = "=0.14.0-rc.1"
 cairo-lang-casm = "=2.10.1"
 cairo-lang-starknet-classes = "=2.10.0"
 cairo-lang-runner = { version = "2.10.0" }
-starknet_api = "0.14.0-rc.1"
+starknet_api = "=0.14.0-rc.1"
 cairo-vm = "=1.0.2"
 starknet-types-core = { version = "0.1.6", features = ["hash", "prime-bigint"] }
 indexmap = "2.1.0"


### PR DESCRIPTION
## Changes
- Restored exact version pinning (using `=` prefix) for `blockifier` and `starknet_api` dependencies
- Changed from `blockifier = "0.14.0-rc.1"` to `blockifier = "=0.14.0-rc.1"`
- Changed from `starknet_api = "0.14.0-rc.1"` to `starknet_api = "=0.14.0-rc.1"`

## Motivation
This PR fixes an accidental removal of the exact version pinning (`=` prefix) that occurred previously. Exact version pinning is critical for these Starknet dependencies to ensure build reproducibility and prevent unexpected behavior from dependency version drift.

## Impact
- Restores consistent versioning strategy across all pinned dependencies
- Ensures build determinism and reproducibility
- Prevents potential issues that could arise from unintended version updates