### PR TITLE
refactor: remove the Addr and Hash generics in consensus

### DIFF
--- a/consensus/integtest/blockchain.go
+++ b/consensus/integtest/blockchain.go
@@ -7,17 +7,17 @@ import (
 
 type blockchain struct {
 	height   types.Height
-	nodeAddr *starknet.Address
+	nodeAddr *types.Addr
 	commits  chan commit
 }
 
 type commit struct {
-	nodeAddr *starknet.Address
+	nodeAddr *types.Addr
 	height   types.Height
 	value    starknet.Value
 }
 
-func newBlockchain(commits chan commit, nodeAddr *starknet.Address) *blockchain {
+func newBlockchain(commits chan commit, nodeAddr *types.Addr) *blockchain {
 	return &blockchain{
 		height:   0,
 		nodeAddr: nodeAddr,

--- a/consensus/integtest/broadcaster.go
+++ b/consensus/integtest/broadcaster.go
@@ -3,23 +3,24 @@ package integtest
 import (
 	"github.com/NethermindEth/juno/consensus/p2p"
 	"github.com/NethermindEth/juno/consensus/starknet"
+	"github.com/NethermindEth/juno/consensus/types"
 )
 
 type (
-	Broadcaster[M starknet.Message] = p2p.Broadcaster[M, starknet.Value, starknet.Hash, starknet.Address]
-	Broadcasters                    = p2p.Broadcasters[starknet.Value, starknet.Hash, starknet.Address]
+	Broadcaster[M starknet.Message] = p2p.Broadcaster[M, starknet.Value]
+	Broadcasters                    = p2p.Broadcasters[starknet.Value]
 )
 
 // Mock broadcaster for testing purposes. It has the map of all listeners and the node's own address
 // to which it will not broadcast.
 type broadcaster[M starknet.Message] struct {
-	addr      *starknet.Address
-	listeners map[starknet.Address]listener[M]
+	addr      *types.Addr
+	listeners map[types.Addr]listener[M]
 }
 
 func newBroadcaster[M starknet.Message](
-	addr *starknet.Address,
-	listeners map[starknet.Address]listener[M],
+	addr *types.Addr,
+	listeners map[types.Addr]listener[M],
 ) broadcaster[M] {
 	return broadcaster[M]{
 		addr:      addr,
@@ -29,7 +30,7 @@ func newBroadcaster[M starknet.Message](
 
 func (b broadcaster[M]) Broadcast(msg M) {
 	for addr, listener := range b.listeners {
-		if !addr.AsFelt().Equal(b.addr.AsFelt()) {
+		if !addr.Equal(b.addr) {
 			go func() {
 				listener.ch <- msg
 			}()

--- a/consensus/integtest/integ_test.go
+++ b/consensus/integtest/integ_test.go
@@ -39,11 +39,11 @@ func getTimeoutFn(cfg testConfig) func(types.Step, types.Round) time.Duration {
 	}
 }
 
-func newDB(t *testing.T) *mocks.MockTendermintDB[starknet.Value, starknet.Hash, starknet.Address] {
+func newDB(t *testing.T) *mocks.MockTendermintDB[starknet.Value] {
 	t.Helper()
 	ctrl := gomock.NewController(t)
 	// Ignore WAL for tests that use this
-	db := mocks.NewMockTendermintDB[starknet.Value, starknet.Hash, starknet.Address](ctrl)
+	db := mocks.NewMockTendermintDB[starknet.Value](ctrl)
 	db.EXPECT().GetWALEntries(gomock.Any()).AnyTimes()
 	db.EXPECT().SetWALEntry(gomock.Any()).AnyTimes()
 	db.EXPECT().Flush().AnyTimes()

--- a/consensus/integtest/listener.go
+++ b/consensus/integtest/listener.go
@@ -6,8 +6,8 @@ import (
 )
 
 type (
-	Listener[M starknet.Message] = p2p.Listener[M, starknet.Value, starknet.Hash, starknet.Address]
-	Listeners                    = p2p.Listeners[starknet.Value, starknet.Hash, starknet.Address]
+	Listener[M starknet.Message] = p2p.Listener[M, starknet.Value]
+	Listeners                    = p2p.Listeners[starknet.Value]
 )
 
 type listener[M starknet.Message] struct {

--- a/consensus/integtest/network.go
+++ b/consensus/integtest/network.go
@@ -2,31 +2,32 @@ package integtest
 
 import (
 	"github.com/NethermindEth/juno/consensus/starknet"
+	"github.com/NethermindEth/juno/consensus/types"
 )
 
 type network struct {
-	proposals  map[starknet.Address]listener[starknet.Proposal]
-	prevotes   map[starknet.Address]listener[starknet.Prevote]
-	precommits map[starknet.Address]listener[starknet.Precommit]
+	proposals  map[types.Addr]listener[types.Proposal[starknet.Value]]
+	prevotes   map[types.Addr]listener[types.Prevote]
+	precommits map[types.Addr]listener[types.Precommit]
 }
 
 func newNetwork(allNodes nodes, buffer int) network {
 	n := network{
-		proposals:  make(map[starknet.Address]listener[starknet.Proposal]),
-		prevotes:   make(map[starknet.Address]listener[starknet.Prevote]),
-		precommits: make(map[starknet.Address]listener[starknet.Precommit]),
+		proposals:  make(map[types.Addr]listener[starknet.Proposal]),
+		prevotes:   make(map[types.Addr]listener[types.Prevote]),
+		precommits: make(map[types.Addr]listener[types.Precommit]),
 	}
 
 	for _, addr := range allNodes.addr {
 		n.proposals[addr] = newListener[starknet.Proposal](buffer)
-		n.prevotes[addr] = newListener[starknet.Prevote](buffer)
-		n.precommits[addr] = newListener[starknet.Precommit](buffer)
+		n.prevotes[addr] = newListener[types.Prevote](buffer)
+		n.precommits[addr] = newListener[types.Precommit](buffer)
 	}
 
 	return n
 }
 
-func (n network) getListeners(addr *starknet.Address) Listeners {
+func (n network) getListeners(addr *types.Addr) Listeners {
 	return Listeners{
 		ProposalListener:  n.proposals[*addr],
 		PrevoteListener:   n.prevotes[*addr],
@@ -34,7 +35,7 @@ func (n network) getListeners(addr *starknet.Address) Listeners {
 	}
 }
 
-func (n network) getBroadcasters(addr *starknet.Address) Broadcasters {
+func (n network) getBroadcasters(addr *types.Addr) Broadcasters {
 	return Broadcasters{
 		ProposalBroadcaster:  newBroadcaster(addr, n.proposals),
 		PrevoteBroadcaster:   newBroadcaster(addr, n.prevotes),

--- a/consensus/integtest/node.go
+++ b/consensus/integtest/node.go
@@ -1,21 +1,21 @@
 package integtest
 
 import (
-	"github.com/NethermindEth/juno/consensus/starknet"
+	"github.com/NethermindEth/juno/consensus/types"
 )
 
 type nodes struct {
-	addr  []starknet.Address
-	index map[starknet.Address]int
+	addr  []types.Addr
+	index map[types.Addr]int
 }
 
 func getNodes(nodeCount int) nodes {
 	nodes := nodes{
-		addr:  make([]starknet.Address, nodeCount),
-		index: make(map[starknet.Address]int),
+		addr:  make([]types.Addr, nodeCount),
+		index: make(map[types.Addr]int),
 	}
 	for i := range nodeCount {
-		nodes.addr[i].AsFelt().SetUint64(uint64(i))
+		nodes.addr[i].SetUint64(uint64(i))
 		nodes.index[nodes.addr[i]] = i
 	}
 	return nodes

--- a/consensus/integtest/validator.go
+++ b/consensus/integtest/validator.go
@@ -4,11 +4,10 @@ import (
 	"math/rand"
 	"slices"
 
-	"github.com/NethermindEth/juno/consensus/starknet"
 	"github.com/NethermindEth/juno/consensus/types"
 )
 
-type validators []starknet.Address
+type validators []types.Addr
 
 func newValidators(allNodes nodes) validators {
 	addresses := slices.Clone(allNodes.addr)
@@ -22,12 +21,12 @@ func (v validators) TotalVotingPower(height types.Height) types.VotingPower {
 	return types.VotingPower(len(v))
 }
 
-func (v validators) ValidatorVotingPower(addr starknet.Address) types.VotingPower {
+func (v validators) ValidatorVotingPower(addr types.Addr) types.VotingPower {
 	return types.VotingPower(1)
 }
 
 // Randomised proposer selection, with prime coefficients so that for each height, the order of proposers is different.
-func (v validators) Proposer(height types.Height, round types.Round) starknet.Address {
+func (v validators) Proposer(height types.Height, round types.Round) types.Addr {
 	idx := (int(height)*31 + int(round)*17) % len(v)
 	return v[idx]
 }

--- a/consensus/mocks/mock_db.go
+++ b/consensus/mocks/mock_db.go
@@ -18,31 +18,31 @@ import (
 )
 
 // MockTendermintDB is a mock of TendermintDB interface.
-type MockTendermintDB[V types.Hashable[H], H types.Hash, A types.Addr] struct {
+type MockTendermintDB[V types.Hashable] struct {
 	ctrl     *gomock.Controller
-	recorder *MockTendermintDBMockRecorder[V, H, A]
+	recorder *MockTendermintDBMockRecorder[V]
 	isgomock struct{}
 }
 
 // MockTendermintDBMockRecorder is the mock recorder for MockTendermintDB.
-type MockTendermintDBMockRecorder[V types.Hashable[H], H types.Hash, A types.Addr] struct {
-	mock *MockTendermintDB[V, H, A]
+type MockTendermintDBMockRecorder[V types.Hashable] struct {
+	mock *MockTendermintDB[V]
 }
 
 // NewMockTendermintDB creates a new mock instance.
-func NewMockTendermintDB[V types.Hashable[H], H types.Hash, A types.Addr](ctrl *gomock.Controller) *MockTendermintDB[V, H, A] {
-	mock := &MockTendermintDB[V, H, A]{ctrl: ctrl}
-	mock.recorder = &MockTendermintDBMockRecorder[V, H, A]{mock}
+func NewMockTendermintDB[V types.Hashable](ctrl *gomock.Controller) *MockTendermintDB[V] {
+	mock := &MockTendermintDB[V]{ctrl: ctrl}
+	mock.recorder = &MockTendermintDBMockRecorder[V]{mock}
 	return mock
 }
 
 // EXPECT returns an object that allows the caller to indicate expected use.
-func (m *MockTendermintDB[V, H, A]) EXPECT() *MockTendermintDBMockRecorder[V, H, A] {
+func (m *MockTendermintDB[V]) EXPECT() *MockTendermintDBMockRecorder[V] {
 	return m.recorder
 }
 
 // DeleteWALEntries mocks base method.
-func (m *MockTendermintDB[V, H, A]) DeleteWALEntries(height types.Height) error {
+func (m *MockTendermintDB[V]) DeleteWALEntries(height types.Height) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DeleteWALEntries", height)
 	ret0, _ := ret[0].(error)
@@ -50,13 +50,13 @@ func (m *MockTendermintDB[V, H, A]) DeleteWALEntries(height types.Height) error 
 }
 
 // DeleteWALEntries indicates an expected call of DeleteWALEntries.
-func (mr *MockTendermintDBMockRecorder[V, H, A]) DeleteWALEntries(height any) *gomock.Call {
+func (mr *MockTendermintDBMockRecorder[V]) DeleteWALEntries(height any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteWALEntries", reflect.TypeOf((*MockTendermintDB[V, H, A])(nil).DeleteWALEntries), height)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteWALEntries", reflect.TypeOf((*MockTendermintDB[V])(nil).DeleteWALEntries), height)
 }
 
 // Flush mocks base method.
-func (m *MockTendermintDB[V, H, A]) Flush() error {
+func (m *MockTendermintDB[V]) Flush() error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Flush")
 	ret0, _ := ret[0].(error)
@@ -64,28 +64,28 @@ func (m *MockTendermintDB[V, H, A]) Flush() error {
 }
 
 // Flush indicates an expected call of Flush.
-func (mr *MockTendermintDBMockRecorder[V, H, A]) Flush() *gomock.Call {
+func (mr *MockTendermintDBMockRecorder[V]) Flush() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Flush", reflect.TypeOf((*MockTendermintDB[V, H, A])(nil).Flush))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Flush", reflect.TypeOf((*MockTendermintDB[V])(nil).Flush))
 }
 
 // GetWALEntries mocks base method.
-func (m *MockTendermintDB[V, H, A]) GetWALEntries(height types.Height) ([]db.WalEntry[V, H, A], error) {
+func (m *MockTendermintDB[V]) GetWALEntries(height types.Height) ([]db.WalEntry[V], error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetWALEntries", height)
-	ret0, _ := ret[0].([]db.WalEntry[V, H, A])
+	ret0, _ := ret[0].([]db.WalEntry[V])
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetWALEntries indicates an expected call of GetWALEntries.
-func (mr *MockTendermintDBMockRecorder[V, H, A]) GetWALEntries(height any) *gomock.Call {
+func (mr *MockTendermintDBMockRecorder[V]) GetWALEntries(height any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetWALEntries", reflect.TypeOf((*MockTendermintDB[V, H, A])(nil).GetWALEntries), height)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetWALEntries", reflect.TypeOf((*MockTendermintDB[V])(nil).GetWALEntries), height)
 }
 
 // SetWALEntry mocks base method.
-func (m *MockTendermintDB[V, H, A]) SetWALEntry(entry types.Message[V, H, A]) error {
+func (m *MockTendermintDB[V]) SetWALEntry(entry types.Message[V]) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SetWALEntry", entry)
 	ret0, _ := ret[0].(error)
@@ -93,7 +93,7 @@ func (m *MockTendermintDB[V, H, A]) SetWALEntry(entry types.Message[V, H, A]) er
 }
 
 // SetWALEntry indicates an expected call of SetWALEntry.
-func (mr *MockTendermintDBMockRecorder[V, H, A]) SetWALEntry(entry any) *gomock.Call {
+func (mr *MockTendermintDBMockRecorder[V]) SetWALEntry(entry any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetWALEntry", reflect.TypeOf((*MockTendermintDB[V, H, A])(nil).SetWALEntry), entry)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetWALEntry", reflect.TypeOf((*MockTendermintDB[V])(nil).SetWALEntry), entry)
 }

--- a/consensus/mocks/mock_state_machine.go
+++ b/consensus/mocks/mock_state_machine.go
@@ -17,107 +17,107 @@ import (
 )
 
 // MockStateMachine is a mock of StateMachine interface.
-type MockStateMachine[V types.Hashable[H], H types.Hash, A types.Addr] struct {
+type MockStateMachine[V types.Hashable] struct {
 	ctrl     *gomock.Controller
-	recorder *MockStateMachineMockRecorder[V, H, A]
+	recorder *MockStateMachineMockRecorder[V]
 	isgomock struct{}
 }
 
 // MockStateMachineMockRecorder is the mock recorder for MockStateMachine.
-type MockStateMachineMockRecorder[V types.Hashable[H], H types.Hash, A types.Addr] struct {
-	mock *MockStateMachine[V, H, A]
+type MockStateMachineMockRecorder[V types.Hashable] struct {
+	mock *MockStateMachine[V]
 }
 
 // NewMockStateMachine creates a new mock instance.
-func NewMockStateMachine[V types.Hashable[H], H types.Hash, A types.Addr](ctrl *gomock.Controller) *MockStateMachine[V, H, A] {
-	mock := &MockStateMachine[V, H, A]{ctrl: ctrl}
-	mock.recorder = &MockStateMachineMockRecorder[V, H, A]{mock}
+func NewMockStateMachine[V types.Hashable](ctrl *gomock.Controller) *MockStateMachine[V] {
+	mock := &MockStateMachine[V]{ctrl: ctrl}
+	mock.recorder = &MockStateMachineMockRecorder[V]{mock}
 	return mock
 }
 
 // EXPECT returns an object that allows the caller to indicate expected use.
-func (m *MockStateMachine[V, H, A]) EXPECT() *MockStateMachineMockRecorder[V, H, A] {
+func (m *MockStateMachine[V]) EXPECT() *MockStateMachineMockRecorder[V] {
 	return m.recorder
 }
 
 // ProcessPrecommit mocks base method.
-func (m *MockStateMachine[V, H, A]) ProcessPrecommit(arg0 types.Precommit[H, A]) []types.Action[V, H, A] {
+func (m *MockStateMachine[V]) ProcessPrecommit(arg0 types.Precommit) []types.Action[V] {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ProcessPrecommit", arg0)
-	ret0, _ := ret[0].([]types.Action[V, H, A])
+	ret0, _ := ret[0].([]types.Action[V])
 	return ret0
 }
 
 // ProcessPrecommit indicates an expected call of ProcessPrecommit.
-func (mr *MockStateMachineMockRecorder[V, H, A]) ProcessPrecommit(arg0 any) *gomock.Call {
+func (mr *MockStateMachineMockRecorder[V]) ProcessPrecommit(arg0 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ProcessPrecommit", reflect.TypeOf((*MockStateMachine[V, H, A])(nil).ProcessPrecommit), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ProcessPrecommit", reflect.TypeOf((*MockStateMachine[V])(nil).ProcessPrecommit), arg0)
 }
 
 // ProcessPrevote mocks base method.
-func (m *MockStateMachine[V, H, A]) ProcessPrevote(arg0 types.Prevote[H, A]) []types.Action[V, H, A] {
+func (m *MockStateMachine[V]) ProcessPrevote(arg0 types.Prevote) []types.Action[V] {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ProcessPrevote", arg0)
-	ret0, _ := ret[0].([]types.Action[V, H, A])
+	ret0, _ := ret[0].([]types.Action[V])
 	return ret0
 }
 
 // ProcessPrevote indicates an expected call of ProcessPrevote.
-func (mr *MockStateMachineMockRecorder[V, H, A]) ProcessPrevote(arg0 any) *gomock.Call {
+func (mr *MockStateMachineMockRecorder[V]) ProcessPrevote(arg0 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ProcessPrevote", reflect.TypeOf((*MockStateMachine[V, H, A])(nil).ProcessPrevote), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ProcessPrevote", reflect.TypeOf((*MockStateMachine[V])(nil).ProcessPrevote), arg0)
 }
 
 // ProcessProposal mocks base method.
-func (m *MockStateMachine[V, H, A]) ProcessProposal(arg0 types.Proposal[V, H, A]) []types.Action[V, H, A] {
+func (m *MockStateMachine[V]) ProcessProposal(arg0 types.Proposal[V]) []types.Action[V] {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ProcessProposal", arg0)
-	ret0, _ := ret[0].([]types.Action[V, H, A])
+	ret0, _ := ret[0].([]types.Action[V])
 	return ret0
 }
 
 // ProcessProposal indicates an expected call of ProcessProposal.
-func (mr *MockStateMachineMockRecorder[V, H, A]) ProcessProposal(arg0 any) *gomock.Call {
+func (mr *MockStateMachineMockRecorder[V]) ProcessProposal(arg0 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ProcessProposal", reflect.TypeOf((*MockStateMachine[V, H, A])(nil).ProcessProposal), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ProcessProposal", reflect.TypeOf((*MockStateMachine[V])(nil).ProcessProposal), arg0)
 }
 
 // ProcessStart mocks base method.
-func (m *MockStateMachine[V, H, A]) ProcessStart(arg0 types.Round) []types.Action[V, H, A] {
+func (m *MockStateMachine[V]) ProcessStart(arg0 types.Round) []types.Action[V] {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ProcessStart", arg0)
-	ret0, _ := ret[0].([]types.Action[V, H, A])
+	ret0, _ := ret[0].([]types.Action[V])
 	return ret0
 }
 
 // ProcessStart indicates an expected call of ProcessStart.
-func (mr *MockStateMachineMockRecorder[V, H, A]) ProcessStart(arg0 any) *gomock.Call {
+func (mr *MockStateMachineMockRecorder[V]) ProcessStart(arg0 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ProcessStart", reflect.TypeOf((*MockStateMachine[V, H, A])(nil).ProcessStart), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ProcessStart", reflect.TypeOf((*MockStateMachine[V])(nil).ProcessStart), arg0)
 }
 
 // ProcessTimeout mocks base method.
-func (m *MockStateMachine[V, H, A]) ProcessTimeout(arg0 types.Timeout) []types.Action[V, H, A] {
+func (m *MockStateMachine[V]) ProcessTimeout(arg0 types.Timeout) []types.Action[V] {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ProcessTimeout", arg0)
-	ret0, _ := ret[0].([]types.Action[V, H, A])
+	ret0, _ := ret[0].([]types.Action[V])
 	return ret0
 }
 
 // ProcessTimeout indicates an expected call of ProcessTimeout.
-func (mr *MockStateMachineMockRecorder[V, H, A]) ProcessTimeout(arg0 any) *gomock.Call {
+func (mr *MockStateMachineMockRecorder[V]) ProcessTimeout(arg0 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ProcessTimeout", reflect.TypeOf((*MockStateMachine[V, H, A])(nil).ProcessTimeout), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ProcessTimeout", reflect.TypeOf((*MockStateMachine[V])(nil).ProcessTimeout), arg0)
 }
 
 // ReplayWAL mocks base method.
-func (m *MockStateMachine[V, H, A]) ReplayWAL() {
+func (m *MockStateMachine[V]) ReplayWAL() {
 	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "ReplayWAL")
 }
 
 // ReplayWAL indicates an expected call of ReplayWAL.
-func (mr *MockStateMachineMockRecorder[V, H, A]) ReplayWAL() *gomock.Call {
+func (mr *MockStateMachineMockRecorder[V]) ReplayWAL() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReplayWAL", reflect.TypeOf((*MockStateMachine[V, H, A])(nil).ReplayWAL))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReplayWAL", reflect.TypeOf((*MockStateMachine[V])(nil).ReplayWAL))
 }

--- a/consensus/p2p/broadcaster.go
+++ b/consensus/p2p/broadcaster.go
@@ -2,13 +2,13 @@ package p2p
 
 import "github.com/NethermindEth/juno/consensus/types"
 
-type Broadcaster[M types.Message[V, H, A], V types.Hashable[H], H types.Hash, A types.Addr] interface {
+type Broadcaster[M types.Message[V], V types.Hashable] interface {
 	// Broadcast will broadcast the message to the whole validator set. The function should not be blocking.
 	Broadcast(M)
 }
 
-type Broadcasters[V types.Hashable[H], H types.Hash, A types.Addr] struct {
-	ProposalBroadcaster  Broadcaster[types.Proposal[V, H, A], V, H, A]
-	PrevoteBroadcaster   Broadcaster[types.Prevote[H, A], V, H, A]
-	PrecommitBroadcaster Broadcaster[types.Precommit[H, A], V, H, A]
+type Broadcasters[V types.Hashable] struct {
+	ProposalBroadcaster  Broadcaster[types.Proposal[V], V]
+	PrevoteBroadcaster   Broadcaster[types.Prevote, V]
+	PrecommitBroadcaster Broadcaster[types.Precommit, V]
 }

--- a/consensus/p2p/listener.go
+++ b/consensus/p2p/listener.go
@@ -2,13 +2,13 @@ package p2p
 
 import "github.com/NethermindEth/juno/consensus/types"
 
-type Listener[M types.Message[V, H, A], V types.Hashable[H], H types.Hash, A types.Addr] interface {
+type Listener[M types.Message[V], V types.Hashable] interface {
 	// Listen would return consensus messages to Tendermint which are set by the validator set.
 	Listen() <-chan M
 }
 
-type Listeners[V types.Hashable[H], H types.Hash, A types.Addr] struct {
-	ProposalListener  Listener[types.Proposal[V, H, A], V, H, A]
-	PrevoteListener   Listener[types.Prevote[H, A], V, H, A]
-	PrecommitListener Listener[types.Precommit[H, A], V, H, A]
+type Listeners[V types.Hashable] struct {
+	ProposalListener  Listener[types.Proposal[V], V]
+	PrevoteListener   Listener[types.Prevote, V]
+	PrecommitListener Listener[types.Precommit, V]
 }

--- a/consensus/starknet/starknet.go
+++ b/consensus/starknet/starknet.go
@@ -4,30 +4,23 @@ import (
 	"github.com/NethermindEth/juno/consensus/types"
 	"github.com/NethermindEth/juno/core/address"
 	"github.com/NethermindEth/juno/core/felt"
-	"github.com/NethermindEth/juno/core/hash"
 )
 
 // TODO: Replace with the actual value type.
 type Value uint64
 
-func (v Value) Hash() hash.Hash {
-	return hash.Hash(*new(felt.Felt).SetUint64(uint64(v)))
+func (v Value) Hash() types.Hash {
+	return types.Hash(*new(felt.Felt).SetUint64(uint64(v)))
 }
 
 type (
 	Address = address.Address
-	Hash    = hash.Hash
+	Hash    = types.Hash
 
-	Message       = types.Message[Value, Hash, Address]
-	Proposal      = types.Proposal[Value, Hash, Address]
-	Prevote       = types.Prevote[Hash, Address]
-	Precommit     = types.Precommit[Hash, Address]
-	Vote          = types.Vote[Hash, Address]
-	MessageHeader = types.MessageHeader[Address]
-	Messages      = types.Messages[Value, Hash, Address]
+	Message  = types.Message[Value]
+	Proposal = types.Proposal[Value]
+	Messages = types.Messages[Value]
 
-	Action             = types.Action[Value, Hash, Address]
-	BroadcastProposal  = types.BroadcastProposal[Value, Hash, Address]
-	BroadcastPrevote   = types.BroadcastPrevote[Hash, Address]
-	BroadcastPrecommit = types.BroadcastPrecommit[Hash, Address]
+	Action            = types.Action[Value]
+	BroadcastProposal = types.BroadcastProposal[Value]
 )

--- a/consensus/tendermint/action_asserter_test.go
+++ b/consensus/tendermint/action_asserter_test.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/NethermindEth/juno/consensus/starknet"
 	"github.com/NethermindEth/juno/consensus/types"
-	"github.com/NethermindEth/juno/core/hash"
 	"github.com/NethermindEth/juno/utils"
 	"github.com/stretchr/testify/assert"
 )
@@ -27,9 +26,9 @@ func (a actionAsserter[T]) expectActions(expected ...starknet.Action) actionAsse
 		switch action := action.(type) {
 		case *starknet.BroadcastProposal:
 			assertProposal(a.testing, a.stateMachine, starknet.Proposal(*action))
-		case *starknet.BroadcastPrevote:
-			assertPrevote(a.testing, a.stateMachine, starknet.Prevote(*action))
-		case *starknet.BroadcastPrecommit:
+		case *types.BroadcastPrevote:
+			assertPrevote(a.testing, a.stateMachine, types.Prevote(*action))
+		case *types.BroadcastPrecommit:
 			// If the post state is not in new height and a value is committed, assert the valid and locked tuples.
 			if a.stateMachine.state.height == action.Height && action.ID != nil {
 				assert.Equal(a.testing, a.stateMachine.state.lockedRound, action.Round)
@@ -37,7 +36,7 @@ func (a actionAsserter[T]) expectActions(expected ...starknet.Action) actionAsse
 				assert.Equal(a.testing, a.stateMachine.state.validRound, action.Round)
 				assert.Equal(a.testing, getHash(a.stateMachine.state.validValue), action.ID)
 			}
-			assertPrecommit(a.testing, a.stateMachine, starknet.Precommit(*action))
+			assertPrecommit(a.testing, a.stateMachine, types.Precommit(*action))
 		case *types.ScheduleTimeout:
 			// ScheduleTimeout doesn't come with any state change, so there's nothing to assert here.
 		}
@@ -45,7 +44,7 @@ func (a actionAsserter[T]) expectActions(expected ...starknet.Action) actionAsse
 	return a
 }
 
-func getHash(val *starknet.Value) *hash.Hash {
+func getHash(val *starknet.Value) *types.Hash {
 	if val != nil {
 		return utils.HeapPtr(val.Hash())
 	}

--- a/consensus/tendermint/action_builder_test.go
+++ b/consensus/tendermint/action_builder_test.go
@@ -7,13 +7,13 @@ import (
 
 // actionBuilder is a helper struct to build expected actions as the result of processing messages and timeouts for the state machine.
 type actionBuilder struct {
-	thisNodeAddr starknet.Address
+	thisNodeAddr types.Addr
 	actionHeight types.Height
 	actionRound  types.Round
 }
 
-func (t actionBuilder) buildMessageHeader() starknet.MessageHeader {
-	return starknet.MessageHeader{Height: t.actionHeight, Round: t.actionRound, Sender: t.thisNodeAddr}
+func (t actionBuilder) buildMessageHeader() types.MessageHeader {
+	return types.MessageHeader{Height: t.actionHeight, Round: t.actionRound, Sender: t.thisNodeAddr}
 }
 
 // broadcastProposal builds and returns a BroadcastProposal action.
@@ -27,7 +27,7 @@ func (t actionBuilder) broadcastProposal(val starknet.Value, validRound types.Ro
 
 // broadcastPrevote builds and returns a BroadcastPrevote action.
 func (t actionBuilder) broadcastPrevote(val *starknet.Value) starknet.Action {
-	return &starknet.BroadcastPrevote{
+	return &types.BroadcastPrevote{
 		MessageHeader: t.buildMessageHeader(),
 		ID:            getHash(val),
 	}
@@ -35,7 +35,7 @@ func (t actionBuilder) broadcastPrevote(val *starknet.Value) starknet.Action {
 
 // broadcastPrecommit builds and returns a BroadcastPrecommit action.
 func (t actionBuilder) broadcastPrecommit(val *starknet.Value) starknet.Action {
-	return &starknet.BroadcastPrecommit{
+	return &types.BroadcastPrecommit{
 		MessageHeader: t.buildMessageHeader(),
 		ID:            getHash(val),
 	}

--- a/consensus/tendermint/assert_utils_test.go
+++ b/consensus/tendermint/assert_utils_test.go
@@ -16,7 +16,7 @@ func assertState(t *testing.T, stateMachine *testStateMachine, expectedHeight ty
 	assert.Equal(t, expectedStep, stateMachine.state.step, "step not equal")
 }
 
-func assertMessage[T starknet.Message](t *testing.T, messages map[types.Height]map[types.Round]map[starknet.Address]T, expectedMsgHeader starknet.MessageHeader, expectedMsg T) {
+func assertMessage[T starknet.Message](t *testing.T, messages map[types.Height]map[types.Round]map[types.Addr]T, expectedMsgHeader types.MessageHeader, expectedMsg T) {
 	t.Helper()
 	assert.Contains(t, messages, expectedMsgHeader.Height, "height not found")
 	assert.Contains(t, messages[expectedMsgHeader.Height], expectedMsgHeader.Round, "round not found")
@@ -35,7 +35,7 @@ func assertProposal(t *testing.T, stateMachine *testStateMachine, expectedMsg st
 }
 
 // assertPrevote asserts that the prevote message is in the state machine, except when the state machine advanced to the next height.
-func assertPrevote(t *testing.T, stateMachine *testStateMachine, expectedMsg starknet.Prevote) {
+func assertPrevote(t *testing.T, stateMachine *testStateMachine, expectedMsg types.Prevote) {
 	t.Helper()
 	// New height will discard the previous height messages.
 	if stateMachine.state.height != expectedMsg.Height {
@@ -45,7 +45,7 @@ func assertPrevote(t *testing.T, stateMachine *testStateMachine, expectedMsg sta
 }
 
 // assertPrecommit asserts that the precommit message is in the state machine, except when the state machine advanced to the next height.
-func assertPrecommit(t *testing.T, stateMachine *testStateMachine, expectedMsg starknet.Precommit) {
+func assertPrecommit(t *testing.T, stateMachine *testStateMachine, expectedMsg types.Precommit) {
 	t.Helper()
 	// New height will discard the previous height messages.
 	if stateMachine.state.height != expectedMsg.Height {

--- a/consensus/tendermint/broadcast.go
+++ b/consensus/tendermint/broadcast.go
@@ -5,9 +5,9 @@ import (
 	"github.com/NethermindEth/juno/utils"
 )
 
-func (t *stateMachine[V, H, A]) sendProposal(value *V) types.Action[V, H, A] {
-	proposalMessage := types.Proposal[V, H, A]{
-		MessageHeader: types.MessageHeader[A]{
+func (t *stateMachine[V]) sendProposal(value *V) types.Action[V] {
+	proposalMessage := types.Proposal[V]{
+		MessageHeader: types.MessageHeader{
 			Height: t.state.height,
 			Round:  t.state.round,
 			Sender: t.nodeAddr,
@@ -22,12 +22,12 @@ func (t *stateMachine[V, H, A]) sendProposal(value *V) types.Action[V, H, A] {
 
 	t.messages.AddProposal(proposalMessage)
 
-	return utils.HeapPtr(types.BroadcastProposal[V, H, A](proposalMessage))
+	return utils.HeapPtr(types.BroadcastProposal[V](proposalMessage))
 }
 
-func (t *stateMachine[V, H, A]) setStepAndSendPrevote(id *H) types.Action[V, H, A] {
-	vote := types.Prevote[H, A]{
-		MessageHeader: types.MessageHeader[A]{
+func (t *stateMachine[V]) setStepAndSendPrevote(id *types.Hash) types.Action[V] {
+	vote := types.Prevote{
+		MessageHeader: types.MessageHeader{
 			Height: t.state.height,
 			Round:  t.state.round,
 			Sender: t.nodeAddr,
@@ -38,12 +38,12 @@ func (t *stateMachine[V, H, A]) setStepAndSendPrevote(id *H) types.Action[V, H, 
 	t.messages.AddPrevote(vote)
 	t.state.step = types.StepPrevote
 
-	return utils.HeapPtr(types.BroadcastPrevote[H, A](vote))
+	return utils.HeapPtr(types.BroadcastPrevote(vote))
 }
 
-func (t *stateMachine[V, H, A]) setStepAndSendPrecommit(id *H) types.Action[V, H, A] {
-	vote := types.Precommit[H, A]{
-		MessageHeader: types.MessageHeader[A]{
+func (t *stateMachine[V]) setStepAndSendPrecommit(id *types.Hash) types.Action[V] {
+	vote := types.Precommit{
+		MessageHeader: types.MessageHeader{
 			Height: t.state.height,
 			Round:  t.state.round,
 			Sender: t.nodeAddr,
@@ -54,5 +54,5 @@ func (t *stateMachine[V, H, A]) setStepAndSendPrecommit(id *H) types.Action[V, H
 	t.messages.AddPrecommit(vote)
 	t.state.step = types.StepPrecommit
 
-	return utils.HeapPtr(types.BroadcastPrecommit[H, A](vote))
+	return utils.HeapPtr(types.BroadcastPrecommit(vote))
 }

--- a/consensus/tendermint/incoming_message_builder_test.go
+++ b/consensus/tendermint/incoming_message_builder_test.go
@@ -12,7 +12,7 @@ import (
 type incomingMessageBuilder struct {
 	testing      *testing.T
 	stateMachine *testStateMachine
-	header       starknet.MessageHeader
+	header       types.MessageHeader
 }
 
 // proposal builds and processes a Proposal message, asserts it's stored in the state machine,
@@ -37,9 +37,9 @@ func (t incomingMessageBuilder) proposal(val starknet.Value, validRound types.Ro
 
 // prevote builds and processes a types.Prevote message, asserts it's stored in the state machine,
 // and returns an actionAsserter to check resulting actions.
-func (t incomingMessageBuilder) prevote(val *starknet.Value) actionAsserter[starknet.Prevote] {
+func (t incomingMessageBuilder) prevote(val *starknet.Value) actionAsserter[types.Prevote] {
 	t.testing.Helper()
-	prevote := starknet.Prevote{
+	prevote := types.Prevote{
 		MessageHeader: t.header,
 		ID:            getHash(val),
 	}
@@ -47,7 +47,7 @@ func (t incomingMessageBuilder) prevote(val *starknet.Value) actionAsserter[star
 
 	assertPrevote(t.testing, t.stateMachine, prevote)
 
-	return actionAsserter[starknet.Prevote]{
+	return actionAsserter[types.Prevote]{
 		testing:      t.testing,
 		stateMachine: t.stateMachine,
 		actions:      actions,
@@ -56,9 +56,9 @@ func (t incomingMessageBuilder) prevote(val *starknet.Value) actionAsserter[star
 
 // precommit builds and processes a Precommit message, asserts it's stored in the state machine,
 // and returns an actionAsserter to check resulting actions.
-func (t incomingMessageBuilder) precommit(val *starknet.Value) actionAsserter[starknet.Precommit] {
+func (t incomingMessageBuilder) precommit(val *starknet.Value) actionAsserter[types.Precommit] {
 	t.testing.Helper()
-	precommit := starknet.Precommit{
+	precommit := types.Precommit{
 		MessageHeader: t.header,
 		ID:            getHash(val),
 	}
@@ -66,7 +66,7 @@ func (t incomingMessageBuilder) precommit(val *starknet.Value) actionAsserter[st
 
 	assertPrecommit(t.testing, t.stateMachine, precommit)
 
-	return actionAsserter[starknet.Precommit]{
+	return actionAsserter[types.Precommit]{
 		testing:      t.testing,
 		stateMachine: t.stateMachine,
 		actions:      actions,

--- a/consensus/tendermint/process.go
+++ b/consensus/tendermint/process.go
@@ -2,11 +2,11 @@ package tendermint
 
 import "github.com/NethermindEth/juno/consensus/types"
 
-func (t *stateMachine[V, H, A]) ProcessStart(round types.Round) []types.Action[V, H, A] {
+func (t *stateMachine[V]) ProcessStart(round types.Round) []types.Action[V] {
 	return t.processLoop(t.startRound(round), nil)
 }
 
-func (t *stateMachine[V, H, A]) ProcessProposal(p types.Proposal[V, H, A]) []types.Action[V, H, A] {
+func (t *stateMachine[V]) ProcessProposal(p types.Proposal[V]) []types.Action[V] {
 	return t.processMessage(p.MessageHeader, func() {
 		if t.messages.AddProposal(p) && !t.replayMode && p.Height == t.state.height {
 			// Store proposal if its the first time we see it
@@ -17,7 +17,7 @@ func (t *stateMachine[V, H, A]) ProcessProposal(p types.Proposal[V, H, A]) []typ
 	})
 }
 
-func (t *stateMachine[V, H, A]) ProcessPrevote(p types.Prevote[H, A]) []types.Action[V, H, A] {
+func (t *stateMachine[V]) ProcessPrevote(p types.Prevote) []types.Action[V] {
 	return t.processMessage(p.MessageHeader, func() {
 		if t.messages.AddPrevote(p) && !t.replayMode && p.Height == t.state.height {
 			// Store prevote if its the first time we see it
@@ -28,7 +28,7 @@ func (t *stateMachine[V, H, A]) ProcessPrevote(p types.Prevote[H, A]) []types.Ac
 	})
 }
 
-func (t *stateMachine[V, H, A]) ProcessPrecommit(p types.Precommit[H, A]) []types.Action[V, H, A] {
+func (t *stateMachine[V]) ProcessPrecommit(p types.Precommit) []types.Action[V] {
 	return t.processMessage(p.MessageHeader, func() {
 		if t.messages.AddPrecommit(p) && !t.replayMode && p.Height == t.state.height {
 			// Store precommit if its the first time we see it
@@ -39,7 +39,7 @@ func (t *stateMachine[V, H, A]) ProcessPrecommit(p types.Precommit[H, A]) []type
 	})
 }
 
-func (t *stateMachine[V, H, A]) processMessage(header types.MessageHeader[A], addMessage func()) []types.Action[V, H, A] {
+func (t *stateMachine[V]) processMessage(header types.MessageHeader, addMessage func()) []types.Action[V] {
 	if !t.preprocessMessage(header, addMessage) {
 		return nil
 	}
@@ -47,7 +47,7 @@ func (t *stateMachine[V, H, A]) processMessage(header types.MessageHeader[A], ad
 	return t.processLoop(nil, &header.Round)
 }
 
-func (t *stateMachine[V, H, A]) ProcessTimeout(tm types.Timeout) []types.Action[V, H, A] {
+func (t *stateMachine[V]) ProcessTimeout(tm types.Timeout) []types.Action[V] {
 	if !t.replayMode && tm.Height == t.state.height {
 		if err := t.db.SetWALEntry(tm); err != nil {
 			t.log.Fatalf("Failed to store timeout trigger in WAL")
@@ -65,8 +65,8 @@ func (t *stateMachine[V, H, A]) ProcessTimeout(tm types.Timeout) []types.Action[
 	return nil
 }
 
-func (t *stateMachine[V, H, A]) processLoop(action types.Action[V, H, A], recentlyReceivedRound *types.Round) []types.Action[V, H, A] {
-	actions := []types.Action[V, H, A]{}
+func (t *stateMachine[V]) processLoop(action types.Action[V], recentlyReceivedRound *types.Round) []types.Action[V] {
+	actions := []types.Action[V]{}
 	if action != nil {
 		actions = append(actions, action)
 	}
@@ -80,10 +80,10 @@ func (t *stateMachine[V, H, A]) processLoop(action types.Action[V, H, A], recent
 	return actions
 }
 
-func (t *stateMachine[V, H, A]) process(recentlyReceivedRound *types.Round) types.Action[V, H, A] {
+func (t *stateMachine[V]) process(recentlyReceivedRound *types.Round) types.Action[V] {
 	cachedProposal := t.findProposal(t.state.round)
 
-	var roundCachedProposal *CachedProposal[V, H, A]
+	var roundCachedProposal *CachedProposal[V]
 	if recentlyReceivedRound != nil {
 		roundCachedProposal = t.findProposal(*recentlyReceivedRound)
 	}

--- a/consensus/tendermint/rule_commit_value.go
+++ b/consensus/tendermint/rule_commit_value.go
@@ -18,7 +18,7 @@ height and round.
 There is no need to check decision_p[h_p] = nil since it is implied that decision are made
 sequentially, i.e. x, x+1, x+2... .
 */
-func (t *stateMachine[V, H, A]) uponCommitValue(cachedProposal *CachedProposal[V, H, A]) bool {
+func (t *stateMachine[V]) uponCommitValue(cachedProposal *CachedProposal[V]) bool {
 	_, hasQuorum := t.checkForQuorumPrecommit(cachedProposal.Round, *cachedProposal.ID)
 
 	// This is checked here instead of inside execution, because it's the only case in execution in this rule
@@ -28,7 +28,7 @@ func (t *stateMachine[V, H, A]) uponCommitValue(cachedProposal *CachedProposal[V
 	return hasQuorum && isValid
 }
 
-func (t *stateMachine[V, H, A]) doCommitValue(cachedProposal *CachedProposal[V, H, A]) types.Action[V, H, A] {
+func (t *stateMachine[V]) doCommitValue(cachedProposal *CachedProposal[V]) types.Action[V] {
 	if err := t.db.Flush(); err != nil {
 		t.log.Fatalf("failed to flush WAL during commit", "height", cachedProposal.Height, "round", cachedProposal.Round, "err", err)
 	}

--- a/consensus/tendermint/rule_first_proposal.go
+++ b/consensus/tendermint/rule_first_proposal.go
@@ -14,16 +14,16 @@ Check the upon condition on line 22:
 
 Since the value's id is expected to be unique the id can be used to compare the values.
 */
-func (t *stateMachine[V, H, A]) uponFirstProposal(cachedProposal *CachedProposal[V, H, A]) bool {
+func (t *stateMachine[V]) uponFirstProposal(cachedProposal *CachedProposal[V]) bool {
 	return cachedProposal.ValidRound == -1 && t.state.step == types.StepPropose
 }
 
-func (t *stateMachine[V, H, A]) doFirstProposal(cachedProposal *CachedProposal[V, H, A]) types.Action[V, H, A] {
+func (t *stateMachine[V]) doFirstProposal(cachedProposal *CachedProposal[V]) types.Action[V] {
 	shouldVoteForValue := cachedProposal.Valid &&
 		(t.state.lockedRound == -1 ||
 			t.state.lockedValue != nil && (*t.state.lockedValue).Hash() == *cachedProposal.ID)
 
-	var votedID *H
+	var votedID *types.Hash
 	if shouldVoteForValue {
 		votedID = cachedProposal.ID
 	}

--- a/consensus/tendermint/rule_polka_any.go
+++ b/consensus/tendermint/rule_polka_any.go
@@ -13,7 +13,7 @@ Check the upon condition on line 34:
 	34: upon 2f + 1 {PREVOTE, h_p, round_p, ∗} while step_p = prevote for the first time do
 	35: schedule OnTimeoutPrevote(h_p, round_p) to be executed after timeoutPrevote(round_p)
 */
-func (t *stateMachine[V, H, A]) uponPolkaAny() bool {
+func (t *stateMachine[V]) uponPolkaAny() bool {
 	prevotes := t.messages.Prevotes[t.state.height][t.state.round]
 	vals := slices.Collect(maps.Keys(prevotes))
 
@@ -26,7 +26,7 @@ func (t *stateMachine[V, H, A]) uponPolkaAny() bool {
 		isFirstTime
 }
 
-func (t *stateMachine[V, H, A]) doPolkaAny() types.Action[V, H, A] {
+func (t *stateMachine[V]) doPolkaAny() types.Action[V] {
 	t.state.timeoutPrevoteScheduled = true
 	return t.scheduleTimeout(types.StepPrevote)
 }

--- a/consensus/tendermint/rule_polka_nil.go
+++ b/consensus/tendermint/rule_polka_nil.go
@@ -11,10 +11,10 @@ Check the upon condition on line 44:
 
 Line 36 and 44 for a round are mutually exclusive.
 */
-func (t *stateMachine[V, H, A]) uponPolkaNil() bool {
+func (t *stateMachine[V]) uponPolkaNil() bool {
 	prevotes := t.messages.Prevotes[t.state.height][t.state.round]
 
-	var vals []A
+	var vals []types.Addr
 	for addr, v := range prevotes {
 		if v.ID == nil {
 			vals = append(vals, addr)
@@ -27,6 +27,6 @@ func (t *stateMachine[V, H, A]) uponPolkaNil() bool {
 	return hasQuorum && t.state.step == types.StepPrevote
 }
 
-func (t *stateMachine[V, H, A]) doPolkaNil() types.Action[V, H, A] {
+func (t *stateMachine[V]) doPolkaNil() types.Action[V] {
 	return t.setStepAndSendPrecommit(nil)
 }

--- a/consensus/tendermint/rule_precommit_any.go
+++ b/consensus/tendermint/rule_precommit_any.go
@@ -13,7 +13,7 @@ Check the upon condition on line 47:
 	47: upon 2f + 1 {PRECOMMIT, h_p, round_p, ∗} for the first time do
 	48: schedule OnTimeoutPrecommit(h_p , round_p) to be executed after timeoutPrecommit(round_p)
 */
-func (t *stateMachine[V, H, A]) uponPrecommitAny() bool {
+func (t *stateMachine[V]) uponPrecommitAny() bool {
 	precommits := t.messages.Precommits[t.state.height][t.state.round]
 	vals := slices.Collect(maps.Keys(precommits))
 
@@ -24,7 +24,7 @@ func (t *stateMachine[V, H, A]) uponPrecommitAny() bool {
 	return hasQuorum && isFirstTime
 }
 
-func (t *stateMachine[V, H, A]) doPrecommitAny() types.Action[V, H, A] {
+func (t *stateMachine[V]) doPrecommitAny() types.Action[V] {
 	t.state.timeoutPrecommitScheduled = true
 	return t.scheduleTimeout(types.StepPrecommit)
 }

--- a/consensus/tendermint/rule_proposal_and_polka_current.go
+++ b/consensus/tendermint/rule_proposal_and_polka_current.go
@@ -17,7 +17,7 @@ Check upon condition on line 36:
 	42: validValue_p ← v
 	43: validRound_p ← round_p
 */
-func (t *stateMachine[V, H, A]) uponProposalAndPolkaCurrent(cachedProposal *CachedProposal[V, H, A]) bool {
+func (t *stateMachine[V]) uponProposalAndPolkaCurrent(cachedProposal *CachedProposal[V]) bool {
 	hasQuorum := t.checkQuorumPrevotesGivenProposalVID(t.state.round, *cachedProposal.ID)
 	firstTime := !t.state.lockedValueAndOrValidValueSet
 	return hasQuorum &&
@@ -26,8 +26,8 @@ func (t *stateMachine[V, H, A]) uponProposalAndPolkaCurrent(cachedProposal *Cach
 		firstTime
 }
 
-func (t *stateMachine[V, H, A]) doProposalAndPolkaCurrent(cachedProposal *CachedProposal[V, H, A]) types.Action[V, H, A] {
-	var action types.Action[V, H, A]
+func (t *stateMachine[V]) doProposalAndPolkaCurrent(cachedProposal *CachedProposal[V]) types.Action[V] {
+	var action types.Action[V]
 	if t.state.step == types.StepPrevote {
 		t.state.lockedValue = cachedProposal.Value
 		t.state.lockedRound = t.state.round

--- a/consensus/tendermint/rule_proposal_and_polka_previous.go
+++ b/consensus/tendermint/rule_proposal_and_polka_previous.go
@@ -13,7 +13,7 @@ Check the upon condition on line 28:
 	32:  	broadcast {PREVOTE, hp, round_p, nil}
 	33: step_p ← prevote
 */
-func (t *stateMachine[V, H, A]) uponProposalAndPolkaPrevious(cachedProposal *CachedProposal[V, H, A]) bool {
+func (t *stateMachine[V]) uponProposalAndPolkaPrevious(cachedProposal *CachedProposal[V]) bool {
 	vr := cachedProposal.ValidRound
 	hasQuorum := t.checkQuorumPrevotesGivenProposalVID(vr, *cachedProposal.ID)
 	return hasQuorum &&
@@ -22,8 +22,8 @@ func (t *stateMachine[V, H, A]) uponProposalAndPolkaPrevious(cachedProposal *Cac
 		vr < t.state.round
 }
 
-func (t *stateMachine[V, H, A]) doProposalAndPolkaPrevious(cachedProposal *CachedProposal[V, H, A]) types.Action[V, H, A] {
-	var votedID *H
+func (t *stateMachine[V]) doProposalAndPolkaPrevious(cachedProposal *CachedProposal[V]) types.Action[V] {
+	var votedID *types.Hash
 	shouldVoteForValue := cachedProposal.Valid &&
 		(t.state.lockedRound <= cachedProposal.ValidRound ||
 			t.state.lockedValue != nil && cachedProposal.ID != nil && (*t.state.lockedValue).Hash() == *cachedProposal.ID)

--- a/consensus/tendermint/rule_skip_round.go
+++ b/consensus/tendermint/rule_skip_round.go
@@ -15,8 +15,8 @@ Check the upon condition on line 55:
 
 If there are f + 1 messages from a newer round, there is at least an honest node in that round.
 */
-func (t *stateMachine[V, H, A]) uponSkipRound(futureR types.Round) bool {
-	vals := make(map[A]struct{})
+func (t *stateMachine[V]) uponSkipRound(futureR types.Round) bool {
+	vals := make(map[types.Addr]struct{})
 	proposals, prevotes, precommits := t.messages.AllMessages(t.state.height, futureR)
 
 	// If a validator has sent proposl, prevote and precommit from a future round then it will only be counted once.
@@ -39,6 +39,6 @@ func (t *stateMachine[V, H, A]) uponSkipRound(futureR types.Round) bool {
 	return isNewerRound && hasQuorum
 }
 
-func (t *stateMachine[V, H, A]) doSkipRound(futureR types.Round) types.Action[V, H, A] {
+func (t *stateMachine[V]) doSkipRound(futureR types.Round) types.Action[V] {
 	return t.startRound(futureR)
 }

--- a/consensus/tendermint/state_machine_context_test.go
+++ b/consensus/tendermint/state_machine_context_test.go
@@ -5,10 +5,9 @@ import (
 
 	"github.com/NethermindEth/juno/consensus/starknet"
 	"github.com/NethermindEth/juno/consensus/types"
-	"github.com/NethermindEth/juno/core/hash"
 )
 
-type testStateMachine = stateMachine[starknet.Value, hash.Hash, starknet.Address]
+type testStateMachine = stateMachine[starknet.Value]
 
 // stateMachineContext is a build struct to build test scenarios for the state machine.
 // Sample usages:
@@ -66,7 +65,7 @@ func (t stateMachineContext) validator(idx int) incomingMessageBuilder {
 	return incomingMessageBuilder{
 		testing:      t.testing,
 		stateMachine: t.stateMachine,
-		header:       starknet.MessageHeader{Height: t.builderHeight, Round: t.builderRound, Sender: *getVal(idx)},
+		header:       types.MessageHeader{Height: t.builderHeight, Round: t.builderRound, Sender: *getVal(idx)},
 	}
 }
 

--- a/consensus/tendermint/tendermint_test.go
+++ b/consensus/tendermint/tendermint_test.go
@@ -53,7 +53,7 @@ func (c *chain) Commit(h types.Height, v starknet.Value) {
 // Implements Validators[felt.Felt] interface
 type validators struct {
 	totalVotingPower types.VotingPower
-	vals             []starknet.Address
+	vals             []types.Addr
 }
 
 func newVals() *validators { return &validators{} }
@@ -62,23 +62,23 @@ func (v *validators) TotalVotingPower(h types.Height) types.VotingPower {
 	return v.totalVotingPower
 }
 
-func (v *validators) ValidatorVotingPower(validatorAddr starknet.Address) types.VotingPower {
+func (v *validators) ValidatorVotingPower(validatorAddr types.Addr) types.VotingPower {
 	return 1
 }
 
 // Proposer is implements round robin
-func (v *validators) Proposer(h types.Height, r types.Round) starknet.Address {
+func (v *validators) Proposer(h types.Height, r types.Round) types.Addr {
 	i := (uint(h) + uint(r)) % uint(v.totalVotingPower)
 	return v.vals[i]
 }
 
-func (v *validators) addValidator(addr starknet.Address) {
+func (v *validators) addValidator(addr types.Addr) {
 	v.vals = append(v.vals, addr)
 	v.totalVotingPower++
 }
 
-func getVal(idx int) *starknet.Address {
-	return (*starknet.Address)(new(felt.Felt).SetUint64(uint64(idx)))
+func getVal(idx int) *types.Addr {
+	return (*types.Addr)(new(felt.Felt).SetUint64(uint64(idx)))
 }
 
 func setupStateMachine(
@@ -95,7 +95,7 @@ func setupStateMachine(
 	thisNodeAddr := getVal(thisValidator)
 	ctrl := gomock.NewController(t)
 	// Ignore WAL for tests that use this
-	db := mocks.NewMockTendermintDB[starknet.Value, starknet.Hash, starknet.Address](ctrl)
+	db := mocks.NewMockTendermintDB[starknet.Value](ctrl)
 	db.EXPECT().SetWALEntry(gomock.Any()).AnyTimes()
 	db.EXPECT().Flush().AnyTimes()
 	db.EXPECT().DeleteWALEntries(gomock.Any()).AnyTimes()

--- a/consensus/tendermint/timeout.go
+++ b/consensus/tendermint/timeout.go
@@ -2,21 +2,21 @@ package tendermint
 
 import "github.com/NethermindEth/juno/consensus/types"
 
-func (t *stateMachine[V, H, A]) onTimeoutPropose(h types.Height, r types.Round) types.Action[V, H, A] {
+func (t *stateMachine[V]) onTimeoutPropose(h types.Height, r types.Round) types.Action[V] {
 	if t.state.height == h && t.state.round == r && t.state.step == types.StepPropose {
 		return t.setStepAndSendPrevote(nil)
 	}
 	return nil
 }
 
-func (t *stateMachine[V, H, A]) onTimeoutPrevote(h types.Height, r types.Round) types.Action[V, H, A] {
+func (t *stateMachine[V]) onTimeoutPrevote(h types.Height, r types.Round) types.Action[V] {
 	if t.state.height == h && t.state.round == r && t.state.step == types.StepPrevote {
 		return t.setStepAndSendPrecommit(nil)
 	}
 	return nil
 }
 
-func (t *stateMachine[V, H, A]) onTimeoutPrecommit(h types.Height, r types.Round) types.Action[V, H, A] {
+func (t *stateMachine[V]) onTimeoutPrecommit(h types.Height, r types.Round) types.Action[V] {
 	if t.state.height == h && t.state.round == r {
 		return t.startRound(r + 1)
 	}

--- a/consensus/types/action.go
+++ b/consensus/types/action.go
@@ -1,21 +1,21 @@
 package types
 
-type Action[V Hashable[H], H Hash, A Addr] interface {
+type Action[V Hashable] interface {
 	isTendermintAction()
 }
 
-type BroadcastProposal[V Hashable[H], H Hash, A Addr] Proposal[V, H, A]
+type BroadcastProposal[V Hashable] Proposal[V]
 
-type BroadcastPrevote[H Hash, A Addr] Prevote[H, A]
+type BroadcastPrevote Prevote
 
-type BroadcastPrecommit[H Hash, A Addr] Precommit[H, A]
+type BroadcastPrecommit Precommit
 
 type ScheduleTimeout Timeout
 
-func (a *BroadcastProposal[V, H, A]) isTendermintAction() {}
+func (a *BroadcastProposal[V]) isTendermintAction() {}
 
-func (a *BroadcastPrevote[H, A]) isTendermintAction() {}
+func (a *BroadcastPrevote) isTendermintAction() {}
 
-func (a *BroadcastPrecommit[H, A]) isTendermintAction() {}
+func (a *BroadcastPrecommit) isTendermintAction() {}
 
 func (a *ScheduleTimeout) isTendermintAction() {}

--- a/consensus/types/types.go
+++ b/consensus/types/types.go
@@ -1,14 +1,20 @@
 package types
 
-type Addr interface {
-	~[4]uint64
-}
-
-type Hash interface {
-	~[4]uint64
-}
+import "github.com/NethermindEth/juno/core/felt"
 
 // Hashable's Hash() is used as ID()
-type Hashable[H Hash] interface {
-	Hash() H
+type Hash felt.Felt
+
+type Addr felt.Felt
+
+func (a *Addr) SetUint64(v uint64) {
+	(*felt.Felt)(a).SetUint64(v)
+}
+
+func (a *Addr) Equal(b *Addr) bool {
+	return (*felt.Felt)(a).Equal((*felt.Felt)(b))
+}
+
+type Hashable interface {
+	Hash() Hash
 }


### PR DESCRIPTION
### Summary

The consensus implementation currently defines `Hash` and `Addr` as generic interfaces to support flexibility across protocols. This was originally intended to allow the consensus logic to work with any hash and address types that can be represented as `[4]uint`.

However, in the context of the Starknet protocol, both the address and hash types are explicitly defined as `felt.Felt`, and this is not expected to change. As a result, the use of generics here is unnecessary and introduces avoidable complexity.

---

### Motivation

- **Unnecessary Boilerplate:** Since `Hash` and `Addr` are used pervasively across the consensus package, requiring them to be passed explicitly as generic parameters to every struct and function results in significant boilerplate and reduces readability.
  
- **Interface Overhead:** Defining these as interfaces requires explicit type declarations, type assertions, and additional complexity that brings no real benefit in this fixed-type context.

- **Improved Ergonomics:** By redefining `Hash` and `Addr` as aliases (e.g., `type Addr felt.Felt`), we significantly reduce syntactic noise and make the code more straightforward and maintainable.

---

### Change

This PR:
- Replaces the generic `Hash` and `Addr` interfaces with type aliases to `felt.Felt`.
- Updates the affected types and function signatures to remove unnecessary generic parameters.

This change simplifies the consensus implementation while preserving all intended functionality under the assumption of fixed `felt.Felt`-based types.

---

### Next (this can be done in a separate PR)

Investigate whether the `Hashable` interface can also be removed by explicitly defining the concrete value types used in the Starknet protocol (e.g., `Block`, `StateUpdate`, etc.). 

Since these types are known and fixed within the protocol, relying on an interface abstraction may be unnecessary. Replacing `Hashable` with concrete types could further simplify the codebase and eliminate another layer of indirection.
