### PR TITLE
Gateway: URL split

### DIFF
--- a/blockchain/blockchain.go
+++ b/blockchain/blockchain.go
@@ -53,7 +53,7 @@ type Reader interface {
 
 var (
 	ErrParentDoesNotMatchHead = errors.New("block's parent hash does not match head block hash")
-	SupportedStarknetVersion  = semver.MustParse("0.13.3")
+	SupportedStarknetVersion  = semver.MustParse("0.14.0")
 )
 
 func CheckBlockVersion(protocolVersion string) error {

--- a/utils/network.go
+++ b/utils/network.go
@@ -44,7 +44,7 @@ var (
 	// The docs states the addresses for each network: https://docs.starknet.io/tools/important-addresses/
 	Mainnet = Network{
 		Name:                "mainnet",
-		FeederURL:           "https://feeder.alpha-mainnet.starknet.io/feeder_gateway/",
+		FeederURL:           "https://alpha-mainnet.starknet.io/feeder_gateway/",
 		GatewayURL:          "https://alpha-mainnet.starknet.io/gateway/",
 		L2ChainID:           "SN_MAIN",
 		L1ChainID:           big.NewInt(1),
@@ -56,7 +56,7 @@ var (
 	}
 	Goerli = Network{
 		Name:       "goerli",
-		FeederURL:  "https://feeder.alpha4.starknet.io/feeder_gateway/",
+		FeederURL:  "https://alpha4.starknet.io/feeder_gateway/",
 		GatewayURL: "https://alpha4.starknet.io/gateway/",
 		L2ChainID:  "SN_GOERLI",
 		//nolint:mnd
@@ -70,7 +70,7 @@ var (
 	}
 	Goerli2 = Network{
 		Name:       "goerli2",
-		FeederURL:  "https://feeder.alpha4-2.starknet.io/feeder_gateway/",
+		FeederURL:  "https://alpha4-2.starknet.io/feeder_gateway/",
 		GatewayURL: "https://alpha4-2.starknet.io/gateway/",
 		L2ChainID:  "SN_GOERLI2",
 		//nolint:mnd
@@ -83,7 +83,7 @@ var (
 	}
 	Integration = Network{
 		Name:       "integration",
-		FeederURL:  "https://feeder.external.integration.starknet.io/feeder_gateway/",
+		FeederURL:  "https://external.integration.starknet.io/feeder_gateway/",
 		GatewayURL: "https://external.integration.starknet.io/gateway/",
 		L2ChainID:  "SN_GOERLI",
 		//nolint:mnd
@@ -97,7 +97,7 @@ var (
 	}
 	Sepolia = Network{
 		Name:       "sepolia",
-		FeederURL:  "https://feeder.alpha-sepolia.starknet.io/feeder_gateway/",
+		FeederURL:  "https://alpha-sepolia.starknet.io/feeder_gateway/",
 		GatewayURL: "https://alpha-sepolia.starknet.io/gateway/",
 		L2ChainID:  "SN_SEPOLIA",
 		//nolint:mnd

--- a/utils/network.go
+++ b/utils/network.go
@@ -44,7 +44,7 @@ var (
 	// The docs states the addresses for each network: https://docs.starknet.io/tools/important-addresses/
 	Mainnet = Network{
 		Name:                "mainnet",
-		FeederURL:           "https://alpha-mainnet.starknet.io/feeder_gateway/",
+		FeederURL:           "https://feeder.alpha-mainnet.starknet.io/feeder_gateway/",
 		GatewayURL:          "https://alpha-mainnet.starknet.io/gateway/",
 		L2ChainID:           "SN_MAIN",
 		L1ChainID:           big.NewInt(1),
@@ -56,7 +56,7 @@ var (
 	}
 	Goerli = Network{
 		Name:       "goerli",
-		FeederURL:  "https://alpha4.starknet.io/feeder_gateway/",
+		FeederURL:  "https://feeder.alpha4.starknet.io/feeder_gateway/",
 		GatewayURL: "https://alpha4.starknet.io/gateway/",
 		L2ChainID:  "SN_GOERLI",
 		//nolint:mnd
@@ -70,7 +70,7 @@ var (
 	}
 	Goerli2 = Network{
 		Name:       "goerli2",
-		FeederURL:  "https://alpha4-2.starknet.io/feeder_gateway/",
+		FeederURL:  "https://feeder.alpha4-2.starknet.io/feeder_gateway/",
 		GatewayURL: "https://alpha4-2.starknet.io/gateway/",
 		L2ChainID:  "SN_GOERLI2",
 		//nolint:mnd
@@ -83,7 +83,7 @@ var (
 	}
 	Integration = Network{
 		Name:       "integration",
-		FeederURL:  "https://external.integration.starknet.io/feeder_gateway/",
+		FeederURL:  "https://feeder.external.integration.starknet.io/feeder_gateway/",
 		GatewayURL: "https://external.integration.starknet.io/gateway/",
 		L2ChainID:  "SN_GOERLI",
 		//nolint:mnd
@@ -97,7 +97,7 @@ var (
 	}
 	Sepolia = Network{
 		Name:       "sepolia",
-		FeederURL:  "https://alpha-sepolia.starknet.io/feeder_gateway/",
+		FeederURL:  "https://feeder.alpha-sepolia.starknet.io/feeder_gateway/",
 		GatewayURL: "https://alpha-sepolia.starknet.io/gateway/",
 		L2ChainID:  "SN_SEPOLIA",
 		//nolint:mnd
@@ -110,7 +110,7 @@ var (
 	}
 	SepoliaIntegration = Network{
 		Name:       "sepolia-integration",
-		FeederURL:  "https://integration-sepolia.starknet.io/feeder_gateway/",
+		FeederURL:  "https://feeder.integration-sepolia.starknet.io/feeder_gateway/",
 		GatewayURL: "https://integration-sepolia.starknet.io/gateway/",
 		L2ChainID:  "SN_INTEGRATION_SEPOLIA",
 		//nolint:mnd

--- a/utils/network_test.go
+++ b/utils/network_test.go
@@ -32,12 +32,12 @@ func TestNetwork(t *testing.T) {
 			feederURL  string
 			gatewayURL string
 		}{
-			{utils.Mainnet, "https://alpha-mainnet.starknet.io/feeder_gateway/", "https://alpha-mainnet.starknet.io/gateway/"},
-			{utils.Goerli, "https://alpha4.starknet.io/feeder_gateway/", "https://alpha4.starknet.io/gateway/"},
-			{utils.Goerli2, "https://alpha4-2.starknet.io/feeder_gateway/", "https://alpha4-2.starknet.io/gateway/"},
-			{utils.Integration, "https://external.integration.starknet.io/feeder_gateway/", "https://external.integration.starknet.io/gateway/"},
-			{utils.Sepolia, "https://alpha-sepolia.starknet.io/feeder_gateway/", "https://alpha-sepolia.starknet.io/gateway/"},
-			{utils.SepoliaIntegration, "https://integration-sepolia.starknet.io/feeder_gateway/", "https://integration-sepolia.starknet.io/gateway/"},
+			{utils.Mainnet, "https://feeder.alpha-mainnet.starknet.io/feeder_gateway/", "https://alpha-mainnet.starknet.io/gateway/"},
+			{utils.Goerli, "https://feeder.alpha4.starknet.io/feeder_gateway/", "https://alpha4.starknet.io/gateway/"},
+			{utils.Goerli2, "https://feeder.alpha4-2.starknet.io/feeder_gateway/", "https://alpha4-2.starknet.io/gateway/"},
+			{utils.Integration, "https://feeder.external.integration.starknet.io/feeder_gateway/", "https://external.integration.starknet.io/gateway/"},
+			{utils.Sepolia, "https://feeder.alpha-sepolia.starknet.io/feeder_gateway/", "https://alpha-sepolia.starknet.io/gateway/"},
+			{utils.SepoliaIntegration, "https://feeder.integration-sepolia.starknet.io/feeder_gateway/", "https://integration-sepolia.starknet.io/gateway/"},
 		}
 
 		for _, tc := range testCases {

--- a/utils/network_test.go
+++ b/utils/network_test.go
@@ -32,11 +32,11 @@ func TestNetwork(t *testing.T) {
 			feederURL  string
 			gatewayURL string
 		}{
-			{utils.Mainnet, "https://feeder.alpha-mainnet.starknet.io/feeder_gateway/", "https://alpha-mainnet.starknet.io/gateway/"},
-			{utils.Goerli, "https://feeder.alpha4.starknet.io/feeder_gateway/", "https://alpha4.starknet.io/gateway/"},
-			{utils.Goerli2, "https://feeder.alpha4-2.starknet.io/feeder_gateway/", "https://alpha4-2.starknet.io/gateway/"},
-			{utils.Integration, "https://feeder.external.integration.starknet.io/feeder_gateway/", "https://external.integration.starknet.io/gateway/"},
-			{utils.Sepolia, "https://feeder.alpha-sepolia.starknet.io/feeder_gateway/", "https://alpha-sepolia.starknet.io/gateway/"},
+			{utils.Mainnet, "https://alpha-mainnet.starknet.io/feeder_gateway/", "https://alpha-mainnet.starknet.io/gateway/"},
+			{utils.Goerli, "https://alpha4.starknet.io/feeder_gateway/", "https://alpha4.starknet.io/gateway/"},
+			{utils.Goerli2, "https://alpha4-2.starknet.io/feeder_gateway/", "https://alpha4-2.starknet.io/gateway/"},
+			{utils.Integration, "https://external.integration.starknet.io/feeder_gateway/", "https://external.integration.starknet.io/gateway/"},
+			{utils.Sepolia, "https://alpha-sepolia.starknet.io/feeder_gateway/", "https://alpha-sepolia.starknet.io/gateway/"},
 			{utils.SepoliaIntegration, "https://feeder.integration-sepolia.starknet.io/feeder_gateway/", "https://integration-sepolia.starknet.io/gateway/"},
 		}
 


### PR DESCRIPTION
Updated Feeder URL, gateway and feeder still uses the same api-key, needs to be clarified
Changed supported starknet version to 0.14.0

Tested on sepolia-integration w/o api-key, my nodes syncs