### PR TITLE
fix(rpc): handle updated entry point not found error format

### DIFF
--- a/rpc/rpccore/rpccore.go
+++ b/rpc/rpccore/rpccore.go
@@ -18,6 +18,7 @@ const (
 	ThrottledVMErr                = "VM throughput limit reached"
 	MaxBlocksBack                 = 1024
 	EntrypointNotFoundFelt string = "0x454e545259504f494e545f4e4f545f464f554e44"
+	ErrEPSNotFound                = "Entry point EntryPointSelector(%s) not found in contract."
 )
 
 //go:generate mockgen -destination=../mocks/mock_gateway_handler.go -package=mocks github.com/NethermindEth/juno/rpc Gateway

--- a/rpc/v6/trace.go
+++ b/rpc/v6/trace.go
@@ -306,7 +306,7 @@ func (h *Handler) Call(funcCall *FunctionCall, id *BlockID) ([]*felt.Felt, *json
 		if len(res.Result) != 0 {
 			if res.Result[0].String() == rpccore.EntrypointNotFoundFelt {
 				strErr = fmt.Sprintf(
-					"Entry point EntryPointSelector(%s) not found in contract.",
+					rpccore.ErrEPSNotFound,
 					funcCall.EntryPointSelector.String(),
 				)
 			} else {

--- a/rpc/v6/trace.go
+++ b/rpc/v6/trace.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"net/http"
 	"slices"
 
@@ -304,7 +305,10 @@ func (h *Handler) Call(funcCall *FunctionCall, id *BlockID) ([]*felt.Felt, *json
 		var strErr string
 		if len(res.Result) != 0 {
 			if res.Result[0].String() == rpccore.EntrypointNotFoundFelt {
-				strErr = rpccore.ErrEntrypointNotFound.Message
+				strErr = fmt.Sprintf(
+					"Entry point EntryPointSelector(%s) not found in contract.",
+					funcCall.EntryPointSelector.String(),
+				)
 			} else {
 				strErr = utils.FeltArrToString(res.Result)
 			}

--- a/rpc/v6/trace_test.go
+++ b/rpc/v6/trace_test.go
@@ -1161,7 +1161,7 @@ func TestCall(t *testing.T) {
 		expectedErr.Data = rpc.ContractErrorData{
 			RevertError: json.RawMessage(`"` +
 				fmt.Sprintf(
-					"Entry point EntryPointSelector(%s) not found in contract.",
+					rpccore.ErrEPSNotFound,
 					selector.String(),
 				) +
 				`"`,

--- a/rpc/v6/trace_test.go
+++ b/rpc/v6/trace_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"testing"
 
 	"github.com/NethermindEth/juno/blockchain"
@@ -1158,7 +1159,13 @@ func TestCall(t *testing.T) {
 		}
 		expectedErr := rpccore.ErrContractError
 		expectedErr.Data = rpc.ContractErrorData{
-			RevertError: json.RawMessage(`"` + rpccore.ErrEntrypointNotFound.Message + `"`),
+			RevertError: json.RawMessage(`"` +
+				fmt.Sprintf(
+					"Entry point EntryPointSelector(%s) not found in contract.",
+					selector.String(),
+				) +
+				`"`,
+			),
 		}
 
 		headsHeader := &core.Header{

--- a/rpc/v7/trace.go
+++ b/rpc/v7/trace.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"net/http"
 	"slices"
 	"strconv"
@@ -357,7 +358,10 @@ func (h *Handler) Call(funcCall FunctionCall, id BlockID) ([]*felt.Felt, *jsonrp
 		var strErr string
 		if len(res.Result) != 0 {
 			if res.Result[0].String() == rpccore.EntrypointNotFoundFelt {
-				strErr = rpccore.ErrEntrypointNotFound.Message
+				strErr = fmt.Sprintf(
+					"Entry point EntryPointSelector(%s) not found in contract.",
+					funcCall.EntryPointSelector.String(),
+				)
 			} else {
 				strErr = utils.FeltArrToString(res.Result)
 			}

--- a/rpc/v7/trace.go
+++ b/rpc/v7/trace.go
@@ -359,7 +359,7 @@ func (h *Handler) Call(funcCall FunctionCall, id BlockID) ([]*felt.Felt, *jsonrp
 		if len(res.Result) != 0 {
 			if res.Result[0].String() == rpccore.EntrypointNotFoundFelt {
 				strErr = fmt.Sprintf(
-					"Entry point EntryPointSelector(%s) not found in contract.",
+					rpccore.ErrEPSNotFound,
 					funcCall.EntryPointSelector.String(),
 				)
 			} else {

--- a/rpc/v7/trace_test.go
+++ b/rpc/v7/trace_test.go
@@ -1542,7 +1542,13 @@ func TestCall(t *testing.T) {
 		}
 		expectedErr := rpccore.ErrContractError
 		expectedErr.Data = rpcv7.ContractErrorData{
-			RevertError: json.RawMessage(`"` + rpccore.ErrEntrypointNotFound.Message + `"`),
+			RevertError: json.RawMessage(`"` +
+				fmt.Sprintf(
+					"Entry point EntryPointSelector(%s) not found in contract.",
+					selector.String(),
+				) +
+				`"`,
+			),
 		}
 
 		headsHeader := &core.Header{

--- a/rpc/v7/trace_test.go
+++ b/rpc/v7/trace_test.go
@@ -1544,7 +1544,7 @@ func TestCall(t *testing.T) {
 		expectedErr.Data = rpcv7.ContractErrorData{
 			RevertError: json.RawMessage(`"` +
 				fmt.Sprintf(
-					"Entry point EntryPointSelector(%s) not found in contract.",
+					rpccore.ErrEPSNotFound,
 					selector.String(),
 				) +
 				`"`,


### PR DESCRIPTION
After the blockifier update, the format of the `entry_point_not_found` error has changed to return only the error's code. This change affected the behavior of RPC v6-7. To address this, explicit error handling has been implemented to properly manage the new error format.