### PR TITLE
Bug fix: set the pending header correctly 

### DIFF
--- a/adapters/sn2core/sn2core.go
+++ b/adapters/sn2core/sn2core.go
@@ -38,6 +38,7 @@ func AdaptBlock(response *starknet.Block, sig *starknet.Signature) (*core.Block,
 	if sig != nil {
 		sigs = append(sigs, sig.Signature)
 	}
+
 	return &core.Block{
 		Header: &core.Header{
 			Hash:             response.Hash,

--- a/rpc/v7/simulation.go
+++ b/rpc/v7/simulation.go
@@ -52,6 +52,7 @@ func (h *Handler) simulateTransactions(id BlockID, transactions []BroadcastedTra
 	if rpcErr != nil {
 		return nil, httpHeader, rpcErr
 	}
+
 	defer h.callAndLogErr(closer, "Failed to close state in starknet_estimateFee")
 
 	header, rpcErr := h.blockHeaderByID(&id)
@@ -60,6 +61,7 @@ func (h *Handler) simulateTransactions(id BlockID, transactions []BroadcastedTra
 	}
 
 	network := h.bcReader.Network()
+
 	txns, classes, paidFeesOnL1, rpcErr := prepareTransactions(transactions, network)
 	if rpcErr != nil {
 		return nil, httpHeader, rpcErr
@@ -69,6 +71,7 @@ func (h *Handler) simulateTransactions(id BlockID, transactions []BroadcastedTra
 	if err != nil {
 		return nil, httpHeader, rpccore.ErrInternal.CloneWithData(err)
 	}
+
 	blockInfo := vm.BlockInfo{
 		Header:                header,
 		BlockHashToBeRevealed: blockHashToBeRevealed,
@@ -171,7 +174,6 @@ func createSimulatedTransactions(
 			l1GasPrice = l1GasPriceStrk
 			l1DataGasPrice = l1DataGasPriceStrk
 		}
-
 		simulatedTransactions[i] = SimulatedTransaction{
 			TransactionTrace: trace,
 			FeeEstimation: FeeEstimate{

--- a/sync/sync.go
+++ b/sync/sync.go
@@ -566,11 +566,6 @@ func (s *Synchronizer) fetchAndStorePending(ctx context.Context) error {
 	}
 
 	pendingBlock.Number = head.Number + 1
-	pendingBlock.L1DAMode = head.L1DAMode
-	pendingBlock.L1GasPriceSTRK = head.L1GasPriceSTRK
-	pendingBlock.L1GasPriceETH = head.L1GasPriceETH
-	pendingBlock.L1DataGasPrice = head.L1DataGasPrice
-	pendingBlock.L2GasPrice = head.L2GasPrice
 	newClasses, err := s.fetchUnknownClasses(ctx, pendingStateUpdate)
 	if err != nil {
 		return err

--- a/sync/sync.go
+++ b/sync/sync.go
@@ -565,11 +565,16 @@ func (s *Synchronizer) fetchAndStorePending(ctx context.Context) error {
 		return err
 	}
 
+	pendingBlock.Number = head.Number + 1
+	pendingBlock.L1DAMode = head.L1DAMode
+	pendingBlock.L1GasPriceSTRK = head.L1GasPriceSTRK
+	pendingBlock.L1GasPriceETH = head.L1GasPriceETH
+	pendingBlock.L1DataGasPrice = head.L1DataGasPrice
+	pendingBlock.L2GasPrice = head.L2GasPrice
 	newClasses, err := s.fetchUnknownClasses(ctx, pendingStateUpdate)
 	if err != nil {
 		return err
 	}
-
 	s.log.Debugw("Found pending block", "txns", pendingBlock.TransactionCount)
 	return s.StorePending(&Pending{
 		Block:       pendingBlock,
@@ -688,6 +693,8 @@ func (s *Synchronizer) storeEmptyPending(latestHeader *core.Header) error {
 			L1GasPriceETH:    latestHeader.L1GasPriceETH,
 			L1GasPriceSTRK:   latestHeader.L1GasPriceSTRK,
 			L2GasPrice:       latestHeader.L2GasPrice,
+			L1DataGasPrice:   latestHeader.L1DataGasPrice,
+			L1DAMode:         latestHeader.L1DAMode,
 		},
 		Transactions: make([]core.Transaction, 0),
 		Receipts:     receipts,

--- a/vm/rust/src/lib.rs
+++ b/vm/rust/src/lib.rs
@@ -11,13 +11,13 @@ use execution::process_transaction;
 use serde::Deserialize;
 use serde_json::json;
 use std::{
-    ffi::{c_char, c_longlong, c_uchar, c_ulonglong, c_void, CStr, CString},
-    slice,
-    sync::Arc,
     collections::BTreeMap,
+    ffi::{c_char, c_longlong, c_uchar, c_ulonglong, c_void, CStr, CString},
     fs::File,
     io::Read,
     path::Path,
+    slice,
+    sync::Arc,
 };
 
 use anyhow::Result;
@@ -67,8 +67,8 @@ use starknet_api::{
 use starknet_types_core::felt::Felt;
 use std::str::FromStr;
 type StarkFelt = Felt;
-use once_cell::sync::Lazy;
 use anyhow::Context;
+use once_cell::sync::Lazy;
 
 // Allow users to call CONSTRUCTOR entry point type which has fixed entry_point_felt "0x28ffe4ff0f226a9107253e17a904099aa4f63a02a5621de0576e5aa71bc5194"
 pub static CONSTRUCTOR_ENTRY_POINT_FELT: Lazy<StarkFelt> = Lazy::new(|| {
@@ -759,11 +759,14 @@ fn build_block_context(
 
 #[allow(static_mut_refs)]
 fn get_versioned_constants(version: *const c_char) -> VersionedConstants {
-    let starknet_version = unsafe { CStr::from_ptr(version) }.to_str()
+    let starknet_version = unsafe { CStr::from_ptr(version) }
+        .to_str()
         .ok()
         .and_then(|version_str| StarknetVersion::try_from(version_str).ok());
 
-    if let (Some(custom_constants), Some(version)) = (unsafe { &CUSTOM_VERSIONED_CONSTANTS }, starknet_version) {
+    if let (Some(custom_constants), Some(version)) =
+        (unsafe { &CUSTOM_VERSIONED_CONSTANTS }, starknet_version)
+    {
         if let Some(constants) = custom_constants.0.get(&version) {
             return constants.clone();
         }
@@ -783,15 +786,18 @@ impl VersionedConstantsMap {
         let mut result = BTreeMap::new();
 
         for (version, path) in version_with_path {
-            let mut file = File::open(Path::new(&path)).with_context(|| format!("Failed to open file: {}", path))?;
+            let mut file = File::open(Path::new(&path))
+                .with_context(|| format!("Failed to open file: {}", path))?;
 
             let mut contents = String::new();
-            file.read_to_string(&mut contents).with_context(|| format!("Failed to read contents of file: {}", path))?;
+            file.read_to_string(&mut contents)
+                .with_context(|| format!("Failed to read contents of file: {}", path))?;
 
-            let constants: VersionedConstants =
-                serde_json::from_str(&contents).with_context(|| format!("Failed to parse JSON in file: {}", path))?;
+            let constants: VersionedConstants = serde_json::from_str(&contents)
+                .with_context(|| format!("Failed to parse JSON in file: {}", path))?;
 
-            let parsed_version = StarknetVersion::try_from(version.as_str()).with_context(|| format!("Failed to parse version string: {}", version))?;
+            let parsed_version = StarknetVersion::try_from(version.as_str())
+                .with_context(|| format!("Failed to parse version string: {}", version))?;
 
             result.insert(parsed_version, constants);
         }
@@ -816,19 +822,21 @@ pub extern "C" fn setVersionedConstants(json_bytes: *const c_char) -> *const c_c
         }
     };
 
-    let versioned_constants_files_paths: Result<BTreeMap<String, String>, _> = serde_json::from_str(json_str);
+    let versioned_constants_files_paths: Result<BTreeMap<String, String>, _> =
+        serde_json::from_str(json_str);
     if let Ok(paths) = versioned_constants_files_paths {
         match VersionedConstantsMap::from_file(paths) {
-            Ok(custom_constants) => {
-                unsafe {
-                    CUSTOM_VERSIONED_CONSTANTS = Some(custom_constants);
-                    return CString::new("").unwrap().into_raw();
-                }
+            Ok(custom_constants) => unsafe {
+                CUSTOM_VERSIONED_CONSTANTS = Some(custom_constants);
+                return CString::new("").unwrap().into_raw();
             },
             Err(e) => {
-                return CString::new(format!("Failed to load versioned constants from paths: {}", e))
-                    .unwrap()
-                    .into_raw();
+                return CString::new(format!(
+                    "Failed to load versioned constants from paths: {}",
+                    e
+                ))
+                .unwrap()
+                .into_raw();
             }
         }
     } else {


### PR DESCRIPTION
closes https://github.com/NethermindEth/juno/issues/2695

Thanks to @infrmtcs for pointing out that the pending block number was not being set correctly. This corrected the estimate fee error (I suspect the fee estimate transaction does some arithmetic on the block number, and having it set to zero resulted in an error). However, we also need to set the rest of the gas price data in the pending header in order to get correct fee estimates.
