### PR TITLE
fix: non-existing block-number bouns to `latest` instead of 'pending'

### DIFF
--- a/rpc/v6/events.go
+++ b/rpc/v6/events.go
@@ -134,6 +134,9 @@ func setEventFilterRange(filter blockchain.EventFilterer, fromID, toID *BlockID,
 		case id.Pending:
 			return filter.SetRangeEndBlockByNumber(filterRange, latestHeight+1)
 		default:
+			if filterRange == blockchain.EventFilterTo {
+				return filter.SetRangeEndBlockByNumber(filterRange, min(id.Number, latestHeight))
+			}
 			return filter.SetRangeEndBlockByNumber(filterRange, id.Number)
 		}
 	}

--- a/rpc/v6/events_test.go
+++ b/rpc/v6/events_test.go
@@ -59,11 +59,11 @@ func TestEvents(t *testing.T) {
 	}
 
 	t.Run("filter non-existent", func(t *testing.T) {
-		t.Run("block number", func(t *testing.T) {
+		t.Run("block number - bound to latest", func(t *testing.T) {
 			args.ToBlock = &rpc.BlockID{Number: 55}
 			events, err := handler.Events(args)
 			require.Nil(t, err)
-			require.Len(t, events.Events, 5)
+			require.Len(t, events.Events, 4)
 		})
 
 		t.Run("block hash", func(t *testing.T) {
@@ -208,7 +208,7 @@ func TestEvents(t *testing.T) {
 
 	t.Run("get pending events with pagination", func(t *testing.T) {
 		var err error
-		pendingB, err = gw.BlockByNumber(t.Context(), 5)
+		pendingB, err = gw.BlockByNumber(t.Context(), 6)
 		require.Nil(t, err)
 
 		args = rpc.EventsArg{
@@ -238,9 +238,9 @@ func TestEvents(t *testing.T) {
 				require.NotEmpty(t, events.ContinuationToken)
 			}
 
-			assert.Equal(t, actualEvent.From, expectedEvent.From)
-			assert.Equal(t, actualEvent.Keys, expectedEvent.Keys)
-			assert.Equal(t, actualEvent.Data, expectedEvent.Data)
+			assert.Equal(t, expectedEvent.From, actualEvent.From)
+			assert.Equal(t, expectedEvent.Keys, actualEvent.Keys)
+			assert.Equal(t, expectedEvent.Data, actualEvent.Data)
 
 			args.ContinuationToken = events.ContinuationToken
 		}

--- a/rpc/v8/events.go
+++ b/rpc/v8/events.go
@@ -39,6 +39,9 @@ func setEventFilterRange(filter blockchain.EventFilterer, from, to *BlockID, lat
 		case hash:
 			return filter.SetRangeEndBlockByHash(filterRange, blockID.Hash())
 		case number:
+			if filterRange == blockchain.EventFilterTo {
+				return filter.SetRangeEndBlockByNumber(filterRange, min(blockID.Number(), latestHeight))
+			}
 			return filter.SetRangeEndBlockByNumber(filterRange, blockID.Number())
 		default:
 			panic("Unknown block id type")


### PR DESCRIPTION
Current approach was upon receiving query on getEvents with `to_block` greater than the `height`, we were bounding the range to [0, Pending] but Pending block does not have blocknumber and this behavior might be confusing for some user. What they experience is for such queries they are receiving some events for non-existing block and response does not specifies block number for such events since Pending block does not have block number. With this PR, queries with block numbers will be bounded in range [0, latest] and pending block events will be only returned when it is explicity queried with pending or pre_confirmed tag.