### PR TITLE
fix(cmd/juno): Fix cmd env tests

### DIFF
--- a/cmd/juno/juno_test.go
+++ b/cmd/juno/juno_test.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"strings"
 	"testing"
 	"time"
 
@@ -663,6 +664,7 @@ network: sepolia
 		},
 	}
 
+	unsetJunoPrefixedEnv(t)
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
 			if tc.cfgFile {
@@ -715,4 +717,18 @@ func tempCfgFile(t *testing.T, cfg string) string {
 	require.NoError(t, f.Sync())
 
 	return f.Name()
+}
+
+func unsetJunoPrefixedEnv(t *testing.T) {
+	t.Helper()
+
+	const prefix = "JUNO_"
+	for _, e := range os.Environ() {
+		pair := strings.Split(e, "=")
+		k := pair[0]
+
+		if strings.HasPrefix(k, prefix) {
+			t.Setenv(k, "")
+		}
+	}
 }


### PR DESCRIPTION
Recently, t.Setenv() was introduced to allow temporary setting of environment variables cmd/juno_test.go. However, it was not correctly implemented because it would only set the environment variable which was being tested. This meant if an environment variable has been set on the system which is not in the list of the tests, then the test would fail.

The solution is to unset all the variables before the test which are automatically reset to their original value after the test.