### PR TITLE
Fix: GetNonce method in RPCv09 not working with 'pre_confirmed'

### DIFF
--- a/rpc/handlers.go
+++ b/rpc/handlers.go
@@ -162,7 +162,7 @@ func (h *Handler) MethodsV0_9() ([]jsonrpc.Method, string) { //nolint:funlen,dup
 		{
 			Name:    "starknet_getNonce",
 			Params:  []jsonrpc.Parameter{{Name: "block_id"}, {Name: "contract_address"}},
-			Handler: h.rpcv6Handler.Nonce,
+			Handler: h.rpcv9Handler.Nonce,
 		},
 		{
 			Name:    "starknet_getStorageAt",

--- a/rpc/v6/block.go
+++ b/rpc/v6/block.go
@@ -69,10 +69,16 @@ type BlockID struct {
 }
 
 func (b *BlockID) UnmarshalJSON(data []byte) error {
-	if string(data) == `"latest"` {
-		b.Latest = true
-	} else if string(data) == `"pending"` {
-		b.Pending = true
+	var blockTag string
+	if err := json.Unmarshal(data, &blockTag); err == nil {
+		switch blockTag {
+		case "latest":
+			b.Latest = true
+		case "pending":
+			b.Pending = true
+		default:
+			return fmt.Errorf("unknown block tag '%s'", blockTag)
+		}
 	} else {
 		jsonObject := make(map[string]json.RawMessage)
 		if err := json.Unmarshal(data, &jsonObject); err != nil {

--- a/rpc/v7/block.go
+++ b/rpc/v7/block.go
@@ -3,6 +3,7 @@ package rpcv7
 import (
 	"encoding/json"
 	"errors"
+	"fmt"
 
 	"github.com/NethermindEth/juno/core"
 	"github.com/NethermindEth/juno/core/felt"
@@ -35,10 +36,16 @@ func (b *BlockID) GetNumber() uint64 {
 }
 
 func (b *BlockID) UnmarshalJSON(data []byte) error {
-	if string(data) == `"latest"` {
-		b.Latest = true
-	} else if string(data) == `"pending"` {
-		b.Pending = true
+	var blockTag string
+	if err := json.Unmarshal(data, &blockTag); err == nil {
+		switch blockTag {
+		case "latest":
+			b.Latest = true
+		case "pending":
+			b.Pending = true
+		default:
+			return fmt.Errorf("unknown block tag '%s'", blockTag)
+		}
 	} else {
 		jsonObject := make(map[string]json.RawMessage)
 		if err := json.Unmarshal(data, &jsonObject); err != nil {

--- a/rpc/v8/block.go
+++ b/rpc/v8/block.go
@@ -90,10 +90,16 @@ func (b *BlockID) Number() uint64 {
 }
 
 func (b *BlockID) UnmarshalJSON(data []byte) error {
-	if string(data) == `"latest"` {
-		b.typeID = latest
-	} else if string(data) == `"pending"` {
-		b.typeID = pending
+	var blockTag string
+	if err := json.Unmarshal(data, &blockTag); err == nil {
+		switch blockTag {
+		case "latest":
+			b.typeID = latest
+		case "pending":
+			b.typeID = pending
+		default:
+			return fmt.Errorf("unknown block tag '%s'", blockTag)
+		}
 	} else {
 		jsonObject := make(map[string]json.RawMessage)
 		if err := json.Unmarshal(data, &jsonObject); err != nil {

--- a/rpc/v9/block.go
+++ b/rpc/v9/block.go
@@ -115,10 +115,16 @@ func (b *BlockID) Number() uint64 {
 }
 
 func (b *BlockID) UnmarshalJSON(data []byte) error {
-	if string(data) == `"latest"` {
-		b.typeID = latest
-	} else if string(data) == `"pre_confirmed"` {
-		b.typeID = preConfirmed
+	var blockTag string
+	if err := json.Unmarshal(data, &blockTag); err == nil {
+		switch blockTag {
+		case "latest":
+			b.typeID = latest
+		case "pre_confirmed":
+			b.typeID = preConfirmed
+		default:
+			return fmt.Errorf("unknown block tag '%s'", blockTag)
+		}
 	} else {
 		jsonObject := make(map[string]json.RawMessage)
 		if err := json.Unmarshal(data, &jsonObject); err != nil {

--- a/rpc/v9/handlers.go
+++ b/rpc/v9/handlers.go
@@ -277,6 +277,11 @@ func (h *Handler) methods() ([]jsonrpc.Method, string) { //nolint: funlen
 			Handler: h.EstimateMessageFee,
 		},
 		{
+			Name:    "starknet_getNonce",
+			Params:  []jsonrpc.Parameter{{Name: "block_id"}, {Name: "contract_address"}},
+			Handler: h.Nonce,
+		},
+		{
 			Name:    "starknet_traceTransaction",
 			Params:  []jsonrpc.Parameter{{Name: "transaction_hash"}},
 			Handler: h.TraceTransaction,

--- a/rpc/v9/nonce.go
+++ b/rpc/v9/nonce.go
@@ -13,7 +13,7 @@ import (
 // Nonce returns the nonce associated with the given address in the given block number
 //
 // It follows the specification defined here:
-// https://github.com/starkware-libs/starknet-specs/blob/a789ccc3432c57777beceaa53a34a7ae2f25fda0/api/starknet_api_openrpc.json#L633
+// https://github.com/starkware-libs/starknet-specs/blob/25533f8b7999219120a4a654709d47dc9376d640/api/starknet_api_openrpc.json#L851
 func (h *Handler) Nonce(id *BlockID, address felt.Felt) (*felt.Felt, *jsonrpc.Error) {
 	stateReader, stateCloser, rpcErr := h.stateByBlockID(id)
 	if rpcErr != nil {

--- a/rpc/v9/nonce.go
+++ b/rpc/v9/nonce.go
@@ -1,0 +1,30 @@
+package rpcv9
+
+import (
+	"github.com/NethermindEth/juno/core/felt"
+	"github.com/NethermindEth/juno/jsonrpc"
+	rpccore "github.com/NethermindEth/juno/rpc/rpccore"
+)
+
+/****************************************************
+		Nonce Handler
+*****************************************************/
+
+// Nonce returns the nonce associated with the given address in the given block number
+//
+// It follows the specification defined here:
+// https://github.com/starkware-libs/starknet-specs/blob/a789ccc3432c57777beceaa53a34a7ae2f25fda0/api/starknet_api_openrpc.json#L633
+func (h *Handler) Nonce(id *BlockID, address felt.Felt) (*felt.Felt, *jsonrpc.Error) {
+	stateReader, stateCloser, rpcErr := h.stateByBlockID(id)
+	if rpcErr != nil {
+		return nil, rpcErr
+	}
+	defer h.callAndLogErr(stateCloser, "Error closing state reader in getNonce")
+
+	nonce, err := stateReader.ContractNonce(&address)
+	if err != nil {
+		return nil, rpccore.ErrContractNotFound
+	}
+
+	return nonce, nil
+}

--- a/rpc/v9/nonce_test.go
+++ b/rpc/v9/nonce_test.go
@@ -1,0 +1,106 @@
+package rpcv9_test
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/NethermindEth/juno/core/felt"
+	"github.com/NethermindEth/juno/db"
+	"github.com/NethermindEth/juno/mocks"
+	"github.com/NethermindEth/juno/rpc/rpccore"
+	rpc "github.com/NethermindEth/juno/rpc/v9"
+	"github.com/NethermindEth/juno/utils"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+)
+
+func TestNonce(t *testing.T) {
+	mockCtrl := gomock.NewController(t)
+
+	mockReader := mocks.NewMockReader(mockCtrl)
+	mockSyncReader := mocks.NewMockSyncReader(mockCtrl)
+	log := utils.NewNopZapLogger()
+	handler := rpc.New(mockReader, mockSyncReader, nil, "", log)
+
+	t.Run("empty blockchain", func(t *testing.T) {
+		mockReader.EXPECT().HeadState().Return(nil, nil, db.ErrKeyNotFound)
+
+		latest := blockIDLatest(t)
+		nonce, rpcErr := handler.Nonce(&latest, felt.Zero)
+		require.Nil(t, nonce)
+		assert.Equal(t, rpccore.ErrBlockNotFound, rpcErr)
+	})
+
+	t.Run("non-existent block hash", func(t *testing.T) {
+		mockReader.EXPECT().StateAtBlockHash(&felt.Zero).Return(nil, nil, db.ErrKeyNotFound)
+
+		hash := blockIDHash(t, &felt.Zero)
+		nonce, rpcErr := handler.Nonce(&hash, felt.Zero)
+		require.Nil(t, nonce)
+		assert.Equal(t, rpccore.ErrBlockNotFound, rpcErr)
+	})
+
+	t.Run("non-existent block number", func(t *testing.T) {
+		mockReader.EXPECT().StateAtBlockNumber(uint64(0)).Return(nil, nil, db.ErrKeyNotFound)
+
+		number := blockIDNumber(t, 0)
+		nonce, rpcErr := handler.Nonce(&number, felt.Zero)
+		require.Nil(t, nonce)
+		assert.Equal(t, rpccore.ErrBlockNotFound, rpcErr)
+	})
+
+	mockState := mocks.NewMockStateHistoryReader(mockCtrl)
+
+	t.Run("non-existent contract", func(t *testing.T) {
+		mockReader.EXPECT().HeadState().Return(mockState, nopCloser, nil)
+		mockState.EXPECT().ContractNonce(&felt.Zero).Return(nil, errors.New("non-existent contract"))
+
+		latest := blockIDLatest(t)
+		nonce, rpcErr := handler.Nonce(&latest, felt.Zero)
+		require.Nil(t, nonce)
+		assert.Equal(t, rpccore.ErrContractNotFound, rpcErr)
+	})
+
+	expectedNonce := new(felt.Felt).SetUint64(1)
+
+	t.Run("blockID - latest", func(t *testing.T) {
+		mockReader.EXPECT().HeadState().Return(mockState, nopCloser, nil)
+		mockState.EXPECT().ContractNonce(&felt.Zero).Return(expectedNonce, nil)
+
+		latest := blockIDLatest(t)
+		nonce, rpcErr := handler.Nonce(&latest, felt.Zero)
+		require.Nil(t, rpcErr)
+		assert.Equal(t, expectedNonce, nonce)
+	})
+
+	t.Run("blockID - hash", func(t *testing.T) {
+		mockReader.EXPECT().StateAtBlockHash(&felt.Zero).Return(mockState, nopCloser, nil)
+		mockState.EXPECT().ContractNonce(&felt.Zero).Return(expectedNonce, nil)
+
+		hash := blockIDHash(t, &felt.Zero)
+		nonce, rpcErr := handler.Nonce(&hash, felt.Zero)
+		require.Nil(t, rpcErr)
+		assert.Equal(t, expectedNonce, nonce)
+	})
+
+	t.Run("blockID - number", func(t *testing.T) {
+		mockReader.EXPECT().StateAtBlockNumber(uint64(0)).Return(mockState, nopCloser, nil)
+		mockState.EXPECT().ContractNonce(&felt.Zero).Return(expectedNonce, nil)
+
+		number := blockIDNumber(t, 0)
+		nonce, rpcErr := handler.Nonce(&number, felt.Zero)
+		require.Nil(t, rpcErr)
+		assert.Equal(t, expectedNonce, nonce)
+	})
+
+	t.Run("blockID - pre_confirmed", func(t *testing.T) {
+		mockSyncReader.EXPECT().PendingState().Return(mockState, nopCloser, nil)
+		mockState.EXPECT().ContractNonce(&felt.Zero).Return(expectedNonce, nil)
+
+		pendingBlockID := blockIDPreConfirmed(t)
+		nonce, rpcErr := handler.Nonce(&pendingBlockID, felt.Zero)
+		require.Nil(t, rpcErr)
+		assert.Equal(t, expectedNonce, nonce)
+	})
+}


### PR DESCRIPTION
- Fix the issue with the GetNonce method not working with 'pre_confirmed' block tag
- Add a user-friendly warning when a user passes a wrong block tag 