### PR TITLE
ci: add automated draft release workflow with binaries and docker build

### DIFF
--- a/.github/workflows/build-binaries.yml
+++ b/.github/workflows/build-binaries.yml
@@ -5,11 +5,17 @@ on:
     tags:
       - 'v*'
   workflow_dispatch:
-  pull_request:
-    branches:
-      - main
-    paths:
-      - .github/workflows/build-binaries.yml
+    inputs:
+      tag:
+        description: 'Release tag (optional)'
+        required: false
+        type: string
+  workflow_call:
+    inputs:
+      tag:
+        description: 'Release tag (optional)'
+        required: false
+        type: string
 
 jobs:
   build:
@@ -50,8 +56,13 @@ jobs:
             core/rust
             starknet/compiler/rust
 
-      - name: Get latest tag
-        run: echo "TAG=$(git describe --tags)" >> $GITHUB_ENV
+      - name: Set TAG env var
+        run: |
+          if [ -n "${{ inputs.tag }}" ]; then
+            echo "TAG=${{ inputs.tag }}" >> $GITHUB_ENV
+          else
+            echo "TAG=$(git describe --tags)" >> $GITHUB_ENV
+          fi
 
       - name: Get artifact name
         run: |
@@ -67,7 +78,7 @@ jobs:
       - name: Install dependencies (macOS)
         if: runner.os == 'macOS'
         run: brew install jemalloc
-          
+
       - name: Build binary
         run: make juno
 
@@ -89,11 +100,14 @@ jobs:
             sha256sum ${{ env.ARTIFACT_NAME }} > ${{ env.ARTIFACT_NAME }}.sha256
           fi
 
+      - name: Zip binary and checksum
+        run: |
+          zip ${{ env.ARTIFACT_NAME }}.zip ${{ env.ARTIFACT_NAME }} ${{ env.ARTIFACT_NAME }}.sha256
+          rm ${{ env.ARTIFACT_NAME }} ${{ env.ARTIFACT_NAME }}.sha256
+
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:
-          name: ${{ env.ARTIFACT_NAME }}
-          path: |
-            ${{ env.ARTIFACT_NAME }}
-            ${{ env.ARTIFACT_NAME }}.sha256
+          name: ${{ env.ARTIFACT_NAME }}.zip
+          path: ${{ env.ARTIFACT_NAME }}.zip
           retention-days: 30

--- a/.github/workflows/build-binaries.yml
+++ b/.github/workflows/build-binaries.yml
@@ -5,17 +5,7 @@ on:
     tags:
       - 'v*'
   workflow_dispatch:
-    inputs:
-      tag:
-        description: 'Release tag (optional)'
-        required: false
-        type: string
   workflow_call:
-    inputs:
-      tag:
-        description: 'Release tag (optional)'
-        required: false
-        type: string
 
 jobs:
   build:
@@ -58,11 +48,7 @@ jobs:
 
       - name: Set TAG env var
         run: |
-          if [ -n "${{ inputs.tag }}" ]; then
-            echo "TAG=${{ inputs.tag }}" >> $GITHUB_ENV
-          else
-            echo "TAG=$(git describe --tags)" >> $GITHUB_ENV
-          fi
+          echo "TAG=$(git describe --tags)" >> $GITHUB_ENV
 
       - name: Get artifact name
         run: |

--- a/.github/workflows/docker-image-build-push.yml
+++ b/.github/workflows/docker-image-build-push.yml
@@ -1,19 +1,34 @@
 name: 'Build and publish Docker image'
 
 on:
+  workflow_call:
+    inputs:
+      tag:
+        description: 'Tag for the Docker image'
+        required: true
+        type: string
+      repo_type:
+        description: 'Choose repository type'
+        type: string
+        default: 'non-official'
   workflow_dispatch:
     inputs:
       tag:
-        description: 'Enter an image tag e.g v0.1.0'
+        description: 'Tag for the Docker image'
         required: true
+        type: string
       repo_type:
         description: 'Choose repository type'
         type: choice
         required: false
         default: 'non-official'
         options:
-        - official
-        - non-official
+          - official
+          - non-official
+
+permissions:
+  contents: read
+  packages: write
 
 jobs:
   build_and_push_docker_image_amd:
@@ -23,7 +38,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
         with:
-            fetch-depth: 0
+          fetch-depth: 0
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -34,13 +49,13 @@ jobs:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
 
-      - name: Build and push
+      - name: Build and push AMD64
         uses: docker/build-push-action@v6
         with:
           context: .
-          platforms: 'linux/amd64'
+          platforms: linux/amd64
           push: true
-          tags: nethermindeth/juno:${{ github.event.inputs.tag }}
+          tags: nethermindeth/juno:${{ inputs.tag }}
 
   build_and_push_docker_image_arm:
     if: github.repository_owner == 'NethermindEth'
@@ -49,32 +64,30 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
         with:
-            fetch-depth: 0
+          fetch-depth: 0
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
-            
+
       - name: Login to Docker Hub
         uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
 
-      - name: Build and push ARM
+      - name: Build and push ARM64
         uses: docker/build-push-action@v6
         with:
           context: .
-          platforms: 'linux/arm64'
+          platforms: linux/arm64
           push: true
-          tags: nethermindeth/juno:${{ github.event.inputs.tag }}-arm64
-      
+          tags: nethermindeth/juno:${{ inputs.tag }}-arm64
+
       - name: Cleanup self-hosted
-        run: |
-          docker system prune -af
+        run: docker system prune -af
 
   create_and_push_official_image:
-    if: github.repository_owner == 'NethermindEth' && github.event.inputs.repo_type == 'official'
-    needs: [build_and_push_docker_image_amd, build_and_push_docker_image_arm]
+    if: github.repository_owner == 'NethermindEth' && inputs.repo_type == 'official'
     runs-on: ubuntu-latest
     steps:
       - name: Set up Docker Buildx
@@ -88,12 +101,11 @@ jobs:
 
       - name: Create and push manifest using buildx
         run: |
-            docker buildx imagetools create nethermindeth/juno:${{ github.event.inputs.tag }} \
-                nethermindeth/juno:${{ github.event.inputs.tag }}-arm64 \
-                --tag nethermind/juno:${{ github.event.inputs.tag }}
+          docker buildx imagetools create \
+            nethermindeth/juno:${{ inputs.tag }} \
+            nethermindeth/juno:${{ inputs.tag }}-arm64 \
+            --tag nethermind/juno:${{ inputs.tag }}
 
-      - name: Clean up environment
+      - name: Clean up Docker config
         if: always()
-        run: |
-          rm -f ${HOME}/.docker/config.json
-  
+        run: rm -f ${HOME}/.docker/config.json

--- a/.github/workflows/docker-image-build-push.yml
+++ b/.github/workflows/docker-image-build-push.yml
@@ -3,20 +3,16 @@ name: 'Build and publish Docker image'
 on:
   workflow_call:
     inputs:
-      tag:
-        description: 'Tag for the Docker image'
-        required: true
-        type: string
       repo_type:
         description: 'Choose repository type'
         type: string
         default: 'non-official'
+    outputs:
+      tag:
+        description: 'The tag that was built'
+        value: ${{ jobs.setup.outputs.tag }}
   workflow_dispatch:
     inputs:
-      tag:
-        description: 'Tag for the Docker image'
-        required: true
-        type: string
       repo_type:
         description: 'Choose repository type'
         type: choice
@@ -31,7 +27,23 @@ permissions:
   packages: write
 
 jobs:
+  setup:
+    if: github.repository_owner == 'NethermindEth'
+    runs-on: ubuntu-latest
+    outputs:
+      tag: ${{ steps.set_tag.outputs.tag }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          
+      - name: Set TAG output
+        id: set_tag
+        run: echo "tag=$(git describe --tags)" >> $GITHUB_OUTPUT
+
   build_and_push_docker_image_amd:
+    needs: setup
     if: github.repository_owner == 'NethermindEth'
     runs-on: ubuntu-latest
     steps:
@@ -55,9 +67,10 @@ jobs:
           context: .
           platforms: linux/amd64
           push: true
-          tags: nethermindeth/juno:${{ inputs.tag }}
+          tags: nethermindeth/juno:${{ needs.setup.outputs.tag }}
 
   build_and_push_docker_image_arm:
+    needs: setup
     if: github.repository_owner == 'NethermindEth'
     runs-on: ubuntu-arm64-4-core
     steps:
@@ -81,12 +94,13 @@ jobs:
           context: .
           platforms: linux/arm64
           push: true
-          tags: nethermindeth/juno:${{ inputs.tag }}-arm64
+          tags: nethermindeth/juno:${{ needs.setup.outputs.tag }}-arm64
 
       - name: Cleanup self-hosted
         run: docker system prune -af
 
   create_and_push_official_image:
+    needs: [setup, build_and_push_docker_image_amd, build_and_push_docker_image_arm]
     if: github.repository_owner == 'NethermindEth' && inputs.repo_type == 'official'
     runs-on: ubuntu-latest
     steps:
@@ -102,9 +116,9 @@ jobs:
       - name: Create and push manifest using buildx
         run: |
           docker buildx imagetools create \
-            nethermindeth/juno:${{ inputs.tag }} \
-            nethermindeth/juno:${{ inputs.tag }}-arm64 \
-            --tag nethermind/juno:${{ inputs.tag }}
+            nethermindeth/juno:${{ needs.setup.outputs.tag }} \
+            nethermindeth/juno:${{ needs.setup.outputs.tag }}-arm64 \
+            --tag nethermind/juno:${{ needs.setup.outputs.tag }}
 
       - name: Clean up Docker config
         if: always()

--- a/.github/workflows/prepare-draft-release.yml
+++ b/.github/workflows/prepare-draft-release.yml
@@ -2,6 +2,8 @@ name: Prepare Draft Release
 
 on:
   push:
+    branches:
+      - wojciechos/release-action
     tags:
       - 'v*'
 

--- a/.github/workflows/prepare-draft-release.yml
+++ b/.github/workflows/prepare-draft-release.yml
@@ -1,0 +1,70 @@
+name: Prepare Draft Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+permissions:
+  contents: read
+
+jobs:
+  set-tag:
+    runs-on: ubuntu-latest
+    outputs:
+      tag: ${{ steps.get_tag.outputs.TAG }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Get latest tag
+        id: get_tag
+        run: |
+          TAG=$(git describe --tags)
+          echo "TAG=$TAG" >> $GITHUB_OUTPUT
+
+  build-binaries:
+    name: Build Binaries
+    needs: set-tag
+    uses: ./.github/workflows/build-binaries.yml
+    with:
+      tag: ${{ needs.set-tag.outputs.tag }}
+
+  docker-image:
+    name: Build and Push Docker Image
+    if: github.repository_owner == 'NethermindEth'
+    needs: set-tag
+    uses: ./.github/workflows/docker-image-build-push.yml
+    with:
+      tag: ${{ needs.set-tag.outputs.tag }}
+      repo_type: 'official'
+    secrets: inherit
+
+  create-release:
+    name: Create Draft Release
+    needs: [set-tag, build-binaries, docker-image]
+    if: always()
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Download binaries
+        uses: actions/download-artifact@v4
+        with:
+          pattern: juno-${{ needs.set-tag.outputs.tag }}-*
+          merge-multiple: true
+          path: binaries
+
+      - name: Create Draft GitHub Release
+        uses: softprops/action-gh-release@c95fe1489396fe8a9eb87c0abf8aa5b2ef267fda
+        with:
+          tag_name: ${{ needs.set-tag.outputs.tag }}
+          name: ${{ needs.set-tag.outputs.tag }}
+          generate_release_notes: true
+          draft: true
+          files: |
+            binaries/*
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/prepare-draft-release.yml
+++ b/.github/workflows/prepare-draft-release.yml
@@ -2,17 +2,17 @@ name: Prepare Draft Release
 
 on:
   push:
-    branches:
-      - wojciechos/release-action
     tags:
       - 'v*'
 
 permissions:
-  contents: read
+  contents: write
+  packages: write
 
 jobs:
   build-binaries:
     name: Build Binaries
+    if: github.repository_owner == 'NethermindEth'
     uses: ./.github/workflows/build-binaries.yml
 
   docker-image:
@@ -20,16 +20,14 @@ jobs:
     if: github.repository_owner == 'NethermindEth'
     uses: ./.github/workflows/docker-image-build-push.yml
     with:
-      repo_type: 'official'
+      repo_type: 'unofficial'
     secrets: inherit
 
   create-release:
     name: Create Draft Release
+    if: github.repository_owner == 'NethermindEth'
     needs: [build-binaries, docker-image]
-    if: always()
     runs-on: ubuntu-latest
-    permissions:
-      contents: write
     steps:
       - name: Download binaries
         uses: actions/download-artifact@v4

--- a/.github/workflows/prepare-draft-release.yml
+++ b/.github/workflows/prepare-draft-release.yml
@@ -9,42 +9,21 @@ permissions:
   contents: read
 
 jobs:
-  set-tag:
-    runs-on: ubuntu-latest
-    outputs:
-      tag: ${{ steps.get_tag.outputs.TAG }}
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-
-      - name: Get latest tag
-        id: get_tag
-        run: |
-          TAG=$(git describe --tags)
-          echo "TAG=$TAG" >> $GITHUB_OUTPUT
-
   build-binaries:
     name: Build Binaries
-    needs: set-tag
     uses: ./.github/workflows/build-binaries.yml
-    with:
-      tag: ${{ needs.set-tag.outputs.tag }}
 
   docker-image:
     name: Build and Push Docker Image
     if: github.repository_owner == 'NethermindEth'
-    needs: set-tag
     uses: ./.github/workflows/docker-image-build-push.yml
     with:
-      tag: ${{ needs.set-tag.outputs.tag }}
       repo_type: 'official'
     secrets: inherit
 
   create-release:
     name: Create Draft Release
-    needs: [set-tag, build-binaries, docker-image]
+    needs: [build-binaries, docker-image]
     if: always()
     runs-on: ubuntu-latest
     permissions:
@@ -53,15 +32,15 @@ jobs:
       - name: Download binaries
         uses: actions/download-artifact@v4
         with:
-          pattern: juno-${{ needs.set-tag.outputs.tag }}-*
+          pattern: juno-*.zip
           merge-multiple: true
           path: binaries
 
       - name: Create Draft GitHub Release
         uses: softprops/action-gh-release@c95fe1489396fe8a9eb87c0abf8aa5b2ef267fda
         with:
-          tag_name: ${{ needs.set-tag.outputs.tag }}
-          name: ${{ needs.set-tag.outputs.tag }}
+          tag_name: ${{ needs.docker-image.outputs.tag }}
+          name: ${{ needs.docker-image.outputs.tag }}
           generate_release_notes: true
           draft: true
           files: |


### PR DESCRIPTION
- Adds workflow triggered on `v*` tag pushes  
- Builds and uploads binaries (`.zip + .sha256`)  
- Builds and pushes Docker images 
- Creates a **draft GitHub release** with auto-generated notes and all assets attached

sample result: https://github.com/NethermindEth/juno/releases/tag/untagged-45a9fcb80ff2acc0b903