### PR TITLE
ci: add fast/full test mode option for CI workflows

### DIFF
--- a/.github/workflows/deploy-and-test.yaml
+++ b/.github/workflows/deploy-and-test.yaml
@@ -23,6 +23,11 @@ on:
         required: false
         type: string
         default: "v0_7"
+      test_mode:
+        required: false
+        type: string
+        default: "full"
+        description: "Test mode to run (fast or full)"
     secrets:
       ARTIFACTORY_NUBIA_USERNAME:
         required: true
@@ -97,6 +102,8 @@ jobs:
   starknet-js:
     needs: [deploy]
     uses: ./.github/workflows/starknet-js-tests.yml
+    with:
+      test_mode: ${{ inputs.test_mode }}
     secrets:
       TEST_RPC_URL: ${{ secrets.RPC_URL }}/${{ inputs.rpc_version }}
       TEST_ACCOUNT_ADDRESS: ${{ secrets.TEST_ACCOUNT_ADDRESS }}

--- a/.github/workflows/deploy-dev-and-test.yml
+++ b/.github/workflows/deploy-dev-and-test.yml
@@ -31,6 +31,7 @@ jobs:
       source_repo: nubia-oci-local-dev
       target_repo: nubia-oci-local-dev
       rpc_version: v0_7
+      test_mode: ${{ github.event_name == 'pull_request' && 'fast' || 'full' }}
     secrets:
       ARTIFACTORY_NUBIA_USERNAME: ${{ secrets.ARTIFACTORY_NUBIA_USERNAME }}
       ARTIFACTORY_NUBIA_TOKEN_DEVELOPER: ${{ secrets.ARTIFACTORY_NUBIA_TOKEN_DEVELOPER }}

--- a/.github/workflows/starknet-js-tests.yml
+++ b/.github/workflows/starknet-js-tests.yml
@@ -2,6 +2,11 @@ name: starknet-js tests
 
 on:
   workflow_call:
+    inputs:
+      test_mode:
+        type: string
+        default: 'full'
+        description: 'Test mode to run (fast or full)'
     secrets:
       TEST_RPC_URL:
         required: false
@@ -27,9 +32,18 @@ jobs:
   
       - name: Install dependencies
         run: npm ci
-  
-      - name: Run tests
-        run: npm test -- rpcProvider.test.ts transactionReceipt.test.ts rpcChannel.test.ts defaultProvider.test.ts contract.test.ts cairo1v2.test.ts cairo1v2_typed.test.ts cairo1.test.ts account.test.ts account.starknetId.test.ts --testNamePattern="^(?!.*(getSyncingStats|traceTransaction)).*$"
+      
+      - name: Set test configuration
+        id: tests
+        run: |
+          if [ "${{ inputs.test_mode }}" == "fast" ]; then
+            echo "tests=rpcProvider.test.ts transactionReceipt.test.ts rpcChannel.test.ts defaultProvider.test.ts" >> $GITHUB_OUTPUT
+          else
+            echo "tests=rpcProvider.test.ts transactionReceipt.test.ts rpcChannel.test.ts defaultProvider.test.ts contract.test.ts cairo1v2.test.ts cairo1v2_typed.test.ts cairo1.test.ts account.test.ts account.starknetId.test.ts" >> $GITHUB_OUTPUT
+          fi
+      
+      - name: Run tests (${{ inputs.test_mode }} mode)
+        run: npm test -- ${{ steps.tests.outputs.tests }} --testNamePattern="^(?!.*(getSyncingStats|traceTransaction)).*$"
         env:
           TEST_RPC_URL: ${{ secrets.TEST_RPC_URL }}
           TEST_ACCOUNT_ADDRESS: ${{ secrets.TEST_ACCOUNT_ADDRESS }}


### PR DESCRIPTION
Full starknet.js test suite takes ~20m. No need to run all of it on every PR. Running just the key tests brings it down to ~4m.
	•	Added test_mode input (fast / full) to deploy-and-test
	•	PRs run fast mode, pushes to main run full
	•	fast mode runs a reduced set for quicker feedback

Speeds up CI without sacrificing useful coverage.