### PR TITLE
rpcv9 handling for rejeceted historical txs

### DIFF
--- a/rpc/v9/subscriptions.go
+++ b/rpc/v9/subscriptions.go
@@ -375,7 +375,7 @@ func (h *Handler) checkTxStatus(
 		return lastStatus, err
 	}
 
-	if status.Finality == TxnStatusRejected || status.Finality == TxnStatusAcceptedOnL1 {
+	if status.Finality == TxnStatusAcceptedOnL1 {
 		sub.cancel()
 	}
 


### PR DESCRIPTION
Upon querying historical transaction status, gateway returns finality status as `RECEIVED` for `REJECTED` transaction and this was resulting in returning `RECEIVED` status in our current implementation. This PR addressses this issue and returns "transaction not found" error instead. Spec does not support `REJECTED` status in RPCv9.