### PR TITLE
fix: failure reason for rejected txs

### DIFF
--- a/clients/feeder/feeder_test.go
+++ b/clients/feeder/feeder_test.go
@@ -601,6 +601,18 @@ func TestTransactionStatusRevertError(t *testing.T) {
 	require.NotEmpty(t, status.RevertError)
 }
 
+func TestTransactionStatusTransactionFailureReason(t *testing.T) {
+	client := feeder.NewTestClient(t, &utils.SepoliaIntegration)
+
+	txnHash := utils.HexToFelt(t, "0x1111")
+	expectedMessage := "some error"
+	expectedErrorCode := "SOME_ERROR_CODE"
+	status, err := client.Transaction(t.Context(), txnHash)
+	require.NoError(t, err)
+	require.Equal(t, expectedMessage, status.FailureReason.Message)
+	require.Equal(t, expectedErrorCode, status.FailureReason.Code)
+}
+
 func TestPublicKey(t *testing.T) {
 	client := feeder.NewTestClient(t, &utils.Integration)
 

--- a/clients/feeder/testdata/sepolia-integration/transaction/0x1111.json
+++ b/clients/feeder/testdata/sepolia-integration/transaction/0x1111.json
@@ -1,4 +1,8 @@
 {
+    "transaction_failure_reason": { 
+        "code" : "SOME_ERROR_CODE",
+        "error_message" :"some error"
+    },
     "execution_status": "REJECTED",
     "finality_status": "RECEIVED",
     "status": "this is deprecated",

--- a/rpc/v7/transaction.go
+++ b/rpc/v7/transaction.go
@@ -679,10 +679,8 @@ func adaptTransactionStatus(txStatus *starknet.TransactionStatus) (*TransactionS
 		status.Execution = TxnSuccess
 	case starknet.Reverted:
 		status.Execution = TxnFailure
-		status.FailureReason = txStatus.RevertError
 	case starknet.Rejected:
 		status.Finality = TxnStatusRejected
-		status.FailureReason = txStatus.RevertError
 	default: // Omit the field on error. It's optional in the spec.
 	}
 

--- a/rpc/v8/subscriptions_test.go
+++ b/rpc/v8/subscriptions_test.go
@@ -304,7 +304,7 @@ func TestSubscribeTxnStatus(t *testing.T) {
 			mockChain.EXPECT().TransactionByHash(txHash).Return(nil, db.ErrKeyNotFound)
 			mockSyncer.EXPECT().PendingBlock().Return(nil)
 			id, conn := createTestTxStatusWebsocket(t, handler, txHash)
-			assertNextTxnStatus(t, conn, id, txHash, TxnStatusRejected, 0, "")
+			assertNextTxnStatus(t, conn, id, txHash, TxnStatusRejected, 0, "some error")
 		})
 
 		t.Run("accepted on L1", func(t *testing.T) {

--- a/rpc/v8/transaction.go
+++ b/rpc/v8/transaction.go
@@ -946,11 +946,10 @@ func adaptTransactionStatus(txStatus *starknet.TransactionStatus) (*TransactionS
 		status.Execution = TxnFailure
 		status.FailureReason = txStatus.RevertError
 	case starknet.Rejected:
-		if txStatus.FailureReason == nil {
-			return nil, fmt.Errorf("rejected transaction must have failure reason")
-		}
 		status.Finality = TxnStatusRejected
-		status.FailureReason = txStatus.FailureReason.Message
+		if txStatus.FailureReason != nil {
+			status.FailureReason = txStatus.FailureReason.Message
+		}
 	default: // Omit the field on error. It's optional in the spec.
 	}
 

--- a/rpc/v8/transaction.go
+++ b/rpc/v8/transaction.go
@@ -946,8 +946,11 @@ func adaptTransactionStatus(txStatus *starknet.TransactionStatus) (*TransactionS
 		status.Execution = TxnFailure
 		status.FailureReason = txStatus.RevertError
 	case starknet.Rejected:
+		if txStatus.FailureReason == nil {
+			return nil, fmt.Errorf("rejected transaction must have failure reason")
+		}
 		status.Finality = TxnStatusRejected
-		status.FailureReason = txStatus.RevertError
+		status.FailureReason = txStatus.FailureReason.Message
 	default: // Omit the field on error. It's optional in the spec.
 	}
 

--- a/rpc/v8/transaction_test.go
+++ b/rpc/v8/transaction_test.go
@@ -1456,10 +1456,9 @@ func TestTransactionStatus(t *testing.T) {
 		txHash, err := new(felt.Felt).SetString("0x1111")
 		require.NoError(t, err)
 
-		handler := rpc.New(mockReader, mockSyncReader, nil, "", log).WithFeeder(client)
+		handler := rpc.New(mockReader, mockSyncReader, nil, log).WithFeeder(client)
 		mockReader.EXPECT().TransactionByHash(txHash).Return(nil, db.ErrKeyNotFound)
-		mockSyncReader.EXPECT().PendingData().Return(nil, sync.ErrPendingBlockNotFound)
-		mockReader.EXPECT().HeadsHeader().Return(nil, db.ErrKeyNotFound)
+		mockSyncReader.EXPECT().PendingBlock().Return(nil)
 
 		status, rpcErr := handler.TransactionStatus(t.Context(), *txHash)
 		require.Nil(t, rpcErr)

--- a/starknet/transaction.go
+++ b/starknet/transaction.go
@@ -180,15 +180,21 @@ type Transaction struct {
 	PaymasterData         *[]*felt.Felt                `json:"paymaster_data,omitempty"`
 }
 
+type TransactionFailureReason struct {
+	Code    string `json:"code"`
+	Message string `json:"error_message"`
+}
+
 type TransactionStatus struct {
-	Status           string          `json:"status"`
-	FinalityStatus   FinalityStatus  `json:"finality_status"`
-	ExecutionStatus  ExecutionStatus `json:"execution_status"`
-	BlockHash        *felt.Felt      `json:"block_hash"`
-	BlockNumber      uint64          `json:"block_number"`
-	TransactionIndex uint64          `json:"transaction_index"`
-	Transaction      *Transaction    `json:"transaction"`
-	RevertError      string          `json:"revert_error"`
+	Status           string                    `json:"status"`
+	FinalityStatus   FinalityStatus            `json:"finality_status"`
+	ExecutionStatus  ExecutionStatus           `json:"execution_status"`
+	BlockHash        *felt.Felt                `json:"block_hash"`
+	BlockNumber      uint64                    `json:"block_number"`
+	TransactionIndex uint64                    `json:"transaction_index"`
+	Transaction      *Transaction              `json:"transaction"`
+	RevertError      string                    `json:"revert_error"`
+	FailureReason    *TransactionFailureReason `json:"transaction_failure_reason,omitempty"`
 }
 
 type Event struct {


### PR DESCRIPTION
Failure reason for rejected transactions were written in to seperate field `transaction_failure_reason` rather than `revert_error` and comes with different structure. This PR addresses the issue, correctly parses failure reason for rejected transactions

Removes Revert Reason from rpcv7 response - [ref](https://github.com/starkware-libs/starknet-specs/blob/76bdde23c7dae370a3340e40f7ca2ef2520e75b9/api/starknet_api_openrpc.json#L225)