### PR TITLE
Corrected typos

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -11,7 +11,7 @@ has been adopted by many other open source communities and we feel it expresses 
 We as members, contributors, and leaders pledge to make participation in our
 community a harassment-free experience for everyone, regardless of age, body
 size, visible or invisible disability, ethnicity, sex characteristics, gender
-identity and expression, level of experience, education, socio-economic status,
+identity and expression, level of experience, education, socioeconomic status,
 nationality, personal appearance, race, religion, or sexual identity
 and orientation.
 
@@ -69,7 +69,7 @@ Read carefully our Contributing Guidelines to know how to contribute properly in
 project. Members and maintainers must adhere to some rules regarding to pull requests
 reviews and creation of issues and pull requests:
 
-* During code reviews do not comment on coding standards and styles -focus on algorithmical,
+* During code reviews do not comment on coding standards and styles -focus on algorithmically,
 structural or naming issues-, help to solve problem.
 * When creating an issue or a pull request, follow the templates provided by the repository and
 fill in the indicated items correctly. If you do not want to use a template, open a blank issue/PR

--- a/consensus/driver/driver.go
+++ b/consensus/driver/driver.go
@@ -63,7 +63,7 @@ func (d *Driver[V, H, A]) Start() {
 		actions := d.stateMachine.ProcessStart(0)
 		d.execute(actions)
 
-		// Todo: check message signature everytime a message is received.
+		// Todo: check message signature every time a message is received.
 		// For the time being it can be assumed the signature is correct.
 
 		for {

--- a/consensus/tendermint/tendermint.go
+++ b/consensus/tendermint/tendermint.go
@@ -9,7 +9,7 @@ import (
 )
 
 type Application[V types.Hashable[H], H types.Hash] interface {
-	// Value returns the value to the Tendermint consensus algorith which can be proposed to other validators.
+	// Value returns the value to the Tendermint consensus algorithm which can be proposed to other validators.
 	Value() V
 
 	// Valid returns true if the provided value is valid according to the application context.

--- a/docs/versioned_docs/version-0.11.0/example_config.md
+++ b/docs/versioned_docs/version-0.11.0/example_config.md
@@ -123,5 +123,5 @@ p2p: false
 # Specify p2p source address as multiaddr
 p2p-addr: ""
 
-# Specify list of p2p boot peers splitted by a comma
+# Specify list of p2p boot peers split by a comma
 p2p-boot-peers: ""

--- a/docs/versioned_docs/version-0.13.0/intro.md
+++ b/docs/versioned_docs/version-0.13.0/intro.md
@@ -7,7 +7,7 @@ title: Introduction
 
 Juno is a Go implementation of a Starknet full-node client created by Nethermind to allow node operators to easily and reliably support the network and advance its decentralisation goals. Juno supports various node setups, from casual to production-grade indexers.
 
-- :cd: **Small database footprint**: Commited to keeping the database size as small as possible
+- :cd: **Small database footprint**: Committed to keeping the database size as small as possible
 - :zap: **Ultra-fast synchronisation**: Limited only by your hardware and the sequencer.
 - :100: **Complete [JSON-RPC spec](https://github.com/starkware-libs/starknet-specs/tree/master) compliance**: Everything Starknet, accessible from a single point.
 - :mag_right: **Minimal RPC response latency**: Ensuring your applications run smoothly.

--- a/docs/versioned_docs/version-0.14.0/intro.md
+++ b/docs/versioned_docs/version-0.14.0/intro.md
@@ -7,7 +7,7 @@ title: Introduction
 
 Juno is a Go implementation of a Starknet full-node client created by Nethermind to allow node operators to easily and reliably support the network and advance its decentralisation goals. Juno supports various node setups, from casual to production-grade indexers.
 
-- :cd: **Small database footprint**: Commited to keeping the database size as small as possible
+- :cd: **Small database footprint**: Committed to keeping the database size as small as possible
 - :zap: **Ultra-fast synchronisation**: Limited only by your hardware and the sequencer.
 - :100: **Complete [JSON-RPC spec](https://github.com/starkware-libs/starknet-specs/tree/master) compliance**: Everything Starknet, accessible from a single point.
 - :mag_right: **Minimal RPC response latency**: Ensuring your applications run smoothly.

--- a/docs/versioned_docs/version-0.9.3/example_config.md
+++ b/docs/versioned_docs/version-0.9.3/example_config.md
@@ -123,5 +123,5 @@ p2p: false
 # Specify p2p source address as multiaddr
 p2p-addr: ""
 
-# Specify list of p2p boot peers splitted by a comma
+# Specify list of p2p boot peers split by a comma
 p2p-boot-peers: ""

--- a/p2p/spec/notes.md
+++ b/p2p/spec/notes.md
@@ -1,7 +1,7 @@
 * Goals: consensus, scale, validator-fullnode separation, cleanup
 * whenever 'bytes' is used to encode large numbers (felts), big endian is used, without storing leading zeros in the number as bytes (so 0x11 is stored as [0x11] not [0x00, 0x00,...,0x11]
 * requests are responded to with a stream of messages that are varint message delimited.
-* When a stream returnes several logical objects, each in several messages, then each object messages should end with a Fin message
+* When a stream returns several logical objects, each in several messages, then each object messages should end with a Fin message
 * Responses to events, receipts and transactions also include block hash for cases of reorg.
 * request_id is handled at the protocol level, specifically to support multiplexing
 * number of messages (especially repeated ones) is capped for ddos
@@ -16,7 +16,7 @@
 * TBD: stark friendly hashes or not (calculate in os? so light nodes don't trust the consensus)
 * TBD: "pubsub" mechanism where a node subscribes to getting push messages instead of GetXXX.
 ** GetXXX messages will need to be supported for network issues / failures
-* Consensus: send (Transactions*, StateDiff*)* Proposal. The state diffs allows paralelization as the transactions following it can be executed from that state in parallel to whatever is already executing
+* Consensus: send (Transactions*, StateDiff*)* Proposal. The state diffs allows parallelization as the transactions following it can be executed from that state in parallel to whatever is already executing
 * Assuming L1 state update will have block header hash and number.
 * tx calldata limited to 30K
 


### PR DESCRIPTION
Changes made in:

- /CODE_OF_CONDUCT.md ("socio-economic" → "socioeconomic")

- /CODE_OF_CONDUCT.md ("algorithmical" → "algorithmically")

- /docs/versioned_docs/version-0.11.0/example_config.md ("splitted" → "split")

- /docs/versioned_docs/version-0.9.3/example_config.md ("splitted" → "split")

- /docs/versioned_docs/version-0.13.0/intro.md ("Commited" → "Committed")

- /docs/versioned_docs/version-0.14.0/intro.md ("Commited" → "Committed")

- /p2p/spec/notes.md ("returnes" → "returns")

- /p2p/spec/notes.md ("paralelization" → "parallelization")

- /consensus/driver/driver.go ("everytime" → "every time")

- /consensus/tendermint/tendermint.go ("algorith" → "algorithm")
