### PR TITLE
feat(metrics): improve L1 monitoring with proper height metrics and rename misleading l1_height

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -37,6 +37,7 @@ require (
 	go.uber.org/mock v0.5.0
 	go.uber.org/zap v1.27.0
 	golang.org/x/crypto v0.36.0
+	golang.org/x/exp v0.0.0-20250218142911-aa4b98e5adaa
 	golang.org/x/sync v0.12.0
 	google.golang.org/grpc v1.71.0
 	google.golang.org/protobuf v1.36.5
@@ -64,7 +65,6 @@ require (
 	github.com/davidlazar/go-crypto v0.0.0-20200604182044-b73af7476f6c // indirect
 	github.com/deckarep/golang-set/v2 v2.6.0 // indirect
 	github.com/decred/dcrd/dcrec/secp256k1/v4 v4.4.0 // indirect
-	github.com/dmarkham/enumer v1.5.11 // indirect
 	github.com/docker/go-units v0.5.0 // indirect
 	github.com/elastic/gosigar v0.14.3 // indirect
 	github.com/ethereum/c-kzg-4844 v1.0.0 // indirect
@@ -106,6 +106,7 @@ require (
 	github.com/koron/go-ssdp v0.0.5 // indirect
 	github.com/kr/pretty v0.3.1 // indirect
 	github.com/kr/text v0.2.0 // indirect
+	github.com/kylelemons/godebug v1.1.0 // indirect
 	github.com/leodido/go-urn v1.4.0 // indirect
 	github.com/libp2p/go-buffer-pool v0.1.0 // indirect
 	github.com/libp2p/go-cidranger v1.1.0 // indirect
@@ -140,7 +141,6 @@ require (
 	github.com/onsi/ginkgo/v2 v2.22.2 // indirect
 	github.com/opencontainers/runtime-spec v1.2.0 // indirect
 	github.com/opentracing/opentracing-go v1.2.0 // indirect
-	github.com/pascaldekloe/name v1.0.0 // indirect
 	github.com/pbnjay/memory v0.0.0-20210728143218-7b4eea64cf58 // indirect
 	github.com/pelletier/go-toml/v2 v2.2.3 // indirect
 	github.com/pion/datachannel v1.5.10 // indirect
@@ -193,7 +193,6 @@ require (
 	go.uber.org/dig v1.18.0 // indirect
 	go.uber.org/fx v1.23.0 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
-	golang.org/x/exp v0.0.0-20250218142911-aa4b98e5adaa // indirect
 	golang.org/x/mod v0.23.0 // indirect
 	golang.org/x/net v0.36.0 // indirect
 	golang.org/x/sys v0.31.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -105,8 +105,6 @@ github.com/decred/dcrd/crypto/blake256 v1.1.0 h1:zPMNGQCm0g4QTY27fOCorQW7EryeQ/U
 github.com/decred/dcrd/crypto/blake256 v1.1.0/go.mod h1:2OfgNZ5wDpcsFmHmCK5gZTPcCXqlm2ArzUIkw9czNJo=
 github.com/decred/dcrd/dcrec/secp256k1/v4 v4.4.0 h1:NMZiJj8QnKe1LgsbDayM4UoHwbvwDRwnI3hwNaAHRnc=
 github.com/decred/dcrd/dcrec/secp256k1/v4 v4.4.0/go.mod h1:ZXNYxsqcloTdSy/rNShjYzMhyjf0LaoftYK0p+A3h40=
-github.com/dmarkham/enumer v1.5.11 h1:quorLCaEfzjJ23Pf7PB9lyyaHseh91YfTM/sAD/4Mbo=
-github.com/dmarkham/enumer v1.5.11/go.mod h1:yixql+kDDQRYqcuBM2n9Vlt7NoT9ixgXhaXry8vmRg8=
 github.com/docker/go-units v0.4.0/go.mod h1:fgPhTUdO+D/Jk86RDLlptpiXQzgHJF7gydDDbaIK4Dk=
 github.com/docker/go-units v0.5.0 h1:69rxXcBk27SvSaaxTtLh/8llcHD8vYHT7WSdRZ/jvr4=
 github.com/docker/go-units v0.5.0/go.mod h1:fgPhTUdO+D/Jk86RDLlptpiXQzgHJF7gydDDbaIK4Dk=
@@ -393,8 +391,6 @@ github.com/opencontainers/runtime-spec v1.2.0/go.mod h1:jwyrGlmzljRJv/Fgzds9SsS/
 github.com/opentracing/opentracing-go v1.2.0 h1:uEJPy/1a5RIPAJ0Ov+OIO8OxWu77jEv+1B0VhjKrZUs=
 github.com/opentracing/opentracing-go v1.2.0/go.mod h1:GxEUsuufX4nBwe+T+Wl9TAgYrxe9dPLANfrWvHYVTgc=
 github.com/openzipkin/zipkin-go v0.1.1/go.mod h1:NtoC/o8u3JlF1lSlyPNswIbeQH9bJTmOf0Erfk+hxe8=
-github.com/pascaldekloe/name v1.0.0 h1:n7LKFgHixETzxpRv2R77YgPUFo85QHGZKrdaYm7eY5U=
-github.com/pascaldekloe/name v1.0.0/go.mod h1:Z//MfYJnH4jVpQ9wkclwu2I2MkHmXTlT9wR5UZScttM=
 github.com/pbnjay/memory v0.0.0-20210728143218-7b4eea64cf58 h1:onHthvaw9LFnH4t2DcNVpwGmV9E1BkGknEliJkfwQj0=
 github.com/pbnjay/memory v0.0.0-20210728143218-7b4eea64cf58/go.mod h1:DXv8WO4yhMYhSNPKjeNKa5WY9YCIEBRbNzFFPJbWO6Y=
 github.com/pelletier/go-toml/v2 v2.2.3 h1:YmeHyLY8mFWbdkNWwpr+qIL2bEqT0o95WSdkNHvL12M=

--- a/l1/eth_subscriber.go
+++ b/l1/eth_subscriber.go
@@ -79,6 +79,17 @@ func (s *EthSubscriber) FinalisedHeight(ctx context.Context) (uint64, error) {
 	return head.Number.Uint64(), nil
 }
 
+func (s *EthSubscriber) LatestHeight(ctx context.Context) (uint64, error) {
+	reqTimer := time.Now()
+	height, err := s.ethClient.BlockNumber(ctx)
+	if err != nil {
+		return 0, fmt.Errorf("get latest Ethereum block number: %w", err)
+	}
+	s.listener.OnL1Call("eth_blockNumber", time.Since(reqTimer))
+
+	return height, nil
+}
+
 func (s *EthSubscriber) Close() {
 	s.ethClient.Close()
 }

--- a/l1/l1.go
+++ b/l1/l1.go
@@ -20,6 +20,7 @@ import (
 //go:generate mockgen -destination=../mocks/mock_subscriber.go -package=mocks github.com/NethermindEth/juno/l1 Subscriber
 type Subscriber interface {
 	FinalisedHeight(ctx context.Context) (uint64, error)
+	LatestHeight(ctx context.Context) (uint64, error)
 	WatchLogStateUpdate(ctx context.Context, sink chan<- *contract.StarknetLogStateUpdate) (event.Subscription, error)
 	ChainID(ctx context.Context) (*big.Int, error)
 	TransactionReceipt(ctx context.Context, txHash common.Hash) (*types.Receipt, error)

--- a/l1/l1_test.go
+++ b/l1/l1_test.go
@@ -170,6 +170,7 @@ func newTestL1Client(service service) *rpc.Server {
 
 type service interface {
 	GetBlockByNumber(ctx context.Context, number string, fullTx bool) (any, error)
+	BlockNumber(ctx context.Context) (string, error)
 }
 
 type testService struct{}
@@ -192,10 +193,18 @@ func (testService) GetBlockByNumber(ctx context.Context, number string, fullTx b
 	}, nil
 }
 
+func (testService) BlockNumber(ctx context.Context) (string, error) {
+	return "0xc8", nil // 200 in hex
+}
+
 type testEmptyService struct{}
 
 func (testEmptyService) GetBlockByNumber(ctx context.Context, number string, fullTx bool) (any, error) {
 	return nil, nil
+}
+
+func (testEmptyService) BlockNumber(ctx context.Context) (string, error) {
+	return "", errors.New("empty service")
 }
 
 type testFaultyService struct{}
@@ -204,15 +213,37 @@ func (testFaultyService) GetBlockByNumber(ctx context.Context, number string, fu
 	return uint(0), nil
 }
 
+func (testFaultyService) BlockNumber(ctx context.Context) (string, error) {
+	return "invalid", nil
+}
+
 func TestEthSubscriber_FinalisedHeight(t *testing.T) {
-	tests := map[string]struct {
+	tests := createEthSubscriberTests(100)
+	testEthSubscriberHeight(t, tests, func(subscriber *l1.EthSubscriber, ctx context.Context) (uint64, error) {
+		return subscriber.FinalisedHeight(ctx)
+	})
+}
+
+func TestEthSubscriber_LatestHeight(t *testing.T) {
+	tests := createEthSubscriberTests(200)
+	testEthSubscriberHeight(t, tests, func(subscriber *l1.EthSubscriber, ctx context.Context) (uint64, error) {
+		return subscriber.LatestHeight(ctx)
+	})
+}
+
+func createEthSubscriberTests(testServiceExpectedHeight uint64) map[string]struct {
+	service        service
+	expectedHeight uint64
+	expectedError  bool
+} {
+	return map[string]struct {
 		service        service
 		expectedHeight uint64
 		expectedError  bool
 	}{
 		"testService": {
 			service:        testService{},
-			expectedHeight: 100,
+			expectedHeight: testServiceExpectedHeight,
 			expectedError:  false,
 		},
 		"testEmptyService": {
@@ -226,21 +257,28 @@ func TestEthSubscriber_FinalisedHeight(t *testing.T) {
 			expectedError:  true,
 		},
 	}
+}
+
+func testEthSubscriberHeight(t *testing.T, tests map[string]struct {
+	service        service
+	expectedHeight uint64
+	expectedError  bool
+}, heightFunc func(*l1.EthSubscriber, context.Context) (uint64, error),
+) {
+	startServer := func(addr string, service service) (*rpc.Server, net.Listener) {
+		srv := newTestL1Client(service)
+		l, err := net.Listen("tcp", addr)
+		if err != nil {
+			t.Fatal("can't listen:", err)
+		}
+		go func() {
+			_ = http.Serve(l, srv.WebsocketHandler([]string{"*"}))
+		}()
+		return srv, l
+	}
 
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
-			startServer := func(addr string, service service) (*rpc.Server, net.Listener) {
-				srv := newTestL1Client(service)
-				l, err := net.Listen("tcp", addr)
-				if err != nil {
-					t.Fatal("can't listen:", err)
-				}
-				go func() {
-					_ = http.Serve(l, srv.WebsocketHandler([]string{"*"}))
-				}()
-				return srv, l
-			}
-
 			ctx, cancel := context.WithTimeout(t.Context(), 12*time.Second)
 			defer cancel()
 
@@ -251,7 +289,7 @@ func TestEthSubscriber_FinalisedHeight(t *testing.T) {
 			require.NoError(t, err)
 			defer subscriber.Close()
 
-			height, err := subscriber.FinalisedHeight(ctx)
+			height, err := heightFunc(subscriber, ctx)
 			require.Equal(t, test.expectedHeight, height)
 			require.Equal(t, test.expectedError, err != nil)
 		})

--- a/mocks/mock_subscriber.go
+++ b/mocks/mock_subscriber.go
@@ -86,6 +86,21 @@ func (mr *MockSubscriberMockRecorder) FinalisedHeight(arg0 any) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FinalisedHeight", reflect.TypeOf((*MockSubscriber)(nil).FinalisedHeight), arg0)
 }
 
+// LatestHeight mocks base method.
+func (m *MockSubscriber) LatestHeight(arg0 context.Context) (uint64, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "LatestHeight", arg0)
+	ret0, _ := ret[0].(uint64)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// LatestHeight indicates an expected call of LatestHeight.
+func (mr *MockSubscriberMockRecorder) LatestHeight(arg0 any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LatestHeight", reflect.TypeOf((*MockSubscriber)(nil).LatestHeight), arg0)
+}
+
 // TransactionReceipt mocks base method.
 func (m *MockSubscriber) TransactionReceipt(arg0 context.Context, arg1 common.Hash) (*types.Receipt, error) {
 	m.ctrl.T.Helper()

--- a/node/metrics.go
+++ b/node/metrics.go
@@ -247,8 +247,8 @@ func makeBlockchainMetrics() blockchain.EventListener {
 func makeL1Metrics(bcReader blockchain.Reader) l1.EventListener {
 	l1Height := prometheus.NewGaugeFunc(prometheus.GaugeOpts{
 		Namespace: "l1",
-		Name:      "height",
-		Help:      "Current L1 (Ethereum) blockchain height",
+		Name:      "latest_verified_l2_block_number",
+		Help:      "Latest L2 block number that has been finalized on L1",
 	}, func() float64 {
 		l1Head, err := bcReader.L1Head()
 		if err != nil {

--- a/node/metrics.go
+++ b/node/metrics.go
@@ -1,6 +1,7 @@
 package node
 
 import (
+	"context"
 	"math"
 	"strconv"
 	"time"
@@ -16,6 +17,8 @@ import (
 	"github.com/cockroachdb/pebble"
 	"github.com/prometheus/client_golang/prometheus"
 )
+
+const l1MetricsTimeout = 5 * time.Second
 
 func makeDBMetrics() db.EventListener {
 	latencyBuckets := []float64{
@@ -244,11 +247,11 @@ func makeBlockchainMetrics() blockchain.EventListener {
 	}
 }
 
-func makeL1Metrics(bcReader blockchain.Reader) l1.EventListener {
-	l1Height := prometheus.NewGaugeFunc(prometheus.GaugeOpts{
+func makeL1Metrics(bcReader blockchain.Reader, l1Subscriber l1.Subscriber) l1.EventListener {
+	l2BlockFinalizedOnL1 := prometheus.NewGaugeFunc(prometheus.GaugeOpts{
 		Namespace: "l1",
-		Name:      "latest_verified_l2_block_number",
-		Help:      "Latest L2 block number that has been finalized on L1",
+		Name:      "l2_finalised_height",
+		Help:      "Latest L2 block number that has been finalised on L1",
 	}, func() float64 {
 		l1Head, err := bcReader.L1Head()
 		if err != nil {
@@ -256,7 +259,38 @@ func makeL1Metrics(bcReader blockchain.Reader) l1.EventListener {
 		}
 		return float64(l1Head.BlockNumber)
 	})
+	prometheus.MustRegister(l2BlockFinalizedOnL1)
+
+	l1Height := prometheus.NewGaugeFunc(prometheus.GaugeOpts{
+		Namespace: "l1",
+		Name:      "finalised_height",
+		Help:      "Current L1 (Ethereum) finalised blockchain height",
+	}, func() float64 {
+		ctx, cancel := context.WithTimeout(context.Background(), l1MetricsTimeout)
+		defer cancel()
+		height, err := l1Subscriber.FinalisedHeight(ctx)
+		if err != nil {
+			return 0
+		}
+		return float64(height)
+	})
 	prometheus.MustRegister(l1Height)
+
+	l1LatestHeight := prometheus.NewGaugeFunc(prometheus.GaugeOpts{
+		Namespace: "l1",
+		Name:      "latest_height",
+		Help:      "Current latest L1 (Ethereum) blockchain height",
+	}, func() float64 {
+		ctx, cancel := context.WithTimeout(context.Background(), l1MetricsTimeout)
+		defer cancel()
+		height, err := l1Subscriber.LatestHeight(ctx)
+		if err != nil {
+			return 0
+		}
+		return float64(height)
+	})
+	prometheus.MustRegister(l1LatestHeight)
+
 	requestLatencies := prometheus.NewHistogramVec(prometheus.HistogramOpts{
 		Namespace: "l1",
 		Subsystem: "client",

--- a/node/metrics_test.go
+++ b/node/metrics_test.go
@@ -1,0 +1,83 @@
+package node
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/NethermindEth/juno/core"
+	"github.com/NethermindEth/juno/mocks"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+)
+
+func assertGaugeValue(t *testing.T, reg *prometheus.Registry, name string, expected float64) {
+	t.Helper()
+	metrics, err := reg.Gather()
+	require.NoError(t, err)
+
+	var found bool
+	for _, metric := range metrics {
+		if metric.GetName() == name {
+			found = true
+			require.Len(t, metric.GetMetric(), 1, "expected 1 metric value")
+			assert.Equal(t, expected, metric.GetMetric()[0].GetGauge().GetValue())
+		}
+	}
+	require.True(t, found, "metric %q not found", name)
+}
+
+func TestMakeL1Metrics(t *testing.T) {
+	originalRegisterer := prometheus.DefaultRegisterer
+	defer func() {
+		prometheus.DefaultRegisterer = originalRegisterer
+	}()
+	prometheus.DefaultRegisterer = prometheus.NewRegistry()
+
+	t.Run("successful metric reporting", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		mockBCReader := mocks.NewMockReader(ctrl)
+		mockSubscriber := mocks.NewMockSubscriber(ctrl)
+
+		reg := prometheus.NewRegistry()
+		prometheus.DefaultRegisterer = reg
+
+		head := &core.L1Head{BlockNumber: 42}
+		mockBCReader.EXPECT().L1Head().Return(head, nil).AnyTimes()
+		mockSubscriber.EXPECT().FinalisedHeight(gomock.Any()).Return(uint64(100), nil).AnyTimes()
+		mockSubscriber.EXPECT().LatestHeight(gomock.Any()).Return(uint64(101), nil).AnyTimes()
+
+		listener := makeL1Metrics(mockBCReader, mockSubscriber)
+		require.NotNil(t, listener)
+
+		assertGaugeValue(t, reg, "l1_l2_finalised_height", 42)
+		assertGaugeValue(t, reg, "l1_finalised_height", 100)
+		assertGaugeValue(t, reg, "l1_latest_height", 101)
+
+		listener.OnL1Call("test_method", time.Second)
+		assert.Equal(t, 1, testutil.CollectAndCount(reg, "l1_client_request_latency"), "l1_client_request_latency")
+	})
+
+	t.Run("error in metric reporting", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		mockBCReader := mocks.NewMockReader(ctrl)
+		mockSubscriber := mocks.NewMockSubscriber(ctrl)
+
+		reg := prometheus.NewRegistry()
+		prometheus.DefaultRegisterer = reg
+
+		mockBCReader.EXPECT().L1Head().Return(nil, errors.New("err")).AnyTimes()
+		mockSubscriber.EXPECT().FinalisedHeight(gomock.Any()).Return(uint64(0), errors.New("err")).AnyTimes()
+		mockSubscriber.EXPECT().LatestHeight(gomock.Any()).Return(uint64(0), errors.New("err")).AnyTimes()
+
+		listener := makeL1Metrics(mockBCReader, mockSubscriber)
+		require.NotNil(t, listener)
+
+		assertGaugeValue(t, reg, "l1_l2_finalised_height", 0)
+		assertGaugeValue(t, reg, "l1_finalised_height", 0)
+		assertGaugeValue(t, reg, "l1_latest_height", 0)
+	})
+}

--- a/node/node.go
+++ b/node/node.go
@@ -418,7 +418,7 @@ func newL1Client(ethNode string, includeMetrics bool, chain *blockchain.Blockcha
 	l1Client := l1.NewClient(ethSubscriber, chain, log)
 
 	if includeMetrics {
-		l1Client.WithEventListener(makeL1Metrics(chain))
+		l1Client.WithEventListener(makeL1Metrics(chain, ethSubscriber))
 	}
 	return l1Client, nil
 }

--- a/node/node.go
+++ b/node/node.go
@@ -418,7 +418,7 @@ func newL1Client(ethNode string, includeMetrics bool, chain *blockchain.Blockcha
 	l1Client := l1.NewClient(ethSubscriber, chain, log)
 
 	if includeMetrics {
-		l1Client.WithEventListener(makeL1Metrics())
+		l1Client.WithEventListener(makeL1Metrics(chain))
 	}
 	return l1Client, nil
 }


### PR DESCRIPTION
- Renamed `l1_height` to `l1_l2_finalised_height` with clearer description  
- Added both finalized and latest L1 block height metrics  
- Fixed zero metrics after restart by switching to on-demand `GaugeFunc` that fetches from DB instead of waiting for L1 events  
- Added tests for metrics

###  **New Metrics**
Metric Name | Description 
-- | -- 
l1_l2_finalised_height | Latest L2 block number that has been finalized on L1 
l1_finalised_height | Current L1 finalized blockchain height
l1_latest_height | Current latest L1 blockchain height 

Sample visualisation:
<img width="1285" alt="image" src="https://github.com/user-attachments/assets/49fc39c5-6949-4be7-8e0d-dd84eef83163" />



