### PR TITLE
chore: Increase throttle to avoid flaky tests

### DIFF
--- a/consensus/p2p/vote/vote_broadcasters_listeners_test.go
+++ b/consensus/p2p/vote/vote_broadcasters_listeners_test.go
@@ -30,7 +30,7 @@ const (
 	logLevel      = zapcore.PanicLevel
 	voteCount     = 1000
 	invalidCount  = 100
-	throttledRate = 5 * time.Millisecond
+	throttledRate = 10 * time.Millisecond
 )
 
 type node struct {


### PR DESCRIPTION
Unit tests may fail on machines with limited resources due to nodes sending messages too quickly. In such cases, Tendermint can penalize overly chatty nodes, leading to test failures. This PR increases the interval between messages to reduce the likelihood of these failures, improving test stability on slower machines.