### PR TITLE
Fix/0.14.0 beta

### DIFF
--- a/consensus/validator/validator_test.go
+++ b/consensus/validator/validator_test.go
@@ -132,7 +132,7 @@ func TestEmptyProposal(t *testing.T) {
 	// Step 3: ProposalFin
 	// Note: this commitment depends on the SupportedStarknetVersion, so block1Hash test should be updated whenever
 	// we update SupportedStarknetVersion
-	block1Hash, err := new(felt.Felt).SetString("0x27a852d180c77e0b7bc2b3e9b635b625db3ae48f2c469c93930c1889ae2d09f")
+	block1Hash, err := new(felt.Felt).SetString("0x9979aca51e836c8fd0f40a777980210120998a236a23d74615219f557a09f1")
 	require.NoError(t, err)
 	proposalFin := types.ProposalFin(*block1Hash)
 	require.NoError(t, validator.ProposalFin(proposalFin))
@@ -197,10 +197,10 @@ func TestProposal(t *testing.T) {
 		Timestamp:        blockInfo.Timestamp,
 		ProtocolVersion:  *blockchain.SupportedStarknetVersion,
 
-		StateDiffCommitment:   *utils.HexToFelt(t, "0x3248f1e62ba170555f7caa03c6f6c89843d5bfdafbf16384210544ef0b548e1"),
+		StateDiffCommitment:   *utils.HexToFelt(t, "0x3362432493bbee0f2469221a15f474e5e03c74fe76ea7ba7f97e7600c07a719"),
 		TransactionCommitment: *utils.HexToFelt(t, "0x4ba493c0b6605d0a7af00e6d401e937989192bb10ba3cc940ee509fee3e664b"),
-		EventCommitment:       *utils.HexToFelt(t, "0x366f7f8dd503ee94f626be1575fbd579692bb990be92b6c5b65b98a6c4faa9a"),
-		ReceiptCommitment:     *utils.HexToFelt(t, "0x513b7abd6c2952930a937580e14a05b0cdd1c69b570862194a023bf85090464"),
+		EventCommitment:       *utils.HexToFelt(t, "0x9c4350067ba4cc77274d9baa723b3547359c24765d1a4e92c82964ebbf8f06"),
+		ReceiptCommitment:     *utils.HexToFelt(t, "0x61f349c979d244924d73d834ec7fedfe32d57171a95adb2786dac1029b8c21a"),
 		ConcatenatedCounts:    *utils.HexToFelt(t, "0x1000000000000000300000000000000048000000000000000"),
 		L1DataGasPriceFRI:     *new(felt.Felt).SetUint64(1),
 		L2GasPriceFRI:         blockInfo.L2GasPriceFRI,

--- a/rpc/v6/transaction.go
+++ b/rpc/v6/transaction.go
@@ -594,7 +594,7 @@ func (h *Handler) AddTransaction(ctx context.Context, tx BroadcastedTransaction)
 	}
 
 	if h.submittedTransactionsCache != nil {
-		h.submittedTransactionsCache.Add(tx.Hash)
+		h.submittedTransactionsCache.Add(res.TransactionHash)
 	}
 
 	return res, nil

--- a/rpc/v6/transaction_test.go
+++ b/rpc/v6/transaction_test.go
@@ -9,7 +9,6 @@ import (
 	"time"
 
 	"github.com/NethermindEth/juno/clients/feeder"
-	"github.com/NethermindEth/juno/clients/gateway"
 	"github.com/NethermindEth/juno/core"
 	"github.com/NethermindEth/juno/core/felt"
 	"github.com/NethermindEth/juno/db"
@@ -1653,12 +1652,13 @@ func TestSubmittedTransactionsCache(t *testing.T) {
 	network := utils.Integration
 
 	client := feeder.NewTestClient(t, &network)
-	gw := gateway.NewTestClient(t)
+
 	cacheSize := 5
 	cacheEntryTimeOut := time.Second
 
 	txnToAdd := &core.InvokeTransaction{
-		Version: new(core.TransactionVersion).SetUint64(3),
+		TransactionHash: new(felt.Felt).SetUint64(12345),
+		Version:         new(core.TransactionVersion).SetUint64(3),
 		TransactionSignature: []*felt.Felt{
 			utils.HexToFelt(t, "0x1"),
 			utils.HexToFelt(t, "0x1"),
@@ -1688,17 +1688,33 @@ func TestSubmittedTransactionsCache(t *testing.T) {
 
 	broadcastedTxn := &rpc.BroadcastedTransaction{Transaction: *rpc.AdaptTransaction(txnToAdd)}
 
-	// transaction not found in db and feeder but found in cache
+	var gatewayResponse struct {
+		TransactionHash *felt.Felt `json:"transaction_hash"`
+		ContractAddress *felt.Felt `json:"address"`
+		ClassHash       *felt.Felt `json:"class_hash"`
+	}
+
+	gatewayResponse.TransactionHash = txnToAdd.TransactionHash
+	rawGatewayResponse, err := json.Marshal(gatewayResponse)
+	require.NoError(t, err)
+
+	mockReader := mocks.NewMockReader(mockCtrl)
+	mockSyncReader := mocks.NewMockSyncReader(mockCtrl)
+	mockGateway := mocks.NewMockGateway(mockCtrl)
+	mockGateway.
+		EXPECT().
+		AddTransaction(gomock.Any(), gomock.Any()).
+		Return(rawGatewayResponse, nil).
+		Times(2)
+
 	t.Run("transaction not found in db and feeder but found in cache", func(t *testing.T) {
 		submittedTransactionCache := rpccore.NewSubmittedTransactionsCache(cacheSize, cacheEntryTimeOut)
 
-		mockReader := mocks.NewMockReader(mockCtrl)
-		mockSyncReader := mocks.NewMockSyncReader(mockCtrl)
 		handler := rpc.New(mockReader, mockSyncReader, nil, "", &utils.Integration, nil).
 			WithFeeder(client).
-			WithGateway(gw).
+			WithGateway(mockGateway).
 			WithSubmittedTransactionsCache(submittedTransactionCache)
-		// Test Gateway server wont add this tx, gateway should return txnNotFound upon querying transaction status
+
 		res, err := handler.AddTransaction(ctx, *broadcastedTxn)
 		require.Nil(t, err)
 		mockReader.EXPECT().TransactionByHash(res.TransactionHash).Return(nil, db.ErrKeyNotFound)
@@ -1716,9 +1732,9 @@ func TestSubmittedTransactionsCache(t *testing.T) {
 		mockSyncReader := mocks.NewMockSyncReader(mockCtrl)
 		handler := rpc.New(mockReader, mockSyncReader, nil, "", &utils.Integration, nil).
 			WithFeeder(client).
-			WithGateway(gw).
+			WithGateway(mockGateway).
 			WithSubmittedTransactionsCache(submittedTransactionCache)
-		// Test Gateway server wont add this tx, gateway should return txnNotFound upon querying transaction status
+
 		res, err := handler.AddTransaction(ctx, *broadcastedTxn)
 		require.Nil(t, err)
 		mockReader.EXPECT().TransactionByHash(res.TransactionHash).Return(nil, db.ErrKeyNotFound)

--- a/rpc/v6/transaction_test.go
+++ b/rpc/v6/transaction_test.go
@@ -1690,8 +1690,6 @@ func TestSubmittedTransactionsCache(t *testing.T) {
 
 	var gatewayResponse struct {
 		TransactionHash *felt.Felt `json:"transaction_hash"`
-		ContractAddress *felt.Felt `json:"address"`
-		ClassHash       *felt.Felt `json:"class_hash"`
 	}
 
 	gatewayResponse.TransactionHash = txnToAdd.TransactionHash

--- a/rpc/v8/transaction.go
+++ b/rpc/v8/transaction.go
@@ -616,7 +616,7 @@ func (h *Handler) AddTransaction(ctx context.Context, tx BroadcastedTransaction)
 	}
 
 	if h.submittedTransactionsCache != nil {
-		h.submittedTransactionsCache.Add(tx.Hash)
+		h.submittedTransactionsCache.Add(res.TransactionHash)
 	}
 
 	return res, nil

--- a/rpc/v8/transaction_test.go
+++ b/rpc/v8/transaction_test.go
@@ -1875,8 +1875,6 @@ func TestSubmittedTransactionsCache(t *testing.T) {
 
 	var gatewayResponse struct {
 		TransactionHash *felt.Felt `json:"transaction_hash"`
-		ContractAddress *felt.Felt `json:"address"`
-		ClassHash       *felt.Felt `json:"class_hash"`
 	}
 
 	gatewayResponse.TransactionHash = txnToAdd.TransactionHash

--- a/utils/network.go
+++ b/utils/network.go
@@ -44,7 +44,7 @@ var (
 	// The docs states the addresses for each network: https://docs.starknet.io/tools/important-addresses/
 	Mainnet = Network{
 		Name:                "mainnet",
-		FeederURL:           "https://alpha-mainnet.starknet.io/feeder_gateway/",
+		FeederURL:           "https://feeder.alpha-mainnet.starknet.io/feeder_gateway/",
 		GatewayURL:          "https://alpha-mainnet.starknet.io/gateway/",
 		L2ChainID:           "SN_MAIN",
 		L1ChainID:           big.NewInt(1),
@@ -97,7 +97,7 @@ var (
 	}
 	Sepolia = Network{
 		Name:       "sepolia",
-		FeederURL:  "https://alpha-sepolia.starknet.io/feeder_gateway/",
+		FeederURL:  "https://feeder.alpha-sepolia.starknet.io/feeder_gateway/",
 		GatewayURL: "https://alpha-sepolia.starknet.io/gateway/",
 		L2ChainID:  "SN_SEPOLIA",
 		//nolint:mnd

--- a/utils/network_test.go
+++ b/utils/network_test.go
@@ -32,11 +32,11 @@ func TestNetwork(t *testing.T) {
 			feederURL  string
 			gatewayURL string
 		}{
-			{utils.Mainnet, "https://alpha-mainnet.starknet.io/feeder_gateway/", "https://alpha-mainnet.starknet.io/gateway/"},
+			{utils.Mainnet, "https://feeder.alpha-mainnet.starknet.io/feeder_gateway/", "https://alpha-mainnet.starknet.io/gateway/"},
 			{utils.Goerli, "https://alpha4.starknet.io/feeder_gateway/", "https://alpha4.starknet.io/gateway/"},
 			{utils.Goerli2, "https://alpha4-2.starknet.io/feeder_gateway/", "https://alpha4-2.starknet.io/gateway/"},
 			{utils.Integration, "https://external.integration.starknet.io/feeder_gateway/", "https://external.integration.starknet.io/gateway/"},
-			{utils.Sepolia, "https://alpha-sepolia.starknet.io/feeder_gateway/", "https://alpha-sepolia.starknet.io/gateway/"},
+			{utils.Sepolia, "https://feeder.alpha-sepolia.starknet.io/feeder_gateway/", "https://alpha-sepolia.starknet.io/gateway/"},
 			{utils.SepoliaIntegration, "https://feeder.integration-sepolia.starknet.io/feeder_gateway/", "https://integration-sepolia.starknet.io/gateway/"},
 		}
 


### PR DESCRIPTION
Includes Minor Changes
- Updates feeder urls
- SubmittedTransactionsCache uses txHash from gateway response
- SubmittedTransactionsCache test uses mock gateway instead of gateway test client
- Updates `validator_test` expected commitments to correct values for starknet version v0.14.0