### PR TITLE
refactor: Add Commit action

### DIFF
--- a/consensus/integtest/blockchain.go
+++ b/consensus/integtest/blockchain.go
@@ -25,10 +25,6 @@ func newBlockchain(commits chan commit, nodeAddr *starknet.Address) *blockchain 
 	}
 }
 
-func (b *blockchain) Height() types.Height {
-	return b.height
-}
-
 func (b *blockchain) Commit(height types.Height, value starknet.Value) {
 	b.height = max(b.height, height)
 	b.commits <- commit{

--- a/consensus/integtest/integ_test.go
+++ b/consensus/integtest/integ_test.go
@@ -9,10 +9,8 @@ import (
 	"github.com/NethermindEth/juno/consensus/starknet"
 	"github.com/NethermindEth/juno/consensus/tendermint"
 	"github.com/NethermindEth/juno/consensus/types"
-	"github.com/NethermindEth/juno/db/pebble"
 	"github.com/NethermindEth/juno/utils"
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
 )
 
@@ -62,23 +60,23 @@ func runTest(t *testing.T, cfg testConfig) {
 
 	// Spawn a network of honest nodes
 	for i := range honestNodeCount {
-		dbPath := t.TempDir()
-		testDB, err := pebble.New(dbPath)
-		require.NoError(t, err)
+		tendermintDB := newDB(t)
 
 		nodeAddr := &allNodes.addr[i]
 
 		stateMachine := tendermint.New(
-			newDB(t),
+			tendermintDB,
 			utils.NewNopZapLogger(),
 			*nodeAddr,
 			&application{},
-			newBlockchain(commits, nodeAddr),
 			validators,
+			types.Height(0),
 		)
 		driver := driver.New(
-			testDB,
+			utils.NewNopZapLogger(),
+			tendermintDB,
 			stateMachine,
+			newBlockchain(commits, nodeAddr),
 			network.getListeners(nodeAddr),
 			network.getBroadcasters(nodeAddr),
 			getTimeoutFn(cfg),

--- a/consensus/starknet/starknet.go
+++ b/consensus/starknet/starknet.go
@@ -30,4 +30,5 @@ type (
 	BroadcastProposal  = types.BroadcastProposal[Value, Hash, Address]
 	BroadcastPrevote   = types.BroadcastPrevote[Hash, Address]
 	BroadcastPrecommit = types.BroadcastPrecommit[Hash, Address]
+	Commit             = types.Commit[Value, Hash, Address]
 )

--- a/consensus/tendermint/action_builder_test.go
+++ b/consensus/tendermint/action_builder_test.go
@@ -49,3 +49,16 @@ func (t actionBuilder) scheduleTimeout(s types.Step) starknet.Action {
 		Round:  t.actionRound,
 	}
 }
+
+// commit returns a commit action.
+func (t actionBuilder) commit(val starknet.Value, validRound types.Round, proposer int) starknet.Action {
+	return &starknet.Commit{
+		MessageHeader: starknet.MessageHeader{
+			Height: t.actionHeight,
+			Round:  t.actionRound,
+			Sender: *getVal(proposer),
+		},
+		Value:      &val,
+		ValidRound: validRound,
+	}
+}

--- a/consensus/tendermint/rule_commit_value.go
+++ b/consensus/tendermint/rule_commit_value.go
@@ -28,17 +28,7 @@ func (t *stateMachine[V, H, A]) uponCommitValue(cachedProposal *CachedProposal[V
 	return hasQuorum && isValid
 }
 
-func (t *stateMachine[V, H, A]) doCommitValue(cachedProposal *CachedProposal[V, H, A]) types.Action[V, H, A] {
-	if err := t.db.Flush(); err != nil {
-		t.log.Fatalf("failed to flush WAL during commit", "height", cachedProposal.Height, "round", cachedProposal.Round, "err", err)
-	}
-
-	t.blockchain.Commit(t.state.height, *cachedProposal.Value)
-
-	if err := t.db.DeleteWALEntries(t.state.height); err != nil {
-		t.log.Errorw("failed to delete WAL messages during commit", "height", cachedProposal.Height, "round", cachedProposal.Round, "err", err)
-	}
-
+func (t *stateMachine[V, H, A]) doCommitValue() types.Action[V, H, A] {
 	t.messages.DeleteHeightMessages(t.state.height)
 	t.state.height++
 	t.state.lockedRound = -1

--- a/consensus/tendermint/rule_commit_value_test.go
+++ b/consensus/tendermint/rule_commit_value_test.go
@@ -28,16 +28,12 @@ func TestCommitValue(t *testing.T) {
 
 		currentRound.validator(0).proposal(committedValue, -1).expectActions(
 			currentRound.action().broadcastPrevote(&committedValue),
+			currentRound.action().commit(committedValue, types.Round(-1), 0),
 			nextRound.action().scheduleTimeout(types.StepPropose),
 		)
 		assert.False(t, stateMachine.state.timeoutPrecommitScheduled)
 
 		assertState(t, stateMachine, types.Height(1), types.Round(0), types.StepPropose)
-
-		// TODO: This is a workaround to get the chain. Find a better way to do this.
-		chain := stateMachine.blockchain.(*chain)
-
-		assert.Equal(t, chain.decision[0], committedValue)
 
 		assert.Empty(t, stateMachine.messages.Proposals)
 		assert.Empty(t, stateMachine.messages.Prevotes)
@@ -59,15 +55,11 @@ func TestCommitValue(t *testing.T) {
 		currentRound.validator(1).precommit(&committedValue)
 		currentRound.validator(2).precommit(&committedValue).expectActions(
 			currentRound.action().scheduleTimeout(types.StepPrecommit),
+			currentRound.action().commit(committedValue, types.Round(-1), 0),
 			nextRound.action().scheduleTimeout(types.StepPropose),
 		)
 
 		assertState(t, stateMachine, types.Height(1), types.Round(0), types.StepPropose)
-
-		// TODO: This is a workaround to get the chain. Find a better way to do this.
-		chain := stateMachine.blockchain.(*chain)
-
-		assert.Equal(t, chain.decision[0], committedValue)
 
 		assert.Empty(t, stateMachine.messages.Proposals)
 		assert.Empty(t, stateMachine.messages.Prevotes)

--- a/consensus/types/action.go
+++ b/consensus/types/action.go
@@ -12,6 +12,8 @@ type BroadcastPrecommit[H Hash, A Addr] Precommit[H, A]
 
 type ScheduleTimeout Timeout
 
+type Commit[V Hashable[H], H Hash, A Addr] Proposal[V, H, A]
+
 func (a *BroadcastProposal[V, H, A]) isTendermintAction() {}
 
 func (a *BroadcastPrevote[H, A]) isTendermintAction() {}
@@ -19,3 +21,5 @@ func (a *BroadcastPrevote[H, A]) isTendermintAction() {}
 func (a *BroadcastPrecommit[H, A]) isTendermintAction() {}
 
 func (a *ScheduleTimeout) isTendermintAction() {}
+
+func (a *Commit[V, H, A]) isTendermintAction() {}


### PR DESCRIPTION
Problem: Proposal demux fails when receiving newer block proposals before committing older blocks (when node lags behind network).

Solution:
- This PR makes Commit an Action to enable Driver notifications for block commits
- Next step is change the P2P PR to block execution until parent commits.

Another reason for this is to gradually move the side effects out of the state machine.