### PR TITLE
refactor: Create a BuildResult types for data that needs to be stored

### DIFF
--- a/blockchain/blockchain.go
+++ b/blockchain/blockchain.go
@@ -507,8 +507,6 @@ func (b *Blockchain) revertHead(txn db.IndexedBatch) error {
 }
 
 type SimulateResult struct {
-	Block            *core.Block
-	StateUpdate      *core.StateUpdate
 	BlockCommitments *core.BlockCommitments
 	ConcatCount      felt.Felt
 }
@@ -521,8 +519,6 @@ func (b *Blockchain) Simulate(
 	newClasses map[felt.Felt]core.Class,
 	sign utils.BlockSignFunc,
 ) (SimulateResult, error) {
-	var newCommitments *core.BlockCommitments
-
 	// Simulate without commit
 	txn := b.database.NewIndexedBatch()
 	defer txn.Reset()
@@ -530,55 +526,27 @@ func (b *Blockchain) Simulate(
 	if err := b.updateStateRoots(txn, block, stateUpdate, newClasses); err != nil {
 		return SimulateResult{}, err
 	}
-	blockHash, commitments, err := core.BlockHash(
-		block,
-		stateUpdate.StateDiff,
-		b.network,
-		block.SequencerAddress)
+
+	commitments, err := b.updateBlockHash(block, stateUpdate)
 	if err != nil {
 		return SimulateResult{}, err
 	}
-	block.Hash = blockHash
-	stateUpdate.BlockHash = blockHash
-	newCommitments = commitments
 
 	concatCount := core.ConcatCounts(
 		block.TransactionCount,
 		block.EventCount,
 		stateUpdate.StateDiff.Length(),
-		block.L1DAMode)
+		block.L1DAMode,
+	)
 
 	if err := b.signBlock(block, stateUpdate, sign); err != nil {
 		return SimulateResult{}, err
 	}
 
 	return SimulateResult{
-		Block:            block,
-		StateUpdate:      stateUpdate,
-		BlockCommitments: newCommitments,
+		BlockCommitments: commitments,
 		ConcatCount:      concatCount,
 	}, nil
-}
-
-// StoreSimulated stores the simulated block. There is no need to recomute the state roots etc
-func (b *Blockchain) StoreSimulated(
-	block *core.Block,
-	stateUpdate *core.StateUpdate,
-	newClasses map[felt.Felt]core.Class,
-	commitments *core.BlockCommitments,
-	sign utils.BlockSignFunc,
-) error {
-	finaliseFn := func(txn db.IndexedBatch) error {
-		if err := b.signBlock(block, stateUpdate, sign); err != nil {
-			return err
-		}
-		if err := b.storeBlockData(txn, block, stateUpdate, commitments); err != nil {
-			return err
-		}
-		return core.WriteChainHeight(txn, block.Number)
-	}
-
-	return b.database.Update(finaliseFn)
 }
 
 // Finalise checks the block correctness and appends it to the chain
@@ -592,7 +560,7 @@ func (b *Blockchain) Finalise(
 		if err := b.updateStateRoots(txn, block, stateUpdate, newClasses); err != nil {
 			return err
 		}
-		commitments, err := b.calculateBlockHash(block, stateUpdate)
+		commitments, err := b.updateBlockHash(block, stateUpdate)
 		if err != nil {
 			return err
 		}
@@ -644,13 +612,14 @@ func (b *Blockchain) updateStateRoots(
 	return nil
 }
 
-// calculateBlockHash computes and sets the block hash and commitments
-func (b *Blockchain) calculateBlockHash(block *core.Block, stateUpdate *core.StateUpdate) (*core.BlockCommitments, error) {
+// updateBlockHash computes and sets the block hash and commitments
+func (b *Blockchain) updateBlockHash(block *core.Block, stateUpdate *core.StateUpdate) (*core.BlockCommitments, error) {
 	blockHash, commitments, err := core.BlockHash(
 		block,
 		stateUpdate.StateDiff,
 		b.network,
-		block.SequencerAddress)
+		block.SequencerAddress,
+	)
 	if err != nil {
 		return nil, err
 	}

--- a/builder/builder.go
+++ b/builder/builder.go
@@ -3,7 +3,6 @@ package builder
 import (
 	"errors"
 	"fmt"
-	"sync/atomic"
 
 	"github.com/Masterminds/semver/v3"
 	"github.com/NethermindEth/juno/adapters/vm2core"
@@ -24,6 +23,11 @@ var (
 	ErrPendingParentHash  = errors.New("pending block parent hash does not match chain head")
 )
 
+type BuildResult struct {
+	Pending            sync.Pending
+	ProposalCommitment types.ProposalCommitment
+}
+
 type Builder struct {
 	// Builder dependencies
 	vm          vm.VM
@@ -35,7 +39,7 @@ type Builder struct {
 
 	// Builder state
 	// TODO: move to a builder state struct
-	pendingBlock      atomic.Pointer[sync.Pending]
+	pendingBlock      *sync.Pending
 	l2GasConsumed     uint64
 	revealedBlockHash *felt.Felt
 }
@@ -59,8 +63,7 @@ func (b *Builder) Finalise(pending *sync.Pending, signer utils.BlockSignFunc, pr
 }
 
 func (b *Builder) Pending() (*sync.Pending, error) {
-	p := b.pendingBlock.Load()
-	if p == nil {
+	if b.pendingBlock == nil {
 		return nil, sync.ErrPendingBlockNotFound
 	}
 	expectedParentHash := &felt.Zero
@@ -68,8 +71,8 @@ func (b *Builder) Pending() (*sync.Pending, error) {
 		expectedParentHash = head.Hash
 	}
 
-	if p.Block.ParentHash.Equal(expectedParentHash) {
-		return p, nil
+	if b.pendingBlock.Block.ParentHash.Equal(expectedParentHash) {
+		return b.pendingBlock, nil
 	}
 
 	return nil, ErrPendingParentHash
@@ -95,7 +98,7 @@ func (b *Builder) PendingState() (core.StateReader, func() error, error) {
 
 func (b *Builder) ClearPending() error {
 	b.l2GasConsumed = 0
-	b.pendingBlock.Store(&sync.Pending{})
+	b.pendingBlock = &sync.Pending{}
 
 	if b.headState != nil {
 		if err := b.headCloser(); err != nil {
@@ -149,7 +152,7 @@ func (b *Builder) InitPendingBlock(sequencerAddress *felt.Felt) error {
 		StateUpdate: &su,
 		NewClasses:  newClasses,
 	}
-	b.pendingBlock.Store(&pending)
+	b.pendingBlock = &pending
 	b.headState, b.headCloser, err = b.blockchain.HeadState()
 	return err
 }
@@ -284,7 +287,7 @@ func (b *Builder) storePending(newPending *sync.Pending) error {
 	if !expectedParentHash.Equal(newPending.Block.ParentHash) {
 		return fmt.Errorf("store pending: %w", blockchain.ErrParentDoesNotMatchHead)
 	}
-	b.pendingBlock.Store(newPending)
+	b.pendingBlock = newPending
 	return nil
 }
 
@@ -329,32 +332,30 @@ func (b *Builder) ProposalInit(pInit *types.ProposalInit) error {
 		StateUpdate: &su,
 		NewClasses:  newClasses,
 	}
-	b.pendingBlock.Store(&pending)
+	b.pendingBlock = &pending
 	b.headState, b.headCloser, err = b.blockchain.HeadState()
 	return err
 }
 
 func (b *Builder) SetBlockInfo(blockInfo *types.BlockInfo) {
-	pending := b.pendingBlock.Load()
-	pending.Block.Header.Number = blockInfo.BlockNumber
-	pending.Block.Header.SequencerAddress = &blockInfo.Builder
-	pending.Block.Header.Timestamp = blockInfo.Timestamp
-	pending.Block.Header.L2GasPrice.PriceInFri = &blockInfo.L2GasPriceFRI
-	pending.Block.Header.L1GasPriceETH = &blockInfo.L1GasPriceWEI
-	pending.Block.Header.L1DataGasPrice.PriceInWei = &blockInfo.L1DataGasPriceWEI
-	pending.Block.Header.L1DAMode = blockInfo.L1DAMode
-	b.pendingBlock.Store(pending)
+	b.pendingBlock.Block.Header.Number = blockInfo.BlockNumber
+	b.pendingBlock.Block.Header.SequencerAddress = &blockInfo.Builder
+	b.pendingBlock.Block.Header.Timestamp = blockInfo.Timestamp
+	b.pendingBlock.Block.Header.L2GasPrice.PriceInFri = &blockInfo.L2GasPriceFRI
+	b.pendingBlock.Block.Header.L1GasPriceETH = &blockInfo.L1GasPriceWEI
+	b.pendingBlock.Block.Header.L1DataGasPrice.PriceInWei = &blockInfo.L1DataGasPriceWEI
+	b.pendingBlock.Block.Header.L1DAMode = blockInfo.L1DAMode
 }
 
-func (b *Builder) ProposalCommitment() (types.ProposalCommitment, error) {
+func (b *Builder) Finish() (BuildResult, error) {
 	pending, err := b.Pending()
 	if err != nil {
-		return types.ProposalCommitment{}, err
+		return BuildResult{}, err
 	}
 
 	simulatedResult, err := b.blockchain.Simulate(pending.Block, pending.StateUpdate, pending.NewClasses, nil)
 	if err != nil {
-		return types.ProposalCommitment{}, err
+		return BuildResult{}, err
 	}
 
 	if simulatedResult.ConcatCount.IsZero() {
@@ -368,26 +369,31 @@ func (b *Builder) ProposalCommitment() (types.ProposalCommitment, error) {
 
 	version, err := semver.NewVersion(pending.Block.ProtocolVersion)
 	if err != nil {
-		return types.ProposalCommitment{}, err
+		return BuildResult{}, err
 	}
 
 	// Todo: we ignore some values until the spec is Finalised: VersionConstantCommitment, NextL2GasPriceFRI
-	return types.ProposalCommitment{
-		BlockNumber:           pending.Block.Number,
-		Builder:               *pending.Block.SequencerAddress,
-		ParentCommitment:      *pending.Block.ParentHash,
-		Timestamp:             pending.Block.Timestamp,
-		ProtocolVersion:       *version,
-		OldStateRoot:          *pending.StateUpdate.OldRoot,
-		StateDiffCommitment:   *simulatedResult.BlockCommitments.StateDiffCommitment,
-		TransactionCommitment: *simulatedResult.BlockCommitments.TransactionCommitment,
-		EventCommitment:       *simulatedResult.BlockCommitments.EventCommitment,
-		ReceiptCommitment:     *simulatedResult.BlockCommitments.ReceiptCommitment,
-		ConcatenatedCounts:    simulatedResult.ConcatCount,
-		L1GasPriceFRI:         *pending.Block.L1GasPriceSTRK,
-		L1DataGasPriceFRI:     *pending.Block.L1DataGasPrice.PriceInFri,
-		L2GasPriceFRI:         *pending.Block.L2GasPrice.PriceInFri,
-		L2GasUsed:             *new(felt.Felt).SetUint64(b.l2GasConsumed),
-		L1DAMode:              pending.Block.L1DAMode,
-	}, nil
+	buildResult := BuildResult{
+		Pending: *pending,
+		ProposalCommitment: types.ProposalCommitment{
+			BlockNumber:           pending.Block.Number,
+			Builder:               *pending.Block.SequencerAddress,
+			ParentCommitment:      *pending.Block.ParentHash,
+			Timestamp:             pending.Block.Timestamp,
+			ProtocolVersion:       *version,
+			OldStateRoot:          *pending.StateUpdate.OldRoot,
+			StateDiffCommitment:   *simulatedResult.BlockCommitments.StateDiffCommitment,
+			TransactionCommitment: *simulatedResult.BlockCommitments.TransactionCommitment,
+			EventCommitment:       *simulatedResult.BlockCommitments.EventCommitment,
+			ReceiptCommitment:     *simulatedResult.BlockCommitments.ReceiptCommitment,
+			ConcatenatedCounts:    simulatedResult.ConcatCount,
+			L1GasPriceFRI:         *pending.Block.L1GasPriceSTRK,
+			L1DataGasPriceFRI:     *pending.Block.L1DataGasPrice.PriceInFri,
+			L2GasPriceFRI:         *pending.Block.L2GasPrice.PriceInFri,
+			L2GasUsed:             *new(felt.Felt).SetUint64(b.l2GasConsumed),
+			L1DAMode:              pending.Block.L1DAMode,
+		},
+	}
+
+	return buildResult, nil
 }

--- a/consensus/proposer/proposer.go
+++ b/consensus/proposer/proposer.go
@@ -188,7 +188,12 @@ func (p *proposer) Txns(ctx context.Context) <-chan []types.Transaction { // Tod
 }
 
 func (p *proposer) ProposalCommitment() (types.ProposalCommitment, error) {
-	return p.builder.ProposalCommitment()
+	buildResult, err := p.builder.Finish()
+	if err != nil {
+		return types.ProposalCommitment{}, err
+	}
+
+	return buildResult.ProposalCommitment, nil
 }
 
 // ProposalFin() returns the block hash of the pending block

--- a/consensus/validator/validator.go
+++ b/consensus/validator/validator.go
@@ -72,12 +72,12 @@ func (v *validator[V, H, A]) TransactionBatch(txns []types.Transaction) error {
 
 // ProposalCommitment checks the set of proposed commitments against those generated locally.
 func (v *validator[V, H, A]) ProposalCommitment(proCom *types.ProposalCommitment) error {
-	expectedCommitments, err := v.builder.ProposalCommitment()
+	buildResult, err := v.builder.Finish()
 	if err != nil {
 		return err
 	}
 
-	return compareProposalCommitment(&expectedCommitments, proCom)
+	return compareProposalCommitment(&buildResult.ProposalCommitment, proCom)
 }
 
 // ProposalFin executes the provided transactions, and stores the result in the pending state


### PR DESCRIPTION
- This create a `BuildResult` type containing the output for `Builder`. This `BuildResult` only contains data and no dependencies like VM and Blockchain, so it's more suitable to be stored in proposal store (in the next PR).
- This also remove the `atomic.Pointer`. The current code isn't enough to guard concurrency, and it's better to let caller control the concurrency in this case, because we need concurrency in validator case, but we don't in proposer case.