### PR TITLE
refactor: Remove precommits argument from Commit function

### DIFF
--- a/consensus/integtest/blockchain.go
+++ b/consensus/integtest/blockchain.go
@@ -29,7 +29,7 @@ func (b *blockchain) Height() types.Height {
 	return b.height
 }
 
-func (b *blockchain) Commit(height types.Height, value value, precommits []types.Precommit[felt.Felt, felt.Felt]) {
+func (b *blockchain) Commit(height types.Height, value value) {
 	b.height = max(b.height, height)
 	b.commits <- commit{
 		nodeAddr: b.nodeAddr,

--- a/consensus/tendermint/action_asserter_test.go
+++ b/consensus/tendermint/action_asserter_test.go
@@ -11,12 +11,10 @@ import (
 )
 
 // actionAsserter is a helper struct to assert the actions of the state machine.
-// inputMessage is the message that was processed to produce the actions.
 // actions is the list of actions that were produced by the state machine after processing the input message.
 type actionAsserter[T any] struct {
 	testing      *testing.T
 	stateMachine *testStateMachine
-	inputMessage T
 	actions      []starknet.Action
 }
 

--- a/consensus/tendermint/incoming_message_builder_test.go
+++ b/consensus/tendermint/incoming_message_builder_test.go
@@ -31,7 +31,6 @@ func (t incomingMessageBuilder) proposal(val starknet.Value, validRound types.Ro
 	return actionAsserter[starknet.Proposal]{
 		testing:      t.testing,
 		stateMachine: t.stateMachine,
-		inputMessage: proposal,
 		actions:      actions,
 	}
 }
@@ -51,7 +50,6 @@ func (t incomingMessageBuilder) prevote(val *starknet.Value) actionAsserter[star
 	return actionAsserter[starknet.Prevote]{
 		testing:      t.testing,
 		stateMachine: t.stateMachine,
-		inputMessage: prevote,
 		actions:      actions,
 	}
 }
@@ -71,7 +69,6 @@ func (t incomingMessageBuilder) precommit(val *starknet.Value) actionAsserter[st
 	return actionAsserter[starknet.Precommit]{
 		testing:      t.testing,
 		stateMachine: t.stateMachine,
-		inputMessage: precommit,
 		actions:      actions,
 	}
 }

--- a/consensus/tendermint/rule_commit_value.go
+++ b/consensus/tendermint/rule_commit_value.go
@@ -33,9 +33,7 @@ func (t *stateMachine[V, H, A]) doCommitValue(cachedProposal *CachedProposal[V, 
 		t.log.Fatalf("failed to flush WAL during commit", "height", cachedProposal.Height, "round", cachedProposal.Round, "err", err)
 	}
 
-	// TODO: Optimise this
-	precommits, _ := t.checkForQuorumPrecommit(cachedProposal.Round, *cachedProposal.ID)
-	t.blockchain.Commit(t.state.height, *cachedProposal.Value, precommits)
+	t.blockchain.Commit(t.state.height, *cachedProposal.Value)
 
 	if err := t.db.DeleteWALEntries(t.state.height); err != nil {
 		t.log.Errorw("failed to delete WAL messages during commit", "height", cachedProposal.Height, "round", cachedProposal.Round, "err", err)

--- a/consensus/tendermint/state_machine_context_test.go
+++ b/consensus/tendermint/state_machine_context_test.go
@@ -48,7 +48,6 @@ func (t stateMachineContext) start() actionAsserter[any] {
 	return actionAsserter[any]{
 		testing:      t.testing,
 		stateMachine: t.stateMachine,
-		inputMessage: nil,
 		actions:      t.stateMachine.ProcessStart(t.builderRound),
 	}
 }
@@ -58,7 +57,6 @@ func (t stateMachineContext) processTimeout(s types.Step) actionAsserter[any] {
 	return actionAsserter[any]{
 		testing:      t.testing,
 		stateMachine: t.stateMachine,
-		inputMessage: nil,
 		actions:      t.stateMachine.ProcessTimeout(types.Timeout{Step: s, Height: t.builderHeight, Round: t.builderRound}),
 	}
 }

--- a/consensus/tendermint/tendermint.go
+++ b/consensus/tendermint/tendermint.go
@@ -16,12 +16,12 @@ type Application[V types.Hashable[H], H types.Hash] interface {
 	Valid(V) bool
 }
 
-type Blockchain[V types.Hashable[H], H types.Hash, A types.Addr] interface {
+type Blockchain[V types.Hashable[H], H types.Hash] interface {
 	// types.Height return the current blockchain height
 	Height() types.Height
 
 	// Commit is called by Tendermint when a block has been decided on and can be committed to the DB.
-	Commit(types.Height, V, []types.Precommit[H, A])
+	Commit(types.Height, V)
 }
 
 type Validators[A types.Addr] interface {
@@ -64,7 +64,7 @@ type stateMachine[V types.Hashable[H], H types.Hash, A types.Addr] struct {
 	messages types.Messages[V, H, A]
 
 	application Application[V, H]
-	blockchain  Blockchain[V, H, A]
+	blockchain  Blockchain[V, H]
 	validators  Validators[A]
 }
 
@@ -89,7 +89,7 @@ func New[V types.Hashable[H], H types.Hash, A types.Addr](
 	log utils.Logger,
 	nodeAddr A,
 	app Application[V, H],
-	chain Blockchain[V, H, A],
+	chain Blockchain[V, H],
 	vals Validators[A],
 ) StateMachine[V, H, A] {
 	return &stateMachine[V, H, A]{

--- a/consensus/tendermint/tendermint_test.go
+++ b/consensus/tendermint/tendermint_test.go
@@ -31,15 +31,13 @@ func (a *app) Valid(v starknet.Value) bool {
 
 // Implements Blockchain[value, felt.Felt] interface
 type chain struct {
-	curHeight            types.Height
-	decision             map[types.Height]starknet.Value
-	decisionCertificates map[types.Height][]starknet.Precommit
+	curHeight types.Height
+	decision  map[types.Height]starknet.Value
 }
 
 func newChain() *chain {
 	return &chain{
-		decision:             make(map[types.Height]starknet.Value),
-		decisionCertificates: make(map[types.Height][]starknet.Precommit),
+		decision: make(map[types.Height]starknet.Value),
 	}
 }
 
@@ -47,9 +45,8 @@ func (c *chain) Height() types.Height {
 	return c.curHeight
 }
 
-func (c *chain) Commit(h types.Height, v starknet.Value, precommits []starknet.Precommit) {
+func (c *chain) Commit(h types.Height, v starknet.Value) {
 	c.decision[c.curHeight] = v
-	c.decisionCertificates[c.curHeight] = precommits
 	c.curHeight++
 }
 


### PR DESCRIPTION
As discussed, the precommits used as proof should be stored in the DB, so we don't need to pass it in `Commit` function.