### PR TITLE
fix: Enable multi-platform support when tagging Docker images as latest

### DIFF
--- a/.github/workflows/docker-image-tag-latest.yml
+++ b/.github/workflows/docker-image-tag-latest.yml
@@ -25,12 +25,9 @@ jobs:
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
-
-      - name: Tag and push official image as latest
-        run: |
-          docker pull nethermind/juno:${{ env.TAG }}
-          docker tag nethermind/juno:${{ env.TAG }} nethermind/juno:latest
-          docker push nethermind/juno:latest
+   
+      - name: Tag and push as latest using buildx
+        run: docker buildx imagetools create --tag nethermind/juno:latest nethermind/juno:${{ env.TAG }}
 
       - name: Clean up Docker config
         if: always()


### PR DESCRIPTION
This PR replaces the current docker pull/tag/push approach with docker buildx imagetools create to correctly tag the latest Docker image as multi-architecture (ARM64 + AMD64).

Currently, the latest tag only includes the AMD64 image because it's re-tagged and pushed from an AMD-only runner. As a result, ARM64 support is missing from the latest tag. By switching to buildx imagetools, we directly copy the existing multi-arch manifest from a published tag to latest, preserving all platforms.