### PR TITLE
fix(rpc/v8): no error for empty storage keys for getStorageProof 

### DIFF
--- a/rpc/v8/storage.go
+++ b/rpc/v8/storage.go
@@ -135,12 +135,8 @@ func (h *Handler) StorageProof(id BlockID,
 
 // Ensures each contract is unique and each storage key in each contract is unique
 func processStorageKeys(storageKeys []StorageKeys) ([]StorageKeys, *jsonrpc.Error) {
-	if storageKeys == nil {
-		return nil, nil
-	}
-
 	if len(storageKeys) == 0 {
-		return nil, jsonrpc.Err(jsonrpc.InvalidParams, MissingContractAddress)
+		return nil, nil
 	}
 
 	merged := make(map[felt.Felt][]felt.Felt, len(storageKeys))

--- a/rpc/v8/storage_test.go
+++ b/rpc/v8/storage_test.go
@@ -189,10 +189,10 @@ func TestStorageProof(t *testing.T) {
 		require.Nil(t, rpcErr)
 		require.NotNil(t, proof)
 	})
-	t.Run("error when contract storage keys are provided but empty", func(t *testing.T) {
+	t.Run("no error when contract storage keys are provided but empty", func(t *testing.T) {
 		proof, rpcErr := handler.StorageProof(blockLatest, nil, nil, []rpc.StorageKeys{})
-		assert.Equal(t, jsonrpc.Err(jsonrpc.InvalidParams, rpc.MissingContractAddress), rpcErr)
-		require.Nil(t, proof)
+		assert.Nil(t, rpcErr)
+		require.NotNil(t, proof)
 	})
 	t.Run("error when address in contract storage keys is nil", func(t *testing.T) {
 		proof, rpcErr := handler.StorageProof(blockLatest, nil, nil, []rpc.StorageKeys{{Contract: nil, Keys: []felt.Felt{*key}}})


### PR DESCRIPTION
**Command**
```
curl --location 'http://192.168.1.45:8235/rpc/v0_8' \
--header 'Content-Type: application/json' \
--data '{
    "id": 4,
    "jsonrpc": "2.0",
    "method": "starknet_getStorageProof",
    "params": {
      "block_id": "latest",
      "class_hashes": [],
      "contract_addresses": ["0x33ba2f0e6fb9a4a63a701728bacd7c86fd7750889c7f454711fa5d2766ce34c"],
      "contracts_storage_keys": []
    }
  }'
```

**Expected behavior**
No error

**Actual behavior**
```
{"jsonrpc":"2.0","error":{"code":-32602,"message":"Invalid Params","data":"missing field: contract_address"},"id":4}
```

Note that this is a partial revert of the previous PR at https://github.com/NethermindEth/juno/issues/2420