### PR TITLE
refactor: return nil when error has already been checked

### DIFF
--- a/p2p/sync/sync.go
+++ b/p2p/sync/sync.go
@@ -670,7 +670,7 @@ func (s *Service) randomPeerStream(ctx context.Context, pids ...protocol.ID) (ne
 		s.removePeer(randPeer)
 		return nil, err
 	}
-	return stream, err
+	return stream, nil
 }
 
 func (s *Service) removePeer(id peer.ID) {

--- a/starknet/class.go
+++ b/starknet/class.go
@@ -72,7 +72,7 @@ func (n *SegmentLengths) UnmarshalJSON(data []byte) error {
 	if err != nil {
 		return json.Unmarshal(data, &n.Children)
 	}
-	return err
+	return nil
 }
 
 func (n SegmentLengths) MarshalJSON() ([]byte, error) {


### PR DESCRIPTION
Since err != nil has been judged before, nil is returned directly here, which is more obvious, readable and less error-prone.