### PR TITLE
fix: pending data wrappers pending block missing `block_number`

### DIFF
--- a/rpc/v6/pending_data_wrapper.go
+++ b/rpc/v6/pending_data_wrapper.go
@@ -42,6 +42,7 @@ func emptyPendingForParent(parentHeader *core.Header) sync.Pending {
 	pendingBlock := &core.Block{
 		Header: &core.Header{
 			ParentHash:       parentHeader.Hash,
+			Number:           parentHeader.Number + 1,
 			SequencerAddress: parentHeader.SequencerAddress,
 			Timestamp:        uint64(time.Now().Unix()),
 			ProtocolVersion:  parentHeader.ProtocolVersion,

--- a/rpc/v6/pending_data_wrapper_test.go
+++ b/rpc/v6/pending_data_wrapper_test.go
@@ -59,6 +59,7 @@ func TestPendingDataWrapper(t *testing.T) {
 		expectedPendingB := &core.Block{
 			Header: &core.Header{
 				ParentHash:       latestBlock.Hash,
+				Number:           latestBlockNumber + 1,
 				SequencerAddress: latestBlock.SequencerAddress,
 				Timestamp:        uint64(time.Now().Unix()),
 				ProtocolVersion:  latestBlock.ProtocolVersion,

--- a/rpc/v7/pending_data_wrapper.go
+++ b/rpc/v7/pending_data_wrapper.go
@@ -42,6 +42,7 @@ func emptyPendingForParent(parentHeader *core.Header) sync.Pending {
 	pendingBlock := &core.Block{
 		Header: &core.Header{
 			ParentHash:       parentHeader.Hash,
+			Number:           parentHeader.Number + 1,
 			SequencerAddress: parentHeader.SequencerAddress,
 			Timestamp:        uint64(time.Now().Unix()),
 			ProtocolVersion:  parentHeader.ProtocolVersion,

--- a/rpc/v7/pending_data_wrapper_test.go
+++ b/rpc/v7/pending_data_wrapper_test.go
@@ -60,6 +60,7 @@ func TestPendingDataWrapper(t *testing.T) {
 		expectedPendingB := &core.Block{
 			Header: &core.Header{
 				ParentHash:       latestBlock.Hash,
+				Number:           latestBlockNumber + 1,
 				SequencerAddress: latestBlock.SequencerAddress,
 				Timestamp:        uint64(time.Now().Unix()),
 				ProtocolVersion:  latestBlock.ProtocolVersion,

--- a/rpc/v8/pending_data_wrapper.go
+++ b/rpc/v8/pending_data_wrapper.go
@@ -42,6 +42,7 @@ func emptyPendingForParent(parentHeader *core.Header) sync.Pending {
 	pendingBlock := &core.Block{
 		Header: &core.Header{
 			ParentHash:       parentHeader.Hash,
+			Number:           parentHeader.Number + 1,
 			SequencerAddress: parentHeader.SequencerAddress,
 			Timestamp:        uint64(time.Now().Unix()),
 			ProtocolVersion:  parentHeader.ProtocolVersion,

--- a/rpc/v8/pending_data_wrapper_test.go
+++ b/rpc/v8/pending_data_wrapper_test.go
@@ -60,6 +60,7 @@ func TestPendingDataWrapper(t *testing.T) {
 		expectedPendingB := &core.Block{
 			Header: &core.Header{
 				ParentHash:       latestBlock.Hash,
+				Number:           latestBlockNumber + 1,
 				SequencerAddress: latestBlock.SequencerAddress,
 				Timestamp:        uint64(time.Now().Unix()),
 				ProtocolVersion:  latestBlock.ProtocolVersion,

--- a/rpc/v9/pending_data_wrapper.go
+++ b/rpc/v9/pending_data_wrapper.go
@@ -69,6 +69,7 @@ func emptyPendingForParent(parentHeader *core.Header) sync.Pending {
 	pendingBlock := &core.Block{
 		Header: &core.Header{
 			ParentHash:       parentHeader.Hash,
+			Number:           parentHeader.Number + 1,
 			SequencerAddress: parentHeader.SequencerAddress,
 			Timestamp:        uint64(time.Now().Unix()),
 			ProtocolVersion:  parentHeader.ProtocolVersion,
@@ -107,8 +108,8 @@ func emptyPreConfirmedForParent(parentHeader *core.Header) core.PreConfirmed {
 	preConfirmedBlock := &core.Block{
 		// pre_confirmed block does not have parent hash
 		Header: &core.Header{
-			SequencerAddress: parentHeader.SequencerAddress,
 			Number:           parentHeader.Number + 1,
+			SequencerAddress: parentHeader.SequencerAddress,
 			Timestamp:        uint64(time.Now().Unix()),
 			ProtocolVersion:  parentHeader.ProtocolVersion,
 			EventsBloom:      core.EventsBloom(receipts),


### PR DESCRIPTION
Pending block does not have `block_number` but we need to assign one for internal use, as we do in sync package. This was missed in pending data wrappers when creating empty pending block.  As a result, the block_number defaulted to 0 during VM executions on the pending block, causing incorrect behavior in RPC versions below 9 when running on network version 0.14.0.