### PR TITLE
fix: mempool.LoadFromDB incorrect restore mempool from db

### DIFF
--- a/mempool/mempool.go
+++ b/mempool/mempool.go
@@ -167,15 +167,7 @@ func (p *Pool) LoadFromDB() error {
 		if err != nil {
 			return err
 		}
-		newMemPoolTxn := &memPoolTxn{Txn: curTxn.Txn}
-		if curTxn.NextHash != nil {
-			nextDBTxn, err := GetTxn(p.db, curTxn.NextHash)
-			if err != nil {
-				return err
-			}
-			newMemPoolTxn = &memPoolTxn{Txn: nextDBTxn.Txn}
-		}
-		p.memTxnList.push(newMemPoolTxn)
+		p.memTxnList.push(&memPoolTxn{Txn: curTxn.Txn})
 		currentHash = curTxn.NextHash
 	}
 

--- a/mempool/mempool_test.go
+++ b/mempool/mempool_test.go
@@ -176,7 +176,7 @@ func TestRestoreMempool(t *testing.T) {
 	restoredTransactions, err := poolRestored.PopBatch(lenRestored)
 	require.NoError(t, err)
 	for i, txn := range restoredTransactions {
-		require.Equal(t, txn.Transaction.Hash(), expectedTxs[i].Transaction.Hash())
+		require.Equal(t, expectedTxs[i].Transaction.Hash(), txn.Transaction.Hash())
 	}
 	lenDB, err = poolRestored.LenDB()
 	require.NoError(t, err)


### PR DESCRIPTION
This PR addresses the incorrect mempool restoration from DB.
Enhanced `TestRestoreMempool` test with deep equality check for `expected transactions` and `restored transactions`

Close #2792 