### PR TITLE
refactor: Process future messages sequentially

### DIFF
--- a/consensus/tendermint/rule_skip_round.go
+++ b/consensus/tendermint/rule_skip_round.go
@@ -14,9 +14,6 @@ Check the upon condition on line 55:
 If there are f + 1 messages from a newer round, there is at least an honest node in that round.
 */
 func (t *Tendermint[V, H, A]) uponSkipRound(futureR round) bool {
-	t.futureMessagesMu.Lock()
-	defer t.futureMessagesMu.Unlock()
-
 	vals := make(map[A]struct{})
 	proposals, prevotes, precommits := t.futureMessages.allMessages(t.state.h, futureR)
 


### PR DESCRIPTION
Depends on #2730 

- Current approach: Read write future messages concurrently, managed by a mutex. When a new round starts, redirect all messages to channels, then the main loop read from these channels concurrently with the listeners.
- New approach: The algorithm explicitly states that the rules can be executed in any order. We can handle the existing messages first before starting to process the listeners. This avoids unnecessary concurrency and mutex.
