### PR TITLE
fix: getEvents returning out-of-range

### DIFF
--- a/blockchain/event_filter.go
+++ b/blockchain/event_filter.go
@@ -136,7 +136,7 @@ func (e *EventFilter) Events(cToken *ContinuationToken, chunkSize uint64) ([]*Fi
 
 	// only canonical blocks
 	if e.toBlock <= latest {
-		return e.canonicalEvents(matchedEvents, curBlock, latest, skippedEvents, chunkSize)
+		return e.canonicalEvents(matchedEvents, curBlock, e.toBlock, skippedEvents, chunkSize)
 	}
 
 	var rToken *ContinuationToken


### PR DESCRIPTION
Bug was instead of passing `e.toBlock` when `e.toBlock` is within range of canonical events (no-pending), `latest` block number has been passed, accidential, this PR corrects the issue by passing `e.toBlock'.
