### PR TITLE
Rianhughes/tendermint catchup p2p sync

### DIFF
--- a/consensus/driver/driver.go
+++ b/consensus/driver/driver.go
@@ -98,6 +98,11 @@ func (d *Driver[V, H, A]) Start() {
 				// Todo: consider blocking consensus altogehter since sending votes for
 				// old heights is a waste of resources, and we can't process the latest height
 				// since we are behind the network (demux can continue though)
+				// Blocking would be simple:
+				// 		case <-d.p2pBehindNetworkNotifier:
+				// 			h := <-d.p2pCommitNotifier
+				//			d.heightPreSync = d.stateMachine.RestartAtHeight(types.Height(h))
+				//			...
 
 				// Todo: consider race conditions and blocking processes
 				// case 1: sync runs ahead of state machine. This means we are behind, and sync will force state machine to jump

--- a/consensus/driver/driver.go
+++ b/consensus/driver/driver.go
@@ -95,6 +95,9 @@ func (d *Driver[V, H, A]) Start() {
 			case p := <-d.listeners.PrecommitListener.Listen():
 				actions = d.stateMachine.ProcessPrecommit(p)
 			case h := <-d.p2pCommitNotifier:
+				// Todo: consider blocking consensus altogehter since sending votes for
+				// old heights is a waste of resources, and we can't process the latest height
+				// since we are behind the network (demux can continue though)
 				d.heightPreSync = d.stateMachine.RestartAtHeight(types.Height(h))
 				d.deleteOldWAL(types.Height(h))
 			}

--- a/consensus/driver/driver.go
+++ b/consensus/driver/driver.go
@@ -98,6 +98,14 @@ func (d *Driver[V, H, A]) Start() {
 				// Todo: consider blocking consensus altogehter since sending votes for
 				// old heights is a waste of resources, and we can't process the latest height
 				// since we are behind the network (demux can continue though)
+
+				// Todo: consider race conditions and blocking processes
+				// case 1: sync runs ahead of state machine. This means we are behind, and sync will force state machine to jump
+				//         to the latest height. This is good.
+				// case 2: state machine runs ahead of the state machine. This isn't possible since p2p sync checks blockchain.Height()
+				//         before querying peers
+				// case 3: sync breaks. Then we never enter this flow, but consensus could still stay at the chain head in the happy flow.
+				// case 4: consensus breaks. Then the sync keeps the node at the chain head, we just don't engage with consensus.
 				d.heightPreSync = d.stateMachine.RestartAtHeight(types.Height(h))
 				d.deleteOldWAL(types.Height(h))
 			}

--- a/consensus/mocks/mock_state_machine.go
+++ b/consensus/mocks/mock_state_machine.go
@@ -121,3 +121,17 @@ func (mr *MockStateMachineMockRecorder[V, H, A]) ReplayWAL() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReplayWAL", reflect.TypeOf((*MockStateMachine[V, H, A])(nil).ReplayWAL))
 }
+
+// RestartAtHeight mocks base method.
+func (m *MockStateMachine[V, H, A]) RestartAtHeight(arg0 types.Height) types.Height {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "RestartAtHeight", arg0)
+	ret0, _ := ret[0].(types.Height)
+	return ret0
+}
+
+// RestartAtHeight indicates an expected call of RestartAtHeight.
+func (mr *MockStateMachineMockRecorder[V, H, A]) RestartAtHeight(arg0 any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RestartAtHeight", reflect.TypeOf((*MockStateMachine[V, H, A])(nil).RestartAtHeight), arg0)
+}

--- a/consensus/tendermint/process.go
+++ b/consensus/tendermint/process.go
@@ -28,6 +28,12 @@ func (t *stateMachine[V, H, A]) ProcessPrevote(p types.Prevote[H, A]) []types.Ac
 	})
 }
 
+func (t *stateMachine[V, H, A]) RestartAtHeight(h types.Height) types.Height {
+	oldHeight := t.state.height
+	t.doCommitValue(h)
+	return oldHeight
+}
+
 func (t *stateMachine[V, H, A]) ProcessPrecommit(p types.Precommit[H, A]) []types.Action[V, H, A] {
 	return t.processMessage(p.MessageHeader, func() {
 		if t.messages.AddPrecommit(p) && !t.replayMode && p.Height == t.state.height {
@@ -115,7 +121,7 @@ func (t *stateMachine[V, H, A]) process(
 
 	// Line 49
 	case roundCachedProposal != nil && t.uponCommitValue(roundCachedProposal):
-		return appendAction(append(existingActions, (*types.Commit[V, H, A])(&roundCachedProposal.Proposal)), t.doCommitValue()), true
+		return appendAction(append(existingActions, (*types.Commit[V, H, A])(&roundCachedProposal.Proposal)), t.doCommitValue(t.state.height)), true
 
 	// Line 55
 	case recentlyReceivedRound != nil && t.uponSkipRound(*recentlyReceivedRound):

--- a/consensus/tendermint/rule_commit_value.go
+++ b/consensus/tendermint/rule_commit_value.go
@@ -28,9 +28,11 @@ func (t *stateMachine[V, H, A]) uponCommitValue(cachedProposal *CachedProposal[V
 	return hasQuorum && isValid
 }
 
-func (t *stateMachine[V, H, A]) doCommitValue() types.Action[V, H, A] {
-	t.messages.DeleteHeightMessages(t.state.height)
-	t.state.height++
+func (t *stateMachine[V, H, A]) doCommitValue(newHeight types.Height) types.Action[V, H, A] {
+	for i := t.state.height; i < newHeight; i++ {
+		t.messages.DeleteHeightMessages(i)
+	}
+	t.state.height = newHeight
 	t.state.lockedRound = -1
 	t.state.lockedValue = nil
 	t.state.validRound = -1

--- a/consensus/tendermint/tendermint.go
+++ b/consensus/tendermint/tendermint.go
@@ -42,6 +42,7 @@ type StateMachine[V types.Hashable[H], H types.Hash, A types.Addr] interface {
 	ProcessProposal(types.Proposal[V, H, A]) []types.Action[V, H, A]
 	ProcessPrevote(types.Prevote[H, A]) []types.Action[V, H, A]
 	ProcessPrecommit(types.Precommit[H, A]) []types.Action[V, H, A]
+	RestartAtHeight(types.Height) types.Height
 }
 
 type stateMachine[V types.Hashable[H], H types.Hash, A types.Addr] struct {

--- a/node/node.go
+++ b/node/node.go
@@ -235,7 +235,7 @@ func New(cfg *Config, version string, logLevel *utils.LogLevel) (*Node, error) {
 				synchronizer = nil
 			}
 			p2pService, err = p2p.New(cfg.P2PAddr, cfg.P2PPublicAddr, version, cfg.P2PPeers, cfg.P2PPrivateKey, cfg.P2PFeederNode,
-				chain, &cfg.Network, log, database)
+				chain, &cfg.Network, log, database, nil)
 			if err != nil {
 				return nil, fmt.Errorf("set up p2p service: %w", err)
 			}

--- a/p2p/p2p.go
+++ b/p2p/p2p.go
@@ -53,7 +53,7 @@ type Service struct {
 }
 
 func New(addr, publicAddr, version, peers, privKeyStr string, feederNode bool, bc *blockchain.Blockchain, snNetwork *utils.Network,
-	log utils.SimpleLogger, database db.KeyValueStore,
+	log utils.SimpleLogger, database db.KeyValueStore, p2pCommitNotifier chan uint64,
 ) (*Service, error) {
 	if addr == "" {
 		// 0.0.0.0/tcp/0 will listen on any interface device and assing a free port.
@@ -110,11 +110,11 @@ func New(addr, publicAddr, version, peers, privKeyStr string, feederNode bool, b
 	// Todo: try to understand what will happen if user passes a multiaddr with p2p public and a private key which doesn't match.
 	// For example, a user passes the following multiaddr: --p2p-addr=/ip4/0.0.0.0/tcp/7778/p2p/(SomePublicKey) and also passes a
 	// --p2p-private-key="SomePrivateKey". However, the private public key pair don't match, in this case what will happen?
-	return NewWithHost(p2pHost, peers, feederNode, bc, snNetwork, log, database)
+	return NewWithHost(p2pHost, peers, feederNode, bc, snNetwork, log, database, p2pCommitNotifier)
 }
 
 func NewWithHost(p2phost host.Host, peers string, feederNode bool, bc *blockchain.Blockchain, snNetwork *utils.Network,
-	log utils.SimpleLogger, database db.KeyValueStore,
+	log utils.SimpleLogger, database db.KeyValueStore, p2pCommitNotifier chan uint64,
 ) (*Service, error) {
 	var (
 		peersAddrInfoS []peer.AddrInfo
@@ -145,7 +145,7 @@ func NewWithHost(p2phost host.Host, peers string, feederNode bool, bc *blockchai
 
 	// todo: reconsider initialising synchroniser here because if node is a feedernode we shouldn't not create an instance of it.
 
-	synchroniser := p2pSync.New(bc, p2phost, snNetwork, log)
+	synchroniser := p2pSync.New(bc, p2phost, snNetwork, log, p2pCommitNotifier)
 	s := &Service{
 		synchroniser: synchroniser,
 		log:          log,

--- a/p2p/p2p_test.go
+++ b/p2p/p2p_test.go
@@ -24,6 +24,7 @@ func TestInvalidKey(t *testing.T) {
 		&utils.Integration,
 		utils.NewNopZapLogger(),
 		nil,
+		nil,
 	)
 
 	require.Error(t, err)
@@ -59,6 +60,7 @@ func TestLoadAndPersistPeers(t *testing.T) {
 		&utils.Integration,
 		utils.NewNopZapLogger(),
 		testDB,
+		nil,
 	)
 	require.NoError(t, err)
 }


### PR DESCRIPTION
This PR implements (what seems to be) a very simple and effective sync mechanism for the consensus protocol.

The main idea is that the p2p sync process runs in the background, and notifies the consensus algorithm
1. whenever it is behind the chain (so that we can stop consensus - we shouldn't waste resources processing outdated heights)
2. has committed a block to the chain (so that the state machine knows which height to start from). 