### PR TITLE
feat(rpc/v0.8.0): update InsufficientAccountBalance error message

### DIFF
--- a/rpc/rpccore/rpccore.go
+++ b/rpc/rpccore/rpccore.go
@@ -57,19 +57,21 @@ var (
 	ErrInsufficientMaxFee               = &jsonrpc.Error{Code: 53, Message: "Max fee is smaller than the minimal transaction cost (validation plus fee transfer)"} //nolint:lll
 	ErrInsufficientResourcesForValidate = &jsonrpc.Error{Code: 53, Message: "The transaction’s resources don’t cover validation or the minimal transaction fee"}   //nolint:lll
 	ErrInsufficientAccountBalance       = &jsonrpc.Error{Code: 54, Message: "Account balance is smaller than the transaction's max_fee"}
-	ErrValidationFailure                = &jsonrpc.Error{Code: 55, Message: "Account validation failed"}
-	ErrCompilationFailed                = &jsonrpc.Error{Code: 56, Message: "Compilation failed"}
-	ErrContractClassSizeTooLarge        = &jsonrpc.Error{Code: 57, Message: "Contract class size is too large"}
-	ErrNonAccount                       = &jsonrpc.Error{Code: 58, Message: "Sender address is not an account contract"}
-	ErrDuplicateTx                      = &jsonrpc.Error{Code: 59, Message: "A transaction with the same hash already exists in the mempool"}
-	ErrCompiledClassHashMismatch        = &jsonrpc.Error{Code: 60, Message: "the compiled class hash did not match the one supplied in the transaction"} //nolint:lll
-	ErrUnsupportedTxVersion             = &jsonrpc.Error{Code: 61, Message: "the transaction version is not supported"}
-	ErrUnsupportedContractClassVersion  = &jsonrpc.Error{Code: 62, Message: "the contract class version is not supported"}
-	ErrUnexpectedError                  = &jsonrpc.Error{Code: 63, Message: "An unexpected error occurred"}
-	ErrInvalidSubscriptionID            = &jsonrpc.Error{Code: 66, Message: "Invalid subscription id"}
-	ErrTooManyAddressesInFilter         = &jsonrpc.Error{Code: 67, Message: "Too many addresses in filter sender_address filter"}
-	ErrTooManyBlocksBack                = &jsonrpc.Error{Code: 68, Message: fmt.Sprintf("Cannot go back more than %v blocks", MaxBlocksBack)}
-	ErrCallOnPending                    = &jsonrpc.Error{Code: 69, Message: "This method does not support being called on the pending block"}
+	ErrInsufficientAccountBalanceV0_8   = &jsonrpc.Error{Code: 54, Message: "Account balance is smaller than the transaction's " +
+		"maximal fee (calculated as the sum of each resource's limit x max price)"}
+	ErrValidationFailure               = &jsonrpc.Error{Code: 55, Message: "Account validation failed"}
+	ErrCompilationFailed               = &jsonrpc.Error{Code: 56, Message: "Compilation failed"}
+	ErrContractClassSizeTooLarge       = &jsonrpc.Error{Code: 57, Message: "Contract class size is too large"}
+	ErrNonAccount                      = &jsonrpc.Error{Code: 58, Message: "Sender address is not an account contract"}
+	ErrDuplicateTx                     = &jsonrpc.Error{Code: 59, Message: "A transaction with the same hash already exists in the mempool"}
+	ErrCompiledClassHashMismatch       = &jsonrpc.Error{Code: 60, Message: "the compiled class hash did not match the one supplied in the transaction"} //nolint:lll
+	ErrUnsupportedTxVersion            = &jsonrpc.Error{Code: 61, Message: "the transaction version is not supported"}
+	ErrUnsupportedContractClassVersion = &jsonrpc.Error{Code: 62, Message: "the contract class version is not supported"}
+	ErrUnexpectedError                 = &jsonrpc.Error{Code: 63, Message: "An unexpected error occurred"}
+	ErrInvalidSubscriptionID           = &jsonrpc.Error{Code: 66, Message: "Invalid subscription id"}
+	ErrTooManyAddressesInFilter        = &jsonrpc.Error{Code: 67, Message: "Too many addresses in filter sender_address filter"}
+	ErrTooManyBlocksBack               = &jsonrpc.Error{Code: 68, Message: fmt.Sprintf("Cannot go back more than %v blocks", MaxBlocksBack)}
+	ErrCallOnPending                   = &jsonrpc.Error{Code: 69, Message: "This method does not support being called on the pending block"}
 
 	// These errors can be only be returned by Juno-specific methods.
 	ErrSubscriptionNotFound = &jsonrpc.Error{Code: 100, Message: "Subscription not found"}

--- a/rpc/v8/transaction.go
+++ b/rpc/v8/transaction.go
@@ -683,7 +683,7 @@ func makeJSONErrorFromGatewayError(err error) *jsonrpc.Error {
 	case gateway.InsufficientResourcesForValidate:
 		return rpccore.ErrInsufficientResourcesForValidate
 	case gateway.InsufficientAccountBalance:
-		return rpccore.ErrInsufficientAccountBalance
+		return rpccore.ErrInsufficientAccountBalanceV0_8
 	case gateway.ValidateFailure:
 		return rpccore.ErrValidationFailure.CloneWithData(gatewayErr.Message)
 	case gateway.ContractBytecodeSizeTooLarge, gateway.ContractClassObjectSizeTooLarge:


### PR DESCRIPTION
Update error message for insufficient account balance to align with Starknet [RPC spec v0.8.0](https://github.com/starkware-libs/starknet-specs/blob/v0.8.0/api/starknet_write_api.json#L243). The error message now clarifies fee calculation as the sum of each resource's limit × max price.