### PR TITLE
refactor: Turn mempool.Pool into an interface

### DIFF
--- a/consensus/driver/mock_proposer_test.go
+++ b/consensus/driver/mock_proposer_test.go
@@ -32,7 +32,11 @@ func (m *mockProposer) Valid(value starknet.Value) bool {
 	return true
 }
 
-func (m *mockProposer) Submit(transactions []mempool.BroadcastedTransaction) {
+func (m *mockProposer) Submit(ctx context.Context, transactions []mempool.BroadcastedTransaction) {
+}
+
+func (m *mockProposer) Push(ctx context.Context, transaction *mempool.BroadcastedTransaction) error {
+	return nil
 }
 
 func (m *mockProposer) Pending() *sync.Pending {

--- a/consensus/proposer/proposer_test.go
+++ b/consensus/proposer/proposer_test.go
@@ -80,7 +80,7 @@ func TestProposer(t *testing.T) {
 	t.Run("Receive transactions", func(t *testing.T) {
 		for i, batch := range firstBatches {
 			t.Run(fmt.Sprintf("Batch size %d", len(batch)), func(t *testing.T) {
-				submit(p, batch)
+				submit(t, p, batch)
 				requireEventually(t, len(batch), func(c *assert.CollectT) {
 					assert.Equal(c, slices.Concat(firstBatches[:i+1]...), p.Pending().Block.Transactions)
 				})
@@ -94,7 +94,7 @@ func TestProposer(t *testing.T) {
 
 		for _, batch := range secondBatches {
 			t.Run(fmt.Sprintf("Submitting %d more transactions", len(batch)), func(t *testing.T) {
-				submit(p, batch)
+				submit(t, p, batch)
 			})
 		}
 
@@ -113,7 +113,7 @@ func TestProposer(t *testing.T) {
 
 		for i, batch := range committedFirstBatches {
 			t.Run(fmt.Sprintf("Batch size %d", len(batch)), func(t *testing.T) {
-				submit(otherProposer, batch)
+				submit(t, otherProposer, batch)
 				requireEventually(t, len(batch), func(c *assert.CollectT) {
 					assert.Equal(c, slices.Concat(committedFirstBatches[:i+1]...), otherProposer.Pending().Block.Transactions)
 				})
@@ -263,7 +263,8 @@ func buildRandomTransaction(t *testing.T, nonce uint64) core.Transaction {
 	}
 }
 
-func submit(proposer proposer.Proposer[starknet.Value, starknet.Hash], batch []core.Transaction) {
+func submit(t *testing.T, proposer proposer.Proposer[starknet.Value, starknet.Hash], batch []core.Transaction) {
+	t.Helper()
 	transactions := make([]mempool.BroadcastedTransaction, len(batch))
 	for i, transaction := range batch {
 		transactions[i] = mempool.BroadcastedTransaction{
@@ -271,7 +272,7 @@ func submit(proposer proposer.Proposer[starknet.Value, starknet.Hash], batch []c
 		}
 	}
 
-	proposer.Submit(transactions)
+	proposer.Submit(t.Context(), transactions)
 }
 
 func assertValue(

--- a/mempool/mempool.go
+++ b/mempool/mempool.go
@@ -1,6 +1,7 @@
 package mempool
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"sync"
@@ -11,6 +12,10 @@ import (
 	"github.com/NethermindEth/juno/db"
 	"github.com/NethermindEth/juno/utils"
 )
+
+type Pool interface {
+	Push(context.Context, *BroadcastedTransaction) error
+}
 
 var (
 	ErrTxnPoolFull  = errors.New("transaction pool is full")
@@ -104,9 +109,9 @@ func (t *memTxnList) popBatch(numToPop int) ([]BroadcastedTransaction, error) {
 	return result, nil
 }
 
-// Pool represents a blockchain mempool, managing transactions using both an
+// SequencerMempool represents a blockchain mempool, managing transactions using both an
 // in-memory and persistent database.
-type Pool struct {
+type SequencerMempool struct {
 	log         utils.SimpleLogger
 	bc          blockchain.Reader
 	db          db.KeyValueStore // to store the persistent mempool
@@ -119,8 +124,8 @@ type Pool struct {
 
 // New initialises the Pool and starts the database writer goroutine.
 // It is the responsibility of the caller to execute the closer function.
-func New(mainDB db.KeyValueStore, bc blockchain.Reader, maxNumTxns int, log utils.SimpleLogger) *Pool {
-	pool := Pool{
+func New(mainDB db.KeyValueStore, bc blockchain.Reader, maxNumTxns int, log utils.SimpleLogger) *SequencerMempool {
+	pool := SequencerMempool{
 		log:         log,
 		bc:          bc,
 		db:          mainDB, // todo: txns should be deleted everytime a new block is stored (builder responsibility)
@@ -133,12 +138,12 @@ func New(mainDB db.KeyValueStore, bc blockchain.Reader, maxNumTxns int, log util
 	return &pool
 }
 
-func (p *Pool) Close() {
+func (p *SequencerMempool) Close() {
 	close(p.dbWriteChan)
 	p.wg.Wait()
 }
 
-func (p *Pool) dbWriter() {
+func (p *SequencerMempool) dbWriter() {
 	p.wg.Add(1)
 	go func() {
 		defer p.wg.Done()
@@ -152,7 +157,7 @@ func (p *Pool) dbWriter() {
 }
 
 // LoadFromDB restores the in-memory transaction pool from the database
-func (p *Pool) LoadFromDB() error {
+func (p *SequencerMempool) LoadFromDB() error {
 	headVal, err := GetHeadValue(p.db)
 	if err != nil {
 		if errors.Is(err, db.ErrKeyNotFound) {
@@ -175,7 +180,7 @@ func (p *Pool) LoadFromDB() error {
 }
 
 // writeToDB adds the transaction to the persistent pool db
-func (p *Pool) writeToDB(userTxn *BroadcastedTransaction) error {
+func (p *SequencerMempool) writeToDB(userTxn *BroadcastedTransaction) error {
 	batch := p.db.NewBatch()
 
 	var tailVal *felt.Felt
@@ -228,7 +233,7 @@ func (p *Pool) writeToDB(userTxn *BroadcastedTransaction) error {
 }
 
 // Push queues a transaction to the pool
-func (p *Pool) Push(userTxn *BroadcastedTransaction) error {
+func (p *SequencerMempool) Push(ctx context.Context, userTxn *BroadcastedTransaction) error {
 	p.log.Debugw("mempool received transaction for pre-processing")
 	err := p.validate(userTxn)
 	if err != nil {
@@ -262,7 +267,7 @@ func (p *Pool) Push(userTxn *BroadcastedTransaction) error {
 	return nil
 }
 
-func (p *Pool) validate(userTxn *BroadcastedTransaction) error {
+func (p *SequencerMempool) validate(userTxn *BroadcastedTransaction) error {
 	if p.memTxnList.len+1 >= p.maxNumTxns {
 		return ErrTxnPoolFull
 	}
@@ -312,12 +317,12 @@ func (p *Pool) validate(userTxn *BroadcastedTransaction) error {
 }
 
 // Pop returns the transaction with the highest priority from the in-memory pool
-func (p *Pool) Pop() (BroadcastedTransaction, error) {
+func (p *SequencerMempool) Pop() (BroadcastedTransaction, error) {
 	return p.memTxnList.pop()
 }
 
 // PopBatch returns a batch of transactions with the highest priority from the in-memory pool
-func (p *Pool) PopBatch(numToPop int) ([]BroadcastedTransaction, error) {
+func (p *SequencerMempool) PopBatch(numToPop int) ([]BroadcastedTransaction, error) {
 	if numToPop <= 0 {
 		return []BroadcastedTransaction{}, nil
 	}
@@ -327,19 +332,19 @@ func (p *Pool) PopBatch(numToPop int) ([]BroadcastedTransaction, error) {
 // Remove removes a set of transactions from the pool
 // todo: should be called by the builder to remove txns from the db everytime a new block is stored.
 // todo: in the consensus+p2p world, the txns should also be removed from the in-memory pool.
-func (p *Pool) Remove(hash ...*felt.Felt) error {
+func (p *SequencerMempool) Remove(hash ...*felt.Felt) error {
 	return errors.New("not implemented")
 }
 
 // Len returns the number of transactions in the in-memory pool
-func (p *Pool) Len() int {
+func (p *SequencerMempool) Len() int {
 	return p.memTxnList.len
 }
 
-func (p *Pool) Wait() <-chan struct{} {
+func (p *SequencerMempool) Wait() <-chan struct{} {
 	return p.txPushed
 }
 
-func (p *Pool) LenDB() (int, error) {
+func (p *SequencerMempool) LenDB() (int, error) {
 	return GetLenDB(p.db)
 }

--- a/mempool/mempool_test.go
+++ b/mempool/mempool_test.go
@@ -63,7 +63,7 @@ func TestMempool(t *testing.T) {
 		senderAddress := new(felt.Felt).SetUint64(i)
 		chain.EXPECT().HeadState().Return(state, func() error { return nil }, nil)
 		state.EXPECT().ContractNonce(senderAddress).Return(&felt.Zero, nil)
-		require.NoError(t, pool.Push(&mempool.BroadcastedTransaction{
+		require.NoError(t, pool.Push(t.Context(), &mempool.BroadcastedTransaction{
 			Transaction: &core.InvokeTransaction{
 				TransactionHash: new(felt.Felt).SetUint64(i),
 				Nonce:           new(felt.Felt).SetUint64(1),
@@ -86,7 +86,7 @@ func TestMempool(t *testing.T) {
 		senderAddress := new(felt.Felt).SetUint64(i)
 		chain.EXPECT().HeadState().Return(state, func() error { return nil }, nil)
 		state.EXPECT().ContractNonce(senderAddress).Return(&felt.Zero, nil)
-		require.NoError(t, pool.Push(&mempool.BroadcastedTransaction{
+		require.NoError(t, pool.Push(t.Context(), &mempool.BroadcastedTransaction{
 			Transaction: &core.InvokeTransaction{
 				TransactionHash: new(felt.Felt).SetUint64(i),
 				Nonce:           new(felt.Felt).SetUint64(1),
@@ -98,7 +98,7 @@ func TestMempool(t *testing.T) {
 	}
 
 	// push more than max
-	require.ErrorIs(t, pool.Push(&mempool.BroadcastedTransaction{
+	require.ErrorIs(t, pool.Push(t.Context(), &mempool.BroadcastedTransaction{
 		Transaction: &core.InvokeTransaction{
 			TransactionHash: new(felt.Felt).SetUint64(123),
 		},
@@ -148,7 +148,7 @@ func TestRestoreMempool(t *testing.T) {
 				Nonce:           new(felt.Felt).SetUint64(0),
 			},
 		}
-		require.NoError(t, pool.Push(&tx))
+		require.NoError(t, pool.Push(t.Context(), &tx))
 		expectedTxs[i-1] = tx
 		require.Equal(t, int(i), pool.Len())
 	}
@@ -215,7 +215,7 @@ func TestWait(t *testing.T) {
 
 	// One transaction.
 	require.NoError(t, bc.Store(block0, &core.BlockCommitments{}, stateUpdate0, nil))
-	require.NoError(t, pool.Push(&mempool.BroadcastedTransaction{
+	require.NoError(t, pool.Push(t.Context(), &mempool.BroadcastedTransaction{
 		Transaction: &core.InvokeTransaction{
 			TransactionHash: new(felt.Felt).SetUint64(1),
 			Nonce:           new(felt.Felt).SetUint64(5),
@@ -263,7 +263,7 @@ func TestPopBatch(t *testing.T) {
 			senderAddress := new(felt.Felt).SetUint64(i)
 			chain.EXPECT().HeadState().Return(state, func() error { return nil }, nil)
 			state.EXPECT().ContractNonce(senderAddress).Return(&felt.Zero, nil)
-			require.NoError(t, pool.Push(&mempool.BroadcastedTransaction{
+			require.NoError(t, pool.Push(t.Context(), &mempool.BroadcastedTransaction{
 				Transaction: &core.InvokeTransaction{
 					TransactionHash: new(felt.Felt).SetUint64(i),
 					Nonce:           new(felt.Felt).SetUint64(1),

--- a/rpc/handlers.go
+++ b/rpc/handlers.go
@@ -82,7 +82,7 @@ func (h *Handler) WithGateway(gatewayClient rpccore.Gateway) *Handler {
 	return h
 }
 
-func (h *Handler) WithMempool(memPool *mempool.Pool) *Handler {
+func (h *Handler) WithMempool(memPool mempool.Pool) *Handler {
 	h.rpcv6Handler.WithMempool(memPool)
 	h.rpcv8Handler.WithMempool(memPool)
 	h.rpcv9Handler.WithMempool(memPool)

--- a/rpc/v6/handlers.go
+++ b/rpc/v6/handlers.go
@@ -35,7 +35,7 @@ type Handler struct {
 	idgen         func() uint64
 	subscriptions stdsync.Map // map[uint64]*subscription
 	newHeads      *feed.Feed[*core.Block]
-	memPool       *mempool.Pool
+	memPool       mempool.Pool
 
 	log                        utils.Logger
 	blockTraceCache            *lru.Cache[traceCacheKey, []TracedBlockTransaction]
@@ -72,7 +72,7 @@ func New(bcReader blockchain.Reader, syncReader sync.Reader, virtualMachine vm.V
 	}
 }
 
-func (h *Handler) WithMempool(memPool *mempool.Pool) *Handler {
+func (h *Handler) WithMempool(memPool mempool.Pool) *Handler {
 	h.memPool = memPool
 	return h
 }

--- a/rpc/v6/transaction.go
+++ b/rpc/v6/transaction.go
@@ -586,7 +586,7 @@ func (h *Handler) AddTransaction(ctx context.Context, tx BroadcastedTransaction)
 		err *jsonrpc.Error
 	)
 	if h.memPool != nil {
-		res, err = h.addToMempool(&tx)
+		res, err = h.addToMempool(ctx, &tx)
 	} else {
 		res, err = h.pushToFeederGateway(ctx, tx)
 	}
@@ -602,12 +602,12 @@ func (h *Handler) AddTransaction(ctx context.Context, tx BroadcastedTransaction)
 	return res, nil
 }
 
-func (h *Handler) addToMempool(tx *BroadcastedTransaction) (*AddTxResponse, *jsonrpc.Error) {
+func (h *Handler) addToMempool(ctx context.Context, tx *BroadcastedTransaction) (*AddTxResponse, *jsonrpc.Error) {
 	userTxn, userClass, paidFeeOnL1, err := AdaptBroadcastedTransaction(tx, h.bcReader.Network())
 	if err != nil {
 		return nil, rpccore.ErrInternal.CloneWithData(err.Error())
 	}
-	if err = h.memPool.Push(&mempool.BroadcastedTransaction{
+	if err = h.memPool.Push(ctx, &mempool.BroadcastedTransaction{
 		Transaction:   userTxn,
 		DeclaredClass: userClass,
 		PaidFeeOnL1:   paidFeeOnL1,

--- a/rpc/v8/handlers.go
+++ b/rpc/v8/handlers.go
@@ -32,7 +32,7 @@ type Handler struct {
 	feederClient  *feeder.Client
 	vm            vm.VM
 	log           utils.Logger
-	memPool       *mempool.Pool
+	memPool       mempool.Pool
 
 	version     string
 	newHeads    *feed.Feed[*core.Block]
@@ -88,7 +88,7 @@ func New(bcReader blockchain.Reader, syncReader sync.Reader, virtualMachine vm.V
 	}
 }
 
-func (h *Handler) WithMempool(memPool *mempool.Pool) *Handler {
+func (h *Handler) WithMempool(memPool mempool.Pool) *Handler {
 	h.memPool = memPool
 	return h
 }

--- a/rpc/v8/transaction.go
+++ b/rpc/v8/transaction.go
@@ -606,7 +606,7 @@ func (h *Handler) AddTransaction(ctx context.Context, tx BroadcastedTransaction)
 		err *jsonrpc.Error
 	)
 	if h.memPool != nil {
-		res, err = h.addToMempool(&tx)
+		res, err = h.addToMempool(ctx, &tx)
 	} else {
 		res, err = h.pushToFeederGateway(ctx, tx)
 	}
@@ -622,12 +622,12 @@ func (h *Handler) AddTransaction(ctx context.Context, tx BroadcastedTransaction)
 	return res, nil
 }
 
-func (h *Handler) addToMempool(tx *BroadcastedTransaction) (*AddTxResponse, *jsonrpc.Error) {
+func (h *Handler) addToMempool(ctx context.Context, tx *BroadcastedTransaction) (*AddTxResponse, *jsonrpc.Error) {
 	userTxn, userClass, paidFeeOnL1, err := AdaptBroadcastedTransaction(tx, h.bcReader.Network())
 	if err != nil {
 		return nil, rpccore.ErrInternal.CloneWithData(err.Error())
 	}
-	if err = h.memPool.Push(&mempool.BroadcastedTransaction{
+	if err = h.memPool.Push(ctx, &mempool.BroadcastedTransaction{
 		Transaction:   userTxn,
 		DeclaredClass: userClass,
 		PaidFeeOnL1:   paidFeeOnL1,

--- a/rpc/v9/handlers.go
+++ b/rpc/v9/handlers.go
@@ -32,7 +32,7 @@ type Handler struct {
 	feederClient  *feeder.Client
 	vm            vm.VM
 	log           utils.Logger
-	memPool       *mempool.Pool
+	memPool       mempool.Pool
 
 	version     string
 	newHeads    *feed.Feed[*core.Block]
@@ -88,7 +88,7 @@ func New(bcReader blockchain.Reader, syncReader sync.Reader, virtualMachine vm.V
 	}
 }
 
-func (h *Handler) WithMempool(memPool *mempool.Pool) *Handler {
+func (h *Handler) WithMempool(memPool mempool.Pool) *Handler {
 	h.memPool = memPool
 	return h
 }

--- a/rpc/v9/transaction.go
+++ b/rpc/v9/transaction.go
@@ -606,7 +606,7 @@ func (h *Handler) AddTransaction(ctx context.Context, tx BroadcastedTransaction)
 		err *jsonrpc.Error
 	)
 	if h.memPool != nil {
-		res, err = h.addToMempool(&tx)
+		res, err = h.addToMempool(ctx, &tx)
 	} else {
 		res, err = h.pushToFeederGateway(ctx, tx)
 	}
@@ -622,12 +622,12 @@ func (h *Handler) AddTransaction(ctx context.Context, tx BroadcastedTransaction)
 	return res, nil
 }
 
-func (h *Handler) addToMempool(tx *BroadcastedTransaction) (*AddTxResponse, *jsonrpc.Error) {
+func (h *Handler) addToMempool(ctx context.Context, tx *BroadcastedTransaction) (*AddTxResponse, *jsonrpc.Error) {
 	userTxn, userClass, paidFeeOnL1, err := AdaptBroadcastedTransaction(tx, h.bcReader.Network())
 	if err != nil {
 		return nil, rpccore.ErrInternal.CloneWithData(err.Error())
 	}
-	if err = h.memPool.Push(&mempool.BroadcastedTransaction{
+	if err = h.memPool.Push(ctx, &mempool.BroadcastedTransaction{
 		Transaction:   userTxn,
 		DeclaredClass: userClass,
 		PaidFeeOnL1:   paidFeeOnL1,

--- a/sequencer/sequencer.go
+++ b/sequencer/sequencer.go
@@ -32,7 +32,7 @@ type Sequencer struct {
 	privKey          *ecdsa.PrivateKey
 	log              utils.Logger
 	blockTime        time.Duration
-	mempool          *mempool.Pool
+	mempool          *mempool.SequencerMempool
 
 	subNewHeads          *feed.Feed[*core.Block]
 	subPendingData       *feed.Feed[core.PendingData]
@@ -45,7 +45,7 @@ type Sequencer struct {
 
 func New(
 	b *builder.Builder,
-	mempool *mempool.Pool,
+	mempool *mempool.SequencerMempool,
 	sequencerAddress *felt.Felt,
 	privKey *ecdsa.PrivateKey,
 	blockTime time.Duration,


### PR DESCRIPTION
To prepare to make `consensus/proposer.Proposer` a drop-in replacement for mempool when consensus mode is used.