### PR TITLE
fix: `starknet_getEvents` return empty response when `from_block` > `to_block`

### DIFF
--- a/blockchain/aggregated_bloom_filter_cache.go
+++ b/blockchain/aggregated_bloom_filter_cache.go
@@ -84,7 +84,6 @@ type MatchedBlockIterator struct {
 }
 
 var (
-	ErrInvalidBlockRange                = errors.New("fromBlock > toBlock")
 	ErrMaxScannedBlockLimitExceed       = errors.New("max scanned blocks exceeded")
 	ErrAggregatedBloomFilterFallbackNil = errors.New("aggregated bloom filter does not have fallback")
 	ErrFetchedFilterBoundsMismatch      = errors.New("fetched filter bounds mismatch")
@@ -102,10 +101,6 @@ func (c *AggregatedBloomFilterCache) NewMatchedBlockIterator(
 	matcher *EventMatcher,
 	runningFilter *core.RunningEventFilter,
 ) (MatchedBlockIterator, error) {
-	if fromBlock > toBlock {
-		return MatchedBlockIterator{}, ErrInvalidBlockRange
-	}
-
 	if runningFilter == nil {
 		return MatchedBlockIterator{}, ErrNilRunningFilter
 	}
@@ -119,6 +114,8 @@ func (c *AggregatedBloomFilterCache) NewMatchedBlockIterator(
 		runningFilter:      runningFilter,
 		matcher:            matcher,
 		currentWindowStart: windowStart,
+		// If from_block > to_block return exhausted iterator
+		done: fromBlock > toBlock,
 	}, nil
 }
 

--- a/blockchain/aggregated_bloom_filter_cache_test.go
+++ b/blockchain/aggregated_bloom_filter_cache_test.go
@@ -276,10 +276,14 @@ func TestMatchedBlockIterator_BasicCases(t *testing.T) {
 		require.NoError(t, err)
 	})
 
-	t.Run("fromBlock > toBlock errors", func(t *testing.T) {
+	t.Run("fromBlock > toBlock should create exhausted iterator", func(t *testing.T) {
 		// FromBlock must lte to toBlock
-		_, err := cache.NewMatchedBlockIterator(2, 1, maxScannedLimit, &eventMatcher, runningFilter)
-		require.Equal(t, blockchain.ErrInvalidBlockRange, err)
+		iter, err := cache.NewMatchedBlockIterator(2, 1, maxScannedLimit, &eventMatcher, runningFilter)
+		require.NoError(t, err)
+		blockNum, ok, err := iter.Next()
+		require.NoError(t, err)
+		require.False(t, ok)
+		require.Equal(t, uint64(0), blockNum)
 	})
 
 	t.Run("range falls into running filter", func(t *testing.T) {

--- a/rpc/v6/events_test.go
+++ b/rpc/v6/events_test.go
@@ -87,6 +87,23 @@ func TestEvents(t *testing.T) {
 		require.Nil(t, err)
 	})
 
+	t.Run("filter with from_block > to_block", func(t *testing.T) {
+		fArgs := rpc.EventsArg{
+			EventFilter: rpc.EventFilter{
+				FromBlock: &rpc.BlockID{Number: 1},
+				ToBlock:   &rpc.BlockID{Number: 0},
+			},
+			ResultPageRequest: rpc.ResultPageRequest{
+				ChunkSize:         100,
+				ContinuationToken: "",
+			},
+		}
+
+		events, err := handler.Events(fArgs)
+		require.Nil(t, err)
+		require.Empty(t, events.Events)
+	})
+
 	t.Run("filter with no address", func(t *testing.T) {
 		args.ToBlock = &rpc.BlockID{Latest: true}
 		args.Address = nil


### PR DESCRIPTION
After introducing `AggregatedBloomFilter` logic, `MatchedBlockIterator` was raising an error on initialization if `from_block` is greater than `to_block`. This PR adjust the iterator to return empty response when `from_block` > `to_block`. 