### PR TITLE
fix: setting header values for new block hash functions

### DIFF
--- a/builder/builder.go
+++ b/builder/builder.go
@@ -294,6 +294,28 @@ func (b *Builder) ProposalInit(pInit *types.ProposalInit) error {
 		Receipts:     []*core.TransactionReceipt{},
 	}
 
+	// Old blocks do not have these values, but we need them
+	// when we transition to a new block hash function
+	if pendingBlock.L1GasPriceSTRK == nil {
+		pendingBlock.L1GasPriceSTRK = new(felt.Felt).SetUint64(1)
+	}
+	if pendingBlock.L1GasPriceETH == nil {
+		pendingBlock.L1GasPriceETH = new(felt.Felt).SetUint64(1)
+	}
+
+	if pendingBlock.L1DataGasPrice == nil {
+		pendingBlock.L1DataGasPrice = &core.GasPrice{
+			PriceInWei: new(felt.Felt).SetUint64(1),
+			PriceInFri: new(felt.Felt).SetUint64(1),
+		}
+	}
+	if pendingBlock.L2GasPrice == nil {
+		pendingBlock.L2GasPrice = &core.GasPrice{
+			PriceInWei: new(felt.Felt).SetUint64(1),
+			PriceInFri: new(felt.Felt).SetUint64(1),
+		}
+	}
+
 	newClasses := make(map[felt.Felt]core.Class)
 	emptyStateDiff := core.EmptyStateDiff()
 	su := core.StateUpdate{

--- a/consensus/validator/validator_test.go
+++ b/consensus/validator/validator_test.go
@@ -151,7 +151,7 @@ func TestEmptyProposal(t *testing.T) {
 	// Step 3: ProposalFin
 	// Note: this commitment depends on the SupportedStarknetVersion, so block1Hash test should be updated whenever
 	// we update SupportedStarknetVersion
-	block1Hash, err := new(felt.Felt).SetString("0x6de5ea1b1db43acda6c32c17bea719af54e98d08acbfc6da33b178bbb8ab326")
+	block1Hash, err := new(felt.Felt).SetString("0x10ccfbbc0b45b229f251b3f058bae326f7c4475fc9e7de802ce29ccea55e68b")
 	require.NoError(t, err)
 	proposalFin := types.ProposalFin(*block1Hash)
 	require.NoError(t, validator.ProposalFin(proposalFin))

--- a/consensus/validator/validator_test.go
+++ b/consensus/validator/validator_test.go
@@ -149,6 +149,8 @@ func TestEmptyProposal(t *testing.T) {
 	require.NoError(t, validator.ProposalCommitment(&emptyCommitment))
 
 	// Step 3: ProposalFin
+	// Note: this commitment depends on the SupportedStarknetVersion, so block1Hash test should be updated whenever
+	// we update SupportedStarknetVersion
 	block1Hash, err := new(felt.Felt).SetString("0x6de5ea1b1db43acda6c32c17bea719af54e98d08acbfc6da33b178bbb8ab326")
 	require.NoError(t, err)
 	proposalFin := types.ProposalFin(*block1Hash)


### PR DESCRIPTION
To compute the block hash for `0.13.4` we need to set the `fee`s in the block header. Normally we get these from the `FGW`. However, for `consensus`, the validator never receives these values (in the empty block flow - we never receive `BlockInfo`) so we can't compute the block hash. We also can't use the values from the old header since they do not always exist (eg we added fees to the header in 0.13.4 that don't exist in old versions).

This PR is a short-term fix.

Longer term, we need the consensus spec to be updated, so that the fields required to compute the block hash are always sent to the validator (if move fields from BlockInfo to ProposalInit).