### PR TITLE
refactor(benchmarks): use b.Loop() for benchmark loops

### DIFF
--- a/core/crypto/ecdsa_test.go
+++ b/core/crypto/ecdsa_test.go
@@ -69,8 +69,7 @@ func BenchmarkVerify(b *testing.B) {
 
 	var verified bool
 	var err error
-	b.ResetTimer()
-	for range b.N {
+	for b.Loop() {
 		verified, err = publicKey.Verify(&signature, msg)
 		require.NoError(b, err)
 	}

--- a/core/crypto/pedersen_hash_test.go
+++ b/core/crypto/pedersen_hash_test.go
@@ -153,7 +153,7 @@ func BenchmarkPedersen(b *testing.B) {
 
 func genRandomFeltSls(b *testing.B, n int) [][]*felt.Felt {
 	randomFeltSls := make([][]*felt.Felt, 0, b.N)
-	for range b.N {
+	for b.Loop() {
 		randomFeltSls = append(randomFeltSls, genRandomFelts(b, n))
 	}
 	return randomFeltSls

--- a/core/receipt_test.go
+++ b/core/receipt_test.go
@@ -94,8 +94,7 @@ func BenchmarkReceiptCommitment(b *testing.B) {
 	receipts := slices.Repeat(baseReceipts, 100)
 	var f *felt.Felt
 	var err error
-	b.ResetTimer()
-	for range b.N {
+	for b.Loop() {
 		f, err = receiptCommitment(receipts)
 		require.NoError(b, err)
 	}

--- a/core/state_update_test.go
+++ b/core/state_update_test.go
@@ -84,8 +84,7 @@ func BenchmarkStateDiffHash(b *testing.B) {
 	su, err := gw.StateUpdate(b.Context(), 38748)
 	require.NoError(b, err)
 
-	b.ResetTimer()
-	for range b.N {
+	for b.Loop() {
 		su.StateDiff.Hash()
 	}
 }

--- a/core/trie/proof_test.go
+++ b/core/trie/proof_test.go
@@ -635,8 +635,7 @@ func BenchmarkVerifyRangeProof(b *testing.B) {
 		values[i-start] = records[i].value
 	}
 
-	b.ResetTimer()
-	for range b.N {
+	for b.Loop() {
 		_, err := trie.VerifyRangeProof(root, keys[0], keys, values, proof)
 		require.NoError(b, err)
 	}

--- a/core/trie/trie_test.go
+++ b/core/trie/trie_test.go
@@ -433,7 +433,7 @@ var benchTriePutR *felt.Felt
 
 func BenchmarkTriePut(b *testing.B) {
 	keys := make([]*felt.Felt, 0, b.N)
-	for range b.N {
+	for b.Loop() {
 		rnd, err := new(felt.Felt).SetRandom()
 		require.NoError(b, err)
 		keys = append(keys, rnd)

--- a/jsonrpc/server_test.go
+++ b/jsonrpc/server_test.go
@@ -565,8 +565,7 @@ func BenchmarkHandle(b *testing.B) {
 	const request = `{"jsonrpc":"2.0","id":1,"method":"test"}`
 	var header http.Header
 	var err error
-	b.ResetTimer()
-	for range b.N {
+	for b.Loop() {
 		_, header, err = server.HandleReader(b.Context(), strings.NewReader(request))
 		require.NoError(b, err)
 		require.NotNil(b, header)


### PR DESCRIPTION
> [!IMPORTANT]
> Review after #2646 

Refactore benchmark loops to use [b.Loop()](https://tip.golang.org/doc/go1.24#new-benchmark-function).
