### PR TITLE
refactor: Separate driver and state machine in Tendermint

### DIFF
--- a/consensus/tendermint/action.go
+++ b/consensus/tendermint/action.go
@@ -1,56 +1,21 @@
 package tendermint
 
-import (
-	"time"
-)
-
 type Action[V Hashable[H], H Hash, A Addr] interface {
-	Execute(d *Driver[V, H, A])
+	isTendermintAction()
 }
 
 type BroadcastProposal[V Hashable[H], H Hash, A Addr] Proposal[V, H, A]
 
-type BroadcastPrevote[V Hashable[H], H Hash, A Addr] Prevote[H, A]
+type BroadcastPrevote[H Hash, A Addr] Prevote[H, A]
 
-type BroadcastPrecommit[V Hashable[H], H Hash, A Addr] Precommit[H, A]
+type BroadcastPrecommit[H Hash, A Addr] Precommit[H, A]
 
-type ScheduleTimeout[V Hashable[H], H Hash, A Addr] timeout
+type ScheduleTimeout timeout
 
-func (a *BroadcastProposal[V, H, A]) Execute(d *Driver[V, H, A]) {
-	d.broadcasters.ProposalBroadcaster.Broadcast(Proposal[V, H, A](*a))
-}
+func (a *BroadcastProposal[V, H, A]) isTendermintAction() {}
 
-func (a *BroadcastPrevote[V, H, A]) Execute(d *Driver[V, H, A]) {
-	d.broadcasters.PrevoteBroadcaster.Broadcast(Prevote[H, A](*a))
-}
+func (a *BroadcastPrevote[H, A]) isTendermintAction() {}
 
-func (a *BroadcastPrecommit[V, H, A]) Execute(d *Driver[V, H, A]) {
-	d.broadcasters.PrecommitBroadcaster.Broadcast(Precommit[H, A](*a))
-}
+func (a *BroadcastPrecommit[H, A]) isTendermintAction() {}
 
-func (a *ScheduleTimeout[V, H, A]) Execute(d *Driver[V, H, A]) {
-	var duration time.Duration
-	switch a.s {
-	case propose:
-		duration = d.timeoutPropose(a.r)
-	case prevote:
-		duration = d.timeoutPrevote(a.r)
-	case precommit:
-		duration = d.timeoutPrecommit(a.r)
-	default:
-		return
-	}
-
-	d.scheduledTms[timeout(*a)] = time.AfterFunc(duration, func() {
-		select {
-		case <-d.quit:
-		case d.timeoutsCh <- timeout(*a):
-		}
-	})
-}
-
-func (d *Driver[V, H, A]) execute(actions []Action[V, H, A]) {
-	for _, action := range actions {
-		action.Execute(d)
-	}
-}
+func (a *ScheduleTimeout) isTendermintAction() {}

--- a/consensus/tendermint/action.go
+++ b/consensus/tendermint/action.go
@@ -1,0 +1,56 @@
+package tendermint
+
+import (
+	"time"
+)
+
+type Action[V Hashable[H], H Hash, A Addr] interface {
+	Execute(d *Driver[V, H, A])
+}
+
+type BroadcastProposal[V Hashable[H], H Hash, A Addr] Proposal[V, H, A]
+
+type BroadcastPrevote[V Hashable[H], H Hash, A Addr] Prevote[H, A]
+
+type BroadcastPrecommit[V Hashable[H], H Hash, A Addr] Precommit[H, A]
+
+type ScheduleTimeout[V Hashable[H], H Hash, A Addr] timeout
+
+func (a *BroadcastProposal[V, H, A]) Execute(d *Driver[V, H, A]) {
+	d.broadcasters.ProposalBroadcaster.Broadcast(Proposal[V, H, A](*a))
+}
+
+func (a *BroadcastPrevote[V, H, A]) Execute(d *Driver[V, H, A]) {
+	d.broadcasters.PrevoteBroadcaster.Broadcast(Prevote[H, A](*a))
+}
+
+func (a *BroadcastPrecommit[V, H, A]) Execute(d *Driver[V, H, A]) {
+	d.broadcasters.PrecommitBroadcaster.Broadcast(Precommit[H, A](*a))
+}
+
+func (a *ScheduleTimeout[V, H, A]) Execute(d *Driver[V, H, A]) {
+	var duration time.Duration
+	switch a.s {
+	case propose:
+		duration = d.timeoutPropose(a.r)
+	case prevote:
+		duration = d.timeoutPrevote(a.r)
+	case precommit:
+		duration = d.timeoutPrecommit(a.r)
+	default:
+		return
+	}
+
+	d.scheduledTms[timeout(*a)] = time.AfterFunc(duration, func() {
+		select {
+		case <-d.quit:
+		case d.timeoutsCh <- timeout(*a):
+		}
+	})
+}
+
+func (d *Driver[V, H, A]) execute(actions []Action[V, H, A]) {
+	for _, action := range actions {
+		action.Execute(d)
+	}
+}

--- a/consensus/tendermint/broadcast.go
+++ b/consensus/tendermint/broadcast.go
@@ -31,7 +31,7 @@ func (t *Tendermint[V, H, A]) setStepAndSendPrevote(id *H) Action[V, H, A] {
 	t.messages.addPrevote(vote)
 	t.state.step = prevote
 
-	return utils.HeapPtr(BroadcastPrevote[V, H, A](vote))
+	return utils.HeapPtr(BroadcastPrevote[H, A](vote))
 }
 
 func (t *Tendermint[V, H, A]) setStepAndSendPrecommit(id *H) Action[V, H, A] {
@@ -47,5 +47,5 @@ func (t *Tendermint[V, H, A]) setStepAndSendPrecommit(id *H) Action[V, H, A] {
 	t.messages.addPrecommit(vote)
 	t.state.step = precommit
 
-	return utils.HeapPtr(BroadcastPrecommit[V, H, A](vote))
+	return utils.HeapPtr(BroadcastPrecommit[H, A](vote))
 }

--- a/consensus/tendermint/broadcast.go
+++ b/consensus/tendermint/broadcast.go
@@ -1,6 +1,8 @@
 package tendermint
 
-func (t *Tendermint[V, H, A]) sendProposal(value *V) {
+import "github.com/NethermindEth/juno/utils"
+
+func (t *Tendermint[V, H, A]) sendProposal(value *V) Action[V, H, A] {
 	proposalMessage := Proposal[V, H, A]{
 		MessageHeader: MessageHeader[A]{
 			Height: t.state.height,
@@ -12,10 +14,11 @@ func (t *Tendermint[V, H, A]) sendProposal(value *V) {
 	}
 
 	t.messages.addProposal(proposalMessage)
-	t.broadcasters.ProposalBroadcaster.Broadcast(proposalMessage)
+
+	return utils.HeapPtr(BroadcastProposal[V, H, A](proposalMessage))
 }
 
-func (t *Tendermint[V, H, A]) sendPrevote(id *H) {
+func (t *Tendermint[V, H, A]) setStepAndSendPrevote(id *H) Action[V, H, A] {
 	vote := Prevote[H, A]{
 		MessageHeader: MessageHeader[A]{
 			Height: t.state.height,
@@ -26,11 +29,12 @@ func (t *Tendermint[V, H, A]) sendPrevote(id *H) {
 	}
 
 	t.messages.addPrevote(vote)
-	t.broadcasters.PrevoteBroadcaster.Broadcast(vote)
 	t.state.step = prevote
+
+	return utils.HeapPtr(BroadcastPrevote[V, H, A](vote))
 }
 
-func (t *Tendermint[V, H, A]) sendPrecommit(id *H) {
+func (t *Tendermint[V, H, A]) setStepAndSendPrecommit(id *H) Action[V, H, A] {
 	vote := Precommit[H, A]{
 		MessageHeader: MessageHeader[A]{
 			Height: t.state.height,
@@ -41,6 +45,7 @@ func (t *Tendermint[V, H, A]) sendPrecommit(id *H) {
 	}
 
 	t.messages.addPrecommit(vote)
-	t.broadcasters.PrecommitBroadcaster.Broadcast(vote)
 	t.state.step = precommit
+
+	return utils.HeapPtr(BroadcastPrecommit[V, H, A](vote))
 }

--- a/consensus/tendermint/process.go
+++ b/consensus/tendermint/process.go
@@ -1,33 +1,58 @@
 package tendermint
 
-func (t *Tendermint[V, H, A]) processMessage(header MessageHeader[A], addMessage func()) {
-	if !t.preprocessMessage(header, addMessage) {
-		return
-	}
-
-	t.processLoop(&header.Round)
+func (t *Tendermint[V, H, A]) processStart(round round) []Action[V, H, A] {
+	return t.processLoop(t.startRound(round), nil)
 }
 
-func (t *Tendermint[V, H, A]) processTimeout(tm timeout) {
+func (t *Tendermint[V, H, A]) processProposal(p Proposal[V, H, A]) []Action[V, H, A] {
+	return t.processMessage(p.MessageHeader, func() { t.messages.addProposal(p) })
+}
+
+func (t *Tendermint[V, H, A]) processPrevote(p Prevote[H, A]) []Action[V, H, A] {
+	return t.processMessage(p.MessageHeader, func() { t.messages.addPrevote(p) })
+}
+
+func (t *Tendermint[V, H, A]) processPrecommit(p Precommit[H, A]) []Action[V, H, A] {
+	return t.processMessage(p.MessageHeader, func() { t.messages.addPrecommit(p) })
+}
+
+func (t *Tendermint[V, H, A]) processMessage(header MessageHeader[A], addMessage func()) []Action[V, H, A] {
+	if !t.preprocessMessage(header, addMessage) {
+		return nil
+	}
+
+	return t.processLoop(nil, &header.Round)
+}
+
+func (t *Tendermint[V, H, A]) processTimeout(tm timeout) []Action[V, H, A] {
 	switch tm.s {
 	case propose:
-		t.onTimeoutPropose(tm.h, tm.r)
+		return t.processLoop(t.onTimeoutPropose(tm.h, tm.r), nil)
 	case prevote:
-		t.onTimeoutPrevote(tm.h, tm.r)
+		return t.processLoop(t.onTimeoutPrevote(tm.h, tm.r), nil)
 	case precommit:
-		t.onTimeoutPrecommit(tm.h, tm.r)
+		return t.processLoop(t.onTimeoutPrecommit(tm.h, tm.r), nil)
 	}
-	t.processLoop(nil)
+
+	return nil
 }
 
-func (t *Tendermint[V, H, A]) processLoop(recentlyReceivedRound *round) {
-	shouldContinue := t.process(recentlyReceivedRound)
-	for shouldContinue {
-		shouldContinue = t.process(recentlyReceivedRound)
+func (t *Tendermint[V, H, A]) processLoop(action Action[V, H, A], recentlyReceivedRound *round) []Action[V, H, A] {
+	actions := []Action[V, H, A]{}
+	if action != nil {
+		actions = append(actions, action)
 	}
+
+	action = t.process(recentlyReceivedRound)
+	for action != nil {
+		actions = append(actions, action)
+		action = t.process(recentlyReceivedRound)
+	}
+
+	return actions
 }
 
-func (t *Tendermint[V, H, A]) process(recentlyReceivedRound *round) bool {
+func (t *Tendermint[V, H, A]) process(recentlyReceivedRound *round) Action[V, H, A] {
 	cachedProposal := t.findProposal(t.state.round)
 
 	var roundCachedProposal *CachedProposal[V, H, A]
@@ -38,39 +63,37 @@ func (t *Tendermint[V, H, A]) process(recentlyReceivedRound *round) bool {
 	switch {
 	// Line 22
 	case cachedProposal != nil && t.uponFirstProposal(cachedProposal):
-		t.doFirstProposal(cachedProposal)
+		return t.doFirstProposal(cachedProposal)
 
 	// Line 28
 	case cachedProposal != nil && t.uponProposalAndPolkaPrevious(cachedProposal):
-		t.doProposalAndPolkaPrevious(cachedProposal)
+		return t.doProposalAndPolkaPrevious(cachedProposal)
 
 	// Line 34
 	case t.uponPolkaAny():
-		t.doPolkaAny()
+		return t.doPolkaAny()
 
 	// Line 36
 	case cachedProposal != nil && t.uponProposalAndPolkaCurrent(cachedProposal):
-		t.doProposalAndPolkaCurrent(cachedProposal)
+		return t.doProposalAndPolkaCurrent(cachedProposal)
 
 	// Line 44
 	case t.uponPolkaNil():
-		t.doPolkaNil()
+		return t.doPolkaNil()
 
 	// Line 47
 	case t.uponPrecommitAny():
-		t.doPrecommitAny()
+		return t.doPrecommitAny()
 
 	// Line 49
 	case roundCachedProposal != nil && t.uponCommitValue(roundCachedProposal):
-		t.doCommitValue(roundCachedProposal)
+		return t.doCommitValue(roundCachedProposal)
 
 	// Line 55
 	case recentlyReceivedRound != nil && t.uponSkipRound(*recentlyReceivedRound):
-		t.doSkipRound(*recentlyReceivedRound)
+		return t.doSkipRound(*recentlyReceivedRound)
 
 	default:
-		return false
+		return nil
 	}
-
-	return true
 }

--- a/consensus/tendermint/propose_test.go
+++ b/consensus/tendermint/propose_test.go
@@ -24,7 +24,7 @@ func TestPropose(t *testing.T) {
 		vals.addValidator(*val4)
 		vals.addValidator(*nodeAddr)
 
-		algo := New(*nodeAddr, app, chain, vals, listeners, broadcasters, tm, tm, tm)
+		algo := NewDriver(*nodeAddr, app, chain, vals, listeners, broadcasters, tm, tm, tm)
 
 		expectedHeight := height(0)
 		rPrime, rPrimeVal := round(4), value(10)
@@ -47,7 +47,7 @@ func TestPropose(t *testing.T) {
 			ID: utils.HeapPtr(rPrimeVal.Hash()),
 		}
 
-		algo.messages.addPrevote(val3Prevote)
+		algo.stateMachine.messages.addPrevote(val3Prevote)
 		proposalListener := listeners.ProposalListener.(*senderAndReceiver[Proposal[value, felt.Felt, felt.Felt],
 			value, felt.Felt, felt.Felt])
 		proposalListener.send(val2Proposal)
@@ -56,17 +56,17 @@ func TestPropose(t *testing.T) {
 		time.Sleep(5 * time.Millisecond)
 		algo.Stop()
 
-		assert.Contains(t, algo.messages.proposals[expectedHeight][rPrime], *val2)
-		assert.Equal(t, val2Proposal, algo.messages.proposals[expectedHeight][rPrime][*val2])
+		assert.Contains(t, algo.stateMachine.messages.proposals[expectedHeight][rPrime], *val2)
+		assert.Equal(t, val2Proposal, algo.stateMachine.messages.proposals[expectedHeight][rPrime][*val2])
 
-		assert.Contains(t, algo.messages.prevotes[expectedHeight][rPrime], *val3)
-		assert.Equal(t, val3Prevote, algo.messages.prevotes[expectedHeight][rPrime][*val3])
+		assert.Contains(t, algo.stateMachine.messages.prevotes[expectedHeight][rPrime], *val3)
+		assert.Equal(t, val3Prevote, algo.stateMachine.messages.prevotes[expectedHeight][rPrime][*val3])
 
 		// The step is not propose because the proposal which is received in round r' leads to consensus
 		// engine broadcasting prevote to the proposal which changes the step from propose to prevote.
-		assert.Equal(t, prevote, algo.state.step)
-		assert.Equal(t, expectedHeight, algo.state.height)
-		assert.Equal(t, rPrime, algo.state.round)
+		assert.Equal(t, prevote, algo.stateMachine.state.step)
+		assert.Equal(t, expectedHeight, algo.stateMachine.state.height)
+		assert.Equal(t, rPrime, algo.stateMachine.state.round)
 	})
 
 	t.Run("Line 55 (Prevote): Start round r' when f+1 future round messages are received from round r'", func(t *testing.T) {
@@ -80,7 +80,7 @@ func TestPropose(t *testing.T) {
 
 		tm := func(r round) time.Duration { return 2 * time.Second }
 
-		algo := New(*nodeAddr, app, chain, vals, listeners, broadcasters, tm, tm, tm)
+		algo := NewDriver(*nodeAddr, app, chain, vals, listeners, broadcasters, tm, tm, tm)
 
 		expectedHeight := height(0)
 		rPrime, rPrimeVal := round(4), value(10)
@@ -102,7 +102,7 @@ func TestPropose(t *testing.T) {
 			ID: utils.HeapPtr(rPrimeVal.Hash()),
 		}
 
-		algo.messages.addPrevote(val2Prevote)
+		algo.stateMachine.messages.addPrevote(val2Prevote)
 		prevoteListener := listeners.PrevoteListener.(*senderAndReceiver[Prevote[felt.Felt, felt.Felt], value,
 			felt.Felt, felt.Felt])
 		prevoteListener.send(val3Prevote)
@@ -111,17 +111,17 @@ func TestPropose(t *testing.T) {
 		time.Sleep(5 * time.Millisecond)
 		algo.Stop()
 
-		assert.Contains(t, algo.messages.prevotes[expectedHeight][rPrime], *val2)
-		assert.Equal(t, val2Prevote, algo.messages.prevotes[expectedHeight][rPrime][*val2])
+		assert.Contains(t, algo.stateMachine.messages.prevotes[expectedHeight][rPrime], *val2)
+		assert.Equal(t, val2Prevote, algo.stateMachine.messages.prevotes[expectedHeight][rPrime][*val2])
 
-		assert.Contains(t, algo.messages.prevotes[expectedHeight][rPrime], *val3)
-		assert.Equal(t, val3Prevote, algo.messages.prevotes[expectedHeight][rPrime][*val3])
+		assert.Contains(t, algo.stateMachine.messages.prevotes[expectedHeight][rPrime], *val3)
+		assert.Equal(t, val3Prevote, algo.stateMachine.messages.prevotes[expectedHeight][rPrime][*val3])
 
 		// The step here remains propose because a proposal is yet to be received to allow the node to send the
 		// prevote for it.
-		assert.Equal(t, propose, algo.state.step)
-		assert.Equal(t, expectedHeight, algo.state.height)
-		assert.Equal(t, rPrime, algo.state.round)
+		assert.Equal(t, propose, algo.stateMachine.state.step)
+		assert.Equal(t, expectedHeight, algo.stateMachine.state.height)
+		assert.Equal(t, rPrime, algo.stateMachine.state.round)
 	})
 
 	t.Run("Line 55 (Precommit): Start round r' when f+1 future round messages are received from round r'", func(t *testing.T) {
@@ -133,7 +133,7 @@ func TestPropose(t *testing.T) {
 		vals.addValidator(*val4)
 		vals.addValidator(*nodeAddr)
 
-		algo := New(*nodeAddr, app, chain, vals, listeners, broadcasters, tm, tm, tm)
+		algo := NewDriver(*nodeAddr, app, chain, vals, listeners, broadcasters, tm, tm, tm)
 
 		expectedHeight := height(0)
 		rPrime := round(4)
@@ -156,7 +156,7 @@ func TestPropose(t *testing.T) {
 			ID: utils.HeapPtr(round4Value.Hash()),
 		}
 
-		algo.messages.addPrevote(val3Prevote)
+		algo.stateMachine.messages.addPrevote(val3Prevote)
 		prevoteListener := listeners.PrecommitListener.(*senderAndReceiver[Precommit[felt.Felt, felt.Felt], value,
 			felt.Felt, felt.Felt])
 		prevoteListener.send(val2Precommit)
@@ -165,17 +165,17 @@ func TestPropose(t *testing.T) {
 		time.Sleep(5 * time.Millisecond)
 		algo.Stop()
 
-		assert.Contains(t, algo.messages.precommits[expectedHeight][rPrime], *val2)
-		assert.Equal(t, val2Precommit, algo.messages.precommits[expectedHeight][rPrime][*val2])
+		assert.Contains(t, algo.stateMachine.messages.precommits[expectedHeight][rPrime], *val2)
+		assert.Equal(t, val2Precommit, algo.stateMachine.messages.precommits[expectedHeight][rPrime][*val2])
 
-		assert.Contains(t, algo.messages.prevotes[expectedHeight][rPrime], *val3)
-		assert.Equal(t, val3Prevote, algo.messages.prevotes[expectedHeight][rPrime][*val3])
+		assert.Contains(t, algo.stateMachine.messages.prevotes[expectedHeight][rPrime], *val3)
+		assert.Equal(t, val3Prevote, algo.stateMachine.messages.prevotes[expectedHeight][rPrime][*val3])
 
 		// The step here remains propose because a proposal is yet to be received to allow the node to send the
 		// prevote for it.
-		assert.Equal(t, propose, algo.state.step)
-		assert.Equal(t, expectedHeight, algo.state.height)
-		assert.Equal(t, rPrime, algo.state.round)
+		assert.Equal(t, propose, algo.stateMachine.state.step)
+		assert.Equal(t, expectedHeight, algo.stateMachine.state.height)
+		assert.Equal(t, rPrime, algo.stateMachine.state.round)
 	})
 
 	t.Run("Line 47: schedule timeout precommit", func(t *testing.T) {
@@ -188,7 +188,7 @@ func TestPropose(t *testing.T) {
 		vals.addValidator(*val4)
 		vals.addValidator(*nodeAddr)
 
-		algo := New(*nodeAddr, app, chain, vals, listeners, broadcasters, tm, tm, tm)
+		algo := NewDriver(*nodeAddr, app, chain, vals, listeners, broadcasters, tm, tm, tm)
 
 		val2Precommit := Precommit[felt.Felt, felt.Felt]{
 			MessageHeader: MessageHeader[felt.Felt]{
@@ -215,8 +215,8 @@ func TestPropose(t *testing.T) {
 			ID: nil,
 		}
 
-		algo.messages.addPrecommit(val2Precommit)
-		algo.messages.addPrecommit(val3Precommit)
+		algo.stateMachine.messages.addPrecommit(val2Precommit)
+		algo.stateMachine.messages.addPrecommit(val3Precommit)
 
 		precommitListner := listeners.PrecommitListener.(*senderAndReceiver[Precommit[felt.Felt, felt.Felt], value,
 			felt.Felt, felt.Felt])
@@ -229,10 +229,10 @@ func TestPropose(t *testing.T) {
 		assert.Equal(t, 2, len(algo.scheduledTms))
 		assert.Contains(t, algo.scheduledTms, timeout{s: precommit, h: 0, r: 0})
 
-		assert.True(t, algo.state.timeoutPrecommitScheduled)
-		assert.Equal(t, propose, algo.state.step)
-		assert.Equal(t, height(0), algo.state.height)
-		assert.Equal(t, round(0), algo.state.round)
+		assert.True(t, algo.stateMachine.state.timeoutPrecommitScheduled)
+		assert.Equal(t, propose, algo.stateMachine.state.step)
+		assert.Equal(t, height(0), algo.stateMachine.state.height)
+		assert.Equal(t, round(0), algo.stateMachine.state.round)
 	})
 
 	t.Run("Line 47: don't schedule timeout precommit multiple times", func(t *testing.T) {
@@ -245,7 +245,7 @@ func TestPropose(t *testing.T) {
 		vals.addValidator(*val4)
 		vals.addValidator(*nodeAddr)
 
-		algo := New(*nodeAddr, app, chain, vals, listeners, broadcasters, tm, tm, tm)
+		algo := NewDriver(*nodeAddr, app, chain, vals, listeners, broadcasters, tm, tm, tm)
 
 		nodePrecommit := Precommit[felt.Felt, felt.Felt]{
 			MessageHeader: MessageHeader[felt.Felt]{
@@ -280,8 +280,8 @@ func TestPropose(t *testing.T) {
 			ID: nil,
 		}
 
-		algo.messages.addPrecommit(val2Precommit)
-		algo.messages.addPrecommit(val3Precommit)
+		algo.stateMachine.messages.addPrecommit(val2Precommit)
+		algo.stateMachine.messages.addPrecommit(val3Precommit)
 
 		precommitListner := listeners.PrecommitListener.(*senderAndReceiver[Precommit[felt.Felt, felt.Felt], value,
 			felt.Felt, felt.Felt])
@@ -298,10 +298,10 @@ func TestPropose(t *testing.T) {
 		assert.Equal(t, 2, len(algo.scheduledTms))
 		assert.Contains(t, algo.scheduledTms, timeout{s: precommit, h: 0, r: 0})
 
-		assert.True(t, algo.state.timeoutPrecommitScheduled)
-		assert.Equal(t, propose, algo.state.step)
-		assert.Equal(t, height(0), algo.state.height)
-		assert.Equal(t, round(0), algo.state.round)
+		assert.True(t, algo.stateMachine.state.timeoutPrecommitScheduled)
+		assert.Equal(t, propose, algo.stateMachine.state.step)
+		assert.Equal(t, height(0), algo.stateMachine.state.height)
+		assert.Equal(t, round(0), algo.stateMachine.state.round)
 	})
 
 	t.Run("OnTimeoutPrecommit: move to next round", func(t *testing.T) {
@@ -315,7 +315,7 @@ func TestPropose(t *testing.T) {
 		vals.addValidator(*val4)
 		vals.addValidator(*nodeAddr)
 
-		algo := New(*nodeAddr, app, chain, vals, listeners, broadcasters, tm, tm, tmPrecommit)
+		algo := NewDriver(*nodeAddr, app, chain, vals, listeners, broadcasters, tm, tm, tmPrecommit)
 
 		val2Precommit := Precommit[felt.Felt, felt.Felt]{
 			MessageHeader: MessageHeader[felt.Felt]{
@@ -342,8 +342,8 @@ func TestPropose(t *testing.T) {
 			ID: nil,
 		}
 
-		algo.messages.addPrecommit(val2Precommit)
-		algo.messages.addPrecommit(val3Precommit)
+		algo.stateMachine.messages.addPrecommit(val2Precommit)
+		algo.stateMachine.messages.addPrecommit(val3Precommit)
 
 		precommitListner := listeners.PrecommitListener.(*senderAndReceiver[Precommit[felt.Felt, felt.Felt], value,
 			felt.Felt, felt.Felt])
@@ -359,10 +359,10 @@ func TestPropose(t *testing.T) {
 		assert.Equal(t, 2, len(algo.scheduledTms))
 		assert.Contains(t, algo.scheduledTms, timeout{s: propose, h: 0, r: 1})
 
-		assert.False(t, algo.state.timeoutPrecommitScheduled)
-		assert.Equal(t, propose, algo.state.step)
-		assert.Equal(t, height(0), algo.state.height)
-		assert.Equal(t, round(1), algo.state.round)
+		assert.False(t, algo.stateMachine.state.timeoutPrecommitScheduled)
+		assert.Equal(t, propose, algo.stateMachine.state.step)
+		assert.Equal(t, height(0), algo.stateMachine.state.height)
+		assert.Equal(t, round(1), algo.stateMachine.state.round)
 	})
 
 	t.Run("Line 49 (Proposal): commit the value", func(t *testing.T) {
@@ -375,7 +375,7 @@ func TestPropose(t *testing.T) {
 		vals.addValidator(*val4)
 		vals.addValidator(*nodeAddr)
 
-		algo := New(*nodeAddr, app, chain, vals, listeners, broadcasters, tm, tm, tm)
+		algo := NewDriver(*nodeAddr, app, chain, vals, listeners, broadcasters, tm, tm, tm)
 
 		h, r := height(0), round(0)
 
@@ -408,9 +408,9 @@ func TestPropose(t *testing.T) {
 		}
 
 		// The node has received all the precommits but has received the corresponding proposal
-		algo.messages.addPrecommit(val2Precommit)
-		algo.messages.addPrecommit(val3Precommit)
-		algo.messages.addPrecommit(val4Precommit)
+		algo.stateMachine.messages.addPrecommit(val2Precommit)
+		algo.stateMachine.messages.addPrecommit(val3Precommit)
+		algo.stateMachine.messages.addPrecommit(val4Precommit)
 
 		// since val2 is the proposer of round 0, the proposal arrives after the precommits
 		val2Proposal := Proposal[value, felt.Felt, felt.Felt]{
@@ -436,9 +436,9 @@ func TestPropose(t *testing.T) {
 		assert.Contains(t, algo.scheduledTms, timeout{s: precommit, h: 0, r: 0})
 		assert.Contains(t, algo.scheduledTms, timeout{s: propose, h: 1, r: 0})
 
-		assert.Equal(t, propose, algo.state.step)
-		assert.Equal(t, height(1), algo.state.height)
-		assert.Equal(t, round(0), algo.state.round)
+		assert.Equal(t, propose, algo.stateMachine.state.step)
+		assert.Equal(t, height(1), algo.stateMachine.state.height)
+		assert.Equal(t, round(0), algo.stateMachine.state.round)
 
 		precommits := []Precommit[felt.Felt, felt.Felt]{val2Precommit, val3Precommit, val4Precommit}
 		assert.Equal(t, chain.decision[0], val)
@@ -446,9 +446,9 @@ func TestPropose(t *testing.T) {
 			assert.True(t, slices.Contains(precommits, p))
 		}
 
-		assert.Equal(t, 0, len(algo.messages.proposals))
-		assert.Equal(t, 0, len(algo.messages.prevotes))
-		assert.Equal(t, 0, len(algo.messages.precommits))
+		assert.Equal(t, 0, len(algo.stateMachine.messages.proposals))
+		assert.Equal(t, 0, len(algo.stateMachine.messages.prevotes))
+		assert.Equal(t, 0, len(algo.stateMachine.messages.precommits))
 	})
 
 	t.Run("Line 49 (Precommit): commit the value", func(t *testing.T) {
@@ -461,7 +461,7 @@ func TestPropose(t *testing.T) {
 		vals.addValidator(*val4)
 		vals.addValidator(*nodeAddr)
 
-		algo := New(*nodeAddr, app, chain, vals, listeners, broadcasters, tm, tm, tm)
+		algo := NewDriver(*nodeAddr, app, chain, vals, listeners, broadcasters, tm, tm, tm)
 
 		h, r := height(0), round(0)
 
@@ -495,9 +495,9 @@ func TestPropose(t *testing.T) {
 		}
 
 		// The node has received all the precommits but has received the corresponding proposal
-		algo.messages.addPrecommit(val2Precommit)
-		algo.messages.addProposal(val2Proposal)
-		algo.messages.addPrecommit(val3Precommit)
+		algo.stateMachine.messages.addPrecommit(val2Precommit)
+		algo.stateMachine.messages.addProposal(val2Proposal)
+		algo.stateMachine.messages.addPrecommit(val3Precommit)
 
 		val4Precommit := Precommit[felt.Felt, felt.Felt]{
 			MessageHeader: MessageHeader[felt.Felt]{
@@ -521,9 +521,9 @@ func TestPropose(t *testing.T) {
 		assert.Contains(t, algo.scheduledTms, timeout{s: precommit, h: 0, r: 0})
 		assert.Contains(t, algo.scheduledTms, timeout{s: propose, h: 1, r: 0})
 
-		assert.Equal(t, propose, algo.state.step)
-		assert.Equal(t, height(1), algo.state.height)
-		assert.Equal(t, round(0), algo.state.round)
+		assert.Equal(t, propose, algo.stateMachine.state.step)
+		assert.Equal(t, height(1), algo.stateMachine.state.height)
+		assert.Equal(t, round(0), algo.stateMachine.state.round)
 
 		precommits := []Precommit[felt.Felt, felt.Felt]{val2Precommit, val3Precommit, val4Precommit}
 		assert.Equal(t, chain.decision[0], val)
@@ -531,9 +531,9 @@ func TestPropose(t *testing.T) {
 			assert.True(t, slices.Contains(precommits, p))
 		}
 
-		assert.Equal(t, 0, len(algo.messages.proposals))
-		assert.Equal(t, 0, len(algo.messages.prevotes))
-		assert.Equal(t, 0, len(algo.messages.precommits))
+		assert.Equal(t, 0, len(algo.stateMachine.messages.proposals))
+		assert.Equal(t, 0, len(algo.stateMachine.messages.prevotes))
+		assert.Equal(t, 0, len(algo.stateMachine.messages.precommits))
 	})
 
 	t.Run("Line 22: receive a new proposal before timeout expiry", func(t *testing.T) {

--- a/consensus/tendermint/rule_commit_value.go
+++ b/consensus/tendermint/rule_commit_value.go
@@ -26,12 +26,12 @@ func (t *Tendermint[V, H, A]) uponCommitValue(cachedProposal *CachedProposal[V, 
 	return hasQuorum && isValid
 }
 
-func (t *Tendermint[V, H, A]) doCommitValue(cachedProposal *CachedProposal[V, H, A]) {
+func (t *Tendermint[V, H, A]) doCommitValue(cachedProposal *CachedProposal[V, H, A]) Action[V, H, A] {
 	// TODO: Optimise this
 	precommits, _ := t.checkForQuorumPrecommit(cachedProposal.Round, *cachedProposal.ID)
 	t.blockchain.Commit(t.state.height, *cachedProposal.Value, precommits)
 
 	t.messages.deleteHeightMessages(t.state.height)
 	t.state.height++
-	t.startRound(0)
+	return t.startRound(0)
 }

--- a/consensus/tendermint/rule_first_proposal.go
+++ b/consensus/tendermint/rule_first_proposal.go
@@ -16,7 +16,7 @@ func (t *Tendermint[V, H, A]) uponFirstProposal(cachedProposal *CachedProposal[V
 	return cachedProposal.ValidRound == -1 && t.state.step == propose
 }
 
-func (t *Tendermint[V, H, A]) doFirstProposal(cachedProposal *CachedProposal[V, H, A]) {
+func (t *Tendermint[V, H, A]) doFirstProposal(cachedProposal *CachedProposal[V, H, A]) Action[V, H, A] {
 	shouldVoteForValue := cachedProposal.Valid &&
 		(t.state.lockedRound == -1 ||
 			t.state.lockedValue != nil && (*t.state.lockedValue).Hash() == *cachedProposal.ID)
@@ -25,5 +25,5 @@ func (t *Tendermint[V, H, A]) doFirstProposal(cachedProposal *CachedProposal[V, 
 	if shouldVoteForValue {
 		votedID = cachedProposal.ID
 	}
-	t.sendPrevote(votedID)
+	return t.setStepAndSendPrevote(votedID)
 }

--- a/consensus/tendermint/rule_polka_any.go
+++ b/consensus/tendermint/rule_polka_any.go
@@ -24,7 +24,7 @@ func (t *Tendermint[V, H, A]) uponPolkaAny() bool {
 		isFirstTime
 }
 
-func (t *Tendermint[V, H, A]) doPolkaAny() {
-	t.scheduleTimeout(t.timeoutPrevote(t.state.round), prevote, t.state.height, t.state.round)
+func (t *Tendermint[V, H, A]) doPolkaAny() Action[V, H, A] {
 	t.state.timeoutPrevoteScheduled = true
+	return t.scheduleTimeout(prevote)
 }

--- a/consensus/tendermint/rule_polka_nil.go
+++ b/consensus/tendermint/rule_polka_nil.go
@@ -25,6 +25,6 @@ func (t *Tendermint[V, H, A]) uponPolkaNil() bool {
 	return hasQuorum && t.state.step == prevote
 }
 
-func (t *Tendermint[V, H, A]) doPolkaNil() {
-	t.sendPrecommit(nil)
+func (t *Tendermint[V, H, A]) doPolkaNil() Action[V, H, A] {
+	return t.setStepAndSendPrecommit(nil)
 }

--- a/consensus/tendermint/rule_precommit_any.go
+++ b/consensus/tendermint/rule_precommit_any.go
@@ -22,7 +22,7 @@ func (t *Tendermint[V, H, A]) uponPrecommitAny() bool {
 	return hasQuorum && isFirstTime
 }
 
-func (t *Tendermint[V, H, A]) doPrecommitAny() {
-	t.scheduleTimeout(t.timeoutPrecommit(t.state.round), precommit, t.state.height, t.state.round)
+func (t *Tendermint[V, H, A]) doPrecommitAny() Action[V, H, A] {
 	t.state.timeoutPrecommitScheduled = true
+	return t.scheduleTimeout(precommit)
 }

--- a/consensus/tendermint/rule_proposal_and_polka_current.go
+++ b/consensus/tendermint/rule_proposal_and_polka_current.go
@@ -22,14 +22,17 @@ func (t *Tendermint[V, H, A]) uponProposalAndPolkaCurrent(cachedProposal *Cached
 		firstTime
 }
 
-func (t *Tendermint[V, H, A]) doProposalAndPolkaCurrent(cachedProposal *CachedProposal[V, H, A]) {
+func (t *Tendermint[V, H, A]) doProposalAndPolkaCurrent(cachedProposal *CachedProposal[V, H, A]) Action[V, H, A] {
+	var action Action[V, H, A]
 	if t.state.step == prevote {
 		t.state.lockedValue = cachedProposal.Value
 		t.state.lockedRound = t.state.round
-		t.sendPrecommit(cachedProposal.ID)
+		action = t.setStepAndSendPrecommit(cachedProposal.ID)
 	}
 
 	t.state.validValue = cachedProposal.Value
 	t.state.validRound = t.state.round
 	t.state.lockedValueAndOrValidValueSet = true
+
+	return action
 }

--- a/consensus/tendermint/rule_proposal_and_polka_previous.go
+++ b/consensus/tendermint/rule_proposal_and_polka_previous.go
@@ -20,7 +20,7 @@ func (t *Tendermint[V, H, A]) uponProposalAndPolkaPrevious(cachedProposal *Cache
 		vr < t.state.round
 }
 
-func (t *Tendermint[V, H, A]) doProposalAndPolkaPrevious(cachedProposal *CachedProposal[V, H, A]) {
+func (t *Tendermint[V, H, A]) doProposalAndPolkaPrevious(cachedProposal *CachedProposal[V, H, A]) Action[V, H, A] {
 	var votedID *H
 	shouldVoteForValue := cachedProposal.Valid &&
 		(t.state.lockedRound <= cachedProposal.ValidRound ||
@@ -28,5 +28,5 @@ func (t *Tendermint[V, H, A]) doProposalAndPolkaPrevious(cachedProposal *CachedP
 	if shouldVoteForValue {
 		votedID = cachedProposal.ID
 	}
-	t.sendPrevote(votedID)
+	return t.setStepAndSendPrevote(votedID)
 }

--- a/consensus/tendermint/rule_skip_round.go
+++ b/consensus/tendermint/rule_skip_round.go
@@ -37,6 +37,6 @@ func (t *Tendermint[V, H, A]) uponSkipRound(futureR round) bool {
 	return isNewerRound && hasQuorum
 }
 
-func (t *Tendermint[V, H, A]) doSkipRound(futureR round) {
-	t.startRound(futureR)
+func (t *Tendermint[V, H, A]) doSkipRound(futureR round) Action[V, H, A] {
+	return t.startRound(futureR)
 }

--- a/consensus/tendermint/tendermint.go
+++ b/consensus/tendermint/tendermint.go
@@ -115,20 +115,12 @@ type Broadcasters[V Hashable[H], H Hash, A Addr] struct {
 	PrecommitBroadcaster Broadcaster[Precommit[H, A], V, H, A]
 }
 
-type Tendermint[V Hashable[H], H Hash, A Addr] struct {
-	nodeAddr A
-
-	state state[V, H] // Todo: Does state need to be protected?
-
-	messages messages[V, H, A]
+type Driver[V Hashable[H], H Hash, A Addr] struct {
+	stateMachine *Tendermint[V, H, A]
 
 	timeoutPropose   timeoutFn
 	timeoutPrevote   timeoutFn
 	timeoutPrecommit timeoutFn
-
-	application Application[V, H]
-	blockchain  Blockchain[V, H, A]
-	validators  Validators[A]
 
 	listeners    Listeners[V, H, A]
 	broadcasters Broadcasters[V, H, A]
@@ -138,6 +130,18 @@ type Tendermint[V Hashable[H], H Hash, A Addr] struct {
 
 	wg   sync.WaitGroup
 	quit chan struct{}
+}
+
+type Tendermint[V Hashable[H], H Hash, A Addr] struct {
+	nodeAddr A
+
+	state state[V, H] // Todo: Does state need to be protected?
+
+	messages messages[V, H, A]
+
+	application Application[V, H]
+	blockchain  Blockchain[V, H, A]
+	validators  Validators[A]
 }
 
 type state[V Hashable[H], H Hash] struct {
@@ -156,8 +160,11 @@ type state[V Hashable[H], H Hash] struct {
 	lockedValueAndOrValidValueSet bool // line36 for the first time condition
 }
 
-func New[V Hashable[H], H Hash, A Addr](nodeAddr A, app Application[V, H], chain Blockchain[V, H, A], vals Validators[A],
-	listeners Listeners[V, H, A], broadcasters Broadcasters[V, H, A], tmPropose, tmPrevote, tmPrecommit timeoutFn,
+func New[V Hashable[H], H Hash, A Addr](
+	nodeAddr A,
+	app Application[V, H],
+	chain Blockchain[V, H, A],
+	vals Validators[A],
 ) *Tendermint[V, H, A] {
 	return &Tendermint[V, H, A]{
 		nodeAddr: nodeAddr,
@@ -166,13 +173,21 @@ func New[V Hashable[H], H Hash, A Addr](nodeAddr A, app Application[V, H], chain
 			lockedRound: -1,
 			validRound:  -1,
 		},
-		messages:         newMessages[V, H, A](),
+		messages:    newMessages[V, H, A](),
+		application: app,
+		blockchain:  chain,
+		validators:  vals,
+	}
+}
+
+func NewDriver[V Hashable[H], H Hash, A Addr](nodeAddr A, app Application[V, H], chain Blockchain[V, H, A], vals Validators[A],
+	listeners Listeners[V, H, A], broadcasters Broadcasters[V, H, A], tmPropose, tmPrevote, tmPrecommit timeoutFn,
+) *Driver[V, H, A] {
+	return &Driver[V, H, A]{
+		stateMachine:     New(nodeAddr, app, chain, vals),
 		timeoutPropose:   tmPropose,
 		timeoutPrevote:   tmPrevote,
 		timeoutPrecommit: tmPrecommit,
-		application:      app,
-		blockchain:       chain,
-		validators:       vals,
 		listeners:        listeners,
 		broadcasters:     broadcasters,
 		scheduledTms:     make(map[timeout]*time.Timer),
@@ -187,49 +202,46 @@ type CachedProposal[V Hashable[H], H Hash, A Addr] struct {
 	ID    *H
 }
 
-func (t *Tendermint[V, H, A]) Start() {
-	t.wg.Add(1)
+func (d *Driver[V, H, A]) Start() {
+	d.wg.Add(1)
 	go func() {
-		defer t.wg.Done()
+		defer d.wg.Done()
 
-		t.startRound(0)
-		t.processLoop(nil)
+		actions := d.stateMachine.processStart(0)
+		d.execute(actions)
 
 		// Todo: check message signature everytime a message is received.
 		// For the time being it can be assumed the signature is correct.
 
 		for {
 			select {
-			case <-t.quit:
+			case <-d.quit:
 				return
-			case tm := <-t.timeoutsCh:
+			case tm := <-d.timeoutsCh:
 				// Handling of timeouts is priorities over messages
-				t.processTimeout(tm)
-				delete(t.scheduledTms, tm)
-			case p := <-t.listeners.ProposalListener.Listen():
-				t.processMessage(p.MessageHeader, func() { t.messages.addProposal(p) })
-			case p := <-t.listeners.PrevoteListener.Listen():
-				t.processMessage(p.MessageHeader, func() { t.messages.addPrevote(p) })
-			case p := <-t.listeners.PrecommitListener.Listen():
-				t.processMessage(p.MessageHeader, func() { t.messages.addPrecommit(p) })
+				actions = d.stateMachine.processTimeout(tm)
+				delete(d.scheduledTms, tm)
+			case p := <-d.listeners.ProposalListener.Listen():
+				actions = d.stateMachine.processProposal(p)
+			case p := <-d.listeners.PrevoteListener.Listen():
+				actions = d.stateMachine.processPrevote(p)
+			case p := <-d.listeners.PrecommitListener.Listen():
+				actions = d.stateMachine.processPrecommit(p)
 			}
+			d.execute(actions)
 		}
 	}()
 }
 
-func (t *Tendermint[V, H, A]) Stop() {
-	close(t.quit)
-	t.wg.Wait()
-	for _, tm := range t.scheduledTms {
+func (d *Driver[V, H, A]) Stop() {
+	close(d.quit)
+	d.wg.Wait()
+	for _, tm := range d.scheduledTms {
 		tm.Stop()
 	}
 }
 
-func (t *Tendermint[V, H, A]) startRound(r round) {
-	if r != 0 && r <= t.state.round {
-		return
-	}
-
+func (t *Tendermint[V, H, A]) startRound(r round) Action[V, H, A] {
 	t.state.round = r
 	t.state.step = propose
 
@@ -244,9 +256,9 @@ func (t *Tendermint[V, H, A]) startRound(r round) {
 		} else {
 			proposalValue = utils.HeapPtr(t.application.Value())
 		}
-		t.sendProposal(proposalValue)
+		return t.sendProposal(proposalValue)
 	} else {
-		t.scheduleTimeout(t.timeoutPropose(r), propose, t.state.height, t.state.round)
+		return t.scheduleTimeout(propose)
 	}
 }
 
@@ -256,14 +268,14 @@ type timeout struct {
 	r round
 }
 
-func (t *Tendermint[V, H, A]) scheduleTimeout(duration time.Duration, s step, h height, r round) {
-	tm := timeout{s: s, h: h, r: r}
-	t.scheduledTms[tm] = time.AfterFunc(duration, func() {
-		select {
-		case <-t.quit:
-		case t.timeoutsCh <- tm:
-		}
-	})
+func (t *Tendermint[V, H, A]) scheduleTimeout(s step) Action[V, H, A] {
+	return utils.HeapPtr(
+		ScheduleTimeout[V, H, A]{
+			s: s,
+			h: t.state.height,
+			r: t.state.round,
+		},
+	)
 }
 
 func (t *Tendermint[V, H, A]) validatorSetVotingPower(vals []A) votingPower {

--- a/consensus/tendermint/tendermint_test.go
+++ b/consensus/tendermint/tendermint_test.go
@@ -137,7 +137,7 @@ func TestStartRound(t *testing.T) {
 		vals.addValidator(*val3)
 		vals.addValidator(*val4)
 
-		algo := New(*nodeAddr, app, chain, vals, listeners, broadcasters, tm, tm, tm)
+		algo := NewDriver(*nodeAddr, app, chain, vals, listeners, broadcasters, tm, tm, tm)
 
 		expectedHeight, expectedRound := height(0), round(0)
 		expectedProposalMsg := Proposal[value, felt.Felt, felt.Felt]{
@@ -159,12 +159,12 @@ func TestStartRound(t *testing.T) {
 		proposal := <-proposalBroadcaster.mCh
 
 		assert.Equal(t, expectedProposalMsg, proposal)
-		assert.Contains(t, algo.messages.proposals[expectedHeight][expectedRound], *nodeAddr)
-		assert.Equal(t, expectedProposalMsg, algo.messages.proposals[expectedHeight][expectedRound][*nodeAddr])
+		assert.Contains(t, algo.stateMachine.messages.proposals[expectedHeight][expectedRound], *nodeAddr)
+		assert.Equal(t, expectedProposalMsg, algo.stateMachine.messages.proposals[expectedHeight][expectedRound][*nodeAddr])
 
-		assert.Equal(t, prevote, algo.state.step)
-		assert.Equal(t, expectedHeight, algo.state.height)
-		assert.Equal(t, expectedRound, algo.state.round)
+		assert.Equal(t, prevote, algo.stateMachine.state.step)
+		assert.Equal(t, expectedHeight, algo.stateMachine.state.height)
+		assert.Equal(t, expectedRound, algo.stateMachine.state.round)
 	})
 
 	t.Run("node is not the proposer: schedule timeoutPropose", func(t *testing.T) {
@@ -176,7 +176,7 @@ func TestStartRound(t *testing.T) {
 		vals.addValidator(*val4)
 		vals.addValidator(*nodeAddr)
 
-		algo := New(*nodeAddr, app, chain, vals, listeners, broadcasters, tm, tm, tm)
+		algo := NewDriver(*nodeAddr, app, chain, vals, listeners, broadcasters, tm, tm, tm)
 
 		algo.Start()
 		algo.Stop()
@@ -185,9 +185,9 @@ func TestStartRound(t *testing.T) {
 
 		assert.Contains(t, algo.scheduledTms, timeout{s: propose, h: 0, r: 0})
 
-		assert.Equal(t, propose, algo.state.step)
-		assert.Equal(t, height(0), algo.state.height)
-		assert.Equal(t, round(0), algo.state.round)
+		assert.Equal(t, propose, algo.stateMachine.state.step)
+		assert.Equal(t, height(0), algo.stateMachine.state.height)
+		assert.Equal(t, round(0), algo.stateMachine.state.round)
 	})
 
 	t.Run("OnTimeoutPropose: round zero the node is not the proposer thus send a prevote nil", func(t *testing.T) {
@@ -207,7 +207,7 @@ func TestStartRound(t *testing.T) {
 		vals.addValidator(*val4)
 		vals.addValidator(*nodeAddr)
 
-		algo := New(*nodeAddr, app, chain, vals, listeners, broadcasters, tm, tm, tm)
+		algo := NewDriver(*nodeAddr, app, chain, vals, listeners, broadcasters, tm, tm, tm)
 
 		expectedHeight, expectedRound := height(0), round(0)
 		expectedPrevoteMsg := Prevote[felt.Felt, felt.Felt]{
@@ -229,12 +229,12 @@ func TestStartRound(t *testing.T) {
 		prevoteMsg := <-prevoteBroadcaster.mCh
 
 		assert.Equal(t, expectedPrevoteMsg, prevoteMsg)
-		assert.Contains(t, algo.messages.prevotes[expectedHeight][expectedRound], *nodeAddr)
-		assert.Equal(t, expectedPrevoteMsg, algo.messages.prevotes[expectedHeight][expectedRound][*nodeAddr])
+		assert.Contains(t, algo.stateMachine.messages.prevotes[expectedHeight][expectedRound], *nodeAddr)
+		assert.Equal(t, expectedPrevoteMsg, algo.stateMachine.messages.prevotes[expectedHeight][expectedRound][*nodeAddr])
 
-		assert.Equal(t, prevote, algo.state.step)
-		assert.Equal(t, expectedHeight, algo.state.height)
-		assert.Equal(t, expectedRound, algo.state.round)
+		assert.Equal(t, prevote, algo.stateMachine.state.step)
+		assert.Equal(t, expectedHeight, algo.stateMachine.state.height)
+		assert.Equal(t, expectedRound, algo.stateMachine.state.round)
 	})
 }
 

--- a/consensus/tendermint/timeout.go
+++ b/consensus/tendermint/timeout.go
@@ -1,19 +1,22 @@
 package tendermint
 
-func (t *Tendermint[_, H, A]) onTimeoutPropose(h height, r round) {
+func (t *Tendermint[V, H, A]) onTimeoutPropose(h height, r round) Action[V, H, A] {
 	if t.state.height == h && t.state.round == r && t.state.step == propose {
-		t.sendPrevote(nil)
+		return t.setStepAndSendPrevote(nil)
 	}
+	return nil
 }
 
-func (t *Tendermint[_, H, A]) onTimeoutPrevote(h height, r round) {
+func (t *Tendermint[V, H, A]) onTimeoutPrevote(h height, r round) Action[V, H, A] {
 	if t.state.height == h && t.state.round == r && t.state.step == prevote {
-		t.sendPrecommit(nil)
+		return t.setStepAndSendPrecommit(nil)
 	}
+	return nil
 }
 
-func (t *Tendermint[_, _, _]) onTimeoutPrecommit(h height, r round) {
+func (t *Tendermint[V, H, A]) onTimeoutPrecommit(h height, r round) Action[V, H, A] {
 	if t.state.height == h && t.state.round == r {
-		t.startRound(r + 1)
+		return t.startRound(r + 1)
 	}
+	return nil
 }


### PR DESCRIPTION
This PR mainly does 2 things:
- Separate the `Tendermint` struct into 2 structs, one is `Tendermint` (I keep the name to reduce the diff) for the pure execution of the state machine itself, and the other is `Driver` which is in charge of the concurrent operations.
- The state machine functions now returns `Action` objects which represent the concurrent actions, including broadcast message and schedule timeout.
Minor changes:
- Rename some functions to better readability.