### PR TITLE
fix(vm): Transaction execution should fail-fast

### DIFF
--- a/vm/rust/src/lib.rs
+++ b/vm/rust/src/lib.rs
@@ -410,6 +410,7 @@ pub extern "C" fn cairoVMExecute(
                         json!(error).to_string()
                     };
                     report_error(reader_handle, err_string.as_str(), txn_index as i64, 0);
+                    return;
                 }
                 ExecutionError::Internal(e) | ExecutionError::Custom(e) => {
                     report_error(
@@ -418,6 +419,7 @@ pub extern "C" fn cairoVMExecute(
                         txn_index as i64,
                         0,
                     );
+                    return;
                 }
             },
             Ok(mut tx_execution_info) => {


### PR DESCRIPTION
During execution of transactions in a block, the function doesn't return on error, but instead continue executing the subsequent transactions on wrong state. Therefore the error messages are likely to be irrelevant, because the first error wasn't reported.
The PR fixes the issue by return immediately after reporting error.