### PR TITLE
fix: estimateFee panic w/ missing required fields

### DIFF
--- a/rpc/v6/block_test.go
+++ b/rpc/v6/block_test.go
@@ -550,12 +550,12 @@ func TestBlockWithTxHashesV013(t *testing.T) {
 				Signature:          &tx.TransactionSignature,
 				CallData:           &tx.CallData,
 				EntryPointSelector: tx.EntryPointSelector,
-				ResourceBounds: &map[rpc.Resource]rpc.ResourceBounds{
-					rpc.ResourceL1Gas: {
+				ResourceBounds: &rpc.ResourceBoundsMap{
+					L1Gas: &rpc.ResourceBounds{
 						MaxAmount:       new(felt.Felt).SetUint64(tx.ResourceBounds[core.ResourceL1Gas].MaxAmount),
 						MaxPricePerUnit: tx.ResourceBounds[core.ResourceL1Gas].MaxPricePerUnit,
 					},
-					rpc.ResourceL2Gas: {
+					L2Gas: &rpc.ResourceBounds{
 						MaxAmount:       new(felt.Felt).SetUint64(tx.ResourceBounds[core.ResourceL2Gas].MaxAmount),
 						MaxPricePerUnit: tx.ResourceBounds[core.ResourceL2Gas].MaxPricePerUnit,
 					},

--- a/rpc/v6/simulation.go
+++ b/rpc/v6/simulation.go
@@ -101,6 +101,11 @@ func (h *Handler) simulateTransactions(id BlockID, transactions []BroadcastedTra
 	return simulatedTransactions, nil
 }
 
+func isVersion3(transaction *BroadcastedTransaction) bool {
+	version := felt.FromUint64(3)
+	return transaction.Transaction.Version != nil && transaction.Transaction.Version.Equal(&version)
+}
+
 func prepareTransactions(transactions []BroadcastedTransaction, network *utils.Network) (
 	[]core.Transaction, []core.Class, []*felt.Felt, *jsonrpc.Error,
 ) {
@@ -109,6 +114,27 @@ func prepareTransactions(transactions []BroadcastedTransaction, network *utils.N
 	paidFeesOnL1 := make([]*felt.Felt, 0)
 
 	for idx := range transactions {
+		// Check for missing required fields in struct that can't be validated by
+		// jsonschema due to validation happening after omit empty
+		//
+		// TODO: as its expected that this will happen in other cases as well,
+		// it might be a good idea to implement a custom validator and unmarshal handler
+		// to solve this problem in a more elegant way
+		if (transactions[idx].Transaction.Type == TxnDeclare ||
+			transactions[idx].Transaction.Type == TxnInvoke) && isVersion3(&transactions[idx]) {
+			if transactions[idx].Transaction.SenderAddress == nil {
+				return nil, nil, nil, jsonrpc.Err(jsonrpc.InvalidParams, "sender_address is required for this transaction type")
+			}
+		}
+
+		if (transactions[idx].Transaction.Type == TxnInvoke ||
+			transactions[idx].Transaction.Type == TxnDeployAccount ||
+			transactions[idx].Transaction.Type == TxnDeclare) && isVersion3(&transactions[idx]) {
+			if transactions[idx].Transaction.ResourceBounds == nil {
+				return nil, nil, nil, jsonrpc.Err(jsonrpc.InvalidParams, "resource_bounds is required for this transaction type")
+			}
+		}
+
 		txn, declaredClass, paidFeeOnL1, aErr := AdaptBroadcastedTransaction(&transactions[idx], network)
 		if aErr != nil {
 			return nil, nil, nil, jsonrpc.Err(jsonrpc.InvalidParams, aErr.Error())

--- a/rpc/v6/simulation_test.go
+++ b/rpc/v6/simulation_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/NethermindEth/juno/core"
 	"github.com/NethermindEth/juno/core/felt"
+	"github.com/NethermindEth/juno/jsonrpc"
 	"github.com/NethermindEth/juno/mocks"
 	rpccore "github.com/NethermindEth/juno/rpc/rpccore"
 	rpc "github.com/NethermindEth/juno/rpc/v6"
@@ -114,4 +115,123 @@ func TestSimulateTransactions(t *testing.T) {
 			"inconsistent lengths: 1 overall fees, 1 traces, 1 gas consumed, 2 data availability, 0 txns",
 		)), err)
 	})
+}
+
+func TestSimulateTransactionsShouldErrorWithoutSenderAddressOrResourceBounds(t *testing.T) {
+	t.Parallel()
+	n := &utils.Mainnet
+	headsHeader := &core.Header{
+		SequencerAddress: n.BlockHashMetaInfo.FallBackSequencerAddress,
+		L1GasPriceETH:    &felt.Zero,
+		L1GasPriceSTRK:   &felt.Zero,
+		L1DAMode:         0,
+		L1DataGasPrice: &core.GasPrice{
+			PriceInWei: &felt.Zero,
+			PriceInFri: &felt.Zero,
+		},
+		L2GasPrice: &core.GasPrice{
+			PriceInWei: &felt.Zero,
+			PriceInFri: &felt.Zero,
+		},
+	}
+
+	version3 := felt.FromUint64(3)
+
+	tests := []struct {
+		name         string
+		transactions []rpc.BroadcastedTransaction
+		err          *jsonrpc.Error
+	}{
+		{
+			name: "declare transaction without sender address",
+			transactions: []rpc.BroadcastedTransaction{
+				{
+					Transaction: rpc.Transaction{
+						Version: &version3,
+						Type:    rpc.TxnDeclare,
+					},
+				},
+			},
+			err: jsonrpc.Err(jsonrpc.InvalidParams, "sender_address is required for this transaction type"),
+		},
+		{
+			name: "declare transaction without resource bounds",
+			transactions: []rpc.BroadcastedTransaction{
+				{
+					Transaction: rpc.Transaction{
+						Version:       &version3,
+						Type:          rpc.TxnDeclare,
+						SenderAddress: &felt.Zero,
+					},
+				},
+			},
+			err: jsonrpc.Err(jsonrpc.InvalidParams, "resource_bounds is required for this transaction type"),
+		},
+		{
+			name: "invoke transaction without sender address",
+			transactions: []rpc.BroadcastedTransaction{
+				{
+					Transaction: rpc.Transaction{
+						Version: &version3,
+						Type:    rpc.TxnInvoke,
+					},
+				},
+			},
+			err: jsonrpc.Err(jsonrpc.InvalidParams, "sender_address is required for this transaction type"),
+		},
+		{
+			name: "invoke transaction without resource bounds",
+			transactions: []rpc.BroadcastedTransaction{
+				{
+					Transaction: rpc.Transaction{
+						Version:       &version3,
+						Type:          rpc.TxnInvoke,
+						SenderAddress: &felt.Zero,
+					},
+				},
+			},
+			err: jsonrpc.Err(jsonrpc.InvalidParams, "resource_bounds is required for this transaction type"),
+		},
+		{
+			name: "deploy account transaction without resource bounds",
+			transactions: []rpc.BroadcastedTransaction{
+				{
+					Transaction: rpc.Transaction{
+						Version: &version3,
+						Type:    rpc.TxnDeployAccount,
+					},
+				},
+			},
+			err: jsonrpc.Err(jsonrpc.InvalidParams, "resource_bounds is required for this transaction type"),
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			mockCtrl := gomock.NewController(t)
+			defer mockCtrl.Finish()
+
+			mockReader := mocks.NewMockReader(mockCtrl)
+			mockVM := mocks.NewMockVM(mockCtrl)
+			mockState := mocks.NewMockStateHistoryReader(mockCtrl)
+
+			mockReader.EXPECT().Network().Return(n)
+			mockReader.EXPECT().HeadState().Return(mockState, nopCloser, nil)
+			mockReader.EXPECT().HeadsHeader().Return(headsHeader, nil)
+
+			handler := rpc.New(mockReader, nil, mockVM, "", n, utils.NewNopZapLogger())
+
+			_, err := handler.SimulateTransactions(
+				rpc.BlockID{Latest: true},
+				test.transactions,
+				[]rpc.SimulationFlag{},
+			)
+			if test.err != nil {
+				require.Equal(t, test.err, err)
+				return
+			}
+			require.Nil(t, err)
+		})
+	}
 }

--- a/rpc/v6/transaction.go
+++ b/rpc/v6/transaction.go
@@ -199,6 +199,10 @@ type ResourceBounds struct {
 	MaxPricePerUnit *felt.Felt `json:"max_price_per_unit"`
 }
 
+// TODO: using Value fields here is a good idea, however
+// we are currently keeping the field's type Reference since the current
+// validation tags we are using does not work well with Value field.
+// We should revisit this when we start implementing custom validations.
 type ResourceBoundsMap struct {
 	L1Gas *ResourceBounds `json:"l1_gas" validate:"required"`
 	L2Gas *ResourceBounds `json:"l2_gas" validate:"required"`

--- a/rpc/v6/transaction.go
+++ b/rpc/v6/transaction.go
@@ -199,30 +199,35 @@ type ResourceBounds struct {
 	MaxPricePerUnit *felt.Felt `json:"max_price_per_unit"`
 }
 
+type ResourceBoundsMap struct {
+	L1Gas *ResourceBounds `json:"l1_gas" validate:"required"`
+	L2Gas *ResourceBounds `json:"l2_gas" validate:"required"`
+}
+
 // https://github.com/starkware-libs/starknet-specs/blob/a789ccc3432c57777beceaa53a34a7ae2f25fda0/api/starknet_api_openrpc.json#L1252
 //
 //nolint:lll
 type Transaction struct {
-	Hash                  *felt.Felt                   `json:"transaction_hash,omitempty"`
-	Type                  TransactionType              `json:"type" validate:"required"`
-	Version               *felt.Felt                   `json:"version,omitempty" validate:"required"`
-	Nonce                 *felt.Felt                   `json:"nonce,omitempty" validate:"required_unless=Version 0x0"`
-	MaxFee                *felt.Felt                   `json:"max_fee,omitempty" validate:"required_if=Version 0x0,required_if=Version 0x1,required_if=Version 0x2"`
-	ContractAddress       *felt.Felt                   `json:"contract_address,omitempty"`
-	ContractAddressSalt   *felt.Felt                   `json:"contract_address_salt,omitempty" validate:"required_if=Type DEPLOY,required_if=Type DEPLOY_ACCOUNT"`
-	ClassHash             *felt.Felt                   `json:"class_hash,omitempty" validate:"required_if=Type DEPLOY,required_if=Type DEPLOY_ACCOUNT"`
-	ConstructorCallData   *[]*felt.Felt                `json:"constructor_calldata,omitempty" validate:"required_if=Type DEPLOY,required_if=Type DEPLOY_ACCOUNT"`
-	SenderAddress         *felt.Felt                   `json:"sender_address,omitempty" validate:"required_if=Type DECLARE,required_if=Type INVOKE Version 0x1,required_if=Type INVOKE Version 0x3"`
-	Signature             *[]*felt.Felt                `json:"signature,omitempty" validate:"required"`
-	CallData              *[]*felt.Felt                `json:"calldata,omitempty" validate:"required_if=Type INVOKE"`
-	EntryPointSelector    *felt.Felt                   `json:"entry_point_selector,omitempty" validate:"required_if=Type INVOKE Version 0x0"`
-	CompiledClassHash     *felt.Felt                   `json:"compiled_class_hash,omitempty" validate:"required_if=Type DECLARE Version 0x2"`
-	ResourceBounds        *map[Resource]ResourceBounds `json:"resource_bounds,omitempty" validate:"required_if=Version 0x3"`
-	Tip                   *felt.Felt                   `json:"tip,omitempty" validate:"required_if=Version 0x3"`
-	PaymasterData         *[]*felt.Felt                `json:"paymaster_data,omitempty" validate:"required_if=Version 0x3"`
-	AccountDeploymentData *[]*felt.Felt                `json:"account_deployment_data,omitempty" validate:"required_if=Type INVOKE Version 0x3,required_if=Type DECLARE Version 0x3"`
-	NonceDAMode           *DataAvailabilityMode        `json:"nonce_data_availability_mode,omitempty" validate:"required_if=Version 0x3"`
-	FeeDAMode             *DataAvailabilityMode        `json:"fee_data_availability_mode,omitempty" validate:"required_if=Version 0x3"`
+	Hash                  *felt.Felt            `json:"transaction_hash,omitempty"`
+	Type                  TransactionType       `json:"type" validate:"required"`
+	Version               *felt.Felt            `json:"version,omitempty" validate:"required"`
+	Nonce                 *felt.Felt            `json:"nonce,omitempty" validate:"required_unless=Version 0x0"`
+	MaxFee                *felt.Felt            `json:"max_fee,omitempty" validate:"required_if=Version 0x0,required_if=Version 0x1,required_if=Version 0x2"`
+	ContractAddress       *felt.Felt            `json:"contract_address,omitempty"`
+	ContractAddressSalt   *felt.Felt            `json:"contract_address_salt,omitempty" validate:"required_if=Type DEPLOY,required_if=Type DEPLOY_ACCOUNT"`
+	ClassHash             *felt.Felt            `json:"class_hash,omitempty" validate:"required_if=Type DEPLOY,required_if=Type DEPLOY_ACCOUNT"`
+	ConstructorCallData   *[]*felt.Felt         `json:"constructor_calldata,omitempty" validate:"required_if=Type DEPLOY,required_if=Type DEPLOY_ACCOUNT"`
+	SenderAddress         *felt.Felt            `json:"sender_address,omitempty" validate:"required_if=Type DECLARE,required_if=Type INVOKE Version 0x1,required_if=Type INVOKE Version 0x3"`
+	Signature             *[]*felt.Felt         `json:"signature,omitempty" validate:"required"`
+	CallData              *[]*felt.Felt         `json:"calldata,omitempty" validate:"required_if=Type INVOKE"`
+	EntryPointSelector    *felt.Felt            `json:"entry_point_selector,omitempty" validate:"required_if=Type INVOKE Version 0x0"`
+	CompiledClassHash     *felt.Felt            `json:"compiled_class_hash,omitempty" validate:"required_if=Type DECLARE Version 0x2"`
+	ResourceBounds        *ResourceBoundsMap    `json:"resource_bounds,omitempty" validate:"required_if=Version 0x3"`
+	Tip                   *felt.Felt            `json:"tip,omitempty" validate:"required_if=Version 0x3"`
+	PaymasterData         *[]*felt.Felt         `json:"paymaster_data,omitempty" validate:"required_if=Version 0x3"`
+	AccountDeploymentData *[]*felt.Felt         `json:"account_deployment_data,omitempty" validate:"required_if=Type INVOKE Version 0x3,required_if=Type DECLARE Version 0x3"`
+	NonceDAMode           *DataAvailabilityMode `json:"nonce_data_availability_mode,omitempty" validate:"required_if=Version 0x3"`
+	FeeDAMode             *DataAvailabilityMode `json:"fee_data_availability_mode,omitempty" validate:"required_if=Version 0x3"`
 }
 
 type TransactionStatus struct {
@@ -309,16 +314,22 @@ type BroadcastedTransaction struct {
 func AdaptBroadcastedTransaction(broadcastedTxn *BroadcastedTransaction,
 	network *utils.Network,
 ) (core.Transaction, core.Class, *felt.Felt, error) {
-	// RPCv6 requests must set l2_gas to zero
-	if broadcastedTxn.ResourceBounds != nil {
-		(*broadcastedTxn.ResourceBounds)[ResourceL2Gas] = ResourceBounds{
-			MaxAmount:       new(felt.Felt).SetUint64(0),
-			MaxPricePerUnit: new(felt.Felt).SetUint64(0),
-		}
-	}
 	var feederTxn starknet.Transaction
 	if err := copier.Copy(&feederTxn, broadcastedTxn.Transaction); err != nil {
 		return nil, nil, nil, err
+	}
+
+	// RPCv6 requests must set l2_gas to zero
+	if broadcastedTxn.ResourceBounds != nil {
+		broadcastedTxn.ResourceBounds = &ResourceBoundsMap{
+			L1Gas: broadcastedTxn.ResourceBounds.L1Gas,
+			L2Gas: &ResourceBounds{
+				MaxAmount:       new(felt.Felt).SetUint64(0),
+				MaxPricePerUnit: new(felt.Felt).SetUint64(0),
+			},
+		}
+		// Copy doesn't covert the struct to enum correctly, so we need to adapt it
+		feederTxn.ResourceBounds = adaptToFeederResourceBounds(broadcastedTxn.ResourceBounds)
 	}
 
 	txn, err := sn2core.AdaptTransaction(&feederTxn)
@@ -369,32 +380,32 @@ func AdaptBroadcastedTransaction(broadcastedTxn *BroadcastedTransaction,
 	return txn, declaredClass, paidFeeOnL1, nil
 }
 
-func adaptResourceBounds(rb map[core.Resource]core.ResourceBounds) map[Resource]ResourceBounds {
-	rpcResourceBounds := make(map[Resource]ResourceBounds)
-	for resource, bounds := range rb {
-		// ResourceL1DataGas is not supported in v6
-		if resource == core.ResourceL1DataGas {
-			continue
-		}
-
-		rpcResourceBounds[Resource(resource)] = ResourceBounds{
-			MaxAmount:       new(felt.Felt).SetUint64(bounds.MaxAmount),
-			MaxPricePerUnit: bounds.MaxPricePerUnit,
-		}
+func adaptResourceBounds(rb map[core.Resource]core.ResourceBounds) ResourceBoundsMap {
+	rpcResourceBounds := ResourceBoundsMap{
+		L1Gas: &ResourceBounds{
+			MaxAmount:       new(felt.Felt).SetUint64(rb[core.ResourceL1Gas].MaxAmount),
+			MaxPricePerUnit: rb[core.ResourceL1Gas].MaxPricePerUnit,
+		},
+		L2Gas: &ResourceBounds{
+			MaxAmount:       new(felt.Felt).SetUint64(rb[core.ResourceL2Gas].MaxAmount),
+			MaxPricePerUnit: rb[core.ResourceL2Gas].MaxPricePerUnit,
+		},
 	}
 	return rpcResourceBounds
 }
 
-func adaptToFeederResourceBounds(rb *map[Resource]ResourceBounds) *map[starknet.Resource]starknet.ResourceBounds { //nolint:gocritic
+func adaptToFeederResourceBounds(rb *ResourceBoundsMap) *map[starknet.Resource]starknet.ResourceBounds { //nolint:gocritic
 	if rb == nil {
 		return nil
 	}
 	feederResourceBounds := make(map[starknet.Resource]starknet.ResourceBounds)
-	for resource, bounds := range *rb {
-		feederResourceBounds[starknet.Resource(resource)] = starknet.ResourceBounds{
-			MaxAmount:       bounds.MaxAmount,
-			MaxPricePerUnit: bounds.MaxPricePerUnit,
-		}
+	feederResourceBounds[starknet.ResourceL1Gas] = starknet.ResourceBounds{
+		MaxAmount:       rb.L1Gas.MaxAmount,
+		MaxPricePerUnit: rb.L1Gas.MaxPricePerUnit,
+	}
+	feederResourceBounds[starknet.ResourceL2Gas] = starknet.ResourceBounds{
+		MaxAmount:       rb.L2Gas.MaxAmount,
+		MaxPricePerUnit: rb.L2Gas.MaxPricePerUnit,
 	}
 	return &feederResourceBounds
 }

--- a/rpc/v6/transaction_test.go
+++ b/rpc/v6/transaction_test.go
@@ -1138,9 +1138,9 @@ func TestAdaptTransaction(t *testing.T) {
 		expectedTx := &rpc.Transaction{
 			Type:    rpc.TxnInvoke,
 			Version: new(felt.Felt).SetUint64(3),
-			ResourceBounds: &map[rpc.Resource]rpc.ResourceBounds{
-				rpc.ResourceL1Gas: {MaxAmount: new(felt.Felt).SetUint64(1), MaxPricePerUnit: new(felt.Felt).SetUint64(2)},
-				rpc.ResourceL2Gas: {MaxAmount: new(felt.Felt).SetUint64(3), MaxPricePerUnit: new(felt.Felt).SetUint64(4)},
+			ResourceBounds: &rpc.ResourceBoundsMap{
+				L1Gas: &rpc.ResourceBounds{MaxAmount: new(felt.Felt).SetUint64(1), MaxPricePerUnit: new(felt.Felt).SetUint64(2)},
+				L2Gas: &rpc.ResourceBounds{MaxAmount: new(felt.Felt).SetUint64(3), MaxPricePerUnit: new(felt.Felt).SetUint64(4)},
 			},
 			Tip: new(felt.Felt).SetUint64(0),
 			// Those 4 fields are pointers to slice (the SliceHeader is allocated, it just refers to a nil array)

--- a/rpc/v7/block_test.go
+++ b/rpc/v7/block_test.go
@@ -422,12 +422,12 @@ func TestBlockWithTxHashesV013(t *testing.T) {
 				Signature:          &tx.TransactionSignature,
 				CallData:           &tx.CallData,
 				EntryPointSelector: tx.EntryPointSelector,
-				ResourceBounds: &map[rpcv7.Resource]rpcv7.ResourceBounds{
-					rpcv7.ResourceL1Gas: {
+				ResourceBounds: &rpcv7.ResourceBoundsMap{
+					L1Gas: &rpcv7.ResourceBounds{
 						MaxAmount:       new(felt.Felt).SetUint64(tx.ResourceBounds[core.ResourceL1Gas].MaxAmount),
 						MaxPricePerUnit: tx.ResourceBounds[core.ResourceL1Gas].MaxPricePerUnit,
 					},
-					rpcv7.ResourceL2Gas: {
+					L2Gas: &rpcv7.ResourceBounds{
 						MaxAmount:       new(felt.Felt).SetUint64(tx.ResourceBounds[core.ResourceL2Gas].MaxAmount),
 						MaxPricePerUnit: tx.ResourceBounds[core.ResourceL2Gas].MaxPricePerUnit,
 					},

--- a/rpc/v7/block_test.go
+++ b/rpc/v7/block_test.go
@@ -422,12 +422,12 @@ func TestBlockWithTxHashesV013(t *testing.T) {
 				Signature:          &tx.TransactionSignature,
 				CallData:           &tx.CallData,
 				EntryPointSelector: tx.EntryPointSelector,
-				ResourceBounds: &rpcv7.ResourceBoundsMap{
-					L1Gas: &rpcv7.ResourceBounds{
+				ResourceBounds: &rpcv6.ResourceBoundsMap{
+					L1Gas: &rpcv6.ResourceBounds{
 						MaxAmount:       new(felt.Felt).SetUint64(tx.ResourceBounds[core.ResourceL1Gas].MaxAmount),
 						MaxPricePerUnit: tx.ResourceBounds[core.ResourceL1Gas].MaxPricePerUnit,
 					},
-					L2Gas: &rpcv7.ResourceBounds{
+					L2Gas: &rpcv6.ResourceBounds{
 						MaxAmount:       new(felt.Felt).SetUint64(tx.ResourceBounds[core.ResourceL2Gas].MaxAmount),
 						MaxPricePerUnit: tx.ResourceBounds[core.ResourceL2Gas].MaxPricePerUnit,
 					},

--- a/rpc/v7/simulation_test.go
+++ b/rpc/v7/simulation_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/NethermindEth/juno/core"
 	"github.com/NethermindEth/juno/core/felt"
+	"github.com/NethermindEth/juno/jsonrpc"
 	"github.com/NethermindEth/juno/mocks"
 	"github.com/NethermindEth/juno/rpc/rpccore"
 	rpcv6 "github.com/NethermindEth/juno/rpc/v6"
@@ -108,4 +109,123 @@ func TestSimulateTransactions(t *testing.T) {
 		)), err)
 		require.Equal(t, httpHeader.Get(rpcv7.ExecutionStepsHeader), "0")
 	})
+}
+
+func TestSimulateTransactionsShouldErrorWithoutSenderAddressOrResourceBounds(t *testing.T) {
+	t.Parallel()
+	n := &utils.Mainnet
+	headsHeader := &core.Header{
+		SequencerAddress: n.BlockHashMetaInfo.FallBackSequencerAddress,
+		L1GasPriceETH:    &felt.Zero,
+		L1GasPriceSTRK:   &felt.Zero,
+		L1DAMode:         0,
+		L1DataGasPrice: &core.GasPrice{
+			PriceInWei: &felt.Zero,
+			PriceInFri: &felt.Zero,
+		},
+		L2GasPrice: &core.GasPrice{
+			PriceInWei: &felt.Zero,
+			PriceInFri: &felt.Zero,
+		},
+	}
+
+	version3 := felt.FromUint64(3)
+
+	tests := []struct {
+		name         string
+		transactions []rpcv7.BroadcastedTransaction
+		err          *jsonrpc.Error
+	}{
+		{
+			name: "declare transaction without sender address",
+			transactions: []rpcv7.BroadcastedTransaction{
+				{
+					Transaction: rpcv7.Transaction{
+						Version: &version3,
+						Type:    rpcv7.TxnDeclare,
+					},
+				},
+			},
+			err: jsonrpc.Err(jsonrpc.InvalidParams, "sender_address is required for this transaction type"),
+		},
+		{
+			name: "declare transaction without resource bounds",
+			transactions: []rpcv7.BroadcastedTransaction{
+				{
+					Transaction: rpcv7.Transaction{
+						Version:       &version3,
+						Type:          rpcv7.TxnDeclare,
+						SenderAddress: &felt.Zero,
+					},
+				},
+			},
+			err: jsonrpc.Err(jsonrpc.InvalidParams, "resource_bounds is required for this transaction type"),
+		},
+		{
+			name: "invoke transaction without sender address",
+			transactions: []rpcv7.BroadcastedTransaction{
+				{
+					Transaction: rpcv7.Transaction{
+						Version: &version3,
+						Type:    rpcv7.TxnInvoke,
+					},
+				},
+			},
+			err: jsonrpc.Err(jsonrpc.InvalidParams, "sender_address is required for this transaction type"),
+		},
+		{
+			name: "invoke transaction without resource bounds",
+			transactions: []rpcv7.BroadcastedTransaction{
+				{
+					Transaction: rpcv7.Transaction{
+						Version:       &version3,
+						Type:          rpcv7.TxnInvoke,
+						SenderAddress: &felt.Zero,
+					},
+				},
+			},
+			err: jsonrpc.Err(jsonrpc.InvalidParams, "resource_bounds is required for this transaction type"),
+		},
+		{
+			name: "deploy account transaction without resource bounds",
+			transactions: []rpcv7.BroadcastedTransaction{
+				{
+					Transaction: rpcv7.Transaction{
+						Version: &version3,
+						Type:    rpcv7.TxnDeployAccount,
+					},
+				},
+			},
+			err: jsonrpc.Err(jsonrpc.InvalidParams, "resource_bounds is required for this transaction type"),
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			mockCtrl := gomock.NewController(t)
+			defer mockCtrl.Finish()
+
+			mockReader := mocks.NewMockReader(mockCtrl)
+			mockVM := mocks.NewMockVM(mockCtrl)
+			mockState := mocks.NewMockStateHistoryReader(mockCtrl)
+
+			mockReader.EXPECT().Network().Return(n)
+			mockReader.EXPECT().HeadState().Return(mockState, nopCloser, nil)
+			mockReader.EXPECT().HeadsHeader().Return(headsHeader, nil)
+
+			handler := rpcv7.New(mockReader, nil, mockVM, "", n, utils.NewNopZapLogger())
+
+			_, _, err := handler.SimulateTransactions(
+				rpcv7.BlockID{Latest: true},
+				test.transactions,
+				[]rpcv6.SimulationFlag{},
+			)
+			if test.err != nil {
+				require.Equal(t, test.err, err)
+				return
+			}
+			require.Nil(t, err)
+		})
+	}
 }

--- a/rpc/v7/transaction.go
+++ b/rpc/v7/transaction.go
@@ -198,30 +198,35 @@ type ResourceBounds struct {
 	MaxPricePerUnit *felt.Felt `json:"max_price_per_unit"`
 }
 
+type ResourceBoundsMap struct {
+	L1Gas *ResourceBounds `json:"l1_gas" validate:"required"`
+	L2Gas *ResourceBounds `json:"l2_gas" validate:"required"`
+}
+
 // https://github.com/starkware-libs/starknet-specs/blob/a789ccc3432c57777beceaa53a34a7ae2f25fda0/api/starknet_api_openrpc.json#L1252
 //
 //nolint:lll
 type Transaction struct {
-	Hash                  *felt.Felt                   `json:"transaction_hash,omitempty"`
-	Type                  TransactionType              `json:"type" validate:"required"`
-	Version               *felt.Felt                   `json:"version,omitempty" validate:"required"`
-	Nonce                 *felt.Felt                   `json:"nonce,omitempty" validate:"required_unless=Version 0x0"`
-	MaxFee                *felt.Felt                   `json:"max_fee,omitempty" validate:"required_if=Version 0x0,required_if=Version 0x1,required_if=Version 0x2"`
-	ContractAddress       *felt.Felt                   `json:"contract_address,omitempty"`
-	ContractAddressSalt   *felt.Felt                   `json:"contract_address_salt,omitempty" validate:"required_if=Type DEPLOY,required_if=Type DEPLOY_ACCOUNT"`
-	ClassHash             *felt.Felt                   `json:"class_hash,omitempty" validate:"required_if=Type DEPLOY,required_if=Type DEPLOY_ACCOUNT"`
-	ConstructorCallData   *[]*felt.Felt                `json:"constructor_calldata,omitempty" validate:"required_if=Type DEPLOY,required_if=Type DEPLOY_ACCOUNT"`
-	SenderAddress         *felt.Felt                   `json:"sender_address,omitempty" validate:"required_if=Type DECLARE,required_if=Type INVOKE Version 0x1,required_if=Type INVOKE Version 0x3"`
-	Signature             *[]*felt.Felt                `json:"signature,omitempty" validate:"required"`
-	CallData              *[]*felt.Felt                `json:"calldata,omitempty" validate:"required_if=Type INVOKE"`
-	EntryPointSelector    *felt.Felt                   `json:"entry_point_selector,omitempty" validate:"required_if=Type INVOKE Version 0x0"`
-	CompiledClassHash     *felt.Felt                   `json:"compiled_class_hash,omitempty" validate:"required_if=Type DECLARE Version 0x2"`
-	ResourceBounds        *map[Resource]ResourceBounds `json:"resource_bounds,omitempty" validate:"required_if=Version 0x3"`
-	Tip                   *felt.Felt                   `json:"tip,omitempty" validate:"required_if=Version 0x3"`
-	PaymasterData         *[]*felt.Felt                `json:"paymaster_data,omitempty" validate:"required_if=Version 0x3"`
-	AccountDeploymentData *[]*felt.Felt                `json:"account_deployment_data,omitempty" validate:"required_if=Type INVOKE Version 0x3,required_if=Type DECLARE Version 0x3"`
-	NonceDAMode           *DataAvailabilityMode        `json:"nonce_data_availability_mode,omitempty" validate:"required_if=Version 0x3"`
-	FeeDAMode             *DataAvailabilityMode        `json:"fee_data_availability_mode,omitempty" validate:"required_if=Version 0x3"`
+	Hash                  *felt.Felt            `json:"transaction_hash,omitempty"`
+	Type                  TransactionType       `json:"type" validate:"required"`
+	Version               *felt.Felt            `json:"version,omitempty" validate:"required"`
+	Nonce                 *felt.Felt            `json:"nonce,omitempty" validate:"required_unless=Version 0x0"`
+	MaxFee                *felt.Felt            `json:"max_fee,omitempty" validate:"required_if=Version 0x0,required_if=Version 0x1,required_if=Version 0x2"`
+	ContractAddress       *felt.Felt            `json:"contract_address,omitempty"`
+	ContractAddressSalt   *felt.Felt            `json:"contract_address_salt,omitempty" validate:"required_if=Type DEPLOY,required_if=Type DEPLOY_ACCOUNT"`
+	ClassHash             *felt.Felt            `json:"class_hash,omitempty" validate:"required_if=Type DEPLOY,required_if=Type DEPLOY_ACCOUNT"`
+	ConstructorCallData   *[]*felt.Felt         `json:"constructor_calldata,omitempty" validate:"required_if=Type DEPLOY,required_if=Type DEPLOY_ACCOUNT"`
+	SenderAddress         *felt.Felt            `json:"sender_address,omitempty" validate:"required_if=Type DECLARE,required_if=Type INVOKE Version 0x1,required_if=Type INVOKE Version 0x3"`
+	Signature             *[]*felt.Felt         `json:"signature,omitempty" validate:"required"`
+	CallData              *[]*felt.Felt         `json:"calldata,omitempty" validate:"required_if=Type INVOKE"`
+	EntryPointSelector    *felt.Felt            `json:"entry_point_selector,omitempty" validate:"required_if=Type INVOKE Version 0x0"`
+	CompiledClassHash     *felt.Felt            `json:"compiled_class_hash,omitempty" validate:"required_if=Type DECLARE Version 0x2"`
+	ResourceBounds        *ResourceBoundsMap    `json:"resource_bounds,omitempty" validate:"required_if=Version 0x3"`
+	Tip                   *felt.Felt            `json:"tip,omitempty" validate:"required_if=Version 0x3"`
+	PaymasterData         *[]*felt.Felt         `json:"paymaster_data,omitempty" validate:"required_if=Version 0x3"`
+	AccountDeploymentData *[]*felt.Felt         `json:"account_deployment_data,omitempty" validate:"required_if=Type INVOKE Version 0x3,required_if=Type DECLARE Version 0x3"`
+	NonceDAMode           *DataAvailabilityMode `json:"nonce_data_availability_mode,omitempty" validate:"required_if=Version 0x3"`
+	FeeDAMode             *DataAvailabilityMode `json:"fee_data_availability_mode,omitempty" validate:"required_if=Version 0x3"`
 }
 
 type TransactionStatus struct {
@@ -297,16 +302,22 @@ type BroadcastedTransaction struct {
 func AdaptBroadcastedTransaction(broadcastedTxn *BroadcastedTransaction,
 	network *utils.Network,
 ) (core.Transaction, core.Class, *felt.Felt, error) {
-	// RPCv7 requests must set l2_gas to zero
-	if broadcastedTxn.ResourceBounds != nil {
-		(*broadcastedTxn.ResourceBounds)[ResourceL2Gas] = ResourceBounds{
-			MaxAmount:       new(felt.Felt).SetUint64(0),
-			MaxPricePerUnit: new(felt.Felt).SetUint64(0),
-		}
-	}
 	var feederTxn starknet.Transaction
 	if err := copier.Copy(&feederTxn, broadcastedTxn.Transaction); err != nil {
 		return nil, nil, nil, err
+	}
+
+	// RPCv7 requests must set l2_gas to zero
+	if broadcastedTxn.ResourceBounds != nil {
+		broadcastedTxn.ResourceBounds = &ResourceBoundsMap{
+			L1Gas: broadcastedTxn.ResourceBounds.L1Gas,
+			L2Gas: &ResourceBounds{
+				MaxAmount:       new(felt.Felt).SetUint64(0),
+				MaxPricePerUnit: new(felt.Felt).SetUint64(0),
+			},
+		}
+		// Copy doesn't covert the struct to enum correctly, so we need to adapt it
+		feederTxn.ResourceBounds = adaptToFeederResourceBounds(broadcastedTxn.ResourceBounds)
 	}
 
 	txn, err := sn2core.AdaptTransaction(&feederTxn)
@@ -356,20 +367,35 @@ func AdaptBroadcastedTransaction(broadcastedTxn *BroadcastedTransaction,
 	return txn, declaredClass, paidFeeOnL1, nil
 }
 
-func adaptResourceBounds(rb map[core.Resource]core.ResourceBounds) map[Resource]ResourceBounds {
-	rpcResourceBounds := make(map[Resource]ResourceBounds)
-	for resource, bounds := range rb {
-		// ResourceL1DataGas is not supported in v7
-		if resource == core.ResourceL1DataGas {
-			continue
-		}
-
-		rpcResourceBounds[Resource(resource)] = ResourceBounds{
-			MaxAmount:       new(felt.Felt).SetUint64(bounds.MaxAmount),
-			MaxPricePerUnit: bounds.MaxPricePerUnit,
-		}
+func adaptResourceBounds(rb map[core.Resource]core.ResourceBounds) ResourceBoundsMap {
+	rpcResourceBounds := ResourceBoundsMap{
+		L1Gas: &ResourceBounds{
+			MaxAmount:       new(felt.Felt).SetUint64(rb[core.ResourceL1Gas].MaxAmount),
+			MaxPricePerUnit: rb[core.ResourceL1Gas].MaxPricePerUnit,
+		},
+		L2Gas: &ResourceBounds{
+			MaxAmount:       new(felt.Felt).SetUint64(rb[core.ResourceL2Gas].MaxAmount),
+			MaxPricePerUnit: rb[core.ResourceL2Gas].MaxPricePerUnit,
+		},
 	}
 	return rpcResourceBounds
+}
+
+func adaptToFeederResourceBounds(rb *ResourceBoundsMap) *map[starknet.Resource]starknet.ResourceBounds { //nolint:gocritic
+	if rb == nil {
+		return nil
+	}
+	feederResourceBounds := make(map[starknet.Resource]starknet.ResourceBounds)
+	feederResourceBounds[starknet.ResourceL1Gas] = starknet.ResourceBounds{
+		MaxAmount:       rb.L1Gas.MaxAmount,
+		MaxPricePerUnit: rb.L1Gas.MaxPricePerUnit,
+	}
+	feederResourceBounds[starknet.ResourceL2Gas] = starknet.ResourceBounds{
+		MaxAmount:       rb.L2Gas.MaxAmount,
+		MaxPricePerUnit: rb.L2Gas.MaxPricePerUnit,
+	}
+
+	return &feederResourceBounds
 }
 
 /****************************************************

--- a/rpc/v7/transaction_test.go
+++ b/rpc/v7/transaction_test.go
@@ -191,16 +191,18 @@ func TestTransactionByBlockIdAndIndex(t *testing.T) {
 func adaptV6TxToV7(t *testing.T, tx *rpcv6.Transaction) *rpc.Transaction {
 	t.Helper()
 
-	var v7ResourceBounds *map[rpc.Resource]rpc.ResourceBounds
+	var v7ResourceBounds *rpc.ResourceBoundsMap
 	if tx.ResourceBounds != nil {
-		v7ResourceBoundsMap := make(map[rpc.Resource]rpc.ResourceBounds)
-		for r, rb := range *tx.ResourceBounds {
-			v7ResourceBoundsMap[rpc.Resource(r)] = rpc.ResourceBounds{
-				MaxAmount:       rb.MaxAmount,
-				MaxPricePerUnit: rb.MaxPricePerUnit,
-			}
+		v7ResourceBounds = &rpc.ResourceBoundsMap{
+			L1Gas: &rpc.ResourceBounds{
+				MaxAmount:       tx.ResourceBounds.L1Gas.MaxAmount,
+				MaxPricePerUnit: tx.ResourceBounds.L1Gas.MaxPricePerUnit,
+			},
+			L2Gas: &rpc.ResourceBounds{
+				MaxAmount:       tx.ResourceBounds.L2Gas.MaxAmount,
+				MaxPricePerUnit: tx.ResourceBounds.L2Gas.MaxPricePerUnit,
+			},
 		}
-		v7ResourceBounds = &v7ResourceBoundsMap
 	}
 
 	var v7NonceDAMode *rpc.DataAvailabilityMode
@@ -817,9 +819,9 @@ func TestAdaptTransaction(t *testing.T) {
 		expectedTx := &rpc.Transaction{
 			Type:    rpc.TxnInvoke,
 			Version: new(felt.Felt).SetUint64(3),
-			ResourceBounds: &map[rpc.Resource]rpc.ResourceBounds{
-				rpc.ResourceL1Gas: {MaxAmount: new(felt.Felt).SetUint64(1), MaxPricePerUnit: new(felt.Felt).SetUint64(2)},
-				rpc.ResourceL2Gas: {MaxAmount: new(felt.Felt).SetUint64(3), MaxPricePerUnit: new(felt.Felt).SetUint64(4)},
+			ResourceBounds: &rpc.ResourceBoundsMap{
+				L1Gas: &rpc.ResourceBounds{MaxAmount: new(felt.Felt).SetUint64(1), MaxPricePerUnit: new(felt.Felt).SetUint64(2)},
+				L2Gas: &rpc.ResourceBounds{MaxAmount: new(felt.Felt).SetUint64(3), MaxPricePerUnit: new(felt.Felt).SetUint64(4)},
 			},
 			Tip: new(felt.Felt).SetUint64(0),
 			// Those 4 fields are pointers to slice (the SliceHeader is allocated, it just refers to a nil array)

--- a/rpc/v7/transaction_test.go
+++ b/rpc/v7/transaction_test.go
@@ -191,14 +191,14 @@ func TestTransactionByBlockIdAndIndex(t *testing.T) {
 func adaptV6TxToV7(t *testing.T, tx *rpcv6.Transaction) *rpc.Transaction {
 	t.Helper()
 
-	var v7ResourceBounds *rpc.ResourceBoundsMap
+	var v7ResourceBounds *rpcv6.ResourceBoundsMap
 	if tx.ResourceBounds != nil {
-		v7ResourceBounds = &rpc.ResourceBoundsMap{
-			L1Gas: &rpc.ResourceBounds{
+		v7ResourceBounds = &rpcv6.ResourceBoundsMap{
+			L1Gas: &rpcv6.ResourceBounds{
 				MaxAmount:       tx.ResourceBounds.L1Gas.MaxAmount,
 				MaxPricePerUnit: tx.ResourceBounds.L1Gas.MaxPricePerUnit,
 			},
-			L2Gas: &rpc.ResourceBounds{
+			L2Gas: &rpcv6.ResourceBounds{
 				MaxAmount:       tx.ResourceBounds.L2Gas.MaxAmount,
 				MaxPricePerUnit: tx.ResourceBounds.L2Gas.MaxPricePerUnit,
 			},
@@ -819,9 +819,9 @@ func TestAdaptTransaction(t *testing.T) {
 		expectedTx := &rpc.Transaction{
 			Type:    rpc.TxnInvoke,
 			Version: new(felt.Felt).SetUint64(3),
-			ResourceBounds: &rpc.ResourceBoundsMap{
-				L1Gas: &rpc.ResourceBounds{MaxAmount: new(felt.Felt).SetUint64(1), MaxPricePerUnit: new(felt.Felt).SetUint64(2)},
-				L2Gas: &rpc.ResourceBounds{MaxAmount: new(felt.Felt).SetUint64(3), MaxPricePerUnit: new(felt.Felt).SetUint64(4)},
+			ResourceBounds: &rpcv6.ResourceBoundsMap{
+				L1Gas: &rpcv6.ResourceBounds{MaxAmount: new(felt.Felt).SetUint64(1), MaxPricePerUnit: new(felt.Felt).SetUint64(2)},
+				L2Gas: &rpcv6.ResourceBounds{MaxAmount: new(felt.Felt).SetUint64(3), MaxPricePerUnit: new(felt.Felt).SetUint64(4)},
 			},
 			Tip: new(felt.Felt).SetUint64(0),
 			// Those 4 fields are pointers to slice (the SliceHeader is allocated, it just refers to a nil array)

--- a/rpc/v8/block_test.go
+++ b/rpc/v8/block_test.go
@@ -423,14 +423,18 @@ func TestBlockWithTxHashesV013(t *testing.T) {
 				Signature:          &tx.TransactionSignature,
 				CallData:           &tx.CallData,
 				EntryPointSelector: tx.EntryPointSelector,
-				ResourceBounds: &map[rpcv8.Resource]rpcv8.ResourceBounds{
-					rpcv8.ResourceL1Gas: {
+				ResourceBounds: &rpcv8.ResourceBoundsMap{
+					L1Gas: &rpcv8.ResourceBounds{
 						MaxAmount:       new(felt.Felt).SetUint64(tx.ResourceBounds[core.ResourceL1Gas].MaxAmount),
 						MaxPricePerUnit: tx.ResourceBounds[core.ResourceL1Gas].MaxPricePerUnit,
 					},
-					rpcv8.ResourceL2Gas: {
+					L2Gas: &rpcv8.ResourceBounds{
 						MaxAmount:       new(felt.Felt).SetUint64(tx.ResourceBounds[core.ResourceL2Gas].MaxAmount),
 						MaxPricePerUnit: tx.ResourceBounds[core.ResourceL2Gas].MaxPricePerUnit,
+					},
+					L1DataGas: &rpcv8.ResourceBounds{
+						MaxAmount:       new(felt.Felt).SetUint64(tx.ResourceBounds[core.ResourceL1DataGas].MaxAmount),
+						MaxPricePerUnit: tx.ResourceBounds[core.ResourceL1DataGas].MaxPricePerUnit,
 					},
 				},
 				Tip:                   new(felt.Felt).SetUint64(tx.Tip),

--- a/rpc/v8/simulation.go
+++ b/rpc/v8/simulation.go
@@ -90,6 +90,11 @@ func (h *Handler) simulateTransactions(id BlockID, transactions []BroadcastedTra
 	return simulatedTransactions, httpHeader, nil
 }
 
+func isVersion3(transaction *BroadcastedTransaction) bool {
+	version := felt.FromUint64(3)
+	return transaction.Transaction.Version != nil && transaction.Transaction.Version.Equal(&version)
+}
+
 func prepareTransactions(transactions []BroadcastedTransaction, network *utils.Network) (
 	[]core.Transaction, []core.Class, []*felt.Felt, *jsonrpc.Error,
 ) {
@@ -98,7 +103,28 @@ func prepareTransactions(transactions []BroadcastedTransaction, network *utils.N
 	paidFeesOnL1 := make([]*felt.Felt, 0)
 
 	for idx := range transactions {
-		txn, declaredClass, paidFeeOnL1, aErr := adaptBroadcastedTransaction(&transactions[idx], network)
+		// Check for missing required fields in struct that can't be validated by
+		// jsonschema due to validation happening after omit empty
+		//
+		// TODO: as its expected that this will happen in other cases as well,
+		// it might be a good idea to implement a custom validator and unmarshal handler
+		// to solve this problem in a more elegant way
+		if (transactions[idx].Transaction.Type == TxnDeclare ||
+			transactions[idx].Transaction.Type == TxnInvoke) && isVersion3(&transactions[idx]) {
+			if transactions[idx].Transaction.SenderAddress == nil {
+				return nil, nil, nil, jsonrpc.Err(jsonrpc.InvalidParams, "sender_address is required for this transaction type")
+			}
+		}
+
+		if (transactions[idx].Transaction.Type == TxnInvoke ||
+			transactions[idx].Transaction.Type == TxnDeployAccount ||
+			transactions[idx].Transaction.Type == TxnDeclare) && isVersion3(&transactions[idx]) {
+			if transactions[idx].Transaction.ResourceBounds == nil {
+				return nil, nil, nil, jsonrpc.Err(jsonrpc.InvalidParams, "resource_bounds is required for this transaction type")
+			}
+		}
+
+		txn, declaredClass, paidFeeOnL1, aErr := AdaptBroadcastedTransaction(&transactions[idx], network)
 		if aErr != nil {
 			return nil, nil, nil, jsonrpc.Err(jsonrpc.InvalidParams, aErr.Error())
 		}

--- a/rpc/v8/simulation.go
+++ b/rpc/v8/simulation.go
@@ -90,9 +90,23 @@ func (h *Handler) simulateTransactions(id BlockID, transactions []BroadcastedTra
 	return simulatedTransactions, httpHeader, nil
 }
 
-func isVersion3(transaction *BroadcastedTransaction) bool {
-	version := felt.FromUint64(3)
-	return transaction.Transaction.Version != nil && transaction.Transaction.Version.Equal(&version)
+func isVersion3(version *felt.Felt) bool {
+	return version != nil && version.Equal(&rpcv6.RPCVersion3Value)
+}
+
+func checkTxHasSenderAddress(tx *BroadcastedTransaction) bool {
+	return (tx.Transaction.Type == TxnDeclare ||
+		tx.Transaction.Type == TxnInvoke) &&
+		isVersion3(tx.Transaction.Version) &&
+		tx.Transaction.SenderAddress == nil
+}
+
+func checkTxHasResourceBounds(tx *BroadcastedTransaction) bool {
+	return (tx.Transaction.Type == TxnInvoke ||
+		tx.Transaction.Type == TxnDeployAccount ||
+		tx.Transaction.Type == TxnDeclare) &&
+		isVersion3(tx.Transaction.Version) &&
+		tx.Transaction.ResourceBounds == nil
 }
 
 func prepareTransactions(transactions []BroadcastedTransaction, network *utils.Network) (
@@ -109,19 +123,12 @@ func prepareTransactions(transactions []BroadcastedTransaction, network *utils.N
 		// TODO: as its expected that this will happen in other cases as well,
 		// it might be a good idea to implement a custom validator and unmarshal handler
 		// to solve this problem in a more elegant way
-		if (transactions[idx].Transaction.Type == TxnDeclare ||
-			transactions[idx].Transaction.Type == TxnInvoke) && isVersion3(&transactions[idx]) {
-			if transactions[idx].Transaction.SenderAddress == nil {
-				return nil, nil, nil, jsonrpc.Err(jsonrpc.InvalidParams, "sender_address is required for this transaction type")
-			}
+		if checkTxHasSenderAddress(&transactions[idx]) {
+			return nil, nil, nil, jsonrpc.Err(jsonrpc.InvalidParams, "sender_address is required for this transaction type")
 		}
 
-		if (transactions[idx].Transaction.Type == TxnInvoke ||
-			transactions[idx].Transaction.Type == TxnDeployAccount ||
-			transactions[idx].Transaction.Type == TxnDeclare) && isVersion3(&transactions[idx]) {
-			if transactions[idx].Transaction.ResourceBounds == nil {
-				return nil, nil, nil, jsonrpc.Err(jsonrpc.InvalidParams, "resource_bounds is required for this transaction type")
-			}
+		if checkTxHasResourceBounds(&transactions[idx]) {
+			return nil, nil, nil, jsonrpc.Err(jsonrpc.InvalidParams, "resource_bounds is required for this transaction type")
 		}
 
 		txn, declaredClass, paidFeeOnL1, aErr := AdaptBroadcastedTransaction(&transactions[idx], network)

--- a/rpc/v8/simulation_test.go
+++ b/rpc/v8/simulation_test.go
@@ -160,3 +160,122 @@ func TestSimulateTransactions(t *testing.T) {
 		})
 	}
 }
+
+func TestSimulateTransactionsShouldErrorWithoutSenderAddressOrResourceBounds(t *testing.T) {
+	t.Parallel()
+	n := &utils.Mainnet
+	headsHeader := &core.Header{
+		SequencerAddress: n.BlockHashMetaInfo.FallBackSequencerAddress,
+		L1GasPriceETH:    &felt.Zero,
+		L1GasPriceSTRK:   &felt.Zero,
+		L1DAMode:         0,
+		L1DataGasPrice: &core.GasPrice{
+			PriceInWei: &felt.Zero,
+			PriceInFri: &felt.Zero,
+		},
+		L2GasPrice: &core.GasPrice{
+			PriceInWei: &felt.Zero,
+			PriceInFri: &felt.Zero,
+		},
+	}
+
+	version3 := felt.FromUint64(3)
+
+	tests := []struct {
+		name         string
+		transactions []rpc.BroadcastedTransaction
+		err          *jsonrpc.Error
+	}{
+		{
+			name: "declare transaction without sender address",
+			transactions: []rpc.BroadcastedTransaction{
+				{
+					Transaction: rpc.Transaction{
+						Version: &version3,
+						Type:    rpc.TxnDeclare,
+					},
+				},
+			},
+			err: jsonrpc.Err(jsonrpc.InvalidParams, "sender_address is required for this transaction type"),
+		},
+		{
+			name: "declare transaction without resource bounds",
+			transactions: []rpc.BroadcastedTransaction{
+				{
+					Transaction: rpc.Transaction{
+						Version:       &version3,
+						Type:          rpc.TxnDeclare,
+						SenderAddress: &felt.Zero,
+					},
+				},
+			},
+			err: jsonrpc.Err(jsonrpc.InvalidParams, "resource_bounds is required for this transaction type"),
+		},
+		{
+			name: "invoke transaction without sender address",
+			transactions: []rpc.BroadcastedTransaction{
+				{
+					Transaction: rpc.Transaction{
+						Version: &version3,
+						Type:    rpc.TxnInvoke,
+					},
+				},
+			},
+			err: jsonrpc.Err(jsonrpc.InvalidParams, "sender_address is required for this transaction type"),
+		},
+		{
+			name: "invoke transaction without resource bounds",
+			transactions: []rpc.BroadcastedTransaction{
+				{
+					Transaction: rpc.Transaction{
+						Version:       &version3,
+						Type:          rpc.TxnInvoke,
+						SenderAddress: &felt.Zero,
+					},
+				},
+			},
+			err: jsonrpc.Err(jsonrpc.InvalidParams, "resource_bounds is required for this transaction type"),
+		},
+		{
+			name: "deploy account transaction without resource bounds",
+			transactions: []rpc.BroadcastedTransaction{
+				{
+					Transaction: rpc.Transaction{
+						Version: &version3,
+						Type:    rpc.TxnDeployAccount,
+					},
+				},
+			},
+			err: jsonrpc.Err(jsonrpc.InvalidParams, "resource_bounds is required for this transaction type"),
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			mockCtrl := gomock.NewController(t)
+			defer mockCtrl.Finish()
+
+			mockReader := mocks.NewMockReader(mockCtrl)
+			mockVM := mocks.NewMockVM(mockCtrl)
+			mockState := mocks.NewMockStateHistoryReader(mockCtrl)
+
+			mockReader.EXPECT().Network().Return(n)
+			mockReader.EXPECT().HeadState().Return(mockState, nopCloser, nil)
+			mockReader.EXPECT().HeadsHeader().Return(headsHeader, nil)
+
+			handler := rpc.New(mockReader, nil, mockVM, "", utils.NewNopZapLogger())
+
+			_, _, err := handler.SimulateTransactions(
+				rpc.BlockID{Latest: true},
+				test.transactions,
+				[]rpcv6.SimulationFlag{},
+			)
+			if test.err != nil {
+				require.Equal(t, test.err, err)
+				return
+			}
+			require.Nil(t, err)
+		})
+	}
+}

--- a/rpc/v8/subscriptions_test.go
+++ b/rpc/v8/subscriptions_test.go
@@ -780,16 +780,29 @@ func TestSubscribePendingTxs(t *testing.T) {
 			},
 			Transactions: []core.Transaction{
 				&core.InvokeTransaction{
-					TransactionHash:       new(felt.Felt).SetUint64(1),
-					CallData:              []*felt.Felt{new(felt.Felt).SetUint64(2)},
-					TransactionSignature:  []*felt.Felt{new(felt.Felt).SetUint64(3)},
-					MaxFee:                new(felt.Felt).SetUint64(4),
-					ContractAddress:       new(felt.Felt).SetUint64(5),
-					Version:               new(core.TransactionVersion).SetUint64(3),
-					EntryPointSelector:    new(felt.Felt).SetUint64(6),
-					Nonce:                 new(felt.Felt).SetUint64(7),
-					SenderAddress:         new(felt.Felt).SetUint64(8),
-					ResourceBounds:        map[core.Resource]core.ResourceBounds{},
+					TransactionHash:      new(felt.Felt).SetUint64(1),
+					CallData:             []*felt.Felt{new(felt.Felt).SetUint64(2)},
+					TransactionSignature: []*felt.Felt{new(felt.Felt).SetUint64(3)},
+					MaxFee:               new(felt.Felt).SetUint64(4),
+					ContractAddress:      new(felt.Felt).SetUint64(5),
+					Version:              new(core.TransactionVersion).SetUint64(3),
+					EntryPointSelector:   new(felt.Felt).SetUint64(6),
+					Nonce:                new(felt.Felt).SetUint64(7),
+					SenderAddress:        new(felt.Felt).SetUint64(8),
+					ResourceBounds: map[core.Resource]core.ResourceBounds{
+						core.ResourceL1Gas: {
+							MaxAmount:       1,
+							MaxPricePerUnit: new(felt.Felt).SetUint64(1),
+						},
+						core.ResourceL2Gas: {
+							MaxAmount:       1,
+							MaxPricePerUnit: new(felt.Felt).SetUint64(1),
+						},
+						core.ResourceL1DataGas: {
+							MaxAmount:       1,
+							MaxPricePerUnit: new(felt.Felt).SetUint64(1),
+						},
+					},
 					Tip:                   9,
 					PaymasterData:         []*felt.Felt{new(felt.Felt).SetUint64(10)},
 					AccountDeploymentData: []*felt.Felt{new(felt.Felt).SetUint64(11)},
@@ -797,7 +810,7 @@ func TestSubscribePendingTxs(t *testing.T) {
 			},
 		})
 
-		want := `{"jsonrpc":"2.0","method":"starknet_subscriptionPendingTransactions","params":{"result":{"transaction_hash":"0x1","type":"INVOKE","version":"0x3","nonce":"0x7","max_fee":"0x4","contract_address":"0x5","sender_address":"0x8","signature":["0x3"],"calldata":["0x2"],"entry_point_selector":"0x6","resource_bounds":{},"tip":"0x9","paymaster_data":["0xa"],"account_deployment_data":["0xb"],"nonce_data_availability_mode":"L1","fee_data_availability_mode":"L1"},"subscription_id":"%s"}}`
+		want := `{"jsonrpc":"2.0","method":"starknet_subscriptionPendingTransactions","params":{"result":{"transaction_hash":"0x1","type":"INVOKE","version":"0x3","nonce":"0x7","max_fee":"0x4","contract_address":"0x5","sender_address":"0x8","signature":["0x3"],"calldata":["0x2"],"entry_point_selector":"0x6","resource_bounds":{"l1_gas":{"max_amount":"0x1","max_price_per_unit":"0x1"},"l2_gas":{"max_amount":"0x1","max_price_per_unit":"0x1"},"l1_data_gas":{"max_amount":"0x1","max_price_per_unit":"0x1"}},"tip":"0x9","paymaster_data":["0xa"],"account_deployment_data":["0xb"],"nonce_data_availability_mode":"L1","fee_data_availability_mode":"L1"},"subscription_id":"%s"}}`
 		want = fmt.Sprintf(want, id)
 		_, pendingTxsGot, err := conn.Read(ctx)
 		require.NoError(t, err)

--- a/rpc/v8/transaction.go
+++ b/rpc/v8/transaction.go
@@ -206,30 +206,36 @@ type ResourceBounds struct {
 	MaxPricePerUnit *felt.Felt `json:"max_price_per_unit"`
 }
 
+type ResourceBoundsMap struct {
+	L1Gas     *ResourceBounds `json:"l1_gas" validate:"required"`
+	L2Gas     *ResourceBounds `json:"l2_gas" validate:"required"`
+	L1DataGas *ResourceBounds `json:"l1_data_gas" validate:"required"`
+}
+
 // https://github.com/starkware-libs/starknet-specs/blob/a789ccc3432c57777beceaa53a34a7ae2f25fda0/api/starknet_api_openrpc.json#L1252
 //
 //nolint:lll
 type Transaction struct {
-	Hash                  *felt.Felt                   `json:"transaction_hash,omitempty"`
-	Type                  TransactionType              `json:"type" validate:"required"`
-	Version               *felt.Felt                   `json:"version,omitempty" validate:"required,version_0x3"`
-	Nonce                 *felt.Felt                   `json:"nonce,omitempty" validate:"required"`
-	MaxFee                *felt.Felt                   `json:"max_fee,omitempty"`
-	ContractAddress       *felt.Felt                   `json:"contract_address,omitempty"`
-	ContractAddressSalt   *felt.Felt                   `json:"contract_address_salt,omitempty" validate:"required_if=Type DEPLOY,required_if=Type DEPLOY_ACCOUNT"`
-	ClassHash             *felt.Felt                   `json:"class_hash,omitempty" validate:"required_if=Type DEPLOY,required_if=Type DEPLOY_ACCOUNT"`
-	ConstructorCallData   *[]*felt.Felt                `json:"constructor_calldata,omitempty" validate:"required_if=Type DEPLOY,required_if=Type DEPLOY_ACCOUNT"`
-	SenderAddress         *felt.Felt                   `json:"sender_address,omitempty" validate:"required_if=Type DECLARE,required_if=Type INVOKE"`
-	Signature             *[]*felt.Felt                `json:"signature,omitempty" validate:"required"`
-	CallData              *[]*felt.Felt                `json:"calldata,omitempty" validate:"required_if=Type INVOKE"`
-	EntryPointSelector    *felt.Felt                   `json:"entry_point_selector,omitempty"`
-	CompiledClassHash     *felt.Felt                   `json:"compiled_class_hash,omitempty"`
-	ResourceBounds        *map[Resource]ResourceBounds `json:"resource_bounds,omitempty" validate:"resource_bounds_required"`
-	Tip                   *felt.Felt                   `json:"tip,omitempty" validate:"required"`
-	PaymasterData         *[]*felt.Felt                `json:"paymaster_data,omitempty" validate:"required"`
-	AccountDeploymentData *[]*felt.Felt                `json:"account_deployment_data,omitempty" validate:"required_if=Type INVOKE,required_if=Type DECLARE"`
-	NonceDAMode           *DataAvailabilityMode        `json:"nonce_data_availability_mode,omitempty" validate:"required"`
-	FeeDAMode             *DataAvailabilityMode        `json:"fee_data_availability_mode,omitempty" validate:"required"`
+	Hash                  *felt.Felt            `json:"transaction_hash,omitempty"`
+	Type                  TransactionType       `json:"type" validate:"required"`
+	Version               *felt.Felt            `json:"version,omitempty" validate:"required,version_0x3"`
+	Nonce                 *felt.Felt            `json:"nonce,omitempty" validate:"required"`
+	MaxFee                *felt.Felt            `json:"max_fee,omitempty"`
+	ContractAddress       *felt.Felt            `json:"contract_address,omitempty"`
+	ContractAddressSalt   *felt.Felt            `json:"contract_address_salt,omitempty" validate:"required_if=Type DEPLOY,required_if=Type DEPLOY_ACCOUNT"`
+	ClassHash             *felt.Felt            `json:"class_hash,omitempty" validate:"required_if=Type DEPLOY,required_if=Type DEPLOY_ACCOUNT"`
+	ConstructorCallData   *[]*felt.Felt         `json:"constructor_calldata,omitempty" validate:"required_if=Type DEPLOY,required_if=Type DEPLOY_ACCOUNT"`
+	SenderAddress         *felt.Felt            `json:"sender_address,omitempty" validate:"required_if=Type DECLARE,required_if=Type INVOKE"`
+	Signature             *[]*felt.Felt         `json:"signature,omitempty" validate:"required"`
+	CallData              *[]*felt.Felt         `json:"calldata,omitempty" validate:"required_if=Type INVOKE"`
+	EntryPointSelector    *felt.Felt            `json:"entry_point_selector,omitempty"`
+	CompiledClassHash     *felt.Felt            `json:"compiled_class_hash,omitempty"`
+	ResourceBounds        *ResourceBoundsMap    `json:"resource_bounds,omitempty" validate:"resource_bounds_required"`
+	Tip                   *felt.Felt            `json:"tip,omitempty" validate:"required"`
+	PaymasterData         *[]*felt.Felt         `json:"paymaster_data,omitempty" validate:"required"`
+	AccountDeploymentData *[]*felt.Felt         `json:"account_deployment_data,omitempty" validate:"required_if=Type INVOKE,required_if=Type DECLARE"`
+	NonceDAMode           *DataAvailabilityMode `json:"nonce_data_availability_mode,omitempty" validate:"required"`
+	FeeDAMode             *DataAvailabilityMode `json:"fee_data_availability_mode,omitempty" validate:"required"`
 }
 
 type TransactionStatus struct {
@@ -302,13 +308,16 @@ type BroadcastedTransaction struct {
 	PaidFeeOnL1   *felt.Felt      `json:"paid_fee_on_l1,omitempty" validate:"required_if=Transaction.Type L1_HANDLER"`
 }
 
-func adaptBroadcastedTransaction(broadcastedTxn *BroadcastedTransaction,
+func AdaptBroadcastedTransaction(broadcastedTxn *BroadcastedTransaction,
 	network *utils.Network,
 ) (core.Transaction, core.Class, *felt.Felt, error) {
 	var feederTxn starknet.Transaction
 	if err := copier.Copy(&feederTxn, broadcastedTxn.Transaction); err != nil {
 		return nil, nil, nil, err
 	}
+
+	// Copy doesn't covert the struct to enum correctly, so we need to adapt it
+	feederTxn.ResourceBounds = adaptToFeederResourceBounds(broadcastedTxn.ResourceBounds)
 
 	txn, err := sn2core.AdaptTransaction(&feederTxn)
 	if err != nil {
@@ -358,28 +367,42 @@ func adaptBroadcastedTransaction(broadcastedTxn *BroadcastedTransaction,
 	return txn, declaredClass, paidFeeOnL1, nil
 }
 
-func adaptResourceBounds(rb map[core.Resource]core.ResourceBounds) map[Resource]ResourceBounds {
-	rpcResourceBounds := make(map[Resource]ResourceBounds)
-	for resource, bounds := range rb {
-		rpcResourceBounds[Resource(resource)] = ResourceBounds{
-			MaxAmount:       new(felt.Felt).SetUint64(bounds.MaxAmount),
-			MaxPricePerUnit: bounds.MaxPricePerUnit,
-		}
+func adaptResourceBounds(rb map[core.Resource]core.ResourceBounds) ResourceBoundsMap {
+	rpcResourceBounds := ResourceBoundsMap{
+		L1Gas: &ResourceBounds{
+			MaxAmount:       new(felt.Felt).SetUint64(rb[core.ResourceL1Gas].MaxAmount),
+			MaxPricePerUnit: rb[core.ResourceL1Gas].MaxPricePerUnit,
+		},
+		L2Gas: &ResourceBounds{
+			MaxAmount:       new(felt.Felt).SetUint64(rb[core.ResourceL2Gas].MaxAmount),
+			MaxPricePerUnit: rb[core.ResourceL2Gas].MaxPricePerUnit,
+		},
+		L1DataGas: &ResourceBounds{
+			MaxAmount:       new(felt.Felt).SetUint64(rb[core.ResourceL1DataGas].MaxAmount),
+			MaxPricePerUnit: rb[core.ResourceL1DataGas].MaxPricePerUnit,
+		},
 	}
 	return rpcResourceBounds
 }
 
-func adaptToFeederResourceBounds(rb *map[Resource]ResourceBounds) *map[starknet.Resource]starknet.ResourceBounds { //nolint:gocritic
+func adaptToFeederResourceBounds(rb *ResourceBoundsMap) *map[starknet.Resource]starknet.ResourceBounds { //nolint:gocritic
 	if rb == nil {
 		return nil
 	}
 	feederResourceBounds := make(map[starknet.Resource]starknet.ResourceBounds)
-	for resource, bounds := range *rb {
-		feederResourceBounds[starknet.Resource(resource)] = starknet.ResourceBounds{
-			MaxAmount:       bounds.MaxAmount,
-			MaxPricePerUnit: bounds.MaxPricePerUnit,
-		}
+	feederResourceBounds[starknet.ResourceL1Gas] = starknet.ResourceBounds{
+		MaxAmount:       rb.L1Gas.MaxAmount,
+		MaxPricePerUnit: rb.L1Gas.MaxPricePerUnit,
 	}
+	feederResourceBounds[starknet.ResourceL2Gas] = starknet.ResourceBounds{
+		MaxAmount:       rb.L2Gas.MaxAmount,
+		MaxPricePerUnit: rb.L2Gas.MaxPricePerUnit,
+	}
+	feederResourceBounds[starknet.ResourceL1DataGas] = starknet.ResourceBounds{
+		MaxAmount:       rb.L1DataGas.MaxAmount,
+		MaxPricePerUnit: rb.L1DataGas.MaxPricePerUnit,
+	}
+
 	return &feederResourceBounds
 }
 

--- a/rpc/v8/transaction.go
+++ b/rpc/v8/transaction.go
@@ -206,6 +206,10 @@ type ResourceBounds struct {
 	MaxPricePerUnit *felt.Felt `json:"max_price_per_unit"`
 }
 
+// TODO: using Value fields here is a good idea, however
+// we are currently keeping the field's type Reference since the current
+// validation tags we are using does not work well with Value field.
+// We should revisit this when we start implementing custom validations.
 type ResourceBoundsMap struct {
 	L1Gas     *ResourceBounds `json:"l1_gas" validate:"required"`
 	L2Gas     *ResourceBounds `json:"l2_gas" validate:"required"`

--- a/rpc/v8/transaction_test.go
+++ b/rpc/v8/transaction_test.go
@@ -1593,3 +1593,91 @@ func TestResourceBoundsValidation(t *testing.T) {
 		})
 	}
 }
+
+func TestAdaptBroadcastedTransaction(t *testing.T) {
+	txnNonZeroL2GasData := `{
+			"type": "DEPLOY_ACCOUNT",
+			"version": "0x3",
+			"signature": [
+				"0x63c0e0fe22d6e82187b84e06f33644f7dc6edce494a317bfcdd0bb57ab862fa",
+				"0x6219aa7d091eac96f07d7d195f12eff9a8786af85ddf41028428ee8f510e75e"
+			],
+			"nonce": "0x1",
+			"contract_address_salt": "0x520b540d51c06e1539cbc42e93a37cbef534082c75a3991179cfac83da67fdb",
+			"constructor_calldata": [
+				"0x33444ad846cdd5f23eb73ff09fe6fddd568284a0fb7d1be20ee482f044dabe2",
+				"0x79dc0da7c54b95f10aa182ad0a46400db63156920adb65eca2654c0945a463",
+				"0x2",
+				"0x510b540d51c06e1539cbc42e93a37cbef534082c75a3991179cfac83da67fdb",
+				"0x0"
+			],
+			"class_hash": "0x26ec026985a3bf9d0cc1fe17326b245dfdc3ff89b8fde106542a3ea56c5a918",
+			"resource_bounds": {
+				"l1_gas": {
+					"max_amount": "0x6fde2b4eb000",
+					"max_price_per_unit": "0x6fde2b4eb000"
+				},
+				"l2_gas": {													
+					"max_amount": "0x6fde2b4eb000",
+					"max_price_per_unit": "0x6fde2b4eb000"
+				},
+				"l1_data_gas": {													
+					"max_amount": "0x6fde2b4eb000",
+					"max_price_per_unit": "0x6fde2b4eb000"
+				}
+			},
+			"tip": "0x1",
+			"paymaster_data": [],
+			"nonce_data_availability_mode": "L1",
+			"fee_data_availability_mode": "L2"
+		}`
+	expectedTxn := core.DeployAccountTransaction{
+		DeployTransaction: core.DeployTransaction{
+			TransactionHash:     utils.HexToFelt(t, "0x279b4c80718c256682226b098aecd3f5b0d0ddcfeb697d0047f4aa31a6e449f"),
+			ContractAddressSalt: utils.HexToFelt(t, "0x520b540d51c06e1539cbc42e93a37cbef534082c75a3991179cfac83da67fdb"),
+			ClassHash:           utils.HexToFelt(t, "0x26ec026985a3bf9d0cc1fe17326b245dfdc3ff89b8fde106542a3ea56c5a918"),
+			ContractAddress:     utils.HexToFelt(t, "0x55e3ecdbd8f0b537b3cf6c31a77dff63ddfd5bf5dcc5ba7eb4d09e91fbe0f91"),
+			ConstructorCallData: []*felt.Felt{
+				utils.HexToFelt(t, "0x33444ad846cdd5f23eb73ff09fe6fddd568284a0fb7d1be20ee482f044dabe2"),
+				utils.HexToFelt(t, "0x79dc0da7c54b95f10aa182ad0a46400db63156920adb65eca2654c0945a463"),
+				utils.HexToFelt(t, "0x2"),
+				utils.HexToFelt(t, "0x510b540d51c06e1539cbc42e93a37cbef534082c75a3991179cfac83da67fdb"),
+				utils.HexToFelt(t, "0x0"),
+			},
+			Version: new(core.TransactionVersion).SetUint64(3),
+		},
+		TransactionSignature: []*felt.Felt{
+			utils.HexToFelt(t, "0x63c0e0fe22d6e82187b84e06f33644f7dc6edce494a317bfcdd0bb57ab862fa"),
+			utils.HexToFelt(t, "0x6219aa7d091eac96f07d7d195f12eff9a8786af85ddf41028428ee8f510e75e"),
+		},
+		Nonce: utils.HexToFelt(t, "0x1"),
+		ResourceBounds: map[core.Resource]core.ResourceBounds{
+			core.ResourceL1Gas: {
+				MaxAmount:       utils.HexToFelt(t, "0x6fde2b4eb000").Uint64(),
+				MaxPricePerUnit: utils.HexToFelt(t, "0x6fde2b4eb000"),
+			},
+			core.ResourceL2Gas: {
+				MaxAmount:       utils.HexToFelt(t, "0x6fde2b4eb000").Uint64(),
+				MaxPricePerUnit: utils.HexToFelt(t, "0x6fde2b4eb000"),
+			},
+			core.ResourceL1DataGas: {
+				MaxAmount:       utils.HexToFelt(t, "0x6fde2b4eb000").Uint64(),
+				MaxPricePerUnit: utils.HexToFelt(t, "0x6fde2b4eb000"),
+			},
+		},
+		Tip:           1, // 0x1
+		PaymasterData: []*felt.Felt{},
+		NonceDAMode:   core.DAModeL1,
+		FeeDAMode:     core.DAModeL2,
+	}
+
+	txnNonZeroL2Gas := rpc.BroadcastedTransaction{}
+	require.NoError(t, json.Unmarshal([]byte(txnNonZeroL2GasData), &txnNonZeroL2Gas))
+
+	tx, _, _, err := rpc.AdaptBroadcastedTransaction(&txnNonZeroL2Gas, &utils.Sepolia)
+	require.NoError(t, err)
+	resultTxn, ok := (tx).(*core.DeployAccountTransaction)
+
+	require.True(t, ok)
+	require.Equal(t, expectedTxn, *resultTxn)
+}

--- a/validator/validator.go
+++ b/validator/validator.go
@@ -18,7 +18,7 @@ var (
 
 func validateResourceBounds(fl validator.FieldLevel) bool {
 	req, ok := fl.Parent().Interface().(rpcv8.Transaction)
-	return ok && req.ResourceBounds != nil && len(*req.ResourceBounds) == 3
+	return ok && req.ResourceBounds != nil
 }
 
 // Custom validation function for version


### PR DESCRIPTION
Closes #2475

This PR fixes the issue by doing the following:

1. Adding checks for the fields at `prepareTransactions`
2. Using a struct for `ResourceBounds` instead of the map, which enforces the required fields when `ResourceBounds` is provided.

The change of using a struct for the `ResourceBounds` does mean that there is a need to manually copy over the values since copy does not convert the rpc `ResourceBounds` to core `ResourceBound` automatically.

When fixing the issue, also found several concerning points:

1. Since `omitempty` takes precedence over the `validate` tag, is there some other fields currently/in the future that might cause the same issue?
2. Since this bug exists for all version of rpc, maintaining multiple rpc directory might not be a good idea, maybe there's a method to better consolidate the different rpc versions?