### PR TITLE
refactor: Make some necessary types and functions public

### DIFF
--- a/consensus/driver/driver.go
+++ b/consensus/driver/driver.go
@@ -1,0 +1,127 @@
+package driver
+
+import (
+	"sync"
+	"time"
+
+	"github.com/NethermindEth/juno/consensus/tendermint"
+)
+
+type timeoutFn func(step tendermint.Step, round tendermint.Round) time.Duration
+
+type Listener[M tendermint.Message[V, H, A], V tendermint.Hashable[H], H tendermint.Hash, A tendermint.Addr] interface {
+	// Listen would return consensus messages to Tendermint which are set by the validator set.
+	Listen() <-chan M
+}
+
+type Broadcaster[M tendermint.Message[V, H, A], V tendermint.Hashable[H], H tendermint.Hash, A tendermint.Addr] interface {
+	// Broadcast will broadcast the message to the whole validator set. The function should not be blocking.
+	Broadcast(M)
+
+	// SendMsg would send a message to a specific validator. This would be required for helping send resquest and
+	// response message to help a specifc validator to catch up.
+	SendMsg(A, M)
+}
+
+type Listeners[V tendermint.Hashable[H], H tendermint.Hash, A tendermint.Addr] struct {
+	ProposalListener  Listener[tendermint.Proposal[V, H, A], V, H, A]
+	PrevoteListener   Listener[tendermint.Prevote[H, A], V, H, A]
+	PrecommitListener Listener[tendermint.Precommit[H, A], V, H, A]
+}
+
+type Broadcasters[V tendermint.Hashable[H], H tendermint.Hash, A tendermint.Addr] struct {
+	ProposalBroadcaster  Broadcaster[tendermint.Proposal[V, H, A], V, H, A]
+	PrevoteBroadcaster   Broadcaster[tendermint.Prevote[H, A], V, H, A]
+	PrecommitBroadcaster Broadcaster[tendermint.Precommit[H, A], V, H, A]
+}
+
+type Driver[V tendermint.Hashable[H], H tendermint.Hash, A tendermint.Addr] struct {
+	stateMachine tendermint.StateMachine[V, H, A]
+
+	getTimeout timeoutFn
+
+	listeners    Listeners[V, H, A]
+	broadcasters Broadcasters[V, H, A]
+
+	scheduledTms map[tendermint.Timeout]*time.Timer
+	timeoutsCh   chan tendermint.Timeout
+
+	wg   sync.WaitGroup
+	quit chan struct{}
+}
+
+func New[V tendermint.Hashable[H], H tendermint.Hash, A tendermint.Addr](
+	stateMachine tendermint.StateMachine[V, H, A],
+	listeners Listeners[V, H, A],
+	broadcasters Broadcasters[V, H, A],
+	getTimeout timeoutFn,
+) *Driver[V, H, A] {
+	return &Driver[V, H, A]{
+		stateMachine: stateMachine,
+		getTimeout:   getTimeout,
+		listeners:    listeners,
+		broadcasters: broadcasters,
+		scheduledTms: make(map[tendermint.Timeout]*time.Timer),
+		timeoutsCh:   make(chan tendermint.Timeout),
+		quit:         make(chan struct{}),
+	}
+}
+
+func (d *Driver[V, H, A]) Start() {
+	d.wg.Add(1)
+	go func() {
+		defer d.wg.Done()
+
+		actions := d.stateMachine.ProcessStart(0)
+		d.execute(actions)
+
+		// Todo: check message signature everytime a message is received.
+		// For the time being it can be assumed the signature is correct.
+
+		for {
+			select {
+			case <-d.quit:
+				return
+			case tm := <-d.timeoutsCh:
+				// Handling of timeouts is priorities over messages
+				delete(d.scheduledTms, tm)
+				actions = d.stateMachine.ProcessTimeout(tm)
+			case p := <-d.listeners.ProposalListener.Listen():
+				actions = d.stateMachine.ProcessProposal(p)
+			case p := <-d.listeners.PrevoteListener.Listen():
+				actions = d.stateMachine.ProcessPrevote(p)
+			case p := <-d.listeners.PrecommitListener.Listen():
+				actions = d.stateMachine.ProcessPrecommit(p)
+			}
+			d.execute(actions)
+		}
+	}()
+}
+
+func (d *Driver[V, H, A]) Stop() {
+	close(d.quit)
+	d.wg.Wait()
+	for _, tm := range d.scheduledTms {
+		tm.Stop()
+	}
+}
+
+func (d *Driver[V, H, A]) execute(actions []tendermint.Action[V, H, A]) {
+	for _, action := range actions {
+		switch action := action.(type) {
+		case *tendermint.BroadcastProposal[V, H, A]:
+			d.broadcasters.ProposalBroadcaster.Broadcast(tendermint.Proposal[V, H, A](*action))
+		case *tendermint.BroadcastPrevote[H, A]:
+			d.broadcasters.PrevoteBroadcaster.Broadcast(tendermint.Prevote[H, A](*action))
+		case *tendermint.BroadcastPrecommit[H, A]:
+			d.broadcasters.PrecommitBroadcaster.Broadcast(tendermint.Precommit[H, A](*action))
+		case *tendermint.ScheduleTimeout:
+			d.scheduledTms[tendermint.Timeout(*action)] = time.AfterFunc(d.getTimeout(action.Step, action.Round), func() {
+				select {
+				case <-d.quit:
+				case d.timeoutsCh <- tendermint.Timeout(*action):
+				}
+			})
+		}
+	}
+}

--- a/consensus/tendermint/action.go
+++ b/consensus/tendermint/action.go
@@ -10,7 +10,7 @@ type BroadcastPrevote[H Hash, A Addr] Prevote[H, A]
 
 type BroadcastPrecommit[H Hash, A Addr] Precommit[H, A]
 
-type ScheduleTimeout timeout
+type ScheduleTimeout Timeout
 
 func (a *BroadcastProposal[V, H, A]) isTendermintAction() {}
 

--- a/consensus/tendermint/action_asserter_test.go
+++ b/consensus/tendermint/action_asserter_test.go
@@ -13,7 +13,7 @@ import (
 // actions is the list of actions that were produced by the state machine after processing the input message.
 type actionAsserter[T any] struct {
 	testing      *testing.T
-	stateMachine *Tendermint[value, felt.Felt, felt.Felt]
+	stateMachine *stateMachine[value, felt.Felt, felt.Felt]
 	inputMessage T
 	actions      []Action[value, felt.Felt, felt.Felt]
 }

--- a/consensus/tendermint/action_builder_test.go
+++ b/consensus/tendermint/action_builder_test.go
@@ -7,8 +7,8 @@ import (
 // actionBuilder is a helper struct to build expected actions as the result of processing messages and timeouts for the state machine.
 type actionBuilder struct {
 	thisNodeAddr felt.Felt
-	actionHeight height
-	actionRound  round
+	actionHeight Height
+	actionRound  Round
 }
 
 func (t actionBuilder) buildMessageHeader() MessageHeader[felt.Felt] {
@@ -16,7 +16,7 @@ func (t actionBuilder) buildMessageHeader() MessageHeader[felt.Felt] {
 }
 
 // broadcastProposal builds and returns a BroadcastProposal action.
-func (t actionBuilder) broadcastProposal(val value, validRound round) Action[value, felt.Felt, felt.Felt] {
+func (t actionBuilder) broadcastProposal(val value, validRound Round) Action[value, felt.Felt, felt.Felt] {
 	return &BroadcastProposal[value, felt.Felt, felt.Felt]{
 		MessageHeader: t.buildMessageHeader(),
 		ValidRound:    validRound,
@@ -41,10 +41,10 @@ func (t actionBuilder) broadcastPrecommit(val *value) Action[value, felt.Felt, f
 }
 
 // scheduleTimeout builds and returns a ScheduleTimeout action.
-func (t actionBuilder) scheduleTimeout(s step) Action[value, felt.Felt, felt.Felt] {
+func (t actionBuilder) scheduleTimeout(s Step) Action[value, felt.Felt, felt.Felt] {
 	return &ScheduleTimeout{
-		s: s,
-		h: t.actionHeight,
-		r: t.actionRound,
+		Step:   s,
+		Height: t.actionHeight,
+		Round:  t.actionRound,
 	}
 }

--- a/consensus/tendermint/assert_utils_test.go
+++ b/consensus/tendermint/assert_utils_test.go
@@ -8,14 +8,14 @@ import (
 )
 
 // assertState asserts that the state machine is in the expected state.
-func assertState(t *testing.T, stateMachine *Tendermint[value, felt.Felt, felt.Felt], expectedHeight height, expectedRound round, expectedStep step) {
+func assertState(t *testing.T, stateMachine *stateMachine[value, felt.Felt, felt.Felt], expectedHeight Height, expectedRound Round, expectedStep Step) {
 	t.Helper()
 	assert.Equal(t, expectedHeight, stateMachine.state.height, "height not equal")
 	assert.Equal(t, expectedRound, stateMachine.state.round, "round not equal")
 	assert.Equal(t, expectedStep, stateMachine.state.step, "step not equal")
 }
 
-func assertMessage[T Message[value, felt.Felt, felt.Felt]](t *testing.T, messages map[height]map[round]map[felt.Felt]T, expectedMsgHeader MessageHeader[felt.Felt], expectedMsg T) {
+func assertMessage[T Message[value, felt.Felt, felt.Felt]](t *testing.T, messages map[Height]map[Round]map[felt.Felt]T, expectedMsgHeader MessageHeader[felt.Felt], expectedMsg T) {
 	t.Helper()
 	assert.Contains(t, messages, expectedMsgHeader.Height, "height not found")
 	assert.Contains(t, messages[expectedMsgHeader.Height], expectedMsgHeader.Round, "round not found")
@@ -24,7 +24,7 @@ func assertMessage[T Message[value, felt.Felt, felt.Felt]](t *testing.T, message
 }
 
 // assertProposal asserts that the proposal message is in the state machine, except when the state machine advanced to the next height.
-func assertProposal(t *testing.T, stateMachine *Tendermint[value, felt.Felt, felt.Felt], expectedMsg Proposal[value, felt.Felt, felt.Felt]) {
+func assertProposal(t *testing.T, stateMachine *stateMachine[value, felt.Felt, felt.Felt], expectedMsg Proposal[value, felt.Felt, felt.Felt]) {
 	t.Helper()
 	// New height will discard the previous height messages.
 	if stateMachine.state.height != expectedMsg.Height {
@@ -34,7 +34,7 @@ func assertProposal(t *testing.T, stateMachine *Tendermint[value, felt.Felt, fel
 }
 
 // assertPrevote asserts that the prevote message is in the state machine, except when the state machine advanced to the next height.
-func assertPrevote(t *testing.T, stateMachine *Tendermint[value, felt.Felt, felt.Felt], expectedMsg Prevote[felt.Felt, felt.Felt]) {
+func assertPrevote(t *testing.T, stateMachine *stateMachine[value, felt.Felt, felt.Felt], expectedMsg Prevote[felt.Felt, felt.Felt]) {
 	t.Helper()
 	// New height will discard the previous height messages.
 	if stateMachine.state.height != expectedMsg.Height {
@@ -44,7 +44,7 @@ func assertPrevote(t *testing.T, stateMachine *Tendermint[value, felt.Felt, felt
 }
 
 // assertPrecommit asserts that the precommit message is in the state machine, except when the state machine advanced to the next height.
-func assertPrecommit(t *testing.T, stateMachine *Tendermint[value, felt.Felt, felt.Felt], expectedMsg Precommit[felt.Felt, felt.Felt]) {
+func assertPrecommit(t *testing.T, stateMachine *stateMachine[value, felt.Felt, felt.Felt], expectedMsg Precommit[felt.Felt, felt.Felt]) {
 	t.Helper()
 	// New height will discard the previous height messages.
 	if stateMachine.state.height != expectedMsg.Height {

--- a/consensus/tendermint/broadcast.go
+++ b/consensus/tendermint/broadcast.go
@@ -2,7 +2,7 @@ package tendermint
 
 import "github.com/NethermindEth/juno/utils"
 
-func (t *Tendermint[V, H, A]) sendProposal(value *V) Action[V, H, A] {
+func (t *stateMachine[V, H, A]) sendProposal(value *V) Action[V, H, A] {
 	proposalMessage := Proposal[V, H, A]{
 		MessageHeader: MessageHeader[A]{
 			Height: t.state.height,
@@ -18,7 +18,7 @@ func (t *Tendermint[V, H, A]) sendProposal(value *V) Action[V, H, A] {
 	return utils.HeapPtr(BroadcastProposal[V, H, A](proposalMessage))
 }
 
-func (t *Tendermint[V, H, A]) setStepAndSendPrevote(id *H) Action[V, H, A] {
+func (t *stateMachine[V, H, A]) setStepAndSendPrevote(id *H) Action[V, H, A] {
 	vote := Prevote[H, A]{
 		MessageHeader: MessageHeader[A]{
 			Height: t.state.height,
@@ -29,12 +29,12 @@ func (t *Tendermint[V, H, A]) setStepAndSendPrevote(id *H) Action[V, H, A] {
 	}
 
 	t.messages.addPrevote(vote)
-	t.state.step = prevote
+	t.state.step = StepPrevote
 
 	return utils.HeapPtr(BroadcastPrevote[H, A](vote))
 }
 
-func (t *Tendermint[V, H, A]) setStepAndSendPrecommit(id *H) Action[V, H, A] {
+func (t *stateMachine[V, H, A]) setStepAndSendPrecommit(id *H) Action[V, H, A] {
 	vote := Precommit[H, A]{
 		MessageHeader: MessageHeader[A]{
 			Height: t.state.height,
@@ -45,7 +45,7 @@ func (t *Tendermint[V, H, A]) setStepAndSendPrecommit(id *H) Action[V, H, A] {
 	}
 
 	t.messages.addPrecommit(vote)
-	t.state.step = precommit
+	t.state.step = StepPrecommit
 
 	return utils.HeapPtr(BroadcastPrecommit[H, A](vote))
 }

--- a/consensus/tendermint/incoming_message_builder_test.go
+++ b/consensus/tendermint/incoming_message_builder_test.go
@@ -10,20 +10,20 @@ import (
 // Each method builds a message, processes it, assert if it's stored in the state machine, and returns an actionAsserter to assert the result actions.
 type incomingMessageBuilder struct {
 	testing      *testing.T
-	stateMachine *Tendermint[value, felt.Felt, felt.Felt]
+	stateMachine *stateMachine[value, felt.Felt, felt.Felt]
 	header       MessageHeader[felt.Felt]
 }
 
 // proposal builds and processes a Proposal message, asserts it's stored in the state machine,
 // and returns an actionAsserter to check resulting actions.
-func (t incomingMessageBuilder) proposal(val value, validRound round) actionAsserter[Proposal[value, felt.Felt, felt.Felt]] {
+func (t incomingMessageBuilder) proposal(val value, validRound Round) actionAsserter[Proposal[value, felt.Felt, felt.Felt]] {
 	t.testing.Helper()
 	proposal := Proposal[value, felt.Felt, felt.Felt]{
 		MessageHeader: t.header,
 		ValidRound:    validRound,
 		Value:         &val,
 	}
-	actions := t.stateMachine.processProposal(proposal)
+	actions := t.stateMachine.ProcessProposal(proposal)
 
 	assertProposal(t.testing, t.stateMachine, proposal)
 
@@ -43,7 +43,7 @@ func (t incomingMessageBuilder) prevote(val *value) actionAsserter[Prevote[felt.
 		MessageHeader: t.header,
 		ID:            getHash(val),
 	}
-	actions := t.stateMachine.processPrevote(prevote)
+	actions := t.stateMachine.ProcessPrevote(prevote)
 
 	assertPrevote(t.testing, t.stateMachine, prevote)
 
@@ -63,7 +63,7 @@ func (t incomingMessageBuilder) precommit(val *value) actionAsserter[Precommit[f
 		MessageHeader: t.header,
 		ID:            getHash(val),
 	}
-	actions := t.stateMachine.processPrecommit(precommit)
+	actions := t.stateMachine.ProcessPrecommit(precommit)
 
 	assertPrecommit(t.testing, t.stateMachine, precommit)
 

--- a/consensus/tendermint/messages.go
+++ b/consensus/tendermint/messages.go
@@ -15,7 +15,7 @@ type Message[V Hashable[H], H Hash, A Addr] interface {
 
 type Proposal[V Hashable[H], H Hash, A Addr] struct {
 	MessageHeader[A]
-	ValidRound round
+	ValidRound Round
 	Value      *V
 }
 
@@ -30,8 +30,8 @@ type Vote[H Hash, A Addr] struct {
 }
 
 type MessageHeader[A Addr] struct {
-	Height height
-	Round  round
+	Height Height
+	Round  Round
 	Sender A
 }
 
@@ -44,22 +44,22 @@ type MessageHeader[A Addr] struct {
 //	How would we keep track of nil votes? In golan map key cannot be nil.
 //	It is not easy to calculate a zero value when dealing with generics.
 type messages[V Hashable[H], H Hash, A Addr] struct {
-	proposals  map[height]map[round]map[A]Proposal[V, H, A]
-	prevotes   map[height]map[round]map[A]Prevote[H, A]
-	precommits map[height]map[round]map[A]Precommit[H, A]
+	proposals  map[Height]map[Round]map[A]Proposal[V, H, A]
+	prevotes   map[Height]map[Round]map[A]Prevote[H, A]
+	precommits map[Height]map[Round]map[A]Precommit[H, A]
 }
 
 func newMessages[V Hashable[H], H Hash, A Addr]() messages[V, H, A] {
 	return messages[V, H, A]{
-		proposals:  make(map[height]map[round]map[A]Proposal[V, H, A]),
-		prevotes:   make(map[height]map[round]map[A]Prevote[H, A]),
-		precommits: make(map[height]map[round]map[A]Precommit[H, A]),
+		proposals:  make(map[Height]map[Round]map[A]Proposal[V, H, A]),
+		prevotes:   make(map[Height]map[Round]map[A]Prevote[H, A]),
+		precommits: make(map[Height]map[Round]map[A]Precommit[H, A]),
 	}
 }
 
-func addMessages[T any, A Addr](storage map[height]map[round]map[A]T, msg T, a A, h height, r round) {
+func addMessages[T any, A Addr](storage map[Height]map[Round]map[A]T, msg T, a A, h Height, r Round) {
 	if _, ok := storage[h]; !ok {
-		storage[h] = make(map[round]map[A]T)
+		storage[h] = make(map[Round]map[A]T)
 	}
 
 	if _, ok := storage[h][r]; !ok {
@@ -84,14 +84,14 @@ func (m *messages[V, H, A]) addPrecommit(p Precommit[H, A]) {
 	addMessages(m.precommits, p, p.Sender, p.Height, p.Round)
 }
 
-func (m *messages[V, H, A]) allMessages(h height, r round) (map[A]Proposal[V, H, A], map[A]Prevote[H, A],
+func (m *messages[V, H, A]) allMessages(h Height, r Round) (map[A]Proposal[V, H, A], map[A]Prevote[H, A],
 	map[A]Precommit[H, A],
 ) {
 	// Todo: Should they be copied?
 	return m.proposals[h][r], m.prevotes[h][r], m.precommits[h][r]
 }
 
-func (m *messages[V, H, A]) deleteHeightMessages(h height) {
+func (m *messages[V, H, A]) deleteHeightMessages(h Height) {
 	delete(m.proposals, h)
 	delete(m.prevotes, h)
 	delete(m.precommits, h)

--- a/consensus/tendermint/process.go
+++ b/consensus/tendermint/process.go
@@ -1,22 +1,22 @@
 package tendermint
 
-func (t *Tendermint[V, H, A]) processStart(round round) []Action[V, H, A] {
+func (t *stateMachine[V, H, A]) ProcessStart(round Round) []Action[V, H, A] {
 	return t.processLoop(t.startRound(round), nil)
 }
 
-func (t *Tendermint[V, H, A]) processProposal(p Proposal[V, H, A]) []Action[V, H, A] {
+func (t *stateMachine[V, H, A]) ProcessProposal(p Proposal[V, H, A]) []Action[V, H, A] {
 	return t.processMessage(p.MessageHeader, func() { t.messages.addProposal(p) })
 }
 
-func (t *Tendermint[V, H, A]) processPrevote(p Prevote[H, A]) []Action[V, H, A] {
+func (t *stateMachine[V, H, A]) ProcessPrevote(p Prevote[H, A]) []Action[V, H, A] {
 	return t.processMessage(p.MessageHeader, func() { t.messages.addPrevote(p) })
 }
 
-func (t *Tendermint[V, H, A]) processPrecommit(p Precommit[H, A]) []Action[V, H, A] {
+func (t *stateMachine[V, H, A]) ProcessPrecommit(p Precommit[H, A]) []Action[V, H, A] {
 	return t.processMessage(p.MessageHeader, func() { t.messages.addPrecommit(p) })
 }
 
-func (t *Tendermint[V, H, A]) processMessage(header MessageHeader[A], addMessage func()) []Action[V, H, A] {
+func (t *stateMachine[V, H, A]) processMessage(header MessageHeader[A], addMessage func()) []Action[V, H, A] {
 	if !t.preprocessMessage(header, addMessage) {
 		return nil
 	}
@@ -24,20 +24,20 @@ func (t *Tendermint[V, H, A]) processMessage(header MessageHeader[A], addMessage
 	return t.processLoop(nil, &header.Round)
 }
 
-func (t *Tendermint[V, H, A]) processTimeout(tm timeout) []Action[V, H, A] {
-	switch tm.s {
-	case propose:
-		return t.processLoop(t.onTimeoutPropose(tm.h, tm.r), nil)
-	case prevote:
-		return t.processLoop(t.onTimeoutPrevote(tm.h, tm.r), nil)
-	case precommit:
-		return t.processLoop(t.onTimeoutPrecommit(tm.h, tm.r), nil)
+func (t *stateMachine[V, H, A]) ProcessTimeout(tm Timeout) []Action[V, H, A] {
+	switch tm.Step {
+	case StepPropose:
+		return t.processLoop(t.onTimeoutPropose(tm.Height, tm.Round), nil)
+	case StepPrevote:
+		return t.processLoop(t.onTimeoutPrevote(tm.Height, tm.Round), nil)
+	case StepPrecommit:
+		return t.processLoop(t.onTimeoutPrecommit(tm.Height, tm.Round), nil)
 	}
 
 	return nil
 }
 
-func (t *Tendermint[V, H, A]) processLoop(action Action[V, H, A], recentlyReceivedRound *round) []Action[V, H, A] {
+func (t *stateMachine[V, H, A]) processLoop(action Action[V, H, A], recentlyReceivedRound *Round) []Action[V, H, A] {
 	actions := []Action[V, H, A]{}
 	if action != nil {
 		actions = append(actions, action)
@@ -52,7 +52,7 @@ func (t *Tendermint[V, H, A]) processLoop(action Action[V, H, A], recentlyReceiv
 	return actions
 }
 
-func (t *Tendermint[V, H, A]) process(recentlyReceivedRound *round) Action[V, H, A] {
+func (t *stateMachine[V, H, A]) process(recentlyReceivedRound *Round) Action[V, H, A] {
 	cachedProposal := t.findProposal(t.state.round)
 
 	var roundCachedProposal *CachedProposal[V, H, A]

--- a/consensus/tendermint/rule_commit_value.go
+++ b/consensus/tendermint/rule_commit_value.go
@@ -16,7 +16,7 @@ height and round.
 There is no need to check decision_p[h_p] = nil since it is implied that decision are made
 sequentially, i.e. x, x+1, x+2... .
 */
-func (t *Tendermint[V, H, A]) uponCommitValue(cachedProposal *CachedProposal[V, H, A]) bool {
+func (t *stateMachine[V, H, A]) uponCommitValue(cachedProposal *CachedProposal[V, H, A]) bool {
 	_, hasQuorum := t.checkForQuorumPrecommit(cachedProposal.Round, *cachedProposal.ID)
 
 	// This is checked here instead of inside execution, because it's the only case in execution in this rule
@@ -26,7 +26,7 @@ func (t *Tendermint[V, H, A]) uponCommitValue(cachedProposal *CachedProposal[V, 
 	return hasQuorum && isValid
 }
 
-func (t *Tendermint[V, H, A]) doCommitValue(cachedProposal *CachedProposal[V, H, A]) Action[V, H, A] {
+func (t *stateMachine[V, H, A]) doCommitValue(cachedProposal *CachedProposal[V, H, A]) Action[V, H, A] {
 	// TODO: Optimise this
 	precommits, _ := t.checkForQuorumPrecommit(cachedProposal.Round, *cachedProposal.ID)
 	t.blockchain.Commit(t.state.height, *cachedProposal.Value, precommits)

--- a/consensus/tendermint/rule_commit_value_test.go
+++ b/consensus/tendermint/rule_commit_value_test.go
@@ -17,22 +17,22 @@ func TestCommitValue(t *testing.T) {
 		committedValue := value(10)
 
 		currentRound.start().expectActions(
-			currentRound.action().scheduleTimeout(propose),
+			currentRound.action().scheduleTimeout(StepPropose),
 		)
 		val0Precommit := currentRound.validator(0).precommit(&committedValue).inputMessage
 		val1Precommit := currentRound.validator(1).precommit(&committedValue).inputMessage
 		val2Precommit := currentRound.validator(2).precommit(&committedValue).expectActions(
-			currentRound.action().scheduleTimeout(precommit),
+			currentRound.action().scheduleTimeout(StepPrecommit),
 		).inputMessage
 		assert.True(t, stateMachine.state.timeoutPrecommitScheduled)
 
 		currentRound.validator(0).proposal(committedValue, -1).expectActions(
 			currentRound.action().broadcastPrevote(&committedValue),
-			nextRound.action().scheduleTimeout(propose),
+			nextRound.action().scheduleTimeout(StepPropose),
 		)
 		assert.False(t, stateMachine.state.timeoutPrecommitScheduled)
 
-		assertState(t, stateMachine, height(1), round(0), propose)
+		assertState(t, stateMachine, Height(1), Round(0), StepPropose)
 
 		// TODO: This is a workaround to get the chain. Find a better way to do this.
 		chain := stateMachine.blockchain.(*chain)
@@ -55,18 +55,18 @@ func TestCommitValue(t *testing.T) {
 		committedValue := value(10)
 
 		currentRound.start().expectActions(
-			currentRound.action().scheduleTimeout(propose),
+			currentRound.action().scheduleTimeout(StepPropose),
 		)
 
 		val0Precommit := currentRound.validator(0).precommit(&committedValue).inputMessage
 		currentRound.validator(0).proposal(committedValue, -1)
 		val1Precommit := currentRound.validator(1).precommit(&committedValue).inputMessage
 		val2Precommit := currentRound.validator(2).precommit(&committedValue).expectActions(
-			currentRound.action().scheduleTimeout(precommit),
-			nextRound.action().scheduleTimeout(propose),
+			currentRound.action().scheduleTimeout(StepPrecommit),
+			nextRound.action().scheduleTimeout(StepPropose),
 		).inputMessage
 
-		assertState(t, stateMachine, height(1), round(0), propose)
+		assertState(t, stateMachine, Height(1), Round(0), StepPropose)
 
 		// TODO: This is a workaround to get the chain. Find a better way to do this.
 		chain := stateMachine.blockchain.(*chain)

--- a/consensus/tendermint/rule_first_proposal.go
+++ b/consensus/tendermint/rule_first_proposal.go
@@ -12,11 +12,11 @@ Check the upon condition on line 22:
 
 Since the value's id is expected to be unique the id can be used to compare the values.
 */
-func (t *Tendermint[V, H, A]) uponFirstProposal(cachedProposal *CachedProposal[V, H, A]) bool {
-	return cachedProposal.ValidRound == -1 && t.state.step == propose
+func (t *stateMachine[V, H, A]) uponFirstProposal(cachedProposal *CachedProposal[V, H, A]) bool {
+	return cachedProposal.ValidRound == -1 && t.state.step == StepPropose
 }
 
-func (t *Tendermint[V, H, A]) doFirstProposal(cachedProposal *CachedProposal[V, H, A]) Action[V, H, A] {
+func (t *stateMachine[V, H, A]) doFirstProposal(cachedProposal *CachedProposal[V, H, A]) Action[V, H, A] {
 	shouldVoteForValue := cachedProposal.Valid &&
 		(t.state.lockedRound == -1 ||
 			t.state.lockedValue != nil && (*t.state.lockedValue).Hash() == *cachedProposal.ID)

--- a/consensus/tendermint/rule_first_proposal_test.go
+++ b/consensus/tendermint/rule_first_proposal_test.go
@@ -20,7 +20,7 @@ func TestFirstProposal(t *testing.T) {
 		currentRound.validator(0).proposal(proposalValue, -1).expectActions(currentRound.action().broadcastPrevote(&proposalValue))
 
 		// Assertions - We should be in prevote step
-		assertState(t, stateMachine, height(0), round(0), prevote)
+		assertState(t, stateMachine, Height(0), Round(0), StepPrevote)
 	})
 
 	t.Run("Line 22: valid proposal with lockedValue matching proposal should prevote for proposal", func(t *testing.T) {
@@ -37,22 +37,22 @@ func TestFirstProposal(t *testing.T) {
 		previousRound.validator(0).prevote(utils.HeapPtr(expectedValue))
 		previousRound.validator(1).prevote(nil)
 		previousRound.validator(2).prevote(utils.HeapPtr(expectedValue))
-		assertState(t, stateMachine, height(0), round(0), precommit)
+		assertState(t, stateMachine, Height(0), Round(0), StepPrecommit)
 
 		// Validator 0 stays silent in the precommit step
 		previousRound.validator(1).precommit(nil)
 		previousRound.validator(2).precommit(utils.HeapPtr(expectedValue))
-		assertState(t, stateMachine, height(0), round(0), precommit)
+		assertState(t, stateMachine, Height(0), Round(0), StepPrecommit)
 		assert.Equal(t, &expectedValue, stateMachine.state.lockedValue)
-		assert.Equal(t, round(0), stateMachine.state.lockedRound)
+		assert.Equal(t, Round(0), stateMachine.state.lockedRound)
 
 		// Precommit timeout
-		previousRound.processTimeout(precommit)
+		previousRound.processTimeout(StepPrecommit)
 
 		// Validator 1 coincidentally proposes the same expected value with lockedRound = -1,
 		// even if it hasn't received a proposal in the previous round.
 		nextRound.validator(1).proposal(expectedValue, -1).expectActions(nextRound.action().broadcastPrevote(&expectedValue))
-		assertState(t, stateMachine, height(0), round(1), prevote)
+		assertState(t, stateMachine, Height(0), Round(1), StepPrevote)
 	})
 
 	t.Run("Line 22: valid proposal with lockedValue not matching proposal should prevote nil", func(t *testing.T) {
@@ -69,21 +69,21 @@ func TestFirstProposal(t *testing.T) {
 		previousRound.validator(0).prevote(utils.HeapPtr(expectedValue))
 		previousRound.validator(1).prevote(nil)
 		previousRound.validator(2).prevote(utils.HeapPtr(expectedValue))
-		assertState(t, stateMachine, height(0), round(0), precommit)
+		assertState(t, stateMachine, Height(0), Round(0), StepPrecommit)
 
 		// Validator 0 stays silent in the precommit step
 		previousRound.validator(1).precommit(nil)
 		previousRound.validator(2).precommit(utils.HeapPtr(expectedValue))
-		assertState(t, stateMachine, height(0), round(0), precommit)
+		assertState(t, stateMachine, Height(0), Round(0), StepPrecommit)
 		assert.Equal(t, &expectedValue, stateMachine.state.lockedValue)
-		assert.Equal(t, round(0), stateMachine.state.lockedRound)
+		assert.Equal(t, Round(0), stateMachine.state.lockedRound)
 
 		// Precommit timeout
-		previousRound.processTimeout(precommit)
+		previousRound.processTimeout(StepPrecommit)
 
 		// Validator 1 proposes an unexpected value, because it hasn't received a proposal in the previous round.
 		nextRound.validator(1).proposal(value(43), -1).expectActions(nextRound.action().broadcastPrevote(nil))
-		assertState(t, stateMachine, height(0), round(1), prevote)
+		assertState(t, stateMachine, Height(0), Round(1), StepPrevote)
 	})
 
 	t.Run("Line 22: invalid proposal should prevote nil", func(t *testing.T) {
@@ -97,7 +97,7 @@ func TestFirstProposal(t *testing.T) {
 		currentRound.validator(0).proposal(value(1e9), -1).expectActions(currentRound.action().broadcastPrevote(nil))
 
 		// Assertions - We should be in prevote step
-		assertState(t, stateMachine, height(0), round(0), prevote)
+		assertState(t, stateMachine, Height(0), Round(0), StepPrevote)
 	})
 
 	t.Run("Line 22: proposal received when not in propose step should do nothing", func(t *testing.T) {
@@ -108,17 +108,17 @@ func TestFirstProposal(t *testing.T) {
 		currentRound.start()
 
 		// Proposal timeout
-		currentRound.processTimeout(propose)
+		currentRound.processTimeout(StepPropose)
 
 		// Receive 2 more prevotes, move to precommit step
 		currentRound.validator(1).prevote(nil)
 		currentRound.validator(2).prevote(nil)
-		assertState(t, stateMachine, height(0), round(0), precommit)
+		assertState(t, stateMachine, Height(0), Round(0), StepPrecommit)
 
 		// Receive a proposal while not in propose step
 		currentRound.validator(0).proposal(value(42), -1).expectActions()
 
 		// Assertions - We should still be in precommit step, nothing changed
-		assertState(t, stateMachine, height(0), round(0), precommit)
+		assertState(t, stateMachine, Height(0), Round(0), StepPrecommit)
 	})
 }

--- a/consensus/tendermint/rule_polka_any.go
+++ b/consensus/tendermint/rule_polka_any.go
@@ -11,7 +11,7 @@ Check the upon condition on line 34:
 	34: upon 2f + 1 {PREVOTE, h_p, round_p, ∗} while step_p = prevote for the first time do
 	35: schedule OnTimeoutPrevote(h_p, round_p) to be executed after timeoutPrevote(round_p)
 */
-func (t *Tendermint[V, H, A]) uponPolkaAny() bool {
+func (t *stateMachine[V, H, A]) uponPolkaAny() bool {
 	prevotes := t.messages.prevotes[t.state.height][t.state.round]
 	vals := slices.Collect(maps.Keys(prevotes))
 
@@ -19,12 +19,12 @@ func (t *Tendermint[V, H, A]) uponPolkaAny() bool {
 
 	hasQuorum := t.validatorSetVotingPower(vals) >= q(t.validators.TotalVotingPower(t.state.height))
 
-	return t.state.step == prevote &&
+	return t.state.step == StepPrevote &&
 		hasQuorum &&
 		isFirstTime
 }
 
-func (t *Tendermint[V, H, A]) doPolkaAny() Action[V, H, A] {
+func (t *stateMachine[V, H, A]) doPolkaAny() Action[V, H, A] {
 	t.state.timeoutPrevoteScheduled = true
-	return t.scheduleTimeout(prevote)
+	return t.scheduleTimeout(StepPrevote)
 }

--- a/consensus/tendermint/rule_polka_any_test.go
+++ b/consensus/tendermint/rule_polka_any_test.go
@@ -20,11 +20,11 @@ func TestPolkaAny(t *testing.T) {
 
 		// Receive 2 more prevotes combined with our own prevote, all in mixed value
 		currentRound.validator(1).prevote(nil)
-		currentRound.validator(2).prevote(utils.HeapPtr(value(44))).expectActions(currentRound.action().scheduleTimeout(prevote))
+		currentRound.validator(2).prevote(utils.HeapPtr(value(44))).expectActions(currentRound.action().scheduleTimeout(StepPrevote))
 		assert.True(t, stateMachine.state.timeoutPrevoteScheduled)
 
 		// Assertions - We should still be in prevote step, but timeout should be scheduled
-		assertState(t, stateMachine, height(0), round(0), prevote)
+		assertState(t, stateMachine, Height(0), Round(0), StepPrevote)
 	})
 
 	t.Run("Line 34: not enough prevotes (less than 2f + 1)", func(t *testing.T) {
@@ -41,7 +41,7 @@ func TestPolkaAny(t *testing.T) {
 		currentRound.validator(0).prevote(utils.HeapPtr(value(42)))
 
 		// No action should be taken
-		assertState(t, stateMachine, height(0), round(0), prevote)
+		assertState(t, stateMachine, Height(0), Round(0), StepPrevote)
 	})
 
 	t.Run("Line 34: enough prevotes but not in prevote step", func(t *testing.T) {
@@ -57,7 +57,7 @@ func TestPolkaAny(t *testing.T) {
 		currentRound.validator(2).prevote(utils.HeapPtr(value(44))).expectActions()
 
 		// Assertions - still in propose step, no timeout should be scheduled
-		assertState(t, stateMachine, height(0), round(0), propose)
+		assertState(t, stateMachine, Height(0), Round(0), StepPropose)
 	})
 
 	t.Run("Line 34: only schedule timeout the first time", func(t *testing.T) {
@@ -72,7 +72,7 @@ func TestPolkaAny(t *testing.T) {
 
 		// Receive 2 prevotes, combined with our own prevote and schedule timeout for prevote
 		currentRound.validator(0).prevote(nil).expectActions()
-		currentRound.validator(1).prevote(utils.HeapPtr(value(43))).expectActions(currentRound.action().scheduleTimeout(prevote))
+		currentRound.validator(1).prevote(utils.HeapPtr(value(43))).expectActions(currentRound.action().scheduleTimeout(StepPrevote))
 		assert.True(t, stateMachine.state.timeoutPrevoteScheduled)
 
 		// Receive 1 more prevote, no timeout should be scheduled
@@ -80,6 +80,6 @@ func TestPolkaAny(t *testing.T) {
 		assert.True(t, stateMachine.state.timeoutPrevoteScheduled)
 
 		// Assertions - We should still be in prevote step
-		assertState(t, stateMachine, height(0), round(0), prevote)
+		assertState(t, stateMachine, Height(0), Round(0), StepPrevote)
 	})
 }

--- a/consensus/tendermint/rule_polka_nil.go
+++ b/consensus/tendermint/rule_polka_nil.go
@@ -9,7 +9,7 @@ Check the upon condition on line 44:
 
 Line 36 and 44 for a round are mutually exclusive.
 */
-func (t *Tendermint[V, H, A]) uponPolkaNil() bool {
+func (t *stateMachine[V, H, A]) uponPolkaNil() bool {
 	prevotes := t.messages.prevotes[t.state.height][t.state.round]
 
 	var vals []A
@@ -22,9 +22,9 @@ func (t *Tendermint[V, H, A]) uponPolkaNil() bool {
 	// TODO: refactor this
 	hasQuorum := t.validatorSetVotingPower(vals) >= q(t.validators.TotalVotingPower(t.state.height))
 
-	return hasQuorum && t.state.step == prevote
+	return hasQuorum && t.state.step == StepPrevote
 }
 
-func (t *Tendermint[V, H, A]) doPolkaNil() Action[V, H, A] {
+func (t *stateMachine[V, H, A]) doPolkaNil() Action[V, H, A] {
 	return t.setStepAndSendPrecommit(nil)
 }

--- a/consensus/tendermint/rule_polka_nil_test.go
+++ b/consensus/tendermint/rule_polka_nil_test.go
@@ -21,7 +21,7 @@ func TestPolkaNil(t *testing.T) {
 		currentRound.validator(2).prevote(nil).expectActions(currentRound.action().broadcastPrecommit(nil))
 
 		// Assertions - We should be in precommit step
-		assertState(t, stateMachine, height(0), round(0), precommit)
+		assertState(t, stateMachine, Height(0), Round(0), StepPrecommit)
 	})
 
 	t.Run("Line 44: upon 2f + 1 {PREVOTE, h_p, round_p, nil} from other nodes broadcast nil precommit", func(t *testing.T) {
@@ -32,17 +32,17 @@ func TestPolkaNil(t *testing.T) {
 		currentRound.start()
 
 		// Timeout proposal
-		currentRound.processTimeout(propose)
+		currentRound.processTimeout(StepPropose)
 
 		// Receive 2 prevotes, combined with our own prevote due to proposal timeout
 		currentRound.validator(0).prevote(nil)
 		currentRound.validator(1).prevote(nil).expectActions(
-			currentRound.action().scheduleTimeout(prevote),
+			currentRound.action().scheduleTimeout(StepPrevote),
 			currentRound.action().broadcastPrecommit(nil),
 		)
 
 		// Assertions - We should be in precommit step
-		assertState(t, stateMachine, height(0), round(0), precommit)
+		assertState(t, stateMachine, Height(0), Round(0), StepPrecommit)
 	})
 
 	t.Run("Line 44: not enough nil prevotes (less than 2f + 1)", func(t *testing.T) {
@@ -57,11 +57,11 @@ func TestPolkaNil(t *testing.T) {
 
 		// Receive 2 prevotes
 		currentRound.validator(0).prevote(nil)
-		currentRound.validator(1).prevote(nil).expectActions(currentRound.action().scheduleTimeout(prevote))
+		currentRound.validator(1).prevote(nil).expectActions(currentRound.action().scheduleTimeout(StepPrevote))
 
 		// Assertions - Only 2 validators prevote nil (not enough for 2f+1 where f=1)
 		// No expected precommit action should occur
-		assertState(t, stateMachine, height(0), round(0), prevote)
+		assertState(t, stateMachine, Height(0), Round(0), StepPrevote)
 	})
 
 	t.Run("Line 44: enough nil prevotes but not in prevote step", func(t *testing.T) {
@@ -77,7 +77,7 @@ func TestPolkaNil(t *testing.T) {
 		currentRound.validator(2).prevote(nil)
 
 		// Assertions - we should still be in propose step
-		assertState(t, stateMachine, height(0), round(0), propose)
+		assertState(t, stateMachine, Height(0), Round(0), StepPropose)
 	})
 
 	t.Run("Line 44: mixed prevotes (some nil, some with value)", func(t *testing.T) {
@@ -99,6 +99,6 @@ func TestPolkaNil(t *testing.T) {
 		currentRound.validator(2).prevote(&val)
 
 		// No precommit action should occur with mixed votes
-		assertState(t, stateMachine, height(0), round(0), prevote)
+		assertState(t, stateMachine, Height(0), Round(0), StepPrevote)
 	})
 }

--- a/consensus/tendermint/rule_precommit_any.go
+++ b/consensus/tendermint/rule_precommit_any.go
@@ -11,7 +11,7 @@ Check the upon condition on line 47:
 	47: upon 2f + 1 {PRECOMMIT, h_p, round_p, ∗} for the first time do
 	48: schedule OnTimeoutPrecommit(h_p , round_p) to be executed after timeoutPrecommit(round_p)
 */
-func (t *Tendermint[V, H, A]) uponPrecommitAny() bool {
+func (t *stateMachine[V, H, A]) uponPrecommitAny() bool {
 	precommits := t.messages.precommits[t.state.height][t.state.round]
 	vals := slices.Collect(maps.Keys(precommits))
 
@@ -22,7 +22,7 @@ func (t *Tendermint[V, H, A]) uponPrecommitAny() bool {
 	return hasQuorum && isFirstTime
 }
 
-func (t *Tendermint[V, H, A]) doPrecommitAny() Action[V, H, A] {
+func (t *stateMachine[V, H, A]) doPrecommitAny() Action[V, H, A] {
 	t.state.timeoutPrecommitScheduled = true
-	return t.scheduleTimeout(precommit)
+	return t.scheduleTimeout(StepPrecommit)
 }

--- a/consensus/tendermint/rule_precommit_any_test.go
+++ b/consensus/tendermint/rule_precommit_any_test.go
@@ -23,10 +23,10 @@ func TestPrecommitAny(t *testing.T) {
 
 		// Receive 2 more precommits combined with our own precommit, all with mixed values
 		currentRound.validator(0).precommit(utils.HeapPtr(value(42)))
-		currentRound.validator(1).precommit(nil).expectActions(currentRound.action().scheduleTimeout(precommit))
+		currentRound.validator(1).precommit(nil).expectActions(currentRound.action().scheduleTimeout(StepPrecommit))
 
 		assert.True(t, stateMachine.state.timeoutPrecommitScheduled)
-		assertState(t, stateMachine, height(0), round(0), precommit)
+		assertState(t, stateMachine, Height(0), Round(0), StepPrecommit)
 	})
 
 	t.Run("Line 47: upon 2f + 1 {PRECOMMIT, h_p, round_p, *} without receiving proposal", func(t *testing.T) {
@@ -39,10 +39,10 @@ func TestPrecommitAny(t *testing.T) {
 		// Receive 3 precommits even though we haven't received a proposal.
 		currentRound.validator(0).precommit(utils.HeapPtr(value(42)))
 		currentRound.validator(1).precommit(nil)
-		currentRound.validator(2).precommit(utils.HeapPtr(value(43))).expectActions(currentRound.action().scheduleTimeout(precommit))
+		currentRound.validator(2).precommit(utils.HeapPtr(value(43))).expectActions(currentRound.action().scheduleTimeout(StepPrecommit))
 
 		assert.True(t, stateMachine.state.timeoutPrecommitScheduled)
-		assertState(t, stateMachine, height(0), round(0), propose)
+		assertState(t, stateMachine, Height(0), Round(0), StepPropose)
 	})
 
 	t.Run("Line 47: not enough precommits (less than 2f + 1)", func(t *testing.T) {
@@ -62,7 +62,7 @@ func TestPrecommitAny(t *testing.T) {
 
 		// No timeout should be scheduled
 		assert.False(t, stateMachine.state.timeoutPrecommitScheduled)
-		assertState(t, stateMachine, height(0), round(0), precommit)
+		assertState(t, stateMachine, Height(0), Round(0), StepPrecommit)
 	})
 
 	t.Run("Line 47: only schedule timeout the first time", func(t *testing.T) {
@@ -79,20 +79,20 @@ func TestPrecommitAny(t *testing.T) {
 		)
 		currentRound.validator(0).prevote(utils.HeapPtr(value(42)))
 		currentRound.validator(1).prevote(utils.HeapPtr(value(42))).expectActions(
-			currentRound.action().scheduleTimeout(prevote),
+			currentRound.action().scheduleTimeout(StepPrevote),
 			currentRound.action().broadcastPrecommit(utils.HeapPtr(value(42))),
 		)
 		assert.False(t, stateMachine.state.timeoutPrecommitScheduled)
-		assertState(t, stateMachine, height(0), round(0), precommit)
+		assertState(t, stateMachine, Height(0), Round(0), StepPrecommit)
 
 		// Receive 2 precommits, combined with our own precommit and schedule timeout
 		currentRound.validator(0).precommit(nil)
-		currentRound.validator(1).precommit(utils.HeapPtr(value(42))).expectActions(currentRound.action().scheduleTimeout(precommit))
+		currentRound.validator(1).precommit(utils.HeapPtr(value(42))).expectActions(currentRound.action().scheduleTimeout(StepPrecommit))
 		assert.True(t, stateMachine.state.timeoutPrecommitScheduled)
-		assertState(t, stateMachine, height(0), round(0), precommit)
+		assertState(t, stateMachine, Height(0), Round(0), StepPrecommit)
 
 		currentRound.validator(2).precommit(nil).expectActions()
 		assert.True(t, stateMachine.state.timeoutPrecommitScheduled)
-		assertState(t, stateMachine, height(0), round(0), precommit)
+		assertState(t, stateMachine, Height(0), Round(0), StepPrecommit)
 	})
 }

--- a/consensus/tendermint/rule_proposal_and_polka_current.go
+++ b/consensus/tendermint/rule_proposal_and_polka_current.go
@@ -13,18 +13,18 @@ Check upon condition on line 36:
 	42: validValue_p ← v
 	43: validRound_p ← round_p
 */
-func (t *Tendermint[V, H, A]) uponProposalAndPolkaCurrent(cachedProposal *CachedProposal[V, H, A]) bool {
+func (t *stateMachine[V, H, A]) uponProposalAndPolkaCurrent(cachedProposal *CachedProposal[V, H, A]) bool {
 	hasQuorum := t.checkQuorumPrevotesGivenProposalVID(t.state.round, *cachedProposal.ID)
 	firstTime := !t.state.lockedValueAndOrValidValueSet
 	return hasQuorum &&
 		cachedProposal.Valid &&
-		t.state.step >= prevote &&
+		t.state.step >= StepPrevote &&
 		firstTime
 }
 
-func (t *Tendermint[V, H, A]) doProposalAndPolkaCurrent(cachedProposal *CachedProposal[V, H, A]) Action[V, H, A] {
+func (t *stateMachine[V, H, A]) doProposalAndPolkaCurrent(cachedProposal *CachedProposal[V, H, A]) Action[V, H, A] {
 	var action Action[V, H, A]
-	if t.state.step == prevote {
+	if t.state.step == StepPrevote {
 		t.state.lockedValue = cachedProposal.Value
 		t.state.lockedRound = t.state.round
 		action = t.setStepAndSendPrecommit(cachedProposal.ID)

--- a/consensus/tendermint/rule_proposal_and_polka_previous.go
+++ b/consensus/tendermint/rule_proposal_and_polka_previous.go
@@ -11,16 +11,16 @@ Check the upon condition on line 28:
 	32:  	broadcast {PREVOTE, hp, round_p, nil}
 	33: step_p ← prevote
 */
-func (t *Tendermint[V, H, A]) uponProposalAndPolkaPrevious(cachedProposal *CachedProposal[V, H, A]) bool {
+func (t *stateMachine[V, H, A]) uponProposalAndPolkaPrevious(cachedProposal *CachedProposal[V, H, A]) bool {
 	vr := cachedProposal.ValidRound
 	hasQuorum := t.checkQuorumPrevotesGivenProposalVID(vr, *cachedProposal.ID)
 	return hasQuorum &&
-		t.state.step == propose &&
+		t.state.step == StepPropose &&
 		vr >= 0 &&
 		vr < t.state.round
 }
 
-func (t *Tendermint[V, H, A]) doProposalAndPolkaPrevious(cachedProposal *CachedProposal[V, H, A]) Action[V, H, A] {
+func (t *stateMachine[V, H, A]) doProposalAndPolkaPrevious(cachedProposal *CachedProposal[V, H, A]) Action[V, H, A] {
 	var votedID *H
 	shouldVoteForValue := cachedProposal.Valid &&
 		(t.state.lockedRound <= cachedProposal.ValidRound ||

--- a/consensus/tendermint/rule_proposal_and_polka_previous_test.go
+++ b/consensus/tendermint/rule_proposal_and_polka_previous_test.go
@@ -27,10 +27,10 @@ func TestProposalAndPolkaPrevious(t *testing.T) {
 		firstRound.validator(2).prevote(&correctValue)
 		firstRound.validator(1).precommit(&correctValue)
 		firstRound.validator(2).precommit(&correctValue)
-		firstRound.processTimeout(prevote)
-		firstRound.processTimeout(precommit)
+		firstRound.processTimeout(StepPrevote)
+		firstRound.processTimeout(StepPrecommit)
 
-		assertState(t, stateMachine, height(0), round(1), propose)
+		assertState(t, stateMachine, Height(0), Round(1), StepPropose)
 
 		// In the 2nd round, validator 1 proposes the correct value with valid round set to the 1st round.
 		// We accept and prevote it because we receive quorum of prevotes in the 1st round.
@@ -73,7 +73,7 @@ func TestProposalAndPolkaPrevious(t *testing.T) {
 		firstRound.validator(0).proposal(firstValue, -1).expectActions(
 			firstRound.action().broadcastPrevote(&firstValue),
 		)
-		assertState(t, stateMachine, height(0), round(0), prevote)
+		assertState(t, stateMachine, Height(0), Round(0), StepPrevote)
 		firstRound.validator(0).prevote(&firstValue)
 
 		// Validator 2 receives no proposal
@@ -84,15 +84,15 @@ func TestProposalAndPolkaPrevious(t *testing.T) {
 			firstRound.action().broadcastPrecommit(&firstValue),
 		)
 		assert.Equal(t, stateMachine.state.lockedValue, &firstValue)
-		assertState(t, stateMachine, height(0), round(0), precommit)
+		assertState(t, stateMachine, Height(0), Round(0), StepPrecommit)
 
 		// Validator 0 sends prevote nil to validator 1, so validator 1 will precommit nil.
 		firstRound.validator(1).precommit(nil)
 		firstRound.validator(2).precommit(nil)
-		firstRound.processTimeout(precommit)
+		firstRound.processTimeout(StepPrecommit)
 
 		assert.Equal(t, stateMachine.state.lockedValue, &firstValue)
-		assertState(t, stateMachine, height(0), round(1), propose)
+		assertState(t, stateMachine, Height(0), Round(1), StepPropose)
 
 		// In the second round, validator 1 proposes a different value, because it didn't lock to the previous value.
 		// We reject it because we locked to the previous value.
@@ -101,9 +101,9 @@ func TestProposalAndPolkaPrevious(t *testing.T) {
 		)
 		secondRound.validator(1).prevote(&secondValue)
 		secondRound.validator(2).prevote(&secondValue).expectActions(
-			secondRound.action().scheduleTimeout(prevote),
+			secondRound.action().scheduleTimeout(StepPrevote),
 		)
-		secondRound.processTimeout(prevote).expectActions(
+		secondRound.processTimeout(StepPrevote).expectActions(
 			secondRound.action().broadcastPrecommit(nil),
 		)
 		// Validator 0 delays sending the prevote so we can only receives after timeout.
@@ -112,10 +112,10 @@ func TestProposalAndPolkaPrevious(t *testing.T) {
 		// Then validator 0 stays silent during the precommit phase.
 		secondRound.validator(1).precommit(&secondValue)
 		secondRound.validator(2).precommit(&secondValue)
-		secondRound.processTimeout(precommit)
+		secondRound.processTimeout(StepPrecommit)
 
 		assert.Equal(t, stateMachine.state.lockedValue, &firstValue)
-		assertState(t, stateMachine, height(0), round(2), propose)
+		assertState(t, stateMachine, Height(0), Round(2), StepPropose)
 
 		// In the third round, validator 2 proposes value from second round. We accept it
 		thirdRound.validator(2).proposal(secondValue, 1).expectActions(

--- a/consensus/tendermint/rule_skip_round.go
+++ b/consensus/tendermint/rule_skip_round.go
@@ -13,7 +13,7 @@ Check the upon condition on line 55:
 
 If there are f + 1 messages from a newer round, there is at least an honest node in that round.
 */
-func (t *Tendermint[V, H, A]) uponSkipRound(futureR round) bool {
+func (t *stateMachine[V, H, A]) uponSkipRound(futureR Round) bool {
 	vals := make(map[A]struct{})
 	proposals, prevotes, precommits := t.messages.allMessages(t.state.height, futureR)
 
@@ -37,6 +37,6 @@ func (t *Tendermint[V, H, A]) uponSkipRound(futureR round) bool {
 	return isNewerRound && hasQuorum
 }
 
-func (t *Tendermint[V, H, A]) doSkipRound(futureR round) Action[V, H, A] {
+func (t *stateMachine[V, H, A]) doSkipRound(futureR Round) Action[V, H, A] {
 	return t.startRound(futureR)
 }

--- a/consensus/tendermint/rule_skip_round_test.go
+++ b/consensus/tendermint/rule_skip_round_test.go
@@ -5,47 +5,47 @@ import "testing"
 func TestSkipRound(t *testing.T) {
 	t.Run("Line 55 (Proposal): Start round r' when f+1 future round messages are received from round r'", func(t *testing.T) {
 		stateMachine := setupStateMachine(t, 4, 3)
-		expectedHeight := height(0)
-		rPrime, rPrimeVal := round(4), value(10)
+		expectedHeight := Height(0)
+		rPrime, rPrimeVal := Round(4), value(10)
 		futureRound := newTestRound(t, stateMachine, expectedHeight, rPrime)
 
-		stateMachine.processStart(round(0))
+		stateMachine.ProcessStart(Round(0))
 		futureRound.validator(1).prevote(&rPrimeVal)
 		futureRound.validator(0).proposal(rPrimeVal, -1)
 
 		// The step is not propose because the proposal which is received in round r' leads to consensus
 		// engine broadcasting prevote to the proposal which changes the step from propose to prevote.
-		assertState(t, stateMachine, expectedHeight, rPrime, prevote)
+		assertState(t, stateMachine, expectedHeight, rPrime, StepPrevote)
 	})
 
 	t.Run("Line 55 (Prevote): Start round r' when f+1 future round messages are received from round r'", func(t *testing.T) {
 		stateMachine := setupStateMachine(t, 4, 3)
-		expectedHeight := height(0)
-		rPrime, rPrimeVal := round(4), value(10)
+		expectedHeight := Height(0)
+		rPrime, rPrimeVal := Round(4), value(10)
 		futureRound := newTestRound(t, stateMachine, expectedHeight, rPrime)
 
-		stateMachine.processStart(round(0))
+		stateMachine.ProcessStart(Round(0))
 		futureRound.validator(0).prevote(&rPrimeVal)
 		futureRound.validator(1).prevote(&rPrimeVal)
 
 		// The step here remains propose because a proposal is yet to be received to allow the node to send the
 		// prevote for it.
-		assertState(t, stateMachine, expectedHeight, rPrime, propose)
+		assertState(t, stateMachine, expectedHeight, rPrime, StepPropose)
 	})
 
 	t.Run("Line 55 (Precommit): Start round r' when f+1 future round messages are received from round r'", func(t *testing.T) {
 		stateMachine := setupStateMachine(t, 4, 3)
-		expectedHeight := height(0)
-		rPrime := round(4)
+		expectedHeight := Height(0)
+		rPrime := Round(4)
 		round4Value := value(10)
 		futureRound := newTestRound(t, stateMachine, expectedHeight, rPrime)
 
-		stateMachine.processStart(round(0))
+		stateMachine.ProcessStart(Round(0))
 		futureRound.validator(1).prevote(&round4Value)
 		futureRound.validator(0).precommit(&round4Value)
 
 		// The step here remains propose because a proposal is yet to be received to allow the node to send the
 		// prevote for it.
-		assertState(t, stateMachine, expectedHeight, rPrime, propose)
+		assertState(t, stateMachine, expectedHeight, rPrime, StepPropose)
 	})
 }

--- a/consensus/tendermint/start_test.go
+++ b/consensus/tendermint/start_test.go
@@ -18,15 +18,15 @@ func TestStartRound(t *testing.T) {
 			currentRound.action().broadcastPrevote(utils.HeapPtr(val)),
 		)
 
-		assertState(t, stateMachine, height(0), round(0), prevote)
+		assertState(t, stateMachine, Height(0), Round(0), StepPrevote)
 	})
 
 	t.Run("node is not the proposer: schedule timeoutPropose", func(t *testing.T) {
 		stateMachine := setupStateMachine(t, 4, 3)
 		currentRound := newTestRound(t, stateMachine, 0, 0)
 
-		currentRound.start().expectActions(currentRound.action().scheduleTimeout(propose))
+		currentRound.start().expectActions(currentRound.action().scheduleTimeout(StepPropose))
 
-		assertState(t, stateMachine, height(0), round(0), propose)
+		assertState(t, stateMachine, Height(0), Round(0), StepPropose)
 	})
 }

--- a/consensus/tendermint/state_machine_context_test.go
+++ b/consensus/tendermint/state_machine_context_test.go
@@ -24,12 +24,12 @@ import (
 // but the height and round of the test construct that is being built.
 type stateMachineContext struct {
 	testing       *testing.T
-	stateMachine  *Tendermint[value, felt.Felt, felt.Felt]
-	builderHeight height
-	builderRound  round
+	stateMachine  *stateMachine[value, felt.Felt, felt.Felt]
+	builderHeight Height
+	builderRound  Round
 }
 
-func newTestRound(t *testing.T, stateMachine *Tendermint[value, felt.Felt, felt.Felt], h height, r round) stateMachineContext {
+func newTestRound(t *testing.T, stateMachine *stateMachine[value, felt.Felt, felt.Felt], h Height, r Round) stateMachineContext {
 	return stateMachineContext{
 		testing:       t,
 		stateMachine:  stateMachine,
@@ -45,17 +45,17 @@ func (t stateMachineContext) start() actionAsserter[any] {
 		testing:      t.testing,
 		stateMachine: t.stateMachine,
 		inputMessage: nil,
-		actions:      t.stateMachine.processStart(t.builderRound),
+		actions:      t.stateMachine.ProcessStart(t.builderRound),
 	}
 }
 
 // processTimeout triggers a timeout and returns an actionAsserter to assert the result actions.
-func (t stateMachineContext) processTimeout(s step) actionAsserter[any] {
+func (t stateMachineContext) processTimeout(s Step) actionAsserter[any] {
 	return actionAsserter[any]{
 		testing:      t.testing,
 		stateMachine: t.stateMachine,
 		inputMessage: nil,
-		actions:      t.stateMachine.processTimeout(timeout{s: s, h: t.builderHeight, r: t.builderRound}),
+		actions:      t.stateMachine.ProcessTimeout(Timeout{Step: s, Height: t.builderHeight, Round: t.builderRound}),
 	}
 }
 

--- a/consensus/tendermint/tendermint.go
+++ b/consensus/tendermint/tendermint.go
@@ -1,33 +1,30 @@
 package tendermint
 
 import (
-	"sync"
-	"time"
-
 	"github.com/NethermindEth/juno/core/felt"
 	"github.com/NethermindEth/juno/utils"
 )
 
 type (
-	step        uint8
-	height      uint
-	round       int
-	votingPower uint
+	Step        uint8
+	Height      uint
+	Round       int
+	VotingPower uint
 )
 
 const (
-	propose step = iota
-	prevote
-	precommit
+	StepPropose Step = iota
+	StepPrevote
+	StepPrecommit
 )
 
-func (s step) String() string {
+func (s Step) String() string {
 	switch s {
-	case propose:
+	case StepPropose:
 		return "propose"
-	case prevote:
+	case StepPrevote:
 		return "prevote"
-	case precommit:
+	case StepPrecommit:
 		return "precommit"
 	default:
 		return "unknown"
@@ -35,11 +32,9 @@ func (s step) String() string {
 }
 
 const (
-	maxFutureHeight = height(5)
-	maxFutureRound  = round(5)
+	maxFutureHeight = Height(5)
+	maxFutureRound  = Round(5)
 )
-
-type timeoutFn func(r round) time.Duration
 
 type Addr interface {
 	// Ethereum Addresses are 20 bytes
@@ -65,22 +60,22 @@ type Application[V Hashable[H], H Hash] interface {
 
 type Blockchain[V Hashable[H], H Hash, A Addr] interface {
 	// Height return the current blockchain height
-	Height() height
+	Height() Height
 
 	// Commit is called by Tendermint when a block has been decided on and can be committed to the DB.
-	Commit(height, V, []Precommit[H, A])
+	Commit(Height, V, []Precommit[H, A])
 }
 
 type Validators[A Addr] interface {
 	// TotalVotingPower represents N which is required to calculate the thresholds.
-	TotalVotingPower(height) votingPower
+	TotalVotingPower(Height) VotingPower
 
 	// ValidatorVotingPower returns the voting power of the a single validator. This is also required to implement
 	// various thresholds. The assumption is that a single validator cannot have voting power more than f.
-	ValidatorVotingPower(A) votingPower
+	ValidatorVotingPower(A) VotingPower
 
 	// Proposer returns the proposer of the current round and height.
-	Proposer(height, round) A
+	Proposer(Height, Round) A
 }
 
 type Slasher[M Message[V, H, A], V Hashable[H], H Hash, A Addr] interface {
@@ -89,50 +84,15 @@ type Slasher[M Message[V, H, A], V Hashable[H], H Hash, A Addr] interface {
 	Equivocation(msgs ...M)
 }
 
-type Listener[M Message[V, H, A], V Hashable[H], H Hash, A Addr] interface {
-	// Listen would return consensus messages to Tendermint which are set by the validator set.
-	Listen() <-chan M
+type StateMachine[V Hashable[H], H Hash, A Addr] interface {
+	ProcessStart(Round) []Action[V, H, A]
+	ProcessTimeout(Timeout) []Action[V, H, A]
+	ProcessProposal(Proposal[V, H, A]) []Action[V, H, A]
+	ProcessPrevote(Prevote[H, A]) []Action[V, H, A]
+	ProcessPrecommit(Precommit[H, A]) []Action[V, H, A]
 }
 
-type Broadcaster[M Message[V, H, A], V Hashable[H], H Hash, A Addr] interface {
-	// Broadcast will broadcast the message to the whole validator set. The function should not be blocking.
-	Broadcast(M)
-
-	// SendMsg would send a message to a specific validator. This would be required for helping send resquest and
-	// response message to help a specifc validator to catch up.
-	SendMsg(A, M)
-}
-
-type Listeners[V Hashable[H], H Hash, A Addr] struct {
-	ProposalListener  Listener[Proposal[V, H, A], V, H, A]
-	PrevoteListener   Listener[Prevote[H, A], V, H, A]
-	PrecommitListener Listener[Precommit[H, A], V, H, A]
-}
-
-type Broadcasters[V Hashable[H], H Hash, A Addr] struct {
-	ProposalBroadcaster  Broadcaster[Proposal[V, H, A], V, H, A]
-	PrevoteBroadcaster   Broadcaster[Prevote[H, A], V, H, A]
-	PrecommitBroadcaster Broadcaster[Precommit[H, A], V, H, A]
-}
-
-type Driver[V Hashable[H], H Hash, A Addr] struct {
-	stateMachine *Tendermint[V, H, A]
-
-	timeoutPropose   timeoutFn
-	timeoutPrevote   timeoutFn
-	timeoutPrecommit timeoutFn
-
-	listeners    Listeners[V, H, A]
-	broadcasters Broadcasters[V, H, A]
-
-	scheduledTms map[timeout]*time.Timer
-	timeoutsCh   chan timeout
-
-	wg   sync.WaitGroup
-	quit chan struct{}
-}
-
-type Tendermint[V Hashable[H], H Hash, A Addr] struct {
+type stateMachine[V Hashable[H], H Hash, A Addr] struct {
 	nodeAddr A
 
 	state state[V, H] // Todo: Does state need to be protected?
@@ -145,14 +105,14 @@ type Tendermint[V Hashable[H], H Hash, A Addr] struct {
 }
 
 type state[V Hashable[H], H Hash] struct {
-	height height
-	round  round
-	step   step
+	height Height
+	round  Round
+	step   Step
 
 	lockedValue *V
-	lockedRound round
+	lockedRound Round
 	validValue  *V
-	validRound  round
+	validRound  Round
 
 	// The following are round level variable therefore when a round changes they must be reset.
 	timeoutPrevoteScheduled       bool // line34 for the first time condition
@@ -165,8 +125,8 @@ func New[V Hashable[H], H Hash, A Addr](
 	app Application[V, H],
 	chain Blockchain[V, H, A],
 	vals Validators[A],
-) *Tendermint[V, H, A] {
-	return &Tendermint[V, H, A]{
+) StateMachine[V, H, A] {
+	return &stateMachine[V, H, A]{
 		nodeAddr: nodeAddr,
 		state: state[V, H]{
 			height:      chain.Height(),
@@ -180,101 +140,15 @@ func New[V Hashable[H], H Hash, A Addr](
 	}
 }
 
-func NewDriver[V Hashable[H], H Hash, A Addr](nodeAddr A, app Application[V, H], chain Blockchain[V, H, A], vals Validators[A],
-	listeners Listeners[V, H, A], broadcasters Broadcasters[V, H, A], tmPropose, tmPrevote, tmPrecommit timeoutFn,
-) *Driver[V, H, A] {
-	return &Driver[V, H, A]{
-		stateMachine:     New(nodeAddr, app, chain, vals),
-		timeoutPropose:   tmPropose,
-		timeoutPrevote:   tmPrevote,
-		timeoutPrecommit: tmPrecommit,
-		listeners:        listeners,
-		broadcasters:     broadcasters,
-		scheduledTms:     make(map[timeout]*time.Timer),
-		timeoutsCh:       make(chan timeout),
-		quit:             make(chan struct{}),
-	}
-}
-
 type CachedProposal[V Hashable[H], H Hash, A Addr] struct {
 	Proposal[V, H, A]
 	Valid bool
 	ID    *H
 }
 
-func (d *Driver[V, H, A]) Start() {
-	d.wg.Add(1)
-	go func() {
-		defer d.wg.Done()
-
-		actions := d.stateMachine.processStart(0)
-		d.execute(actions)
-
-		// Todo: check message signature everytime a message is received.
-		// For the time being it can be assumed the signature is correct.
-
-		for {
-			select {
-			case <-d.quit:
-				return
-			case tm := <-d.timeoutsCh:
-				// Handling of timeouts is priorities over messages
-				actions = d.stateMachine.processTimeout(tm)
-				delete(d.scheduledTms, tm)
-			case p := <-d.listeners.ProposalListener.Listen():
-				actions = d.stateMachine.processProposal(p)
-			case p := <-d.listeners.PrevoteListener.Listen():
-				actions = d.stateMachine.processPrevote(p)
-			case p := <-d.listeners.PrecommitListener.Listen():
-				actions = d.stateMachine.processPrecommit(p)
-			}
-			d.execute(actions)
-		}
-	}()
-}
-
-func (d *Driver[V, H, A]) execute(actions []Action[V, H, A]) {
-	for _, action := range actions {
-		switch action := action.(type) {
-		case *BroadcastProposal[V, H, A]:
-			d.broadcasters.ProposalBroadcaster.Broadcast(Proposal[V, H, A](*action))
-		case *BroadcastPrevote[H, A]:
-			d.broadcasters.PrevoteBroadcaster.Broadcast(Prevote[H, A](*action))
-		case *BroadcastPrecommit[H, A]:
-			d.broadcasters.PrecommitBroadcaster.Broadcast(Precommit[H, A](*action))
-		case *ScheduleTimeout:
-			var duration time.Duration
-			switch action.s {
-			case propose:
-				duration = d.timeoutPropose(action.r)
-			case prevote:
-				duration = d.timeoutPrevote(action.r)
-			case precommit:
-				duration = d.timeoutPrecommit(action.r)
-			default:
-				return
-			}
-			d.scheduledTms[timeout(*action)] = time.AfterFunc(duration, func() {
-				select {
-				case <-d.quit:
-				case d.timeoutsCh <- timeout(*action):
-				}
-			})
-		}
-	}
-}
-
-func (d *Driver[V, H, A]) Stop() {
-	close(d.quit)
-	d.wg.Wait()
-	for _, tm := range d.scheduledTms {
-		tm.Stop()
-	}
-}
-
-func (t *Tendermint[V, H, A]) startRound(r round) Action[V, H, A] {
+func (t *stateMachine[V, H, A]) startRound(r Round) Action[V, H, A] {
 	t.state.round = r
-	t.state.step = propose
+	t.state.step = StepPropose
 
 	t.state.timeoutPrevoteScheduled = false
 	t.state.lockedValueAndOrValidValueSet = false
@@ -289,28 +163,28 @@ func (t *Tendermint[V, H, A]) startRound(r round) Action[V, H, A] {
 		}
 		return t.sendProposal(proposalValue)
 	} else {
-		return t.scheduleTimeout(propose)
+		return t.scheduleTimeout(StepPropose)
 	}
 }
 
-type timeout struct {
-	s step
-	h height
-	r round
+type Timeout struct {
+	Step   Step
+	Height Height
+	Round  Round
 }
 
-func (t *Tendermint[V, H, A]) scheduleTimeout(s step) Action[V, H, A] {
+func (t *stateMachine[V, H, A]) scheduleTimeout(s Step) Action[V, H, A] {
 	return utils.HeapPtr(
 		ScheduleTimeout{
-			s: s,
-			h: t.state.height,
-			r: t.state.round,
+			Step:   s,
+			Height: t.state.height,
+			Round:  t.state.round,
 		},
 	)
 }
 
-func (t *Tendermint[V, H, A]) validatorSetVotingPower(vals []A) votingPower {
-	var totalVotingPower votingPower
+func (t *stateMachine[V, H, A]) validatorSetVotingPower(vals []A) VotingPower {
+	var totalVotingPower VotingPower
 	for _, v := range vals {
 		totalVotingPower += t.validators.ValidatorVotingPower(v)
 	}
@@ -318,12 +192,12 @@ func (t *Tendermint[V, H, A]) validatorSetVotingPower(vals []A) votingPower {
 }
 
 // Todo: add separate unit tests to check f and q thresholds.
-func f(totalVotingPower votingPower) votingPower {
+func f(totalVotingPower VotingPower) VotingPower {
 	// note: integer division automatically floors the result as it return the quotient.
 	return (totalVotingPower - 1) / 3
 }
 
-func q(totalVotingPower votingPower) votingPower {
+func q(totalVotingPower VotingPower) VotingPower {
 	// Unfortunately there is no ceiling function for integers in go.
 	d := totalVotingPower * 2
 	q := d / 3
@@ -339,10 +213,10 @@ func q(totalVotingPower votingPower) votingPower {
 // - if height is the current height, round is within [0, current round + maxFutureRound]
 // - if height is a future height, round is within [0, maxFutureRound]
 // The message is processed immediately if all the conditions above are met plus height is the current height.
-func (t *Tendermint[V, H, A]) preprocessMessage(header MessageHeader[A], addMessage func()) bool {
+func (t *stateMachine[V, H, A]) preprocessMessage(header MessageHeader[A], addMessage func()) bool {
 	isCurrentHeight := header.Height == t.state.height
 
-	var currentRoundOfHeaderHeight round
+	var currentRoundOfHeaderHeight Round
 	// If the height is a future height, the round is considered to be 0, as the height hasn't started yet.
 	if isCurrentHeight {
 		currentRoundOfHeaderHeight = t.state.round
@@ -360,7 +234,7 @@ func (t *Tendermint[V, H, A]) preprocessMessage(header MessageHeader[A], addMess
 }
 
 // TODO: Improve performance. Current complexity is O(n).
-func (t *Tendermint[V, H, A]) checkForQuorumPrecommit(r round, vID H) (matchingPrecommits []Precommit[H, A], hasQuorum bool) {
+func (t *stateMachine[V, H, A]) checkForQuorumPrecommit(r Round, vID H) (matchingPrecommits []Precommit[H, A], hasQuorum bool) {
 	precommits, ok := t.messages.precommits[t.state.height][r]
 	if !ok {
 		return nil, false
@@ -377,7 +251,7 @@ func (t *Tendermint[V, H, A]) checkForQuorumPrecommit(r round, vID H) (matchingP
 }
 
 // TODO: Improve performance. Current complexity is O(n).
-func (t *Tendermint[V, H, A]) checkQuorumPrevotesGivenProposalVID(r round, vID H) (hasQuorum bool) {
+func (t *stateMachine[V, H, A]) checkQuorumPrevotesGivenProposalVID(r Round, vID H) (hasQuorum bool) {
 	prevotes, ok := t.messages.prevotes[t.state.height][r]
 	if !ok {
 		return false
@@ -392,7 +266,7 @@ func (t *Tendermint[V, H, A]) checkQuorumPrevotesGivenProposalVID(r round, vID H
 	return t.validatorSetVotingPower(vals) >= q(t.validators.TotalVotingPower(t.state.height))
 }
 
-func (t *Tendermint[V, H, A]) findProposal(r round) *CachedProposal[V, H, A] {
+func (t *stateMachine[V, H, A]) findProposal(r Round) *CachedProposal[V, H, A] {
 	v, ok := t.messages.proposals[t.state.height][r][t.validators.Proposer(t.state.height, r)]
 	if !ok {
 		return nil

--- a/consensus/tendermint/tendermint_test.go
+++ b/consensus/tendermint/tendermint_test.go
@@ -32,23 +32,23 @@ func (a *app) Valid(v value) bool {
 
 // Implements Blockchain[value, felt.Felt] interface
 type chain struct {
-	curHeight            height
-	decision             map[height]value
-	decisionCertificates map[height][]Precommit[felt.Felt, felt.Felt]
+	curHeight            Height
+	decision             map[Height]value
+	decisionCertificates map[Height][]Precommit[felt.Felt, felt.Felt]
 }
 
 func newChain() *chain {
 	return &chain{
-		decision:             make(map[height]value),
-		decisionCertificates: make(map[height][]Precommit[felt.Felt, felt.Felt]),
+		decision:             make(map[Height]value),
+		decisionCertificates: make(map[Height][]Precommit[felt.Felt, felt.Felt]),
 	}
 }
 
-func (c *chain) Height() height {
+func (c *chain) Height() Height {
 	return c.curHeight
 }
 
-func (c *chain) Commit(h height, v value, precommits []Precommit[felt.Felt, felt.Felt]) {
+func (c *chain) Commit(h Height, v value, precommits []Precommit[felt.Felt, felt.Felt]) {
 	c.decision[c.curHeight] = v
 	c.decisionCertificates[c.curHeight] = precommits
 	c.curHeight++
@@ -56,22 +56,22 @@ func (c *chain) Commit(h height, v value, precommits []Precommit[felt.Felt, felt
 
 // Implements Validators[felt.Felt] interface
 type validators struct {
-	totalVotingPower votingPower
+	totalVotingPower VotingPower
 	vals             []felt.Felt
 }
 
 func newVals() *validators { return &validators{} }
 
-func (v *validators) TotalVotingPower(h height) votingPower {
+func (v *validators) TotalVotingPower(h Height) VotingPower {
 	return v.totalVotingPower
 }
 
-func (v *validators) ValidatorVotingPower(validatorAddr felt.Felt) votingPower {
+func (v *validators) ValidatorVotingPower(validatorAddr felt.Felt) VotingPower {
 	return 1
 }
 
 // Proposer is implements round robin
-func (v *validators) Proposer(h height, r round) felt.Felt {
+func (v *validators) Proposer(h Height, r Round) felt.Felt {
 	i := (uint(h) + uint(r)) % uint(v.totalVotingPower)
 	return v.vals[i]
 }
@@ -88,7 +88,7 @@ func getVal(idx int) *felt.Felt {
 func setupStateMachine(
 	t *testing.T,
 	numValidators, thisValidator int, //nolint:unparam // This is because in all current tests numValidators is always 4.
-) *Tendermint[value, felt.Felt, felt.Felt] {
+) *stateMachine[value, felt.Felt, felt.Felt] {
 	t.Helper()
 	app, chain, vals := newApp(), newChain(), newVals()
 
@@ -98,14 +98,14 @@ func setupStateMachine(
 
 	thisNodeAddr := getVal(thisValidator)
 
-	return New(*thisNodeAddr, app, chain, vals)
+	return New(*thisNodeAddr, app, chain, vals).(*stateMachine[value, felt.Felt, felt.Felt])
 }
 
 func TestThresholds(t *testing.T) {
 	tests := []struct {
-		n votingPower
-		q votingPower
-		f votingPower
+		n VotingPower
+		q VotingPower
+		f VotingPower
 	}{
 		{1, 1, 0},
 		{2, 2, 0},

--- a/consensus/tendermint/timeout.go
+++ b/consensus/tendermint/timeout.go
@@ -1,20 +1,20 @@
 package tendermint
 
-func (t *Tendermint[V, H, A]) onTimeoutPropose(h height, r round) Action[V, H, A] {
-	if t.state.height == h && t.state.round == r && t.state.step == propose {
+func (t *stateMachine[V, H, A]) onTimeoutPropose(h Height, r Round) Action[V, H, A] {
+	if t.state.height == h && t.state.round == r && t.state.step == StepPropose {
 		return t.setStepAndSendPrevote(nil)
 	}
 	return nil
 }
 
-func (t *Tendermint[V, H, A]) onTimeoutPrevote(h height, r round) Action[V, H, A] {
-	if t.state.height == h && t.state.round == r && t.state.step == prevote {
+func (t *stateMachine[V, H, A]) onTimeoutPrevote(h Height, r Round) Action[V, H, A] {
+	if t.state.height == h && t.state.round == r && t.state.step == StepPrevote {
 		return t.setStepAndSendPrecommit(nil)
 	}
 	return nil
 }
 
-func (t *Tendermint[V, H, A]) onTimeoutPrecommit(h height, r round) Action[V, H, A] {
+func (t *stateMachine[V, H, A]) onTimeoutPrecommit(h Height, r Round) Action[V, H, A] {
 	if t.state.height == h && t.state.round == r {
 		return t.startRound(r + 1)
 	}

--- a/consensus/tendermint/timeout_test.go
+++ b/consensus/tendermint/timeout_test.go
@@ -12,10 +12,10 @@ func TestTimeout(t *testing.T) {
 		stateMachine := setupStateMachine(t, 4, 3)
 		currentRound := newTestRound(t, stateMachine, 0, 0)
 
-		currentRound.start().expectActions(currentRound.action().scheduleTimeout(propose))
-		currentRound.processTimeout(propose).expectActions(currentRound.action().broadcastPrevote(nil))
+		currentRound.start().expectActions(currentRound.action().scheduleTimeout(StepPropose))
+		currentRound.processTimeout(StepPropose).expectActions(currentRound.action().broadcastPrevote(nil))
 
-		assertState(t, stateMachine, height(0), round(0), prevote)
+		assertState(t, stateMachine, Height(0), Round(0), StepPrevote)
 	})
 
 	t.Run("OnTimeoutPrevote: move to next round", func(t *testing.T) {
@@ -26,12 +26,12 @@ func TestTimeout(t *testing.T) {
 		currentRound.start()
 		currentRound.validator(0).proposal(value(42), -1)
 		currentRound.validator(1).prevote(utils.HeapPtr(value(42)))
-		currentRound.validator(2).prevote(nil).expectActions(currentRound.action().scheduleTimeout(prevote))
+		currentRound.validator(2).prevote(nil).expectActions(currentRound.action().scheduleTimeout(StepPrevote))
 		assert.True(t, stateMachine.state.timeoutPrevoteScheduled)
-		assertState(t, stateMachine, height(0), round(0), prevote)
+		assertState(t, stateMachine, Height(0), Round(0), StepPrevote)
 
-		currentRound.processTimeout(prevote).expectActions(currentRound.action().broadcastPrecommit(nil))
-		assertState(t, stateMachine, height(0), round(0), precommit)
+		currentRound.processTimeout(StepPrevote).expectActions(currentRound.action().broadcastPrecommit(nil))
+		assertState(t, stateMachine, Height(0), Round(0), StepPrecommit)
 	})
 
 	t.Run("OnTimeoutPrecommit: move to next round", func(t *testing.T) {
@@ -43,20 +43,20 @@ func TestTimeout(t *testing.T) {
 		currentRound.start()
 		currentRound.validator(0).precommit(utils.HeapPtr(value(10)))
 		currentRound.validator(1).precommit(nil)
-		currentRound.validator(2).precommit(nil).expectActions(currentRound.action().scheduleTimeout(precommit))
+		currentRound.validator(2).precommit(nil).expectActions(currentRound.action().scheduleTimeout(StepPrecommit))
 		assert.True(t, stateMachine.state.timeoutPrecommitScheduled)
 
-		currentRound.processTimeout(precommit).expectActions(nextRound.action().scheduleTimeout(propose))
+		currentRound.processTimeout(StepPrecommit).expectActions(nextRound.action().scheduleTimeout(StepPropose))
 		assert.False(t, stateMachine.state.timeoutPrecommitScheduled)
 
-		assertState(t, stateMachine, height(0), round(1), propose)
+		assertState(t, stateMachine, Height(0), Round(1), StepPropose)
 
 		// Do nothing on old timeout
-		currentRound.processTimeout(propose).expectActions()
-		assertState(t, stateMachine, height(0), round(1), propose)
+		currentRound.processTimeout(StepPropose).expectActions()
+		assertState(t, stateMachine, Height(0), Round(1), StepPropose)
 
-		currentRound.processTimeout(prevote).expectActions()
-		assertState(t, stateMachine, height(0), round(1), propose)
+		currentRound.processTimeout(StepPrevote).expectActions()
+		assertState(t, stateMachine, Height(0), Round(1), StepPropose)
 	})
 
 	t.Run("Ignore old timeout on new height", func(t *testing.T) {
@@ -66,28 +66,28 @@ func TestTimeout(t *testing.T) {
 
 		committedValue := value(10)
 
-		currentRound.start().expectActions(currentRound.action().scheduleTimeout(propose))
+		currentRound.start().expectActions(currentRound.action().scheduleTimeout(StepPropose))
 
 		// Honest validators quickly agree on a value
 		currentRound.validator(0).proposal(committedValue, -1)
 		currentRound.validator(0).prevote(&committedValue)
 		currentRound.validator(1).prevote(&committedValue).expectActions(
-			currentRound.action().scheduleTimeout(prevote),
+			currentRound.action().scheduleTimeout(StepPrevote),
 			currentRound.action().broadcastPrecommit(&committedValue),
 		)
 		currentRound.validator(0).precommit(&committedValue)
 		currentRound.validator(2).precommit(nil).expectActions(
-			currentRound.action().scheduleTimeout(precommit),
+			currentRound.action().scheduleTimeout(StepPrecommit),
 		)
 		currentRound.validator(1).precommit(&committedValue)
 
 		// All old timeout should do nothing
-		assertState(t, stateMachine, height(1), round(0), propose)
-		currentRound.processTimeout(propose).expectActions()
-		assertState(t, stateMachine, height(1), round(0), propose)
-		currentRound.processTimeout(prevote).expectActions()
-		assertState(t, stateMachine, height(1), round(0), propose)
-		currentRound.processTimeout(precommit).expectActions()
-		assertState(t, stateMachine, height(1), round(0), propose)
+		assertState(t, stateMachine, Height(1), Round(0), StepPropose)
+		currentRound.processTimeout(StepPropose).expectActions()
+		assertState(t, stateMachine, Height(1), Round(0), StepPropose)
+		currentRound.processTimeout(StepPrevote).expectActions()
+		assertState(t, stateMachine, Height(1), Round(0), StepPropose)
+		currentRound.processTimeout(StepPrecommit).expectActions()
+		assertState(t, stateMachine, Height(1), Round(0), StepPropose)
 	})
 }


### PR DESCRIPTION
Although the number of changes is big, the changes are minor:
- Move the `Driver` struct and its functions to a separate `driver` package. The tests are added in the next PR.
- Rename `Tendermint` struct to `stateMachine` and add `StateMachine` interface to list the exported functions from `stateMachine`.
- Rename `timeout`, `step`, `height`, `round` and `votingPower` to `Timeout`, `Step`, `Height`, `Round` and `VotingPower` to be able to use in `driver` package.
- Rename `propose`, `prevote` and `precommit` steps to `StepPropose`, `StepPrevote` and `StepPrecommit`. The `Step` prefix is to differentiate with the message types.