### PR TITLE
rpc fix: update adaptResourceBounds to set L2Gas to zero in rpc v6 and v7

### DIFF
--- a/rpc/v6/transaction.go
+++ b/rpc/v6/transaction.go
@@ -364,14 +364,15 @@ func adaptBroadcastedTransaction(broadcastedTxn *BroadcastedTransaction,
 
 func adaptResourceBounds(rb map[core.Resource]core.ResourceBounds) map[Resource]ResourceBounds {
 	rpcResourceBounds := make(map[Resource]ResourceBounds)
-	for resource, bounds := range rb {
-		// ResourceL1DataGas is not supported in v6
-		if resource == core.ResourceL1DataGas {
-			continue
-		}
-
-		rpcResourceBounds[Resource(resource)] = ResourceBounds{
+	if bounds, ok := rb[core.ResourceL1Gas]; ok {
+		rpcResourceBounds[Resource(core.ResourceL1Gas)] = ResourceBounds{
 			MaxAmount:       new(felt.Felt).SetUint64(bounds.MaxAmount),
+			MaxPricePerUnit: bounds.MaxPricePerUnit,
+		}
+	}
+	if bounds, ok := rb[core.ResourceL2Gas]; ok {
+		rpcResourceBounds[Resource(core.ResourceL2Gas)] = ResourceBounds{
+			MaxAmount:       new(felt.Felt).SetUint64(0),
 			MaxPricePerUnit: bounds.MaxPricePerUnit,
 		}
 	}

--- a/rpc/v7/transaction.go
+++ b/rpc/v7/transaction.go
@@ -352,14 +352,16 @@ func adaptBroadcastedTransaction(broadcastedTxn *BroadcastedTransaction,
 
 func adaptResourceBounds(rb map[core.Resource]core.ResourceBounds) map[Resource]ResourceBounds {
 	rpcResourceBounds := make(map[Resource]ResourceBounds)
-	for resource, bounds := range rb {
-		// ResourceL1DataGas is not supported in v7
-		if resource == core.ResourceL1DataGas {
-			continue
-		}
 
-		rpcResourceBounds[Resource(resource)] = ResourceBounds{
+	if bounds, ok := rb[core.ResourceL1Gas]; ok {
+		rpcResourceBounds[Resource(core.ResourceL1Gas)] = ResourceBounds{
 			MaxAmount:       new(felt.Felt).SetUint64(bounds.MaxAmount),
+			MaxPricePerUnit: bounds.MaxPricePerUnit,
+		}
+	}
+	if bounds, ok := rb[core.ResourceL2Gas]; ok {
+		rpcResourceBounds[Resource(core.ResourceL2Gas)] = ResourceBounds{
+			MaxAmount:       new(felt.Felt).SetUint64(0),
 			MaxPricePerUnit: bounds.MaxPricePerUnit,
 		}
 	}


### PR DESCRIPTION
closes https://github.com/NethermindEth/juno/issues/2699

https://github.com/starkware-libs/sequencer/blob/6c14c03e2d9d6f72ae05c98442dbaf17c243433e/crates/starknet_api/src/transaction/fields.rs#L442-L448
