### PR TITLE
ci: add automated draft release workflow with binaries and docker build

### DIFF
--- a/.github/workflows/build-binaries.yml
+++ b/.github/workflows/build-binaries.yml
@@ -5,11 +5,7 @@ on:
     tags:
       - 'v*'
   workflow_dispatch:
-  pull_request:
-    branches:
-      - main
-    paths:
-      - .github/workflows/build-binaries.yml
+  workflow_call:
 
 jobs:
   build:
@@ -50,7 +46,7 @@ jobs:
             core/rust
             starknet/compiler/rust
 
-      - name: Get latest tag
+      - name: Set TAG env var
         run: echo "TAG=$(git describe --tags)" >> $GITHUB_ENV
 
       - name: Get artifact name
@@ -67,7 +63,7 @@ jobs:
       - name: Install dependencies (macOS)
         if: runner.os == 'macOS'
         run: brew install jemalloc
-          
+
       - name: Build binary
         run: make juno
 
@@ -89,11 +85,14 @@ jobs:
             sha256sum ${{ env.ARTIFACT_NAME }} > ${{ env.ARTIFACT_NAME }}.sha256
           fi
 
+      - name: Zip binary and checksum
+        run: |
+          zip ${{ env.ARTIFACT_NAME }}.zip ${{ env.ARTIFACT_NAME }} ${{ env.ARTIFACT_NAME }}.sha256
+          rm ${{ env.ARTIFACT_NAME }} ${{ env.ARTIFACT_NAME }}.sha256
+
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:
-          name: ${{ env.ARTIFACT_NAME }}
-          path: |
-            ${{ env.ARTIFACT_NAME }}
-            ${{ env.ARTIFACT_NAME }}.sha256
+          name: ${{ env.ARTIFACT_NAME }}.zip
+          path: ${{ env.ARTIFACT_NAME }}.zip
           retention-days: 30

--- a/.github/workflows/docker-image-build-push.yml
+++ b/.github/workflows/docker-image-build-push.yml
@@ -1,29 +1,56 @@
 name: 'Build and publish Docker image'
 
 on:
+  workflow_call:
+    inputs:
+      repo_type:
+        description: 'Choose repository type'
+        type: string
+        default: 'non-official'
+    outputs:
+      tag:
+        description: 'The tag that was built'
+        value: ${{ jobs.setup.outputs.tag }}
   workflow_dispatch:
     inputs:
-      tag:
-        description: 'Enter an image tag e.g v0.1.0'
-        required: true
       repo_type:
         description: 'Choose repository type'
         type: choice
         required: false
         default: 'non-official'
         options:
-        - official
-        - non-official
+          - official
+          - non-official
+
+permissions:
+  contents: read
+  packages: write
 
 jobs:
+  setup:
+    if: github.repository_owner == 'NethermindEth'
+    runs-on: ubuntu-latest
+    outputs:
+      tag: ${{ steps.set_tag.outputs.tag }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          
+      - name: Set TAG output
+        id: set_tag
+        run: echo "tag=$(git describe --tags)" >> $GITHUB_OUTPUT
+
   build_and_push_docker_image_amd:
+    needs: setup
     if: github.repository_owner == 'NethermindEth'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
         with:
-            fetch-depth: 0
+          fetch-depth: 0
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -34,47 +61,47 @@ jobs:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
 
-      - name: Build and push
+      - name: Build and push AMD64
         uses: docker/build-push-action@v6
         with:
           context: .
-          platforms: 'linux/amd64'
+          platforms: linux/amd64
           push: true
-          tags: nethermindeth/juno:${{ github.event.inputs.tag }}
+          tags: nethermindeth/juno:${{ needs.setup.outputs.tag }}
 
   build_and_push_docker_image_arm:
+    needs: setup
     if: github.repository_owner == 'NethermindEth'
     runs-on: ubuntu-arm64-4-core
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
         with:
-            fetch-depth: 0
+          fetch-depth: 0
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
-            
+
       - name: Login to Docker Hub
         uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
 
-      - name: Build and push ARM
+      - name: Build and push ARM64
         uses: docker/build-push-action@v6
         with:
           context: .
-          platforms: 'linux/arm64'
+          platforms: linux/arm64
           push: true
-          tags: nethermindeth/juno:${{ github.event.inputs.tag }}-arm64
-      
+          tags: nethermindeth/juno:${{ needs.setup.outputs.tag }}-arm64
+
       - name: Cleanup self-hosted
-        run: |
-          docker system prune -af
+        run: docker system prune -af
 
   create_and_push_official_image:
-    if: github.repository_owner == 'NethermindEth' && github.event.inputs.repo_type == 'official'
-    needs: [build_and_push_docker_image_amd, build_and_push_docker_image_arm]
+    needs: [setup, build_and_push_docker_image_amd, build_and_push_docker_image_arm]
+    if: github.repository_owner == 'NethermindEth' && inputs.repo_type == 'official'
     runs-on: ubuntu-latest
     steps:
       - name: Set up Docker Buildx
@@ -88,12 +115,11 @@ jobs:
 
       - name: Create and push manifest using buildx
         run: |
-            docker buildx imagetools create nethermindeth/juno:${{ github.event.inputs.tag }} \
-                nethermindeth/juno:${{ github.event.inputs.tag }}-arm64 \
-                --tag nethermind/juno:${{ github.event.inputs.tag }}
+          docker buildx imagetools create \
+            nethermindeth/juno:${{ needs.setup.outputs.tag }} \
+            nethermindeth/juno:${{ needs.setup.outputs.tag }}-arm64 \
+            --tag nethermind/juno:${{ needs.setup.outputs.tag }}
 
-      - name: Clean up environment
+      - name: Clean up Docker config
         if: always()
-        run: |
-          rm -f ${HOME}/.docker/config.json
-  
+        run: rm -f ${HOME}/.docker/config.json

--- a/.github/workflows/docker-image-tag-latest.yml
+++ b/.github/workflows/docker-image-tag-latest.yml
@@ -1,0 +1,37 @@
+name: 'Tag Official Docker Image as Latest'
+
+on:
+  workflow_dispatch: {}
+  release:
+    types: [published]
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  tag_official_image_as_latest:
+    if: github.repository_owner == 'NethermindEth'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set tag from ref
+        run: echo "TAG=${GITHUB_REF#refs/tags/}" >> $GITHUB_ENV
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+
+      - name: Tag and push official image as latest
+        run: |
+          docker pull nethermind/juno:${{ env.TAG }}
+          docker tag nethermind/juno:${{ env.TAG }} nethermind/juno:latest
+          docker push nethermind/juno:latest
+
+      - name: Clean up Docker config
+        if: always()
+        run: rm -f ${HOME}/.docker/config.json

--- a/.github/workflows/prepare-draft-release.yml
+++ b/.github/workflows/prepare-draft-release.yml
@@ -1,0 +1,49 @@
+name: Prepare Draft Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+permissions:
+  contents: write
+  packages: write
+
+jobs:
+  build-binaries:
+    name: Build Binaries
+    if: github.repository_owner == 'NethermindEth'
+    uses: ./.github/workflows/build-binaries.yml
+
+  docker-image:
+    name: Build and Push Docker Image
+    if: github.repository_owner == 'NethermindEth'
+    uses: ./.github/workflows/docker-image-build-push.yml
+    with:
+      repo_type: 'official'
+    secrets: inherit
+
+  create-release:
+    name: Create Draft Release
+    if: github.repository_owner == 'NethermindEth'
+    needs: [build-binaries, docker-image]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download binaries
+        uses: actions/download-artifact@v4
+        with:
+          pattern: juno-*.zip
+          merge-multiple: true
+          path: binaries
+
+      - name: Create Draft GitHub Release
+        uses: softprops/action-gh-release@c95fe1489396fe8a9eb87c0abf8aa5b2ef267fda
+        with:
+          tag_name: ${{ needs.docker-image.outputs.tag }}
+          name: ${{ needs.docker-image.outputs.tag }}
+          generate_release_notes: true
+          draft: true
+          files: |
+            binaries/*
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
- Adds workflow triggered on `v*` tag pushes  
- Builds and uploads binaries  
- Builds and pushes Docker images 
- Creates a draft GitHub release with auto-generated notes and binaries attached
- Add workflow to re-tag to latest, triggered manually or on pubishe release event

sample result: https://github.com/NethermindEth/juno/releases/tag/untagged-ddf7896ed66ac3a2d0b8