### PR TITLE
ci: add auth token support to RPC URLs in CI workflows

### DIFF
--- a/.github/workflows/deploy-and-test.yaml
+++ b/.github/workflows/deploy-and-test.yaml
@@ -37,6 +37,8 @@ on:
         required: true
       TEST_ACCOUNT_PRIVATE_KEY:
         required: true
+      AUTH_TOKEN:
+        required: true
 
 concurrency:
   group: shared_${{ inputs.environment }}_environment
@@ -89,13 +91,13 @@ jobs:
             
       - name: Verify Deployment Version
         run: |
-          bash .github/workflow-scripts/verify_deployment.sh ${{ secrets.RPC_URL }} ${{ inputs.docker_image_tag }}
+          bash .github/workflow-scripts/verify_deployment.sh ${{ secrets.RPC_URL }}?apikey=${{ secrets.AUTH_TOKEN }} ${{ inputs.docker_image_tag }}
 
   starknet-rs:
     needs: [deploy]
     uses: ./.github/workflows/starknet-rs-tests.yml
     secrets:
-      STARKNET_RPC: ${{ secrets.RPC_URL }}/v0_7
+      STARKNET_RPC: ${{ secrets.RPC_URL }}/v0_7?apikey=${{ secrets.AUTH_TOKEN }}
 
   starknet-js:
     needs: [deploy]
@@ -103,7 +105,7 @@ jobs:
     with:
       test_mode: ${{ inputs.test_mode }}
     secrets:
-      TEST_RPC_URL: ${{ secrets.RPC_URL }}/v0_7
+      TEST_RPC_URL: ${{ secrets.RPC_URL }}/v0_7?apikey=${{ secrets.AUTH_TOKEN }}
       TEST_ACCOUNT_ADDRESS: ${{ secrets.TEST_ACCOUNT_ADDRESS }}
       TEST_ACCOUNT_PRIVATE_KEY: ${{ secrets.TEST_ACCOUNT_PRIVATE_KEY }}
 
@@ -115,6 +117,7 @@ jobs:
       rpc_version: v0_7
     secrets:
       TEST_RPC_URL: ${{ secrets.RPC_URL }}
+      AUTH_TOKEN: ${{ secrets.AUTH_TOKEN }}
 
   starknet-go-rpcv08:
     needs: [deploy]
@@ -125,3 +128,4 @@ jobs:
     secrets:
       TEST_RPC_URL: ${{ secrets.RPC_URL }}
       TEST_WS_RPC_URL: ${{ secrets.WS_RPC_URL }}
+      AUTH_TOKEN: ${{ secrets.AUTH_TOKEN }}

--- a/.github/workflows/deploy-dev-and-test.yml
+++ b/.github/workflows/deploy-dev-and-test.yml
@@ -13,6 +13,7 @@ on:
 permissions:
   contents: read
 
+  
 jobs:
   build:
     # Skip for PRs from forks as they don't have access to secrets
@@ -52,3 +53,4 @@ jobs:
       WS_RPC_URL: ${{ secrets.DEV_WS_SEPOLIA_URL }}
       TEST_ACCOUNT_ADDRESS: ${{ secrets.TEST_ACCOUNT_ADDRESS }}
       TEST_ACCOUNT_PRIVATE_KEY: ${{ secrets.TEST_ACCOUNT_PRIVATE_KEY }}
+      AUTH_TOKEN: ${{ secrets.DEV_AUTH_TOKEN }}

--- a/.github/workflows/starknet-go-tests.yml
+++ b/.github/workflows/starknet-go-tests.yml
@@ -17,6 +17,8 @@ on:
         required: true
       TEST_WS_RPC_URL:
         required: false
+      AUTH_TOKEN:
+        required: true
 
 jobs:
   test:
@@ -40,16 +42,17 @@ jobs:
         run: |
           RPC_URL="${{ secrets.TEST_RPC_URL }}"
           VERSION="${{ inputs.rpc_version }}"
+          AUTH_PARAM="?apikey=${{ secrets.AUTH_TOKEN }}"
 
           if [ "$VERSION" = "v0_7" ]; then
-            echo "INTEGRATION_BASE=${RPC_URL}/${VERSION}" >> $GITHUB_ENV
+            echo "INTEGRATION_BASE=${RPC_URL}/${VERSION}${AUTH_PARAM}" >> $GITHUB_ENV
           elif [ "$VERSION" = "v0_8" ]; then
             if [ -z "${{ secrets.TEST_WS_RPC_URL }}" ]; then
               echo "Error: TEST_WS_RPC_URL secret must be set for RPC v0_8"
               exit 1
             fi
-            echo "HTTP_PROVIDER_URL=${RPC_URL}/${VERSION}" >> $GITHUB_ENV
-            echo "WS_PROVIDER_URL=${{ secrets.TEST_WS_RPC_URL }}/${VERSION}" >> $GITHUB_ENV
+            echo "HTTP_PROVIDER_URL=${RPC_URL}/${VERSION}${AUTH_PARAM}" >> $GITHUB_ENV
+            echo "WS_PROVIDER_URL=${{ secrets.TEST_WS_RPC_URL }}/${VERSION}${AUTH_PARAM}" >> $GITHUB_ENV
           else
             echo "Version $VERSION is not supported."
             exit 1

--- a/.github/workflows/starknet-js-tests.yml
+++ b/.github/workflows/starknet-js-tests.yml
@@ -13,7 +13,7 @@ on:
       TEST_ACCOUNT_ADDRESS:
         required: false
       TEST_ACCOUNT_PRIVATE_KEY:
-          required: false
+        required: false
 
 jobs:
   test:


### PR DESCRIPTION
Added DEV_AUTH_TOKEN parameter to all test workflows to authenticate RPC requests with the required apikey parameter.