### PR TITLE
Fix(RPC 0.8): V3 tx missing 'l1_data_gas' field handling

### DIFF
--- a/.github/workflows/deploy-and-test.yaml
+++ b/.github/workflows/deploy-and-test.yaml
@@ -97,7 +97,7 @@ jobs:
     needs: [deploy]
     uses: ./.github/workflows/starknet-rs-tests.yml
     secrets:
-      STARKNET_RPC: ${{ secrets.RPC_URL }}/v0_7?apikey=${{ secrets.AUTH_TOKEN }}
+      STARKNET_RPC: ${{ secrets.RPC_URL }}/v0_8?apikey=${{ secrets.AUTH_TOKEN }}
 
   starknet-js:
     needs: [deploy]

--- a/.github/workflows/deploy-and-test.yaml
+++ b/.github/workflows/deploy-and-test.yaml
@@ -123,7 +123,7 @@ jobs:
     needs: [deploy]
     uses: ./.github/workflows/starknet-go-tests.yml
     with:
-      ref: f8f0b717aa5b59c797540c0567f309ae78537e09
+      ref: 298264d89acbbd6611fcafa09c5b40acd9d35515
       rpc_version: v0_8
     secrets:
       TEST_RPC_URL: ${{ secrets.RPC_URL }}

--- a/.github/workflows/starknet-rs-tests.yml
+++ b/.github/workflows/starknet-rs-tests.yml
@@ -14,7 +14,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: xJonathanLEI/starknet-rs
-          ref: starknet/v0.14.0
+          ref: starknet/v0.15.0
 
       - name: Setup Rust
         uses: actions-rs/toolchain@v1

--- a/.github/workflows/starknet-rs-tests.yml
+++ b/.github/workflows/starknet-rs-tests.yml
@@ -14,7 +14,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: xJonathanLEI/starknet-rs
-          ref: starknet/v0.12.0
+          ref: starknet/v0.14.0
 
       - name: Setup Rust
         uses: actions-rs/toolchain@v1

--- a/rpc/v8/block_test.go
+++ b/rpc/v8/block_test.go
@@ -432,7 +432,10 @@ func TestBlockWithTxHashesV013(t *testing.T) {
 						MaxAmount:       new(felt.Felt).SetUint64(tx.ResourceBounds[core.ResourceL2Gas].MaxAmount),
 						MaxPricePerUnit: tx.ResourceBounds[core.ResourceL2Gas].MaxPricePerUnit,
 					},
-					L1DataGas: nil,
+					L1DataGas: &rpcv8.ResourceBounds{
+						MaxAmount:       &felt.Zero,
+						MaxPricePerUnit: &felt.Zero,
+					},
 				},
 				Tip:                   new(felt.Felt).SetUint64(tx.Tip),
 				PaymasterData:         &tx.PaymasterData,

--- a/rpc/v8/transaction.go
+++ b/rpc/v8/transaction.go
@@ -217,29 +217,17 @@ type ResourceBoundsMap struct {
 }
 
 func (r *ResourceBoundsMap) MarshalJSON() ([]byte, error) {
-	type tempResourceBoundsMap struct {
-		L1Gas *ResourceBounds `json:"l1_gas"`
-		L2Gas *ResourceBounds `json:"l2_gas"`
-	}
-
-	temp := tempResourceBoundsMap{
-		L1Gas: r.L1Gas,
-		L2Gas: r.L2Gas,
-	}
-
-	// Check if L1DataGas is nil, if it is, remove it from the struct/map
+	// Check if L1DataGas is nil, if it is, provide default values
 	if r.L1DataGas == nil {
-		return json.Marshal(temp)
+		r.L1DataGas = &ResourceBounds{
+			MaxAmount:       &felt.Zero,
+			MaxPricePerUnit: &felt.Zero,
+		}
 	}
 
-	// L1Gas and L2Gas should always be present.
-	return json.Marshal(struct {
-		*tempResourceBoundsMap
-		L1DataGas *ResourceBounds `json:"l1_data_gas"`
-	}{
-		tempResourceBoundsMap: &temp,
-		L1DataGas:             r.L1DataGas,
-	})
+	// Define an alias to avoid recursion
+	type alias ResourceBoundsMap
+	return json.Marshal((*alias)(r))
 }
 
 // https://github.com/starkware-libs/starknet-specs/blob/a789ccc3432c57777beceaa53a34a7ae2f25fda0/api/starknet_api_openrpc.json#L1252

--- a/rpc/v8/transaction.go
+++ b/rpc/v8/transaction.go
@@ -387,6 +387,11 @@ func adaptResourceBounds(rb map[core.Resource]core.ResourceBounds) ResourceBound
 			MaxAmount:       new(felt.Felt).SetUint64(rb[core.ResourceL1DataGas].MaxAmount),
 			MaxPricePerUnit: rb[core.ResourceL1DataGas].MaxPricePerUnit,
 		}
+	} else {
+		l1DataGasResourceBounds = &ResourceBounds{
+			MaxAmount:       &felt.Zero,
+			MaxPricePerUnit: &felt.Zero,
+		}
 	}
 
 	// As L1Gas & L2Gas will always be present, we can directly assign them

--- a/rpc/v8/transaction_test.go
+++ b/rpc/v8/transaction_test.go
@@ -372,6 +372,10 @@ func TestTransactionByHash(t *testing.T) {
 						"max_amount": "0x60",
 						"max_price_per_unit": "0x13ac02cbe617"
 					},
+					"l1_data_gas": {
+						"max_amount": "0x0",
+						"max_price_per_unit": "0x0"
+					},
 					"l2_gas": { "max_amount": "0x0", "max_price_per_unit": "0x0" }
 				},
 				"tip": "0x0",
@@ -1793,6 +1797,10 @@ func TestResourceBoundsMapMarshalJSON(t *testing.T) {
 				"l2_gas": {
 					"max_amount": "0xc8",
 					"max_price_per_unit": "0x14"
+				},
+				"l1_data_gas": {
+					"max_amount": "0x0",
+					"max_price_per_unit": "0x0"
 				}
 			}`,
 		},


### PR DESCRIPTION
This PR adjusts marshaling of `ResourceBoundsMap.L1DataGas` field to always be non-nil and return default values.

In order to ensure `starknet-rs` integration tests related to v3 txs expecting `l1_data_gas` field are passing, changes made in #2797 are added to this PR

Closes #2799 