### PR TITLE
feat: Add scaffolding for proposal state machine

### DIFF
--- a/consensus/p2p/validator/state_machine.go
+++ b/consensus/p2p/validator/state_machine.go
@@ -1,0 +1,111 @@
+package validator
+
+import (
+	"context"
+	"errors"
+
+	"github.com/NethermindEth/juno/consensus/starknet"
+	"github.com/NethermindEth/juno/consensus/types"
+	"github.com/starknet-io/starknet-p2pspecs/p2p/proto/consensus/consensus"
+)
+
+// TODO: better error handling
+var errInvalidMessage = errors.New("invalid message")
+
+type ProposalStateMachine interface {
+	OnEvent(context.Context, Transition, *consensus.ProposalPart) (ProposalStateMachine, error)
+}
+
+// InitialState handles the first step in the proposal flow,
+// accepting only a ProposalInit message to begin the process.
+type InitialState struct{}
+
+func (s *InitialState) OnEvent(
+	ctx context.Context,
+	transition Transition,
+	part *consensus.ProposalPart,
+) (ProposalStateMachine, error) {
+	switch part := part.GetMessages().(type) {
+	case *consensus.ProposalPart_Init:
+		return transition.OnProposalInit(ctx, s, part.Init)
+	default:
+		return nil, errInvalidMessage
+	}
+}
+
+// AwaitingBlockInfoOrCommitmentState handles the transition after ProposalInit,
+// accepting either a BlockInfo (for full proposals) or a Commitment (for empty blocks).
+type AwaitingBlockInfoOrCommitmentState struct {
+	Header     *starknet.MessageHeader
+	ValidRound types.Round
+}
+
+func (s *AwaitingBlockInfoOrCommitmentState) OnEvent(
+	ctx context.Context,
+	transition Transition,
+	part *consensus.ProposalPart,
+) (ProposalStateMachine, error) {
+	switch part := part.GetMessages().(type) {
+	case *consensus.ProposalPart_BlockInfo:
+		return transition.OnBlockInfo(ctx, s, part.BlockInfo)
+	case *consensus.ProposalPart_Commitment:
+		return transition.OnEmptyBlockCommitment(ctx, s, part.Commitment)
+	default:
+		return nil, errInvalidMessage
+	}
+}
+
+// ReceivingTransactionsState handles the flow where transaction batches are received,
+// continuing until a ProposalCommitment message is received to conclude the input.
+type ReceivingTransactionsState struct {
+	Header     *starknet.MessageHeader
+	ValidRound types.Round
+	Value      *starknet.Value
+}
+
+func (s *ReceivingTransactionsState) OnEvent(
+	ctx context.Context,
+	transition Transition,
+	part *consensus.ProposalPart,
+) (ProposalStateMachine, error) {
+	switch part := part.GetMessages().(type) {
+	case *consensus.ProposalPart_Transactions:
+		return transition.OnTransactions(ctx, s, part.Transactions.Transactions)
+	case *consensus.ProposalPart_Commitment:
+		return transition.OnProposalCommitment(ctx, s, part.Commitment)
+	default:
+		return nil, errInvalidMessage
+	}
+}
+
+// AwaitingProposalFinState handles the final phase of the proposal flow,
+// waiting for a ProposalFin message that commits the hash of the proposed value.
+type AwaitingProposalFinState struct {
+	Header     *starknet.MessageHeader
+	ValidRound types.Round
+	Value      *starknet.Value
+}
+
+func (s *AwaitingProposalFinState) OnEvent(
+	ctx context.Context,
+	transition Transition,
+	part *consensus.ProposalPart,
+) (ProposalStateMachine, error) {
+	switch part := part.GetMessages().(type) {
+	case *consensus.ProposalPart_Fin:
+		return transition.OnProposalFin(ctx, s, part.Fin)
+	default:
+		return nil, errInvalidMessage
+	}
+}
+
+// FinState contains the output of the proposal flow.
+type FinState starknet.Proposal
+
+func (s *FinState) OnEvent(
+	ctx context.Context,
+	transition Transition,
+	part *consensus.ProposalPart,
+) (ProposalStateMachine, error) {
+	return nil, errInvalidMessage
+}

--- a/consensus/p2p/validator/state_machine_test.go
+++ b/consensus/p2p/validator/state_machine_test.go
@@ -1,0 +1,245 @@
+package validator_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/NethermindEth/juno/consensus/p2p/validator"
+	"github.com/NethermindEth/juno/consensus/starknet"
+	"github.com/NethermindEth/juno/consensus/types"
+	"github.com/NethermindEth/juno/core/felt"
+	"github.com/starknet-io/starknet-p2pspecs/p2p/proto/common"
+	"github.com/starknet-io/starknet-p2pspecs/p2p/proto/consensus/consensus"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type validTransitionTestStep struct {
+	event     *consensus.ProposalPart
+	postState validator.ProposalStateMachine
+}
+
+func TestProposalStateMachine_ValidTranstions(t *testing.T) {
+	height := uint64(1337)
+	round := uint32(1338)
+	validRound := types.Round(-1)
+	proposer := validator.GetRandomAddress(t)
+
+	expectedHeader := &starknet.MessageHeader{
+		Height: types.Height(height),
+		Round:  types.Round(round),
+		Sender: starknet.Address(*new(felt.Felt).SetBytes(proposer.Elements)),
+	}
+	t.Run("valid proposal stream", func(t *testing.T) {
+		value := uint64(1339)
+		starknetValue := starknet.Value(value)
+		expectedHash := &common.Hash{Elements: validator.ToBytes(*new(felt.Felt).SetUint64(value))}
+		expectedProposal := &starknet.Proposal{
+			MessageHeader: *expectedHeader,
+			ValidRound:    validRound,
+			Value:         &starknetValue,
+		}
+
+		runTestSteps(t, []validTransitionTestStep{
+			{
+				event: &consensus.ProposalPart{
+					Messages: &consensus.ProposalPart_Init{Init: &consensus.ProposalInit{
+						BlockNumber: height,
+						Round:       round,
+						Proposer:    proposer,
+					}},
+				},
+				postState: &validator.AwaitingBlockInfoOrCommitmentState{
+					Header:     expectedHeader,
+					ValidRound: validRound,
+				},
+			},
+			{
+				event: &consensus.ProposalPart{
+					Messages: &consensus.ProposalPart_BlockInfo{BlockInfo: &consensus.BlockInfo{
+						BlockNumber: height,
+						Timestamp:   value,
+					}},
+				},
+				postState: &validator.ReceivingTransactionsState{
+					Header:     expectedHeader,
+					ValidRound: validRound,
+					Value:      &starknetValue,
+				},
+			},
+			{
+				event: &consensus.ProposalPart{
+					Messages: &consensus.ProposalPart_Transactions{Transactions: &consensus.TransactionBatch{
+						Transactions: validator.GetRandomTransactions(t, 4),
+					}},
+				},
+				postState: &validator.ReceivingTransactionsState{
+					Header:     expectedHeader,
+					ValidRound: validRound,
+					Value:      &starknetValue,
+				},
+			},
+			{
+				event: &consensus.ProposalPart{
+					Messages: &consensus.ProposalPart_Transactions{Transactions: &consensus.TransactionBatch{
+						Transactions: validator.GetRandomTransactions(t, 5),
+					}},
+				},
+				postState: &validator.ReceivingTransactionsState{
+					Header:     expectedHeader,
+					ValidRound: validRound,
+					Value:      &starknetValue,
+				},
+			},
+			{
+				event: &consensus.ProposalPart{
+					Messages: &consensus.ProposalPart_Commitment{
+						Commitment: &consensus.ProposalCommitment{
+							BlockNumber: height,
+							Timestamp:   value,
+						},
+					},
+				},
+				postState: &validator.AwaitingProposalFinState{
+					Header:     expectedHeader,
+					ValidRound: validRound,
+					Value:      &starknetValue,
+				},
+			},
+			{
+				event: &consensus.ProposalPart{
+					Messages: &consensus.ProposalPart_Fin{
+						Fin: &consensus.ProposalFin{
+							ProposalCommitment: expectedHash,
+						},
+					},
+				},
+				postState: (*validator.FinState)(expectedProposal),
+			},
+		})
+	})
+
+	t.Run("empty proposal stream", func(t *testing.T) {
+		expectedProposal := &starknet.Proposal{
+			MessageHeader: *expectedHeader,
+			ValidRound:    validRound,
+		}
+		runTestSteps(t, []validTransitionTestStep{
+			{
+				event: &consensus.ProposalPart{
+					Messages: &consensus.ProposalPart_Init{Init: &consensus.ProposalInit{
+						BlockNumber: height,
+						Round:       round,
+						Proposer:    proposer,
+					}},
+				},
+				postState: &validator.AwaitingBlockInfoOrCommitmentState{
+					Header:     expectedHeader,
+					ValidRound: validRound,
+				},
+			},
+			{
+				event: &consensus.ProposalPart{
+					Messages: &consensus.ProposalPart_Commitment{
+						Commitment: &consensus.ProposalCommitment{
+							BlockNumber: 1337,
+							Timestamp:   1338,
+						},
+					},
+				},
+				postState: &validator.AwaitingProposalFinState{
+					Header:     expectedHeader,
+					ValidRound: validRound,
+				},
+			},
+			{
+				event: &consensus.ProposalPart{
+					Messages: &consensus.ProposalPart_Fin{
+						Fin: &consensus.ProposalFin{},
+					},
+				},
+				postState: (*validator.FinState)(expectedProposal),
+			},
+		})
+	})
+}
+
+func runTestSteps(t *testing.T, steps []validTransitionTestStep) {
+	var err error
+	transition := validator.NewTransition()
+	var state validator.ProposalStateMachine = &validator.InitialState{}
+
+	for _, step := range steps {
+		t.Run(fmt.Sprintf("apply %T to get %T", step.event.Messages, step.postState), func(t *testing.T) {
+			state, err = state.OnEvent(t.Context(), transition, step.event)
+			require.NoError(t, err)
+			assert.Equal(t, step.postState, state)
+		})
+	}
+}
+
+type invalidTransitionTestCase struct {
+	state  validator.ProposalStateMachine
+	events []*consensus.ProposalPart
+}
+
+func TestProposalStateMachine_InvalidTransitions(t *testing.T) {
+	steps := []invalidTransitionTestCase{
+		{
+			state: &validator.InitialState{},
+			events: []*consensus.ProposalPart{
+				{Messages: &consensus.ProposalPart_BlockInfo{}},
+				{Messages: &consensus.ProposalPart_Commitment{}},
+				{Messages: &consensus.ProposalPart_Transactions{}},
+				{Messages: &consensus.ProposalPart_Fin{}},
+			},
+		},
+		{
+			state: &validator.AwaitingBlockInfoOrCommitmentState{},
+			events: []*consensus.ProposalPart{
+				{Messages: &consensus.ProposalPart_Init{}},
+				{Messages: &consensus.ProposalPart_Transactions{}},
+				{Messages: &consensus.ProposalPart_Fin{}},
+			},
+		},
+		{
+			state: &validator.ReceivingTransactionsState{},
+			events: []*consensus.ProposalPart{
+				{Messages: &consensus.ProposalPart_Init{}},
+				{Messages: &consensus.ProposalPart_BlockInfo{}},
+				{Messages: &consensus.ProposalPart_Fin{}},
+			},
+		},
+		{
+			state: &validator.AwaitingProposalFinState{},
+			events: []*consensus.ProposalPart{
+				{Messages: &consensus.ProposalPart_Init{}},
+				{Messages: &consensus.ProposalPart_BlockInfo{}},
+				{Messages: &consensus.ProposalPart_Transactions{}},
+				{Messages: &consensus.ProposalPart_Commitment{}},
+			},
+		},
+		{
+			state: &validator.FinState{},
+			events: []*consensus.ProposalPart{
+				{Messages: &consensus.ProposalPart_Init{}},
+				{Messages: &consensus.ProposalPart_BlockInfo{}},
+				{Messages: &consensus.ProposalPart_Transactions{}},
+				{Messages: &consensus.ProposalPart_Commitment{}},
+				{Messages: &consensus.ProposalPart_Fin{}},
+			},
+		},
+	}
+
+	transition := validator.NewTransition()
+	for _, step := range steps {
+		t.Run(fmt.Sprintf("State %T", step.state), func(t *testing.T) {
+			for _, event := range step.events {
+				t.Run(fmt.Sprintf("Event %T", event.Messages), func(t *testing.T) {
+					_, err := step.state.OnEvent(t.Context(), transition, event)
+					require.Error(t, err)
+				})
+			}
+		})
+	}
+}

--- a/consensus/p2p/validator/transition.go
+++ b/consensus/p2p/validator/transition.go
@@ -1,0 +1,161 @@
+package validator
+
+import (
+	"context"
+	"errors"
+
+	"github.com/NethermindEth/juno/consensus/starknet"
+	"github.com/NethermindEth/juno/consensus/types"
+	"github.com/NethermindEth/juno/core/felt"
+	"github.com/NethermindEth/juno/utils"
+	"github.com/starknet-io/starknet-p2pspecs/p2p/proto/consensus/consensus"
+)
+
+var (
+	errNilProposer  = errors.New("proposer is nil")
+	errHashMismatch = errors.New("hash mismatch")
+)
+
+type Transition interface {
+	OnProposalInit(
+		context.Context,
+		*InitialState,
+		*consensus.ProposalInit,
+	) (*AwaitingBlockInfoOrCommitmentState, error)
+	OnEmptyBlockCommitment(
+		context.Context,
+		*AwaitingBlockInfoOrCommitmentState,
+		*consensus.ProposalCommitment,
+	) (*AwaitingProposalFinState, error)
+	OnBlockInfo(
+		context.Context,
+		*AwaitingBlockInfoOrCommitmentState,
+		*consensus.BlockInfo,
+	) (*ReceivingTransactionsState, error)
+	OnTransactions(
+		context.Context,
+		*ReceivingTransactionsState,
+		[]*consensus.ConsensusTransaction,
+	) (*ReceivingTransactionsState, error)
+	OnProposalCommitment(
+		context.Context,
+		*ReceivingTransactionsState,
+		*consensus.ProposalCommitment,
+	) (*AwaitingProposalFinState, error)
+	OnProposalFin(
+		context.Context,
+		*AwaitingProposalFinState,
+		*consensus.ProposalFin,
+	) (*FinState, error)
+}
+
+type transition struct{}
+
+func NewTransition() Transition {
+	return &transition{}
+}
+
+// TODO: Implement this function properly
+func (t *transition) OnProposalInit(
+	ctx context.Context,
+	state *InitialState,
+	init *consensus.ProposalInit,
+) (*AwaitingBlockInfoOrCommitmentState, error) {
+	validRound := types.Round(-1)
+	if init.ValidRound != nil {
+		validRound = types.Round(*init.ValidRound)
+	}
+
+	if init.Proposer == nil {
+		return nil, errNilProposer
+	}
+	sender := starknet.Address(felt.FromBytes(init.Proposer.Elements))
+
+	return &AwaitingBlockInfoOrCommitmentState{
+		Header: &starknet.MessageHeader{
+			Height: types.Height(init.BlockNumber),
+			Round:  types.Round(init.Round),
+			Sender: sender,
+		},
+		ValidRound: validRound,
+	}, nil
+}
+
+// TODO: Implement this function properly
+func (t *transition) OnEmptyBlockCommitment(
+	ctx context.Context,
+	state *AwaitingBlockInfoOrCommitmentState,
+	commitment *consensus.ProposalCommitment,
+) (*AwaitingProposalFinState, error) {
+	return &AwaitingProposalFinState{
+		Header:     state.Header,
+		ValidRound: state.ValidRound,
+		Value:      nil,
+	}, nil
+}
+
+// TODO: Implement this function properly
+func (t *transition) OnBlockInfo(
+	ctx context.Context,
+	state *AwaitingBlockInfoOrCommitmentState,
+	blockInfo *consensus.BlockInfo,
+) (*ReceivingTransactionsState, error) {
+	return &ReceivingTransactionsState{
+		Header:     state.Header,
+		ValidRound: state.ValidRound,
+		Value:      utils.HeapPtr(starknet.Value(blockInfo.Timestamp)),
+	}, nil
+}
+
+// TODO: Implement this function properly
+func (t *transition) OnTransactions(
+	ctx context.Context,
+	state *ReceivingTransactionsState,
+	transactions []*consensus.ConsensusTransaction,
+) (*ReceivingTransactionsState, error) {
+	return &ReceivingTransactionsState{
+		Header:     state.Header,
+		ValidRound: state.ValidRound,
+		Value:      state.Value,
+	}, nil
+}
+
+// TODO: Implement this function properly
+func (t *transition) OnProposalCommitment(
+	ctx context.Context,
+	state *ReceivingTransactionsState,
+	commitment *consensus.ProposalCommitment,
+) (*AwaitingProposalFinState, error) {
+	return &AwaitingProposalFinState{
+		Header:     state.Header,
+		ValidRound: state.ValidRound,
+		Value:      state.Value,
+	}, nil
+}
+
+// TODO: Implement this function properly
+func (t *transition) OnProposalFin(
+	ctx context.Context,
+	state *AwaitingProposalFinState,
+	fin *consensus.ProposalFin,
+) (*FinState, error) {
+	// Check if expected and actual are both nil or both non-nil
+	if (state.Value == nil) != (fin.ProposalCommitment == nil) {
+		return nil, errHashMismatch
+	}
+
+	// If both are non-nil, check if they are equal
+	if state.Value != nil {
+		expected := state.Value.Hash()
+		actual := starknet.Hash(felt.FromBytes(fin.ProposalCommitment.Elements))
+		if expected != actual {
+			return nil, errHashMismatch
+		}
+	}
+
+	return &FinState{
+		MessageHeader: *state.Header,
+		Value:         state.Value,
+		ValidRound:    state.ValidRound,
+	}, nil
+}

--- a/consensus/p2p/validator/validator_utils_test.go
+++ b/consensus/p2p/validator/validator_utils_test.go
@@ -1,0 +1,52 @@
+package validator
+
+import (
+	"testing"
+
+	"github.com/NethermindEth/juno/core/felt"
+	"github.com/starknet-io/starknet-p2pspecs/p2p/proto/common"
+	"github.com/starknet-io/starknet-p2pspecs/p2p/proto/consensus/consensus"
+	"github.com/starknet-io/starknet-p2pspecs/p2p/proto/transaction"
+	"github.com/stretchr/testify/require"
+)
+
+func ToBytes(felt felt.Felt) []byte {
+	feltBytes := felt.Bytes()
+	return feltBytes[:]
+}
+
+func getRandomFelt(t *testing.T) []byte {
+	t.Helper()
+
+	addr, err := new(felt.Felt).SetRandom()
+	require.NoError(t, err)
+
+	addrBytes := addr.Bytes()
+	return addrBytes[:]
+}
+
+func GetRandomAddress(t *testing.T) *common.Address {
+	t.Helper()
+
+	addr, err := new(felt.Felt).SetRandom()
+	require.NoError(t, err)
+
+	return &common.Address{Elements: ToBytes(*addr)}
+}
+
+func getRandomTransaction(t *testing.T) *consensus.ConsensusTransaction {
+	t.Helper()
+	return &consensus.ConsensusTransaction{
+		Txn:             &consensus.ConsensusTransaction_InvokeV3{InvokeV3: &transaction.InvokeV3{}},
+		TransactionHash: &common.Hash{Elements: getRandomFelt(t)},
+	}
+}
+
+func GetRandomTransactions(t *testing.T, count int) []*consensus.ConsensusTransaction {
+	t.Helper()
+	transactions := make([]*consensus.ConsensusTransaction, count)
+	for i := range transactions {
+		transactions[i] = getRandomTransaction(t)
+	}
+	return transactions
+}


### PR DESCRIPTION
```mermaid
stateDiagram-v2
    InitialState --> ReceivingBlockInfoState: OnInit(ProposalInit)
    ReceivingBlockInfoState --> ReceivingHashState: OnEmptyBlock(ProposalCommitment)
    ReceivingBlockInfoState --> ReceivingTransactionsState: OnBlockInfo(BlockInfo)
    ReceivingTransactionsState --> ReceivingTransactionsState: OnTransactions([]ConsensusTransaction)
    ReceivingTransactionsState --> ReceivingHashState: OnCommitment(ProposalCommitment)
    ReceivingHashState --> FinState: OnFin(ProposalFin)
```