### PR TITLE
fix: missing import compilation error due to merge conflict

### DIFF
--- a/rpc/v7/simulation.go
+++ b/rpc/v7/simulation.go
@@ -3,6 +3,7 @@ package rpcv7
 import (
 	"encoding/json"
 	"errors"
+	"fmt"
 	"net/http"
 	"slices"
 	"strconv"

--- a/rpc/v7/simulation_test.go
+++ b/rpc/v7/simulation_test.go
@@ -102,7 +102,7 @@ func TestSimulateTransactions(t *testing.T) {
 				NumSteps:         uint64(0),
 			}, nil)
 
-		_, httpHeader, err := handler.SimulateTransactions(rpcv7.BlockID{Latest: true}, []rpcv7.BroadcastedTransaction{}, []rpcv7.SimulationFlag{rpcv7.SkipValidateFlag})
+		_, httpHeader, err := handler.SimulateTransactions(rpcv7.BlockID{Latest: true}, []rpcv7.BroadcastedTransaction{}, []rpcv6.SimulationFlag{rpcv6.SkipValidateFlag})
 		require.Equal(t, rpccore.ErrInternal.CloneWithData(errors.New(
 			"inconsistent lengths: 1 overall fees, 1 traces, 1 gas consumed, 2 data availability, 0 txns",
 		)), err)


### PR DESCRIPTION
#2602 added an `fmt` usage while #2496 removed it.