### PR TITLE
fix: when pending data is invalid return empty pending/pre_confirmed for latest

### DIFF
--- a/rpc/v6/block_test.go
+++ b/rpc/v6/block_test.go
@@ -185,6 +185,7 @@ func TestBlockTransactionCount(t *testing.T) {
 		latestBlock.Hash = nil
 		latestBlock.GlobalStateRoot = nil
 		mockSyncReader.EXPECT().PendingData().Return(nil, sync.ErrPendingBlockNotFound)
+		mockReader.EXPECT().HeadsHeader().Return(nil, db.ErrKeyNotFound)
 
 		count, rpcErr := handler.BlockTransactionCount(rpc.BlockID{Pending: true})
 		require.Equal(t, rpccore.ErrBlockNotFound, rpcErr)

--- a/rpc/v6/pending_data_wrapper.go
+++ b/rpc/v6/pending_data_wrapper.go
@@ -1,6 +1,7 @@
 package rpcv6
 
 import (
+	"errors"
 	"time"
 
 	"github.com/NethermindEth/juno/core"
@@ -10,21 +11,22 @@ import (
 
 func (h *Handler) PendingData() (*core.PendingData, error) {
 	pending, err := h.syncReader.PendingData()
-	if err != nil {
+	if err != nil && !errors.Is(err, sync.ErrPendingBlockNotFound) {
 		return nil, err
 	}
 	// If pending network is polling pending block and running on < 0.14.0
-	if pending.Variant() == core.PendingBlockVariant {
+	if err == nil && pending.Variant() == core.PendingBlockVariant {
 		return pending, nil
-	} else {
-		// If pre_confirmed, network is polling pre_confirmed block and running on >= 0.14.0
-		latestHeader, err := h.bcReader.HeadsHeader()
-		if err != nil {
-			return nil, err
-		}
-		emptyPending := emptyPendingForParent(latestHeader).AsPendingData()
-		return &emptyPending, nil
 	}
+
+	// If pre_confirmed, network is polling pre_confirmed block and running on >= 0.14.0
+	latestHeader, err := h.bcReader.HeadsHeader()
+	if err != nil {
+		return nil, err
+	}
+	emptyPending := emptyPendingForParent(latestHeader)
+	emptyPendingData := emptyPending.AsPendingData()
+	return &emptyPendingData, nil
 }
 
 func (h *Handler) PendingBlock() *core.Block {
@@ -35,7 +37,7 @@ func (h *Handler) PendingBlock() *core.Block {
 	return pending.GetBlock()
 }
 
-func emptyPendingForParent(parentHeader *core.Header) *sync.Pending {
+func emptyPendingForParent(parentHeader *core.Header) sync.Pending {
 	receipts := make([]*core.TransactionReceipt, 0)
 	pendingBlock := &core.Block{
 		Header: &core.Header{
@@ -63,7 +65,7 @@ func emptyPendingForParent(parentHeader *core.Header) *sync.Pending {
 		ReplacedClasses:   make(map[felt.Felt]*felt.Felt),
 	}
 
-	return &sync.Pending{
+	return sync.Pending{
 		Block: pendingBlock,
 		StateUpdate: &core.StateUpdate{
 			OldRoot:   parentHeader.GlobalStateRoot,

--- a/rpc/v6/transaction_test.go
+++ b/rpc/v6/transaction_test.go
@@ -51,6 +51,7 @@ func TestTransactionByHashNotFound(t *testing.T) {
 
 		randomTxHash := new(felt.Felt).SetBytes([]byte("random hash"))
 		mockReader.EXPECT().TransactionByHash(randomTxHash).Return(nil, db.ErrKeyNotFound)
+		mockReader.EXPECT().HeadsHeader().Return(nil, db.ErrKeyNotFound)
 		mockSyncReader.EXPECT().PendingData().Return(nil, sync.ErrPendingBlockNotFound)
 
 		n := &utils.Mainnet
@@ -629,6 +630,7 @@ func TestTransactionReceiptByHash(t *testing.T) {
 
 		mockReader.EXPECT().TransactionByHash(gomock.Any()).Return(nil, db.ErrKeyNotFound)
 		mockSyncReader.EXPECT().PendingData().Return(nil, sync.ErrPendingBlockNotFound)
+		mockReader.EXPECT().HeadsHeader().Return(nil, db.ErrKeyNotFound)
 
 		txHash := new(felt.Felt).SetBytes([]byte("some tx hash"))
 		tx, rpcErr := handler.TransactionReceiptByHash(*txHash)
@@ -1554,6 +1556,7 @@ func TestTransactionStatus(t *testing.T) {
 						mockReader.EXPECT().TransactionByHash(notFoundTest.hash).Return(nil, db.ErrKeyNotFound).Times(2)
 						syncReader.EXPECT().PendingData().Return(nil, sync.ErrPendingBlockNotFound).Times(2)
 						handler := rpc.New(mockReader, syncReader, nil, "", test.network, nil)
+						mockReader.EXPECT().HeadsHeader().Return(nil, db.ErrKeyNotFound).Times(2)
 						_, err := handler.TransactionStatus(ctx, *notFoundTest.hash)
 						require.Equal(t, rpccore.ErrTxnHashNotFound.Code, err.Code)
 
@@ -1571,6 +1574,7 @@ func TestTransactionStatus(t *testing.T) {
 				syncReader := mocks.NewMockSyncReader(mockCtrl)
 				mockReader.EXPECT().TransactionByHash(test.notFoundTxHash).Return(nil, db.ErrKeyNotFound)
 				syncReader.EXPECT().PendingData().Return(nil, sync.ErrPendingBlockNotFound)
+				mockReader.EXPECT().HeadsHeader().Return(nil, db.ErrKeyNotFound)
 				handler := rpc.New(mockReader, syncReader, nil, "", test.network, nil).WithFeeder(client)
 
 				_, err := handler.TransactionStatus(ctx, *test.notFoundTxHash)
@@ -1733,6 +1737,7 @@ func TestSubmittedTransactionsCache(t *testing.T) {
 		require.Nil(t, err)
 		mockReader.EXPECT().TransactionByHash(res.TransactionHash).Return(nil, db.ErrKeyNotFound)
 		mockSyncReader.EXPECT().PendingData().Return(nil, sync.ErrPendingBlockNotFound)
+		mockReader.EXPECT().HeadsHeader().Return(nil, db.ErrKeyNotFound)
 
 		status, err := handler.TransactionStatus(ctx, *res.TransactionHash)
 		require.Nil(t, err)
@@ -1753,6 +1758,7 @@ func TestSubmittedTransactionsCache(t *testing.T) {
 		require.Nil(t, err)
 		mockReader.EXPECT().TransactionByHash(res.TransactionHash).Return(nil, db.ErrKeyNotFound)
 		mockSyncReader.EXPECT().PendingData().Return(nil, sync.ErrPendingBlockNotFound)
+		mockReader.EXPECT().HeadsHeader().Return(nil, db.ErrKeyNotFound)
 		// Expire cache entry
 		time.Sleep(cacheEntryTimeOut)
 		status, err := handler.TransactionStatus(ctx, *res.TransactionHash)

--- a/rpc/v7/transaction_test.go
+++ b/rpc/v7/transaction_test.go
@@ -259,7 +259,7 @@ func TestTransactionReceiptByHash(t *testing.T) {
 		txHash := new(felt.Felt).SetBytes([]byte("random hash"))
 		mockReader.EXPECT().TransactionByHash(txHash).Return(nil, db.ErrKeyNotFound)
 		mockSyncer.EXPECT().PendingData().Return(nil, sync.ErrPendingBlockNotFound)
-
+		mockReader.EXPECT().HeadsHeader().Return(nil, db.ErrKeyNotFound)
 		tx, rpcErr := handler.TransactionReceiptByHash(*txHash)
 		assert.Nil(t, tx)
 		assert.Equal(t, rpccore.ErrTxnHashNotFound, rpcErr)
@@ -943,7 +943,7 @@ func TestTransactionStatus(t *testing.T) {
 
 						mockSyncer := mocks.NewMockSyncReader(mockCtrl)
 						mockSyncer.EXPECT().PendingData().Return(nil, sync.ErrPendingBlockNotFound).Times(2)
-
+						mockReader.EXPECT().HeadsHeader().Return(nil, db.ErrKeyNotFound).Times(2)
 						handler := rpc.New(mockReader, mockSyncer, nil, "", test.network, nil)
 						_, err := handler.TransactionStatus(ctx, *notFoundTest.hash)
 						require.Equal(t, rpccore.ErrTxnHashNotFound.Code, err.Code)
@@ -964,6 +964,7 @@ func TestTransactionStatus(t *testing.T) {
 
 				mockSyncer := mocks.NewMockSyncReader(mockCtrl)
 				mockSyncer.EXPECT().PendingData().Return(nil, sync.ErrPendingBlockNotFound)
+				mockReader.EXPECT().HeadsHeader().Return(nil, db.ErrKeyNotFound)
 
 				handler := rpc.New(mockReader, mockSyncer, nil, "", test.network, nil).WithFeeder(client)
 

--- a/rpc/v8/pending_data_wrapper.go
+++ b/rpc/v8/pending_data_wrapper.go
@@ -1,6 +1,7 @@
 package rpcv8
 
 import (
+	"errors"
 	"time"
 
 	"github.com/NethermindEth/juno/core"
@@ -10,21 +11,22 @@ import (
 
 func (h *Handler) PendingData() (*core.PendingData, error) {
 	pending, err := h.syncReader.PendingData()
-	if err != nil {
+	if err != nil && !errors.Is(err, sync.ErrPendingBlockNotFound) {
 		return nil, err
 	}
 	// If pending network is polling pending block and running on < 0.14.0
-	if pending.Variant() == core.PendingBlockVariant {
+	if err == nil && pending.Variant() == core.PendingBlockVariant {
 		return pending, nil
-	} else {
-		// If pre_confirmed, network is polling pre_confirmed block and running on >= 0.14.0
-		latestHeader, err := h.bcReader.HeadsHeader()
-		if err != nil {
-			return nil, err
-		}
-		emptyPending := emptyPendingForParent(latestHeader).AsPendingData()
-		return &emptyPending, nil
 	}
+
+	// If pre_confirmed, network is polling pre_confirmed block and running on >= 0.14.0
+	latestHeader, err := h.bcReader.HeadsHeader()
+	if err != nil {
+		return nil, err
+	}
+	emptyPending := emptyPendingForParent(latestHeader)
+	emptyPendingData := emptyPending.AsPendingData()
+	return &emptyPendingData, nil
 }
 
 func (h *Handler) PendingBlock() *core.Block {
@@ -35,7 +37,7 @@ func (h *Handler) PendingBlock() *core.Block {
 	return pending.GetBlock()
 }
 
-func emptyPendingForParent(parentHeader *core.Header) *sync.Pending {
+func emptyPendingForParent(parentHeader *core.Header) sync.Pending {
 	receipts := make([]*core.TransactionReceipt, 0)
 	pendingBlock := &core.Block{
 		Header: &core.Header{
@@ -63,7 +65,7 @@ func emptyPendingForParent(parentHeader *core.Header) *sync.Pending {
 		ReplacedClasses:   make(map[felt.Felt]*felt.Felt),
 	}
 
-	return &sync.Pending{
+	return sync.Pending{
 		Block: pendingBlock,
 		StateUpdate: &core.StateUpdate{
 			OldRoot:   parentHeader.GlobalStateRoot,

--- a/rpc/v8/subscriptions_test.go
+++ b/rpc/v8/subscriptions_test.go
@@ -268,7 +268,7 @@ func TestSubscribeTxnStatus(t *testing.T) {
 
 		mockChain.EXPECT().TransactionByHash(txHash).Return(nil, db.ErrKeyNotFound).AnyTimes()
 		mockSyncer.EXPECT().PendingData().Return(nil, sync.ErrPendingBlockNotFound).AnyTimes()
-
+		mockChain.EXPECT().HeadsHeader().Return(nil, db.ErrKeyNotFound).AnyTimes()
 		id, _ := createTestTxStatusWebsocket(t, handler, txHash)
 
 		_, hasSubscription := handler.subscriptions.Load(string(id))
@@ -288,6 +288,7 @@ func TestSubscribeTxnStatus(t *testing.T) {
 		handler := New(mockChain, mockSyncer, nil, "", log)
 		handler.WithFeeder(feeder.NewTestClient(t, &utils.SepoliaIntegration))
 		mockSyncer.EXPECT().PendingData().Return(nil, sync.ErrPendingBlockNotFound).AnyTimes()
+		mockChain.EXPECT().HeadsHeader().Return(nil, db.ErrKeyNotFound).AnyTimes()
 		t.Run("reverted", func(t *testing.T) {
 			txHash, err := new(felt.Felt).SetString("0x1011")
 			require.NoError(t, err)
@@ -335,6 +336,7 @@ func TestSubscribeTxnStatus(t *testing.T) {
 
 		mockChain.EXPECT().TransactionByHash(txHash).Return(nil, db.ErrKeyNotFound)
 		mockSyncer.EXPECT().PendingData().Return(nil, sync.ErrPendingBlockNotFound)
+		mockChain.EXPECT().HeadsHeader().Return(nil, db.ErrKeyNotFound)
 		id, conn := createTestTxStatusWebsocket(t, handler, txHash)
 		assertNextTxnStatus(t, conn, id, txHash, TxnStatusReceived, TxnSuccess, "")
 
@@ -694,7 +696,7 @@ func TestSubscribePendingTxs(t *testing.T) {
 	mockChain := mocks.NewMockReader(mockCtrl)
 	l1Feed := feed.New[*core.L1Head]()
 	mockChain.EXPECT().SubscribeL1Head().Return(blockchain.L1HeadSubscription{Subscription: l1Feed.Subscribe()})
-
+	mockChain.EXPECT().HeadsHeader().Return(nil, db.ErrKeyNotFound).Times(3)
 	syncer := newFakeSyncer()
 	handler, server := setupRPC(t, ctx, mockChain, syncer)
 

--- a/rpc/v8/transaction_test.go
+++ b/rpc/v8/transaction_test.go
@@ -36,6 +36,7 @@ func TestTransactionByHashNotFound(t *testing.T) {
 	txHash := new(felt.Felt).SetBytes([]byte("random hash"))
 	mockReader.EXPECT().TransactionByHash(txHash).Return(nil, db.ErrKeyNotFound)
 	mockSyncReader.EXPECT().PendingData().Return(nil, sync.ErrPendingBlockNotFound)
+	mockReader.EXPECT().HeadsHeader().Return(nil, db.ErrKeyNotFound)
 
 	handler := rpc.New(mockReader, mockSyncReader, nil, "", nil)
 
@@ -622,6 +623,7 @@ func TestTransactionReceiptByHash(t *testing.T) {
 		txHash := new(felt.Felt).SetBytes([]byte("random hash"))
 		mockReader.EXPECT().TransactionByHash(txHash).Return(nil, db.ErrKeyNotFound)
 		mockSyncReader.EXPECT().PendingData().Return(nil, sync.ErrPendingBlockNotFound)
+		mockReader.EXPECT().HeadsHeader().Return(nil, db.ErrKeyNotFound)
 
 		tx, rpcErr := handler.TransactionReceiptByHash(*txHash)
 		assert.Nil(t, tx)
@@ -1434,6 +1436,7 @@ func TestTransactionStatus(t *testing.T) {
 						mockSyncReader := mocks.NewMockSyncReader(mockCtrl)
 						mockReader.EXPECT().TransactionByHash(notFoundTest.hash).Return(nil, db.ErrKeyNotFound).Times(2)
 						mockSyncReader.EXPECT().PendingData().Return(nil, sync.ErrPendingBlockNotFound).Times(2)
+						mockReader.EXPECT().HeadsHeader().Return(nil, db.ErrKeyNotFound).Times(2)
 						handler := rpc.New(mockReader, mockSyncReader, nil, "", log)
 						_, err := handler.TransactionStatus(ctx, *notFoundTest.hash)
 						require.Equal(t, rpccore.ErrTxnHashNotFound.Code, err.Code)
@@ -1452,6 +1455,7 @@ func TestTransactionStatus(t *testing.T) {
 				mockSyncReader := mocks.NewMockSyncReader(mockCtrl)
 				mockReader.EXPECT().TransactionByHash(test.notFoundTxHash).Return(nil, db.ErrKeyNotFound)
 				mockSyncReader.EXPECT().PendingData().Return(nil, sync.ErrPendingBlockNotFound)
+				mockReader.EXPECT().HeadsHeader().Return(nil, db.ErrKeyNotFound)
 				handler := rpc.New(mockReader, mockSyncReader, nil, "", log).WithFeeder(client)
 
 				_, err := handler.TransactionStatus(ctx, *test.notFoundTxHash)
@@ -1913,7 +1917,7 @@ func TestSubmittedTransactionsCache(t *testing.T) {
 		require.Nil(t, err)
 		mockReader.EXPECT().TransactionByHash(res.TransactionHash).Return(nil, db.ErrKeyNotFound)
 		mockSyncReader.EXPECT().PendingData().Return(nil, sync.ErrPendingBlockNotFound)
-
+		mockReader.EXPECT().HeadsHeader().Return(nil, db.ErrKeyNotFound)
 		status, err := handler.TransactionStatus(ctx, *res.TransactionHash)
 		require.Nil(t, err)
 		require.Equal(t, rpc.TxnStatusReceived, status.Finality)
@@ -1931,6 +1935,7 @@ func TestSubmittedTransactionsCache(t *testing.T) {
 		require.Nil(t, err)
 		mockReader.EXPECT().TransactionByHash(res.TransactionHash).Return(nil, db.ErrKeyNotFound)
 		mockSyncReader.EXPECT().PendingData().Return(nil, sync.ErrPendingBlockNotFound)
+		mockReader.EXPECT().HeadsHeader().Return(nil, db.ErrKeyNotFound)
 		// Expire cache entry
 		time.Sleep(cacheEntryTimeOut)
 		status, err := handler.TransactionStatus(ctx, *res.TransactionHash)

--- a/rpc/v9/block_test.go
+++ b/rpc/v9/block_test.go
@@ -129,6 +129,7 @@ func TestBlockTransactionCount(t *testing.T) {
 		latestBlock.Hash = nil
 		latestBlock.GlobalStateRoot = nil
 		mockSyncReader.EXPECT().PendingData().Return(nil, sync.ErrPendingBlockNotFound)
+		mockReader.EXPECT().HeadsHeader().Return(nil, db.ErrKeyNotFound)
 		preConfirmed := blockIDPreConfirmed(t)
 		count, rpcErr := handler.BlockTransactionCount(&preConfirmed)
 		require.Equal(t, rpccore.ErrBlockNotFound, rpcErr)

--- a/rpc/v9/helpers.go
+++ b/rpc/v9/helpers.go
@@ -38,7 +38,7 @@ func (h *Handler) blockByID(blockID *BlockID) (*core.Block, *jsonrpc.Error) {
 	switch blockID.Type() {
 	case preConfirmed:
 		var pending *core.PendingData
-		pending, err = h.syncReader.PendingData()
+		pending, err = h.PendingData()
 		if err == nil {
 			block = pending.GetBlock()
 		}
@@ -68,7 +68,7 @@ func (h *Handler) blockHeaderByID(blockID *BlockID) (*core.Header, *jsonrpc.Erro
 	switch blockID.Type() {
 	case preConfirmed:
 		var pending *core.PendingData
-		pending, err = h.syncReader.PendingData()
+		pending, err = h.PendingData()
 		if err == nil {
 			header = pending.GetBlock().Header
 		}

--- a/rpc/v9/subscriptions.go
+++ b/rpc/v9/subscriptions.go
@@ -523,7 +523,7 @@ func (h *Handler) SubscribePendingTxs(ctx context.Context, getDetails bool, send
 
 	subscriber := subscriber{
 		onStart: func(ctx context.Context, id string, _ *subscription, _ any) error {
-			pendingData, err := h.syncReader.PendingData()
+			pendingData, err := h.PendingData()
 			if err != nil {
 				if errors.Is(err, sync.ErrPendingBlockNotFound) {
 					return nil

--- a/rpc/v9/subscriptions_test.go
+++ b/rpc/v9/subscriptions_test.go
@@ -354,11 +354,10 @@ func TestSubscribeTxnStatus(t *testing.T) {
 		mockChain.EXPECT().TransactionByHash(txHash).Return(nil, db.ErrKeyNotFound)
 		mockSyncer.EXPECT().PendingData().Return(nil, sync.ErrPendingBlockNotFound).Times(2)
 		mockChain.EXPECT().HeadsHeader().Return(nil, db.ErrKeyNotFound).Times(2)
-		fmt.Print("HEre check 0\n")
+
 		id, conn := createTestTxStatusWebsocket(t, handler, txHash)
-		fmt.Print("HEre check 0.1\n")
+
 		assertNextTxnStatus(t, conn, id, txHash, TxnStatusReceived, UnknownExecution, "")
-		fmt.Print("HEre check 0.2\n")
 		// Candidate Status
 		mockChain.EXPECT().TransactionByHash(txHash).Return(nil, db.ErrKeyNotFound)
 		preConfirmed := core.NewPreConfirmed(
@@ -375,7 +374,7 @@ func TestSubscribeTxnStatus(t *testing.T) {
 		handler.preConfirmedFeed.Send(&core.PreConfirmed{
 			Block: &core.Block{Header: &core.Header{}},
 		})
-		fmt.Print("HEre check 1\n")
+
 		assertNextTxnStatus(t, conn, id, txHash, TxnStatusCandidate, UnknownExecution, "")
 		require.Equal(t, block.Transactions[0].Hash(), txHash)
 

--- a/rpc/v9/subscriptions_test.go
+++ b/rpc/v9/subscriptions_test.go
@@ -269,7 +269,8 @@ func TestSubscribeTxnStatus(t *testing.T) {
 		handler := New(mockChain, mockSyncer, nil, "", log).WithSubmittedTransactionsCache(cache)
 
 		mockChain.EXPECT().TransactionByHash(txHash).Return(nil, db.ErrKeyNotFound).AnyTimes()
-		mockSyncer.EXPECT().PendingData().Return(nil, sync.ErrPreConfirmedBlockNotFound).AnyTimes()
+		mockSyncer.EXPECT().PendingData().Return(nil, sync.ErrPendingBlockNotFound).AnyTimes()
+		mockChain.EXPECT().HeadsHeader().Return(nil, db.ErrKeyNotFound).AnyTimes()
 		mockSyncer.EXPECT().PendingBlock().Return(nil).AnyTimes()
 		id, _ := createTestTxStatusWebsocket(t, handler, txHash)
 
@@ -289,14 +290,14 @@ func TestSubscribeTxnStatus(t *testing.T) {
 		mockSyncer := mocks.NewMockSyncReader(mockCtrl)
 		handler := New(mockChain, mockSyncer, nil, "", log)
 		handler.WithFeeder(feeder.NewTestClient(t, &utils.SepoliaIntegration))
-
+		mockSyncer.EXPECT().PendingData().Return(nil, sync.ErrPendingBlockNotFound).AnyTimes()
+		mockChain.EXPECT().HeadsHeader().Return(nil, db.ErrKeyNotFound).AnyTimes()
 		t.Run("reverted", func(t *testing.T) {
 			txHash, err := new(felt.Felt).SetString("0x1011")
 			require.NoError(t, err)
 
 			mockChain.EXPECT().TransactionByHash(txHash).Return(nil, db.ErrKeyNotFound)
-			mockSyncer.EXPECT().PendingData().Return(nil, sync.ErrPreConfirmedBlockNotFound)
-			mockSyncer.EXPECT().PendingBlock().Return(nil)
+
 			id, conn := createTestTxStatusWebsocket(t, handler, txHash)
 			assertNextTxnStatus(t, conn, id, txHash, TxnStatusAcceptedOnL2, TxnFailure, "some error")
 		})
@@ -305,8 +306,6 @@ func TestSubscribeTxnStatus(t *testing.T) {
 			require.NoError(t, err)
 
 			mockChain.EXPECT().TransactionByHash(txHash).Return(nil, db.ErrKeyNotFound)
-			mockSyncer.EXPECT().PendingData().Return(nil, sync.ErrPreConfirmedBlockNotFound)
-			mockSyncer.EXPECT().PendingBlock().Return(nil)
 			id, conn := createTestTxStatusWebsocket(t, handler, txHash)
 			assertNextTxnStatus(t, conn, id, txHash, TxnStatusAcceptedOnL1, TxnSuccess, "")
 		})
@@ -353,11 +352,13 @@ func TestSubscribeTxnStatus(t *testing.T) {
 		require.Nil(t, addErr)
 		txHash := addRes.TransactionHash
 		mockChain.EXPECT().TransactionByHash(txHash).Return(nil, db.ErrKeyNotFound)
-		mockSyncer.EXPECT().PendingData().Return(nil, sync.ErrPreConfirmedBlockNotFound)
-		mockSyncer.EXPECT().PendingBlock().Return(nil)
+		mockSyncer.EXPECT().PendingData().Return(nil, sync.ErrPendingBlockNotFound).Times(2)
+		mockChain.EXPECT().HeadsHeader().Return(nil, db.ErrKeyNotFound).Times(2)
+		fmt.Print("HEre check 0\n")
 		id, conn := createTestTxStatusWebsocket(t, handler, txHash)
-
+		fmt.Print("HEre check 0.1\n")
 		assertNextTxnStatus(t, conn, id, txHash, TxnStatusReceived, UnknownExecution, "")
+		fmt.Print("HEre check 0.2\n")
 		// Candidate Status
 		mockChain.EXPECT().TransactionByHash(txHash).Return(nil, db.ErrKeyNotFound)
 		preConfirmed := core.NewPreConfirmed(
@@ -370,12 +371,11 @@ func TestSubscribeTxnStatus(t *testing.T) {
 		mockSyncer.EXPECT().PendingData().Return(
 			&pendingData,
 			nil,
-		).Times(2)
-		mockSyncer.EXPECT().PendingBlock().Return(nil)
+		).Times(4)
 		handler.preConfirmedFeed.Send(&core.PreConfirmed{
 			Block: &core.Block{Header: &core.Header{}},
 		})
-
+		fmt.Print("HEre check 1\n")
 		assertNextTxnStatus(t, conn, id, txHash, TxnStatusCandidate, UnknownExecution, "")
 		require.Equal(t, block.Transactions[0].Hash(), txHash)
 
@@ -394,7 +394,6 @@ func TestSubscribeTxnStatus(t *testing.T) {
 			CandidateTxs: []core.Transaction{block.Transactions[0]},
 		}
 
-		mockSyncer.EXPECT().PendingBlock().Return(preConfirmed.Block)
 		handler.preConfirmedFeed.Send(&preConfirmed)
 		assertNextTxnStatus(t, conn, id, txHash, TxnStatusPreConfirmed, TxnSuccess, "")
 		// Accepted on l1 Status
@@ -752,7 +751,10 @@ func TestSubscribePendingTxs(t *testing.T) {
 	mockChain := mocks.NewMockReader(mockCtrl)
 	l1Feed := feed.New[*core.L1Head]()
 	mockChain.EXPECT().SubscribeL1Head().Return(blockchain.L1HeadSubscription{Subscription: l1Feed.Subscribe()})
-
+	mockChain.EXPECT().HeadsHeader().Return(&core.Header{
+		ProtocolVersion: "0.14.0",
+		Number:          0,
+	}, nil).Times(3)
 	syncer := newFakeSyncer()
 	handler, server := setupRPC(t, ctx, mockChain, syncer)
 

--- a/rpc/v9/trace.go
+++ b/rpc/v9/trace.go
@@ -106,7 +106,7 @@ func (h *Handler) TraceTransaction(ctx context.Context, hash felt.Felt) (Transac
 	}
 
 	var pendingData *core.PendingData
-	pendingData, err = h.syncReader.PendingData()
+	pendingData, err = h.PendingData()
 	if err != nil {
 		// for traceTransaction handlers there is no block not found error
 		return TransactionTrace{}, httpHeader, rpccore.ErrTxnHashNotFound

--- a/rpc/v9/transaction.go
+++ b/rpc/v9/transaction.go
@@ -491,7 +491,7 @@ func (h *Handler) TransactionByHash(hash felt.Felt) (*Transaction, *jsonrpc.Erro
 		return nil, rpccore.ErrInternal.CloneWithData(err)
 	}
 	// Check pending data
-	preConfirmed, err := h.syncReader.PendingData()
+	preConfirmed, err := h.PendingData()
 	if err != nil {
 		return nil, rpccore.ErrTxnHashNotFound
 	}
@@ -526,7 +526,7 @@ func (h *Handler) TransactionByBlockIDAndIndex(
 	}
 
 	if blockID.IsPreConfirmed() {
-		pending, err := h.syncReader.PendingData()
+		pending, err := h.PendingData()
 		if err != nil {
 			return nil, rpccore.ErrBlockNotFound
 		}
@@ -567,7 +567,7 @@ func (h *Handler) TransactionReceiptByHash(hash felt.Felt) (*TransactionReceipt,
 			return nil, rpccore.ErrInternal.CloneWithData(err)
 		}
 
-		preconfirmedB = h.syncReader.PendingBlock()
+		preconfirmedB = h.PendingBlock()
 		if preconfirmedB == nil {
 			return nil, rpccore.ErrTxnHashNotFound
 		}
@@ -743,7 +743,7 @@ func (h *Handler) TransactionStatus(ctx context.Context, hash felt.Felt) (Transa
 		// Search pre-confirmed block for 'CANDIDATE' status
 		var txStatus *starknet.TransactionStatus
 		var err error
-		preConfirmedB, err := h.syncReader.PendingData()
+		preConfirmedB, err := h.PendingData()
 
 		if err == nil {
 			for _, txn := range preConfirmedB.GetCandidateTransaction() {

--- a/sync/sync.go
+++ b/sync/sync.go
@@ -25,7 +25,6 @@ var (
 	_ Reader          = (*Synchronizer)(nil)
 
 	ErrPendingBlockNotFound          = errors.New("pending block not found")
-	ErrPreConfirmedBlockNotFound     = errors.New("pre_confirmed block not found")
 	ErrMustSwitchPollingPreConfirmed = errors.New(
 		"reached starknet 0.14.0. node requires switching from pending to polling pre_confirmed blocks",
 	)


### PR DESCRIPTION
It is possible for receiving `ErrPendingBlockNotFound`, even though pending data is not nil. Accessor for pending data checks if pending data complies with semantics if not returns `ErrPendingBlockNotFound`. In between pending data is fetched and latest header is fetched there is chance that latest is updated by new block thus invalidates the pending data we fetched. In such cases we will return empty pending data for latest header