### PR TITLE
fix(rpc): starknet_getCompiledCasm returns ErrCompilationError

### DIFF
--- a/rpc/rpccore/rpccore.go
+++ b/rpc/rpccore/rpccore.go
@@ -72,6 +72,7 @@ var (
 	ErrTooManyAddressesInFilter        = &jsonrpc.Error{Code: 67, Message: "Too many addresses in filter sender_address filter"}
 	ErrTooManyBlocksBack               = &jsonrpc.Error{Code: 68, Message: fmt.Sprintf("Cannot go back more than %v blocks", MaxBlocksBack)}
 	ErrCallOnPending                   = &jsonrpc.Error{Code: 69, Message: "This method does not support being called on the pending block"}
+	ErrCompilationError                = &jsonrpc.Error{Code: 100, Message: "Failed to compile the contract"}
 
 	// These errors can be only be returned by Juno-specific methods.
 	ErrSubscriptionNotFound = &jsonrpc.Error{Code: 100, Message: "Subscription not found"}

--- a/rpc/v8/compiled_casm.go
+++ b/rpc/v8/compiled_casm.go
@@ -57,7 +57,7 @@ func (h *Handler) CompiledCasm(classHash *felt.Felt) (*CasmCompiledContractClass
 	case *core.Cairo0Class:
 		resp, err := adaptCairo0Class(class)
 		if err != nil {
-			return nil, jsonrpc.Err(jsonrpc.InternalError, err.Error())
+			return nil, rpccore.ErrCompilationError.CloneWithData(err.Error())
 		}
 		return resp, nil
 	case *core.Cairo1Class:


### PR DESCRIPTION
rpc v8 `starknet_getCompiledCasm` should return [COMPILATION_ERROR](https://github.com/starkware-libs/starknet-specs/blob/v0.8.0/api/starknet_executables.json#L34)

- In the handler, we are not really compiling the sierra to casm, it seems like we only adapt the already compiled casm (cairo0Class or cairo1class) to CasmCompiledContractClass type. But i guess if we get any error when adapting, we can consider them as compilation errors.
- Also, it seems adapting the cairo 1 class cannot give any error (does not return any), see [here](https://github.com/NethermindEth/juno/blob/main/rpc/v8/compiled_casm.go#L64). So, we'll never get any compilation error for cairo1 class "compilation" (already compiled as I said)
- There is already an error `ErrCompilationFailed` [here](https://github.com/NethermindEth/juno/blob/main/rpc/rpccore/rpccore.go#L63). very similar to the one I added. I still added this new one because it seems like the specs distinct both (not same error code for example): [COMPILATION_FAILED](https://github.com/starkware-libs/starknet-specs/blob/v0.8.0/api/starknet_write_api.json#L250) & [COMPILATION_ERROR](https://github.com/starkware-libs/starknet-specs/blob/v0.8.0/api/starknet_executables.json#L1353)