### PR TITLE
fix(rpc): fix processedEvents not handled if starting from pending

### DIFF
--- a/blockchain/event_filter.go
+++ b/blockchain/event_filter.go
@@ -124,9 +124,11 @@ func (e *EventFilter) Events(cToken *ContinuationToken, chunkSize uint64) ([]*Fi
 		}
 	}
 
+	var skippedEvents uint64
 	curBlock := e.fromBlock
 	// skip the blocks that we previously processed for this request
 	if cToken != nil {
+		skippedEvents = cToken.processedEvents
 		curBlock = cToken.fromBlock
 	}
 
@@ -161,7 +163,7 @@ func (e *EventFilter) Events(cToken *ContinuationToken, chunkSize uint64) ([]*Fi
 		}
 
 		var processedEvents uint64
-		matchedEvents, processedEvents, err = e.matcher.AppendBlockEvents(matchedEvents, header, receipts, cToken, chunkSize)
+		matchedEvents, processedEvents, err = e.matcher.AppendBlockEvents(matchedEvents, header, receipts, skippedEvents, chunkSize)
 		if err != nil {
 			if errors.Is(err, errChunkSizeReached) {
 				rToken = &ContinuationToken{fromBlock: curBlock, processedEvents: processedEvents}
@@ -169,6 +171,9 @@ func (e *EventFilter) Events(cToken *ContinuationToken, chunkSize uint64) ([]*Fi
 			}
 			return nil, nil, err
 		}
+
+		// Skipped events are processed, so we can reset the counter
+		skippedEvents = 0
 	}
 
 	if rToken == nil && remainingScannedBlocks == 0 && curBlock <= e.toBlock {

--- a/blockchain/event_matcher.go
+++ b/blockchain/event_matcher.go
@@ -93,7 +93,7 @@ func (e *EventMatcher) TestBloom(bloomFilter *bloom.BloomFilter) bool {
 }
 
 func (e *EventMatcher) AppendBlockEvents(matchedEventsSofar []*FilteredEvent, header *core.Header, receipts []*core.TransactionReceipt,
-	cToken *ContinuationToken, chunkSize uint64,
+	skippedEvents uint64, chunkSize uint64,
 ) ([]*FilteredEvent, uint64, error) {
 	processedEvents := uint64(0)
 	for _, receipt := range receipts {
@@ -106,7 +106,7 @@ func (e *EventMatcher) AppendBlockEvents(matchedEventsSofar []*FilteredEvent, he
 
 			// if last request was interrupted mid-block, and we are still processing that block, skip events
 			// that were already processed
-			if cToken != nil && header.Number == cToken.fromBlock && processedEvents < cToken.processedEvents {
+			if processedEvents < skippedEvents {
 				processedEvents++
 				continue
 			}


### PR DESCRIPTION
Should fix #2666 
The existing code check if `header.Number == cToken.fromBlock` to know if it's processing the first block and skipping the previously processed events in that case. However, if starting from pending, header.Number = 0.
The alternative solution is to reset the counter after the first block.