### PR TITLE
feat: add /live and /ready endpoints with support during DB migration

### DIFF
--- a/migration/migration_pkg_test.go
+++ b/migration/migration_pkg_test.go
@@ -502,7 +502,7 @@ func TestMigrateIfNeeded(t *testing.T) {
 				},
 			},
 		}
-		require.ErrorContains(t, migrateIfNeeded(t.Context(), testDB, &utils.Mainnet, utils.NewNopZapLogger(), migrations), "bar")
+		require.ErrorContains(t, migrateIfNeeded(t.Context(), testDB, &utils.Mainnet, utils.NewNopZapLogger(), migrations, &HTTPConfig{}), "bar")
 	})
 
 	t.Run("call with new tx", func(t *testing.T) {
@@ -522,7 +522,7 @@ func TestMigrateIfNeeded(t *testing.T) {
 				},
 			},
 		}
-		require.NoError(t, migrateIfNeeded(t.Context(), testDB, &utils.Mainnet, utils.NewNopZapLogger(), migrations))
+		require.NoError(t, migrateIfNeeded(t.Context(), testDB, &utils.Mainnet, utils.NewNopZapLogger(), migrations, &HTTPConfig{}))
 	})
 
 	t.Run("error during migration", func(t *testing.T) {
@@ -537,7 +537,7 @@ func TestMigrateIfNeeded(t *testing.T) {
 				},
 			},
 		}
-		require.ErrorContains(t, migrateIfNeeded(t.Context(), testDB, &utils.Mainnet, utils.NewNopZapLogger(), migrations), "foo")
+		require.ErrorContains(t, migrateIfNeeded(t.Context(), testDB, &utils.Mainnet, utils.NewNopZapLogger(), migrations, &HTTPConfig{}), "foo")
 	})
 
 	t.Run("error if using new db on old version of juno", func(t *testing.T) {
@@ -552,9 +552,9 @@ func TestMigrateIfNeeded(t *testing.T) {
 				},
 			},
 		}
-		require.NoError(t, migrateIfNeeded(t.Context(), testDB, &utils.Mainnet, utils.NewNopZapLogger(), migrations))
+		require.NoError(t, migrateIfNeeded(t.Context(), testDB, &utils.Mainnet, utils.NewNopZapLogger(), migrations, &HTTPConfig{}))
 		want := "db is from a newer, incompatible version of Juno"
-		require.ErrorContains(t, migrateIfNeeded(t.Context(), testDB, &utils.Mainnet, utils.NewNopZapLogger(), []Migration{}), want)
+		require.ErrorContains(t, migrateIfNeeded(t.Context(), testDB, &utils.Mainnet, utils.NewNopZapLogger(), []Migration{}, &HTTPConfig{}), want)
 	})
 }
 

--- a/migration/migration_test.go
+++ b/migration/migration_test.go
@@ -16,7 +16,7 @@ func TestMigrateIfNeeded(t *testing.T) {
 	ctx, cancel := context.WithCancel(t.Context())
 	cancel()
 	t.Run("Migration should not happen on cancelled ctx", func(t *testing.T) {
-		require.ErrorIs(t, migration.MigrateIfNeeded(ctx, testDB, &utils.Mainnet, utils.NewNopZapLogger()), ctx.Err())
+		require.ErrorIs(t, migration.MigrateIfNeeded(ctx, testDB, &utils.Mainnet, utils.NewNopZapLogger(), &migration.HTTPConfig{}), ctx.Err())
 	})
 
 	meta, err := migration.SchemaMetadata(testDB)
@@ -25,7 +25,7 @@ func TestMigrateIfNeeded(t *testing.T) {
 	require.Nil(t, meta.IntermediateState)
 
 	t.Run("Migration should happen on empty DB", func(t *testing.T) {
-		require.NoError(t, migration.MigrateIfNeeded(t.Context(), testDB, &utils.Mainnet, utils.NewNopZapLogger()))
+		require.NoError(t, migration.MigrateIfNeeded(t.Context(), testDB, &utils.Mainnet, utils.NewNopZapLogger(), &migration.HTTPConfig{}))
 	})
 
 	meta, err = migration.SchemaMetadata(testDB)
@@ -34,7 +34,7 @@ func TestMigrateIfNeeded(t *testing.T) {
 	require.Nil(t, meta.IntermediateState)
 
 	t.Run("subsequent calls to MigrateIfNeeded should not change the DB version", func(t *testing.T) {
-		require.NoError(t, migration.MigrateIfNeeded(t.Context(), testDB, &utils.Mainnet, utils.NewNopZapLogger()))
+		require.NoError(t, migration.MigrateIfNeeded(t.Context(), testDB, &utils.Mainnet, utils.NewNopZapLogger(), &migration.HTTPConfig{}))
 		postVersion, postErr := migration.SchemaMetadata(testDB)
 		require.NoError(t, postErr)
 		require.Equal(t, meta, postVersion)

--- a/node/http.go
+++ b/node/http.go
@@ -239,6 +239,7 @@ func NewReadinessHandlers(bcReader blockchain.Reader, syncReader sync.Reader) *r
 func (h *readinessHandlers) HandleReadySync(w http.ResponseWriter, r *http.Request) {
 	if !h.isSynced() {
 		w.WriteHeader(http.StatusServiceUnavailable)
+		w.Write([]byte("Node not synced yet.")) //nolint:errcheck
 		return
 	}
 
@@ -260,4 +261,8 @@ func (h *readinessHandlers) isSynced() bool {
 	}
 
 	return head.Number+SyncBlockRange >= highestBlockHeader.Number
+}
+
+func (h *readinessHandlers) HandleLive(w http.ResponseWriter, r *http.Request) {
+	w.WriteHeader(http.StatusOK)
 }


### PR DESCRIPTION
Closes https://github.com/NethermindEth/juno/issues/2915

This PR starts a temporary HTTP server during database migration, which provides /live and /ready endpoints so k8 could gracefully handle this

After migration, the temporary server is stopped and replaced by the main RPC server, which also exposes the same /live and /ready endpoints.

Added two standard Kubernetes probe endpoints:
	•	/live – always returns 200 OK to prevent unnecessary restarts - for k8 livenessProbe
	•	/ready – returns 503 during migration or if the node is not yet synced - for k8 readinessProbe
(replaces and unifies previous /ready/sync behavior)
