### PR TITLE
fix: getEvents queries with not existing block number should be bounded to [0,latest]

### DIFF
--- a/rpc/v6/events.go
+++ b/rpc/v6/events.go
@@ -134,6 +134,9 @@ func setEventFilterRange(filter blockchain.EventFilterer, fromID, toID *BlockID,
 		case id.Pending:
 			return filter.SetRangeEndBlockByNumber(filterRange, latestHeight+1)
 		default:
+			if filterRange == blockchain.EventFilterTo {
+				return filter.SetRangeEndBlockByNumber(filterRange, min(id.Number, latestHeight))
+			}
 			return filter.SetRangeEndBlockByNumber(filterRange, id.Number)
 		}
 	}

--- a/rpc/v8/events.go
+++ b/rpc/v8/events.go
@@ -39,6 +39,9 @@ func setEventFilterRange(filter blockchain.EventFilterer, from, to *BlockID, lat
 		case hash:
 			return filter.SetRangeEndBlockByHash(filterRange, blockID.Hash())
 		case number:
+			if filterRange == blockchain.EventFilterTo {
+				return filter.SetRangeEndBlockByNumber(filterRange, min(blockID.Number(), latestHeight))
+			}
 			return filter.SetRangeEndBlockByNumber(filterRange, blockID.Number())
 		default:
 			panic("Unknown block id type")

--- a/rpc/v9/events.go
+++ b/rpc/v9/events.go
@@ -41,6 +41,9 @@ func setEventFilterRange(filter blockchain.EventFilterer, from, to *BlockID, lat
 		case hash:
 			return filter.SetRangeEndBlockByHash(filterRange, blockID.Hash())
 		case number:
+			if filterRange == blockchain.EventFilterTo {
+				return filter.SetRangeEndBlockByNumber(filterRange, min(blockID.Number(), latestHeight))
+			}
 			return filter.SetRangeEndBlockByNumber(filterRange, blockID.Number())
 		default:
 			panic("Unknown block id type")


### PR DESCRIPTION
Current approach was upon receiving query on `getEvents` with `to_block` greater than the height, we were bounding the range to [0, Pending] but Pending block does not have blocknumber and this behavior might be confusing for some user. What they experience is for such queries they are receiving some events for non-existing block and response does not specifies block number for such events since Pending block does not have block number. With this PR, queries with block numbers will be bounded in range [0, latest] and pending block events will be only returned when it is explicity queried with `pending` or `pre_confirmed` tag.

Closes #2955