### PR TITLE
feat(ci): allow manual workflow trigger and skip builds for fork PRs

### DIFF
--- a/.github/workflows/deploy-dev-and-test.yml
+++ b/.github/workflows/deploy-dev-and-test.yml
@@ -7,12 +7,15 @@ on:
     branches: [main]
   push:
     branches: [main]
+  workflow_dispatch:
 
 permissions:
   contents: read
 
 jobs:
   build:
+    # Skip for PRs from forks as they don't have access to secrets
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
     uses: ./.github/workflows/build-image.yaml
     secrets:
       ARTIFACTORY_NUBIA_USERNAME: ${{ secrets.ARTIFACTORY_NUBIA_USERNAME }}


### PR DESCRIPTION
- Add workflow_dispatch trigger in deploy-dev-and-test to enable manual execution of the workflow
- Add conditional check to skip builds for pull requests from forks since they don't have access to repository secrets and always fail anyway