### PR TITLE
refactor: Common functions to send Tendermint messages

### DIFF
--- a/consensus/tendermint/broadcast.go
+++ b/consensus/tendermint/broadcast.go
@@ -1,0 +1,40 @@
+package tendermint
+
+func (t *Tendermint[V, H, A]) sendProposal(value *V) {
+	proposalMessage := Proposal[V, H, A]{
+		H:          t.state.h,
+		R:          t.state.r,
+		ValidRound: t.state.validRound,
+		Value:      value,
+		Sender:     t.nodeAddr,
+	}
+
+	t.messages.addProposal(proposalMessage)
+	t.broadcasters.ProposalBroadcaster.Broadcast(proposalMessage)
+}
+
+func (t *Tendermint[V, H, A]) sendPrevote(id *H) {
+	vote := Prevote[H, A]{
+		H:      t.state.h,
+		R:      t.state.r,
+		ID:     id,
+		Sender: t.nodeAddr,
+	}
+
+	t.messages.addPrevote(vote)
+	t.broadcasters.PrevoteBroadcaster.Broadcast(vote)
+	t.state.s = prevote
+}
+
+func (t *Tendermint[V, H, A]) sendPrecommit(id *H) {
+	vote := Precommit[H, A]{
+		H:      t.state.h,
+		R:      t.state.r,
+		ID:     id,
+		Sender: t.nodeAddr,
+	}
+
+	t.messages.addPrecommit(vote)
+	t.broadcasters.PrecommitBroadcaster.Broadcast(vote)
+	t.state.s = precommit
+}

--- a/consensus/tendermint/messages.go
+++ b/consensus/tendermint/messages.go
@@ -16,7 +16,7 @@ type Message[V Hashable[H], H Hash, A Addr] interface {
 type Proposal[V Hashable[H], H Hash, A Addr] struct {
 	H          height
 	R          round
-	ValidRound int
+	ValidRound round
 	Value      *V
 
 	Sender A

--- a/consensus/tendermint/prevote.go
+++ b/consensus/tendermint/prevote.go
@@ -68,7 +68,7 @@ func (t *Tendermint[V, H, A]) line28WhenPrevoteIsReceived(p Prevote[H, A], prevo
 
 		if proposal != nil && t.validatorSetVotingPower(vals) >= q(t.validators.TotalVotingPower(p.H)) {
 			var votedID *H
-			if t.state.lockedRound >= int(vr) || (*t.state.lockedValue).Hash() == *p.ID {
+			if t.state.lockedRound >= vr || (*t.state.lockedValue).Hash() == *p.ID {
 				votedID = p.ID
 			}
 			t.sendPrevote(votedID)
@@ -147,12 +147,12 @@ func (t *Tendermint[V, H, A]) line36WhenPrevoteIsReceived(p Prevote[H, A], propo
 
 			if t.state.s == prevote {
 				t.state.lockedValue = proposal.Value
-				t.state.lockedRound = int(cr)
+				t.state.lockedRound = cr
 				t.sendPrecommit(p.ID)
 			}
 
 			t.state.validValue = proposal.Value
-			t.state.validRound = int(cr)
+			t.state.validRound = cr
 			t.state.lockedValueAndOrValidValueSet = true
 		}
 	}

--- a/consensus/tendermint/prevote.go
+++ b/consensus/tendermint/prevote.go
@@ -26,15 +26,15 @@ func (t *Tendermint[V, H, A]) handlePrevote(p Prevote[H, A]) {
 
 	t.messages.addPrevote(p)
 
-	proposalsForHR, prevotesForHR, _ := t.messages.allMessages(p.H, p.R)
+	_, prevotesForHR, _ := t.messages.allMessages(p.H, p.R)
 
-	t.line28WhenPrevoteIsReceived(p, prevotesForHR)
+	t.line28WhenPrevoteIsReceived(p)
 
 	if p.R == t.state.r {
 		t.line34(p, prevotesForHR)
 		t.line44(p, prevotesForHR)
 
-		t.line36WhenPrevoteIsReceived(p, proposalsForHR, prevotesForHR)
+		t.line36WhenPrevoteIsReceived(p)
 	}
 }
 
@@ -56,17 +56,13 @@ validity of the proposal can be skipped.
 Calculating quorum of prevotes is more resource intensive than checking other condition on line	28,
 therefore, it is checked in a subsequent if statement.
 */
-func (t *Tendermint[V, H, A]) line28WhenPrevoteIsReceived(p Prevote[H, A], prevotesForHR map[A][]Prevote[H, A]) {
+func (t *Tendermint[V, H, A]) line28WhenPrevoteIsReceived(p Prevote[H, A]) {
 	// vr >= 0 doesn't need to be checked since vr is a uint
 	if vr := p.R; p.ID != nil && t.state.s == propose && vr < t.state.r {
-		cr := t.state.r
+		proposal := t.findMatchingProposal(t.state.r, *p.ID)
+		hasQuorum := t.checkQuorumPrevotesGivenProposalVID(p.R, *p.ID)
 
-		proposalsForHCR, _, _ := t.messages.allMessages(p.H, cr)
-
-		proposal := t.checkForMatchingProposalGivenPrevote(p, proposalsForHCR)
-		vals := checkForQuorumPrevotesGivenPrevote(p, prevotesForHR)
-
-		if proposal != nil && t.validatorSetVotingPower(vals) >= q(t.validators.TotalVotingPower(p.H)) {
+		if proposal != nil && hasQuorum {
 			var votedID *H
 			if t.state.lockedRound >= vr || (*t.state.lockedValue).Hash() == *p.ID {
 				votedID = p.ID
@@ -135,14 +131,12 @@ validity of the proposal can be skipped.
 Calculating quorum of prevotes is more resource intensive than checking other condition on line 36,
 therefore, it is checked in a subsequent if statement.
 */
-func (t *Tendermint[V, H, A]) line36WhenPrevoteIsReceived(p Prevote[H, A], proposalsForHR map[A][]Proposal[V, H, A],
-	prevotesForHR map[A][]Prevote[H, A],
-) {
-	if !t.state.lockedValueAndOrValidValueSet && t.state.s >= prevote {
-		proposal := t.checkForMatchingProposalGivenPrevote(p, proposalsForHR)
-		vals := checkForQuorumPrevotesGivenPrevote(p, prevotesForHR)
+func (t *Tendermint[V, H, A]) line36WhenPrevoteIsReceived(p Prevote[H, A]) {
+	if p.ID != nil && !t.state.lockedValueAndOrValidValueSet && t.state.s >= prevote {
+		proposal := t.findMatchingProposal(t.state.r, *p.ID)
+		hasQuorum := t.checkQuorumPrevotesGivenProposalVID(p.R, *p.ID)
 
-		if proposal != nil && t.validatorSetVotingPower(vals) >= q(t.validators.TotalVotingPower(p.H)) {
+		if proposal != nil && hasQuorum {
 			cr := t.state.r
 
 			if t.state.s == prevote {

--- a/consensus/tendermint/propose.go
+++ b/consensus/tendermint/propose.go
@@ -97,7 +97,7 @@ The implementation uses nil as -1 to avoid using int type.
 
 Since the value's id is expected to be unique the id can be used to compare the values.
 */
-func (t *Tendermint[V, H, A]) line22(vr int, proposalFromProposer, validProposal bool, vID H) {
+func (t *Tendermint[V, H, A]) line22(vr round, proposalFromProposer, validProposal bool, vID H) {
 	if vr == -1 && proposalFromProposer && t.state.s == propose {
 		var votedID *H
 		if validProposal && (t.state.lockedRound == -1 || (*t.state.lockedValue).Hash() == vID) {
@@ -121,10 +121,10 @@ Check the upon condition on line 28:
 Ideally, the condition on line 28 would be checked in a single if statement, however,
 this cannot be done because valid round needs to be non-nil before the prevotes are fetched.
 */
-func (t *Tendermint[V, H, A]) line28WhenProposalIsReceived(p Proposal[V, H, A], vr int, proposalFromProposer bool,
+func (t *Tendermint[V, H, A]) line28WhenProposalIsReceived(p Proposal[V, H, A], vr round, proposalFromProposer bool,
 	vID H, validProposal bool,
 ) {
-	if vr != -1 && proposalFromProposer && t.state.s == propose && vr >= 0 && vr < int(t.state.r) {
+	if vr != -1 && proposalFromProposer && t.state.s == propose && vr >= 0 && vr < t.state.r {
 		_, prevotesForHVr, _ := t.messages.allMessages(p.H, round(vr))
 
 		vals := checkQuorumPrevotesGivenProposalVID(prevotesForHVr, vID)
@@ -174,12 +174,12 @@ func (t *Tendermint[V, H, A]) line36WhenProposalIsReceived(p Proposal[V, H, A], 
 
 			if t.state.s == prevote {
 				t.state.lockedValue = p.Value
-				t.state.lockedRound = int(cr)
+				t.state.lockedRound = cr
 				t.sendPrecommit(&vID)
 			}
 
 			t.state.validValue = p.Value
-			t.state.validRound = int(cr)
+			t.state.validRound = cr
 			t.state.lockedValueAndOrValidValueSet = true
 		}
 	}

--- a/consensus/tendermint/propose.go
+++ b/consensus/tendermint/propose.go
@@ -32,9 +32,9 @@ func (t *Tendermint[V, H, A]) handleProposal(p Proposal[V, H, A]) {
 		t.messages.addProposal(p)
 	}
 
-	_, prevotesForHR, precommitsForHR := t.messages.allMessages(p.H, p.R)
+	_, prevotesForHR, _ := t.messages.allMessages(p.H, p.R)
 
-	if t.line49WhenProposalIsReceived(p, precommitsForHR, vID, validProposal, proposalFromProposer) {
+	if t.line49WhenProposalIsReceived(p, vID, validProposal, proposalFromProposer) {
 		return
 	}
 
@@ -45,7 +45,7 @@ func (t *Tendermint[V, H, A]) handleProposal(p Proposal[V, H, A]) {
 	}
 
 	t.line22(vr, proposalFromProposer, validProposal, vID)
-	t.line28WhenProposalIsReceived(p, vr, proposalFromProposer, vID, validProposal)
+	t.line28WhenProposalIsReceived(vr, proposalFromProposer, vID, validProposal)
 	t.line36WhenProposalIsReceived(p, validProposal, proposalFromProposer, prevotesForHR, vID)
 }
 
@@ -63,13 +63,10 @@ Check the upon condition on line 49:
 	 sequentially, i.e. x, x+1, x+2... . The validity of the proposal value can be checked in the same if
 	 statement since there is no else statement.
 */
-func (t *Tendermint[V, H, A]) line49WhenProposalIsReceived(p Proposal[V, H, A], precommitsForHR map[A][]Precommit[H,
-	A], vID H, validProposal bool, proposalFromProposer bool,
-) bool {
-	precommits, vals := checkForQuorumPrecommit[H, A](precommitsForHR, vID)
+func (t *Tendermint[V, H, A]) line49WhenProposalIsReceived(p Proposal[V, H, A], vID H, validProposal, proposalFromProposer bool) bool {
+	precommits, hasQuorum := t.checkForQuorumPrecommit(p.R, vID)
 
-	if validProposal && proposalFromProposer &&
-		t.validatorSetVotingPower(vals) >= q(t.validators.TotalVotingPower(p.H)) {
+	if validProposal && proposalFromProposer && hasQuorum {
 		// After committing the block, how the new height and round is started needs to be coordinated
 		// with the synchronisation process.
 		t.blockchain.Commit(t.state.h, *p.Value, precommits)
@@ -121,15 +118,12 @@ Check the upon condition on line 28:
 Ideally, the condition on line 28 would be checked in a single if statement, however,
 this cannot be done because valid round needs to be non-nil before the prevotes are fetched.
 */
-func (t *Tendermint[V, H, A]) line28WhenProposalIsReceived(p Proposal[V, H, A], vr round, proposalFromProposer bool,
+func (t *Tendermint[V, H, A]) line28WhenProposalIsReceived(vr round, proposalFromProposer bool,
 	vID H, validProposal bool,
 ) {
 	if vr != -1 && proposalFromProposer && t.state.s == propose && vr >= 0 && vr < t.state.r {
-		_, prevotesForHVr, _ := t.messages.allMessages(p.H, round(vr))
-
-		vals := checkQuorumPrevotesGivenProposalVID(prevotesForHVr, vID)
-
-		if t.validatorSetVotingPower(vals) >= q(t.validators.TotalVotingPower(p.H)) {
+		hasQuorum := t.checkQuorumPrevotesGivenProposalVID(vr, vID)
+		if hasQuorum {
 			var votedID *H
 			if validProposal && (t.state.lockedRound <= vr || (*t.state.lockedValue).Hash() == vID) {
 				votedID = &vID

--- a/consensus/tendermint/tendermint.go
+++ b/consensus/tendermint/tendermint.go
@@ -13,7 +13,7 @@ import (
 type (
 	step        uint8
 	height      uint
-	round       uint
+	round       int
 	votingPower uint
 )
 
@@ -156,9 +156,9 @@ type state[V Hashable[H], H Hash] struct {
 	s step
 
 	lockedValue *V
-	lockedRound int
+	lockedRound round
 	validValue  *V
-	validRound  int
+	validRound  round
 
 	// The following are round level variable therefore when a round changes they must be reset.
 	timeoutPrevoteScheduled       bool // line34 for the first time condition


### PR DESCRIPTION
- The logic to broadcast messages are duplicate across different rules, so I move them to a separate file `broadcast.go`
- `lockedRound` and `validRound` are rounds, so they should use `round` type.
- The round in the algorithm can be negative (-1), it has its own comparison logic, so it should be `int` instead of using `uint` and `nil` as a workaround.
- Functions to calculate quorum are refactored to a separate one, and we can optimize it later.