### PR TITLE
final sequencer PR

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -179,3 +179,30 @@ pathfinder: juno-cached ## Run a node to sync from pathfinder feedernode. P2P us
 
 test-fuzz: ## Run fuzzing script
 	./scripts/fuzz_all.sh
+
+sequencer:
+	./build/juno \
+	--http \
+	--http-port=6060 \
+	--http-host=0.0.0.0 \
+	--db-path=../seq-db-tmp \
+	--log-level=debug \
+	--seq-enable \
+	--seq-block-time=1 \
+	--network sequencer \
+	--disable-l1-verification \
+	--rpc-call-max-steps=4123000
+
+sequencer-with-accounts:
+	./build/juno \
+    --http \
+    --http-port=6060 \
+    --http-host=0.0.0.0 \
+    --db-path=../seq-db-tmp-w-accounts \
+    --log-level=debug \
+    --seq-enable \
+    --seq-block-time=1 \
+	--network sequencer \
+	--disable-l1-verification \
+	--seq-genesis-file "./genesis/genesis_prefund_accounts.json" \
+    --rpc-call-max-steps=4123000

--- a/adapters/vm2core/vm2core.go
+++ b/adapters/vm2core/vm2core.go
@@ -87,3 +87,59 @@ func AdaptStateDiff(fromStateDiff *vm.StateDiff) core.StateDiff {
 	}
 	return toStateDiff
 }
+
+func Receipt(fee *felt.Felt, txn core.Transaction,
+	trace *vm.TransactionTrace, txnReceipt *vm.TransactionReceipt,
+) *core.TransactionReceipt {
+	// Determine fee unit based on transaction version
+	feeUnit := core.WEI
+	if txn.TxVersion().Is(3) {
+		feeUnit = core.STRK
+	}
+
+	return &core.TransactionReceipt{
+		Fee:                fee,
+		FeeUnit:            feeUnit,
+		Events:             AdaptOrderedEvents(trace.AllEvents()),
+		ExecutionResources: AdaptExecutionResources(trace.TotalExecutionResources(), &txnReceipt.Gas),
+		L1ToL2Message:      nil, // Todo: sequencer currently can't post messages to L1 (follow up PR)
+		L2ToL1Message:      AdaptOrderedMessagesToL1(trace.AllMessages()),
+		TransactionHash:    txn.Hash(),
+		Reverted:           trace.IsReverted(),
+		RevertReason:       trace.RevertReason(),
+	}
+}
+
+func AdaptExecutionResources(resources *vm.ExecutionResources, totalGas *vm.GasConsumed) *core.ExecutionResources {
+	return &core.ExecutionResources{
+		BuiltinInstanceCounter: core.BuiltinInstanceCounter{
+			Pedersen:     resources.Pedersen,
+			RangeCheck:   resources.RangeCheck,
+			Bitwise:      resources.Bitwise,
+			Ecsda:        resources.Ecdsa,
+			EcOp:         resources.EcOp,
+			Keccak:       resources.Keccak,
+			Poseidon:     resources.Poseidon,
+			SegmentArena: resources.SegmentArena,
+			Output:       resources.Output,
+			AddMod:       resources.AddMod,
+			MulMod:       resources.MulMod,
+			RangeCheck96: resources.RangeCheck96,
+		},
+		MemoryHoles:      resources.MemoryHoles,
+		Steps:            resources.Steps,
+		DataAvailability: adaptDA(resources.DataAvailability),
+		TotalGasConsumed: &core.GasConsumed{L1Gas: totalGas.L1Gas, L1DataGas: totalGas.L1DataGas, L2Gas: 0}, // Todo
+	}
+}
+
+func adaptDA(da *vm.DataAvailability) *core.DataAvailability {
+	if da == nil {
+		return nil
+	}
+
+	return &core.DataAvailability{
+		L1Gas:     da.L1Gas,
+		L1DataGas: da.L1DataGas,
+	}
+}

--- a/builder/builder.go
+++ b/builder/builder.go
@@ -1,0 +1,456 @@
+package builder
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync/atomic"
+	"time"
+
+	"github.com/NethermindEth/juno/adapters/vm2core"
+	"github.com/NethermindEth/juno/blockchain"
+	"github.com/NethermindEth/juno/core"
+	"github.com/NethermindEth/juno/core/crypto"
+	"github.com/NethermindEth/juno/core/felt"
+	"github.com/NethermindEth/juno/db"
+	"github.com/NethermindEth/juno/feed"
+	"github.com/NethermindEth/juno/mempool"
+	"github.com/NethermindEth/juno/plugin"
+	"github.com/NethermindEth/juno/service"
+	"github.com/NethermindEth/juno/sync"
+	"github.com/NethermindEth/juno/utils"
+	"github.com/NethermindEth/juno/vm"
+	"github.com/consensys/gnark-crypto/ecc/stark-curve/ecdsa"
+)
+
+var (
+	_                    service.Service = (*Builder)(nil)
+	_                    sync.Reader     = (*Builder)(nil)
+	ErrPendingParentHash                 = errors.New("pending block parent hash does not match chain head")
+)
+
+type Builder struct {
+	ownAddress  felt.Felt
+	privKey     *ecdsa.PrivateKey
+	blockTime   time.Duration
+	disableFees bool
+
+	bc              *blockchain.Blockchain
+	db              db.DB
+	vm              vm.VM
+	log             utils.Logger
+	subNewHeads     *feed.Feed[*core.Block]
+	subPendingBlock *feed.Feed[*core.Block]
+	subReorgFeed    *feed.Feed[*sync.ReorgBlockRange]
+	mempool         *mempool.Pool
+	mempoolCloser   func() error
+	plugin          plugin.JunoPlugin
+
+	pendingBlock atomic.Pointer[sync.Pending]
+	headState    core.StateReader
+	headCloser   blockchain.StateCloser
+}
+
+func New(privKey *ecdsa.PrivateKey, ownAddr *felt.Felt, bc *blockchain.Blockchain, vm vm.VM,
+	blockTime time.Duration, mempool *mempool.Pool, log utils.Logger, disableFees bool, database db.DB,
+	mempoolCloser func() error,
+) Builder {
+	return Builder{
+		ownAddress: *ownAddr,
+		privKey:    privKey,
+		blockTime:  blockTime,
+		log:        log,
+
+		disableFees:     disableFees,
+		bc:              bc,
+		db:              database,
+		mempool:         mempool,
+		vm:              vm,
+		subNewHeads:     feed.New[*core.Block](),
+		subPendingBlock: feed.New[*core.Block](),
+		subReorgFeed:    feed.New[*sync.ReorgBlockRange](),
+		mempoolCloser:   mempoolCloser,
+	}
+}
+
+func (b *Builder) WithPlugin(junoPlugin plugin.JunoPlugin) *Builder {
+	b.plugin = junoPlugin
+	return b
+}
+
+func (b *Builder) Pending() (*sync.Pending, error) {
+	p := b.pendingBlock.Load()
+	if p == nil {
+		return nil, sync.ErrPendingBlockNotFound
+	}
+
+	expectedParentHash := &felt.Zero
+	if head, err := b.bc.HeadsHeader(); err == nil {
+		expectedParentHash = head.Hash
+	}
+	if p.Block.ParentHash.Equal(expectedParentHash) {
+		return p, nil
+	}
+
+	return nil, ErrPendingParentHash
+}
+
+func (b *Builder) PendingBlock() *core.Block {
+	pending, err := b.Pending()
+	if err != nil {
+		return nil
+	}
+	return pending.Block
+}
+
+func (b *Builder) PendingState() (core.StateReader, func() error, error) {
+	txn, err := b.db.NewTransaction(false)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	pending, err := b.Pending()
+	if err != nil {
+		return nil, nil, utils.RunAndWrapOnError(txn.Discard, err)
+	}
+
+	return sync.NewPendingState(pending.StateUpdate.StateDiff, pending.NewClasses, core.NewState(txn)), txn.Discard, nil
+}
+
+func (b *Builder) Run(ctx context.Context) error {
+	defer func() {
+		if err := b.mempoolCloser(); err != nil {
+			b.log.Errorw("closing mempool", "err", err)
+		}
+	}()
+
+	// Clear pending state on shutdown
+	defer func() {
+		if pErr := b.ClearPending(); pErr != nil {
+			b.log.Errorw("clearing pending", "err", pErr)
+		}
+	}()
+
+	if err := b.InitPendingBlock(); err != nil {
+		return err
+	}
+
+	doneListen := make(chan struct{})
+	go func() {
+		if pErr := b.listenPool(ctx); pErr != nil {
+			if pErr != mempool.ErrTxnPoolEmpty {
+				b.log.Warnw("listening pool", "err", pErr)
+			}
+		}
+		close(doneListen)
+	}()
+
+	for {
+		select {
+		case <-ctx.Done():
+			<-doneListen
+			return nil
+		case <-time.After(b.blockTime):
+			b.log.Infof("Finalising new block")
+			err := b.Finalise(b.Sign)
+			if err != nil {
+				return err
+			}
+		}
+	}
+}
+
+func (b *Builder) ClearPending() error {
+	b.pendingBlock.Store(&sync.Pending{})
+
+	if b.headState != nil {
+		if err := b.headCloser(); err != nil {
+			return err
+		}
+		b.headState = nil
+		b.headCloser = nil
+	}
+	return nil
+}
+
+func (b *Builder) InitPendingBlock() error {
+	header, err := b.bc.HeadsHeader()
+	if err != nil {
+		return err
+	}
+	pendingBlock := core.Block{
+		Header: &core.Header{
+			ParentHash:       header.Hash,
+			Number:           header.Number + 1,
+			SequencerAddress: &b.ownAddress,
+			// Todo: dynamically set fees (follow-up PR)
+			L1GasPriceETH:  new(felt.Felt).SetUint64(1),
+			L1GasPriceSTRK: new(felt.Felt).SetUint64(1),
+			L1DAMode:       core.Calldata,
+			L1DataGasPrice: &core.GasPrice{
+				PriceInWei: new(felt.Felt).SetUint64(1),
+				PriceInFri: new(felt.Felt).SetUint64(1),
+			},
+		},
+		Transactions: []core.Transaction{},
+		Receipts:     []*core.TransactionReceipt{},
+	}
+	newClasses := make(map[felt.Felt]core.Class)
+	emptyStateDiff := core.EmptyStateDiff()
+	su := core.StateUpdate{
+		StateDiff: &emptyStateDiff,
+	}
+	pending := sync.Pending{
+		Block:       &pendingBlock,
+		StateUpdate: &su,
+		NewClasses:  newClasses,
+	}
+	b.pendingBlock.Store(&pending)
+	b.headState, b.headCloser, err = b.bc.HeadState()
+	return err
+}
+
+// Finalise the pending block and initialise the next one
+func (b *Builder) Finalise(signFunc blockchain.BlockSignFunc) error {
+	pending, err := b.Pending()
+	if err != nil {
+		return err
+	}
+	if err := b.bc.Finalise(pending.Block, pending.StateUpdate, pending.NewClasses, b.Sign); err != nil {
+		return err
+	}
+	b.log.Infow("Finalised block", "number", pending.Block.Number, "hash",
+		pending.Block.Hash.ShortString(), "state", pending.Block.GlobalStateRoot.ShortString())
+
+	if b.plugin != nil {
+		err := b.plugin.NewBlock(pending.Block, pending.StateUpdate, pending.NewClasses)
+		if err != nil {
+			b.log.Errorw("error sending new block to plugin", err)
+		}
+	}
+	// push the new block head to the feed
+	b.subNewHeads.Send(b.PendingBlock())
+
+	if err := b.ClearPending(); err != nil {
+		return err
+	}
+	return b.InitPendingBlock()
+}
+
+func (b *Builder) StartingBlockNumber() (uint64, error) {
+	return 0, nil
+}
+
+func (b *Builder) HighestBlockHeader() *core.Header {
+	return nil
+}
+
+// Sign returns the builder's signature over data.
+func (b *Builder) Sign(blockHash, stateDiffCommitment *felt.Felt) ([]*felt.Felt, error) {
+	data := crypto.PoseidonArray(blockHash, stateDiffCommitment).Bytes()
+	signatureBytes, err := b.privKey.Sign(data[:], nil)
+	if err != nil {
+		return nil, err
+	}
+	sig := make([]*felt.Felt, 0)
+	for start := 0; start < len(signatureBytes); {
+		step := len(signatureBytes[start:])
+		if step > felt.Bytes {
+			step = felt.Bytes
+		}
+		sig = append(sig, new(felt.Felt).SetBytes(signatureBytes[start:step]))
+		start += step
+	}
+	return sig, nil
+}
+
+// listenPool waits until the mempool has transactions, then
+// executes them one by one until the mempool is empty.
+func (b *Builder) listenPool(ctx context.Context) error {
+	for {
+		if err := b.depletePool(ctx); err != nil {
+			if !errors.Is(err, db.ErrKeyNotFound) {
+				return err
+			}
+		}
+
+		// push the pending block to the feed
+		b.subPendingBlock.Send(b.PendingBlock())
+
+		select {
+		case <-ctx.Done():
+			return nil
+		// We wait for the mempool to get more txns before we continue
+		case <-b.mempool.Wait():
+			continue
+		}
+	}
+}
+
+// depletePool pops all available transactions from the mempool,
+// and executes them in sequence, applying the state changes
+// to the pending state
+func (b *Builder) depletePool(ctx context.Context) error {
+	blockHashToBeRevealed, err := b.getRevealedBlockHash()
+	if err != nil {
+		return err
+	}
+	for {
+		userTxn, err := b.mempool.Pop()
+		if err != nil {
+			return err
+		}
+		b.log.Debugw("running txn", "hash", userTxn.Transaction.Hash().String())
+		if err = b.runTxn(&userTxn, blockHashToBeRevealed); err != nil {
+			b.log.Debugw("failed txn", "hash", userTxn.Transaction.Hash().String(), "err", err.Error())
+			var txnExecutionError vm.TransactionExecutionError
+			if !errors.As(err, &txnExecutionError) {
+				return err
+			}
+		}
+
+		select {
+		case <-ctx.Done():
+			return nil
+		default:
+		}
+	}
+}
+
+func (b *Builder) getRevealedBlockHash() (*felt.Felt, error) {
+	blockHeight, err := b.bc.Height()
+	if err != nil {
+		return nil, err
+	}
+	const blockHashLag = 10
+	if blockHeight < blockHashLag {
+		return nil, nil
+	}
+
+	header, err := b.bc.BlockHeaderByNumber(blockHeight - blockHashLag)
+	if err != nil {
+		return nil, err
+	}
+	return header.Hash, nil
+}
+
+// runTxn executes the provided transaction and applies the state changes
+// to the pending state
+func (b *Builder) runTxn(txn *mempool.BroadcastedTransaction, blockHashToBeRevealed *felt.Felt) error {
+	// Get the pending state
+	pending, err := b.Pending()
+	if err != nil {
+		return err
+	}
+
+	// Create a state writer for the transaction execution
+	state := sync.NewPendingStateWriter(pending.StateUpdate.StateDiff, pending.NewClasses, b.headState)
+
+	// Prepare declared classes, if any
+	var declaredClass []core.Class
+	if txn.DeclaredClass != nil {
+		declaredClass = append(declaredClass, txn.DeclaredClass)
+	}
+
+	paidFeesOnL1 := []*felt.Felt{}
+	if txn.PaidFeeOnL1 != nil {
+		paidFeesOnL1 = append(paidFeesOnL1, txn.PaidFeeOnL1)
+	}
+	// Execute the transaction
+	vmResults, err := b.vm.Execute(
+		[]core.Transaction{txn.Transaction},
+		declaredClass,
+		paidFeesOnL1,
+		&vm.BlockInfo{
+			Header:                pending.Block.Header,
+			BlockHashToBeRevealed: blockHashToBeRevealed,
+		},
+		state,
+		b.bc.Network(),
+		false, false, false, true)
+	if err != nil {
+		return err
+	}
+
+	// Handle declared classes for declare transactions
+	if b.hasDeclaredClasses(vmResults.Traces[0].StateDiff) {
+		if err := b.processClassDeclaration(txn, &state); err != nil {
+			return err
+		}
+	}
+
+	// Create transaction receipt
+	receipt := vm2core.Receipt(vmResults.OverallFees[0], txn.Transaction, &vmResults.Traces[0], &vmResults.Receipts[0])
+
+	// Process state diff
+	seqTrace := vm2core.AdaptStateDiff(vmResults.Traces[0].StateDiff)
+
+	// Update pending block with transaction results
+	b.updatePendingBlock(pending, receipt, txn.Transaction, seqTrace)
+
+	return b.StorePending(pending)
+}
+
+// hasDeclaredClasses checks if the state diff contains declared classes
+func (b *Builder) hasDeclaredClasses(stateDiff *vm.StateDiff) bool {
+	return stateDiff.DeclaredClasses != nil || stateDiff.DeprecatedDeclaredClasses != nil
+}
+
+// processClassDeclaration handles class declaration storage for declare transactions
+func (b *Builder) processClassDeclaration(txn *mempool.BroadcastedTransaction, state *sync.PendingStateWriter) error {
+	if t, ok := (txn.Transaction).(*core.DeclareTransaction); ok {
+		if err := state.SetContractClass(t.ClassHash, txn.DeclaredClass); err != nil {
+			b.log.Errorw("failed to set contract class", "err", err)
+			return err
+		}
+
+		if t.CompiledClassHash != nil {
+			if err := state.SetCompiledClassHash(t.ClassHash, t.CompiledClassHash); err != nil {
+				b.log.Errorw("failed to SetCompiledClassHash", "err", err)
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+// updatePendingBlock updates the pending block with transaction results
+func (b *Builder) updatePendingBlock(pending *sync.Pending, receipt *core.TransactionReceipt,
+	transaction core.Transaction, stateDiff core.StateDiff,
+) {
+	pending.Block.Receipts = append(pending.Block.Receipts, receipt)
+	pending.Block.Transactions = append(pending.Block.Transactions, transaction)
+	pending.Block.TransactionCount += 1
+	pending.Block.EventCount += uint64(len(receipt.Events))
+	pending.StateUpdate.StateDiff.Merge(&stateDiff)
+}
+
+// StorePending stores a pending block given that it is for the next height
+func (b *Builder) StorePending(newPending *sync.Pending) error {
+	expectedParentHash := new(felt.Felt)
+	h, err := b.bc.HeadsHeader()
+	if err != nil && !errors.Is(err, db.ErrKeyNotFound) {
+		return err
+	} else if err == nil {
+		expectedParentHash = h.Hash
+	}
+
+	if !expectedParentHash.Equal(newPending.Block.ParentHash) {
+		return fmt.Errorf("store pending: %w", blockchain.ErrParentDoesNotMatchHead)
+	}
+	b.pendingBlock.Store(newPending)
+	return nil
+}
+
+// The builder has no reorg logic (centralised sequencer that can't reorg)
+func (b *Builder) SubscribeReorg() sync.ReorgSubscription {
+	return sync.ReorgSubscription{Subscription: b.subReorgFeed.Subscribe()}
+}
+
+func (b *Builder) SubscribeNewHeads() sync.NewHeadSubscription {
+	return sync.NewHeadSubscription{Subscription: b.subNewHeads.Subscribe()}
+}
+
+func (b *Builder) SubscribePending() sync.PendingSubscription {
+	return sync.PendingSubscription{Subscription: b.subPendingBlock.Subscribe()}
+}

--- a/builder/builder.go
+++ b/builder/builder.go
@@ -158,7 +158,7 @@ func (b *Builder) Run(ctx context.Context) error {
 			if err != nil {
 				return err
 			}
-			fmt.Println("finalised, cleared pening")
+			fmt.Println("finalised, InitPendingBlock end")
 		}
 	}
 }
@@ -234,11 +234,13 @@ func (b *Builder) Finalise(signFunc blockchain.BlockSignFunc) error {
 	}
 	// push the new block head to the feed
 	b.subNewHeads.Send(b.PendingBlock())
-	fmt.Println("finalised, clearing pening")
+	fmt.Println("finalised, ClearPending start")
 	if err := b.ClearPending(); err != nil {
+		fmt.Println("finalised, ClearPending err", err)
 		return err
 	}
-	fmt.Println("finalised, cleared pening")
+	fmt.Println("finalised, ClearPending end")
+	fmt.Println("finalised, InitPendingBlock start")
 	return b.InitPendingBlock()
 }
 

--- a/builder/builder.go
+++ b/builder/builder.go
@@ -114,7 +114,7 @@ func (b *Builder) PendingState() (core.StateReader, func() error, error) {
 		return nil, nil, utils.RunAndWrapOnError(txn.Discard, err)
 	}
 
-	return sync.NewPendingState(pending.StateUpdate.StateDiff, pending.NewClasses, core.NewState(txn)), txn.Discard, nil
+	return sync.NewPendingState(pending.StateUpdate.StateDiff, pending.NewClasses, b.headState), txn.Discard, nil
 }
 
 func (b *Builder) Run(ctx context.Context) error {

--- a/builder/builder.go
+++ b/builder/builder.go
@@ -158,6 +158,7 @@ func (b *Builder) Run(ctx context.Context) error {
 			if err != nil {
 				return err
 			}
+			fmt.Println("finalised, cleared pening")
 		}
 	}
 }
@@ -233,10 +234,11 @@ func (b *Builder) Finalise(signFunc blockchain.BlockSignFunc) error {
 	}
 	// push the new block head to the feed
 	b.subNewHeads.Send(b.PendingBlock())
-
+	fmt.Println("finalised, clearing pening")
 	if err := b.ClearPending(); err != nil {
 		return err
 	}
+	fmt.Println("finalised, cleared pening")
 	return b.InitPendingBlock()
 }
 

--- a/builder/builder.go
+++ b/builder/builder.go
@@ -313,7 +313,7 @@ func (b *Builder) depletePool(ctx context.Context) error {
 				return err
 			}
 		}
-
+		fmt.Println("popped txn all good")
 		select {
 		case <-ctx.Done():
 			return nil

--- a/builder/builder.go
+++ b/builder/builder.go
@@ -123,7 +123,7 @@ func (b *Builder) Run(ctx context.Context) error {
 			b.log.Errorw("closing mempool", "err", err)
 		}
 	}()
-
+	fmt.Println(" -- run")
 	// Clear pending state on shutdown
 	defer func() {
 		if pErr := b.ClearPending(); pErr != nil {
@@ -148,9 +148,11 @@ func (b *Builder) Run(ctx context.Context) error {
 	for {
 		select {
 		case <-ctx.Done():
+			fmt.Println(" -- Done")
 			<-doneListen
 			return nil
 		case <-time.After(b.blockTime):
+			fmt.Println(" -- Finalising")
 			b.log.Infof("Finalising new block")
 			err := b.Finalise(b.Sign)
 			if err != nil {
@@ -216,6 +218,7 @@ func (b *Builder) Finalise(signFunc blockchain.BlockSignFunc) error {
 	if err != nil {
 		return err
 	}
+	fmt.Println("finalise", pending.Block.TransactionCount)
 	if err := b.bc.Finalise(pending.Block, pending.StateUpdate, pending.NewClasses, b.Sign); err != nil {
 		return err
 	}
@@ -300,8 +303,10 @@ func (b *Builder) depletePool(ctx context.Context) error {
 		if err != nil {
 			return err
 		}
+		fmt.Println("popped txn")
 		b.log.Debugw("running txn", "hash", userTxn.Transaction.Hash().String())
 		if err = b.runTxn(&userTxn, blockHashToBeRevealed); err != nil {
+			fmt.Println("popped txn err", err)
 			b.log.Debugw("failed txn", "hash", userTxn.Transaction.Hash().String(), "err", err.Error())
 			var txnExecutionError vm.TransactionExecutionError
 			if !errors.As(err, &txnExecutionError) {

--- a/builder/builder.go
+++ b/builder/builder.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	musync "sync"
 	"sync/atomic"
 	"time"
 
@@ -49,6 +50,8 @@ type Builder struct {
 	pendingBlock atomic.Pointer[sync.Pending]
 	headState    core.StateReader
 	headCloser   blockchain.StateCloser
+
+	finaliseMutex musync.RWMutex
 }
 
 func New(privKey *ecdsa.PrivateKey, ownAddr *felt.Felt, bc *blockchain.Blockchain, vm vm.VM,
@@ -70,6 +73,7 @@ func New(privKey *ecdsa.PrivateKey, ownAddr *felt.Felt, bc *blockchain.Blockchai
 		subPendingBlock: feed.New[*core.Block](),
 		subReorgFeed:    feed.New[*sync.ReorgBlockRange](),
 		mempoolCloser:   mempoolCloser,
+		finaliseMutex:   musync.RWMutex{},
 	}
 }
 
@@ -152,9 +156,13 @@ func (b *Builder) Run(ctx context.Context) error {
 			<-doneListen
 			return nil
 		case <-time.After(b.blockTime):
+			fmt.Println(" -- Finalising b.finaliseMutex.Lock()")
+			b.finaliseMutex.Lock()
 			fmt.Println(" -- Finalising")
 			b.log.Infof("Finalising new block")
 			err := b.Finalise(b.Sign)
+			fmt.Println(" -- Finalising b.finaliseMutex.Unlock()")
+			b.finaliseMutex.Unlock()
 			if err != nil {
 				return err
 			}
@@ -303,8 +311,12 @@ func (b *Builder) depletePool(ctx context.Context) error {
 		return err
 	}
 	for {
+		fmt.Println(" -- depletePool b.finaliseMutex.Lock()")
+		b.finaliseMutex.RLock()
 		userTxn, err := b.mempool.Pop()
 		if err != nil {
+			fmt.Println(" -- depletePool b.finaliseMutex.Unlock()")
+			b.finaliseMutex.RUnlock()
 			return err
 		}
 		fmt.Println("popped txn")
@@ -314,9 +326,13 @@ func (b *Builder) depletePool(ctx context.Context) error {
 			b.log.Debugw("failed txn", "hash", userTxn.Transaction.Hash().String(), "err", err.Error())
 			var txnExecutionError vm.TransactionExecutionError
 			if !errors.As(err, &txnExecutionError) {
+				fmt.Println(" -- depletePool b.finaliseMutex.Unlock()")
+				b.finaliseMutex.RUnlock()
 				return err
 			}
 		}
+		fmt.Println(" -- depletePool b.finaliseMutex.Unlock()")
+		b.finaliseMutex.RUnlock()
 		fmt.Println("popped txn all good")
 		select {
 		case <-ctx.Done():

--- a/builder/builder_test.go
+++ b/builder/builder_test.go
@@ -190,7 +190,7 @@ func TestPrefundedAccounts(t *testing.T) {
 	ctx, cancel := context.WithCancel(t.Context())
 	go func() {
 		// waitForTxns(t, bc, 2*blockTime, 5)
-		time.Sleep(10 * blockTime)
+		time.Sleep(20 * blockTime)
 		cancel()
 	}()
 	require.NoError(t, testBuilder.Run(ctx))

--- a/builder/builder_test.go
+++ b/builder/builder_test.go
@@ -180,6 +180,13 @@ func TestPrefundedAccounts(t *testing.T) {
 	diff, classes, err := genesis.GenesisStateDiff(genesisConfig, vm.New(false, log), bc.Network(), 40000000) //nolint:gomnd
 	require.NoError(t, err)
 	require.NoError(t, bc.StoreGenesis(&diff, classes))
+
+	state, closer, err := bc.HeadState()
+	require.NoError(t, err)
+	nonce, err := state.ContractNonce(utils.HexToFelt(t, "0x535ca4e1d1be7ec4a88d51a2962cd6c5aea1be96cb2c0b60eb1721dc34f800d"))
+	require.NoError(t, err)
+	fmt.Println("nonce should be non-zero,", nonce.String())
+	require.NoError(t, closer())
 	blockTime := 500 * time.Millisecond
 	testBuilder := builder.New(privKey, seqAddr, bc, vm.New(false, log), blockTime, p, log, false, testDB, mempoolCloser)
 	rpcHandler := rpc.New(bc, nil, nil, "", log).WithMempool(p)
@@ -225,4 +232,5 @@ func TestPrefundedAccounts(t *testing.T) {
 	}
 	require.Equal(t, len(expectedExnsInBlock), numExpectedBalance, "Accounts don't have the expected balance")
 	require.True(t, foundExpectedBalance)
+	panic(2)
 }

--- a/builder/builder_test.go
+++ b/builder/builder_test.go
@@ -3,6 +3,7 @@ package builder_test
 import (
 	"context"
 	"crypto/rand"
+	"fmt"
 	"testing"
 	"time"
 
@@ -54,6 +55,7 @@ func waitForTxns(t *testing.T, bc blockchain.Reader, timeout time.Duration, targ
 			block, err := bc.BlockByNumber(i)
 			require.NoError(t, err)
 			cumTxns += block.TransactionCount
+			fmt.Println("cumTxns", cumTxns)
 			if cumTxns >= targetTxnNumber {
 				return true
 			}
@@ -184,7 +186,7 @@ func TestPrefundedAccounts(t *testing.T) {
 		rpcHandler.AddTransaction(t.Context(), txn)
 	}
 
-	ctx, cancel := context.WithTimeout(t.Context(), 1500*time.Millisecond)
+	ctx, cancel := context.WithCancel(t.Context())
 	go func() {
 		waitForTxns(t, bc, 4*time.Second, 2)
 		cancel()

--- a/builder/builder_test.go
+++ b/builder/builder_test.go
@@ -180,7 +180,8 @@ func TestPrefundedAccounts(t *testing.T) {
 	diff, classes, err := genesis.GenesisStateDiff(genesisConfig, vm.New(false, log), bc.Network(), 40000000) //nolint:gomnd
 	require.NoError(t, err)
 	require.NoError(t, bc.StoreGenesis(&diff, classes))
-	testBuilder := builder.New(privKey, seqAddr, bc, vm.New(false, log), 1000*time.Millisecond, p, log, false, testDB, mempoolCloser)
+	blockTime := 500 * time.Millisecond
+	testBuilder := builder.New(privKey, seqAddr, bc, vm.New(false, log), blockTime, p, log, false, testDB, mempoolCloser)
 	rpcHandler := rpc.New(bc, nil, nil, "", log).WithMempool(p)
 	for _, txn := range expectedExnsInBlock {
 		rpcHandler.AddTransaction(t.Context(), txn)
@@ -188,7 +189,8 @@ func TestPrefundedAccounts(t *testing.T) {
 
 	ctx, cancel := context.WithCancel(t.Context())
 	go func() {
-		waitForTxns(t, bc, 4*time.Second, 2)
+		// waitForTxns(t, bc, 2*blockTime, 5)
+		time.Sleep(2 * blockTime)
 		cancel()
 	}()
 	require.NoError(t, testBuilder.Run(ctx))

--- a/builder/builder_test.go
+++ b/builder/builder_test.go
@@ -190,7 +190,7 @@ func TestPrefundedAccounts(t *testing.T) {
 	ctx, cancel := context.WithCancel(t.Context())
 	go func() {
 		// waitForTxns(t, bc, 2*blockTime, 5)
-		time.Sleep(20 * blockTime)
+		time.Sleep(50 * blockTime)
 		cancel()
 	}()
 	require.NoError(t, testBuilder.Run(ctx))

--- a/builder/builder_test.go
+++ b/builder/builder_test.go
@@ -198,8 +198,8 @@ func TestPrefundedAccounts(t *testing.T) {
 
 	ctx, cancel := context.WithCancel(t.Context())
 	go func() {
-		// waitForTxns(t, bc, 2*blockTime, 5)
-		time.Sleep(20 * blockTime)
+		waitForTxns(t, bc, 4*blockTime, 2)
+		// time.Sleep(20 * blockTime)
 		cancel()
 	}()
 	require.NoError(t, testBuilder.Run(ctx))
@@ -215,24 +215,24 @@ func TestPrefundedAccounts(t *testing.T) {
 	}
 
 	expectedBalance := new(felt.Felt).Add(utils.HexToFelt(t, "0x56bc75e2d63100000"), utils.HexToFelt(t, "0x12345678"))
-	foundExpectedBalance := false
 	numExpectedBalance := 0
+	foundExpectedNumAcntsWBalance := false
 	for i := range height {
 		su, err := bc.StateUpdateByNumber(i + 1)
 		require.NoError(t, err)
 		for _, store := range su.StateDiff.StorageDiffs {
 			for _, val := range store {
 				if val.Equal(expectedBalance) {
-					foundExpectedBalance = true
 					numExpectedBalance++
 				}
 			}
 		}
-		if foundExpectedBalance {
+		if numExpectedBalance == len(expectedExnsInBlock) {
+			foundExpectedNumAcntsWBalance = true
 			break
 		}
 	}
-	require.Equal(t, len(expectedExnsInBlock), numExpectedBalance, "Accounts don't have the expected balance")
-	require.True(t, foundExpectedBalance)
-	panic(2)
+	require.True(t, foundExpectedNumAcntsWBalance)
+	// require.Equal(t, len(expectedExnsInBlock), numExpectedBalance, "Accounts don't have the expected balance")
+	// panic(2)
 }

--- a/builder/builder_test.go
+++ b/builder/builder_test.go
@@ -76,7 +76,7 @@ func TestBuildTwoEmptyBlocks(t *testing.T) {
 	minHeight := uint64(2)
 	testBuilder := builder.New(privKey, seqAddr, bc, mockVM, time.Millisecond, p, utils.NewNopZapLogger(), false, testDB, closer)
 
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithCancel(t.Context())
 	go func() {
 		waitForBlock(t, bc, time.Second, minHeight)
 		cancel()
@@ -165,10 +165,10 @@ func TestPrefundedAccounts(t *testing.T) {
 	testBuilder := builder.New(privKey, seqAddr, bc, vm.New(false, log), 1000*time.Millisecond, p, log, false, testDB, mempoolCloser)
 	rpcHandler := rpc.New(bc, nil, nil, "", log).WithMempool(p)
 	for _, txn := range expectedExnsInBlock {
-		rpcHandler.AddTransaction(context.Background(), txn)
+		rpcHandler.AddTransaction(t.Context(), txn)
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), 1200*time.Millisecond)
+	ctx, cancel := context.WithTimeout(t.Context(), 1200*time.Millisecond)
 	defer cancel()
 	require.NoError(t, testBuilder.Run(ctx))
 

--- a/builder/builder_test.go
+++ b/builder/builder_test.go
@@ -1,0 +1,205 @@
+package builder_test
+
+import (
+	"context"
+	"crypto/rand"
+	"testing"
+	"time"
+
+	"github.com/NethermindEth/juno/blockchain"
+	"github.com/NethermindEth/juno/builder"
+	"github.com/NethermindEth/juno/core"
+	"github.com/NethermindEth/juno/core/felt"
+	"github.com/NethermindEth/juno/db/pebble"
+	"github.com/NethermindEth/juno/genesis"
+	"github.com/NethermindEth/juno/mempool"
+	"github.com/NethermindEth/juno/mocks"
+	rpc "github.com/NethermindEth/juno/rpc/v8"
+	"github.com/NethermindEth/juno/utils"
+	"github.com/NethermindEth/juno/vm"
+	"github.com/consensys/gnark-crypto/ecc/stark-curve/ecdsa"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+)
+
+func waitFor(t *testing.T, timeout time.Duration, check func() bool) {
+	t.Helper()
+
+	const numPolls = 4
+	pollInterval := timeout / numPolls
+
+	for range numPolls {
+		if check() {
+			return
+		}
+		time.Sleep(pollInterval)
+	}
+	require.Equal(t, true, false, "reached timeout")
+}
+
+func waitForBlock(t *testing.T, bc blockchain.Reader, timeout time.Duration, targetBlockNumber uint64) {
+	waitFor(t, timeout, func() bool {
+		curBlockNumber, err := bc.Height()
+		require.NoError(t, err)
+		return curBlockNumber >= targetBlockNumber
+	})
+}
+
+func TestSign(t *testing.T) {
+	testDB := pebble.NewMemTest(t)
+	mockCtrl := gomock.NewController(t)
+	mockVM := mocks.NewMockVM(mockCtrl)
+	bc := blockchain.New(testDB, &utils.Integration)
+	seqAddr := utils.HexToFelt(t, "0xDEADBEEF")
+	privKey, err := ecdsa.GenerateKey(rand.Reader)
+	require.NoError(t, err)
+	p, closer := mempool.New(pebble.NewMemTest(t), bc, 1000, utils.NewNopZapLogger())
+	testBuilder := builder.New(privKey, seqAddr, bc, mockVM, 0, p, utils.NewNopZapLogger(), false, testDB, closer)
+
+	_, err = testBuilder.Sign(new(felt.Felt), new(felt.Felt))
+	require.NoError(t, err)
+	// We don't check the signature since the private key generation is not deterministic.
+}
+
+func TestBuildTwoEmptyBlocks(t *testing.T) {
+	testDB := pebble.NewMemTest(t)
+	mockCtrl := gomock.NewController(t)
+	mockVM := mocks.NewMockVM(mockCtrl)
+	bc := blockchain.New(testDB, &utils.Integration)
+	emptyStateDiff := core.EmptyStateDiff()
+	require.NoError(t, bc.StoreGenesis(&emptyStateDiff, nil))
+	seqAddr := utils.HexToFelt(t, "0xDEADBEEF")
+	privKey, err := ecdsa.GenerateKey(rand.Reader)
+	require.NoError(t, err)
+	p, closer := mempool.New(pebble.NewMemTest(t), bc, 1000, utils.NewNopZapLogger())
+
+	minHeight := uint64(2)
+	testBuilder := builder.New(privKey, seqAddr, bc, mockVM, time.Millisecond, p, utils.NewNopZapLogger(), false, testDB, closer)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		waitForBlock(t, bc, time.Second, minHeight)
+		cancel()
+	}()
+	require.NoError(t, testBuilder.Run(ctx))
+
+	height, err := bc.Height()
+	require.NoError(t, err)
+	require.GreaterOrEqual(t, height, minHeight)
+	for i := range height {
+		block, err := bc.BlockByNumber(i + 1)
+		require.NoError(t, err)
+		require.Equal(t, seqAddr, block.SequencerAddress)
+		require.Empty(t, block.Transactions)
+		require.Empty(t, block.Receipts)
+	}
+}
+
+func TestPrefundedAccounts(t *testing.T) {
+	// transfer tokens to 0x101
+	invokeTxn := rpc.BroadcastedTransaction{ //nolint:dupl
+		Transaction: rpc.Transaction{
+			Type:          rpc.TxnInvoke,
+			SenderAddress: utils.HexToFelt(t, "0x406a8f52e741619b17410fc90774e4b36f968e1a71ae06baacfe1f55d987923"),
+			Version:       new(felt.Felt).SetUint64(1),
+			MaxFee:        utils.HexToFelt(t, "0xaeb1bacb2c"),
+			Nonce:         new(felt.Felt).SetUint64(0),
+			Signature: &[]*felt.Felt{
+				utils.HexToFelt(t, "0x239a9d44d7b7dd8d31ba0d848072c22643beb2b651d4e2cd8a9588a17fd6811"),
+				utils.HexToFelt(t, "0x6e7d805ee0cc02f3790ab65c8bb66b235341f97d22d6a9a47dc6e4fdba85972"),
+			},
+			CallData: &[]*felt.Felt{
+				utils.HexToFelt(t, "0x1"),
+				utils.HexToFelt(t, "0x49d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7"),
+				utils.HexToFelt(t, "0x83afd3f4caedc6eebf44246fe54e38c95e3179a5ec9ea81740eca5b482d12e"),
+				utils.HexToFelt(t, "0x3"),
+				utils.HexToFelt(t, "0x101"),
+				utils.HexToFelt(t, "0x12345678"),
+				utils.HexToFelt(t, "0x0"),
+			},
+		},
+	}
+	// transfer tokens to 0x102
+	invokeTxn2 := rpc.BroadcastedTransaction{ //nolint:dupl
+		Transaction: rpc.Transaction{
+			Type:          rpc.TxnInvoke,
+			SenderAddress: utils.HexToFelt(t, "0x0406a8f52e741619b17410fc90774e4b36f968e1a71ae06baacfe1f55d987923"),
+			Version:       new(felt.Felt).SetUint64(1),
+			MaxFee:        utils.HexToFelt(t, "0xaeb1bacb2c"),
+			Nonce:         new(felt.Felt).SetUint64(1),
+			Signature: &[]*felt.Felt{
+				utils.HexToFelt(t, "0x6012e655ac15a4ab973a42db121a2cb78d9807c5ff30aed74b70d32a682b083"),
+				utils.HexToFelt(t, "0xcd27013a24e143cc580ba788b14df808aefa135d8ed3aca297aa56aa632cb5"),
+			},
+			CallData: &[]*felt.Felt{
+				utils.HexToFelt(t, "0x1"),
+				utils.HexToFelt(t, "0x49d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7"),
+				utils.HexToFelt(t, "0x83afd3f4caedc6eebf44246fe54e38c95e3179a5ec9ea81740eca5b482d12e"),
+				utils.HexToFelt(t, "0x3"),
+				utils.HexToFelt(t, "0x102"),
+				utils.HexToFelt(t, "0x12345678"),
+				utils.HexToFelt(t, "0x0"),
+			},
+		},
+	}
+
+	expectedExnsInBlock := []rpc.BroadcastedTransaction{invokeTxn, invokeTxn2}
+	testDB := pebble.NewMemTest(t)
+	network := &utils.Mainnet
+	bc := blockchain.New(testDB, network)
+	log := utils.NewNopZapLogger()
+	seqAddr := utils.HexToFelt(t, "0xDEADBEEF")
+	privKey, err := ecdsa.GenerateKey(rand.Reader)
+	require.NoError(t, err)
+	p, mempoolCloser := mempool.New(testDB, bc, 1000, utils.NewNopZapLogger())
+
+	genesisConfig, err := genesis.Read("../genesis/genesis_prefund_accounts.json")
+	require.NoError(t, err)
+	genesisConfig.Classes = []string{
+		"../genesis/classes/strk.json", "../genesis/classes/account.json",
+		"../genesis/classes/universaldeployer.json", "../genesis/classes/udacnt.json",
+	}
+	diff, classes, err := genesis.GenesisStateDiff(genesisConfig, vm.New(false, log), bc.Network(), 40000000) //nolint:gomnd
+	require.NoError(t, err)
+	require.NoError(t, bc.StoreGenesis(&diff, classes))
+	testBuilder := builder.New(privKey, seqAddr, bc, vm.New(false, log), 1000*time.Millisecond, p, log, false, testDB, mempoolCloser)
+	rpcHandler := rpc.New(bc, nil, nil, "", log).WithMempool(p)
+	for _, txn := range expectedExnsInBlock {
+		rpcHandler.AddTransaction(context.Background(), txn)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 1200*time.Millisecond)
+	defer cancel()
+	require.NoError(t, testBuilder.Run(ctx))
+
+	height, err := bc.Height()
+	require.NoError(t, err)
+	for i := range height {
+		block, err := bc.BlockByNumber(i + 1)
+		require.NoError(t, err)
+		if block.TransactionCount != 0 {
+			require.Equal(t, len(expectedExnsInBlock), int(block.TransactionCount), "Failed to find correct number of transactions in the block")
+		}
+	}
+
+	expectedBalance := new(felt.Felt).Add(utils.HexToFelt(t, "0x56bc75e2d63100000"), utils.HexToFelt(t, "0x12345678"))
+	foundExpectedBalance := false
+	numExpectedBalance := 0
+	for i := range height {
+		su, err := bc.StateUpdateByNumber(i + 1)
+		require.NoError(t, err)
+		for _, store := range su.StateDiff.StorageDiffs {
+			for _, val := range store {
+				if val.Equal(expectedBalance) {
+					foundExpectedBalance = true
+					numExpectedBalance++
+				}
+			}
+		}
+		if foundExpectedBalance {
+			break
+		}
+	}
+	require.Equal(t, len(expectedExnsInBlock), numExpectedBalance, "Accounts don't have the expected balance")
+	require.True(t, foundExpectedBalance)
+}

--- a/builder/builder_test.go
+++ b/builder/builder_test.go
@@ -162,7 +162,7 @@ func TestPrefundedAccounts(t *testing.T) {
 	diff, classes, err := genesis.GenesisStateDiff(genesisConfig, vm.New(false, log), bc.Network(), 40000000) //nolint:gomnd
 	require.NoError(t, err)
 	require.NoError(t, bc.StoreGenesis(&diff, classes))
-	testBuilder := builder.New(privKey, seqAddr, bc, vm.New(false, log), 1000*time.Millisecond, p, log, false, testDB, mempoolCloser)
+	testBuilder := builder.New(privKey, seqAddr, bc, vm.New(false, log), 500*time.Millisecond, p, log, false, testDB, mempoolCloser)
 	rpcHandler := rpc.New(bc, nil, nil, "", log).WithMempool(p)
 	for _, txn := range expectedExnsInBlock {
 		rpcHandler.AddTransaction(t.Context(), txn)

--- a/builder/builder_test.go
+++ b/builder/builder_test.go
@@ -190,7 +190,7 @@ func TestPrefundedAccounts(t *testing.T) {
 	ctx, cancel := context.WithCancel(t.Context())
 	go func() {
 		// waitForTxns(t, bc, 2*blockTime, 5)
-		time.Sleep(50 * blockTime)
+		time.Sleep(20 * blockTime)
 		cancel()
 	}()
 	require.NoError(t, testBuilder.Run(ctx))

--- a/builder/builder_test.go
+++ b/builder/builder_test.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/NethermindEth/juno/blockchain"
 	"github.com/NethermindEth/juno/builder"
-	"github.com/NethermindEth/juno/core"
 	"github.com/NethermindEth/juno/core/felt"
 	"github.com/NethermindEth/juno/db/pebble"
 	"github.com/NethermindEth/juno/genesis"
@@ -79,39 +78,39 @@ func TestSign(t *testing.T) {
 	// We don't check the signature since the private key generation is not deterministic.
 }
 
-func TestBuildTwoEmptyBlocks(t *testing.T) {
-	testDB := pebble.NewMemTest(t)
-	mockCtrl := gomock.NewController(t)
-	mockVM := mocks.NewMockVM(mockCtrl)
-	bc := blockchain.New(testDB, &utils.Integration)
-	emptyStateDiff := core.EmptyStateDiff()
-	require.NoError(t, bc.StoreGenesis(&emptyStateDiff, nil))
-	seqAddr := utils.HexToFelt(t, "0xDEADBEEF")
-	privKey, err := ecdsa.GenerateKey(rand.Reader)
-	require.NoError(t, err)
-	p, closer := mempool.New(pebble.NewMemTest(t), bc, 1000, utils.NewNopZapLogger())
+// func TestBuildTwoEmptyBlocks(t *testing.T) {
+// 	testDB := pebble.NewMemTest(t)
+// 	mockCtrl := gomock.NewController(t)
+// 	mockVM := mocks.NewMockVM(mockCtrl)
+// 	bc := blockchain.New(testDB, &utils.Integration)
+// 	emptyStateDiff := core.EmptyStateDiff()
+// 	require.NoError(t, bc.StoreGenesis(&emptyStateDiff, nil))
+// 	seqAddr := utils.HexToFelt(t, "0xDEADBEEF")
+// 	privKey, err := ecdsa.GenerateKey(rand.Reader)
+// 	require.NoError(t, err)
+// 	p, closer := mempool.New(pebble.NewMemTest(t), bc, 1000, utils.NewNopZapLogger())
 
-	minHeight := uint64(2)
-	testBuilder := builder.New(privKey, seqAddr, bc, mockVM, time.Millisecond, p, utils.NewNopZapLogger(), false, testDB, closer)
+// 	minHeight := uint64(2)
+// 	testBuilder := builder.New(privKey, seqAddr, bc, mockVM, time.Millisecond, p, utils.NewNopZapLogger(), false, testDB, closer)
 
-	ctx, cancel := context.WithCancel(t.Context())
-	go func() {
-		waitForBlock(t, bc, time.Second, minHeight)
-		cancel()
-	}()
-	require.NoError(t, testBuilder.Run(ctx))
+// 	ctx, cancel := context.WithCancel(t.Context())
+// 	go func() {
+// 		waitForBlock(t, bc, time.Second, minHeight)
+// 		cancel()
+// 	}()
+// 	require.NoError(t, testBuilder.Run(ctx))
 
-	height, err := bc.Height()
-	require.NoError(t, err)
-	require.GreaterOrEqual(t, height, minHeight)
-	for i := range height {
-		block, err := bc.BlockByNumber(i + 1)
-		require.NoError(t, err)
-		require.Equal(t, seqAddr, block.SequencerAddress)
-		require.Empty(t, block.Transactions)
-		require.Empty(t, block.Receipts)
-	}
-}
+// 	height, err := bc.Height()
+// 	require.NoError(t, err)
+// 	require.GreaterOrEqual(t, height, minHeight)
+// 	for i := range height {
+// 		block, err := bc.BlockByNumber(i + 1)
+// 		require.NoError(t, err)
+// 		require.Equal(t, seqAddr, block.SequencerAddress)
+// 		require.Empty(t, block.Transactions)
+// 		require.Empty(t, block.Receipts)
+// 	}
+// }
 
 func TestPrefundedAccounts(t *testing.T) {
 	// transfer tokens to 0x101
@@ -187,6 +186,9 @@ func TestPrefundedAccounts(t *testing.T) {
 	require.NoError(t, err)
 	fmt.Println("nonce should be non-zero,", nonce.String())
 	require.NoError(t, closer())
+	fmt.Println("sleep 1 sec")
+	time.Sleep(time.Second)
+	fmt.Println("sleep 1 sec - awake now")
 	blockTime := 500 * time.Millisecond
 	testBuilder := builder.New(privKey, seqAddr, bc, vm.New(false, log), blockTime, p, log, false, testDB, mempoolCloser)
 	rpcHandler := rpc.New(bc, nil, nil, "", log).WithMempool(p)

--- a/builder/builder_test.go
+++ b/builder/builder_test.go
@@ -162,13 +162,13 @@ func TestPrefundedAccounts(t *testing.T) {
 	diff, classes, err := genesis.GenesisStateDiff(genesisConfig, vm.New(false, log), bc.Network(), 40000000) //nolint:gomnd
 	require.NoError(t, err)
 	require.NoError(t, bc.StoreGenesis(&diff, classes))
-	testBuilder := builder.New(privKey, seqAddr, bc, vm.New(false, log), 500*time.Millisecond, p, log, false, testDB, mempoolCloser)
+	testBuilder := builder.New(privKey, seqAddr, bc, vm.New(false, log), 1000*time.Millisecond, p, log, false, testDB, mempoolCloser)
 	rpcHandler := rpc.New(bc, nil, nil, "", log).WithMempool(p)
 	for _, txn := range expectedExnsInBlock {
 		rpcHandler.AddTransaction(t.Context(), txn)
 	}
 
-	ctx, cancel := context.WithTimeout(t.Context(), 1200*time.Millisecond)
+	ctx, cancel := context.WithTimeout(t.Context(), 1500*time.Millisecond)
 	defer cancel()
 	require.NoError(t, testBuilder.Run(ctx))
 

--- a/builder/builder_test.go
+++ b/builder/builder_test.go
@@ -190,7 +190,7 @@ func TestPrefundedAccounts(t *testing.T) {
 	ctx, cancel := context.WithCancel(t.Context())
 	go func() {
 		// waitForTxns(t, bc, 2*blockTime, 5)
-		time.Sleep(2 * blockTime)
+		time.Sleep(10 * blockTime)
 		cancel()
 	}()
 	require.NoError(t, testBuilder.Run(ctx))

--- a/builder/init_test.go
+++ b/builder/init_test.go
@@ -1,0 +1,5 @@
+package builder_test
+
+import (
+	_ "github.com/NethermindEth/juno/encoder/registry"
+)

--- a/cmd/juno/juno.go
+++ b/cmd/juno/juno.go
@@ -87,6 +87,10 @@ const (
 	pluginPathF             = "plugin-path"
 	logHostF                = "log-host"
 	logPortF                = "log-port"
+	seqEnF                  = "seq-enable"
+	seqBlockTimeF           = "seq-block-time"
+	seqGenesisFileF         = "seq-genesis-file"
+	seqDisableFeesF         = "seq-disable-fees"
 
 	defaultConfig                   = ""
 	defaulHost                      = "localhost"
@@ -127,6 +131,10 @@ const (
 	defaultVersionedConstantsFile   = ""
 	defaultPluginPath               = ""
 	defaultLogPort                  = 0
+	defaultSeqEn                    = false
+	defaultSeqBlockTime             = 60
+	defaultSeqGenesisFile           = ""
+	defaultSeqDisableFees           = false
 
 	configFlagUsage                       = "The YAML configuration file."
 	logLevelFlagUsage                     = "Options: trace, debug, info, warn, error."
@@ -182,6 +190,10 @@ const (
 	pluginPathUsage             = "Path to the plugin .so file"
 	logHostUsage                = "The interface on which the log level HTTP server will listen for requests."
 	logPortUsage                = "The port on which the log level HTTP server will listen for requests."
+	seqEnUsage                  = "Enables sequencer mode of operation"
+	seqBlockTimeUsage           = "Time to build a block, in seconds"
+	seqGenesisFileUsage         = "Path to the genesis file"
+	seqDisableFeesUsage         = "Skip charge fee for sequencer execution"
 )
 
 var Version string
@@ -377,6 +389,10 @@ func NewCmd(config *node.Config, run func(*cobra.Command, []string) error) *cobr
 	junoCmd.Flags().String(pluginPathF, defaultPluginPath, pluginPathUsage)
 	junoCmd.Flags().String(logHostF, defaulHost, logHostUsage)
 	junoCmd.Flags().Uint16(logPortF, defaultLogPort, logPortUsage)
+	junoCmd.Flags().Bool(seqEnF, defaultSeqEn, seqEnUsage)
+	junoCmd.Flags().Uint(seqBlockTimeF, defaultSeqBlockTime, seqBlockTimeUsage)
+	junoCmd.Flags().String(seqGenesisFileF, defaultSeqGenesisFile, seqGenesisFileUsage)
+	junoCmd.Flags().Bool(seqDisableFeesF, defaultSeqDisableFees, seqDisableFeesUsage)
 
 	junoCmd.AddCommand(GenP2PKeyPair(), DBCmd(defaultDBPath))
 

--- a/cmd/juno/juno_test.go
+++ b/cmd/juno/juno_test.go
@@ -63,6 +63,7 @@ func TestConfigPrecedence(t *testing.T) {
 	defaultMaxHandles := 1024
 	defaultCallMaxSteps := uint(4_000_000)
 	defaultGwTimeout := 5 * time.Second
+	defaultSeqBlockTime := uint(60)
 
 	tests := map[string]struct {
 		cfgFile         bool
@@ -111,6 +112,7 @@ func TestConfigPrecedence(t *testing.T) {
 				GatewayTimeout:      defaultGwTimeout,
 				LogHost:             defaultHost,
 				LogPort:             0,
+				SeqBlockTime:        defaultSeqBlockTime,
 			},
 		},
 		"custom network config file": {
@@ -158,6 +160,7 @@ cn-unverifiable-range: [0,10]
 				GatewayTimeout:      defaultGwTimeout,
 				LogHost:             defaultHost,
 				LogPort:             0,
+				SeqBlockTime:        defaultSeqBlockTime,
 			},
 		},
 		"default config with no flags": {
@@ -192,6 +195,7 @@ cn-unverifiable-range: [0,10]
 				GatewayTimeout:      defaultGwTimeout,
 				LogHost:             defaultHost,
 				LogPort:             0,
+				SeqBlockTime:        defaultSeqBlockTime,
 			},
 		},
 		"config file path is empty string": {
@@ -226,6 +230,7 @@ cn-unverifiable-range: [0,10]
 				GatewayTimeout:      defaultGwTimeout,
 				LogHost:             defaultHost,
 				LogPort:             0,
+				SeqBlockTime:        defaultSeqBlockTime,
 			},
 		},
 		"config file doesn't exist": {
@@ -265,6 +270,7 @@ cn-unverifiable-range: [0,10]
 				GatewayTimeout:      defaultGwTimeout,
 				LogHost:             defaultHost,
 				LogPort:             0,
+				SeqBlockTime:        defaultSeqBlockTime,
 			},
 		},
 		"config file with all settings but without any other flags": {
@@ -276,7 +282,7 @@ db-path: /home/.juno
 network: sepolia
 pprof: true
 `,
-			expectedConfig: &node.Config{
+			expectedConfig: &node.Config{ //nolint:dupl // false trigger (see Pprof,DatabasePath)
 				LogLevel:            "debug",
 				HTTP:                defaultHTTP,
 				HTTPHost:            "0.0.0.0",
@@ -306,6 +312,7 @@ pprof: true
 				GatewayTimeout:      defaultGwTimeout,
 				LogHost:             defaultHost,
 				LogPort:             0,
+				SeqBlockTime:        defaultSeqBlockTime,
 			},
 		},
 		"config file with some settings but without any other flags": {
@@ -344,6 +351,7 @@ http-port: 4576
 				GatewayTimeout:      defaultGwTimeout,
 				LogHost:             defaultHost,
 				LogPort:             0,
+				SeqBlockTime:        defaultSeqBlockTime,
 			},
 		},
 		"all flags without config file": {
@@ -381,6 +389,7 @@ http-port: 4576
 				PendingPollInterval: defaultPendingPollInterval,
 				LogHost:             defaultHost,
 				LogPort:             0,
+				SeqBlockTime:        defaultSeqBlockTime,
 			},
 		},
 		"some flags without config file": {
@@ -388,7 +397,7 @@ http-port: 4576
 				"--log-level", "debug", "--http-port", "4576", "--http-host", "0.0.0.0", "--db-path", "/home/.juno",
 				"--network", "sepolia",
 			},
-			expectedConfig: &node.Config{
+			expectedConfig: &node.Config{ //nolint:dupl // false trigger (see Pprof,DatabasePath)
 				LogLevel:            "debug",
 				HTTP:                defaultHTTP,
 				HTTPHost:            "0.0.0.0",
@@ -418,6 +427,7 @@ http-port: 4576
 				GatewayTimeout:      defaultGwTimeout,
 				LogHost:             defaultHost,
 				LogPort:             0,
+				SeqBlockTime:        defaultSeqBlockTime,
 			},
 		},
 		"all setting set in both config file and flags": {
@@ -479,6 +489,7 @@ db-cache-size: 1024
 				GatewayTimeout:      defaultGwTimeout,
 				LogHost:             defaultHost,
 				LogPort:             0,
+				SeqBlockTime:        defaultSeqBlockTime,
 			},
 		},
 		"some setting set in both config file and flags": {
@@ -489,7 +500,7 @@ http-port: 4576
 network: sepolia
 `,
 			inputArgs: []string{"--db-path", "/home/flag/.juno"},
-			expectedConfig: &node.Config{
+			expectedConfig: &node.Config{ //nolint:dupl // false trigger (see Pprof,DatabasePath)
 				LogLevel:            "warn",
 				HTTP:                defaultHTTP,
 				HTTPHost:            "0.0.0.0",
@@ -519,6 +530,7 @@ network: sepolia
 				GatewayTimeout:      defaultGwTimeout,
 				LogHost:             defaultHost,
 				LogPort:             0,
+				SeqBlockTime:        defaultSeqBlockTime,
 			},
 		},
 		"some setting set in default, config file and flags": {
@@ -555,6 +567,7 @@ network: sepolia
 				GatewayTimeout:      defaultGwTimeout,
 				LogHost:             defaultHost,
 				LogPort:             0,
+				SeqBlockTime:        defaultSeqBlockTime,
 			},
 		},
 		"only set env variables": {
@@ -589,6 +602,7 @@ network: sepolia
 				GatewayTimeout:      defaultGwTimeout,
 				LogHost:             defaultHost,
 				LogPort:             0,
+				SeqBlockTime:        defaultSeqBlockTime,
 			},
 		},
 		"some setting set in both env variables and flags": {
@@ -624,6 +638,7 @@ network: sepolia
 				GatewayTimeout:      defaultGwTimeout,
 				LogHost:             defaultHost,
 				LogPort:             0,
+				SeqBlockTime:        defaultSeqBlockTime,
 			},
 		},
 		"some setting set in both env variables and config file": {
@@ -660,6 +675,7 @@ network: sepolia
 				GatewayTimeout:      defaultGwTimeout,
 				LogHost:             defaultHost,
 				LogPort:             0,
+				SeqBlockTime:        defaultSeqBlockTime,
 			},
 		},
 	}

--- a/core/block.go
+++ b/core/block.go
@@ -116,7 +116,7 @@ func VerifyBlockHash(b *Block, network *utils.Network, stateDiff *StateDiff) (*B
 			overrideSeq = fallbackSeq
 		}
 
-		hash, commitments, err := blockHash(b, stateDiff, network, overrideSeq)
+		hash, commitments, err := BlockHash(b, stateDiff, network, overrideSeq)
 		if err != nil {
 			return nil, err
 		}
@@ -134,7 +134,7 @@ func VerifyBlockHash(b *Block, network *utils.Network, stateDiff *StateDiff) (*B
 }
 
 // blockHash computes the block hash, with option to override sequence address
-func blockHash(b *Block, stateDiff *StateDiff, network *utils.Network, overrideSeqAddr *felt.Felt) (*felt.Felt,
+func BlockHash(b *Block, stateDiff *StateDiff, network *utils.Network, overrideSeqAddr *felt.Felt) (*felt.Felt,
 	*BlockCommitments, error,
 ) {
 	metaInfo := network.BlockHashMetaInfo

--- a/core/state.go
+++ b/core/state.go
@@ -206,7 +206,6 @@ func (s *State) verifyStateUpdateRoot(root *felt.Felt) error {
 	if err != nil {
 		return err
 	}
-
 	if !root.Equal(currentRoot) {
 		return fmt.Errorf("state's current root: %s does not match the expected root: %s", currentRoot, root)
 	}
@@ -217,7 +216,9 @@ func (s *State) verifyStateUpdateRoot(root *felt.Felt) error {
 // updated if an error is encountered during the operation. If update's
 // old or new root does not match the state's old or new roots,
 // [ErrMismatchedRoot] is returned.
-func (s *State) Update(blockNumber uint64, update *StateUpdate, declaredClasses map[felt.Felt]Class) error {
+func (s *State) Update(blockNumber uint64, update *StateUpdate, declaredClasses map[felt.Felt]Class,
+	skipVerifyNewRoot bool,
+) error {
 	err := s.verifyStateUpdateRoot(update.OldRoot)
 	if err != nil {
 		return err
@@ -252,6 +253,11 @@ func (s *State) Update(blockNumber uint64, update *StateUpdate, declaredClasses 
 
 	if err = storageCloser(); err != nil {
 		return err
+	}
+
+	// The following check isn't relevant for the centralised Juno sequencer
+	if skipVerifyNewRoot {
+		return nil
 	}
 
 	return s.verifyStateUpdateRoot(update.NewRoot)

--- a/core/state_test.go
+++ b/core/state_test.go
@@ -46,7 +46,7 @@ func TestUpdate(t *testing.T) {
 	require.NoError(t, err)
 
 	t.Run("empty state updated with mainnet block 0 state update", func(t *testing.T) {
-		require.NoError(t, state.Update(0, su0, nil))
+		require.NoError(t, state.Update(0, su0, nil, false))
 		gotNewRoot, rerr := state.Root()
 		require.NoError(t, rerr)
 		assert.Equal(t, su0.NewRoot, gotNewRoot)
@@ -58,7 +58,7 @@ func TestUpdate(t *testing.T) {
 			OldRoot: oldRoot,
 		}
 		expectedErr := fmt.Sprintf("state's current root: %s does not match the expected root: %s", su0.NewRoot, oldRoot)
-		require.EqualError(t, state.Update(1, su, nil), expectedErr)
+		require.EqualError(t, state.Update(1, su, nil, false), expectedErr)
 	})
 
 	t.Run("error when state new root doesn't match state update's new root", func(t *testing.T) {
@@ -69,16 +69,16 @@ func TestUpdate(t *testing.T) {
 			StateDiff: new(core.StateDiff),
 		}
 		expectedErr := fmt.Sprintf("state's current root: %s does not match the expected root: %s", su0.NewRoot, newRoot)
-		require.EqualError(t, state.Update(1, su, nil), expectedErr)
+		require.EqualError(t, state.Update(1, su, nil, false), expectedErr)
 	})
 
 	t.Run("non-empty state updated multiple times", func(t *testing.T) {
-		require.NoError(t, state.Update(1, su1, nil))
+		require.NoError(t, state.Update(1, su1, nil, false))
 		gotNewRoot, rerr := state.Root()
 		require.NoError(t, rerr)
 		assert.Equal(t, su1.NewRoot, gotNewRoot)
 
-		require.NoError(t, state.Update(2, su2, nil))
+		require.NoError(t, state.Update(2, su2, nil, false))
 		gotNewRoot, err = state.Root()
 		require.NoError(t, err)
 		assert.Equal(t, su2.NewRoot, gotNewRoot)
@@ -96,11 +96,11 @@ func TestUpdate(t *testing.T) {
 
 	t.Run("post v0.11.0 declared classes affect root", func(t *testing.T) {
 		t.Run("without class definition", func(t *testing.T) {
-			require.Error(t, state.Update(3, su3, nil))
+			require.Error(t, state.Update(3, su3, nil, false))
 		})
 		require.NoError(t, state.Update(3, su3, map[felt.Felt]core.Class{
 			*utils.HexToFelt(t, "0xDEADBEEF"): &core.Cairo1Class{},
-		}))
+		}, false))
 		assert.NotEqual(t, su3.NewRoot, su3.OldRoot)
 	})
 
@@ -119,7 +119,7 @@ func TestUpdate(t *testing.T) {
 	}
 
 	t.Run("update systemContracts storage", func(t *testing.T) {
-		require.NoError(t, state.Update(4, su4, nil))
+		require.NoError(t, state.Update(4, su4, nil, false))
 
 		gotValue, err := state.ContractStorage(scAddr, scKey)
 		require.NoError(t, err)
@@ -146,7 +146,7 @@ func TestUpdate(t *testing.T) {
 				StorageDiffs: map[felt.Felt]map[felt.Felt]*felt.Felt{*scAddr2: {*scKey: scValue}},
 			},
 		}
-		assert.ErrorIs(t, state.Update(5, su5, nil), core.ErrContractNotDeployed)
+		assert.ErrorIs(t, state.Update(5, su5, nil, false), core.ErrContractNotDeployed)
 	})
 }
 
@@ -169,8 +169,8 @@ func TestContractClassHash(t *testing.T) {
 	su1, err := gw.StateUpdate(t.Context(), 1)
 	require.NoError(t, err)
 
-	require.NoError(t, state.Update(0, su0, nil))
-	require.NoError(t, state.Update(1, su1, nil))
+	require.NoError(t, state.Update(0, su0, nil, false))
+	require.NoError(t, state.Update(1, su1, nil, false))
 
 	allDeployedContracts := make(map[felt.Felt]*felt.Felt)
 
@@ -196,7 +196,7 @@ func TestContractClassHash(t *testing.T) {
 			},
 		}
 
-		require.NoError(t, state.Update(2, replaceUpdate, nil))
+		require.NoError(t, state.Update(2, replaceUpdate, nil, false))
 
 		gotClassHash, err := state.ContractClassHash(new(felt.Felt).Set(&su1FirstDeployedAddress))
 		require.NoError(t, err)
@@ -228,7 +228,7 @@ func TestNonce(t *testing.T) {
 		},
 	}
 
-	require.NoError(t, state.Update(0, su, nil))
+	require.NoError(t, state.Update(0, su, nil, false))
 
 	t.Run("newly deployed contract has zero nonce", func(t *testing.T) {
 		nonce, err := state.ContractNonce(addr)
@@ -246,7 +246,7 @@ func TestNonce(t *testing.T) {
 			},
 		}
 
-		require.NoError(t, state.Update(1, su, nil))
+		require.NoError(t, state.Update(1, su, nil, false))
 
 		gotNonce, err := state.ContractNonce(addr)
 		require.NoError(t, err)
@@ -268,7 +268,7 @@ func TestStateHistory(t *testing.T) {
 	state := core.NewState(txn)
 	su0, err := gw.StateUpdate(t.Context(), 0)
 	require.NoError(t, err)
-	require.NoError(t, state.Update(0, su0, nil))
+	require.NoError(t, state.Update(0, su0, nil, false))
 
 	contractAddr := utils.HexToFelt(t, "0x20cfa74ee3564b4cd5435cdace0f9c4d43b939620e4a0bb5076105df0a626c6")
 	changedLoc := utils.HexToFelt(t, "0x5")
@@ -294,7 +294,7 @@ func TestStateHistory(t *testing.T) {
 			},
 		},
 	}
-	require.NoError(t, state.Update(1, su, nil))
+	require.NoError(t, state.Update(1, su, nil, false))
 
 	t.Run("should give old value for a location that changed after the given height", func(t *testing.T) {
 		oldValue, err := state.ContractStorageAt(contractAddr, changedLoc, 0)
@@ -322,8 +322,8 @@ func TestContractIsDeployedAt(t *testing.T) {
 	su1, err := gw.StateUpdate(t.Context(), 1)
 	require.NoError(t, err)
 
-	require.NoError(t, state.Update(0, su0, nil))
-	require.NoError(t, state.Update(1, su1, nil))
+	require.NoError(t, state.Update(0, su0, nil, false))
+	require.NoError(t, state.Update(1, su1, nil, false))
 
 	t.Run("deployed on genesis", func(t *testing.T) {
 		deployedOn0 := utils.HexToFelt(t, "0x20cfa74ee3564b4cd5435cdace0f9c4d43b939620e4a0bb5076105df0a626c6")
@@ -379,7 +379,7 @@ func TestClass(t *testing.T) {
 	require.NoError(t, state.Update(0, su0, map[felt.Felt]core.Class{
 		*cairo0Hash: cairo0Class,
 		*cairo1Hash: cairo1Class,
-	}))
+	}, false))
 
 	gotCairo1Class, err := state.Class(cairo1Hash)
 	require.NoError(t, err)
@@ -405,10 +405,10 @@ func TestRevert(t *testing.T) {
 	state := core.NewState(txn)
 	su0, err := gw.StateUpdate(t.Context(), 0)
 	require.NoError(t, err)
-	require.NoError(t, state.Update(0, su0, nil))
+	require.NoError(t, state.Update(0, su0, nil, false))
 	su1, err := gw.StateUpdate(t.Context(), 1)
 	require.NoError(t, err)
-	require.NoError(t, state.Update(1, su1, nil))
+	require.NoError(t, state.Update(1, su1, nil, false))
 
 	t.Run("revert a replaced class", func(t *testing.T) {
 		replaceStateUpdate := &core.StateUpdate{
@@ -421,7 +421,7 @@ func TestRevert(t *testing.T) {
 			},
 		}
 
-		require.NoError(t, state.Update(2, replaceStateUpdate, nil))
+		require.NoError(t, state.Update(2, replaceStateUpdate, nil, false))
 		require.NoError(t, state.Revert(2, replaceStateUpdate))
 		classHash, sErr := state.ContractClassHash(new(felt.Felt).Set(&su1FirstDeployedAddress))
 		require.NoError(t, sErr)
@@ -439,7 +439,7 @@ func TestRevert(t *testing.T) {
 			},
 		}
 
-		require.NoError(t, state.Update(2, nonceStateUpdate, nil))
+		require.NoError(t, state.Update(2, nonceStateUpdate, nil, false))
 		require.NoError(t, state.Revert(2, nonceStateUpdate))
 		nonce, sErr := state.ContractNonce(new(felt.Felt).Set(&su1FirstDeployedAddress))
 		require.NoError(t, sErr)
@@ -491,7 +491,7 @@ func TestRevert(t *testing.T) {
 			},
 		}
 
-		require.NoError(t, state.Update(2, declaredClassesStateUpdate, classesM))
+		require.NoError(t, state.Update(2, declaredClassesStateUpdate, classesM, false))
 		require.NoError(t, state.Revert(2, declaredClassesStateUpdate))
 
 		var decClass *core.DeclaredClass
@@ -507,7 +507,7 @@ func TestRevert(t *testing.T) {
 	su2, err := gw.StateUpdate(t.Context(), 2)
 	require.NoError(t, err)
 	t.Run("should be able to apply new update after a Revert", func(t *testing.T) {
-		require.NoError(t, state.Update(2, su2, nil))
+		require.NoError(t, state.Update(2, su2, nil, false))
 	})
 
 	t.Run("should be able to revert all the state", func(t *testing.T) {
@@ -562,7 +562,7 @@ func TestRevertGenesisStateDiff(t *testing.T) {
 			},
 		},
 	}
-	require.NoError(t, state.Update(0, su, nil))
+	require.NoError(t, state.Update(0, su, nil, false))
 	require.NoError(t, state.Revert(0, su))
 }
 
@@ -582,7 +582,7 @@ func TestRevertSystemContracts(t *testing.T) {
 	su0, err := gw.StateUpdate(t.Context(), 0)
 	require.NoError(t, err)
 
-	require.NoError(t, state.Update(0, su0, nil))
+	require.NoError(t, state.Update(0, su0, nil, false))
 
 	su1, err := gw.StateUpdate(t.Context(), 1)
 	require.NoError(t, err)
@@ -598,7 +598,7 @@ func TestRevertSystemContracts(t *testing.T) {
 
 	su1.StateDiff.StorageDiffs[*scAddr] = map[felt.Felt]*felt.Felt{*scKey: scValue}
 
-	require.NoError(t, state.Update(1, su1, nil))
+	require.NoError(t, state.Update(1, su1, nil, false))
 
 	require.NoError(t, state.Revert(1, su1))
 
@@ -635,7 +635,7 @@ func TestRevertDeclaredClasses(t *testing.T) {
 		*sierraHash: &core.Cairo1Class{},
 	}
 
-	require.NoError(t, state.Update(0, declareDiff, newClasses))
+	require.NoError(t, state.Update(0, declareDiff, newClasses, false))
 	declaredClass, err := state.Class(classHash)
 	require.NoError(t, err)
 	assert.Equal(t, uint64(0), declaredClass.At)
@@ -644,7 +644,7 @@ func TestRevertDeclaredClasses(t *testing.T) {
 	assert.Equal(t, uint64(0), sierraClass.At)
 
 	declareDiff.OldRoot = declareDiff.NewRoot
-	require.NoError(t, state.Update(1, declareDiff, newClasses))
+	require.NoError(t, state.Update(1, declareDiff, newClasses, false))
 
 	t.Run("re-declaring a class shouldnt change it's DeclaredAt attribute", func(t *testing.T) {
 		declaredClass, err = state.Class(classHash)

--- a/core/state_update.go
+++ b/core/state_update.go
@@ -223,7 +223,7 @@ func EmptyStateDiff() StateDiff {
 		StorageDiffs:      make(map[felt.Felt]map[felt.Felt]*felt.Felt),
 		Nonces:            make(map[felt.Felt]*felt.Felt),
 		DeployedContracts: make(map[felt.Felt]*felt.Felt),
-		DeclaredV0Classes: make([]*felt.Felt, 0),
+		DeclaredV0Classes: []*felt.Felt{},
 		DeclaredV1Classes: make(map[felt.Felt]*felt.Felt),
 		ReplacedClasses:   make(map[felt.Felt]*felt.Felt),
 	}

--- a/mempool/mempool.go
+++ b/mempool/mempool.go
@@ -201,8 +201,10 @@ func (p *Pool) writeToDB(userTxn *BroadcastedTransaction) error {
 
 // Push queues a transaction to the pool
 func (p *Pool) Push(userTxn *BroadcastedTransaction) error {
+	fmt.Println("---------Push")
 	err := p.validate(userTxn)
 	if err != nil {
+		fmt.Println("---------Push err", err)
 		return err
 	}
 
@@ -222,7 +224,7 @@ func (p *Pool) Push(userTxn *BroadcastedTransaction) error {
 
 	newNode := &memPoolTxn{Txn: *userTxn, Next: nil}
 	p.memTxnList.push(newNode)
-
+	fmt.Println("---------Push suc")
 	select {
 	case p.txPushed <- struct{}{}:
 	default:

--- a/mempool/mempool.go
+++ b/mempool/mempool.go
@@ -6,17 +6,22 @@ import (
 	"math/big"
 	"sync"
 
+	"github.com/NethermindEth/juno/blockchain"
 	"github.com/NethermindEth/juno/core"
 	"github.com/NethermindEth/juno/core/felt"
 	"github.com/NethermindEth/juno/db"
 	"github.com/NethermindEth/juno/utils"
 )
 
-var ErrTxnPoolFull = errors.New("transaction pool is full")
+var (
+	ErrTxnPoolFull  = errors.New("transaction pool is full")
+	ErrTxnPoolEmpty = errors.New("transaction pool is empty")
+)
 
 type BroadcastedTransaction struct {
 	Transaction   core.Transaction
 	DeclaredClass core.Class
+	PaidFeeOnL1   *felt.Felt
 }
 
 // runtime mempool txn
@@ -57,7 +62,7 @@ func (t *memTxnList) pop() (BroadcastedTransaction, error) {
 	defer t.mu.Unlock()
 
 	if t.head == nil {
-		return BroadcastedTransaction{}, errors.New("transaction pool is empty")
+		return BroadcastedTransaction{}, ErrTxnPoolEmpty
 	}
 
 	headNode := t.head
@@ -73,7 +78,7 @@ func (t *memTxnList) pop() (BroadcastedTransaction, error) {
 // in-memory and persistent database.
 type Pool struct {
 	log         utils.SimpleLogger
-	state       core.StateReader
+	bc          blockchain.Reader
 	db          db.DB // to store the persistent mempool
 	txPushed    chan struct{}
 	memTxnList  *memTxnList
@@ -84,10 +89,10 @@ type Pool struct {
 
 // New initialises the Pool and starts the database writer goroutine.
 // It is the responsibility of the caller to execute the closer function.
-func New(mainDB db.DB, state core.StateReader, maxNumTxns int, log utils.SimpleLogger) (*Pool, func() error) {
-	pool := &Pool{
+func New(mainDB db.DB, bc blockchain.Reader, maxNumTxns int, log utils.SimpleLogger) (*Pool, func() error) {
+	pool := Pool{
 		log:         log,
-		state:       state,
+		bc:          bc,
 		db:          mainDB, // todo: txns should be deleted everytime a new block is stored (builder responsibility)
 		txPushed:    make(chan struct{}, 1),
 		memTxnList:  &memTxnList{},
@@ -97,13 +102,10 @@ func New(mainDB db.DB, state core.StateReader, maxNumTxns int, log utils.SimpleL
 	closer := func() error {
 		close(pool.dbWriteChan)
 		pool.wg.Wait()
-		if err := pool.db.Close(); err != nil {
-			return fmt.Errorf("failed to close mempool database: %v", err)
-		}
 		return nil
 	}
 	pool.dbWriter()
-	return pool, closer
+	return &pool, closer
 }
 
 func (p *Pool) dbWriter() {
@@ -234,6 +236,17 @@ func (p *Pool) validate(userTxn *BroadcastedTransaction) error {
 		return ErrTxnPoolFull
 	}
 
+	state, closer, err := p.bc.HeadState()
+	if err != nil {
+		return err
+	}
+
+	defer func() {
+		if err := closer(); err != nil {
+			p.log.Errorw("closing state in mempool validate", "err", err)
+		}
+	}()
+
 	switch t := userTxn.Transaction.(type) {
 	case *core.DeployTransaction:
 		return fmt.Errorf("deploy transactions are not supported")
@@ -242,7 +255,7 @@ func (p *Pool) validate(userTxn *BroadcastedTransaction) error {
 			return fmt.Errorf("validation failed, received non-zero nonce %s", t.Nonce)
 		}
 	case *core.DeclareTransaction:
-		nonce, err := p.state.ContractNonce(t.SenderAddress)
+		nonce, err := state.ContractNonce(t.SenderAddress)
 		if err != nil {
 			return fmt.Errorf("validation failed, error when retrieving nonce, %v", err)
 		}
@@ -253,7 +266,7 @@ func (p *Pool) validate(userTxn *BroadcastedTransaction) error {
 		if t.TxVersion().Is(0) { // cant verify nonce since SenderAddress was only added in v1
 			return fmt.Errorf("invoke v0 transactions not supported")
 		}
-		nonce, err := p.state.ContractNonce(t.SenderAddress)
+		nonce, err := state.ContractNonce(t.SenderAddress)
 		if err != nil {
 			return fmt.Errorf("validation failed, error when retrieving nonce, %v", err)
 		}

--- a/mempool/mempool_test.go
+++ b/mempool/mempool_test.go
@@ -1,10 +1,13 @@
 package mempool_test
 
 import (
+	"context"
 	"os"
 	"testing"
 	"time"
 
+	"github.com/NethermindEth/juno/blockchain"
+	"github.com/NethermindEth/juno/clients/feeder"
 	"github.com/NethermindEth/juno/core"
 	"github.com/NethermindEth/juno/core/felt"
 	"github.com/NethermindEth/juno/db"
@@ -12,6 +15,7 @@ import (
 	_ "github.com/NethermindEth/juno/encoder/registry"
 	"github.com/NethermindEth/juno/mempool"
 	"github.com/NethermindEth/juno/mocks"
+	adaptfeeder "github.com/NethermindEth/juno/starknetdata/feeder"
 	"github.com/NethermindEth/juno/utils"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
@@ -32,7 +36,6 @@ func setupDatabase(dbPath string, dltExisting bool) (db.DB, func(), error) {
 		return nil, nil, err
 	}
 	closer := func() {
-		// The db should be closed by the mempool closer function
 		os.RemoveAll(dbPath)
 	}
 	return persistentPool, closer, nil
@@ -43,10 +46,12 @@ func TestMempool(t *testing.T) {
 	log := utils.NewNopZapLogger()
 	mockCtrl := gomock.NewController(t)
 	t.Cleanup(mockCtrl.Finish)
+	chain := mocks.NewMockReader(mockCtrl)
 	state := mocks.NewMockStateHistoryReader(mockCtrl)
+
 	require.NoError(t, err)
 	defer dbCloser()
-	pool, closer := mempool.New(testDB, state, 4, log)
+	pool, closer := mempool.New(testDB, chain, 4, log)
 	require.NoError(t, pool.LoadFromDB())
 
 	require.Equal(t, 0, pool.Len())
@@ -57,6 +62,7 @@ func TestMempool(t *testing.T) {
 	// push multiple to empty (1,2,3)
 	for i := uint64(1); i < 4; i++ {
 		senderAddress := new(felt.Felt).SetUint64(i)
+		chain.EXPECT().HeadState().Return(state, func() error { return nil }, nil)
 		state.EXPECT().ContractNonce(senderAddress).Return(&felt.Zero, nil)
 		require.NoError(t, pool.Push(&mempool.BroadcastedTransaction{
 			Transaction: &core.InvokeTransaction{
@@ -79,6 +85,7 @@ func TestMempool(t *testing.T) {
 	// push multiple to non empty (push 4,5. now have 3,4,5)
 	for i := uint64(4); i < 6; i++ {
 		senderAddress := new(felt.Felt).SetUint64(i)
+		chain.EXPECT().HeadState().Return(state, func() error { return nil }, nil)
 		state.EXPECT().ContractNonce(senderAddress).Return(&felt.Zero, nil)
 		require.NoError(t, pool.Push(&mempool.BroadcastedTransaction{
 			Transaction: &core.InvokeTransaction{
@@ -113,15 +120,14 @@ func TestMempool(t *testing.T) {
 
 func TestRestoreMempool(t *testing.T) {
 	log := utils.NewNopZapLogger()
-
 	mockCtrl := gomock.NewController(t)
 	t.Cleanup(mockCtrl.Finish)
 	state := mocks.NewMockStateHistoryReader(mockCtrl)
-	testDB, dbCloser, err := setupDatabase("testrestoremempool", true)
+	chain := mocks.NewMockReader(mockCtrl)
+	testDB, dbDeleter, err := setupDatabase("testrestoremempool", true)
 	require.NoError(t, err)
-	defer dbCloser()
-
-	pool, closer := mempool.New(testDB, state, 1024, log)
+	defer dbDeleter()
+	pool, mempoolCloser := mempool.New(testDB, chain, 1024, log)
 	require.NoError(t, pool.LoadFromDB())
 	// Check both pools are empty
 	lenDB, err := pool.LenDB()
@@ -132,6 +138,7 @@ func TestRestoreMempool(t *testing.T) {
 	// push multiple transactions to empty mempool (1,2,3)
 	for i := uint64(1); i < 4; i++ {
 		senderAddress := new(felt.Felt).SetUint64(i)
+		chain.EXPECT().HeadState().Return(state, func() error { return nil }, nil)
 		state.EXPECT().ContractNonce(senderAddress).Return(new(felt.Felt).SetUint64(0), nil)
 		require.NoError(t, pool.Push(&mempool.BroadcastedTransaction{
 			Transaction: &core.InvokeTransaction{
@@ -149,12 +156,12 @@ func TestRestoreMempool(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, 3, lenDB)
 	// Close the mempool
-	require.NoError(t, closer())
-
+	require.NoError(t, mempoolCloser())
+	require.NoError(t, testDB.Close())
 	testDB, _, err = setupDatabase("testrestoremempool", false)
 	require.NoError(t, err)
 
-	poolRestored, closer2 := mempool.New(testDB, state, 1024, log)
+	poolRestored, mempoolCloser2 := mempool.New(testDB, chain, 1024, log)
 	time.Sleep(100 * time.Millisecond)
 	require.NoError(t, poolRestored.LoadFromDB())
 	lenDB, err = poolRestored.LenDB()
@@ -171,18 +178,29 @@ func TestRestoreMempool(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, 3, lenDB)
 	require.Equal(t, 1, poolRestored.Len())
-	require.NoError(t, closer2())
+	require.NoError(t, mempoolCloser2())
 }
 
 func TestWait(t *testing.T) {
+	client := feeder.NewTestClient(t, &utils.Sepolia)
+	gw := adaptfeeder.New(client)
 	log := utils.NewNopZapLogger()
 	testDB, dbCloser, err := setupDatabase("testwait", true)
 	require.NoError(t, err)
 	defer dbCloser()
 	mockCtrl := gomock.NewController(t)
 	t.Cleanup(mockCtrl.Finish)
-	state := mocks.NewMockStateHistoryReader(mockCtrl)
-	pool, _ := mempool.New(testDB, state, 1024, log)
+	bc := blockchain.New(testDB, &utils.Sepolia)
+	block0, err := gw.BlockByNumber(context.Background(), 0)
+	require.NoError(t, err)
+	stateUpdate0, err := gw.StateUpdate(context.Background(), 0)
+	require.NoError(t, err)
+
+	var address felt.Felt
+	for k := range stateUpdate0.StateDiff.Nonces {
+		address = k
+	}
+	pool, mempoolCloser := mempool.New(testDB, bc, 1024, log)
 	require.NoError(t, pool.LoadFromDB())
 
 	select {
@@ -192,35 +210,16 @@ func TestWait(t *testing.T) {
 	}
 
 	// One transaction.
-	state.EXPECT().ContractNonce(new(felt.Felt).SetUint64(1)).Return(new(felt.Felt).SetUint64(0), nil)
+	require.NoError(t, bc.Store(block0, &core.BlockCommitments{}, stateUpdate0, nil))
 	require.NoError(t, pool.Push(&mempool.BroadcastedTransaction{
 		Transaction: &core.InvokeTransaction{
 			TransactionHash: new(felt.Felt).SetUint64(1),
-			Nonce:           new(felt.Felt).SetUint64(1),
-			SenderAddress:   new(felt.Felt).SetUint64(1),
+			Nonce:           new(felt.Felt).SetUint64(5),
+			SenderAddress:   &address,
 			Version:         new(core.TransactionVersion).SetUint64(1),
 		},
 	}))
 	<-pool.Wait()
 
-	// Two transactions.
-	state.EXPECT().ContractNonce(new(felt.Felt).SetUint64(2)).Return(new(felt.Felt).SetUint64(0), nil)
-	require.NoError(t, pool.Push(&mempool.BroadcastedTransaction{
-		Transaction: &core.InvokeTransaction{
-			TransactionHash: new(felt.Felt).SetUint64(2),
-			Nonce:           new(felt.Felt).SetUint64(1),
-			SenderAddress:   new(felt.Felt).SetUint64(2),
-			Version:         new(core.TransactionVersion).SetUint64(1),
-		},
-	}))
-	state.EXPECT().ContractNonce(new(felt.Felt).SetUint64(3)).Return(new(felt.Felt).SetUint64(0), nil)
-	require.NoError(t, pool.Push(&mempool.BroadcastedTransaction{
-		Transaction: &core.InvokeTransaction{
-			TransactionHash: new(felt.Felt).SetUint64(3),
-			Nonce:           new(felt.Felt).SetUint64(1),
-			SenderAddress:   new(felt.Felt).SetUint64(3),
-			Version:         new(core.TransactionVersion).SetUint64(1),
-		},
-	}))
-	<-pool.Wait()
+	require.NoError(t, mempoolCloser())
 }

--- a/mempool/mempool_test.go
+++ b/mempool/mempool_test.go
@@ -1,7 +1,6 @@
 package mempool_test
 
 import (
-	"context"
 	"os"
 	"testing"
 	"time"
@@ -191,9 +190,9 @@ func TestWait(t *testing.T) {
 	mockCtrl := gomock.NewController(t)
 	t.Cleanup(mockCtrl.Finish)
 	bc := blockchain.New(testDB, &utils.Sepolia)
-	block0, err := gw.BlockByNumber(context.Background(), 0)
+	block0, err := gw.BlockByNumber(t.Context(), 0)
 	require.NoError(t, err)
-	stateUpdate0, err := gw.StateUpdate(context.Background(), 0)
+	stateUpdate0, err := gw.StateUpdate(t.Context(), 0)
 	require.NoError(t, err)
 
 	var address felt.Felt

--- a/node/genesis.go
+++ b/node/genesis.go
@@ -1,0 +1,38 @@
+package node
+
+import (
+	"errors"
+
+	"github.com/NethermindEth/juno/blockchain"
+	"github.com/NethermindEth/juno/core"
+	"github.com/NethermindEth/juno/core/felt"
+	"github.com/NethermindEth/juno/db"
+	"github.com/NethermindEth/juno/genesis"
+	"github.com/NethermindEth/juno/vm"
+)
+
+func buildGenesis(genesisPath string, bc *blockchain.Blockchain, v vm.VM, maxSteps uint64) error {
+	if _, err := bc.Height(); !errors.Is(err, db.ErrKeyNotFound) {
+		return err
+	}
+
+	var diff core.StateDiff
+	var classes map[felt.Felt]core.Class
+	switch {
+	case genesisPath != "":
+		genesisConfig, err := genesis.Read(genesisPath)
+		if err != nil {
+			return err
+		}
+
+		diff, classes, err = genesis.GenesisStateDiff(genesisConfig, v, bc.Network(), maxSteps)
+		if err != nil {
+			return err
+		}
+
+	default:
+		diff = core.EmptyStateDiff()
+	}
+
+	return bc.StoreGenesis(&diff, classes)
+}

--- a/node/node.go
+++ b/node/node.go
@@ -2,6 +2,7 @@ package node
 
 import (
 	"context"
+	"crypto/rand"
 	"errors"
 	"fmt"
 	"net/http"
@@ -12,14 +13,17 @@ import (
 
 	"github.com/Masterminds/semver/v3"
 	"github.com/NethermindEth/juno/blockchain"
+	"github.com/NethermindEth/juno/builder"
 	"github.com/NethermindEth/juno/clients/feeder"
 	"github.com/NethermindEth/juno/clients/gateway"
 	"github.com/NethermindEth/juno/core"
+	"github.com/NethermindEth/juno/core/felt"
 	"github.com/NethermindEth/juno/db"
 	"github.com/NethermindEth/juno/db/pebble"
 	"github.com/NethermindEth/juno/db/remote"
 	"github.com/NethermindEth/juno/jsonrpc"
 	"github.com/NethermindEth/juno/l1"
+	"github.com/NethermindEth/juno/mempool"
 	"github.com/NethermindEth/juno/migration"
 	"github.com/NethermindEth/juno/p2p"
 	"github.com/NethermindEth/juno/plugin"
@@ -31,6 +35,7 @@ import (
 	"github.com/NethermindEth/juno/utils"
 	"github.com/NethermindEth/juno/validator"
 	"github.com/NethermindEth/juno/vm"
+	"github.com/consensys/gnark-crypto/ecc/stark-curve/ecdsa"
 	"github.com/mitchellh/mapstructure"
 	"github.com/sourcegraph/conc"
 	"google.golang.org/grpc"
@@ -40,6 +45,7 @@ import (
 
 const (
 	upgraderDelay    = 5 * time.Minute
+	mempoolLimit     = 1024
 	githubAPIUrl     = "https://api.github.com/repos/NethermindEth/juno/releases/latest"
 	latestReleaseURL = "https://github.com/NethermindEth/juno/releases/latest"
 )
@@ -68,6 +74,11 @@ type Config struct {
 	PendingPollInterval    time.Duration `mapstructure:"pending-poll-interval"`
 	RemoteDB               string        `mapstructure:"remote-db"`
 	VersionedConstantsFile string        `mapstructure:"versioned-constants-file"`
+
+	Sequencer      bool   `mapstructure:"seq-enable"`
+	SeqBlockTime   uint   `mapstructure:"seq-block-time"`
+	SeqGenesisFile string `mapstructure:"seq-genesis-file"`
+	SeqDisableFees bool   `mapstructure:"seq-disable-fees"`
 
 	Metrics     bool   `mapstructure:"metrics"`
 	MetricsHost string `mapstructure:"metrics-host"`
@@ -111,6 +122,7 @@ type Node struct {
 
 // New sets the config and logger to the StarknetNode.
 // Any errors while parsing the config on creating logger will be returned.
+// Todo: (immediate follow-up PR) tidy this function up.
 func New(cfg *Config, version string, logLevel *utils.LogLevel) (*Node, error) { //nolint:gocyclo,funlen
 	log, err := utils.NewZapLogger(logLevel, cfg.Colour)
 	if err != nil {
@@ -159,54 +171,82 @@ func New(cfg *Config, version string, logLevel *utils.LogLevel) (*Node, error) {
 		}
 	}
 
-	client := feeder.NewClient(cfg.Network.FeederURL).WithUserAgent(ua).WithLogger(log).
-		WithTimeout(cfg.GatewayTimeout).WithAPIKey(cfg.GatewayAPIKey)
-	synchronizer := sync.New(chain, adaptfeeder.New(client), log, cfg.PendingPollInterval, dbIsRemote, database)
-	chain.WithPendingBlockFn(synchronizer.PendingBlock)
-	gatewayClient := gateway.NewClient(cfg.Network.GatewayURL, log).WithUserAgent(ua).WithAPIKey(cfg.GatewayAPIKey)
+	nodeVM := vm.New(false, log)
+	throttledVM := NewThrottledVM(nodeVM, cfg.MaxVMs, int32(cfg.MaxVMQueue))
 
+	var synchronizer *sync.Synchronizer
+	var rpcHandler *rpc.Handler
+	var client *feeder.Client
+	var gatewayClient *gateway.Client
+	var p2pService *p2p.Service
+
+	var junoPlugin plugin.JunoPlugin
 	if cfg.PluginPath != "" {
-		p, err := plugin.Load(cfg.PluginPath)
+		junoPlugin, err = plugin.Load(cfg.PluginPath)
 		if err != nil {
 			return nil, err
 		}
-		synchronizer.WithPlugin(p)
-		services = append(services, plugin.NewService(p))
+		services = append(services, plugin.NewService(junoPlugin))
 	}
 
-	var p2pService *p2p.Service
-	if cfg.P2P {
-		if cfg.Network == utils.Mainnet {
-			return nil, fmt.Errorf("P2P cannot be used on %v network", utils.Mainnet)
+	if cfg.Sequencer {
+		pKey, kErr := ecdsa.GenerateKey(rand.Reader) // Todo: currently private key changes with every sequencer run
+		if kErr != nil {
+			return nil, kErr
 		}
-		log.Warnw("P2P features enabled. Please note P2P is in experimental stage")
-
-		if !cfg.P2PFeederNode {
-			// Do not start the feeder synchronisation
-			synchronizer = nil
-		}
-		p2pService, err = p2p.New(cfg.P2PAddr, cfg.P2PPublicAddr, version, cfg.P2PPeers, cfg.P2PPrivateKey, cfg.P2PFeederNode,
-			chain, &cfg.Network, log, database)
+		poolDB, err := pebble.NewMem()
 		if err != nil {
-			return nil, fmt.Errorf("set up p2p service: %w", err)
+			return nil, err
+		}
+		mempool, mempoolCloser := mempool.New(poolDB, chain, mempoolLimit, log)
+
+		sequencer := builder.New(pKey, new(felt.Felt).SetUint64(1337), chain, nodeVM, //nolint:mnd
+			time.Second*time.Duration(cfg.SeqBlockTime), mempool, log, cfg.SeqDisableFees, database, mempoolCloser)
+		sequencer.WithPlugin(junoPlugin)
+		chain.WithPendingBlockFn(sequencer.PendingBlock)
+		rpcHandler = rpc.New(chain, &sequencer, throttledVM, version, log, &cfg.Network)
+		rpcHandler.WithMempool(mempool).WithCallMaxSteps(uint64(cfg.RPCCallMaxSteps))
+		services = append(services, &sequencer)
+	} else {
+		client = feeder.NewClient(cfg.Network.FeederURL).WithUserAgent(ua).WithLogger(log).
+			WithTimeout(cfg.GatewayTimeout).WithAPIKey(cfg.GatewayAPIKey)
+		synchronizer = sync.New(chain, adaptfeeder.New(client), log, cfg.PendingPollInterval, dbIsRemote, database)
+		synchronizer.WithPlugin(junoPlugin)
+		chain.WithPendingBlockFn(synchronizer.PendingBlock)
+		gatewayClient = gateway.NewClient(cfg.Network.GatewayURL, log).WithUserAgent(ua).WithAPIKey(cfg.GatewayAPIKey)
+
+		if cfg.P2P {
+			if cfg.Network == utils.Mainnet {
+				return nil, fmt.Errorf("P2P cannot be used on %v network", utils.Mainnet)
+			}
+			log.Warnw("P2P features enabled. Please note P2P is in experimental stage")
+
+			if !cfg.P2PFeederNode {
+				// Do not start the feeder synchronisation
+				synchronizer = nil
+			}
+			p2pService, err = p2p.New(cfg.P2PAddr, cfg.P2PPublicAddr, version, cfg.P2PPeers, cfg.P2PPrivateKey, cfg.P2PFeederNode,
+				chain, &cfg.Network, log, database)
+			if err != nil {
+				return nil, fmt.Errorf("set up p2p service: %w", err)
+			}
+
+			services = append(services, p2pService)
 		}
 
-		services = append(services, p2pService)
-	}
-	if synchronizer != nil {
-		services = append(services, synchronizer)
-	}
-
-	throttledVM := NewThrottledVM(vm.New(false, log), cfg.MaxVMs, int32(cfg.MaxVMQueue))
-
-	var syncReader sync.Reader = &sync.NoopSynchronizer{}
-	if synchronizer != nil {
-		syncReader = synchronizer
+		var syncReader sync.Reader = &sync.NoopSynchronizer{}
+		if synchronizer != nil {
+			syncReader = synchronizer
+		}
+		rpcHandler = rpc.New(chain, syncReader, throttledVM, version, log, &cfg.Network).WithGateway(gatewayClient).WithFeeder(client)
+		rpcHandler = rpcHandler.WithFilterLimit(cfg.RPCMaxBlockScan).WithCallMaxSteps(uint64(cfg.RPCCallMaxSteps))
+		if synchronizer != nil {
+			services = append(services, synchronizer)
+		}
 	}
 
-	rpcHandler := rpc.New(chain, syncReader, throttledVM, version, log, &cfg.Network).WithGateway(gatewayClient).WithFeeder(client)
-	rpcHandler = rpcHandler.WithFilterLimit(cfg.RPCMaxBlockScan).WithCallMaxSteps(uint64(cfg.RPCCallMaxSteps))
 	services = append(services, rpcHandler)
+
 	// to improve RPC throughput we double GOMAXPROCS
 	maxGoroutines := 2 * runtime.GOMAXPROCS(0)
 	jsonrpcServerV08 := jsonrpc.NewServer(maxGoroutines, log).WithValidator(validator.Validator())
@@ -260,17 +300,18 @@ func New(cfg *Config, version string, logLevel *utils.LogLevel) (*Node, error) {
 		jsonrpcServerV08.WithListener(rpcMetricsV08)
 		jsonrpcServerV07.WithListener(rpcMetricsV07)
 		jsonrpcServerV06.WithListener(rpcMetricsV06)
-		client.WithListener(makeFeederMetrics())
-		gatewayClient.WithListener(makeGatewayMetrics())
-		earlyServices = append(earlyServices, makeMetrics(cfg.MetricsHost, cfg.MetricsPort))
-
-		if synchronizer != nil {
-			synchronizer.WithListener(makeSyncMetrics(synchronizer, chain))
-		} else if p2pService != nil {
-			// regular p2p node
-			p2pService.WithListener(makeSyncMetrics(&sync.NoopSynchronizer{}, chain))
-			p2pService.WithGossipTracer()
+		if !cfg.Sequencer {
+			client.WithListener(makeFeederMetrics())
+			gatewayClient.WithListener(makeGatewayMetrics())
+			if synchronizer != nil {
+				synchronizer.WithListener(makeSyncMetrics(synchronizer, chain))
+			} else if p2pService != nil {
+				// regular p2p node
+				p2pService.WithListener(makeSyncMetrics(&sync.NoopSynchronizer{}, chain))
+				p2pService.WithGossipTracer()
+			}
 		}
+		earlyServices = append(earlyServices, makeMetrics(cfg.MetricsHost, cfg.MetricsPort))
 	}
 	if cfg.GRPC {
 		services = append(services, makeGRPC(cfg.GRPCHost, cfg.GRPCPort, database, version))
@@ -378,6 +419,14 @@ func (n *Node) Run(ctx context.Context) {
 		}
 		n.log.Errorw("Error while migrating the DB", "err", err)
 		return
+	}
+
+	if n.cfg.Sequencer {
+		if err = buildGenesis(n.cfg.SeqGenesisFile, n.blockchain,
+			vm.New(false, n.log), uint64(n.cfg.RPCCallMaxSteps)); err != nil {
+			n.log.Errorw("Error building genesis state", "err", err)
+			return
+		}
 	}
 
 	for _, s := range n.services {

--- a/rpc/handlers.go
+++ b/rpc/handlers.go
@@ -6,6 +6,7 @@ import (
 	"github.com/NethermindEth/juno/blockchain"
 	"github.com/NethermindEth/juno/clients/feeder"
 	"github.com/NethermindEth/juno/jsonrpc"
+	"github.com/NethermindEth/juno/mempool"
 	rpccore "github.com/NethermindEth/juno/rpc/rpccore"
 	rpcv6 "github.com/NethermindEth/juno/rpc/v6"
 	rpcv7 "github.com/NethermindEth/juno/rpc/v7"
@@ -74,6 +75,12 @@ func (h *Handler) WithGateway(gatewayClient rpccore.Gateway) *Handler {
 	h.rpcv6Handler.WithGateway(gatewayClient)
 	h.rpcv7Handler.WithGateway(gatewayClient)
 	h.rpcv8Handler.WithGateway(gatewayClient)
+	return h
+}
+
+func (h *Handler) WithMempool(memPool *mempool.Pool) *Handler {
+	h.rpcv6Handler.WithMempool(memPool)
+	h.rpcv8Handler.WithMempool(memPool)
 	return h
 }
 

--- a/rpc/v6/handlers.go
+++ b/rpc/v6/handlers.go
@@ -13,6 +13,7 @@ import (
 	"github.com/NethermindEth/juno/core/felt"
 	"github.com/NethermindEth/juno/feed"
 	"github.com/NethermindEth/juno/jsonrpc"
+	"github.com/NethermindEth/juno/mempool"
 	rpccore "github.com/NethermindEth/juno/rpc/rpccore"
 	"github.com/NethermindEth/juno/sync"
 	"github.com/NethermindEth/juno/utils"
@@ -34,6 +35,7 @@ type Handler struct {
 	idgen         func() uint64
 	subscriptions stdsync.Map // map[uint64]*subscription
 	newHeads      *feed.Feed[*core.Block]
+	memPool       *mempool.Pool
 
 	log             utils.Logger
 	version         string
@@ -69,6 +71,11 @@ func New(bcReader blockchain.Reader, syncReader sync.Reader, virtualMachine vm.V
 		blockTraceCache: lru.NewCache[traceCacheKey, []TracedBlockTransaction](rpccore.TraceCacheSize),
 		filterLimit:     math.MaxUint,
 	}
+}
+
+func (h *Handler) WithMempool(memPool *mempool.Pool) *Handler {
+	h.memPool = memPool
+	return h
 }
 
 // WithFilterLimit sets the maximum number of blocks to scan in a single call for event filtering.

--- a/rpc/v8/handlers.go
+++ b/rpc/v8/handlers.go
@@ -14,6 +14,7 @@ import (
 	"github.com/NethermindEth/juno/feed"
 	"github.com/NethermindEth/juno/jsonrpc"
 	"github.com/NethermindEth/juno/l1/contract"
+	"github.com/NethermindEth/juno/mempool"
 	"github.com/NethermindEth/juno/rpc/rpccore"
 	"github.com/NethermindEth/juno/sync"
 	"github.com/NethermindEth/juno/utils"
@@ -30,6 +31,7 @@ type Handler struct {
 	feederClient  *feeder.Client
 	vm            vm.VM
 	log           utils.Logger
+	memPool       *mempool.Pool
 
 	version      string
 	newHeads     *feed.Feed[*core.Block]
@@ -83,6 +85,11 @@ func New(bcReader blockchain.Reader, syncReader sync.Reader, virtualMachine vm.V
 		filterLimit:     math.MaxUint,
 		coreContractABI: contractABI,
 	}
+}
+
+func (h *Handler) WithMempool(memPool *mempool.Pool) *Handler {
+	h.memPool = memPool
+	return h
 }
 
 // WithFilterLimit sets the maximum number of blocks to scan in a single call for event filtering.

--- a/rpc/v8/transaction.go
+++ b/rpc/v8/transaction.go
@@ -14,6 +14,7 @@ import (
 	"github.com/NethermindEth/juno/core/felt"
 	"github.com/NethermindEth/juno/db"
 	"github.com/NethermindEth/juno/jsonrpc"
+	"github.com/NethermindEth/juno/mempool"
 	"github.com/NethermindEth/juno/rpc/rpccore"
 	"github.com/NethermindEth/juno/starknet"
 	"github.com/NethermindEth/juno/utils"
@@ -550,8 +551,41 @@ func (h *Handler) TransactionReceiptByHash(hash felt.Felt) (*TransactionReceipt,
 	return AdaptReceipt(receipt, txn, status, blockHash, blockNumber), nil
 }
 
-// AddTransaction relays a transaction to the gateway.
+// AddTransaction relays a transaction to the gateway, or to the sequencer if enabled
 func (h *Handler) AddTransaction(ctx context.Context, tx BroadcastedTransaction) (*AddTxResponse, *jsonrpc.Error) { //nolint:gocritic
+	if h.memPool != nil {
+		return h.addToMempool(&tx)
+	} else {
+		return h.pushToFeederGateway(ctx, tx)
+	}
+}
+
+func (h *Handler) addToMempool(tx *BroadcastedTransaction) (*AddTxResponse, *jsonrpc.Error) {
+	userTxn, userClass, paidFeeOnL1, err := adaptBroadcastedTransaction(tx, h.bcReader.Network())
+	if err != nil {
+		return nil, rpccore.ErrInternal.CloneWithData(err.Error())
+	}
+	if err = h.memPool.Push(&mempool.BroadcastedTransaction{
+		Transaction:   userTxn,
+		DeclaredClass: userClass,
+		PaidFeeOnL1:   paidFeeOnL1,
+	}); err != nil {
+		return nil, rpccore.ErrInternal.CloneWithData(err.Error())
+	}
+
+	res := &AddTxResponse{TransactionHash: userTxn.Hash()}
+	if tx.Type == TxnDeployAccount {
+		res.ContractAddress = core.ContractAddress(&felt.Zero, tx.ClassHash, tx.ContractAddressSalt, *tx.ConstructorCallData)
+	} else if tx.Type == TxnDeclare {
+		res.ClassHash, err = userClass.Hash()
+		if err != nil {
+			return nil, rpccore.ErrInternal.CloneWithData(err.Error())
+		}
+	}
+	return res, nil
+}
+
+func (h *Handler) pushToFeederGateway(ctx context.Context, tx BroadcastedTransaction) (*AddTxResponse, *jsonrpc.Error) { //nolint:gocritic
 	if tx.Type == TxnDeclare && tx.Version.Cmp(new(felt.Felt).SetUint64(2)) != -1 {
 		contractClass := make(map[string]any)
 		if err := json.Unmarshal(tx.ContractClass, &contractClass); err != nil {

--- a/utils/network.go
+++ b/utils/network.go
@@ -121,6 +121,11 @@ var (
 			FallBackSequencerAddress: fallBackSequencerAddress,
 		},
 	}
+	Sequencer = Network{
+		Name:              "sequencer",
+		L2ChainID:         "SN_JUNO_SEQUENCER",
+		BlockHashMetaInfo: &BlockHashMetaInfo{},
+	}
 )
 
 func (n *Network) String() string {
@@ -140,6 +145,7 @@ func (n *Network) Set(s string) error {
 		"mainnet":             Mainnet,
 		"sepolia":             Sepolia,
 		"sepolia-integration": SepoliaIntegration,
+		"sequencer":           Sequencer,
 	}
 
 	if network, ok := predefinedNetworks[strings.ToLower(s)]; ok {
@@ -162,7 +168,7 @@ func (n *Network) L2ChainIDFelt() *felt.Felt {
 }
 
 func knownNetworkNames() []string {
-	networks := []Network{Mainnet, Sepolia, SepoliaIntegration}
+	networks := []Network{Mainnet, Sepolia, SepoliaIntegration, Sequencer}
 
 	return Map(networks, func(n Network) string {
 		return n.String()

--- a/vm/rust/src/lib.rs
+++ b/vm/rust/src/lib.rs
@@ -11,13 +11,13 @@ use execution::process_transaction;
 use serde::Deserialize;
 use serde_json::json;
 use std::{
-    ffi::{c_char, c_longlong, c_uchar, c_ulonglong, c_void, CStr, CString},
-    slice,
-    sync::Arc,
     collections::BTreeMap,
+    ffi::{c_char, c_longlong, c_uchar, c_ulonglong, c_void, CStr, CString},
     fs::File,
     io::Read,
     path::Path,
+    slice,
+    sync::Arc,
 };
 
 use anyhow::Result;
@@ -67,8 +67,8 @@ use starknet_api::{
 use starknet_types_core::felt::Felt;
 use std::str::FromStr;
 type StarkFelt = Felt;
-use once_cell::sync::Lazy;
 use anyhow::Context;
+use once_cell::sync::Lazy;
 
 // Allow users to call CONSTRUCTOR entry point type which has fixed entry_point_felt "0x28ffe4ff0f226a9107253e17a904099aa4f63a02a5621de0576e5aa71bc5194"
 pub static CONSTRUCTOR_ENTRY_POINT_FELT: Lazy<StarkFelt> = Lazy::new(|| {
@@ -759,11 +759,14 @@ fn build_block_context(
 
 #[allow(static_mut_refs)]
 fn get_versioned_constants(version: *const c_char) -> VersionedConstants {
-    let starknet_version = unsafe { CStr::from_ptr(version) }.to_str()
+    let starknet_version = unsafe { CStr::from_ptr(version) }
+        .to_str()
         .ok()
         .and_then(|version_str| StarknetVersion::try_from(version_str).ok());
 
-    if let (Some(custom_constants), Some(version)) = (unsafe { &CUSTOM_VERSIONED_CONSTANTS }, starknet_version) {
+    if let (Some(custom_constants), Some(version)) =
+        (unsafe { &CUSTOM_VERSIONED_CONSTANTS }, starknet_version)
+    {
         if let Some(constants) = custom_constants.0.get(&version) {
             return constants.clone();
         }
@@ -783,15 +786,18 @@ impl VersionedConstantsMap {
         let mut result = BTreeMap::new();
 
         for (version, path) in version_with_path {
-            let mut file = File::open(Path::new(&path)).with_context(|| format!("Failed to open file: {}", path))?;
+            let mut file = File::open(Path::new(&path))
+                .with_context(|| format!("Failed to open file: {}", path))?;
 
             let mut contents = String::new();
-            file.read_to_string(&mut contents).with_context(|| format!("Failed to read contents of file: {}", path))?;
+            file.read_to_string(&mut contents)
+                .with_context(|| format!("Failed to read contents of file: {}", path))?;
 
-            let constants: VersionedConstants =
-                serde_json::from_str(&contents).with_context(|| format!("Failed to parse JSON in file: {}", path))?;
+            let constants: VersionedConstants = serde_json::from_str(&contents)
+                .with_context(|| format!("Failed to parse JSON in file: {}", path))?;
 
-            let parsed_version = StarknetVersion::try_from(version.as_str()).with_context(|| format!("Failed to parse version string: {}", version))?;
+            let parsed_version = StarknetVersion::try_from(version.as_str())
+                .with_context(|| format!("Failed to parse version string: {}", version))?;
 
             result.insert(parsed_version, constants);
         }
@@ -816,19 +822,21 @@ pub extern "C" fn setVersionedConstants(json_bytes: *const c_char) -> *const c_c
         }
     };
 
-    let versioned_constants_files_paths: Result<BTreeMap<String, String>, _> = serde_json::from_str(json_str);
+    let versioned_constants_files_paths: Result<BTreeMap<String, String>, _> =
+        serde_json::from_str(json_str);
     if let Ok(paths) = versioned_constants_files_paths {
         match VersionedConstantsMap::from_file(paths) {
-            Ok(custom_constants) => {
-                unsafe {
-                    CUSTOM_VERSIONED_CONSTANTS = Some(custom_constants);
-                    return CString::new("").unwrap().into_raw();
-                }
+            Ok(custom_constants) => unsafe {
+                CUSTOM_VERSIONED_CONSTANTS = Some(custom_constants);
+                return CString::new("").unwrap().into_raw();
             },
             Err(e) => {
-                return CString::new(format!("Failed to load versioned constants from paths: {}", e))
-                    .unwrap()
-                    .into_raw();
+                return CString::new(format!(
+                    "Failed to load versioned constants from paths: {}",
+                    e
+                ))
+                .unwrap()
+                .into_raw();
             }
         }
     } else {

--- a/vm/trace.go
+++ b/vm/trace.go
@@ -110,6 +110,33 @@ type TransactionTrace struct {
 	ExecutionResources    *ExecutionResources `json:"execution_resources,omitempty"`
 }
 
+// Todo: this was deleted during RP refactoring. However, the builder pkg needs it.
+// Think about if we can handle this more elegantly.
+func (t *TransactionTrace) TotalExecutionResources() *ExecutionResources {
+	total := new(ExecutionResources)
+	for _, invocation := range t.allInvocations() {
+		r := invocation.ExecutionResources
+		if r == nil {
+			continue
+		}
+		total.Pedersen += r.Pedersen
+		total.RangeCheck += r.RangeCheck
+		total.Bitwise += r.Bitwise
+		total.Ecdsa += r.Ecdsa
+		total.EcOp += r.EcOp
+		total.Keccak += r.Keccak
+		total.Poseidon += r.Poseidon
+		total.SegmentArena += r.SegmentArena
+		total.MemoryHoles += r.MemoryHoles
+		total.Steps += r.Steps
+	}
+	return total
+}
+
+func (t *TransactionTrace) IsReverted() bool {
+	return t.ExecuteInvocation != nil && t.ExecuteInvocation.FunctionInvocation == nil
+}
+
 type TransactionReceipt struct {
 	Fee   *felt.Felt
 	Gas   GasConsumed

--- a/vm/vm_test.go
+++ b/vm/vm_test.go
@@ -42,7 +42,7 @@ func TestCallDeprecatedCairo(t *testing.T) {
 		},
 	}, map[felt.Felt]core.Class{
 		*classHash: simpleClass,
-	}))
+	}, false))
 
 	entryPoint := utils.HexToFelt(t, "0x39e11d48192e4333233c7eb19d10ad67c362bb28580c604d67884c85da39695")
 
@@ -64,7 +64,7 @@ func TestCallDeprecatedCairo(t *testing.T) {
 				},
 			},
 		},
-	}, nil))
+	}, nil, false))
 
 	ret, err = New(false, nil).Call(&CallInfo{
 		ContractAddress: contractAddr,
@@ -102,7 +102,7 @@ func TestCallDeprecatedCairoMaxSteps(t *testing.T) {
 		},
 	}, map[felt.Felt]core.Class{
 		*classHash: simpleClass,
-	}))
+	}, false))
 
 	entryPoint := utils.HexToFelt(t, "0x39e11d48192e4333233c7eb19d10ad67c362bb28580c604d67884c85da39695")
 
@@ -141,7 +141,7 @@ func TestCallCairo(t *testing.T) {
 		},
 	}, map[felt.Felt]core.Class{
 		*classHash: simpleClass,
-	}))
+	}, false))
 
 	logLevel := utils.NewLogLevel(utils.ERROR)
 	log, err := utils.NewZapLogger(logLevel, false)
@@ -170,7 +170,7 @@ func TestCallCairo(t *testing.T) {
 				},
 			},
 		},
-	}, nil))
+	}, nil, false))
 
 	ret, err = New(false, log).Call(&CallInfo{
 		ContractAddress: contractAddr,
@@ -209,7 +209,7 @@ func TestCallInfoErrorHandling(t *testing.T) {
 		},
 	}, map[felt.Felt]core.Class{
 		*classHash: simpleClass,
-	}))
+	}, false))
 
 	logLevel := utils.NewLogLevel(utils.ERROR)
 	log, err := utils.NewZapLogger(logLevel, false)


### PR DESCRIPTION
This is the final PR to be merged before Juno can officially function as a sequencer. 

* The main addition is the `builder` pkg, which implements a new service that pops transactions from the mempool, executes them, builds a new block, and then stores it (given the verification checks pass). 
* The RPC pkg is updated so that transactions will be pushed to the `mempool` or the feeder-gateway, depending on which mode the user runs Juno in.
* The `mempool` pkg was updated to contain a reference to the `blockchain`, in place of the `state`, since we can only access the `state` via the `blockchain` type. 
* Some new sequencer related command line flags were added. 
* I also added two `make` commands to start the sequencer with a blank state (kind of useless tbh since we need accounts and fee tokens to be pre-deployed to do anything, but imo it's useful to have), and a state where we deploy accounts and fee tokens (as specified in the `genesis_prefunded_accounst.json` file)