### PR TITLE
fix: pending state access `PendingBlockNotFound`

### DIFF
--- a/rpc/v7/pending_data_wrapper_test.go
+++ b/rpc/v7/pending_data_wrapper_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/NethermindEth/juno/core"
 	"github.com/NethermindEth/juno/core/felt"
 	"github.com/NethermindEth/juno/mocks"
-	rpc "github.com/NethermindEth/juno/rpc/v8"
+	rpc "github.com/NethermindEth/juno/rpc/v7"
 	adaptfeeder "github.com/NethermindEth/juno/starknetdata/feeder"
 	"github.com/NethermindEth/juno/sync"
 	"github.com/NethermindEth/juno/utils"
@@ -16,14 +16,14 @@ import (
 	"go.uber.org/mock/gomock"
 )
 
-func TestPendingDataWrapper(t *testing.T) {
+func TestPendingDataWrapper_PebndingData(t *testing.T) {
 	mockCtrl := gomock.NewController(t)
 	t.Cleanup(mockCtrl.Finish)
 	mockSyncReader := mocks.NewMockSyncReader(mockCtrl)
 	n := utils.HeapPtr(utils.Sepolia)
 	mockReader := mocks.NewMockReader(mockCtrl)
 	log := utils.NewNopZapLogger()
-	handler := rpc.New(mockReader, mockSyncReader, nil, "", log)
+	handler := rpc.New(mockReader, mockSyncReader, nil, "", &utils.Sepolia, log)
 
 	client := feeder.NewTestClient(t, n)
 	gw := adaptfeeder.New(client)
@@ -100,5 +100,57 @@ func TestPendingDataWrapper(t *testing.T) {
 			pending.GetStateUpdate(),
 			pending.GetNewClasses(),
 		))
+	})
+}
+
+func TestPendingDataWrapper_PendingState(t *testing.T) {
+	mockCtrl := gomock.NewController(t)
+	t.Cleanup(mockCtrl.Finish)
+	mockSyncReader := mocks.NewMockSyncReader(mockCtrl)
+	mockReader := mocks.NewMockReader(mockCtrl)
+	handler := rpc.New(mockReader, mockSyncReader, nil, "", &utils.Sepolia, nil)
+
+	mockState := mocks.NewMockStateHistoryReader(mockCtrl)
+	t.Run("Returns pending state when starknet version < 0.14.0", func(t *testing.T) {
+		pending := sync.Pending{}
+		pendingData := pending.AsPendingData()
+		mockSyncReader.EXPECT().PendingData().Return(
+			&pendingData,
+			nil,
+		)
+		mockSyncReader.EXPECT().PendingState().Return(mockState, nopCloser, nil)
+		pendingState, closer, err := handler.PendingState()
+
+		require.NoError(t, err)
+		require.NotNil(t, pendingState)
+		require.NotNil(t, closer)
+	})
+
+	t.Run("Returns latest state starknet version >= 0.14.0", func(t *testing.T) {
+		preConfirmed := core.PreConfirmed{}
+		pendingData := preConfirmed.AsPendingData()
+		mockSyncReader.EXPECT().PendingData().Return(
+			&pendingData,
+			nil,
+		)
+		mockReader.EXPECT().HeadState().Return(mockState, nopCloser, nil)
+		pending, closer, err := handler.PendingState()
+
+		require.NoError(t, err)
+		require.NotNil(t, pending)
+		require.NotNil(t, closer)
+	})
+
+	t.Run("Returns latest state when pending data is nil", func(t *testing.T) {
+		mockSyncReader.EXPECT().PendingData().Return(
+			nil,
+			sync.ErrPendingBlockNotFound,
+		)
+		mockReader.EXPECT().HeadState().Return(mockState, nopCloser, nil)
+		pending, closer, err := handler.PendingState()
+
+		require.NoError(t, err)
+		require.NotNil(t, pending)
+		require.NotNil(t, closer)
 	})
 }

--- a/rpc/v8/pending_data_wrapper_test.go
+++ b/rpc/v8/pending_data_wrapper_test.go
@@ -16,7 +16,7 @@ import (
 	"go.uber.org/mock/gomock"
 )
 
-func TestPendingDataWrapper(t *testing.T) {
+func TestPendingDataWrapper_PendingData(t *testing.T) {
 	mockCtrl := gomock.NewController(t)
 	t.Cleanup(mockCtrl.Finish)
 	mockSyncReader := mocks.NewMockSyncReader(mockCtrl)
@@ -100,5 +100,57 @@ func TestPendingDataWrapper(t *testing.T) {
 			pending.GetStateUpdate(),
 			pending.GetNewClasses(),
 		))
+	})
+}
+
+func TestPendingDataWrapper_PendingState(t *testing.T) {
+	mockCtrl := gomock.NewController(t)
+	t.Cleanup(mockCtrl.Finish)
+	mockSyncReader := mocks.NewMockSyncReader(mockCtrl)
+	mockReader := mocks.NewMockReader(mockCtrl)
+	handler := rpc.New(mockReader, mockSyncReader, nil, "", nil)
+
+	mockState := mocks.NewMockStateHistoryReader(mockCtrl)
+	t.Run("Returns pending state when starknet version < 0.14.0", func(t *testing.T) {
+		pending := sync.Pending{}
+		pendingData := pending.AsPendingData()
+		mockSyncReader.EXPECT().PendingData().Return(
+			&pendingData,
+			nil,
+		)
+		mockSyncReader.EXPECT().PendingState().Return(mockState, nopCloser, nil)
+		pendingState, closer, err := handler.PendingState()
+
+		require.NoError(t, err)
+		require.NotNil(t, pendingState)
+		require.NotNil(t, closer)
+	})
+
+	t.Run("Returns latest state starknet version >= 0.14.0", func(t *testing.T) {
+		preConfirmed := core.PreConfirmed{}
+		pendingData := preConfirmed.AsPendingData()
+		mockSyncReader.EXPECT().PendingData().Return(
+			&pendingData,
+			nil,
+		)
+		mockReader.EXPECT().HeadState().Return(mockState, nopCloser, nil)
+		pending, closer, err := handler.PendingState()
+
+		require.NoError(t, err)
+		require.NotNil(t, pending)
+		require.NotNil(t, closer)
+	})
+
+	t.Run("Returns latest state when pending data is nil", func(t *testing.T) {
+		mockSyncReader.EXPECT().PendingData().Return(
+			nil,
+			sync.ErrPendingBlockNotFound,
+		)
+		mockReader.EXPECT().HeadState().Return(mockState, nopCloser, nil)
+		pending, closer, err := handler.PendingState()
+
+		require.NoError(t, err)
+		require.NotNil(t, pending)
+		require.NotNil(t, closer)
 	})
 }

--- a/rpc/v9/helpers.go
+++ b/rpc/v9/helpers.go
@@ -143,7 +143,7 @@ func (h *Handler) stateByBlockID(blockID *BlockID) (core.StateReader, blockchain
 	var err error
 	switch blockID.Type() {
 	case preConfirmed:
-		reader, closer, err = h.syncReader.PendingState()
+		reader, closer, err = h.PendingState()
 	case latest:
 		reader, closer, err = h.bcReader.HeadState()
 	case hash:

--- a/rpc/v9/pending_data_wrapper.go
+++ b/rpc/v9/pending_data_wrapper.go
@@ -48,6 +48,18 @@ func (h *Handler) PendingBlock() *core.Block {
 	return pending.GetBlock()
 }
 
+func (h *Handler) PendingState() (core.StateReader, func() error, error) {
+	state, closer, err := h.syncReader.PendingState()
+	if err != nil {
+		if errors.Is(err, sync.ErrPendingBlockNotFound) {
+			return h.bcReader.HeadState()
+		}
+		return nil, nil, err
+	}
+
+	return state, closer, nil
+}
+
 func (h *Handler) PendingBlockFinalityStatus() TxnFinalityStatus {
 	pending, err := h.PendingData()
 	if err != nil {

--- a/rpc/v9/pending_data_wrapper_test.go
+++ b/rpc/v9/pending_data_wrapper_test.go
@@ -91,3 +91,36 @@ func TestPendingDataWrapper(t *testing.T) {
 		require.Equal(t, rpc.TxnPreConfirmed, handler.PendingBlockFinalityStatus())
 	})
 }
+
+func TestPendingDataWrapper_PendingState(t *testing.T) {
+	mockCtrl := gomock.NewController(t)
+	t.Cleanup(mockCtrl.Finish)
+	mockSyncReader := mocks.NewMockSyncReader(mockCtrl)
+	mockReader := mocks.NewMockReader(mockCtrl)
+	handler := rpc.New(mockReader, mockSyncReader, nil, "", nil)
+
+	mockState := mocks.NewMockStateHistoryReader(mockCtrl)
+	t.Run("Returns pending state", func(t *testing.T) {
+		mockSyncReader.EXPECT().PendingState().Return(mockState, nopCloser, nil)
+		pendingState, closer, err := handler.PendingState()
+
+		require.NoError(t, err)
+		require.NotNil(t, pendingState)
+		require.NotNil(t, closer)
+	})
+
+	t.Run("Returns latest state when pending data is nil", func(t *testing.T) {
+		mockSyncReader.EXPECT().PendingState().Return(
+			nil,
+			nil,
+			sync.ErrPendingBlockNotFound,
+		)
+
+		mockReader.EXPECT().HeadState().Return(mockState, nopCloser, nil)
+		pending, closer, err := handler.PendingState()
+
+		require.NoError(t, err)
+		require.NotNil(t, pending)
+		require.NotNil(t, closer)
+	})
+}

--- a/rpc/v9/trace.go
+++ b/rpc/v9/trace.go
@@ -289,7 +289,7 @@ func (h *Handler) traceBlockTransactions(ctx context.Context, block *core.Block)
 		headStateCloser blockchain.StateCloser
 	)
 	if isPending {
-		headState, headStateCloser, err = h.syncReader.PendingState()
+		headState, headStateCloser, err = h.PendingState()
 	} else {
 		headState, headStateCloser, err = h.bcReader.HeadState()
 	}


### PR DESCRIPTION
sync.PendingData() returns `sync.ErrPendingBlockNotFound` either when the data is `nil` or when the cached pending data is outdated and no longer represents the current pending/pre-confirmed state. Juno updates the pending data after fetching each block, but it’s possible to encounter validation failures if PendingData is updated after a read yet before fetching the latest header for validation. This issue has been addressed before for PendingData access in wrappers, but this was missed in `PendingState` accesses. With these changes, we will use latest state if our pending data is invalid