### PR TITLE
test(ci): add dual RPC v0.7 and v0.8 starknet-go testing in workflows

### DIFF
--- a/.github/workflows/deploy-and-test.yaml
+++ b/.github/workflows/deploy-and-test.yaml
@@ -19,10 +19,6 @@ on:
         required: true
         type: string
         description: "Target repository for the image"
-      rpc_version:
-        required: false
-        type: string
-        default: "v0_7"
       test_mode:
         required: false
         type: string
@@ -35,15 +31,17 @@ on:
         required: true
       RPC_URL:
         required: true
+      WS_RPC_URL:
+        required: true
       TEST_ACCOUNT_ADDRESS:
         required: true
       TEST_ACCOUNT_PRIVATE_KEY:
         required: true
 
 concurrency:
-    group: shared_${{ inputs.environment }}_environment
-    cancel-in-progress: false 
-    
+  group: shared_${{ inputs.environment }}_environment
+  cancel-in-progress: false 
+
 permissions:
   contents: read  
 
@@ -97,7 +95,7 @@ jobs:
     needs: [deploy]
     uses: ./.github/workflows/starknet-rs-tests.yml
     secrets:
-      STARKNET_RPC: ${{ secrets.RPC_URL }}/${{ inputs.rpc_version }}
+      STARKNET_RPC: ${{ secrets.RPC_URL }}/v0_7
 
   starknet-js:
     needs: [deploy]
@@ -105,12 +103,25 @@ jobs:
     with:
       test_mode: ${{ inputs.test_mode }}
     secrets:
-      TEST_RPC_URL: ${{ secrets.RPC_URL }}/${{ inputs.rpc_version }}
+      TEST_RPC_URL: ${{ secrets.RPC_URL }}/v0_7
       TEST_ACCOUNT_ADDRESS: ${{ secrets.TEST_ACCOUNT_ADDRESS }}
       TEST_ACCOUNT_PRIVATE_KEY: ${{ secrets.TEST_ACCOUNT_PRIVATE_KEY }}
 
-  starknet-go:
+  starknet-go-rpcv07:
     needs: [deploy]
     uses: ./.github/workflows/starknet-go-tests.yml
+    with:
+      ref: 1ede19210c10f1f1f9c3cb49a42f737cd90eda5e
+      rpc_version: v0_7
     secrets:
-      TEST_RPC_URL: ${{ secrets.RPC_URL }}/${{ inputs.rpc_version }} 
+      TEST_RPC_URL: ${{ secrets.RPC_URL }}
+
+  starknet-go-rpcv08:
+    needs: [deploy]
+    uses: ./.github/workflows/starknet-go-tests.yml
+    with:
+      ref: 0993fd35590564b0de79f0d757ff2609a5ed0798
+      rpc_version: v0_8
+    secrets:
+      TEST_RPC_URL: ${{ secrets.RPC_URL }}
+      TEST_WS_RPC_URL: ${{ secrets.WS_RPC_URL }}

--- a/.github/workflows/deploy-dev-and-test.yml
+++ b/.github/workflows/deploy-dev-and-test.yml
@@ -30,11 +30,11 @@ jobs:
       environment: Development
       source_repo: nubia-oci-local-dev
       target_repo: nubia-oci-local-dev
-      rpc_version: v0_7
       test_mode: ${{ github.event_name == 'pull_request' && 'fast' || 'full' }}
     secrets:
       ARTIFACTORY_NUBIA_USERNAME: ${{ secrets.ARTIFACTORY_NUBIA_USERNAME }}
       ARTIFACTORY_NUBIA_TOKEN_DEVELOPER: ${{ secrets.ARTIFACTORY_NUBIA_TOKEN_DEVELOPER }}
       RPC_URL: ${{ secrets.DEV_SEPOLIA_URL }}
+      WS_RPC_URL: ${{ secrets.DEV_WS_SEPOLIA_URL }}
       TEST_ACCOUNT_ADDRESS: ${{ secrets.TEST_ACCOUNT_ADDRESS }}
       TEST_ACCOUNT_PRIVATE_KEY: ${{ secrets.TEST_ACCOUNT_PRIVATE_KEY }}

--- a/.github/workflows/deploy-staging-and-test.yml
+++ b/.github/workflows/deploy-staging-and-test.yml
@@ -7,18 +7,9 @@ on:
         description: 'Docker image tag from Dev to promote'
         required: true
         type: string
-      rpc_version:
-        description: 'RPC version for tests (e.g., v0_7)'
-        required: true
-        default: 'v0_7'
-        type: string
 
 permissions:
   contents: read
-
-concurrency:
-  group: shared_staging_environment
-  cancel-in-progress: false
 
 jobs:
   promote_to_staging:
@@ -28,10 +19,10 @@ jobs:
       environment: Staging
       source_repo: nubia-oci-local-dev
       target_repo: nubia-oci-local-staging
-      rpc_version: ${{ inputs.rpc_version }}
     secrets:
       ARTIFACTORY_NUBIA_USERNAME: ${{ secrets.ARTIFACTORY_NUBIA_USERNAME }}
       ARTIFACTORY_NUBIA_TOKEN_DEVELOPER: ${{ secrets.ARTIFACTORY_NUBIA_TOKEN_DEVELOPER }}
       RPC_URL: ${{ secrets.STAGING_SEPOLIA_URL }}
+      WS_RPC_URL: ${{ secrets.STAGING_WS_SEPOLIA_URL }}
       TEST_ACCOUNT_ADDRESS: ${{ secrets.TEST_ACCOUNT_ADDRESS }}
       TEST_ACCOUNT_PRIVATE_KEY: ${{ secrets.TEST_ACCOUNT_PRIVATE_KEY }}

--- a/.github/workflows/starknet-go-tests.yml
+++ b/.github/workflows/starknet-go-tests.yml
@@ -8,9 +8,15 @@ on:
         required: false
         default: '1ede19210c10f1f1f9c3cb49a42f737cd90eda5e'
         type: string
+      rpc_version:
+        description: 'The RPC version to test (v0_7 or v0_8)'
+        required: true
+        type: string
     secrets:
       TEST_RPC_URL:
         required: true
+      TEST_WS_RPC_URL:
+        required: false
 
 jobs:
   test:
@@ -30,7 +36,26 @@ jobs:
       - name: Install dependencies
         run: go mod download
 
-      - name: Test RPC on testnet
-        run: cd rpc && go test -skip 'TestBlockWithReceipts'  -timeout 1200s -v -env testnet .
-        env:
-          INTEGRATION_BASE: ${{ secrets.TEST_RPC_URL }}
+      - name: Configure test environment variables
+        run: |
+          RPC_URL="${{ secrets.TEST_RPC_URL }}"
+          VERSION="${{ inputs.rpc_version }}"
+
+          if [ "$VERSION" = "v0_7" ]; then
+            echo "INTEGRATION_BASE=${RPC_URL}/${VERSION}" >> $GITHUB_ENV
+          elif [ "$VERSION" = "v0_8" ]; then
+            if [ -z "${{ secrets.TEST_WS_RPC_URL }}" ]; then
+              echo "Error: TEST_WS_RPC_URL secret must be set for RPC v0_8"
+              exit 1
+            fi
+            echo "HTTP_PROVIDER_URL=${RPC_URL}/${VERSION}" >> $GITHUB_ENV
+            echo "WS_PROVIDER_URL=${{ secrets.TEST_WS_RPC_URL }}/${VERSION}" >> $GITHUB_ENV
+          else
+            echo "Version $VERSION is not supported."
+            exit 1
+          fi
+
+      - name: Run RPC tests
+        run: |
+          cd rpc
+          go test -timeout 1200s -v -env testnet .


### PR DESCRIPTION
- Remove `rpc_version` param from deploy-and-test.yaml to allow testing multiple versions
- Add `ref` param to checkout specific starknet.go version (e.g. latest supports only RPC v0.8)
- Add temporary logic in starknet.go to set proper env vars depending on version(required due to changes in latest starknet.go)
- For RPC v0.8, enable and run WebSocket tests using configured secret