### PR TITLE
refactor: Remove unnecessary dependencies on message data for some rules

### DIFF
--- a/consensus/tendermint/precommit.go
+++ b/consensus/tendermint/precommit.go
@@ -28,7 +28,7 @@ func (t *Tendermint[V, H, A]) handlePrecommit(p Precommit[H, A]) {
 		return
 	}
 
-	if t.uponPrecommitAny(p) {
-		t.doPrecommitAny(p)
+	if t.uponPrecommitAny() {
+		t.doPrecommitAny()
 	}
 }

--- a/consensus/tendermint/prevote.go
+++ b/consensus/tendermint/prevote.go
@@ -28,11 +28,11 @@ func (t *Tendermint[V, H, A]) handlePrevote(p Prevote[H, A]) {
 	}
 
 	if p.Round == t.state.round {
-		if t.uponPolkaAny(p) {
-			t.doPolkaAny(p)
+		if t.uponPolkaAny() {
+			t.doPolkaAny()
 		}
 
-		if t.uponPolkaNil(p) {
+		if t.uponPolkaNil() {
 			t.doPolkaNil()
 		}
 	}

--- a/consensus/tendermint/rule_polka_any.go
+++ b/consensus/tendermint/rule_polka_any.go
@@ -11,21 +11,20 @@ Check the upon condition on line 34:
 	34: upon 2f + 1 {PREVOTE, h_p, round_p, ∗} while step_p = prevote for the first time do
 	35: schedule OnTimeoutPrevote(h_p, round_p) to be executed after timeoutPrevote(round_p)
 */
-func (t *Tendermint[V, H, A]) uponPolkaAny(p Prevote[H, A]) bool {
+func (t *Tendermint[V, H, A]) uponPolkaAny() bool {
 	prevotes := t.messages.prevotes[t.state.height][t.state.round]
 	vals := slices.Collect(maps.Keys(prevotes))
 
 	isFirstTime := !t.state.timeoutPrevoteScheduled
 
-	hasQuorum := t.validatorSetVotingPower(vals) >= q(t.validators.TotalVotingPower(p.Height))
+	hasQuorum := t.validatorSetVotingPower(vals) >= q(t.validators.TotalVotingPower(t.state.height))
 
-	return p.Round == t.state.round &&
-		t.state.step == prevote &&
+	return t.state.step == prevote &&
 		hasQuorum &&
 		isFirstTime
 }
 
-func (t *Tendermint[V, H, A]) doPolkaAny(p Prevote[H, A]) {
-	t.scheduleTimeout(t.timeoutPrevote(p.Round), prevote, p.Height, p.Round)
+func (t *Tendermint[V, H, A]) doPolkaAny() {
+	t.scheduleTimeout(t.timeoutPrevote(t.state.round), prevote, t.state.height, t.state.round)
 	t.state.timeoutPrevoteScheduled = true
 }

--- a/consensus/tendermint/rule_polka_nil.go
+++ b/consensus/tendermint/rule_polka_nil.go
@@ -9,7 +9,7 @@ Check the upon condition on line 44:
 
 Line 36 and 44 for a round are mutually exclusive.
 */
-func (t *Tendermint[V, H, A]) uponPolkaNil(p Prevote[H, A]) bool {
+func (t *Tendermint[V, H, A]) uponPolkaNil() bool {
 	prevotes := t.messages.prevotes[t.state.height][t.state.round]
 
 	var vals []A
@@ -22,7 +22,7 @@ func (t *Tendermint[V, H, A]) uponPolkaNil(p Prevote[H, A]) bool {
 	}
 
 	// TODO: refactor this
-	hasQuorum := t.validatorSetVotingPower(vals) >= q(t.validators.TotalVotingPower(p.Height))
+	hasQuorum := t.validatorSetVotingPower(vals) >= q(t.validators.TotalVotingPower(t.state.height))
 
 	return hasQuorum && t.state.step == prevote
 }

--- a/consensus/tendermint/rule_precommit_any.go
+++ b/consensus/tendermint/rule_precommit_any.go
@@ -11,20 +11,18 @@ Check the upon condition on line 47:
 	47: upon 2f + 1 {PRECOMMIT, h_p, round_p, ∗} for the first time do
 	48: schedule OnTimeoutPrecommit(h_p , round_p) to be executed after timeoutPrecommit(round_p)
 */
-func (t *Tendermint[V, H, A]) uponPrecommitAny(p Precommit[H, A]) bool {
+func (t *Tendermint[V, H, A]) uponPrecommitAny() bool {
 	precommits := t.messages.precommits[t.state.height][t.state.round]
 	vals := slices.Collect(maps.Keys(precommits))
 
 	isFirstTime := !t.state.timeoutPrecommitScheduled
 
-	hasQuorum := t.validatorSetVotingPower(vals) >= q(t.validators.TotalVotingPower(p.Height))
+	hasQuorum := t.validatorSetVotingPower(vals) >= q(t.validators.TotalVotingPower(t.state.height))
 
-	return p.Round == t.state.round &&
-		hasQuorum &&
-		isFirstTime
+	return hasQuorum && isFirstTime
 }
 
-func (t *Tendermint[V, H, A]) doPrecommitAny(p Precommit[H, A]) {
-	t.scheduleTimeout(t.timeoutPrecommit(p.Round), precommit, p.Height, p.Round)
+func (t *Tendermint[V, H, A]) doPrecommitAny() {
+	t.scheduleTimeout(t.timeoutPrecommit(t.state.round), precommit, t.state.height, t.state.round)
 	t.state.timeoutPrecommitScheduled = true
 }


### PR DESCRIPTION
Rationale: Among 8 rules, only `precommit_any` and `skip_round` are not requiring messages to be in current round. We can remove the message from other rule arguments and check the condition against the current height and round instead.