### PR TITLE
refactor: create a package for real starknet types used in tendermint

### DIFF
--- a/consensus/db/db_test.go
+++ b/consensus/db/db_test.go
@@ -3,40 +3,38 @@ package db
 import (
 	"testing"
 
+	"github.com/NethermindEth/juno/consensus/starknet"
 	"github.com/NethermindEth/juno/consensus/types"
 	"github.com/NethermindEth/juno/core/felt"
+	"github.com/NethermindEth/juno/core/hash"
 	"github.com/NethermindEth/juno/db"
 	"github.com/NethermindEth/juno/db/pebble"
 	"github.com/NethermindEth/juno/utils"
 	"github.com/stretchr/testify/require"
 )
 
-type value uint64
+type testTendermintDB = TendermintDB[starknet.Value, hash.Hash, starknet.Address]
 
-func (v value) Hash() felt.Felt {
-	return *new(felt.Felt).SetUint64(uint64(v))
-}
-
-func newTestTMDB(t *testing.T) (TendermintDB[value, felt.Felt, felt.Felt], db.KeyValueStore, string) {
+func newTestTMDB(t *testing.T) (testTendermintDB, db.KeyValueStore, string) {
 	t.Helper()
 	dbPath := t.TempDir()
 	testDB, err := pebble.New(dbPath)
 	require.NoError(t, err)
 
-	tmState := NewTendermintDB[value, felt.Felt, felt.Felt](testDB, types.Height(0))
+	tmState := NewTendermintDB[starknet.Value, hash.Hash, starknet.Address](testDB, types.Height(0))
 	require.NotNil(t, tmState)
 
 	return tmState, testDB, dbPath
 }
 
-func reopenTestTMDB(t *testing.T, oldDB db.KeyValueStore, dbPath string, testHeight types.Height) (TendermintDB[value, felt.Felt, felt.Felt], db.KeyValueStore) {
+func reopenTestTMDB(t *testing.T, oldDB db.KeyValueStore, dbPath string, testHeight types.Height) (testTendermintDB, db.KeyValueStore) {
 	t.Helper()
 	require.NoError(t, oldDB.Close())
 
 	newDB, err := pebble.New(dbPath)
 	require.NoError(t, err)
 
-	tmState := NewTendermintDB[value, felt.Felt, felt.Felt](newDB, testHeight)
+	tmState := NewTendermintDB[starknet.Value, hash.Hash, starknet.Address](newDB, testHeight)
 	return tmState, newDB
 }
 
@@ -45,28 +43,28 @@ func TestWALLifecycle(t *testing.T) {
 	testRound := types.Round(1)
 	testStep := types.StepPrevote
 
-	sender1 := *new(felt.Felt).SetUint64(1)
-	sender2 := *new(felt.Felt).SetUint64(2)
-	sender3 := *new(felt.Felt).SetUint64(3)
-	var val1 value = 10
+	sender1 := starknet.Address(*new(felt.Felt).SetUint64(1))
+	sender2 := starknet.Address(*new(felt.Felt).SetUint64(2))
+	sender3 := starknet.Address(*new(felt.Felt).SetUint64(3))
+	var val1 starknet.Value = 10
 	valHash1 := val1.Hash()
 
-	proposal := types.Proposal[value, felt.Felt, felt.Felt]{
-		MessageHeader: types.MessageHeader[felt.Felt]{Height: testHeight, Round: testRound, Sender: sender1},
+	proposal := starknet.Proposal{
+		MessageHeader: starknet.MessageHeader{Height: testHeight, Round: testRound, Sender: sender1},
 		ValidRound:    testRound,
 		Value:         utils.HeapPtr(val1),
 	}
-	prevote := types.Prevote[felt.Felt, felt.Felt]{
-		MessageHeader: types.MessageHeader[felt.Felt]{Height: testHeight, Round: testRound, Sender: sender2},
+	prevote := starknet.Prevote{
+		MessageHeader: starknet.MessageHeader{Height: testHeight, Round: testRound, Sender: sender2},
 		ID:            &valHash1,
 	}
-	precommit := types.Precommit[felt.Felt, felt.Felt]{
-		MessageHeader: types.MessageHeader[felt.Felt]{Height: testHeight, Round: testRound, Sender: sender3},
+	precommit := starknet.Precommit{
+		MessageHeader: starknet.MessageHeader{Height: testHeight, Round: testRound, Sender: sender3},
 		ID:            &valHash1,
 	}
 	timeoutMsg := types.Timeout{Height: testHeight, Round: testRound, Step: testStep}
 
-	expectedEntries := []WalEntry[value, felt.Felt, felt.Felt]{
+	expectedEntries := []WalEntry[starknet.Value, hash.Hash, starknet.Address]{
 		{Type: types.MessageTypeProposal, Entry: proposal},
 		{Type: types.MessageTypePrevote, Entry: prevote},
 		{Type: types.MessageTypePrecommit, Entry: precommit},

--- a/consensus/driver/driver_test.go
+++ b/consensus/driver/driver_test.go
@@ -9,12 +9,20 @@ import (
 	"github.com/NethermindEth/juno/consensus/driver"
 	"github.com/NethermindEth/juno/consensus/mocks"
 	"github.com/NethermindEth/juno/consensus/p2p"
+	"github.com/NethermindEth/juno/consensus/starknet"
 	"github.com/NethermindEth/juno/consensus/types"
 	"github.com/NethermindEth/juno/core/felt"
+	"github.com/NethermindEth/juno/core/hash"
 	"github.com/NethermindEth/juno/db/memory"
 	"github.com/NethermindEth/juno/utils"
 	"github.com/stretchr/testify/assert"
 	"go.uber.org/mock/gomock"
+)
+
+type (
+	broadcaster[M starknet.Message] = p2p.Broadcaster[M, starknet.Value, starknet.Hash, starknet.Address]
+	listeners                       = p2p.Listeners[starknet.Value, starknet.Hash, starknet.Address]
+	broadcasters                    = p2p.Broadcasters[starknet.Value, starknet.Hash, starknet.Address]
 )
 
 const (
@@ -23,22 +31,16 @@ const (
 )
 
 type expectedBroadcast struct {
-	proposals  []types.Proposal[value, felt.Felt, felt.Felt]
-	prevotes   []types.Prevote[felt.Felt, felt.Felt]
-	precommits []types.Precommit[felt.Felt, felt.Felt]
+	proposals  []starknet.Proposal
+	prevotes   []starknet.Prevote
+	precommits []starknet.Precommit
 }
 
-type value uint64
-
-func (v value) Hash() felt.Felt {
-	return *new(felt.Felt).SetUint64(uint64(v))
-}
-
-type mockListener[M types.Message[value, felt.Felt, felt.Felt]] struct {
+type mockListener[M starknet.Message] struct {
 	ch chan M
 }
 
-func newMockListener[M types.Message[value, felt.Felt, felt.Felt]](ch chan M) *mockListener[M] {
+func newMockListener[M starknet.Message](ch chan M) *mockListener[M] {
 	return &mockListener[M]{
 		ch: ch,
 	}
@@ -48,7 +50,7 @@ func (m *mockListener[M]) Listen() <-chan M {
 	return m.ch
 }
 
-type mockBroadcaster[M types.Message[value, felt.Felt, felt.Felt]] struct {
+type mockBroadcaster[M starknet.Message] struct {
 	wg                  sync.WaitGroup
 	mu                  sync.Mutex
 	broadcastedMessages []M
@@ -62,22 +64,22 @@ func (m *mockBroadcaster[M]) Broadcast(msg M) {
 }
 
 func mockListeners(
-	proposalCh chan types.Proposal[value, felt.Felt, felt.Felt],
-	prevoteCh chan types.Prevote[felt.Felt, felt.Felt],
-	precommitCh chan types.Precommit[felt.Felt, felt.Felt],
-) p2p.Listeners[value, felt.Felt, felt.Felt] {
-	return p2p.Listeners[value, felt.Felt, felt.Felt]{
+	proposalCh chan starknet.Proposal,
+	prevoteCh chan starknet.Prevote,
+	precommitCh chan starknet.Precommit,
+) listeners {
+	return listeners{
 		ProposalListener:  newMockListener(proposalCh),
 		PrevoteListener:   newMockListener(prevoteCh),
 		PrecommitListener: newMockListener(precommitCh),
 	}
 }
 
-func mockBroadcasters() p2p.Broadcasters[value, felt.Felt, felt.Felt] {
-	return p2p.Broadcasters[value, felt.Felt, felt.Felt]{
-		ProposalBroadcaster:  &mockBroadcaster[types.Proposal[value, felt.Felt, felt.Felt]]{},
-		PrevoteBroadcaster:   &mockBroadcaster[types.Prevote[felt.Felt, felt.Felt]]{},
-		PrecommitBroadcaster: &mockBroadcaster[types.Precommit[felt.Felt, felt.Felt]]{},
+func mockBroadcasters() broadcasters {
+	return broadcasters{
+		ProposalBroadcaster:  &mockBroadcaster[starknet.Proposal]{},
+		PrevoteBroadcaster:   &mockBroadcaster[starknet.Prevote]{},
+		PrecommitBroadcaster: &mockBroadcaster[starknet.Precommit]{},
 	}
 }
 
@@ -85,33 +87,33 @@ func mockTimeoutFn(step types.Step, round types.Round) time.Duration {
 	return 1 * time.Millisecond
 }
 
-func getRandMessageHeader(random *rand.Rand) types.MessageHeader[felt.Felt] {
-	return types.MessageHeader[felt.Felt]{
+func getRandMessageHeader(random *rand.Rand) starknet.MessageHeader {
+	return starknet.MessageHeader{
 		Height: types.Height(random.Uint32()),
 		Round:  types.Round(random.Int()),
-		Sender: felt.FromUint64(random.Uint64()),
+		Sender: starknet.Address(felt.FromUint64(random.Uint64())),
 	}
 }
 
-func getRandProposal(random *rand.Rand) types.Proposal[value, felt.Felt, felt.Felt] {
-	return types.Proposal[value, felt.Felt, felt.Felt]{
+func getRandProposal(random *rand.Rand) starknet.Proposal {
+	return starknet.Proposal{
 		MessageHeader: getRandMessageHeader(random),
-		Value:         utils.HeapPtr(value(random.Uint64())),
+		Value:         utils.HeapPtr(starknet.Value(random.Uint64())),
 		ValidRound:    types.Round(random.Int()),
 	}
 }
 
-func getRandPrevote(random *rand.Rand) types.Prevote[felt.Felt, felt.Felt] {
-	return types.Prevote[felt.Felt, felt.Felt]{
+func getRandPrevote(random *rand.Rand) starknet.Prevote {
+	return starknet.Prevote{
 		MessageHeader: getRandMessageHeader(random),
-		ID:            utils.HeapPtr(felt.FromUint64(random.Uint64())),
+		ID:            utils.HeapPtr(hash.Hash(felt.FromUint64(random.Uint64()))),
 	}
 }
 
-func getRandPrecommit(random *rand.Rand) types.Precommit[felt.Felt, felt.Felt] {
-	return types.Precommit[felt.Felt, felt.Felt]{
+func getRandPrecommit(random *rand.Rand) starknet.Precommit {
+	return starknet.Precommit{
 		MessageHeader: getRandMessageHeader(random),
-		ID:            utils.HeapPtr(felt.FromUint64(random.Uint64())),
+		ID:            utils.HeapPtr(hash.Hash(felt.FromUint64(random.Uint64()))),
 	}
 }
 
@@ -129,42 +131,42 @@ func getRandTimeout(random *rand.Rand, step types.Step) types.Timeout {
 func generateAndRegisterRandomActions(
 	random *rand.Rand,
 	expectedBroadcast *expectedBroadcast,
-) []types.Action[value, felt.Felt, felt.Felt] {
-	actions := make([]types.Action[value, felt.Felt, felt.Felt], actionCount)
+) []starknet.Action {
+	actions := make([]starknet.Action, actionCount)
 	for i := range actionCount {
 		switch random.Int() % 3 {
 		case 0:
 			proposal := getRandProposal(random)
 			expectedBroadcast.proposals = append(expectedBroadcast.proposals, proposal)
-			actions[i] = utils.HeapPtr(types.BroadcastProposal[value, felt.Felt, felt.Felt](proposal))
+			actions[i] = utils.HeapPtr(starknet.BroadcastProposal(proposal))
 		case 1:
 			prevote := getRandPrevote(random)
 			expectedBroadcast.prevotes = append(expectedBroadcast.prevotes, prevote)
-			actions[i] = utils.HeapPtr(types.BroadcastPrevote[felt.Felt, felt.Felt](prevote))
+			actions[i] = utils.HeapPtr(starknet.BroadcastPrevote(prevote))
 		case 2:
 			precommit := getRandPrecommit(random)
 			expectedBroadcast.precommits = append(expectedBroadcast.precommits, precommit)
-			actions[i] = utils.HeapPtr(types.BroadcastPrecommit[felt.Felt, felt.Felt](precommit))
+			actions[i] = utils.HeapPtr(starknet.BroadcastPrecommit(precommit))
 		}
 	}
 	return actions
 }
 
-func toAction(timeout types.Timeout) types.Action[value, felt.Felt, felt.Felt] {
+func toAction(timeout types.Timeout) starknet.Action {
 	return utils.HeapPtr(types.ScheduleTimeout(timeout))
 }
 
-func increaseBroadcasterWaitGroup[M types.Message[value, felt.Felt, felt.Felt]](
+func increaseBroadcasterWaitGroup[M starknet.Message](
 	expectedBroadcast []M,
-	broadcaster p2p.Broadcaster[M, value, felt.Felt, felt.Felt],
+	broadcaster broadcaster[M],
 ) {
 	broadcaster.(*mockBroadcaster[M]).wg.Add(len(expectedBroadcast))
 }
 
-func waitAndAssertBroadcaster[M types.Message[value, felt.Felt, felt.Felt]](
+func waitAndAssertBroadcaster[M starknet.Message](
 	t *testing.T,
 	expectedBroadcast []M,
-	broadcaster p2p.Broadcaster[M, value, felt.Felt, felt.Felt],
+	broadcaster broadcaster[M],
 ) {
 	mockBroadcaster := broadcaster.(*mockBroadcaster[M])
 	mockBroadcaster.wg.Wait()
@@ -182,12 +184,12 @@ func TestDriver(t *testing.T) {
 
 	expectedBroadcast := &expectedBroadcast{}
 
-	proposalCh := make(chan types.Proposal[value, felt.Felt, felt.Felt])
-	prevoteCh := make(chan types.Prevote[felt.Felt, felt.Felt])
-	precommitCh := make(chan types.Precommit[felt.Felt, felt.Felt])
+	proposalCh := make(chan starknet.Proposal)
+	prevoteCh := make(chan starknet.Prevote)
+	precommitCh := make(chan starknet.Precommit)
 	broadcasters := mockBroadcasters()
 
-	stateMachine := mocks.NewMockStateMachine[value, felt.Felt, felt.Felt](ctrl)
+	stateMachine := mocks.NewMockStateMachine[starknet.Value, hash.Hash, starknet.Address](ctrl)
 	stateMachine.EXPECT().ReplayWAL().AnyTimes().Return() // ignore WAL replay logic here
 	driver := driver.New(memory.New(), stateMachine, mockListeners(proposalCh, prevoteCh, precommitCh), broadcasters, mockTimeoutFn)
 

--- a/consensus/starknet/starknet.go
+++ b/consensus/starknet/starknet.go
@@ -1,0 +1,33 @@
+package starknet
+
+import (
+	"github.com/NethermindEth/juno/consensus/types"
+	"github.com/NethermindEth/juno/core/address"
+	"github.com/NethermindEth/juno/core/felt"
+	"github.com/NethermindEth/juno/core/hash"
+)
+
+// TODO: Replace with the actual value type.
+type Value uint64
+
+func (v Value) Hash() hash.Hash {
+	return hash.Hash(*new(felt.Felt).SetUint64(uint64(v)))
+}
+
+type (
+	Address = address.Address
+	Hash    = hash.Hash
+
+	Message       = types.Message[Value, Hash, Address]
+	Proposal      = types.Proposal[Value, Hash, Address]
+	Prevote       = types.Prevote[Hash, Address]
+	Precommit     = types.Precommit[Hash, Address]
+	Vote          = types.Vote[Hash, Address]
+	MessageHeader = types.MessageHeader[Address]
+	Messages      = types.Messages[Value, Hash, Address]
+
+	Action             = types.Action[Value, Hash, Address]
+	BroadcastProposal  = types.BroadcastProposal[Value, Hash, Address]
+	BroadcastPrevote   = types.BroadcastPrevote[Hash, Address]
+	BroadcastPrecommit = types.BroadcastPrecommit[Hash, Address]
+)

--- a/consensus/tendermint/action_asserter_test.go
+++ b/consensus/tendermint/action_asserter_test.go
@@ -3,8 +3,9 @@ package tendermint
 import (
 	"testing"
 
+	"github.com/NethermindEth/juno/consensus/starknet"
 	"github.com/NethermindEth/juno/consensus/types"
-	"github.com/NethermindEth/juno/core/felt"
+	"github.com/NethermindEth/juno/core/hash"
 	"github.com/NethermindEth/juno/utils"
 	"github.com/stretchr/testify/assert"
 )
@@ -14,23 +15,23 @@ import (
 // actions is the list of actions that were produced by the state machine after processing the input message.
 type actionAsserter[T any] struct {
 	testing      *testing.T
-	stateMachine *stateMachine[value, felt.Felt, felt.Felt]
+	stateMachine *testStateMachine
 	inputMessage T
-	actions      []types.Action[value, felt.Felt, felt.Felt]
+	actions      []starknet.Action
 }
 
 // expectActions asserts the expected actions are in the result actions.
 // It also asserts additional conditions for each of the expected actions.
-func (a actionAsserter[T]) expectActions(expected ...types.Action[value, felt.Felt, felt.Felt]) actionAsserter[T] {
+func (a actionAsserter[T]) expectActions(expected ...starknet.Action) actionAsserter[T] {
 	a.testing.Helper()
 	assert.ElementsMatch(a.testing, expected, a.actions)
 	for _, action := range expected {
 		switch action := action.(type) {
-		case *types.BroadcastProposal[value, felt.Felt, felt.Felt]:
-			assertProposal(a.testing, a.stateMachine, types.Proposal[value, felt.Felt, felt.Felt](*action))
-		case *types.BroadcastPrevote[felt.Felt, felt.Felt]:
-			assertPrevote(a.testing, a.stateMachine, types.Prevote[felt.Felt, felt.Felt](*action))
-		case *types.BroadcastPrecommit[felt.Felt, felt.Felt]:
+		case *starknet.BroadcastProposal:
+			assertProposal(a.testing, a.stateMachine, starknet.Proposal(*action))
+		case *starknet.BroadcastPrevote:
+			assertPrevote(a.testing, a.stateMachine, starknet.Prevote(*action))
+		case *starknet.BroadcastPrecommit:
 			// If the post state is not in new height and a value is committed, assert the valid and locked tuples.
 			if a.stateMachine.state.height == action.Height && action.ID != nil {
 				assert.Equal(a.testing, a.stateMachine.state.lockedRound, action.Round)
@@ -38,7 +39,7 @@ func (a actionAsserter[T]) expectActions(expected ...types.Action[value, felt.Fe
 				assert.Equal(a.testing, a.stateMachine.state.validRound, action.Round)
 				assert.Equal(a.testing, getHash(a.stateMachine.state.validValue), action.ID)
 			}
-			assertPrecommit(a.testing, a.stateMachine, types.Precommit[felt.Felt, felt.Felt](*action))
+			assertPrecommit(a.testing, a.stateMachine, starknet.Precommit(*action))
 		case *types.ScheduleTimeout:
 			// ScheduleTimeout doesn't come with any state change, so there's nothing to assert here.
 		}
@@ -46,7 +47,7 @@ func (a actionAsserter[T]) expectActions(expected ...types.Action[value, felt.Fe
 	return a
 }
 
-func getHash(val *value) *felt.Felt {
+func getHash(val *starknet.Value) *hash.Hash {
 	if val != nil {
 		return utils.HeapPtr(val.Hash())
 	}

--- a/consensus/tendermint/action_builder_test.go
+++ b/consensus/tendermint/action_builder_test.go
@@ -1,24 +1,24 @@
 package tendermint
 
 import (
+	"github.com/NethermindEth/juno/consensus/starknet"
 	"github.com/NethermindEth/juno/consensus/types"
-	"github.com/NethermindEth/juno/core/felt"
 )
 
 // actionBuilder is a helper struct to build expected actions as the result of processing messages and timeouts for the state machine.
 type actionBuilder struct {
-	thisNodeAddr felt.Felt
+	thisNodeAddr starknet.Address
 	actionHeight types.Height
 	actionRound  types.Round
 }
 
-func (t actionBuilder) buildMessageHeader() types.MessageHeader[felt.Felt] {
-	return types.MessageHeader[felt.Felt]{Height: t.actionHeight, Round: t.actionRound, Sender: t.thisNodeAddr}
+func (t actionBuilder) buildMessageHeader() starknet.MessageHeader {
+	return starknet.MessageHeader{Height: t.actionHeight, Round: t.actionRound, Sender: t.thisNodeAddr}
 }
 
 // broadcastProposal builds and returns a BroadcastProposal action.
-func (t actionBuilder) broadcastProposal(val value, validRound types.Round) types.Action[value, felt.Felt, felt.Felt] {
-	return &types.BroadcastProposal[value, felt.Felt, felt.Felt]{
+func (t actionBuilder) broadcastProposal(val starknet.Value, validRound types.Round) starknet.Action {
+	return &starknet.BroadcastProposal{
 		MessageHeader: t.buildMessageHeader(),
 		ValidRound:    validRound,
 		Value:         &val,
@@ -26,23 +26,23 @@ func (t actionBuilder) broadcastProposal(val value, validRound types.Round) type
 }
 
 // broadcastPrevote builds and returns a BroadcastPrevote action.
-func (t actionBuilder) broadcastPrevote(val *value) types.Action[value, felt.Felt, felt.Felt] {
-	return &types.BroadcastPrevote[felt.Felt, felt.Felt]{
+func (t actionBuilder) broadcastPrevote(val *starknet.Value) starknet.Action {
+	return &starknet.BroadcastPrevote{
 		MessageHeader: t.buildMessageHeader(),
 		ID:            getHash(val),
 	}
 }
 
 // broadcastPrecommit builds and returns a BroadcastPrecommit action.
-func (t actionBuilder) broadcastPrecommit(val *value) types.Action[value, felt.Felt, felt.Felt] {
-	return &types.BroadcastPrecommit[felt.Felt, felt.Felt]{
+func (t actionBuilder) broadcastPrecommit(val *starknet.Value) starknet.Action {
+	return &starknet.BroadcastPrecommit{
 		MessageHeader: t.buildMessageHeader(),
 		ID:            getHash(val),
 	}
 }
 
 // scheduleTimeout builds and returns a ScheduleTimeout action.
-func (t actionBuilder) scheduleTimeout(s types.Step) types.Action[value, felt.Felt, felt.Felt] {
+func (t actionBuilder) scheduleTimeout(s types.Step) starknet.Action {
 	return &types.ScheduleTimeout{
 		Step:   s,
 		Height: t.actionHeight,

--- a/consensus/tendermint/assert_utils_test.go
+++ b/consensus/tendermint/assert_utils_test.go
@@ -3,20 +3,20 @@ package tendermint
 import (
 	"testing"
 
+	"github.com/NethermindEth/juno/consensus/starknet"
 	"github.com/NethermindEth/juno/consensus/types"
-	"github.com/NethermindEth/juno/core/felt"
 	"github.com/stretchr/testify/assert"
 )
 
 // assertState asserts that the state machine is in the expected state.
-func assertState(t *testing.T, stateMachine *stateMachine[value, felt.Felt, felt.Felt], expectedHeight types.Height, expectedRound types.Round, expectedStep types.Step) {
+func assertState(t *testing.T, stateMachine *testStateMachine, expectedHeight types.Height, expectedRound types.Round, expectedStep types.Step) {
 	t.Helper()
 	assert.Equal(t, expectedHeight, stateMachine.state.height, "height not equal")
 	assert.Equal(t, expectedRound, stateMachine.state.round, "round not equal")
 	assert.Equal(t, expectedStep, stateMachine.state.step, "step not equal")
 }
 
-func assertMessage[T types.Message[value, felt.Felt, felt.Felt]](t *testing.T, messages map[types.Height]map[types.Round]map[felt.Felt]T, expectedMsgHeader types.MessageHeader[felt.Felt], expectedMsg T) {
+func assertMessage[T starknet.Message](t *testing.T, messages map[types.Height]map[types.Round]map[starknet.Address]T, expectedMsgHeader starknet.MessageHeader, expectedMsg T) {
 	t.Helper()
 	assert.Contains(t, messages, expectedMsgHeader.Height, "height not found")
 	assert.Contains(t, messages[expectedMsgHeader.Height], expectedMsgHeader.Round, "round not found")
@@ -25,7 +25,7 @@ func assertMessage[T types.Message[value, felt.Felt, felt.Felt]](t *testing.T, m
 }
 
 // assertProposal asserts that the proposal message is in the state machine, except when the state machine advanced to the next height.
-func assertProposal(t *testing.T, stateMachine *stateMachine[value, felt.Felt, felt.Felt], expectedMsg types.Proposal[value, felt.Felt, felt.Felt]) {
+func assertProposal(t *testing.T, stateMachine *testStateMachine, expectedMsg starknet.Proposal) {
 	t.Helper()
 	// New height will discard the previous height messages.
 	if stateMachine.state.height != expectedMsg.Height {
@@ -35,7 +35,7 @@ func assertProposal(t *testing.T, stateMachine *stateMachine[value, felt.Felt, f
 }
 
 // assertPrevote asserts that the prevote message is in the state machine, except when the state machine advanced to the next height.
-func assertPrevote(t *testing.T, stateMachine *stateMachine[value, felt.Felt, felt.Felt], expectedMsg types.Prevote[felt.Felt, felt.Felt]) {
+func assertPrevote(t *testing.T, stateMachine *testStateMachine, expectedMsg starknet.Prevote) {
 	t.Helper()
 	// New height will discard the previous height messages.
 	if stateMachine.state.height != expectedMsg.Height {
@@ -45,7 +45,7 @@ func assertPrevote(t *testing.T, stateMachine *stateMachine[value, felt.Felt, fe
 }
 
 // assertPrecommit asserts that the precommit message is in the state machine, except when the state machine advanced to the next height.
-func assertPrecommit(t *testing.T, stateMachine *stateMachine[value, felt.Felt, felt.Felt], expectedMsg types.Precommit[felt.Felt, felt.Felt]) {
+func assertPrecommit(t *testing.T, stateMachine *testStateMachine, expectedMsg starknet.Precommit) {
 	t.Helper()
 	// New height will discard the previous height messages.
 	if stateMachine.state.height != expectedMsg.Height {

--- a/consensus/tendermint/incoming_message_builder_test.go
+++ b/consensus/tendermint/incoming_message_builder_test.go
@@ -3,23 +3,23 @@ package tendermint
 import (
 	"testing"
 
+	"github.com/NethermindEth/juno/consensus/starknet"
 	"github.com/NethermindEth/juno/consensus/types"
-	"github.com/NethermindEth/juno/core/felt"
 )
 
 // incomingMessageBuilder is a helper struct to build incoming messages received from other nodes for the state machine.
 // Each method builds a message, processes it, assert if it's stored in the state machine, and returns an actionAsserter to assert the result actions.
 type incomingMessageBuilder struct {
 	testing      *testing.T
-	stateMachine *stateMachine[value, felt.Felt, felt.Felt]
-	header       types.MessageHeader[felt.Felt]
+	stateMachine *testStateMachine
+	header       starknet.MessageHeader
 }
 
 // proposal builds and processes a Proposal message, asserts it's stored in the state machine,
 // and returns an actionAsserter to check resulting actions.
-func (t incomingMessageBuilder) proposal(val value, validRound types.Round) actionAsserter[types.Proposal[value, felt.Felt, felt.Felt]] {
+func (t incomingMessageBuilder) proposal(val starknet.Value, validRound types.Round) actionAsserter[starknet.Proposal] {
 	t.testing.Helper()
-	proposal := types.Proposal[value, felt.Felt, felt.Felt]{
+	proposal := starknet.Proposal{
 		MessageHeader: t.header,
 		ValidRound:    validRound,
 		Value:         &val,
@@ -28,7 +28,7 @@ func (t incomingMessageBuilder) proposal(val value, validRound types.Round) acti
 
 	assertProposal(t.testing, t.stateMachine, proposal)
 
-	return actionAsserter[types.Proposal[value, felt.Felt, felt.Felt]]{
+	return actionAsserter[starknet.Proposal]{
 		testing:      t.testing,
 		stateMachine: t.stateMachine,
 		inputMessage: proposal,
@@ -38,9 +38,9 @@ func (t incomingMessageBuilder) proposal(val value, validRound types.Round) acti
 
 // prevote builds and processes a types.Prevote message, asserts it's stored in the state machine,
 // and returns an actionAsserter to check resulting actions.
-func (t incomingMessageBuilder) prevote(val *value) actionAsserter[types.Prevote[felt.Felt, felt.Felt]] {
+func (t incomingMessageBuilder) prevote(val *starknet.Value) actionAsserter[starknet.Prevote] {
 	t.testing.Helper()
-	prevote := types.Prevote[felt.Felt, felt.Felt]{
+	prevote := starknet.Prevote{
 		MessageHeader: t.header,
 		ID:            getHash(val),
 	}
@@ -48,7 +48,7 @@ func (t incomingMessageBuilder) prevote(val *value) actionAsserter[types.Prevote
 
 	assertPrevote(t.testing, t.stateMachine, prevote)
 
-	return actionAsserter[types.Prevote[felt.Felt, felt.Felt]]{
+	return actionAsserter[starknet.Prevote]{
 		testing:      t.testing,
 		stateMachine: t.stateMachine,
 		inputMessage: prevote,
@@ -58,9 +58,9 @@ func (t incomingMessageBuilder) prevote(val *value) actionAsserter[types.Prevote
 
 // precommit builds and processes a Precommit message, asserts it's stored in the state machine,
 // and returns an actionAsserter to check resulting actions.
-func (t incomingMessageBuilder) precommit(val *value) actionAsserter[types.Precommit[felt.Felt, felt.Felt]] {
+func (t incomingMessageBuilder) precommit(val *starknet.Value) actionAsserter[starknet.Precommit] {
 	t.testing.Helper()
-	precommit := types.Precommit[felt.Felt, felt.Felt]{
+	precommit := starknet.Precommit{
 		MessageHeader: t.header,
 		ID:            getHash(val),
 	}
@@ -68,7 +68,7 @@ func (t incomingMessageBuilder) precommit(val *value) actionAsserter[types.Preco
 
 	assertPrecommit(t.testing, t.stateMachine, precommit)
 
-	return actionAsserter[types.Precommit[felt.Felt, felt.Felt]]{
+	return actionAsserter[starknet.Precommit]{
 		testing:      t.testing,
 		stateMachine: t.stateMachine,
 		inputMessage: precommit,

--- a/consensus/tendermint/rule_commit_value_test.go
+++ b/consensus/tendermint/rule_commit_value_test.go
@@ -4,8 +4,8 @@ import (
 	"slices"
 	"testing"
 
+	"github.com/NethermindEth/juno/consensus/starknet"
 	"github.com/NethermindEth/juno/consensus/types"
-	"github.com/NethermindEth/juno/core/felt"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -15,7 +15,7 @@ func TestCommitValue(t *testing.T) {
 		currentRound := newTestRound(t, stateMachine, 0, 0)
 		nextRound := newTestRound(t, stateMachine, 1, 0)
 
-		committedValue := value(10)
+		committedValue := starknet.Value(10)
 
 		currentRound.start().expectActions(
 			currentRound.action().scheduleTimeout(types.StepPropose),
@@ -38,7 +38,7 @@ func TestCommitValue(t *testing.T) {
 		// TODO: This is a workaround to get the chain. Find a better way to do this.
 		chain := stateMachine.blockchain.(*chain)
 
-		precommits := []types.Precommit[felt.Felt, felt.Felt]{val0Precommit, val1Precommit, val2Precommit}
+		precommits := []starknet.Precommit{val0Precommit, val1Precommit, val2Precommit}
 		assert.Equal(t, chain.decision[0], committedValue)
 		for _, p := range chain.decisionCertificates[0] {
 			assert.True(t, slices.Contains(precommits, p))
@@ -53,7 +53,7 @@ func TestCommitValue(t *testing.T) {
 		stateMachine := setupStateMachine(t, 4, 3)
 		currentRound := newTestRound(t, stateMachine, 0, 0)
 		nextRound := newTestRound(t, stateMachine, 1, 0)
-		committedValue := value(10)
+		committedValue := starknet.Value(10)
 
 		currentRound.start().expectActions(
 			currentRound.action().scheduleTimeout(types.StepPropose),
@@ -72,7 +72,7 @@ func TestCommitValue(t *testing.T) {
 		// TODO: This is a workaround to get the chain. Find a better way to do this.
 		chain := stateMachine.blockchain.(*chain)
 
-		precommits := []types.Precommit[felt.Felt, felt.Felt]{val0Precommit, val1Precommit, val2Precommit}
+		precommits := []starknet.Precommit{val0Precommit, val1Precommit, val2Precommit}
 		assert.Equal(t, chain.decision[0], committedValue)
 		for _, p := range chain.decisionCertificates[0] {
 			assert.True(t, slices.Contains(precommits, p))

--- a/consensus/tendermint/rule_first_proposal_test.go
+++ b/consensus/tendermint/rule_first_proposal_test.go
@@ -3,6 +3,7 @@ package tendermint
 import (
 	"testing"
 
+	"github.com/NethermindEth/juno/consensus/starknet"
 	"github.com/NethermindEth/juno/consensus/types"
 	"github.com/NethermindEth/juno/utils"
 	"github.com/stretchr/testify/assert"
@@ -17,7 +18,7 @@ func TestFirstProposal(t *testing.T) {
 		currentRound.start()
 
 		// Receive a valid proposal with lockedRound = -1
-		proposalValue := value(42)
+		proposalValue := starknet.Value(42)
 		currentRound.validator(0).proposal(proposalValue, -1).expectActions(currentRound.action().broadcastPrevote(&proposalValue))
 
 		// Assertions - We should be in prevote step
@@ -29,7 +30,7 @@ func TestFirstProposal(t *testing.T) {
 		previousRound := newTestRound(t, stateMachine, 0, 0)
 		nextRound := newTestRound(t, stateMachine, 0, 1)
 
-		expectedValue := value(42)
+		expectedValue := starknet.Value(42)
 
 		// Simulate the previous round such that it times out in the precommit step
 		// Validator 0 is a faulty proposer, proposing an invalid value to validator 1
@@ -61,7 +62,7 @@ func TestFirstProposal(t *testing.T) {
 		previousRound := newTestRound(t, stateMachine, 0, 0)
 		nextRound := newTestRound(t, stateMachine, 0, 1)
 
-		expectedValue := value(42)
+		expectedValue := starknet.Value(42)
 
 		// Simulate the previous round such that it times out in the precommit step
 		// Validator 0 is a faulty proposer, proposing an invalid value to validator 1
@@ -83,7 +84,7 @@ func TestFirstProposal(t *testing.T) {
 		previousRound.processTimeout(types.StepPrecommit)
 
 		// Validator 1 proposes an unexpected value, because it hasn't received a proposal in the previous round.
-		nextRound.validator(1).proposal(value(43), -1).expectActions(nextRound.action().broadcastPrevote(nil))
+		nextRound.validator(1).proposal(starknet.Value(43), -1).expectActions(nextRound.action().broadcastPrevote(nil))
 		assertState(t, stateMachine, types.Height(0), types.Round(1), types.StepPrevote)
 	})
 
@@ -95,7 +96,7 @@ func TestFirstProposal(t *testing.T) {
 		currentRound.start()
 
 		// Receive an invalid proposal
-		currentRound.validator(0).proposal(value(1e9), -1).expectActions(currentRound.action().broadcastPrevote(nil))
+		currentRound.validator(0).proposal(starknet.Value(1e9), -1).expectActions(currentRound.action().broadcastPrevote(nil))
 
 		// Assertions - We should be in prevote step
 		assertState(t, stateMachine, types.Height(0), types.Round(0), types.StepPrevote)
@@ -117,7 +118,7 @@ func TestFirstProposal(t *testing.T) {
 		assertState(t, stateMachine, types.Height(0), types.Round(0), types.StepPrecommit)
 
 		// Receive a proposal while not in propose step
-		currentRound.validator(0).proposal(value(42), -1).expectActions()
+		currentRound.validator(0).proposal(starknet.Value(42), -1).expectActions()
 
 		// Assertions - We should still be in precommit step, nothing changed
 		assertState(t, stateMachine, types.Height(0), types.Round(0), types.StepPrecommit)

--- a/consensus/tendermint/rule_polka_any_test.go
+++ b/consensus/tendermint/rule_polka_any_test.go
@@ -3,6 +3,7 @@ package tendermint
 import (
 	"testing"
 
+	"github.com/NethermindEth/juno/consensus/starknet"
 	"github.com/NethermindEth/juno/consensus/types"
 	"github.com/NethermindEth/juno/utils"
 	"github.com/stretchr/testify/assert"
@@ -17,11 +18,11 @@ func TestPolkaAny(t *testing.T) {
 		currentRound.start()
 
 		// Receive a proposal and move to prevote step
-		currentRound.validator(0).proposal(value(42), -1)
+		currentRound.validator(0).proposal(starknet.Value(42), -1)
 
 		// Receive 2 more prevotes combined with our own prevote, all in mixed value
 		currentRound.validator(1).prevote(nil)
-		currentRound.validator(2).prevote(utils.HeapPtr(value(44))).expectActions(currentRound.action().scheduleTimeout(types.StepPrevote))
+		currentRound.validator(2).prevote(utils.HeapPtr(starknet.Value(44))).expectActions(currentRound.action().scheduleTimeout(types.StepPrevote))
 		assert.True(t, stateMachine.state.timeoutPrevoteScheduled)
 
 		// Assertions - We should still be in prevote step, but timeout should be scheduled
@@ -36,10 +37,10 @@ func TestPolkaAny(t *testing.T) {
 		currentRound.start()
 
 		// Receive a proposal and move to prevote step
-		currentRound.validator(0).proposal(value(42), -1)
+		currentRound.validator(0).proposal(starknet.Value(42), -1)
 
 		// Receive 1 more prevote (not enough for 2f+1 where f=1)
-		currentRound.validator(0).prevote(utils.HeapPtr(value(42)))
+		currentRound.validator(0).prevote(utils.HeapPtr(starknet.Value(42)))
 
 		// No action should be taken
 		assertState(t, stateMachine, types.Height(0), types.Round(0), types.StepPrevote)
@@ -53,9 +54,9 @@ func TestPolkaAny(t *testing.T) {
 		currentRound.start()
 
 		// Add enough prevotes, but since we're not in prevote step, nothing should happen
-		currentRound.validator(0).prevote(utils.HeapPtr(value(42))).expectActions()
-		currentRound.validator(1).prevote(utils.HeapPtr(value(43))).expectActions()
-		currentRound.validator(2).prevote(utils.HeapPtr(value(44))).expectActions()
+		currentRound.validator(0).prevote(utils.HeapPtr(starknet.Value(42))).expectActions()
+		currentRound.validator(1).prevote(utils.HeapPtr(starknet.Value(43))).expectActions()
+		currentRound.validator(2).prevote(utils.HeapPtr(starknet.Value(44))).expectActions()
 
 		// Assertions - still in propose step, no timeout should be scheduled
 		assertState(t, stateMachine, types.Height(0), types.Round(0), types.StepPropose)
@@ -69,15 +70,15 @@ func TestPolkaAny(t *testing.T) {
 		currentRound.start()
 
 		// Receive a proposal and move to prevote step
-		currentRound.validator(0).proposal(value(42), -1)
+		currentRound.validator(0).proposal(starknet.Value(42), -1)
 
 		// Receive 2 prevotes, combined with our own prevote and schedule timeout for prevote
 		currentRound.validator(0).prevote(nil).expectActions()
-		currentRound.validator(1).prevote(utils.HeapPtr(value(43))).expectActions(currentRound.action().scheduleTimeout(types.StepPrevote))
+		currentRound.validator(1).prevote(utils.HeapPtr(starknet.Value(43))).expectActions(currentRound.action().scheduleTimeout(types.StepPrevote))
 		assert.True(t, stateMachine.state.timeoutPrevoteScheduled)
 
 		// Receive 1 more prevote, no timeout should be scheduled
-		currentRound.validator(2).prevote(utils.HeapPtr(value(44))).expectActions()
+		currentRound.validator(2).prevote(utils.HeapPtr(starknet.Value(44))).expectActions()
 		assert.True(t, stateMachine.state.timeoutPrevoteScheduled)
 
 		// Assertions - We should still be in prevote step

--- a/consensus/tendermint/rule_polka_nil_test.go
+++ b/consensus/tendermint/rule_polka_nil_test.go
@@ -3,6 +3,7 @@ package tendermint
 import (
 	"testing"
 
+	"github.com/NethermindEth/juno/consensus/starknet"
 	"github.com/NethermindEth/juno/consensus/types"
 )
 
@@ -15,7 +16,7 @@ func TestPolkaNil(t *testing.T) {
 		currentRound.start()
 
 		// Receive a proposal and move to prevote step
-		currentRound.validator(0).proposal(value(42), -1)
+		currentRound.validator(0).proposal(starknet.Value(42), -1)
 
 		// Receive 3 prevotes
 		currentRound.validator(0).prevote(nil)
@@ -55,7 +56,7 @@ func TestPolkaNil(t *testing.T) {
 		currentRound.start()
 
 		// Receive a proposal and move to prevote step
-		currentRound.validator(0).proposal(value(42), -1)
+		currentRound.validator(0).proposal(starknet.Value(42), -1)
 
 		// Receive 2 prevotes
 		currentRound.validator(0).prevote(nil)
@@ -90,14 +91,14 @@ func TestPolkaNil(t *testing.T) {
 		currentRound.start()
 
 		// Receive a proposal and move to prevote step
-		currentRound.validator(0).proposal(value(42), -1)
+		currentRound.validator(0).proposal(starknet.Value(42), -1)
 
 		// Receive 2 prevotes
 		currentRound.validator(0).prevote(nil)
 		currentRound.validator(1).prevote(nil)
 
 		// This validator votes for a value instead of nil
-		val := value(42)
+		val := starknet.Value(42)
 		currentRound.validator(2).prevote(&val)
 
 		// No precommit action should occur with mixed votes

--- a/consensus/tendermint/rule_precommit_any_test.go
+++ b/consensus/tendermint/rule_precommit_any_test.go
@@ -3,6 +3,7 @@ package tendermint
 import (
 	"testing"
 
+	"github.com/NethermindEth/juno/consensus/starknet"
 	"github.com/NethermindEth/juno/consensus/types"
 	"github.com/NethermindEth/juno/utils"
 	"github.com/stretchr/testify/assert"
@@ -17,13 +18,13 @@ func TestPrecommitAny(t *testing.T) {
 		currentRound.start()
 
 		// We need to get to precommit step, so first go through proposal and prevote
-		currentRound.validator(0).proposal(value(42), -1)
-		currentRound.validator(0).prevote(utils.HeapPtr(value(42)))
+		currentRound.validator(0).proposal(starknet.Value(42), -1)
+		currentRound.validator(0).prevote(utils.HeapPtr(starknet.Value(42)))
 		currentRound.validator(1).prevote(nil)
-		currentRound.validator(2).prevote(utils.HeapPtr(value(42)))
+		currentRound.validator(2).prevote(utils.HeapPtr(starknet.Value(42)))
 
 		// Receive 2 more precommits combined with our own precommit, all with mixed values
-		currentRound.validator(0).precommit(utils.HeapPtr(value(42)))
+		currentRound.validator(0).precommit(utils.HeapPtr(starknet.Value(42)))
 		currentRound.validator(1).precommit(nil).expectActions(currentRound.action().scheduleTimeout(types.StepPrecommit))
 
 		assert.True(t, stateMachine.state.timeoutPrecommitScheduled)
@@ -38,9 +39,9 @@ func TestPrecommitAny(t *testing.T) {
 		currentRound.start()
 
 		// Receive 3 precommits even though we haven't received a proposal.
-		currentRound.validator(0).precommit(utils.HeapPtr(value(42)))
+		currentRound.validator(0).precommit(utils.HeapPtr(starknet.Value(42)))
 		currentRound.validator(1).precommit(nil)
-		currentRound.validator(2).precommit(utils.HeapPtr(value(43))).expectActions(currentRound.action().scheduleTimeout(types.StepPrecommit))
+		currentRound.validator(2).precommit(utils.HeapPtr(starknet.Value(43))).expectActions(currentRound.action().scheduleTimeout(types.StepPrecommit))
 
 		assert.True(t, stateMachine.state.timeoutPrecommitScheduled)
 		assertState(t, stateMachine, types.Height(0), types.Round(0), types.StepPropose)
@@ -54,12 +55,12 @@ func TestPrecommitAny(t *testing.T) {
 		currentRound.start()
 
 		// Set up to reach precommit step
-		currentRound.validator(0).proposal(value(42), -1)
-		currentRound.validator(0).prevote(utils.HeapPtr(value(42)))
-		currentRound.validator(1).prevote(utils.HeapPtr(value(42)))
+		currentRound.validator(0).proposal(starknet.Value(42), -1)
+		currentRound.validator(0).prevote(utils.HeapPtr(starknet.Value(42)))
+		currentRound.validator(1).prevote(utils.HeapPtr(starknet.Value(42)))
 
 		// Receive 1 more precommit (not enough for 2f+1 where f=1)
-		currentRound.validator(1).precommit(utils.HeapPtr(value(42))).expectActions()
+		currentRound.validator(1).precommit(utils.HeapPtr(starknet.Value(42))).expectActions()
 
 		// No timeout should be scheduled
 		assert.False(t, stateMachine.state.timeoutPrecommitScheduled)
@@ -75,20 +76,20 @@ func TestPrecommitAny(t *testing.T) {
 
 		// Set up to reach precommit step
 		// Validator 0 is a faulty proposer
-		currentRound.validator(0).proposal(value(42), -1).expectActions(
-			currentRound.action().broadcastPrevote(utils.HeapPtr(value(42))),
+		currentRound.validator(0).proposal(starknet.Value(42), -1).expectActions(
+			currentRound.action().broadcastPrevote(utils.HeapPtr(starknet.Value(42))),
 		)
-		currentRound.validator(0).prevote(utils.HeapPtr(value(42)))
-		currentRound.validator(1).prevote(utils.HeapPtr(value(42))).expectActions(
+		currentRound.validator(0).prevote(utils.HeapPtr(starknet.Value(42)))
+		currentRound.validator(1).prevote(utils.HeapPtr(starknet.Value(42))).expectActions(
 			currentRound.action().scheduleTimeout(types.StepPrevote),
-			currentRound.action().broadcastPrecommit(utils.HeapPtr(value(42))),
+			currentRound.action().broadcastPrecommit(utils.HeapPtr(starknet.Value(42))),
 		)
 		assert.False(t, stateMachine.state.timeoutPrecommitScheduled)
 		assertState(t, stateMachine, types.Height(0), types.Round(0), types.StepPrecommit)
 
 		// Receive 2 precommits, combined with our own precommit and schedule timeout
 		currentRound.validator(0).precommit(nil)
-		currentRound.validator(1).precommit(utils.HeapPtr(value(42))).expectActions(currentRound.action().scheduleTimeout(types.StepPrecommit))
+		currentRound.validator(1).precommit(utils.HeapPtr(starknet.Value(42))).expectActions(currentRound.action().scheduleTimeout(types.StepPrecommit))
 		assert.True(t, stateMachine.state.timeoutPrecommitScheduled)
 		assertState(t, stateMachine, types.Height(0), types.Round(0), types.StepPrecommit)
 

--- a/consensus/tendermint/rule_proposal_and_polka_current_test.go
+++ b/consensus/tendermint/rule_proposal_and_polka_current_test.go
@@ -3,6 +3,7 @@ package tendermint
 import (
 	"testing"
 
+	"github.com/NethermindEth/juno/consensus/starknet"
 	"github.com/NethermindEth/juno/consensus/types"
 	"github.com/stretchr/testify/assert"
 )
@@ -12,7 +13,7 @@ func TestProposalAndPolkaCurrent(t *testing.T) {
 		stateMachine := setupStateMachine(t, 4, 3)
 		currentRound := newTestRound(t, stateMachine, 0, 0)
 
-		committedValue := value(42)
+		committedValue := starknet.Value(42)
 
 		// Initialise the round
 		currentRound.start()
@@ -36,7 +37,7 @@ func TestProposalAndPolkaCurrent(t *testing.T) {
 		stateMachine := setupStateMachine(t, 4, 1)
 		currentRound := newTestRound(t, stateMachine, 0, 0)
 		nextRound := newTestRound(t, stateMachine, 0, 1)
-		committedValue := value(42)
+		committedValue := starknet.Value(42)
 
 		// Initialise the round
 		currentRound.start()
@@ -79,7 +80,7 @@ func TestProposalAndPolkaCurrent(t *testing.T) {
 		stateMachine := setupStateMachine(t, 4, 3)
 		currentRound := newTestRound(t, stateMachine, 0, 0)
 
-		committedValue := value(42)
+		committedValue := starknet.Value(42)
 
 		// Initialise the round
 		currentRound.start()

--- a/consensus/tendermint/rule_proposal_and_polka_previous_test.go
+++ b/consensus/tendermint/rule_proposal_and_polka_previous_test.go
@@ -3,6 +3,7 @@ package tendermint
 import (
 	"testing"
 
+	"github.com/NethermindEth/juno/consensus/starknet"
 	"github.com/NethermindEth/juno/consensus/types"
 	"github.com/stretchr/testify/assert"
 )
@@ -15,8 +16,8 @@ func TestProposalAndPolkaPrevious(t *testing.T) {
 		firstRound := newTestRound(t, stateMachine, 0, 0)
 		secondRound := newTestRound(t, stateMachine, 0, 1)
 
-		wrongValue := value(42)
-		correctValue := value(43)
+		wrongValue := starknet.Value(42)
+		correctValue := starknet.Value(43)
 
 		// In the first round, validator 0 sent us a different (valid) value from all the other peers
 		firstRound.start()
@@ -66,8 +67,8 @@ func TestProposalAndPolkaPrevious(t *testing.T) {
 		secondRound := newTestRound(t, stateMachine, 0, 1)
 		thirdRound := newTestRound(t, stateMachine, 0, 2)
 
-		firstValue := value(42)
-		secondValue := value(43)
+		firstValue := starknet.Value(42)
+		secondValue := starknet.Value(43)
 
 		// In the first round, validator 0 "tricked" us to lock to a value but sent a different value to validator 2.
 		firstRound.start()

--- a/consensus/tendermint/rule_skip_round_test.go
+++ b/consensus/tendermint/rule_skip_round_test.go
@@ -3,6 +3,7 @@ package tendermint
 import (
 	"testing"
 
+	"github.com/NethermindEth/juno/consensus/starknet"
 	"github.com/NethermindEth/juno/consensus/types"
 )
 
@@ -10,7 +11,7 @@ func TestSkipRound(t *testing.T) {
 	t.Run("Line 55 (Proposal): Start round r' when f+1 future round messages are received from round r'", func(t *testing.T) {
 		stateMachine := setupStateMachine(t, 4, 3)
 		expectedHeight := types.Height(0)
-		rPrime, rPrimeVal := types.Round(4), value(10)
+		rPrime, rPrimeVal := types.Round(4), starknet.Value(10)
 		futureRound := newTestRound(t, stateMachine, expectedHeight, rPrime)
 
 		stateMachine.ProcessStart(types.Round(0))
@@ -25,7 +26,7 @@ func TestSkipRound(t *testing.T) {
 	t.Run("Line 55 (Prevote): Start round r' when f+1 future round messages are received from round r'", func(t *testing.T) {
 		stateMachine := setupStateMachine(t, 4, 3)
 		expectedHeight := types.Height(0)
-		rPrime, rPrimeVal := types.Round(4), value(10)
+		rPrime, rPrimeVal := types.Round(4), starknet.Value(10)
 		futureRound := newTestRound(t, stateMachine, expectedHeight, rPrime)
 
 		stateMachine.ProcessStart(types.Round(0))
@@ -41,7 +42,7 @@ func TestSkipRound(t *testing.T) {
 		stateMachine := setupStateMachine(t, 4, 3)
 		expectedHeight := types.Height(0)
 		rPrime := types.Round(4)
-		round4Value := value(10)
+		round4Value := starknet.Value(10)
 		futureRound := newTestRound(t, stateMachine, expectedHeight, rPrime)
 
 		stateMachine.ProcessStart(types.Round(0))

--- a/consensus/tendermint/start_test.go
+++ b/consensus/tendermint/start_test.go
@@ -3,6 +3,7 @@ package tendermint
 import (
 	"testing"
 
+	"github.com/NethermindEth/juno/consensus/starknet"
 	"github.com/NethermindEth/juno/consensus/types"
 	"github.com/NethermindEth/juno/utils"
 )
@@ -13,7 +14,7 @@ func TestStartRound(t *testing.T) {
 
 		currentRound := newTestRound(t, stateMachine, 0, 0)
 
-		val := value(1)
+		val := starknet.Value(1)
 		currentRound.start().expectActions(
 			currentRound.action().broadcastProposal(val, -1),
 			currentRound.action().broadcastPrevote(utils.HeapPtr(val)),

--- a/consensus/tendermint/state_machine_context_test.go
+++ b/consensus/tendermint/state_machine_context_test.go
@@ -3,9 +3,12 @@ package tendermint
 import (
 	"testing"
 
+	"github.com/NethermindEth/juno/consensus/starknet"
 	"github.com/NethermindEth/juno/consensus/types"
-	"github.com/NethermindEth/juno/core/felt"
+	"github.com/NethermindEth/juno/core/hash"
 )
+
+type testStateMachine = stateMachine[starknet.Value, hash.Hash, starknet.Address]
 
 // stateMachineContext is a build struct to build test scenarios for the state machine.
 // Sample usages:
@@ -25,12 +28,12 @@ import (
 // but the height and round of the test construct that is being built.
 type stateMachineContext struct {
 	testing       *testing.T
-	stateMachine  *stateMachine[value, felt.Felt, felt.Felt]
+	stateMachine  *testStateMachine
 	builderHeight types.Height
 	builderRound  types.Round
 }
 
-func newTestRound(t *testing.T, stateMachine *stateMachine[value, felt.Felt, felt.Felt], h types.Height, r types.Round) stateMachineContext {
+func newTestRound(t *testing.T, stateMachine *testStateMachine, h types.Height, r types.Round) stateMachineContext {
 	return stateMachineContext{
 		testing:       t,
 		stateMachine:  stateMachine,
@@ -65,7 +68,7 @@ func (t stateMachineContext) validator(idx int) incomingMessageBuilder {
 	return incomingMessageBuilder{
 		testing:      t.testing,
 		stateMachine: t.stateMachine,
-		header:       types.MessageHeader[felt.Felt]{Height: t.builderHeight, Round: t.builderRound, Sender: *getVal(idx)},
+		header:       starknet.MessageHeader{Height: t.builderHeight, Round: t.builderRound, Sender: *getVal(idx)},
 	}
 }
 

--- a/consensus/tendermint/timeout_test.go
+++ b/consensus/tendermint/timeout_test.go
@@ -3,6 +3,7 @@ package tendermint
 import (
 	"testing"
 
+	"github.com/NethermindEth/juno/consensus/starknet"
 	"github.com/NethermindEth/juno/consensus/types"
 	"github.com/NethermindEth/juno/utils"
 	"github.com/stretchr/testify/assert"
@@ -25,8 +26,8 @@ func TestTimeout(t *testing.T) {
 		currentRound := newTestRound(t, stateMachine, 0, 0)
 
 		currentRound.start()
-		currentRound.validator(0).proposal(value(42), -1)
-		currentRound.validator(1).prevote(utils.HeapPtr(value(42)))
+		currentRound.validator(0).proposal(starknet.Value(42), -1)
+		currentRound.validator(1).prevote(utils.HeapPtr(starknet.Value(42)))
 		currentRound.validator(2).prevote(nil).expectActions(currentRound.action().scheduleTimeout(types.StepPrevote))
 		assert.True(t, stateMachine.state.timeoutPrevoteScheduled)
 		assertState(t, stateMachine, types.Height(0), types.Round(0), types.StepPrevote)
@@ -42,7 +43,7 @@ func TestTimeout(t *testing.T) {
 		nextRound := newTestRound(t, stateMachine, 0, 1)
 
 		currentRound.start()
-		currentRound.validator(0).precommit(utils.HeapPtr(value(10)))
+		currentRound.validator(0).precommit(utils.HeapPtr(starknet.Value(10)))
 		currentRound.validator(1).precommit(nil)
 		currentRound.validator(2).precommit(nil).expectActions(currentRound.action().scheduleTimeout(types.StepPrecommit))
 		assert.True(t, stateMachine.state.timeoutPrecommitScheduled)
@@ -65,7 +66,7 @@ func TestTimeout(t *testing.T) {
 
 		currentRound := newTestRound(t, stateMachine, 0, 0)
 
-		committedValue := value(10)
+		committedValue := starknet.Value(10)
 
 		currentRound.start().expectActions(currentRound.action().scheduleTimeout(types.StepPropose))
 

--- a/consensus/types/types.go
+++ b/consensus/types/types.go
@@ -1,14 +1,11 @@
 package types
 
-import "github.com/NethermindEth/juno/core/felt"
-
 type Addr interface {
-	// Ethereum Addresses are 20 bytes
-	~[20]byte | felt.Felt
+	~[4]uint64
 }
 
 type Hash interface {
-	~[32]byte | felt.Felt
+	~[4]uint64
 }
 
 // Hashable's Hash() is used as ID()


### PR DESCRIPTION
This `consensus/starknet` package defines the aliases for concrete types to be used in production.