### PR TITLE
refactor: Add MessageHeader type

### DIFF
--- a/consensus/tendermint/broadcast.go
+++ b/consensus/tendermint/broadcast.go
@@ -2,11 +2,13 @@ package tendermint
 
 func (t *Tendermint[V, H, A]) sendProposal(value *V) {
 	proposalMessage := Proposal[V, H, A]{
-		Height:     t.state.height,
-		Round:      t.state.round,
+		MessageHeader: MessageHeader[A]{
+			Height: t.state.height,
+			Round:  t.state.round,
+			Sender: t.nodeAddr,
+		},
 		ValidRound: t.state.validRound,
 		Value:      value,
-		Sender:     t.nodeAddr,
 	}
 
 	t.messages.addProposal(proposalMessage)
@@ -15,10 +17,12 @@ func (t *Tendermint[V, H, A]) sendProposal(value *V) {
 
 func (t *Tendermint[V, H, A]) sendPrevote(id *H) {
 	vote := Prevote[H, A]{
-		Height: t.state.height,
-		Round:  t.state.round,
-		ID:     id,
-		Sender: t.nodeAddr,
+		MessageHeader: MessageHeader[A]{
+			Height: t.state.height,
+			Round:  t.state.round,
+			Sender: t.nodeAddr,
+		},
+		ID: id,
 	}
 
 	t.messages.addPrevote(vote)
@@ -28,10 +32,12 @@ func (t *Tendermint[V, H, A]) sendPrevote(id *H) {
 
 func (t *Tendermint[V, H, A]) sendPrecommit(id *H) {
 	vote := Precommit[H, A]{
-		Height: t.state.height,
-		Round:  t.state.round,
-		ID:     id,
-		Sender: t.nodeAddr,
+		MessageHeader: MessageHeader[A]{
+			Height: t.state.height,
+			Round:  t.state.round,
+			Sender: t.nodeAddr,
+		},
+		ID: id,
 	}
 
 	t.messages.addPrecommit(vote)

--- a/consensus/tendermint/messages.go
+++ b/consensus/tendermint/messages.go
@@ -14,12 +14,9 @@ type Message[V Hashable[H], H Hash, A Addr] interface {
 }
 
 type Proposal[V Hashable[H], H Hash, A Addr] struct {
-	Height     height
-	Round      round
+	MessageHeader[A]
 	ValidRound round
 	Value      *V
-
-	Sender A
 }
 
 type (
@@ -28,10 +25,13 @@ type (
 )
 
 type Vote[H Hash, A Addr] struct {
+	MessageHeader[A]
+	ID *H
+}
+
+type MessageHeader[A Addr] struct {
 	Height height
 	Round  round
-	ID     *H
-
 	Sender A
 }
 

--- a/consensus/tendermint/precommit.go
+++ b/consensus/tendermint/precommit.go
@@ -1,21 +1,7 @@
 package tendermint
 
 func (t *Tendermint[V, H, A]) handlePrecommit(p Precommit[H, A]) {
-	if p.Height < t.state.height {
-		return
-	}
-
-	if !handleFutureHeightMessage(
-		t,
-		p,
-		func(p Precommit[H, A]) height { return p.Height },
-		func(p Precommit[H, A]) round { return p.Round },
-		t.futureMessages.addPrecommit,
-	) {
-		return
-	}
-
-	if !handleFutureRoundMessage(t, p, func(p Precommit[H, A]) round { return p.Round }, t.futureMessages.addPrecommit) {
+	if !t.preprocessMessage(p.MessageHeader, func() { t.futureMessages.addPrecommit(p) }) {
 		return
 	}
 

--- a/consensus/tendermint/prevote.go
+++ b/consensus/tendermint/prevote.go
@@ -1,21 +1,7 @@
 package tendermint
 
 func (t *Tendermint[V, H, A]) handlePrevote(p Prevote[H, A]) {
-	if p.Height < t.state.height {
-		return
-	}
-
-	if !handleFutureHeightMessage(
-		t,
-		p,
-		func(p Prevote[H, A]) height { return p.Height },
-		func(p Prevote[H, A]) round { return p.Round },
-		t.futureMessages.addPrevote,
-	) {
-		return
-	}
-
-	if !handleFutureRoundMessage(t, p, func(p Prevote[H, A]) round { return p.Round }, t.futureMessages.addPrevote) {
+	if !t.preprocessMessage(p.MessageHeader, func() { t.futureMessages.addPrevote(p) }) {
 		return
 	}
 

--- a/consensus/tendermint/propose.go
+++ b/consensus/tendermint/propose.go
@@ -3,21 +3,7 @@ package tendermint
 import "github.com/NethermindEth/juno/utils"
 
 func (t *Tendermint[V, H, A]) handleProposal(p Proposal[V, H, A]) {
-	if p.Height < t.state.height {
-		return
-	}
-
-	if !handleFutureHeightMessage(
-		t,
-		p,
-		func(p Proposal[V, H, A]) height { return p.Height },
-		func(p Proposal[V, H, A]) round { return p.Round },
-		t.futureMessages.addProposal,
-	) {
-		return
-	}
-
-	if !handleFutureRoundMessage(t, p, func(p Proposal[V, H, A]) round { return p.Round }, t.futureMessages.addProposal) {
+	if !t.preprocessMessage(p.MessageHeader, func() { t.futureMessages.addProposal(p) }) {
 		return
 	}
 

--- a/consensus/tendermint/propose_test.go
+++ b/consensus/tendermint/propose_test.go
@@ -29,18 +29,22 @@ func TestPropose(t *testing.T) {
 		expectedHeight := height(0)
 		rPrime, rPrimeVal := round(4), value(10)
 		val2Proposal := Proposal[value, felt.Felt, felt.Felt]{
-			Height:     expectedHeight,
-			Round:      rPrime,
+			MessageHeader: MessageHeader[felt.Felt]{
+				Height: expectedHeight,
+				Round:  rPrime,
+				Sender: *val2,
+			},
 			ValidRound: -1,
 			Value:      &rPrimeVal,
-			Sender:     *val2,
 		}
 
 		val3Prevote := Prevote[felt.Felt, felt.Felt]{
-			Height: expectedHeight,
-			Round:  rPrime,
-			ID:     utils.HeapPtr(rPrimeVal.Hash()),
-			Sender: *val3,
+			MessageHeader: MessageHeader[felt.Felt]{
+				Height: expectedHeight,
+				Round:  rPrime,
+				Sender: *val3,
+			},
+			ID: utils.HeapPtr(rPrimeVal.Hash()),
 		}
 
 		algo.futureMessages.addPrevote(val3Prevote)
@@ -81,17 +85,21 @@ func TestPropose(t *testing.T) {
 		expectedHeight := height(0)
 		rPrime, rPrimeVal := round(4), value(10)
 		val2Prevote := Prevote[felt.Felt, felt.Felt]{
-			Height: expectedHeight,
-			Round:  rPrime,
-			ID:     utils.HeapPtr(rPrimeVal.Hash()),
-			Sender: *val2,
+			MessageHeader: MessageHeader[felt.Felt]{
+				Height: expectedHeight,
+				Round:  rPrime,
+				Sender: *val2,
+			},
+			ID: utils.HeapPtr(rPrimeVal.Hash()),
 		}
 
 		val3Prevote := Prevote[felt.Felt, felt.Felt]{
-			Height: expectedHeight,
-			Round:  rPrime,
-			ID:     utils.HeapPtr(rPrimeVal.Hash()),
-			Sender: *val3,
+			MessageHeader: MessageHeader[felt.Felt]{
+				Height: expectedHeight,
+				Round:  rPrime,
+				Sender: *val3,
+			},
+			ID: utils.HeapPtr(rPrimeVal.Hash()),
 		}
 
 		algo.futureMessages.addPrevote(val2Prevote)
@@ -131,17 +139,21 @@ func TestPropose(t *testing.T) {
 		rPrime := round(4)
 		round4Value := value(10)
 		val2Precommit := Precommit[felt.Felt, felt.Felt]{
-			Height: expectedHeight,
-			Round:  rPrime,
-			ID:     utils.HeapPtr(round4Value.Hash()),
-			Sender: *val2,
+			MessageHeader: MessageHeader[felt.Felt]{
+				Height: expectedHeight,
+				Round:  rPrime,
+				Sender: *val2,
+			},
+			ID: utils.HeapPtr(round4Value.Hash()),
 		}
 
 		val3Prevote := Prevote[felt.Felt, felt.Felt]{
-			Height: expectedHeight,
-			Round:  rPrime,
-			ID:     utils.HeapPtr(round4Value.Hash()),
-			Sender: *val3,
+			MessageHeader: MessageHeader[felt.Felt]{
+				Height: expectedHeight,
+				Round:  rPrime,
+				Sender: *val3,
+			},
+			ID: utils.HeapPtr(round4Value.Hash()),
 		}
 
 		algo.futureMessages.addPrevote(val3Prevote)
@@ -179,22 +191,28 @@ func TestPropose(t *testing.T) {
 		algo := New[value, felt.Felt, felt.Felt](*nodeAddr, app, chain, vals, listeners, broadcasters, tm, tm, tm)
 
 		val2Precommit := Precommit[felt.Felt, felt.Felt]{
-			Height: 0,
-			Round:  0,
-			ID:     utils.HeapPtr(value(10).Hash()),
-			Sender: *val2,
+			MessageHeader: MessageHeader[felt.Felt]{
+				Height: 0,
+				Round:  0,
+				Sender: *val2,
+			},
+			ID: utils.HeapPtr(value(10).Hash()),
 		}
 		val3Precommit := Precommit[felt.Felt, felt.Felt]{
-			Height: 0,
-			Round:  0,
-			ID:     nil,
-			Sender: *val3,
+			MessageHeader: MessageHeader[felt.Felt]{
+				Height: 0,
+				Round:  0,
+				Sender: *val3,
+			},
+			ID: nil,
 		}
 		val4Precommit := Precommit[felt.Felt, felt.Felt]{
-			Height: 0,
-			Round:  0,
-			ID:     nil,
-			Sender: *val4,
+			MessageHeader: MessageHeader[felt.Felt]{
+				Height: 0,
+				Round:  0,
+				Sender: *val4,
+			},
+			ID: nil,
 		}
 
 		algo.messages.addPrecommit(val2Precommit)
@@ -230,28 +248,36 @@ func TestPropose(t *testing.T) {
 		algo := New[value, felt.Felt, felt.Felt](*nodeAddr, app, chain, vals, listeners, broadcasters, tm, tm, tm)
 
 		nodePrecommit := Precommit[felt.Felt, felt.Felt]{
-			Height: 0,
-			Round:  0,
-			ID:     nil,
-			Sender: *nodeAddr,
+			MessageHeader: MessageHeader[felt.Felt]{
+				Height: 0,
+				Round:  0,
+				Sender: *nodeAddr,
+			},
+			ID: nil,
 		}
 		val2Precommit := Precommit[felt.Felt, felt.Felt]{
-			Height: 0,
-			Round:  0,
-			ID:     utils.HeapPtr(value(10).Hash()),
-			Sender: *val2,
+			MessageHeader: MessageHeader[felt.Felt]{
+				Height: 0,
+				Round:  0,
+				Sender: *val2,
+			},
+			ID: utils.HeapPtr(value(10).Hash()),
 		}
 		val3Precommit := Precommit[felt.Felt, felt.Felt]{
-			Height: 0,
-			Round:  0,
-			ID:     nil,
-			Sender: *val3,
+			MessageHeader: MessageHeader[felt.Felt]{
+				Height: 0,
+				Round:  0,
+				Sender: *val3,
+			},
+			ID: nil,
 		}
 		val4Precommit := Precommit[felt.Felt, felt.Felt]{
-			Height: 0,
-			Round:  0,
-			ID:     nil,
-			Sender: *val4,
+			MessageHeader: MessageHeader[felt.Felt]{
+				Height: 0,
+				Round:  0,
+				Sender: *val4,
+			},
+			ID: nil,
 		}
 
 		algo.messages.addPrecommit(val2Precommit)
@@ -292,22 +318,28 @@ func TestPropose(t *testing.T) {
 		algo := New[value, felt.Felt, felt.Felt](*nodeAddr, app, chain, vals, listeners, broadcasters, tm, tm, tmPrecommit)
 
 		val2Precommit := Precommit[felt.Felt, felt.Felt]{
-			Height: 0,
-			Round:  0,
-			ID:     utils.HeapPtr(value(10).Hash()),
-			Sender: *val2,
+			MessageHeader: MessageHeader[felt.Felt]{
+				Height: 0,
+				Round:  0,
+				Sender: *val2,
+			},
+			ID: utils.HeapPtr(value(10).Hash()),
 		}
 		val3Precommit := Precommit[felt.Felt, felt.Felt]{
-			Height: 0,
-			Round:  0,
-			ID:     nil,
-			Sender: *val3,
+			MessageHeader: MessageHeader[felt.Felt]{
+				Height: 0,
+				Round:  0,
+				Sender: *val3,
+			},
+			ID: nil,
 		}
 		val4Precommit := Precommit[felt.Felt, felt.Felt]{
-			Height: 0,
-			Round:  0,
-			ID:     nil,
-			Sender: *val4,
+			MessageHeader: MessageHeader[felt.Felt]{
+				Height: 0,
+				Round:  0,
+				Sender: *val4,
+			},
+			ID: nil,
 		}
 
 		algo.messages.addPrecommit(val2Precommit)
@@ -351,22 +383,28 @@ func TestPropose(t *testing.T) {
 		vID := val.Hash()
 
 		val2Precommit := Precommit[felt.Felt, felt.Felt]{
-			Height: h,
-			Round:  r,
-			ID:     &vID,
-			Sender: *val2,
+			MessageHeader: MessageHeader[felt.Felt]{
+				Height: h,
+				Round:  r,
+				Sender: *val2,
+			},
+			ID: &vID,
 		}
 		val3Precommit := Precommit[felt.Felt, felt.Felt]{
-			Height: h,
-			Round:  r,
-			ID:     &vID,
-			Sender: *val3,
+			MessageHeader: MessageHeader[felt.Felt]{
+				Height: h,
+				Round:  r,
+				Sender: *val3,
+			},
+			ID: &vID,
 		}
 		val4Precommit := Precommit[felt.Felt, felt.Felt]{
-			Height: h,
-			Round:  r,
-			ID:     &vID,
-			Sender: *val4,
+			MessageHeader: MessageHeader[felt.Felt]{
+				Height: h,
+				Round:  r,
+				Sender: *val4,
+			},
+			ID: &vID,
 		}
 
 		// The node has received all the precommits but has received the corresponding proposal
@@ -376,11 +414,13 @@ func TestPropose(t *testing.T) {
 
 		// since val2 is the proposer of round 0, the proposal arrives after the precommits
 		val2Proposal := Proposal[value, felt.Felt, felt.Felt]{
-			Height:     h,
-			Round:      r,
+			MessageHeader: MessageHeader[felt.Felt]{
+				Height: h,
+				Round:  r,
+				Sender: *val2,
+			},
 			ValidRound: -1,
 			Value:      &val,
-			Sender:     *val2,
 		}
 
 		proposalListener := listeners.ProposalListener.(*senderAndReceiver[Proposal[value, felt.Felt, felt.Felt],
@@ -427,23 +467,29 @@ func TestPropose(t *testing.T) {
 		vID := val.Hash()
 
 		val2Precommit := Precommit[felt.Felt, felt.Felt]{
-			Height: h,
-			Round:  r,
-			ID:     &vID,
-			Sender: *val2,
+			MessageHeader: MessageHeader[felt.Felt]{
+				Height: h,
+				Round:  r,
+				Sender: *val2,
+			},
+			ID: &vID,
 		}
 		val2Proposal := Proposal[value, felt.Felt, felt.Felt]{
-			Height:     h,
-			Round:      r,
+			MessageHeader: MessageHeader[felt.Felt]{
+				Height: h,
+				Round:  r,
+				Sender: *val2,
+			},
 			ValidRound: -1,
 			Value:      &val,
-			Sender:     *val2,
 		}
 		val3Precommit := Precommit[felt.Felt, felt.Felt]{
-			Height: h,
-			Round:  r,
-			ID:     &vID,
-			Sender: *val3,
+			MessageHeader: MessageHeader[felt.Felt]{
+				Height: h,
+				Round:  r,
+				Sender: *val3,
+			},
+			ID: &vID,
 		}
 
 		// The node has received all the precommits but has received the corresponding proposal
@@ -452,10 +498,12 @@ func TestPropose(t *testing.T) {
 		algo.messages.addPrecommit(val3Precommit)
 
 		val4Precommit := Precommit[felt.Felt, felt.Felt]{
-			Height: h,
-			Round:  r,
-			ID:     &vID,
-			Sender: *val4,
+			MessageHeader: MessageHeader[felt.Felt]{
+				Height: h,
+				Round:  r,
+				Sender: *val4,
+			},
+			ID: &vID,
 		}
 
 		precommitListner := listeners.PrecommitListener.(*senderAndReceiver[Precommit[felt.Felt, felt.Felt],

--- a/consensus/tendermint/tendermint_test.go
+++ b/consensus/tendermint/tendermint_test.go
@@ -141,11 +141,13 @@ func TestStartRound(t *testing.T) {
 
 		expectedHeight, expectedRound := height(0), round(0)
 		expectedProposalMsg := Proposal[value, felt.Felt, felt.Felt]{
-			Height:     0,
-			Round:      0,
+			MessageHeader: MessageHeader[felt.Felt]{
+				Height: 0,
+				Round:  0,
+				Sender: *nodeAddr,
+			},
 			ValidRound: -1,
 			Value:      utils.HeapPtr(app.cur + 1),
-			Sender:     *nodeAddr,
 		}
 
 		proposalBroadcaster := broadcasters.ProposalBroadcaster.(*senderAndReceiver[Proposal[value, felt.Felt,
@@ -209,10 +211,12 @@ func TestStartRound(t *testing.T) {
 
 		expectedHeight, expectedRound := height(0), round(0)
 		expectedPrevoteMsg := Prevote[felt.Felt, felt.Felt]{
-			Height: 0,
-			Round:  0,
-			ID:     nil,
-			Sender: *nodeAddr,
+			MessageHeader: MessageHeader[felt.Felt]{
+				Height: 0,
+				Round:  0,
+				Sender: *nodeAddr,
+			},
+			ID: nil,
 		}
 
 		prevoteBroadcaster := broadcasters.PrevoteBroadcaster.(*senderAndReceiver[Prevote[felt.Felt, felt.Felt], value,


### PR DESCRIPTION
This PR creates a header type for common fields in message, which helps to simplify the check for future height and round to be type agnostic.