### PR TITLE
feat(rpc/v0.8.0): change Offset type from *felt.Felt to uint64 in CasmEntryPoint

### DIFF
--- a/rpc/v8/compiled_casm.go
+++ b/rpc/v8/compiled_casm.go
@@ -15,7 +15,7 @@ import (
 )
 
 type CasmEntryPoint struct {
-	Offset   *felt.Felt `json:"offset"`
+	Offset   uint64     `json:"offset"`
 	Selector *felt.Felt `json:"selector"`
 	Builtins []string   `json:"builtins"`
 }
@@ -105,7 +105,7 @@ func adaptCairo0Class(class *core.Cairo0Class) (*CasmCompiledContractClass, erro
 
 	adaptEntryPoint := func(ep core.EntryPoint) CasmEntryPoint {
 		return CasmEntryPoint{
-			Offset:   ep.Offset,
+			Offset:   ep.Offset.Uint64(),
 			Selector: ep.Selector,
 			Builtins: nil,
 		}
@@ -129,7 +129,7 @@ func adaptCairo0Class(class *core.Cairo0Class) (*CasmCompiledContractClass, erro
 func adaptCompiledClass(class *core.CompiledClass) *CasmCompiledContractClass {
 	adaptEntryPoint := func(ep core.CompiledEntryPoint) CasmEntryPoint {
 		return CasmEntryPoint{
-			Offset:   new(felt.Felt).SetUint64(ep.Offset),
+			Offset:   ep.Offset,
 			Selector: ep.Selector,
 			Builtins: ep.Builtins,
 		}

--- a/rpc/v8/compiled_casm_test.go
+++ b/rpc/v8/compiled_casm_test.go
@@ -87,7 +87,7 @@ func TestCompiledCasm(t *testing.T) {
 
 func adaptEntryPoint(point core.EntryPoint) rpc.CasmEntryPoint {
 	return rpc.CasmEntryPoint{
-		Offset:   point.Offset,
+		Offset:   point.Offset.Uint64(),
 		Selector: point.Selector,
 		Builtins: nil,
 	}

--- a/rpc/v8/compiled_casm_test.go
+++ b/rpc/v8/compiled_casm_test.go
@@ -3,6 +3,7 @@ package rpcv8_test
 import (
 	"encoding/json"
 	"fmt"
+	"math/big"
 	"testing"
 
 	clientFeeder "github.com/NethermindEth/juno/clients/feeder"
@@ -82,6 +83,45 @@ func TestCompiledCasm(t *testing.T) {
 			Hints:    json.RawMessage(`[[2,[{"Dst":0}]]]`),
 			Bytecode: cairo0Definition.Data,
 		}, resp)
+	})
+
+	t.Run("cairo1", func(t *testing.T) {
+		classHash := utils.HexToFelt(t, "0x222")
+
+		// Create a compiled class with test data
+		compiledClass := &core.CompiledClass{
+			CompilerVersion: "1.0.0",
+			Prime:           big.NewInt(123),
+			External: []core.CompiledEntryPoint{
+				{
+					Offset:   42, // Test the uint64 offset
+					Selector: utils.HexToFelt(t, "0xabc"),
+					Builtins: []string{"range_check"},
+				},
+			},
+			Constructor: []core.CompiledEntryPoint{},
+			L1Handler:   []core.CompiledEntryPoint{},
+			Bytecode:    []*felt.Felt{utils.HexToFelt(t, "0x123")},
+		}
+
+		cairo1Class := &core.Cairo1Class{
+			Compiled: compiledClass,
+		}
+
+		mockState := mocks.NewMockStateHistoryReader(mockCtrl)
+		mockState.EXPECT().Class(classHash).Return(&core.DeclaredClass{Class: cairo1Class}, nil)
+		rd.EXPECT().HeadState().Return(mockState, nopCloser, nil)
+
+		resp, rpcErr := handler.CompiledCasm(classHash)
+		require.Nil(t, rpcErr)
+
+		// Verify that the offset is correctly passed as uint64
+		require.Len(t, resp.EntryPointsByType.External, 1)
+		assert.Equal(t, uint64(42), resp.EntryPointsByType.External[0].Offset)
+		assert.Equal(t, utils.HexToFelt(t, "0xabc"), resp.EntryPointsByType.External[0].Selector)
+		assert.Equal(t, []string{"range_check"}, resp.EntryPointsByType.External[0].Builtins)
+		assert.Equal(t, utils.ToHex(big.NewInt(123)), resp.Prime)
+		assert.Equal(t, "1.0.0", resp.CompilerVersion)
 	})
 }
 


### PR DESCRIPTION
Changed Offset field type to match Starknet v0.8.0 specification, where the offset for `starknet_getCompiledCasm` response is now represented as an integer.

Reference: https://github.com/starkware-libs/starknet-specs/blob/v0.8.0/api/starknet_executables.json#L136