### PR TITLE
refactor: replace for i := range b.N with for b.Loop() and remove calls to b.StopTimer, b.StartTimer, and b.ResetTimer

### DIFF
--- a/core/crypto/ecdsa_test.go
+++ b/core/crypto/ecdsa_test.go
@@ -69,8 +69,8 @@ func BenchmarkVerify(b *testing.B) {
 
 	var verified bool
 	var err error
-	b.ResetTimer()
-	for range b.N {
+
+	for b.Loop() {
 		verified, err = publicKey.Verify(&signature, msg)
 		require.NoError(b, err)
 	}

--- a/core/crypto/pedersen_hash_test.go
+++ b/core/crypto/pedersen_hash_test.go
@@ -153,7 +153,7 @@ func BenchmarkPedersen(b *testing.B) {
 
 func genRandomFeltSls(b *testing.B, n int) [][]*felt.Felt {
 	randomFeltSls := make([][]*felt.Felt, 0, b.N)
-	for range b.N {
+	for b.Loop() {
 		randomFeltSls = append(randomFeltSls, genRandomFelts(b, n))
 	}
 	return randomFeltSls

--- a/core/trie/proof_test.go
+++ b/core/trie/proof_test.go
@@ -634,8 +634,7 @@ func BenchmarkVerifyRangeProof(b *testing.B) {
 		values[i-start] = records[i].value
 	}
 
-	b.ResetTimer()
-	for range b.N {
+	for b.Loop() {
 		_, err := trie.VerifyRangeProof(root, keys[0], keys, values, proof)
 		require.NoError(b, err)
 	}

--- a/core/trie/trie_test.go
+++ b/core/trie/trie_test.go
@@ -434,7 +434,7 @@ var benchTriePutR *felt.Felt
 
 func BenchmarkTriePut(b *testing.B) {
 	keys := make([]*felt.Felt, 0, b.N)
-	for range b.N {
+	for b.Loop() {
 		rnd, err := new(felt.Felt).SetRandom()
 		require.NoError(b, err)
 		keys = append(keys, rnd)

--- a/core/trie2/proof_test.go
+++ b/core/trie2/proof_test.go
@@ -607,8 +607,7 @@ func BenchmarkVerifyRangeProof(b *testing.B) {
 		values[i-start] = records[i].value
 	}
 
-	b.ResetTimer()
-	for range b.N {
+	for b.Loop() {
 		_, err := VerifyRangeProof(&root, keys[0], keys, values, proof)
 		require.NoError(b, err)
 	}

--- a/jsonrpc/server_test.go
+++ b/jsonrpc/server_test.go
@@ -565,8 +565,8 @@ func BenchmarkHandle(b *testing.B) {
 	const request = `{"jsonrpc":"2.0","id":1,"method":"test"}`
 	var header http.Header
 	var err error
-	b.ResetTimer()
-	for range b.N {
+
+	for b.Loop() {
 		_, header, err = server.HandleReader(b.Context(), strings.NewReader(request))
 		require.NoError(b, err)
 		require.NotNil(b, header)


### PR DESCRIPTION
replace "for i := range b.N" or "for range b.N" in a benchmark with "for b.Loop()", and remove any preceding calls to b.StopTimer, b.StartTimer, and b.ResetTimer.