### PR TITLE
fix: update /ready to return 200 only when node is fully synced

### DIFF
--- a/node/http.go
+++ b/node/http.go
@@ -221,9 +221,6 @@ func makePPROF(host string, port uint16) *httpService {
 	return makeHTTPService(host, port, mux)
 }
 
-const SyncBlockRange = 6
-
-// TODO: remember to delete this
 type readinessHandlers struct {
 	bcReader   blockchain.Reader
 	syncReader sync.Reader
@@ -260,7 +257,7 @@ func (h *readinessHandlers) isSynced() bool {
 		return false
 	}
 
-	return head.Number+SyncBlockRange >= highestBlockHeader.Number
+	return head.Number >= highestBlockHeader.Number
 }
 
 func (h *readinessHandlers) HandleLive(w http.ResponseWriter, r *http.Request) {

--- a/node/http_test.go
+++ b/node/http_test.go
@@ -22,9 +22,9 @@ func TestHandleReadySync(t *testing.T) {
 	readinessHandlers := node.NewReadinessHandlers(mockReader, synchronizer)
 	ctx := t.Context()
 
-	t.Run("ready and blockNumber outside blockRange to highestBlock", func(t *testing.T) {
+	t.Run("not ready when blockNumber is behind highestBlock", func(t *testing.T) {
 		blockNum := uint64(2)
-		highestBlock := blockNum + node.SyncBlockRange + 1
+		highestBlock := blockNum + 1
 		mockReader.EXPECT().HeadsHeader().Return(&core.Header{Number: blockNum}, nil)
 		synchronizer.EXPECT().HighestBlockHeader().Return(&core.Header{Number: highestBlock, Hash: new(felt.Felt).SetUint64(highestBlock)})
 
@@ -38,7 +38,7 @@ func TestHandleReadySync(t *testing.T) {
 		assert.Equal(t, http.StatusServiceUnavailable, rr.Code)
 	})
 
-	t.Run("ready & blockNumber is larger than highestBlock", func(t *testing.T) {
+	t.Run("not ready when blockNumber is ahead of highestBlock", func(t *testing.T) {
 		blockNum := uint64(2)
 		highestBlock := uint64(1)
 
@@ -55,9 +55,9 @@ func TestHandleReadySync(t *testing.T) {
 		assert.Equal(t, http.StatusServiceUnavailable, rr.Code)
 	})
 
-	t.Run("ready & blockNumber is in blockRange of highestBlock", func(t *testing.T) {
+	t.Run("ready when blockNumber equals highestBlock", func(t *testing.T) {
 		blockNum := uint64(3)
-		highestBlock := blockNum + node.SyncBlockRange
+		highestBlock := blockNum
 
 		mockReader.EXPECT().HeadsHeader().Return(&core.Header{Number: blockNum}, nil)
 		synchronizer.EXPECT().HighestBlockHeader().Return(&core.Header{Number: highestBlock, Hash: new(felt.Felt).SetUint64(highestBlock)})


### PR DESCRIPTION
This PR updates the /ready, /ready/sync endpoint behavior.
Previously, it returned 200 OK when the node was within 6 blocks of the highest known block.
Now, it only returns 200 OK when the node is fully synced (i.e., current == highest).

Returning ready while still a few blocks behind could cause issues (e.g., during attestation windows or node restarts).
This change ensures the node is actually in sync before being considered ready.