### PR TITLE
feat: rpcv9 new block and transaction statuses

### DIFF
--- a/node/node.go
+++ b/node/node.go
@@ -281,6 +281,11 @@ func New(cfg *Config, version string, logLevel *utils.LogLevel) (*Node, error) {
 
 	// to improve RPC throughput we double GOMAXPROCS
 	maxGoroutines := 2 * runtime.GOMAXPROCS(0)
+	jsonrpcServerV09 := jsonrpc.NewServer(maxGoroutines, log).WithValidator(validator.Validator())
+	methodsV09, pathV09 := rpcHandler.MethodsV0_9()
+	if err = jsonrpcServerV09.RegisterMethods(methodsV09...); err != nil {
+		return nil, err
+	}
 	jsonrpcServerV08 := jsonrpc.NewServer(maxGoroutines, log).WithValidator(validator.Validator())
 	methodsV08, pathV08 := rpcHandler.MethodsV0_8()
 	if err = jsonrpcServerV08.RegisterMethods(methodsV08...); err != nil {
@@ -298,10 +303,12 @@ func New(cfg *Config, version string, logLevel *utils.LogLevel) (*Node, error) {
 	}
 	rpcServers := map[string]*jsonrpc.Server{
 		"/":              jsonrpcServerV08,
+		pathV09:          jsonrpcServerV09,
 		pathV08:          jsonrpcServerV08,
 		pathV07:          jsonrpcServerV07,
 		pathV06:          jsonrpcServerV06,
 		"/rpc":           jsonrpcServerV08,
+		"/rpc" + pathV09: jsonrpcServerV09,
 		"/rpc" + pathV08: jsonrpcServerV08,
 		"/rpc" + pathV07: jsonrpcServerV07,
 		"/rpc" + pathV06: jsonrpcServerV06,

--- a/rpc/handlers.go
+++ b/rpc/handlers.go
@@ -146,21 +146,21 @@ func (h *Handler) MethodsV0_9() ([]jsonrpc.Method, string) { //nolint:funlen
 			Params:  []jsonrpc.Parameter{{Name: "transaction_hash"}},
 			Handler: h.rpcv9Handler.TransactionReceiptByHash,
 		},
-		// {
-		// 	Name:    "starknet_getBlockTransactionCount",
-		// 	Params:  []jsonrpc.Parameter{{Name: "block_id"}},
-		// 	Handler: h.rpcv9Handler.BlockTransactionCount,
-		// },
+		{
+			Name:    "starknet_getBlockTransactionCount",
+			Params:  []jsonrpc.Parameter{{Name: "block_id"}},
+			Handler: h.rpcv9Handler.BlockTransactionCount,
+		},
 		{
 			Name:    "starknet_getTransactionByBlockIdAndIndex",
 			Params:  []jsonrpc.Parameter{{Name: "block_id"}, {Name: "index"}},
 			Handler: h.rpcv9Handler.TransactionByBlockIDAndIndex,
 		},
-		// {
-		// 	Name:    "starknet_getStateUpdate",
-		// 	Params:  []jsonrpc.Parameter{{Name: "block_id"}},
-		// 	Handler: h.rpcv9Handler.StateUpdate,
-		// },
+		{
+			Name:    "starknet_getStateUpdate",
+			Params:  []jsonrpc.Parameter{{Name: "block_id"}},
+			Handler: h.rpcv9Handler.StateUpdate,
+		},
 		{
 			Name:    "starknet_syncing",
 			Handler: h.rpcv6Handler.Syncing,
@@ -175,21 +175,21 @@ func (h *Handler) MethodsV0_9() ([]jsonrpc.Method, string) { //nolint:funlen
 			Params:  []jsonrpc.Parameter{{Name: "contract_address"}, {Name: "key"}, {Name: "block_id"}},
 			Handler: h.rpcv9Handler.StorageAt,
 		},
-		// {
-		// 	Name:    "starknet_getClassHashAt",
-		// 	Params:  []jsonrpc.Parameter{{Name: "block_id"}, {Name: "contract_address"}},
-		// 	Handler: h.rpcv9Handler.ClassHashAt,
-		// },
-		// {
-		// 	Name:    "starknet_getClass",
-		// 	Params:  []jsonrpc.Parameter{{Name: "block_id"}, {Name: "class_hash"}},
-		// 	Handler: h.rpcv9Handler.Class,
-		// },
-		// {
-		// 	Name:    "starknet_getClassAt",
-		// 	Params:  []jsonrpc.Parameter{{Name: "block_id"}, {Name: "contract_address"}},
-		// 	Handler: h.rpcv9Handler.ClassAt,
-		// },
+		{
+			Name:    "starknet_getClassHashAt",
+			Params:  []jsonrpc.Parameter{{Name: "block_id"}, {Name: "contract_address"}},
+			Handler: h.rpcv9Handler.ClassHashAt,
+		},
+		{
+			Name:    "starknet_getClass",
+			Params:  []jsonrpc.Parameter{{Name: "block_id"}, {Name: "class_hash"}},
+			Handler: h.rpcv9Handler.Class,
+		},
+		{
+			Name:    "starknet_getClassAt",
+			Params:  []jsonrpc.Parameter{{Name: "block_id"}, {Name: "contract_address"}},
+			Handler: h.rpcv9Handler.ClassAt,
+		},
 		{
 			Name:    "starknet_addInvokeTransaction",
 			Params:  []jsonrpc.Parameter{{Name: "invoke_transaction"}},
@@ -205,11 +205,11 @@ func (h *Handler) MethodsV0_9() ([]jsonrpc.Method, string) { //nolint:funlen
 			Params:  []jsonrpc.Parameter{{Name: "declare_transaction"}},
 			Handler: h.rpcv9Handler.AddTransaction,
 		},
-		// {
-		// 	Name:    "starknet_getEvents",
-		// 	Params:  []jsonrpc.Parameter{{Name: "filter"}},
-		// 	Handler: h.rpcv9Handler.Events,
-		// },
+		{
+			Name:    "starknet_getEvents",
+			Params:  []jsonrpc.Parameter{{Name: "filter"}},
+			Handler: h.rpcv9Handler.Events,
+		},
 		{
 			Name:    "juno_version",
 			Handler: h.rpcv9Handler.Version,

--- a/rpc/handlers.go
+++ b/rpc/handlers.go
@@ -165,11 +165,11 @@ func (h *Handler) MethodsV0_9() ([]jsonrpc.Method, string) { //nolint:funlen
 			Name:    "starknet_syncing",
 			Handler: h.rpcv6Handler.Syncing,
 		},
-		// {
-		// 	Name:    "starknet_getNonce",
-		// 	Params:  []jsonrpc.Parameter{{Name: "block_id"}, {Name: "contract_address"}},
-		// 	Handler: h.rpcv9Handler.Nonce,
-		// },
+		{
+			Name:    "starknet_getNonce",
+			Params:  []jsonrpc.Parameter{{Name: "block_id"}, {Name: "contract_address"}},
+			Handler: h.rpcv9Handler.Nonce,
+		},
 		{
 			Name:    "starknet_getStorageAt",
 			Params:  []jsonrpc.Parameter{{Name: "contract_address"}, {Name: "key"}, {Name: "block_id"}},

--- a/rpc/rpccore/rpccore.go
+++ b/rpc/rpccore/rpccore.go
@@ -72,6 +72,9 @@ var (
 	ErrTooManyAddressesInFilter        = &jsonrpc.Error{Code: 67, Message: "Too many addresses in filter sender_address filter"}
 	ErrTooManyBlocksBack               = &jsonrpc.Error{Code: 68, Message: fmt.Sprintf("Cannot go back more than %v blocks", MaxBlocksBack)}
 	ErrCallOnPending                   = &jsonrpc.Error{Code: 69, Message: "This method does not support being called on the pending block"}
+	ErrCallOnPreConfirmed              = &jsonrpc.Error{
+		Code: 70, Message: "This method does not support being called on the pre_confirmed block",
+	}
 
 	// These errors can be only be returned by Juno-specific methods.
 	ErrSubscriptionNotFound = &jsonrpc.Error{Code: 100, Message: "Subscription not found"}

--- a/rpc/v6/block.go
+++ b/rpc/v6/block.go
@@ -69,10 +69,16 @@ type BlockID struct {
 }
 
 func (b *BlockID) UnmarshalJSON(data []byte) error {
-	if string(data) == `"latest"` {
-		b.Latest = true
-	} else if string(data) == `"pending"` {
-		b.Pending = true
+	var blockTag string
+	if err := json.Unmarshal(data, &blockTag); err == nil {
+		switch blockTag {
+		case "latest":
+			b.Latest = true
+		case "pending":
+			b.Pending = true
+		default:
+			return fmt.Errorf("unknown block tag '%s'", blockTag)
+		}
 	} else {
 		jsonObject := make(map[string]json.RawMessage)
 		if err := json.Unmarshal(data, &jsonObject); err != nil {

--- a/rpc/v7/block.go
+++ b/rpc/v7/block.go
@@ -3,6 +3,7 @@ package rpcv7
 import (
 	"encoding/json"
 	"errors"
+	"fmt"
 
 	"github.com/NethermindEth/juno/core"
 	"github.com/NethermindEth/juno/core/felt"
@@ -35,10 +36,16 @@ func (b *BlockID) GetNumber() uint64 {
 }
 
 func (b *BlockID) UnmarshalJSON(data []byte) error {
-	if string(data) == `"latest"` {
-		b.Latest = true
-	} else if string(data) == `"pending"` {
-		b.Pending = true
+	var blockTag string
+	if err := json.Unmarshal(data, &blockTag); err == nil {
+		switch blockTag {
+		case "latest":
+			b.Latest = true
+		case "pending":
+			b.Pending = true
+		default:
+			return fmt.Errorf("unknown block tag '%s'", blockTag)
+		}
 	} else {
 		jsonObject := make(map[string]json.RawMessage)
 		if err := json.Unmarshal(data, &jsonObject); err != nil {

--- a/rpc/v8/block.go
+++ b/rpc/v8/block.go
@@ -90,10 +90,16 @@ func (b *BlockID) Number() uint64 {
 }
 
 func (b *BlockID) UnmarshalJSON(data []byte) error {
-	if string(data) == `"latest"` {
-		b.typeID = latest
-	} else if string(data) == `"pending"` {
-		b.typeID = pending
+	var blockTag string
+	if err := json.Unmarshal(data, &blockTag); err == nil {
+		switch blockTag {
+		case "latest":
+			b.typeID = latest
+		case "pending":
+			b.typeID = pending
+		default:
+			return fmt.Errorf("unknown block tag '%s'", blockTag)
+		}
 	} else {
 		jsonObject := make(map[string]json.RawMessage)
 		if err := json.Unmarshal(data, &jsonObject); err != nil {

--- a/rpc/v9/block.go
+++ b/rpc/v9/block.go
@@ -11,10 +11,35 @@ import (
 	rpcv6 "github.com/NethermindEth/juno/rpc/v6"
 )
 
+// https://github.com/starkware-libs/starknet-specs/blob/fbf8710c2d2dcdb70a95776f257d080392ad0816/api/starknet_api_openrpc.json#L2353-L2363
+type BlockStatus uint8
+
+const (
+	BlockPreConfirmed BlockStatus = iota
+	BlockAcceptedL2
+	BlockAcceptedL1
+	BlockRejected
+)
+
+func (s BlockStatus) MarshalText() ([]byte, error) {
+	switch s {
+	case BlockPreConfirmed:
+		return []byte("PRE_CONFIRMED"), nil
+	case BlockAcceptedL2:
+		return []byte("ACCEPTED_ON_L2"), nil
+	case BlockAcceptedL1:
+		return []byte("ACCEPTED_ON_L1"), nil
+	case BlockRejected:
+		return []byte("REJECTED"), nil
+	default:
+		return nil, fmt.Errorf("unknown block status %v", s)
+	}
+}
+
 type blockIDType uint8
 
 const (
-	pending blockIDType = iota + 1
+	preConfirmed blockIDType = iota + 1
 	latest
 	hash
 	number
@@ -22,8 +47,8 @@ const (
 
 func (b *blockIDType) String() string {
 	switch *b {
-	case pending:
-		return "pending"
+	case preConfirmed:
+		return "pre_confirmed"
 	case latest:
 		return "latest"
 	case hash:
@@ -59,8 +84,8 @@ func (b *BlockID) Type() blockIDType {
 	return b.typeID
 }
 
-func (b *BlockID) IsPending() bool {
-	return b.typeID == pending
+func (b *BlockID) IsPreConfirmed() bool {
+	return b.typeID == preConfirmed
 }
 
 func (b *BlockID) IsLatest() bool {
@@ -90,10 +115,16 @@ func (b *BlockID) Number() uint64 {
 }
 
 func (b *BlockID) UnmarshalJSON(data []byte) error {
-	if string(data) == `"latest"` {
-		b.typeID = latest
-	} else if string(data) == `"pending"` {
-		b.typeID = pending
+	var blockTag string
+	if err := json.Unmarshal(data, &blockTag); err == nil {
+		switch blockTag {
+		case "latest":
+			b.typeID = latest
+		case "pre_confirmed":
+			b.typeID = preConfirmed
+		default:
+			return fmt.Errorf("unknown block tag '%s'", blockTag)
+		}
 	} else {
 		jsonObject := make(map[string]json.RawMessage)
 		if err := json.Unmarshal(data, &jsonObject); err != nil {
@@ -116,22 +147,35 @@ func (b *BlockID) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
-// https://github.com/starkware-libs/starknet-specs/blob/a789ccc3432c57777beceaa53a34a7ae2f25fda0/api/starknet_api_openrpc.json#L1072
+// Allows omitting ParentHash, pre_confirmed block does not have parentHash
+// BLOCK_HEADER
+// https://github.com/starkware-libs/starknet-specs/blob/0bf403bfafbfbe0eaa52103a9c7df545bec8f73b/api/starknet_api_openrpc.json#L1622
+// PRE_CONFIRMED_BLOCK_HEADER
+// https://github.com/starkware-libs/starknet-specs/blob/0bf403bfafbfbe0eaa52103a9c7df545bec8f73b/api/starknet_api_openrpc.json#L1636
 type BlockHeader struct {
-	rpcv6.BlockHeader
-	L2GasPrice *rpcv6.ResourcePrice `json:"l2_gas_price"`
+	Hash             *felt.Felt           `json:"block_hash,omitempty"`
+	ParentHash       *felt.Felt           `json:"parent_hash,omitempty"`
+	Number           *uint64              `json:"block_number,omitempty"`
+	NewRoot          *felt.Felt           `json:"new_root,omitempty"`
+	Timestamp        uint64               `json:"timestamp"`
+	SequencerAddress *felt.Felt           `json:"sequencer_address,omitempty"`
+	L1GasPrice       *rpcv6.ResourcePrice `json:"l1_gas_price"`
+	L1DataGasPrice   *rpcv6.ResourcePrice `json:"l1_data_gas_price,omitempty"`
+	L1DAMode         *rpcv6.L1DAMode      `json:"l1_da_mode,omitempty"`
+	StarknetVersion  string               `json:"starknet_version"`
+	L2GasPrice       *rpcv6.ResourcePrice `json:"l2_gas_price"`
 }
 
 // https://github.com/starkware-libs/starknet-specs/blob/a789ccc3432c57777beceaa53a34a7ae2f25fda0/api/starknet_api_openrpc.json#L1131
 type BlockWithTxs struct {
-	Status rpcv6.BlockStatus `json:"status,omitempty"`
+	Status BlockStatus `json:"status,omitempty"`
 	BlockHeader
 	Transactions []*Transaction `json:"transactions"`
 }
 
-// https://github.com/starkware-libs/starknet-specs/blob/a789ccc3432c57777beceaa53a34a7ae2f25fda0/api/starknet_api_openrpc.json#L1109
+// https://github.com/starkware-libs/starknet-specs/blob/9377851884da5c81f757b6ae0ed47e84f9e7c058/api/starknet_api_openrpc.json#L43
 type BlockWithTxHashes struct {
-	Status rpcv6.BlockStatus `json:"status,omitempty"`
+	Status BlockStatus `json:"status,omitempty"`
 	BlockHeader
 	TxnHashes []*felt.Felt `json:"transactions"`
 }
@@ -142,7 +186,7 @@ type TransactionWithReceipt struct {
 }
 
 type BlockWithReceipts struct {
-	Status rpcv6.BlockStatus `json:"status,omitempty"`
+	Status BlockStatus `json:"status,omitempty"`
 	BlockHeader
 	Transactions []TransactionWithReceipt `json:"transactions"`
 }
@@ -151,10 +195,23 @@ type BlockWithReceipts struct {
 		Block Handlers
 *****************************************************/
 
+// BlockTransactionCount returns the number of transactions in a block
+// identified by the given BlockID.
+//
+// It follows the specification defined here:
+// https://github.com/starkware-libs/starknet-specs/blob/9377851884da5c81f757b6ae0ed47e84f9e7c058/api/starknet_api_openrpc.json#L548
+func (h *Handler) BlockTransactionCount(id *BlockID) (uint64, *jsonrpc.Error) {
+	header, rpcErr := h.blockHeaderByID(id)
+	if rpcErr != nil {
+		return 0, rpcErr
+	}
+	return header.TransactionCount, nil
+}
+
 // BlockWithTxHashes returns the block information with transaction hashes given a block ID.
 //
 // It follows the specification defined here:
-// https://github.com/starkware-libs/starknet-specs/blob/a789ccc3432c57777beceaa53a34a7ae2f25fda0/api/starknet_api_openrpc.json#L11
+// https://github.com/starkware-libs/starknet-specs/blob/9377851884da5c81f757b6ae0ed47e84f9e7c058/api/starknet_api_openrpc.json#L25
 func (h *Handler) BlockWithTxHashes(id *BlockID) (*BlockWithTxHashes, *jsonrpc.Error) {
 	block, rpcErr := h.blockByID(id)
 	if rpcErr != nil {
@@ -178,6 +235,10 @@ func (h *Handler) BlockWithTxHashes(id *BlockID) (*BlockWithTxHashes, *jsonrpc.E
 	}, nil
 }
 
+// BlockWithTxHashes returns the block information with transaction receipts given a block ID.
+//
+// It follows the specification defined here:
+// https://github.com/starkware-libs/starknet-specs/blob/9377851884da5c81f757b6ae0ed47e84f9e7c058/api/starknet_api_openrpc.json#L99
 func (h *Handler) BlockWithReceipts(id *BlockID) (*BlockWithReceipts, *jsonrpc.Error) {
 	block, rpcErr := h.blockByID(id)
 	if rpcErr != nil {
@@ -189,9 +250,13 @@ func (h *Handler) BlockWithReceipts(id *BlockID) (*BlockWithReceipts, *jsonrpc.E
 		return nil, rpcErr
 	}
 
-	finalityStatus := TxnAcceptedOnL2
-	if blockStatus == rpcv6.BlockAcceptedL1 {
+	var finalityStatus TxnFinalityStatus
+	if blockStatus == BlockAcceptedL1 {
 		finalityStatus = TxnAcceptedOnL1
+	} else if blockStatus == BlockAcceptedL2 {
+		finalityStatus = TxnAcceptedOnL2
+	} else {
+		finalityStatus = h.PendingBlockFinalityStatus()
 	}
 
 	txsWithReceipts := make([]TransactionWithReceipt, len(block.Transactions))
@@ -217,7 +282,7 @@ func (h *Handler) BlockWithReceipts(id *BlockID) (*BlockWithReceipts, *jsonrpc.E
 // BlockWithTxs returns the block information with full transactions given a block ID.
 //
 // It follows the specification defined here:
-// https://github.com/starkware-libs/starknet-specs/blob/a789ccc3432c57777beceaa53a34a7ae2f25fda0/api/starknet_api_openrpc.json#L44
+// https://github.com/starkware-libs/starknet-specs/blob/9377851884da5c81f757b6ae0ed47e84f9e7c058/api/starknet_api_openrpc.json#L62
 func (h *Handler) BlockWithTxs(blockID *BlockID) (*BlockWithTxs, *jsonrpc.Error) {
 	block, rpcErr := h.blockByID(blockID)
 	if rpcErr != nil {
@@ -241,28 +306,24 @@ func (h *Handler) BlockWithTxs(blockID *BlockID) (*BlockWithTxs, *jsonrpc.Error)
 	}, nil
 }
 
-func (h *Handler) blockStatus(id *BlockID, block *core.Block) (rpcv6.BlockStatus, *jsonrpc.Error) {
+func (h *Handler) blockStatus(id *BlockID, block *core.Block) (BlockStatus, *jsonrpc.Error) {
 	l1H, jsonErr := h.l1Head()
 	if jsonErr != nil {
 		return 0, jsonErr
 	}
 
-	status := rpcv6.BlockAcceptedL2
-	if id.IsPending() {
-		status = rpcv6.BlockPending
+	status := BlockAcceptedL2
+	if id.IsPreConfirmed() {
+		status = BlockPreConfirmed
 	} else if isL1Verified(block.Number, l1H) {
-		status = rpcv6.BlockAcceptedL1
+		status = BlockAcceptedL1
 	}
 
 	return status, nil
 }
 
 func adaptBlockHeader(header *core.Header) BlockHeader {
-	var blockNumber *uint64
-	// if header.Hash == nil it's a pending block
-	if header.Hash != nil {
-		blockNumber = &header.Number
-	}
+	blockNumber := &header.Number
 
 	sequencerAddress := header.SequencerAddress
 	if sequencerAddress == nil {
@@ -304,22 +365,20 @@ func adaptBlockHeader(header *core.Header) BlockHeader {
 	}
 
 	return BlockHeader{
-		BlockHeader: rpcv6.BlockHeader{
-			Hash:             header.Hash,
-			ParentHash:       header.ParentHash,
-			Number:           blockNumber,
-			NewRoot:          header.GlobalStateRoot,
-			Timestamp:        header.Timestamp,
-			SequencerAddress: sequencerAddress,
-			L1GasPrice: &rpcv6.ResourcePrice{
-				InWei: header.L1GasPriceETH,
-				InFri: nilToZero(header.L1GasPriceSTRK),
-			},
-			L1DataGasPrice:  &l1DataGasPrice,
-			L1DAMode:        &l1DAMode,
-			StarknetVersion: header.ProtocolVersion,
+		Hash:             header.Hash,
+		ParentHash:       header.ParentHash,
+		Number:           blockNumber,
+		NewRoot:          header.GlobalStateRoot,
+		Timestamp:        header.Timestamp,
+		SequencerAddress: sequencerAddress,
+		L1GasPrice: &rpcv6.ResourcePrice{
+			InWei: header.L1GasPriceETH,
+			InFri: nilToZero(header.L1GasPriceSTRK),
 		},
-		L2GasPrice: &l2GasPrice,
+		L1DataGasPrice:  &l1DataGasPrice,
+		L1DAMode:        &l1DAMode,
+		StarknetVersion: header.ProtocolVersion,
+		L2GasPrice:      &l2GasPrice,
 	}
 }
 

--- a/rpc/v9/class.go
+++ b/rpc/v9/class.go
@@ -7,6 +7,9 @@ import (
 	"github.com/NethermindEth/juno/adapters/sn2core"
 	"github.com/NethermindEth/juno/core"
 	"github.com/NethermindEth/juno/core/felt"
+	"github.com/NethermindEth/juno/jsonrpc"
+	"github.com/NethermindEth/juno/rpc/rpccore"
+	rpcv6 "github.com/NethermindEth/juno/rpc/v6"
 	"github.com/NethermindEth/juno/starknet"
 	"github.com/NethermindEth/juno/starknet/compiler"
 	"github.com/NethermindEth/juno/utils"
@@ -51,4 +54,105 @@ func adaptDeclaredClass(declaredClass json.RawMessage) (core.Class, error) {
 	default:
 		return nil, errors.New("empty class")
 	}
+}
+
+/****************************************************
+		Class Handlers
+*****************************************************/
+
+// Class gets the contract class definition in the given block associated with the given hash
+//
+// It follows the specification defined here:
+// https://github.com/starkware-libs/starknet-specs/blob/9377851884da5c81f757b6ae0ed47e84f9e7c058/api/starknet_api_openrpc.json#L410
+func (h *Handler) Class(id *BlockID, classHash *felt.Felt) (*rpcv6.Class, *jsonrpc.Error) {
+	state, stateCloser, rpcErr := h.stateByBlockID(id)
+	if rpcErr != nil {
+		return nil, rpcErr
+	}
+	defer h.callAndLogErr(stateCloser, "Error closing state reader in getClass")
+
+	declared, err := state.Class(classHash)
+	if err != nil {
+		return nil, rpccore.ErrClassHashNotFound
+	}
+
+	var rpcClass *rpcv6.Class
+	switch c := declared.Class.(type) {
+	case *core.Cairo0Class:
+		adaptEntryPoint := func(ep core.EntryPoint) rpcv6.EntryPoint {
+			return rpcv6.EntryPoint{
+				Offset:   ep.Offset,
+				Selector: ep.Selector,
+			}
+		}
+
+		rpcClass = &rpcv6.Class{
+			Abi:     c.Abi,
+			Program: c.Program,
+			EntryPoints: rpcv6.EntryPoints{
+				// Note that utils.Map returns nil if provided slice is nil
+				// but this is not the case here, because we rely on sn2core adapters that will set it to empty slice
+				// if it's nil. In the API spec these fields are required.
+				Constructor: utils.Map(c.Constructors, adaptEntryPoint),
+				External:    utils.Map(c.Externals, adaptEntryPoint),
+				L1Handler:   utils.Map(c.L1Handlers, adaptEntryPoint),
+			},
+		}
+	case *core.Cairo1Class:
+		adaptEntryPoint := func(ep core.SierraEntryPoint) rpcv6.EntryPoint {
+			return rpcv6.EntryPoint{
+				Index:    &ep.Index,
+				Selector: ep.Selector,
+			}
+		}
+
+		rpcClass = &rpcv6.Class{
+			Abi:                  c.Abi,
+			SierraProgram:        c.Program,
+			ContractClassVersion: c.SemanticVersion,
+			EntryPoints: rpcv6.EntryPoints{
+				// Note that utils.Map returns nil if provided slice is nil
+				// but this is not the case here, because we rely on sn2core adapters that will set it to empty slice
+				// if it's nil. In the API spec these fields are required.
+				Constructor: utils.Map(c.EntryPoints.Constructor, adaptEntryPoint),
+				External:    utils.Map(c.EntryPoints.External, adaptEntryPoint),
+				L1Handler:   utils.Map(c.EntryPoints.L1Handler, adaptEntryPoint),
+			},
+		}
+	default:
+		return nil, rpccore.ErrClassHashNotFound
+	}
+
+	return rpcClass, nil
+}
+
+// ClassAt gets the contract class definition in the given block instantiated by the given contract address
+//
+// It follows the specification defined here:
+// https://github.com/starkware-libs/starknet-specs/blob/9377851884da5c81f757b6ae0ed47e84f9e7c058/api/starknet_api_openrpc.json#L499
+func (h *Handler) ClassAt(id *BlockID, address *felt.Felt) (*rpcv6.Class, *jsonrpc.Error) {
+	classHash, err := h.ClassHashAt(id, address)
+	if err != nil {
+		return nil, err
+	}
+	return h.Class(id, classHash)
+}
+
+// ClassHashAt gets the class hash for the contract deployed at the given address in the given block.
+//
+// It follows the specification defined here:
+// https://github.com/starkware-libs/starknet-specs/blob/9377851884da5c81f757b6ae0ed47e84f9e7c058/api/starknet_api_openrpc.json#L459
+func (h *Handler) ClassHashAt(id *BlockID, address *felt.Felt) (*felt.Felt, *jsonrpc.Error) {
+	stateReader, stateCloser, rpcErr := h.stateByBlockID(id)
+	if rpcErr != nil {
+		return nil, rpcErr
+	}
+	defer h.callAndLogErr(stateCloser, "Error closing state reader in getClassHashAt")
+
+	classHash, err := stateReader.ContractClassHash(address)
+	if err != nil {
+		return nil, rpccore.ErrContractNotFound
+	}
+
+	return classHash, nil
 }

--- a/rpc/v9/class_test.go
+++ b/rpc/v9/class_test.go
@@ -1,0 +1,285 @@
+package rpcv9_test
+
+import (
+	"encoding/json"
+	"errors"
+	"testing"
+
+	"github.com/NethermindEth/juno/clients/feeder"
+	"github.com/NethermindEth/juno/core"
+	"github.com/NethermindEth/juno/core/felt"
+	"github.com/NethermindEth/juno/db"
+	"github.com/NethermindEth/juno/mocks"
+	rpccore "github.com/NethermindEth/juno/rpc/rpccore"
+	rpcv6 "github.com/NethermindEth/juno/rpc/v6"
+	rpcv9 "github.com/NethermindEth/juno/rpc/v9"
+	adaptfeeder "github.com/NethermindEth/juno/starknetdata/feeder"
+	"github.com/NethermindEth/juno/utils"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+)
+
+func TestClass(t *testing.T) {
+	n := &utils.Integration
+	integrationClient := feeder.NewTestClient(t, n)
+	integGw := adaptfeeder.New(integrationClient)
+
+	mockCtrl := gomock.NewController(t)
+	t.Cleanup(mockCtrl.Finish)
+
+	mockReader := mocks.NewMockReader(mockCtrl)
+	mockState := mocks.NewMockStateHistoryReader(mockCtrl)
+
+	mockState.EXPECT().Class(gomock.Any()).DoAndReturn(func(classHash *felt.Felt) (*core.DeclaredClass, error) {
+		class, err := integGw.Class(t.Context(), classHash)
+		return &core.DeclaredClass{Class: class, At: 0}, err
+	}).AnyTimes()
+	mockReader.EXPECT().HeadState().Return(mockState, func() error {
+		return nil
+	}, nil).AnyTimes()
+	mockReader.EXPECT().HeadsHeader().Return(new(core.Header), nil).AnyTimes()
+	handler := rpcv9.New(mockReader, nil, nil, utils.NewNopZapLogger())
+
+	latest := blockIDLatest(t)
+
+	t.Run("sierra class", func(t *testing.T) {
+		hash := utils.HexToFelt(t, "0x1cd2edfb485241c4403254d550de0a097fa76743cd30696f714a491a454bad5")
+
+		coreClass, err := integGw.Class(t.Context(), hash)
+		require.NoError(t, err)
+
+		class, rpcErr := handler.Class(&latest, hash)
+		require.Nil(t, rpcErr)
+		cairo1Class := coreClass.(*core.Cairo1Class)
+		assertEqualCairo1Class(t, cairo1Class, class)
+	})
+
+	t.Run("casm class", func(t *testing.T) {
+		hash := utils.HexToFelt(t, "0x4631b6b3fa31e140524b7d21ba784cea223e618bffe60b5bbdca44a8b45be04")
+
+		coreClass, err := integGw.Class(t.Context(), hash)
+		require.NoError(t, err)
+
+		class, rpcErr := handler.Class(&latest, hash)
+		require.Nil(t, rpcErr)
+
+		cairo0Class := coreClass.(*core.Cairo0Class)
+		assertEqualCairo0Class(t, cairo0Class, class)
+	})
+
+	t.Run("state by id error", func(t *testing.T) {
+		mockReader := mocks.NewMockReader(mockCtrl)
+		handler := rpcv9.New(mockReader, nil, nil, utils.NewNopZapLogger())
+
+		mockReader.EXPECT().HeadState().Return(nil, nil, db.ErrKeyNotFound)
+
+		_, rpcErr := handler.Class(&latest, &felt.Zero)
+		require.NotNil(t, rpcErr)
+		require.Equal(t, rpccore.ErrBlockNotFound, rpcErr)
+	})
+
+	t.Run("class hash not found error", func(t *testing.T) {
+		mockReader := mocks.NewMockReader(mockCtrl)
+		mockState := mocks.NewMockStateHistoryReader(mockCtrl)
+		handler := rpcv9.New(mockReader, nil, nil, utils.NewNopZapLogger())
+
+		mockReader.EXPECT().HeadState().Return(mockState, func() error {
+			return nil
+		}, nil)
+		mockState.EXPECT().Class(gomock.Any()).Return(nil, errors.New("class hash not found"))
+
+		_, rpcErr := handler.Class(&latest, &felt.Zero)
+		require.NotNil(t, rpcErr)
+		require.Equal(t, rpccore.ErrClassHashNotFound, rpcErr)
+	})
+}
+
+func TestClassAt(t *testing.T) {
+	n := &utils.Integration
+	integrationClient := feeder.NewTestClient(t, n)
+	integGw := adaptfeeder.New(integrationClient)
+
+	mockCtrl := gomock.NewController(t)
+	t.Cleanup(mockCtrl.Finish)
+
+	mockReader := mocks.NewMockReader(mockCtrl)
+	mockState := mocks.NewMockStateHistoryReader(mockCtrl)
+
+	cairo0ContractAddress, _ := new(felt.Felt).SetRandom()
+	cairo0ClassHash := utils.HexToFelt(t, "0x4631b6b3fa31e140524b7d21ba784cea223e618bffe60b5bbdca44a8b45be04")
+	mockState.EXPECT().ContractClassHash(cairo0ContractAddress).Return(cairo0ClassHash, nil)
+
+	cairo1ContractAddress, _ := new(felt.Felt).SetRandom()
+	cairo1ClassHash := utils.HexToFelt(t, "0x1cd2edfb485241c4403254d550de0a097fa76743cd30696f714a491a454bad5")
+	mockState.EXPECT().ContractClassHash(cairo1ContractAddress).Return(cairo1ClassHash, nil)
+
+	mockState.EXPECT().Class(gomock.Any()).DoAndReturn(func(classHash *felt.Felt) (*core.DeclaredClass, error) {
+		class, err := integGw.Class(t.Context(), classHash)
+		return &core.DeclaredClass{Class: class, At: 0}, err
+	}).AnyTimes()
+	mockReader.EXPECT().HeadState().Return(mockState, func() error {
+		return nil
+	}, nil).AnyTimes()
+	mockReader.EXPECT().HeadsHeader().Return(new(core.Header), nil).AnyTimes()
+	handler := rpcv9.New(mockReader, nil, nil, utils.NewNopZapLogger())
+
+	latest := blockIDLatest(t)
+
+	t.Run("sierra class", func(t *testing.T) {
+		coreClass, err := integGw.Class(t.Context(), cairo1ClassHash)
+		require.NoError(t, err)
+
+		class, rpcErr := handler.ClassAt(&latest, cairo1ContractAddress)
+		require.Nil(t, rpcErr)
+		cairo1Class := coreClass.(*core.Cairo1Class)
+		assertEqualCairo1Class(t, cairo1Class, class)
+	})
+
+	t.Run("casm class", func(t *testing.T) {
+		coreClass, err := integGw.Class(t.Context(), cairo0ClassHash)
+		require.NoError(t, err)
+
+		class, rpcErr := handler.ClassAt(&latest, cairo0ContractAddress)
+		require.Nil(t, rpcErr)
+
+		cairo0Class := coreClass.(*core.Cairo0Class)
+		assertEqualCairo0Class(t, cairo0Class, class)
+	})
+}
+
+func TestClassHashAt(t *testing.T) {
+	mockCtrl := gomock.NewController(t)
+	t.Cleanup(mockCtrl.Finish)
+
+	mockReader := mocks.NewMockReader(mockCtrl)
+	mockSyncReader := mocks.NewMockSyncReader(mockCtrl)
+	log := utils.NewNopZapLogger()
+	handler := rpcv9.New(mockReader, mockSyncReader, nil, log)
+
+	t.Run("empty blockchain", func(t *testing.T) {
+		mockReader.EXPECT().HeadState().Return(nil, nil, db.ErrKeyNotFound)
+		latest := blockIDLatest(t)
+		classHash, rpcErr := handler.ClassHashAt(&latest, &felt.Zero)
+		require.Nil(t, classHash)
+		assert.Equal(t, rpccore.ErrBlockNotFound, rpcErr)
+	})
+
+	t.Run("non-existent block hash", func(t *testing.T) {
+		mockReader.EXPECT().StateAtBlockHash(&felt.Zero).Return(nil, nil, db.ErrKeyNotFound)
+		hash := blockIDHash(t, &felt.Zero)
+		classHash, rpcErr := handler.ClassHashAt(&hash, &felt.Zero)
+		require.Nil(t, classHash)
+		assert.Equal(t, rpccore.ErrBlockNotFound, rpcErr)
+	})
+
+	t.Run("non-existent block number", func(t *testing.T) {
+		mockReader.EXPECT().StateAtBlockNumber(uint64(0)).Return(nil, nil, db.ErrKeyNotFound)
+		number := blockIDNumber(t, 0)
+		classHash, rpcErr := handler.ClassHashAt(&number, &felt.Zero)
+		require.Nil(t, classHash)
+		assert.Equal(t, rpccore.ErrBlockNotFound, rpcErr)
+	})
+
+	mockState := mocks.NewMockStateHistoryReader(mockCtrl)
+
+	t.Run("non-existent contract", func(t *testing.T) {
+		mockReader.EXPECT().HeadState().Return(mockState, nopCloser, nil)
+		mockState.EXPECT().ContractClassHash(gomock.Any()).Return(nil, errors.New("non-existent contract"))
+		latest := blockIDLatest(t)
+		classHash, rpcErr := handler.ClassHashAt(&latest, &felt.Zero)
+		require.Nil(t, classHash)
+		assert.Equal(t, rpccore.ErrContractNotFound, rpcErr)
+	})
+
+	expectedClassHash := new(felt.Felt).SetUint64(3)
+
+	t.Run("blockID - latest", func(t *testing.T) {
+		mockReader.EXPECT().HeadState().Return(mockState, nopCloser, nil)
+		mockState.EXPECT().ContractClassHash(gomock.Any()).Return(expectedClassHash, nil)
+		latest := blockIDLatest(t)
+		classHash, rpcErr := handler.ClassHashAt(&latest, &felt.Zero)
+		require.Nil(t, rpcErr)
+		assert.Equal(t, expectedClassHash, classHash)
+	})
+
+	t.Run("blockID - hash", func(t *testing.T) {
+		mockReader.EXPECT().StateAtBlockHash(&felt.Zero).Return(mockState, nopCloser, nil)
+		mockState.EXPECT().ContractClassHash(gomock.Any()).Return(expectedClassHash, nil)
+		hash := blockIDHash(t, &felt.Zero)
+		classHash, rpcErr := handler.ClassHashAt(&hash, &felt.Zero)
+		require.Nil(t, rpcErr)
+		assert.Equal(t, expectedClassHash, classHash)
+	})
+
+	t.Run("blockID - number", func(t *testing.T) {
+		mockReader.EXPECT().StateAtBlockNumber(uint64(0)).Return(mockState, nopCloser, nil)
+		mockState.EXPECT().ContractClassHash(gomock.Any()).Return(expectedClassHash, nil)
+		number := blockIDNumber(t, 0)
+		classHash, rpcErr := handler.ClassHashAt(&number, &felt.Zero)
+		require.Nil(t, rpcErr)
+		assert.Equal(t, expectedClassHash, classHash)
+	})
+
+	t.Run("blockID - pre_confirmed", func(t *testing.T) {
+		mockSyncReader.EXPECT().PendingState().Return(mockState, nopCloser, nil)
+		mockState.EXPECT().ContractClassHash(gomock.Any()).Return(expectedClassHash, nil)
+		preConfirmed := blockIDPreConfirmed(t)
+		classHash, rpcErr := handler.ClassHashAt(&preConfirmed, &felt.Zero)
+		require.Nil(t, rpcErr)
+		assert.Equal(t, expectedClassHash, classHash)
+	})
+}
+
+func assertEqualCairo0Class(t *testing.T, cairo0Class *core.Cairo0Class, class *rpcv6.Class) {
+	assert.Equal(t, cairo0Class.Program, class.Program)
+	assert.Equal(t, cairo0Class.Abi, class.Abi.(json.RawMessage))
+
+	require.Equal(t, len(cairo0Class.L1Handlers), len(class.EntryPoints.L1Handler))
+	for idx := range cairo0Class.L1Handlers {
+		assert.Nil(t, class.EntryPoints.L1Handler[idx].Index)
+		assert.Equal(t, cairo0Class.L1Handlers[idx].Offset, class.EntryPoints.L1Handler[idx].Offset)
+		assert.Equal(t, cairo0Class.L1Handlers[idx].Selector, class.EntryPoints.L1Handler[idx].Selector)
+	}
+
+	require.Equal(t, len(cairo0Class.Constructors), len(class.EntryPoints.Constructor))
+	for idx := range cairo0Class.Constructors {
+		assert.Nil(t, class.EntryPoints.Constructor[idx].Index)
+		assert.Equal(t, cairo0Class.Constructors[idx].Offset, class.EntryPoints.Constructor[idx].Offset)
+		assert.Equal(t, cairo0Class.Constructors[idx].Selector, class.EntryPoints.Constructor[idx].Selector)
+	}
+
+	require.Equal(t, len(cairo0Class.Externals), len(class.EntryPoints.External))
+	for idx := range cairo0Class.Externals {
+		assert.Nil(t, class.EntryPoints.External[idx].Index)
+		assert.Equal(t, cairo0Class.Externals[idx].Offset, class.EntryPoints.External[idx].Offset)
+		assert.Equal(t, cairo0Class.Externals[idx].Selector, class.EntryPoints.External[idx].Selector)
+	}
+}
+
+func assertEqualCairo1Class(t *testing.T, cairo1Class *core.Cairo1Class, class *rpcv6.Class) {
+	assert.Equal(t, cairo1Class.Program, class.SierraProgram)
+	assert.Equal(t, cairo1Class.Abi, class.Abi.(string))
+	assert.Equal(t, cairo1Class.SemanticVersion, class.ContractClassVersion)
+
+	require.Equal(t, len(cairo1Class.EntryPoints.L1Handler), len(class.EntryPoints.L1Handler))
+	for idx := range cairo1Class.EntryPoints.L1Handler {
+		assert.Nil(t, class.EntryPoints.L1Handler[idx].Offset)
+		assert.Equal(t, cairo1Class.EntryPoints.L1Handler[idx].Index, *class.EntryPoints.L1Handler[idx].Index)
+		assert.Equal(t, cairo1Class.EntryPoints.L1Handler[idx].Selector, class.EntryPoints.L1Handler[idx].Selector)
+	}
+
+	require.Equal(t, len(cairo1Class.EntryPoints.Constructor), len(class.EntryPoints.Constructor))
+	for idx := range cairo1Class.EntryPoints.Constructor {
+		assert.Nil(t, class.EntryPoints.Constructor[idx].Offset)
+		assert.Equal(t, cairo1Class.EntryPoints.Constructor[idx].Index, *class.EntryPoints.Constructor[idx].Index)
+		assert.Equal(t, cairo1Class.EntryPoints.Constructor[idx].Selector, class.EntryPoints.Constructor[idx].Selector)
+	}
+
+	require.Equal(t, len(cairo1Class.EntryPoints.External), len(class.EntryPoints.External))
+	for idx := range cairo1Class.EntryPoints.External {
+		assert.Nil(t, class.EntryPoints.External[idx].Offset)
+		assert.Equal(t, cairo1Class.EntryPoints.External[idx].Index, *class.EntryPoints.External[idx].Index)
+		assert.Equal(t, cairo1Class.EntryPoints.External[idx].Selector, class.EntryPoints.External[idx].Selector)
+	}
+}

--- a/rpc/v9/events.go
+++ b/rpc/v9/events.go
@@ -3,22 +3,24 @@ package rpcv9
 import (
 	"github.com/NethermindEth/juno/blockchain"
 	"github.com/NethermindEth/juno/core/felt"
+	"github.com/NethermindEth/juno/jsonrpc"
+	"github.com/NethermindEth/juno/rpc/rpccore"
+	rpcv6 "github.com/NethermindEth/juno/rpc/v6"
 )
 
+type EventArgs struct {
+	EventFilter
+	rpcv6.ResultPageRequest
+}
+
+type EventFilter struct {
+	FromBlock *BlockID      `json:"from_block"`
+	ToBlock   *BlockID      `json:"to_block"`
+	Address   *felt.Felt    `json:"address"`
+	Keys      [][]felt.Felt `json:"keys"`
+}
+
 type SubscriptionID string
-
-type Event struct {
-	From *felt.Felt   `json:"from_address,omitempty"`
-	Keys []*felt.Felt `json:"keys"`
-	Data []*felt.Felt `json:"data"`
-}
-
-type EmittedEvent struct {
-	*Event
-	BlockNumber     *uint64    `json:"block_number,omitempty"`
-	BlockHash       *felt.Felt `json:"block_hash,omitempty"`
-	TransactionHash *felt.Felt `json:"transaction_hash"`
-}
 
 func (h *Handler) unsubscribe(sub *subscription, id string) {
 	sub.cancel()
@@ -32,7 +34,7 @@ func setEventFilterRange(filter blockchain.EventFilterer, from, to *BlockID, lat
 		}
 
 		switch blockID.Type() {
-		case pending:
+		case preConfirmed:
 			return filter.SetRangeEndBlockByNumber(filterRange, latestHeight+1)
 		case latest:
 			return filter.SetRangeEndBlockByNumber(filterRange, latestHeight)
@@ -52,4 +54,79 @@ func setEventFilterRange(filter blockchain.EventFilterer, from, to *BlockID, lat
 		return err
 	}
 	return set(blockchain.EventFilterTo, to)
+}
+
+/****************************************************
+		Events Handlers
+*****************************************************/
+
+// Events gets the events matching a filter
+//
+// It follows the specification defined here:
+// https://github.com/starkware-libs/starknet-specs/blob/9377851884da5c81f757b6ae0ed47e84f9e7c058/api/starknet_api_openrpc.json#L813
+func (h *Handler) Events(args EventArgs) (rpcv6.EventsChunk, *jsonrpc.Error) {
+	if args.ChunkSize > rpccore.MaxEventChunkSize {
+		return rpcv6.EventsChunk{}, rpccore.ErrPageSizeTooBig
+	} else {
+		lenKeys := len(args.Keys)
+		for _, keys := range args.Keys {
+			lenKeys += len(keys)
+		}
+		if lenKeys > rpccore.MaxEventFilterKeys {
+			return rpcv6.EventsChunk{}, rpccore.ErrTooManyKeysInFilter
+		}
+	}
+
+	height, err := h.bcReader.Height()
+	if err != nil {
+		return rpcv6.EventsChunk{}, rpccore.ErrInternal
+	}
+
+	filter, err := h.bcReader.EventFilter(args.EventFilter.Address, args.EventFilter.Keys, h.PendingBlock)
+	if err != nil {
+		return rpcv6.EventsChunk{}, rpccore.ErrInternal
+	}
+	filter = filter.WithLimit(h.filterLimit)
+	defer h.callAndLogErr(filter.Close, "Error closing event filter in events")
+
+	var cToken *blockchain.ContinuationToken
+	if args.ContinuationToken != "" {
+		cToken = new(blockchain.ContinuationToken)
+		if err = cToken.FromString(args.ContinuationToken); err != nil {
+			return rpcv6.EventsChunk{}, rpccore.ErrInvalidContinuationToken
+		}
+	}
+
+	if err = setEventFilterRange(filter, args.EventFilter.FromBlock, args.EventFilter.ToBlock, height); err != nil {
+		return rpcv6.EventsChunk{}, rpccore.ErrBlockNotFound
+	}
+
+	filteredEvents, cToken, err := filter.Events(cToken, args.ChunkSize)
+	if err != nil {
+		return rpcv6.EventsChunk{}, rpccore.ErrInternal
+	}
+
+	emittedEvents := make([]*rpcv6.EmittedEvent, len(filteredEvents))
+	for i, fEvent := range filteredEvents {
+		var blockNumber *uint64
+		if fEvent.BlockHash != nil {
+			blockNumber = fEvent.BlockNumber
+		}
+		emittedEvents[i] = &rpcv6.EmittedEvent{
+			BlockNumber:     blockNumber,
+			BlockHash:       fEvent.BlockHash,
+			TransactionHash: fEvent.TransactionHash,
+			Event: &rpcv6.Event{
+				From: fEvent.From,
+				Keys: fEvent.Keys,
+				Data: fEvent.Data,
+			},
+		}
+	}
+
+	cTokenStr := ""
+	if cToken != nil {
+		cTokenStr = cToken.String()
+	}
+	return rpcv6.EventsChunk{Events: emittedEvents, ContinuationToken: cTokenStr}, nil
 }

--- a/rpc/v9/events_test.go
+++ b/rpc/v9/events_test.go
@@ -1,0 +1,288 @@
+package rpcv9_test
+
+import (
+	"testing"
+
+	"github.com/NethermindEth/juno/blockchain"
+	"github.com/NethermindEth/juno/clients/feeder"
+	"github.com/NethermindEth/juno/core"
+	"github.com/NethermindEth/juno/core/felt"
+	"github.com/NethermindEth/juno/db/memory"
+	"github.com/NethermindEth/juno/mocks"
+	rpccore "github.com/NethermindEth/juno/rpc/rpccore"
+	rpcv6 "github.com/NethermindEth/juno/rpc/v6"
+	rpc "github.com/NethermindEth/juno/rpc/v9"
+	adaptfeeder "github.com/NethermindEth/juno/starknetdata/feeder"
+	"github.com/NethermindEth/juno/utils"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+)
+
+func TestEvents(t *testing.T) {
+	var preConfirmedB *core.Block
+
+	testDB := memory.New()
+	n := &utils.Sepolia
+	chain := blockchain.New(testDB, n)
+
+	mockCtrl := gomock.NewController(t)
+	t.Cleanup(mockCtrl.Finish)
+
+	mockSyncReader := mocks.NewMockSyncReader(mockCtrl)
+
+	client := feeder.NewTestClient(t, n)
+	gw := adaptfeeder.New(client)
+	for i := range 7 {
+		b, err := gw.BlockByNumber(t.Context(), uint64(i))
+		require.NoError(t, err)
+		s, err := gw.StateUpdate(t.Context(), uint64(i))
+		require.NoError(t, err)
+
+		if b.Number < 6 {
+			require.NoError(t, chain.Store(b, &core.BlockCommitments{}, s, nil))
+		} else {
+			b.Hash = nil
+			b.GlobalStateRoot = nil
+			preConfirmedB = b
+		}
+	}
+
+	handler := rpc.New(chain, mockSyncReader, nil, utils.NewNopZapLogger())
+	from := utils.HexToFelt(t, "0x49d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7")
+	blockNumber := blockIDNumber(t, 0)
+	latest := blockIDLatest(t)
+	args := rpc.EventArgs{
+		EventFilter: rpc.EventFilter{
+			FromBlock: &blockNumber,
+			ToBlock:   &latest,
+			Address:   from,
+			Keys:      [][]felt.Felt{},
+		},
+		ResultPageRequest: rpcv6.ResultPageRequest{
+			ChunkSize:         100,
+			ContinuationToken: "",
+		},
+	}
+
+	t.Run("filter non-existent", func(t *testing.T) {
+		t.Run("block number - bounds to latest", func(t *testing.T) {
+			number := blockIDNumber(t, 55)
+			args.ToBlock = &number
+			events, err := handler.Events(args)
+			require.Nil(t, err)
+			require.Len(t, events.Events, 4)
+		})
+
+		t.Run("block hash", func(t *testing.T) {
+			hash := blockIDHash(t, new(felt.Felt).SetUint64(55))
+			args.ToBlock = &hash
+			_, err := handler.Events(args)
+			require.Equal(t, rpccore.ErrBlockNotFound, err)
+		})
+	})
+
+	t.Run("filter with from_block > to_block", func(t *testing.T) {
+		fromBlock := blockIDNumber(t, 1)
+		toBlock := blockIDNumber(t, 0)
+		fArgs := rpc.EventArgs{
+			EventFilter: rpc.EventFilter{
+				FromBlock: &fromBlock,
+				ToBlock:   &toBlock,
+			},
+			ResultPageRequest: rpcv6.ResultPageRequest{
+				ChunkSize:         100,
+				ContinuationToken: "",
+			},
+		}
+
+		events, err := handler.Events(fArgs)
+		require.Nil(t, err)
+		require.Empty(t, events.Events)
+	})
+
+	t.Run("filter with no from_block", func(t *testing.T) {
+		args.FromBlock = nil
+		args.ToBlock = &latest
+		_, err := handler.Events(args)
+		require.Nil(t, err)
+	})
+
+	t.Run("filter with no to_block", func(t *testing.T) {
+		number := blockIDNumber(t, 0)
+		args.FromBlock = &number
+		args.ToBlock = nil
+		_, err := handler.Events(args)
+		require.Nil(t, err)
+	})
+
+	t.Run("filter with no address", func(t *testing.T) {
+		args.ToBlock = &latest
+		args.Address = nil
+		_, err := handler.Events(args)
+		require.Nil(t, err)
+	})
+
+	t.Run("filter with no keys", func(t *testing.T) {
+		var allEvents []*rpcv6.EmittedEvent
+		t.Run("get canonical events without pagination", func(t *testing.T) {
+			args.ToBlock = &latest
+			args.Address = from
+			events, err := handler.Events(args)
+			require.Nil(t, err)
+			require.Len(t, events.Events, 4)
+			require.Empty(t, events.ContinuationToken)
+			allEvents = events.Events
+		})
+
+		t.Run("accumulate events with pagination", func(t *testing.T) {
+			var accEvents []*rpcv6.EmittedEvent
+			args.ChunkSize = 1
+
+			for range len(allEvents) + 1 {
+				events, err := handler.Events(args)
+				require.Nil(t, err)
+				accEvents = append(accEvents, events.Events...)
+				args.ContinuationToken = events.ContinuationToken
+				if args.ContinuationToken == "" {
+					break
+				}
+			}
+			require.Equal(t, allEvents, accEvents)
+		})
+	})
+
+	t.Run("filter with keys", func(t *testing.T) {
+		key := utils.HexToFelt(t, "0x2e8a4ec40a36a027111fafdb6a46746ff1b0125d5067fbaebd8b5f227185a1e")
+
+		t.Run("get all events without pagination", func(t *testing.T) {
+			args.ChunkSize = 100
+			args.Keys = append(args.Keys, []felt.Felt{*key})
+			events, err := handler.Events(args)
+			require.Nil(t, err)
+			require.Len(t, events.Events, 1)
+			require.Empty(t, events.ContinuationToken)
+
+			require.Equal(t, from, events.Events[0].From)
+			require.Equal(t, []*felt.Felt{key}, events.Events[0].Keys)
+			require.Equal(t, []*felt.Felt{
+				utils.HexToFelt(t, "0x23be95f90bf41685e18a4356e57b0cfdc1da22bf382ead8b64108353915c1e5"),
+				utils.HexToFelt(t, "0x0"),
+				utils.HexToFelt(t, "0x4"),
+				utils.HexToFelt(t, "0x4574686572"),
+				utils.HexToFelt(t, "0x455448"),
+				utils.HexToFelt(t, "0x12"),
+				utils.HexToFelt(t, "0x4c5772d1914fe6ce891b64eb35bf3522aeae1315647314aac58b01137607f3f"),
+				utils.HexToFelt(t, "0x0"),
+			}, events.Events[0].Data)
+			require.Equal(t, uint64(4), *events.Events[0].BlockNumber)
+			require.Equal(t, utils.HexToFelt(t, "0x445152a69e628774b0f78a952e6f9ba0ffcda1374724b314140928fd2f31f4c"), events.Events[0].BlockHash)
+			require.Equal(t, utils.HexToFelt(t, "0x3c9dfcd3fe66be18b661ee4ebb62520bb4f13d4182b040b3c2be9a12dbcc09b"), events.Events[0].TransactionHash)
+		})
+	})
+
+	t.Run("large page size", func(t *testing.T) {
+		args.ChunkSize = 10240 + 1
+		events, err := handler.Events(args)
+		require.Equal(t, rpccore.ErrPageSizeTooBig, err)
+		require.Empty(t, events)
+	})
+
+	t.Run("too many keys", func(t *testing.T) {
+		args.ChunkSize = 2
+		args.Keys = make([][]felt.Felt, 1024+1)
+		events, err := handler.Events(args)
+		require.Equal(t, rpccore.ErrTooManyKeysInFilter, err)
+		require.Empty(t, events)
+	})
+
+	t.Run("filter with limit", func(t *testing.T) {
+		handler = handler.WithFilterLimit(1)
+		args.Address = utils.HexToFelt(t, "0x49d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7")
+		args.ChunkSize = 100
+		args.Keys = make([][]felt.Felt, 0)
+
+		events, err := handler.Events(args)
+		require.Nil(t, err)
+		require.Equal(t, "4-0", events.ContinuationToken)
+		require.NotEmpty(t, events.Events)
+
+		handler = handler.WithFilterLimit(7)
+		events, err = handler.Events(args)
+		require.Nil(t, err)
+		require.Empty(t, events.ContinuationToken)
+		require.NotEmpty(t, events.Events)
+	})
+
+	t.Run("get pre_confirmed events without pagination", func(t *testing.T) {
+		preConfirmed := core.NewPreConfirmed(preConfirmedB, nil, nil, nil)
+		mockSyncReader.EXPECT().PendingData().Return(
+			&preConfirmed,
+			nil,
+		)
+		preConfirmedID := blockIDPreConfirmed(t)
+		args = rpc.EventArgs{
+			EventFilter: rpc.EventFilter{
+				FromBlock: &preConfirmedID,
+				ToBlock:   &preConfirmedID,
+			},
+			ResultPageRequest: rpcv6.ResultPageRequest{
+				ChunkSize:         100,
+				ContinuationToken: "",
+			},
+		}
+		events, err := handler.Events(args)
+		require.Nil(t, err)
+		require.Len(t, events.Events, 2)
+		require.Empty(t, events.ContinuationToken)
+
+		assert.Nil(t, events.Events[0].BlockHash)
+		assert.Nil(t, events.Events[0].BlockNumber)
+		assert.Equal(t, utils.HexToFelt(t, "0x785c2ada3f53fbc66078d47715c27718f92e6e48b96372b36e5197de69b82b5"), events.Events[0].TransactionHash)
+	})
+
+	t.Run("get pre_confirmed events with pagination", func(t *testing.T) {
+		var err error
+		preConfirmedB, err = gw.BlockByNumber(t.Context(), 6)
+		require.Nil(t, err)
+		preConfirmedID := blockIDPreConfirmed(t)
+		args = rpc.EventArgs{
+			EventFilter: rpc.EventFilter{
+				FromBlock: &preConfirmedID,
+				ToBlock:   &preConfirmedID,
+			},
+			ResultPageRequest: rpcv6.ResultPageRequest{
+				ChunkSize: 1,
+			},
+		}
+
+		allEvents := []*core.Event{}
+
+		for _, receipt := range preConfirmedB.Receipts {
+			allEvents = append(allEvents, receipt.Events...)
+		}
+
+		preConfirmed := core.NewPreConfirmed(preConfirmedB, nil, nil, nil)
+		mockSyncReader.EXPECT().PendingData().Return(
+			&preConfirmed,
+			nil,
+		).Times(len(allEvents))
+
+		for i, expectedEvent := range allEvents {
+			events, err := handler.Events(args)
+			require.Nil(t, err)
+			require.Len(t, events.Events, 1)
+			actualEvent := events.Events[0]
+			if i == len(allEvents)-1 {
+				require.Empty(t, events.ContinuationToken)
+			} else {
+				require.NotEmpty(t, events.ContinuationToken)
+			}
+
+			assert.Equal(t, expectedEvent.From.String(), actualEvent.From.String())
+			assert.Equal(t, expectedEvent.Keys, actualEvent.Keys)
+			assert.Equal(t, expectedEvent.Data, actualEvent.Data)
+			args.ContinuationToken = events.ContinuationToken
+		}
+	})
+}

--- a/rpc/v9/handlers.go
+++ b/rpc/v9/handlers.go
@@ -263,11 +263,6 @@ func (h *Handler) methods() ([]jsonrpc.Method, string) { //nolint: funlen
 			Params:  []jsonrpc.Parameter{{Name: "message"}, {Name: "block_id"}},
 			Handler: h.EstimateMessageFee,
 		},
-		// {
-		// 	Name:    "starknet_getNonce",
-		// 	Params:  []jsonrpc.Parameter{{Name: "block_id"}, {Name: "contract_address"}},
-		// 	Handler: h.Nonce,
-		// },
 		{
 			Name:    "starknet_getNonce",
 			Params:  []jsonrpc.Parameter{{Name: "block_id"}, {Name: "contract_address"}},

--- a/rpc/v9/handlers.go
+++ b/rpc/v9/handlers.go
@@ -269,6 +269,11 @@ func (h *Handler) methods() ([]jsonrpc.Method, string) { //nolint: funlen
 		// 	Handler: h.Nonce,
 		// },
 		{
+			Name:    "starknet_getNonce",
+			Params:  []jsonrpc.Parameter{{Name: "block_id"}, {Name: "contract_address"}},
+			Handler: h.Nonce,
+		},
+		{
 			Name:    "starknet_traceTransaction",
 			Params:  []jsonrpc.Parameter{{Name: "transaction_hash"}},
 			Handler: h.TraceTransaction,

--- a/rpc/v9/handlers.go
+++ b/rpc/v9/handlers.go
@@ -184,41 +184,41 @@ func (h *Handler) methods() ([]jsonrpc.Method, string) { //nolint: funlen
 			Params:  []jsonrpc.Parameter{{Name: "transaction_hash"}},
 			Handler: h.TransactionReceiptByHash,
 		},
-		// {
-		// 	Name:    "starknet_getBlockTransactionCount",
-		// 	Params:  []jsonrpc.Parameter{{Name: "block_id"}},
-		// 	Handler: h.BlockTransactionCount,
-		// },
+		{
+			Name:    "starknet_getBlockTransactionCount",
+			Params:  []jsonrpc.Parameter{{Name: "block_id"}},
+			Handler: h.BlockTransactionCount,
+		},
 		{
 			Name:    "starknet_getTransactionByBlockIdAndIndex",
 			Params:  []jsonrpc.Parameter{{Name: "block_id"}, {Name: "index"}},
 			Handler: h.TransactionByBlockIDAndIndex,
 		},
-		// {
-		// 	Name:    "starknet_getStateUpdate",
-		// 	Params:  []jsonrpc.Parameter{{Name: "block_id"}},
-		// 	Handler: h.StateUpdate,
-		// },
+		{
+			Name:    "starknet_getStateUpdate",
+			Params:  []jsonrpc.Parameter{{Name: "block_id"}},
+			Handler: h.StateUpdate,
+		},
 		{
 			Name:    "starknet_getStorageAt",
 			Params:  []jsonrpc.Parameter{{Name: "contract_address"}, {Name: "key"}, {Name: "block_id"}},
 			Handler: h.StorageAt,
 		},
-		// {
-		// 	Name:    "starknet_getClassHashAt",
-		// 	Params:  []jsonrpc.Parameter{{Name: "block_id"}, {Name: "contract_address"}},
-		// 	Handler: h.ClassHashAt,
-		// },
-		// {
-		// 	Name:    "starknet_getClass",
-		// 	Params:  []jsonrpc.Parameter{{Name: "block_id"}, {Name: "class_hash"}},
-		// 	Handler: h.Class,
-		// },
-		// {
-		// 	Name:    "starknet_getClassAt",
-		// 	Params:  []jsonrpc.Parameter{{Name: "block_id"}, {Name: "contract_address"}},
-		// 	Handler: h.ClassAt,
-		// },
+		{
+			Name:    "starknet_getClassHashAt",
+			Params:  []jsonrpc.Parameter{{Name: "block_id"}, {Name: "contract_address"}},
+			Handler: h.ClassHashAt,
+		},
+		{
+			Name:    "starknet_getClass",
+			Params:  []jsonrpc.Parameter{{Name: "block_id"}, {Name: "class_hash"}},
+			Handler: h.Class,
+		},
+		{
+			Name:    "starknet_getClassAt",
+			Params:  []jsonrpc.Parameter{{Name: "block_id"}, {Name: "contract_address"}},
+			Handler: h.ClassAt,
+		},
 		{
 			Name:    "starknet_addInvokeTransaction",
 			Params:  []jsonrpc.Parameter{{Name: "invoke_transaction"}},
@@ -234,11 +234,11 @@ func (h *Handler) methods() ([]jsonrpc.Method, string) { //nolint: funlen
 			Params:  []jsonrpc.Parameter{{Name: "declare_transaction"}},
 			Handler: h.AddTransaction,
 		},
-		// {
-		// 	Name:    "starknet_getEvents",
-		// 	Params:  []jsonrpc.Parameter{{Name: "filter"}},
-		// 	Handler: h.Events,
-		// },
+		{
+			Name:    "starknet_getEvents",
+			Params:  []jsonrpc.Parameter{{Name: "filter"}},
+			Handler: h.Events,
+		},
 		{
 			Name:    "juno_version",
 			Handler: h.Version,

--- a/rpc/v9/handlers_test.go
+++ b/rpc/v9/handlers_test.go
@@ -9,7 +9,6 @@ import (
 	"github.com/NethermindEth/juno/node"
 	rpcv6 "github.com/NethermindEth/juno/rpc/v6"
 	rpcv9 "github.com/NethermindEth/juno/rpc/v9"
-	"github.com/NethermindEth/juno/sync"
 	"github.com/NethermindEth/juno/utils"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -95,8 +94,6 @@ func TestThrottledVMError(t *testing.T) {
 		mockReader.EXPECT().StateAtBlockHash(header.ParentHash).Return(state, nopCloser, nil)
 		headState := mocks.NewMockStateHistoryReader(mockCtrl)
 		headState.EXPECT().Class(declareTx.ClassHash).Return(declaredClass, nil)
-		pending := sync.NewPending(nil, nil, nil)
-		mockSyncReader.EXPECT().PendingData().Return(&pending, nil)
 		mockSyncReader.EXPECT().PendingState().Return(headState, nopCloser, nil)
 
 		blockID := blockIDHash(t, blockHash)

--- a/rpc/v9/helpers.go
+++ b/rpc/v9/helpers.go
@@ -36,7 +36,7 @@ func (h *Handler) blockByID(blockID *BlockID) (*core.Block, *jsonrpc.Error) {
 	var err error
 
 	switch blockID.Type() {
-	case pending:
+	case preConfirmed:
 		var pending core.PendingData
 		pending, err = h.PendingData()
 		if err == nil {
@@ -66,11 +66,11 @@ func (h *Handler) blockHeaderByID(blockID *BlockID) (*core.Header, *jsonrpc.Erro
 	var header *core.Header
 	var err error
 	switch blockID.Type() {
-	case pending:
+	case preConfirmed:
 		var pending core.PendingData
 		pending, err = h.PendingData()
 		if err == nil {
-			header = pending.GetHeader()
+			header = pending.GetBlock().Header
 		}
 	case latest:
 		header, err = h.bcReader.HeadsHeader()
@@ -142,7 +142,7 @@ func (h *Handler) stateByBlockID(blockID *BlockID) (core.StateReader, blockchain
 	var closer blockchain.StateCloser
 	var err error
 	switch blockID.Type() {
-	case pending:
+	case preConfirmed:
 		reader, closer, err = h.PendingState()
 	case latest:
 		reader, closer, err = h.bcReader.HeadState()

--- a/rpc/v9/nonce.go
+++ b/rpc/v9/nonce.go
@@ -14,14 +14,14 @@ import (
 //
 // It follows the specification defined here:
 // https://github.com/starkware-libs/starknet-specs/blob/25533f8b7999219120a4a654709d47dc9376d640/api/starknet_api_openrpc.json#L851
-func (h *Handler) Nonce(id *BlockID, address felt.Felt) (*felt.Felt, *jsonrpc.Error) {
+func (h *Handler) Nonce(id *BlockID, address *felt.Felt) (*felt.Felt, *jsonrpc.Error) {
 	stateReader, stateCloser, rpcErr := h.stateByBlockID(id)
 	if rpcErr != nil {
 		return nil, rpcErr
 	}
 	defer h.callAndLogErr(stateCloser, "Error closing state reader in getNonce")
 
-	nonce, err := stateReader.ContractNonce(&address)
+	nonce, err := stateReader.ContractNonce(address)
 	if err != nil {
 		return nil, rpccore.ErrContractNotFound
 	}

--- a/rpc/v9/nonce.go
+++ b/rpc/v9/nonce.go
@@ -1,0 +1,30 @@
+package rpcv9
+
+import (
+	"github.com/NethermindEth/juno/core/felt"
+	"github.com/NethermindEth/juno/jsonrpc"
+	rpccore "github.com/NethermindEth/juno/rpc/rpccore"
+)
+
+/****************************************************
+		Nonce Handler
+*****************************************************/
+
+// Nonce returns the nonce associated with the given address in the given block number
+//
+// It follows the specification defined here:
+// https://github.com/starkware-libs/starknet-specs/blob/25533f8b7999219120a4a654709d47dc9376d640/api/starknet_api_openrpc.json#L851
+func (h *Handler) Nonce(id *BlockID, address felt.Felt) (*felt.Felt, *jsonrpc.Error) {
+	stateReader, stateCloser, rpcErr := h.stateByBlockID(id)
+	if rpcErr != nil {
+		return nil, rpcErr
+	}
+	defer h.callAndLogErr(stateCloser, "Error closing state reader in getNonce")
+
+	nonce, err := stateReader.ContractNonce(&address)
+	if err != nil {
+		return nil, rpccore.ErrContractNotFound
+	}
+
+	return nonce, nil
+}

--- a/rpc/v9/nonce_test.go
+++ b/rpc/v9/nonce_test.go
@@ -98,8 +98,8 @@ func TestNonce(t *testing.T) {
 		mockSyncReader.EXPECT().PendingState().Return(mockState, nopCloser, nil)
 		mockState.EXPECT().ContractNonce(&felt.Zero).Return(expectedNonce, nil)
 
-		pendingBlockID := blockIDPreConfirmed(t)
-		nonce, rpcErr := handler.Nonce(&pendingBlockID, felt.Zero)
+		preConfirmedBlockID := blockIDPreConfirmed(t)
+		nonce, rpcErr := handler.Nonce(&preConfirmedBlockID, felt.Zero)
 		require.Nil(t, rpcErr)
 		assert.Equal(t, expectedNonce, nonce)
 	})

--- a/rpc/v9/nonce_test.go
+++ b/rpc/v9/nonce_test.go
@@ -21,7 +21,7 @@ func TestNonce(t *testing.T) {
 	mockReader := mocks.NewMockReader(mockCtrl)
 	mockSyncReader := mocks.NewMockSyncReader(mockCtrl)
 	log := utils.NewNopZapLogger()
-	handler := rpc.New(mockReader, mockSyncReader, nil, "", log)
+	handler := rpc.New(mockReader, mockSyncReader, nil, log)
 
 	t.Run("empty blockchain", func(t *testing.T) {
 		mockReader.EXPECT().HeadState().Return(nil, nil, db.ErrKeyNotFound)

--- a/rpc/v9/nonce_test.go
+++ b/rpc/v9/nonce_test.go
@@ -27,7 +27,7 @@ func TestNonce(t *testing.T) {
 		mockReader.EXPECT().HeadState().Return(nil, nil, db.ErrKeyNotFound)
 
 		latest := blockIDLatest(t)
-		nonce, rpcErr := handler.Nonce(&latest, felt.Zero)
+		nonce, rpcErr := handler.Nonce(&latest, &felt.Zero)
 		require.Nil(t, nonce)
 		assert.Equal(t, rpccore.ErrBlockNotFound, rpcErr)
 	})
@@ -36,7 +36,7 @@ func TestNonce(t *testing.T) {
 		mockReader.EXPECT().StateAtBlockHash(&felt.Zero).Return(nil, nil, db.ErrKeyNotFound)
 
 		hash := blockIDHash(t, &felt.Zero)
-		nonce, rpcErr := handler.Nonce(&hash, felt.Zero)
+		nonce, rpcErr := handler.Nonce(&hash, &felt.Zero)
 		require.Nil(t, nonce)
 		assert.Equal(t, rpccore.ErrBlockNotFound, rpcErr)
 	})
@@ -45,7 +45,7 @@ func TestNonce(t *testing.T) {
 		mockReader.EXPECT().StateAtBlockNumber(uint64(0)).Return(nil, nil, db.ErrKeyNotFound)
 
 		number := blockIDNumber(t, 0)
-		nonce, rpcErr := handler.Nonce(&number, felt.Zero)
+		nonce, rpcErr := handler.Nonce(&number, &felt.Zero)
 		require.Nil(t, nonce)
 		assert.Equal(t, rpccore.ErrBlockNotFound, rpcErr)
 	})
@@ -57,7 +57,7 @@ func TestNonce(t *testing.T) {
 		mockState.EXPECT().ContractNonce(&felt.Zero).Return(nil, errors.New("non-existent contract"))
 
 		latest := blockIDLatest(t)
-		nonce, rpcErr := handler.Nonce(&latest, felt.Zero)
+		nonce, rpcErr := handler.Nonce(&latest, &felt.Zero)
 		require.Nil(t, nonce)
 		assert.Equal(t, rpccore.ErrContractNotFound, rpcErr)
 	})
@@ -69,7 +69,7 @@ func TestNonce(t *testing.T) {
 		mockState.EXPECT().ContractNonce(&felt.Zero).Return(expectedNonce, nil)
 
 		latest := blockIDLatest(t)
-		nonce, rpcErr := handler.Nonce(&latest, felt.Zero)
+		nonce, rpcErr := handler.Nonce(&latest, &felt.Zero)
 		require.Nil(t, rpcErr)
 		assert.Equal(t, expectedNonce, nonce)
 	})
@@ -79,7 +79,7 @@ func TestNonce(t *testing.T) {
 		mockState.EXPECT().ContractNonce(&felt.Zero).Return(expectedNonce, nil)
 
 		hash := blockIDHash(t, &felt.Zero)
-		nonce, rpcErr := handler.Nonce(&hash, felt.Zero)
+		nonce, rpcErr := handler.Nonce(&hash, &felt.Zero)
 		require.Nil(t, rpcErr)
 		assert.Equal(t, expectedNonce, nonce)
 	})
@@ -89,7 +89,7 @@ func TestNonce(t *testing.T) {
 		mockState.EXPECT().ContractNonce(&felt.Zero).Return(expectedNonce, nil)
 
 		number := blockIDNumber(t, 0)
-		nonce, rpcErr := handler.Nonce(&number, felt.Zero)
+		nonce, rpcErr := handler.Nonce(&number, &felt.Zero)
 		require.Nil(t, rpcErr)
 		assert.Equal(t, expectedNonce, nonce)
 	})
@@ -99,7 +99,7 @@ func TestNonce(t *testing.T) {
 		mockState.EXPECT().ContractNonce(&felt.Zero).Return(expectedNonce, nil)
 
 		preConfirmedBlockID := blockIDPreConfirmed(t)
-		nonce, rpcErr := handler.Nonce(&preConfirmedBlockID, felt.Zero)
+		nonce, rpcErr := handler.Nonce(&preConfirmedBlockID, &felt.Zero)
 		require.Nil(t, rpcErr)
 		assert.Equal(t, expectedNonce, nonce)
 	})

--- a/rpc/v9/nonce_test.go
+++ b/rpc/v9/nonce_test.go
@@ -1,0 +1,106 @@
+package rpcv9_test
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/NethermindEth/juno/core/felt"
+	"github.com/NethermindEth/juno/db"
+	"github.com/NethermindEth/juno/mocks"
+	"github.com/NethermindEth/juno/rpc/rpccore"
+	rpc "github.com/NethermindEth/juno/rpc/v9"
+	"github.com/NethermindEth/juno/utils"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+)
+
+func TestNonce(t *testing.T) {
+	mockCtrl := gomock.NewController(t)
+
+	mockReader := mocks.NewMockReader(mockCtrl)
+	mockSyncReader := mocks.NewMockSyncReader(mockCtrl)
+	log := utils.NewNopZapLogger()
+	handler := rpc.New(mockReader, mockSyncReader, nil, "", log)
+
+	t.Run("empty blockchain", func(t *testing.T) {
+		mockReader.EXPECT().HeadState().Return(nil, nil, db.ErrKeyNotFound)
+
+		latest := blockIDLatest(t)
+		nonce, rpcErr := handler.Nonce(&latest, felt.Zero)
+		require.Nil(t, nonce)
+		assert.Equal(t, rpccore.ErrBlockNotFound, rpcErr)
+	})
+
+	t.Run("non-existent block hash", func(t *testing.T) {
+		mockReader.EXPECT().StateAtBlockHash(&felt.Zero).Return(nil, nil, db.ErrKeyNotFound)
+
+		hash := blockIDHash(t, &felt.Zero)
+		nonce, rpcErr := handler.Nonce(&hash, felt.Zero)
+		require.Nil(t, nonce)
+		assert.Equal(t, rpccore.ErrBlockNotFound, rpcErr)
+	})
+
+	t.Run("non-existent block number", func(t *testing.T) {
+		mockReader.EXPECT().StateAtBlockNumber(uint64(0)).Return(nil, nil, db.ErrKeyNotFound)
+
+		number := blockIDNumber(t, 0)
+		nonce, rpcErr := handler.Nonce(&number, felt.Zero)
+		require.Nil(t, nonce)
+		assert.Equal(t, rpccore.ErrBlockNotFound, rpcErr)
+	})
+
+	mockState := mocks.NewMockStateHistoryReader(mockCtrl)
+
+	t.Run("non-existent contract", func(t *testing.T) {
+		mockReader.EXPECT().HeadState().Return(mockState, nopCloser, nil)
+		mockState.EXPECT().ContractNonce(&felt.Zero).Return(nil, errors.New("non-existent contract"))
+
+		latest := blockIDLatest(t)
+		nonce, rpcErr := handler.Nonce(&latest, felt.Zero)
+		require.Nil(t, nonce)
+		assert.Equal(t, rpccore.ErrContractNotFound, rpcErr)
+	})
+
+	expectedNonce := new(felt.Felt).SetUint64(1)
+
+	t.Run("blockID - latest", func(t *testing.T) {
+		mockReader.EXPECT().HeadState().Return(mockState, nopCloser, nil)
+		mockState.EXPECT().ContractNonce(&felt.Zero).Return(expectedNonce, nil)
+
+		latest := blockIDLatest(t)
+		nonce, rpcErr := handler.Nonce(&latest, felt.Zero)
+		require.Nil(t, rpcErr)
+		assert.Equal(t, expectedNonce, nonce)
+	})
+
+	t.Run("blockID - hash", func(t *testing.T) {
+		mockReader.EXPECT().StateAtBlockHash(&felt.Zero).Return(mockState, nopCloser, nil)
+		mockState.EXPECT().ContractNonce(&felt.Zero).Return(expectedNonce, nil)
+
+		hash := blockIDHash(t, &felt.Zero)
+		nonce, rpcErr := handler.Nonce(&hash, felt.Zero)
+		require.Nil(t, rpcErr)
+		assert.Equal(t, expectedNonce, nonce)
+	})
+
+	t.Run("blockID - number", func(t *testing.T) {
+		mockReader.EXPECT().StateAtBlockNumber(uint64(0)).Return(mockState, nopCloser, nil)
+		mockState.EXPECT().ContractNonce(&felt.Zero).Return(expectedNonce, nil)
+
+		number := blockIDNumber(t, 0)
+		nonce, rpcErr := handler.Nonce(&number, felt.Zero)
+		require.Nil(t, rpcErr)
+		assert.Equal(t, expectedNonce, nonce)
+	})
+
+	t.Run("blockID - pre_confirmed", func(t *testing.T) {
+		mockSyncReader.EXPECT().PendingState().Return(mockState, nopCloser, nil)
+		mockState.EXPECT().ContractNonce(&felt.Zero).Return(expectedNonce, nil)
+
+		pendingBlockID := blockIDPreConfirmed(t)
+		nonce, rpcErr := handler.Nonce(&pendingBlockID, felt.Zero)
+		require.Nil(t, rpcErr)
+		assert.Equal(t, expectedNonce, nonce)
+	})
+}

--- a/rpc/v9/pending_data_wrapper_test.go
+++ b/rpc/v9/pending_data_wrapper_test.go
@@ -2,11 +2,9 @@ package rpcv9_test
 
 import (
 	"testing"
-	"time"
 
 	"github.com/NethermindEth/juno/clients/feeder"
 	"github.com/NethermindEth/juno/core"
-	"github.com/NethermindEth/juno/core/felt"
 	"github.com/NethermindEth/juno/mocks"
 	rpc "github.com/NethermindEth/juno/rpc/v9"
 	adaptfeeder "github.com/NethermindEth/juno/starknetdata/feeder"
@@ -16,7 +14,7 @@ import (
 	"go.uber.org/mock/gomock"
 )
 
-func TestPendingDataWrapper_PendingData(t *testing.T) {
+func TestPendingDataWrapper(t *testing.T) {
 	mockCtrl := gomock.NewController(t)
 	t.Cleanup(mockCtrl.Finish)
 	mockSyncReader := mocks.NewMockSyncReader(mockCtrl)
@@ -24,7 +22,6 @@ func TestPendingDataWrapper_PendingData(t *testing.T) {
 	mockReader := mocks.NewMockReader(mockCtrl)
 	log := utils.NewNopZapLogger()
 	handler := rpc.New(mockReader, mockSyncReader, nil, log)
-
 	client := feeder.NewTestClient(t, n)
 	gw := adaptfeeder.New(client)
 
@@ -40,64 +37,54 @@ func TestPendingDataWrapper_PendingData(t *testing.T) {
 		)
 		pending, err := handler.PendingData()
 		require.NoError(t, err)
+		require.Equal(t, core.PendingBlockVariant, pending.Variant())
 		require.Equal(t, expectedPending, sync.Pending{
 			Block:       pending.GetBlock(),
 			StateUpdate: pending.GetStateUpdate(),
 			NewClasses:  pending.GetNewClasses(),
 		})
 	})
-	t.Run("Returns empty pending block when starknet version >= 0.14.0", func(t *testing.T) {
-		preConfirmed := core.NewPreConfirmed(nil, nil, nil, nil)
+
+	t.Run("Returns pre_confirmed block data when starknet version >= 0.14.0", func(t *testing.T) {
+		expectedPending := core.NewPreConfirmed(latestBlock, nil, nil, nil)
 		mockSyncReader.EXPECT().PendingData().Return(
-			&preConfirmed,
+			&expectedPending,
 			nil,
 		)
-		mockReader.EXPECT().HeadsHeader().Return(latestBlock.Header, nil)
-
-		receipts := make([]*core.TransactionReceipt, 0)
-		expectedPendingB := &core.Block{
-			Header: &core.Header{
-				ParentHash:       latestBlock.Hash,
-				Number:           latestBlockNumber + 1,
-				SequencerAddress: latestBlock.SequencerAddress,
-				Timestamp:        uint64(time.Now().Unix()),
-				ProtocolVersion:  latestBlock.ProtocolVersion,
-				EventsBloom:      core.EventsBloom(receipts),
-				L1GasPriceETH:    latestBlock.L1GasPriceETH,
-				L1GasPriceSTRK:   latestBlock.L1GasPriceSTRK,
-				L2GasPrice:       latestBlock.L2GasPrice,
-				L1DataGasPrice:   latestBlock.L1DataGasPrice,
-				L1DAMode:         latestBlock.L1DAMode,
-			},
-			Transactions: make([]core.Transaction, 0),
-			Receipts:     receipts,
-		}
-
-		emptyStateDiff := &core.StateDiff{
-			StorageDiffs:      make(map[felt.Felt]map[felt.Felt]*felt.Felt),
-			Nonces:            make(map[felt.Felt]*felt.Felt),
-			DeployedContracts: make(map[felt.Felt]*felt.Felt),
-			DeclaredV0Classes: make([]*felt.Felt, 0),
-			DeclaredV1Classes: make(map[felt.Felt]*felt.Felt),
-			ReplacedClasses:   make(map[felt.Felt]*felt.Felt),
-		}
-
-		expectedPending := &sync.Pending{
-			Block: expectedPendingB,
-			StateUpdate: &core.StateUpdate{
-				OldRoot:   latestBlock.GlobalStateRoot,
-				StateDiff: emptyStateDiff,
-			},
-			NewClasses: make(map[felt.Felt]core.Class, 0),
-		}
-
 		pending, err := handler.PendingData()
 		require.NoError(t, err)
-		require.Equal(t, *expectedPending, sync.NewPending(
-			pending.GetBlock(),
-			pending.GetStateUpdate(),
-			pending.GetNewClasses(),
-		))
+		require.Equal(t, core.PreConfirmedBlockVariant, pending.Variant())
+		require.Equal(t, expectedPending, core.PreConfirmed{
+			Block:                 pending.GetBlock(),
+			StateUpdate:           pending.GetStateUpdate(),
+			NewClasses:            pending.GetNewClasses(),
+			CandidateTxs:          pending.GetCandidateTransaction(),
+			TransactionStateDiffs: nil,
+		})
+	})
+
+	t.Run("Finality status is ACCEPTED_ON_L2 when pending block", func(t *testing.T) {
+		expectedPending := sync.NewPending(latestBlock, nil, nil)
+		mockSyncReader.EXPECT().PendingData().Return(
+			&expectedPending,
+			nil,
+		).Times(2)
+		pending, err := handler.PendingData()
+		require.NoError(t, err)
+		require.Equal(t, core.PendingBlockVariant, pending.Variant())
+		require.Equal(t, rpc.TxnAcceptedOnL2, handler.PendingBlockFinalityStatus())
+	})
+
+	t.Run("Finality status is PRE_CONFIRMED when pre_confirmed block", func(t *testing.T) {
+		expectedPending := core.NewPreConfirmed(latestBlock, nil, nil, nil)
+		mockSyncReader.EXPECT().PendingData().Return(
+			&expectedPending,
+			nil,
+		).Times(2)
+		pending, err := handler.PendingData()
+		require.NoError(t, err)
+		require.Equal(t, core.PreConfirmedBlockVariant, pending.Variant())
+		require.Equal(t, rpc.TxnPreConfirmed, handler.PendingBlockFinalityStatus())
 	})
 }
 
@@ -109,11 +96,7 @@ func TestPendingDataWrapper_PendingState(t *testing.T) {
 	handler := rpc.New(mockReader, mockSyncReader, nil, nil)
 
 	mockState := mocks.NewMockStateHistoryReader(mockCtrl)
-	t.Run("Returns pending state when starknet version < 0.14.0", func(t *testing.T) {
-		mockSyncReader.EXPECT().PendingData().Return(
-			&sync.Pending{},
-			nil,
-		)
+	t.Run("Returns pending state", func(t *testing.T) {
 		mockSyncReader.EXPECT().PendingState().Return(mockState, nopCloser, nil)
 		pendingState, closer, err := handler.PendingState()
 
@@ -122,24 +105,13 @@ func TestPendingDataWrapper_PendingState(t *testing.T) {
 		require.NotNil(t, closer)
 	})
 
-	t.Run("Returns latest state starknet version >= 0.14.0", func(t *testing.T) {
-		mockSyncReader.EXPECT().PendingData().Return(
-			&core.PreConfirmed{},
-			nil,
-		)
-		mockReader.EXPECT().HeadState().Return(mockState, nopCloser, nil)
-		pending, closer, err := handler.PendingState()
-
-		require.NoError(t, err)
-		require.NotNil(t, pending)
-		require.NotNil(t, closer)
-	})
-
 	t.Run("Returns latest state when pending data is nil", func(t *testing.T) {
-		mockSyncReader.EXPECT().PendingData().Return(
+		mockSyncReader.EXPECT().PendingState().Return(
+			nil,
 			nil,
 			sync.ErrPendingBlockNotFound,
 		)
+
 		mockReader.EXPECT().HeadState().Return(mockState, nopCloser, nil)
 		pending, closer, err := handler.PendingState()
 

--- a/rpc/v9/state_update.go
+++ b/rpc/v9/state_update.go
@@ -1,0 +1,125 @@
+package rpcv9
+
+import (
+	"errors"
+
+	"github.com/NethermindEth/juno/core"
+	"github.com/NethermindEth/juno/db"
+	"github.com/NethermindEth/juno/jsonrpc"
+	"github.com/NethermindEth/juno/rpc/rpccore"
+	rpcv6 "github.com/NethermindEth/juno/rpc/v6"
+	"github.com/NethermindEth/juno/sync"
+)
+
+/****************************************************
+		StateUpdate Handlers
+*****************************************************/
+
+// StateUpdate returns the state update identified by the given BlockID.
+//
+// It follows the specification defined here:
+// https://github.com/starkware-libs/starknet-specs/blob/9377851884da5c81f757b6ae0ed47e84f9e7c058/api/starknet_api_openrpc.json#L136
+func (h *Handler) StateUpdate(id *BlockID) (rpcv6.StateUpdate, *jsonrpc.Error) {
+	update, err := h.stateUpdateByID(id)
+	if err != nil {
+		if errors.Is(err, db.ErrKeyNotFound) || errors.Is(err, sync.ErrPendingBlockNotFound) {
+			return rpcv6.StateUpdate{}, rpccore.ErrBlockNotFound
+		}
+		return rpcv6.StateUpdate{}, rpccore.ErrInternal.CloneWithData(err)
+	}
+
+	index := 0
+	nonces := make([]rpcv6.Nonce, len(update.StateDiff.Nonces))
+	for addr, nonce := range update.StateDiff.Nonces {
+		nonces[index] = rpcv6.Nonce{ContractAddress: addr, Nonce: *nonce}
+		index++
+	}
+
+	index = 0
+	storageDiffs := make([]rpcv6.StorageDiff, len(update.StateDiff.StorageDiffs))
+	for addr, diffs := range update.StateDiff.StorageDiffs {
+		entries := make([]rpcv6.Entry, len(diffs))
+		entryIdx := 0
+		for key, value := range diffs {
+			entries[entryIdx] = rpcv6.Entry{
+				Key:   key,
+				Value: *value,
+			}
+			entryIdx++
+		}
+
+		storageDiffs[index] = rpcv6.StorageDiff{
+			Address:        addr,
+			StorageEntries: entries,
+		}
+		index++
+	}
+
+	index = 0
+	deployedContracts := make([]rpcv6.DeployedContract, len(update.StateDiff.DeployedContracts))
+	for addr, classHash := range update.StateDiff.DeployedContracts {
+		deployedContracts[index] = rpcv6.DeployedContract{
+			Address:   addr,
+			ClassHash: *classHash,
+		}
+		index++
+	}
+
+	index = 0
+	declaredClasses := make([]rpcv6.DeclaredClass, len(update.StateDiff.DeclaredV1Classes))
+	for classHash, compiledClassHash := range update.StateDiff.DeclaredV1Classes {
+		declaredClasses[index] = rpcv6.DeclaredClass{
+			ClassHash:         classHash,
+			CompiledClassHash: *compiledClassHash,
+		}
+		index++
+	}
+
+	index = 0
+	replacedClasses := make([]rpcv6.ReplacedClass, len(update.StateDiff.ReplacedClasses))
+	for addr, classHash := range update.StateDiff.ReplacedClasses {
+		replacedClasses[index] = rpcv6.ReplacedClass{
+			ClassHash:       *classHash,
+			ContractAddress: addr,
+		}
+		index++
+	}
+
+	return rpcv6.StateUpdate{
+		BlockHash: update.BlockHash,
+		OldRoot:   update.OldRoot,
+		NewRoot:   update.NewRoot,
+		StateDiff: &rpcv6.StateDiff{
+			DeprecatedDeclaredClasses: update.StateDiff.DeclaredV0Classes,
+			DeclaredClasses:           declaredClasses,
+			ReplacedClasses:           replacedClasses,
+			Nonces:                    nonces,
+			StorageDiffs:              storageDiffs,
+			DeployedContracts:         deployedContracts,
+		},
+	}, nil
+}
+
+func (h *Handler) stateUpdateByID(id *BlockID) (*core.StateUpdate, error) {
+	switch id.Type() {
+	case latest:
+		if height, heightErr := h.bcReader.Height(); heightErr != nil {
+			return nil, heightErr
+		} else {
+			return h.bcReader.StateUpdateByNumber(height)
+		}
+	case preConfirmed:
+		var pending core.PendingData
+		pending, err := h.PendingData()
+		if err != nil {
+			return nil, err
+		}
+		return pending.GetStateUpdate(), nil
+	case hash:
+		return h.bcReader.StateUpdateByHash(id.Hash())
+	case number:
+		return h.bcReader.StateUpdateByNumber(id.Number())
+	default:
+		panic("unknown block type id")
+	}
+}

--- a/rpc/v9/state_update_test.go
+++ b/rpc/v9/state_update_test.go
@@ -1,0 +1,161 @@
+package rpcv9_test
+
+import (
+	"testing"
+
+	"github.com/NethermindEth/juno/blockchain"
+	"github.com/NethermindEth/juno/clients/feeder"
+	"github.com/NethermindEth/juno/core"
+	"github.com/NethermindEth/juno/core/felt"
+	"github.com/NethermindEth/juno/db/memory"
+	"github.com/NethermindEth/juno/mocks"
+	rpccore "github.com/NethermindEth/juno/rpc/rpccore"
+	rpcv6 "github.com/NethermindEth/juno/rpc/v6"
+	rpcv9 "github.com/NethermindEth/juno/rpc/v9"
+	adaptfeeder "github.com/NethermindEth/juno/starknetdata/feeder"
+	"github.com/NethermindEth/juno/sync"
+	"github.com/NethermindEth/juno/utils"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+)
+
+func TestStateUpdate(t *testing.T) {
+	errTests := map[string]rpcv9.BlockID{
+		"latest":        blockIDLatest(t),
+		"pre_confirmed": blockIDPreConfirmed(t),
+		"hash":          blockIDHash(t, &felt.One),
+		"number":        blockIDNumber(t, 1),
+	}
+	mockCtrl := gomock.NewController(t)
+	t.Cleanup(mockCtrl.Finish)
+	var mockSyncReader *mocks.MockSyncReader
+
+	n := &utils.Mainnet
+	for description, id := range errTests {
+		t.Run(description, func(t *testing.T) {
+			chain := blockchain.New(memory.New(), n)
+			if description == "pre_confirmed" {
+				mockSyncReader = mocks.NewMockSyncReader(mockCtrl)
+				mockSyncReader.EXPECT().PendingData().Return(nil, sync.ErrPendingBlockNotFound)
+			}
+			log := utils.NewNopZapLogger()
+			handler := rpcv9.New(chain, mockSyncReader, nil, log)
+
+			update, rpcErr := handler.StateUpdate(&id)
+			assert.Empty(t, update)
+			assert.Equal(t, rpccore.ErrBlockNotFound, rpcErr)
+		})
+	}
+
+	log := utils.NewNopZapLogger()
+	mockReader := mocks.NewMockReader(mockCtrl)
+	handler := rpcv9.New(mockReader, mockSyncReader, nil, log)
+	client := feeder.NewTestClient(t, n)
+	mainnetGw := adaptfeeder.New(client)
+
+	update21656, err := mainnetGw.StateUpdate(t.Context(), 21656)
+	require.NoError(t, err)
+
+	checkUpdate := func(t *testing.T, coreUpdate *core.StateUpdate, rpcUpdate *rpcv6.StateUpdate) {
+		t.Helper()
+		require.Equal(t, coreUpdate.BlockHash, rpcUpdate.BlockHash)
+		require.Equal(t, coreUpdate.NewRoot, rpcUpdate.NewRoot)
+		require.Equal(t, coreUpdate.OldRoot, rpcUpdate.OldRoot)
+
+		require.Equal(t, len(coreUpdate.StateDiff.StorageDiffs), len(rpcUpdate.StateDiff.StorageDiffs))
+		for _, diff := range rpcUpdate.StateDiff.StorageDiffs {
+			coreDiffs := coreUpdate.StateDiff.StorageDiffs[diff.Address]
+			require.Equal(t, len(coreDiffs), len(diff.StorageEntries))
+			for _, entry := range diff.StorageEntries {
+				require.Equal(t, *coreDiffs[entry.Key], entry.Value)
+			}
+		}
+
+		require.Equal(t, len(coreUpdate.StateDiff.Nonces), len(rpcUpdate.StateDiff.Nonces))
+		for _, nonce := range rpcUpdate.StateDiff.Nonces {
+			require.Equal(t, *coreUpdate.StateDiff.Nonces[nonce.ContractAddress], nonce.Nonce)
+		}
+
+		require.Equal(t, len(coreUpdate.StateDiff.DeployedContracts), len(rpcUpdate.StateDiff.DeployedContracts))
+		for _, deployedContract := range rpcUpdate.StateDiff.DeployedContracts {
+			require.Equal(t, *coreUpdate.StateDiff.DeployedContracts[deployedContract.Address], deployedContract.ClassHash)
+		}
+
+		require.Equal(t, coreUpdate.StateDiff.DeclaredV0Classes, rpcUpdate.StateDiff.DeprecatedDeclaredClasses)
+
+		require.Equal(t, len(coreUpdate.StateDiff.ReplacedClasses), len(rpcUpdate.StateDiff.ReplacedClasses))
+		for index := range rpcUpdate.StateDiff.ReplacedClasses {
+			require.Equal(t, *coreUpdate.StateDiff.ReplacedClasses[rpcUpdate.StateDiff.ReplacedClasses[index].ContractAddress],
+				rpcUpdate.StateDiff.ReplacedClasses[index].ClassHash)
+		}
+
+		require.Equal(t, len(coreUpdate.StateDiff.DeclaredV1Classes), len(rpcUpdate.StateDiff.DeclaredClasses))
+		for index := range rpcUpdate.StateDiff.DeclaredClasses {
+			require.Equal(t, *coreUpdate.StateDiff.DeclaredV1Classes[rpcUpdate.StateDiff.DeclaredClasses[index].ClassHash],
+				rpcUpdate.StateDiff.DeclaredClasses[index].CompiledClassHash)
+		}
+	}
+
+	t.Run("latest", func(t *testing.T) {
+		mockReader.EXPECT().Height().Return(uint64(21656), nil)
+		mockReader.EXPECT().StateUpdateByNumber(uint64(21656)).Return(update21656, nil)
+		latest := blockIDLatest(t)
+		update, rpcErr := handler.StateUpdate(&latest)
+		require.Nil(t, rpcErr)
+		checkUpdate(t, update21656, &update)
+	})
+
+	t.Run("by height", func(t *testing.T) {
+		mockReader.EXPECT().StateUpdateByNumber(uint64(21656)).Return(update21656, nil)
+		number := blockIDNumber(t, 21656)
+		update, rpcErr := handler.StateUpdate(&number)
+		require.Nil(t, rpcErr)
+		checkUpdate(t, update21656, &update)
+	})
+
+	t.Run("by hash", func(t *testing.T) {
+		mockReader.EXPECT().StateUpdateByHash(update21656.BlockHash).Return(update21656, nil)
+		hash := blockIDHash(t, update21656.BlockHash)
+		update, rpcErr := handler.StateUpdate(&hash)
+		require.Nil(t, rpcErr)
+		checkUpdate(t, update21656, &update)
+	})
+
+	t.Run("post v0.11.0", func(t *testing.T) {
+		integrationClient := feeder.NewTestClient(t, &utils.Integration)
+		integGw := adaptfeeder.New(integrationClient)
+
+		for name, height := range map[string]uint64{
+			"declared Cairo0 classes": 283746,
+			"declared Cairo1 classes": 283364,
+			"replaced classes":        283428,
+		} {
+			t.Run(name, func(t *testing.T) {
+				gwUpdate, err := integGw.StateUpdate(t.Context(), height)
+				require.NoError(t, err)
+				number := blockIDNumber(t, height)
+				mockReader.EXPECT().StateUpdateByNumber(height).Return(gwUpdate, nil)
+				blockIDNumber(t, height)
+				update, rpcErr := handler.StateUpdate(&number)
+				require.Nil(t, rpcErr)
+
+				checkUpdate(t, gwUpdate, &update)
+			})
+		}
+	})
+
+	t.Run("pre_confirmed", func(t *testing.T) {
+		update21656.BlockHash = nil
+		update21656.NewRoot = nil
+		preConfirmed := core.NewPreConfirmed(nil, update21656, nil, nil)
+		mockSyncReader.EXPECT().PendingData().Return(
+			&preConfirmed,
+			nil,
+		)
+		preConfirmedID := blockIDPreConfirmed(t)
+		update, rpcErr := handler.StateUpdate(&preConfirmedID)
+		require.Nil(t, rpcErr)
+		checkUpdate(t, update21656, &update)
+	})
+}

--- a/rpc/v9/storage.go
+++ b/rpc/v9/storage.go
@@ -179,9 +179,8 @@ func (h *Handler) isBlockSupported(blockID *BlockID, chainHeight uint64) *jsonrp
 	switch {
 	case blockID.IsLatest():
 		return nil
-	case blockID.IsPending():
-		// TODO: Remove this case when specs replaced BLOCK_ID by another type.
-		return rpccore.ErrCallOnPending
+	case blockID.IsPreConfirmed():
+		return rpccore.ErrCallOnPreConfirmed
 	case blockID.IsHash():
 		header, err := h.bcReader.BlockHeaderByHash(blockID.Hash())
 		if err != nil {

--- a/rpc/v9/storage_test.go
+++ b/rpc/v9/storage_test.go
@@ -132,14 +132,14 @@ func TestStorageAt(t *testing.T) {
 		assert.Equal(t, expectedStorage, storageValue)
 	})
 
-	t.Run("blockID - pending", func(t *testing.T) {
+	t.Run("blockID - pre_confirmed", func(t *testing.T) {
 		pending := sync.NewPending(nil, nil, nil)
 		mockSyncReader.EXPECT().PendingData().Return(&pending, nil)
 		mockSyncReader.EXPECT().PendingState().Return(mockState, nopCloser, nil)
 		mockState.EXPECT().ContractClassHash(&felt.Zero).Return(nil, nil)
 		mockState.EXPECT().ContractStorage(gomock.Any(), gomock.Any()).Return(expectedStorage, nil)
-		pendingID := blockIDPending(t)
-		storageValue, rpcErr := handler.StorageAt(&felt.Zero, &felt.Zero, &pendingID)
+		preConfirmedID := blockIDPreConfirmed(t)
+		storageValue, rpcErr := handler.StorageAt(&felt.Zero, &felt.Zero, &preConfirmedID)
 		require.Nil(t, rpcErr)
 		assert.Equal(t, expectedStorage, storageValue)
 	})
@@ -224,10 +224,10 @@ func TestStorageProof(t *testing.T) {
 		assert.Equal(t, rpccore.ErrBlockNotFound, rpcErr)
 		require.Nil(t, proof)
 	})
-	t.Run("error for pending block", func(t *testing.T) {
-		blockID := blockIDPending(t)
+	t.Run("error for pre_confirmed block", func(t *testing.T) {
+		blockID := blockIDPreConfirmed(t)
 		proof, rpcErr := handler.StorageProof(&blockID, nil, nil, nil)
-		assert.Equal(t, rpccore.ErrCallOnPending, rpcErr)
+		assert.Equal(t, rpccore.ErrCallOnPreConfirmed, rpcErr)
 		require.Nil(t, proof)
 	})
 	t.Run("no error when block number matches head", func(t *testing.T) {

--- a/rpc/v9/storage_test.go
+++ b/rpc/v9/storage_test.go
@@ -99,7 +99,7 @@ func TestStorageAt(t *testing.T) {
 
 	expectedStorage := new(felt.Felt).SetUint64(1)
 
-	t.Run("blockID - latest", func(t *testing.T) {
+	t.Run("blockID - latest", func(t *testing.T) { //nolint:dupl
 		mockReader.EXPECT().HeadState().Return(mockState, nopCloser, nil)
 		mockState.EXPECT().ContractClassHash(&felt.Zero).Return(nil, nil)
 		mockState.EXPECT().ContractStorage(gomock.Any(), gomock.Any()).Return(expectedStorage, nil)
@@ -132,7 +132,7 @@ func TestStorageAt(t *testing.T) {
 		assert.Equal(t, expectedStorage, storageValue)
 	})
 
-	t.Run("blockID - pre_confirmed", func(t *testing.T) {
+	t.Run("blockID - pre_confirmed", func(t *testing.T) { //nolint:dupl //false alarm block tag differs
 		mockSyncReader.EXPECT().PendingState().Return(mockState, nopCloser, nil)
 		mockState.EXPECT().ContractClassHash(&felt.Zero).Return(nil, nil)
 		mockState.EXPECT().ContractStorage(gomock.Any(), gomock.Any()).Return(expectedStorage, nil)

--- a/rpc/v9/storage_test.go
+++ b/rpc/v9/storage_test.go
@@ -133,8 +133,6 @@ func TestStorageAt(t *testing.T) {
 	})
 
 	t.Run("blockID - pre_confirmed", func(t *testing.T) {
-		pending := sync.NewPending(nil, nil, nil)
-		mockSyncReader.EXPECT().PendingData().Return(&pending, nil)
 		mockSyncReader.EXPECT().PendingState().Return(mockState, nopCloser, nil)
 		mockState.EXPECT().ContractClassHash(&felt.Zero).Return(nil, nil)
 		mockState.EXPECT().ContractStorage(gomock.Any(), gomock.Any()).Return(expectedStorage, nil)

--- a/rpc/v9/subscriptions.go
+++ b/rpc/v9/subscriptions.go
@@ -41,7 +41,7 @@ func (e errorTxnHashNotFound) Error() string {
 	return fmt.Sprintf("transaction %v not found", e.txHash)
 }
 
-// As per the spec, this is the same as BlockID, but without `pending`
+// As per the spec, this is the same as BlockID, but without `pre_confirmed`
 type SubscriptionBlockID BlockID
 
 func (b *SubscriptionBlockID) Type() blockIDType {
@@ -162,7 +162,7 @@ func (h *Handler) subscribe(
 				}
 			case pending := <-pendingRecv:
 				if err := subscriber.onPendingData(subscriptionCtx, id, sub, pending); err != nil {
-					h.log.Warnw("Error on pending", "id", id, "err", err)
+					h.log.Warnw("Error on pending data", "id", id, "err", err)
 					return
 				}
 			}

--- a/rpc/v9/subscriptions.go
+++ b/rpc/v9/subscriptions.go
@@ -553,6 +553,8 @@ func (h *Handler) onPendingBlock(
 
 // If getDetails is true, response will contain the transaction details.
 // If getDetails is false, response will only contain the transaction hashes.
+//
+//nolint:unused // retained for future use in 0.9.0-rc3, currently unused
 func (h *Handler) onPreConfirmedBlock(
 	id string,
 	w jsonrpc.Conn,

--- a/rpc/v9/subscriptions.go
+++ b/rpc/v9/subscriptions.go
@@ -210,18 +210,14 @@ func (h *Handler) SubscribeEvents(
 				ctx, w, id, requestedHeader.Number, headHeader.Number, fromAddr, keys, nil,
 			)
 		},
-		onReorg: func(
-			ctx context.Context, id string, _ *subscription, reorg *sync.ReorgBlockRange,
-		) error {
+		onReorg: func(ctx context.Context, id string, _ *subscription, reorg *sync.ReorgBlockRange) error {
 			if err := sendReorg(w, reorg, id); err != nil {
 				return err
 			}
 			nextBlock = reorg.StartBlockNum
 			return nil
 		},
-		onNewHead: func(
-			ctx context.Context, id string, _ *subscription, head *core.Block,
-		) error {
+		onNewHead: func(ctx context.Context, id string, _ *subscription, head *core.Block) error {
 			err := h.processEvents(
 				ctx, w, id, nextBlock, head.Number, fromAddr, keys, eventsPreviouslySent,
 			)
@@ -258,22 +254,16 @@ func (h *Handler) SubscribeTransactionStatus(ctx context.Context, txHash *felt.F
 	var err error
 
 	subscriber := subscriber{
-		onStart: func(
-			ctx context.Context, id string, sub *subscription, _ any,
-		) error {
+		onStart: func(ctx context.Context, id string, sub *subscription, _ any) error {
 			if lastStatus, err = h.getInitialTxStatus(ctx, sub, id, txHash); err != nil {
 				return err
 			}
 			return nil
 		},
-		onReorg: func(
-			ctx context.Context, id string, _ *subscription, reorg *sync.ReorgBlockRange,
-		) error {
+		onReorg: func(ctx context.Context, id string, _ *subscription, reorg *sync.ReorgBlockRange) error {
 			return sendReorg(w, reorg, id)
 		},
-		onNewHead: func(
-			ctx context.Context, id string, sub *subscription, head *core.Block,
-		) error {
+		onNewHead: func(ctx context.Context, id string, sub *subscription, head *core.Block) error {
 			if lastStatus < TxnStatusAcceptedOnL2 {
 				if lastStatus, err = h.checkTxStatus(ctx, sub, id, txHash, lastStatus); err != nil {
 					return err
@@ -289,9 +279,7 @@ func (h *Handler) SubscribeTransactionStatus(ctx context.Context, txHash *felt.F
 			}
 			return nil
 		},
-		onL1Head: func(
-			ctx context.Context, id string, sub *subscription, l1Head *core.L1Head,
-		) error {
+		onL1Head: func(ctx context.Context, id string, sub *subscription, l1Head *core.L1Head) error {
 			if lastStatus, err = h.checkTxStatus(ctx, sub, id, txHash, lastStatus); err != nil {
 				return err
 			}
@@ -466,14 +454,10 @@ func (h *Handler) SubscribeNewHeads(ctx context.Context, blockID *SubscriptionBl
 		onStart: func(ctx context.Context, id string, _ *subscription, _ any) error {
 			return h.sendHistoricalHeaders(ctx, startHeader, latestHeader, w, id)
 		},
-		onReorg: func(
-			ctx context.Context, id string, _ *subscription, reorg *sync.ReorgBlockRange,
-		) error {
+		onReorg: func(ctx context.Context, id string, _ *subscription, reorg *sync.ReorgBlockRange) error {
 			return sendReorg(w, reorg, id)
 		},
-		onNewHead: func(
-			ctx context.Context, id string, _ *subscription, head *core.Block,
-		) error {
+		onNewHead: func(ctx context.Context, id string, _ *subscription, head *core.Block) error {
 			return sendHeader(w, head.Header, id)
 		},
 	}

--- a/rpc/v9/subscriptions_test.go
+++ b/rpc/v9/subscriptions_test.go
@@ -1141,6 +1141,7 @@ func createTestPendingBlock(t *testing.T, b *core.Block, txCount int) *core.Bloc
 	return &pending
 }
 
+//nolint:unused // retained for future use in 0.9.0-rc3, currently unused
 func createTestPreConfirmed(t *testing.T, b *core.Block, preConfirmedCount int) *core.PreConfirmed {
 	t.Helper()
 

--- a/rpc/v9/subscriptions_test.go
+++ b/rpc/v9/subscriptions_test.go
@@ -1,4 +1,3 @@
-// todo(rdr): is ok for this tests to use rpcv9 instead of rpcv9 pkg
 package rpcv9
 
 import (
@@ -21,6 +20,7 @@ import (
 	"github.com/NethermindEth/juno/jsonrpc"
 	"github.com/NethermindEth/juno/mocks"
 	"github.com/NethermindEth/juno/rpc/rpccore"
+	rpcv6 "github.com/NethermindEth/juno/rpc/v6"
 	adaptfeeder "github.com/NethermindEth/juno/starknetdata/feeder"
 	"github.com/NethermindEth/juno/sync"
 	"github.com/NethermindEth/juno/utils"
@@ -266,11 +266,13 @@ func TestSubscribeTxnStatus(t *testing.T) {
 
 		mockChain := mocks.NewMockReader(mockCtrl)
 		mockSyncer := mocks.NewMockSyncReader(mockCtrl)
-		handler := New(mockChain, mockSyncer, nil, log)
+		cache := rpccore.NewSubmittedTransactionsCache(15, 5*time.Minute)
+		handler := New(mockChain, mockSyncer, nil, log).WithSubmittedTransactionsCache(cache)
 
 		mockChain.EXPECT().TransactionByHash(txHash).Return(nil, db.ErrKeyNotFound).AnyTimes()
 		mockSyncer.EXPECT().PendingData().Return(nil, sync.ErrPendingBlockNotFound).AnyTimes()
 		mockChain.EXPECT().HeadsHeader().Return(nil, db.ErrKeyNotFound).AnyTimes()
+		mockSyncer.EXPECT().PendingBlock().Return(nil).AnyTimes()
 		id, _ := createTestTxStatusWebsocket(t, handler, txHash)
 
 		_, hasSubscription := handler.subscriptions.Load(string(id))
@@ -296,19 +298,10 @@ func TestSubscribeTxnStatus(t *testing.T) {
 			require.NoError(t, err)
 
 			mockChain.EXPECT().TransactionByHash(txHash).Return(nil, db.ErrKeyNotFound)
+
 			id, conn := createTestTxStatusWebsocket(t, handler, txHash)
 			assertNextTxnStatus(t, conn, id, txHash, TxnStatusAcceptedOnL2, TxnFailure, "some error")
 		})
-
-		t.Run("rejected", func(t *testing.T) {
-			txHash, err := new(felt.Felt).SetString("0x1111")
-			require.NoError(t, err)
-
-			mockChain.EXPECT().TransactionByHash(txHash).Return(nil, db.ErrKeyNotFound)
-			id, conn := createTestTxStatusWebsocket(t, handler, txHash)
-			assertNextTxnStatus(t, conn, id, txHash, TxnStatusRejected, 0, "some error")
-		})
-
 		t.Run("accepted on L1", func(t *testing.T) {
 			txHash, err := new(felt.Felt).SetString("0x1010")
 			require.NoError(t, err)
@@ -324,32 +317,91 @@ func TestSubscribeTxnStatus(t *testing.T) {
 		t.Cleanup(mockCtrl.Finish)
 
 		client := feeder.NewTestClient(t, &utils.SepoliaIntegration)
-		gw := adaptfeeder.New(client)
+		mockGateway := mocks.NewMockGateway(mockCtrl)
+		adapterFeeder := adaptfeeder.New(client)
 		mockChain := mocks.NewMockReader(mockCtrl)
 		mockSyncer := mocks.NewMockSyncReader(mockCtrl)
-		handler := New(mockChain, mockSyncer, nil, log)
-		handler.WithFeeder(client)
+		cache := rpccore.NewSubmittedTransactionsCache(15, 5*time.Minute)
+		handler := New(mockChain, mockSyncer, nil, log).
+			WithFeeder(client).
+			WithGateway(mockGateway).
+			WithSubmittedTransactionsCache(cache)
 
-		block, err := gw.BlockByNumber(t.Context(), 38748)
+		block, err := adapterFeeder.BlockByNumber(t.Context(), 38748)
 		require.NoError(t, err)
 
-		txHash, err := new(felt.Felt).SetString("0x1001")
+		txToBroadcast := BroadcastedTransaction{Transaction: *AdaptTransaction(block.Transactions[0])}
+
+		var tempGatewayResponse struct {
+			TransactionHash *felt.Felt `json:"transaction_hash"`
+			ContractAddress *felt.Felt `json:"address"`
+			ClassHash       *felt.Felt `json:"class_hash"`
+		}
+
+		tempGatewayResponse.TransactionHash = txToBroadcast.Hash
+		resRaw, err := json.Marshal(tempGatewayResponse)
 		require.NoError(t, err)
+		mockGateway.
+			EXPECT().
+			AddTransaction(gomock.Any(), gomock.Any()).Return(resRaw, nil).
+			AnyTimes()
+
+		addRes, addErr := handler.AddTransaction(
+			t.Context(),
+			txToBroadcast,
+		)
+		require.Nil(t, addErr)
+		txHash := addRes.TransactionHash
+		mockChain.EXPECT().TransactionByHash(txHash).Return(nil, db.ErrKeyNotFound)
+		mockSyncer.EXPECT().PendingData().Return(nil, sync.ErrPendingBlockNotFound).Times(2)
+		mockChain.EXPECT().HeadsHeader().Return(nil, db.ErrKeyNotFound).Times(2)
+
+		id, conn := createTestTxStatusWebsocket(t, handler, txHash)
+
+		assertNextTxnStatus(t, conn, id, txHash, TxnStatusReceived, UnknownExecution, "")
+		// Candidate Status
+		mockChain.EXPECT().TransactionByHash(txHash).Return(nil, db.ErrKeyNotFound)
+		preConfirmed := core.NewPreConfirmed(
+			&core.Block{Header: block.Header},
+			nil,
+			nil,
+			[]core.Transaction{block.Transactions[0]})
+
+		mockSyncer.EXPECT().PendingData().Return(
+			&preConfirmed,
+			nil,
+		).Times(4)
+		handler.pendingData.Send(&core.PreConfirmed{
+			Block: &core.Block{Header: &core.Header{}},
+		})
+
+		assertNextTxnStatus(t, conn, id, txHash, TxnStatusCandidate, UnknownExecution, "")
+		require.Equal(t, block.Transactions[0].Hash(), txHash)
+
+		// PreConfirmed Status
+		rpcTx := AdaptTransaction(block.Transactions[0])
+		rpcTx.Hash = txHash
 
 		mockChain.EXPECT().TransactionByHash(txHash).Return(nil, db.ErrKeyNotFound)
-		mockSyncer.EXPECT().PendingData().Return(nil, sync.ErrPendingBlockNotFound)
-		mockChain.EXPECT().HeadsHeader().Return(nil, db.ErrKeyNotFound)
-		id, conn := createTestTxStatusWebsocket(t, handler, txHash)
-		assertNextTxnStatus(t, conn, id, txHash, TxnStatusReceived, TxnSuccess, "")
+		preConfirmed = core.PreConfirmed{
+			Block: &core.Block{
+				Transactions: []core.Transaction{
+					block.Transactions[0],
+				},
+				Receipts: []*core.TransactionReceipt{block.Receipts[0]},
+			},
+			CandidateTxs: []core.Transaction{block.Transactions[0]},
+		}
 
+		handler.pendingData.Send(&preConfirmed)
+		assertNextTxnStatus(t, conn, id, txHash, TxnStatusPreConfirmed, TxnSuccess, "")
+		// Accepted on l1 Status
 		mockChain.EXPECT().TransactionByHash(txHash).Return(block.Transactions[0], nil)
 		mockChain.EXPECT().Receipt(txHash).Return(block.Receipts[0], block.Hash, block.Number, nil)
 		mockChain.EXPECT().L1Head().Return(nil, db.ErrKeyNotFound)
-		for i := range 3 {
-			handler.pendingData.Send(&sync.Pending{Block: &core.Block{Header: &core.Header{}}})
-			handler.pendingData.Send(&sync.Pending{Block: &core.Block{Header: &core.Header{}}})
-			handler.newHeads.Send(&core.Block{Header: &core.Header{Number: block.Number + 1 + uint64(i)}})
-		}
+
+		handler.newHeads.Send(&core.Block{Header: &core.Header{Number: block.Number + 1}})
+
 		assertNextTxnStatus(t, conn, id, txHash, TxnStatusAcceptedOnL2, TxnSuccess, "")
 
 		l1Head := &core.L1Head{BlockNumber: block.Number}
@@ -856,7 +908,7 @@ func TestSubscribePendingTxs(t *testing.T) {
 
 		subCtx := context.WithValue(t.Context(), jsonrpc.ConnKey{}, &fakeConn{w: serverConn})
 
-		id, rpcErr := handler.SubscribePendingTxs(subCtx, nil, addresses)
+		id, rpcErr := handler.SubscribePendingTxs(subCtx, false, addresses)
 		assert.Zero(t, id)
 		assert.Equal(t, rpccore.ErrTooManyAddressesInFilter, rpcErr)
 	})
@@ -1069,7 +1121,7 @@ func assertNextTxnStatus(t *testing.T, conn net.Conn, id SubscriptionID, txHash 
 	})
 }
 
-func assertNextEvents(t *testing.T, conn net.Conn, id SubscriptionID, emittedEvents []*EmittedEvent) {
+func assertNextEvents(t *testing.T, conn net.Conn, id SubscriptionID, emittedEvents []*rpcv6.EmittedEvent) {
 	t.Helper()
 
 	for _, emitted := range emittedEvents {
@@ -1089,11 +1141,34 @@ func createTestPendingBlock(t *testing.T, b *core.Block, txCount int) *core.Bloc
 	return &pending
 }
 
-func createTestEvents(t *testing.T, b *core.Block) ([]*blockchain.FilteredEvent, []*EmittedEvent) {
+func createTestPreConfirmed(t *testing.T, b *core.Block, preConfirmedCount int) *core.PreConfirmed {
+	t.Helper()
+
+	actualTxCount := len(b.Transactions)
+	var preConfirmed core.PreConfirmed
+	if candidateCount := actualTxCount - preConfirmedCount; candidateCount > 0 {
+		preConfirmed.CandidateTxs = make([]core.Transaction, 0, candidateCount)
+		for i := actualTxCount - candidateCount; i < actualTxCount; i++ {
+			preConfirmed.CandidateTxs = append(preConfirmed.CandidateTxs, b.Transactions[i])
+		}
+	}
+
+	preConfirmedBlock := *b
+	preConfirmedBlock.Header.Number = 0
+	preConfirmedBlock.Header.Hash = nil
+	preConfirmedBlock.Hash = nil
+	preConfirmedBlock.Transactions = preConfirmedBlock.Transactions[:preConfirmedCount]
+	preConfirmedBlock.Receipts = preConfirmedBlock.Receipts[:preConfirmedCount]
+
+	preConfirmed.Block = &preConfirmedBlock
+	return &preConfirmed
+}
+
+func createTestEvents(t *testing.T, b *core.Block) ([]*blockchain.FilteredEvent, []*rpcv6.EmittedEvent) {
 	t.Helper()
 
 	var filtered []*blockchain.FilteredEvent
-	var emitted []*EmittedEvent
+	var emitted []*rpcv6.EmittedEvent
 	for _, receipt := range b.Receipts {
 		for i, event := range receipt.Events {
 			filtered = append(filtered, &blockchain.FilteredEvent{
@@ -1103,8 +1178,8 @@ func createTestEvents(t *testing.T, b *core.Block) ([]*blockchain.FilteredEvent,
 				TransactionHash: receipt.TransactionHash,
 				EventIndex:      i,
 			})
-			emitted = append(emitted, &EmittedEvent{
-				Event: &Event{
+			emitted = append(emitted, &rpcv6.EmittedEvent{
+				Event: &rpcv6.Event{
 					From: event.From,
 					Keys: event.Keys,
 					Data: event.Data,

--- a/rpc/v9/trace.go
+++ b/rpc/v9/trace.go
@@ -121,10 +121,10 @@ func (h *Handler) TraceTransaction(ctx context.Context, hash felt.Felt) (*Transa
 func (h *Handler) TraceBlockTransactions(
 	ctx context.Context, id *BlockID,
 ) ([]TracedBlockTransaction, http.Header, *jsonrpc.Error) {
-	if id.IsPending() {
+	if id.IsPreConfirmed() {
 		httpHeader := http.Header{}
 		httpHeader.Set(ExecutionStepsHeader, "0")
-		return nil, httpHeader, rpccore.ErrCallOnPending
+		return nil, httpHeader, rpccore.ErrCallOnPreConfirmed
 	}
 
 	block, rpcErr := h.blockByID(id)

--- a/rpc/v9/trace_test.go
+++ b/rpc/v9/trace_test.go
@@ -609,7 +609,7 @@ func TestTraceBlockTransactions(t *testing.T) {
 				update, httpHeader, rpcErr := handler.TraceBlockTransactions(t.Context(), &blockID)
 				assert.Nil(t, update)
 				assert.Equal(t, httpHeader.Get(rpc.ExecutionStepsHeader), "0")
-				assert.Equal(t, rpccore.ErrCallOnPending, rpcErr)
+				assert.Equal(t, rpccore.ErrCallOnPreConfirmed, rpcErr)
 			} else {
 				update, httpHeader, rpcErr := handler.TraceBlockTransactions(t.Context(), &blockID)
 				assert.Nil(t, update)

--- a/rpc/v9/trace_test.go
+++ b/rpc/v9/trace_test.go
@@ -408,7 +408,7 @@ func TestTraceTransaction(t *testing.T) {
 		mockSyncReader.EXPECT().PendingData().Return(
 			&pending,
 			nil,
-		).Times(2)
+		)
 
 		mockReader.EXPECT().StateAtBlockHash(header.ParentHash).Return(nil, nopCloser, nil)
 		headState := mocks.NewMockStateHistoryReader(mockCtrl)

--- a/rpc/v9/transaction_test.go
+++ b/rpc/v9/transaction_test.go
@@ -61,7 +61,7 @@ func TestTransactionByHashNotFoundInPreConfirmedBlock(t *testing.T) {
 		Version:         new(core.TransactionVersion).SetUint64(1),
 	}
 
-	preConfirmed := &core.PreConfirmed{
+	preConfirmed := core.PreConfirmed{
 		Block: &core.Block{
 			Transactions: []core.Transaction{preConfirmedTx},
 		},

--- a/rpc/v9/transaction_test.go
+++ b/rpc/v9/transaction_test.go
@@ -1497,11 +1497,16 @@ func TestTransactionStatus(t *testing.T) {
 				require.Equal(t, err, rpccore.ErrTxnHashNotFound)
 			})
 
+			sepoliaIntClient := feeder.NewTestClient(t, &utils.SepoliaIntegration)
+			sepoliaIntGw := adaptfeeder.New(sepoliaIntClient)
+			blockNumber := uint64(1204672)
+			preConfirmed, gwErr := sepoliaIntGw.PreConfirmedBlockByNumber(t.Context(), blockNumber)
+			require.NoError(t, gwErr)
+
 			t.Run("transaction found in preconfirmed block", func(t *testing.T) {
 				mockReader := mocks.NewMockReader(mockCtrl)
 				mockSyncReader := mocks.NewMockSyncReader(mockCtrl)
 
-				preConfirmed := getTestPreConfirmed(t)
 				preConfirmedTx := preConfirmed.Block.Transactions[0].Hash()
 				mockReader.EXPECT().TransactionByHash(preConfirmedTx).Return(nil, db.ErrKeyNotFound)
 				mockSyncReader.EXPECT().PendingData().Return(&preConfirmed, nil).Times(2)
@@ -1517,7 +1522,7 @@ func TestTransactionStatus(t *testing.T) {
 				mockReader := mocks.NewMockReader(mockCtrl)
 				mockSyncReader := mocks.NewMockSyncReader(mockCtrl)
 
-				preConfirmed := getTestPreConfirmed(t)
+				require.Greater(t, len(preConfirmed.CandidateTxs), 0)
 				for _, candidateTx := range preConfirmed.CandidateTxs {
 					mockReader.EXPECT().TransactionByHash(candidateTx.Hash()).Return(nil, db.ErrKeyNotFound)
 					mockSyncReader.EXPECT().PendingData().Return(&preConfirmed, nil).Times(2)
@@ -2029,185 +2034,4 @@ func TestSubmittedTransactionsCache(t *testing.T) {
 		require.Equal(t, rpccore.ErrTxnHashNotFound, err)
 		require.Empty(t, status)
 	})
-}
-
-func getTestPreConfirmed(t *testing.T) core.PreConfirmed {
-	t.Helper()
-
-	preConfirmedJSONStr := `{
-    "status": "PRE_CONFIRMED",
-    "starknet_version": "0.14.0",
-    "l1_da_mode": "BLOB",
-    "l1_gas_price": {
-        "price_in_fri": "0xe8d4a51000",
-        "price_in_wei": "0x3b9aca00"
-    },
-    "l1_data_gas_price": {
-        "price_in_fri": "0x3e8",
-        "price_in_wei": "0x1"
-    },
-    "l2_gas_price": {
-        "price_in_fri": "0x186a0",
-        "price_in_wei": "0x64"
-    },
-    "timestamp": 1750157184,
-    "sequencer_address": "0x1176a1bd84444c89232ec27754698e5d2e7e1a7f1539f12027f28b23ec9f3d8",
-    "transactions": [
-        {
-            "type": "INVOKE_FUNCTION",
-            "resource_bounds": {
-                "L1_GAS": {
-                    "max_amount": "0x11170",
-                    "max_price_per_unit": "0x2d79883d20000"
-                },
-                "L2_GAS": {
-                    "max_amount": "0x5f5e100",
-                    "max_price_per_unit": "0xba43b7400"
-                },
-                "L1_DATA_GAS": {
-                    "max_amount": "0x2710",
-                    "max_price_per_unit": "0x2d79883d20000"
-                }
-            },
-            "tip": "0x0",
-            "calldata": [
-                "0x2",
-                "0x4ed90820844c31bbec1995996767f3e3f2a78f0bbb3289ee381f8efe40d80b2",
-                "0x2468d193cd15b621b24c2a602b8dbcfa5eaa14f88416c40c09d7fd12592cb4b",
-                "0x0",
-                "0x4ed90820844c31bbec1995996767f3e3f2a78f0bbb3289ee381f8efe40d80b2",
-                "0x31aafc75f498fdfa7528880ad27246b4c15af4954f96228c9a132b328de1c92",
-                "0x6",
-                "0x25b019aa77b0c2b8d1c8039e145993e761eb466c683899821361ef5cca79045",
-                "0x3",
-                "0x525f6c2f38ca502b110f75ee2fbd9c90b5fe249590331c2fe2107c88bc3c3bf",
-                "0x302e4cd1e8c5b26c0df536e4039373b761cf035125cc2761d21603a12c4f9c5",
-                "0x57cdc35ae42f4afcac71b308658aabc375ef852be5c4a8c7e37e474510a966b",
-                "0x7f3f817b69bf989b100f4e194b939edbe7b2049a05695fce9cab4a83b6d5f0d"
-            ],
-            "sender_address": "0x352057331d5ad77465315d30b98135ddb815b86aa485d659dfeef59a904f88d",
-            "nonce": "0x2dc88c",
-            "signature": [
-                "0xac616ba95b63b87ac84e23dae4a68730716b32daee0bf1a23941ee43fd7fe3",
-                "0x34fbea4bccfd668de816fa8ca2f7fea6c16a1d3749ebb68bf058edd5a139c3c"
-            ],
-            "nonce_data_availability_mode": 0,
-            "fee_data_availability_mode": 0,
-            "paymaster_data": [],
-            "account_deployment_data": [],
-            "transaction_hash": "0x51188824aab8a9d7213d7e359538c0513c6d3e63d214dca076b34c5895a4ee8",
-            "version": "0x3"
-        },
-        {
-            "type": "INVOKE_FUNCTION",
-            "resource_bounds": {
-                "L1_GAS": {
-                    "max_amount": "0x11170",
-                    "max_price_per_unit": "0x2d79883d20000"
-                },
-                "L2_GAS": {
-                    "max_amount": "0x5f5e100",
-                    "max_price_per_unit": "0xba43b7400"
-                },
-                "L1_DATA_GAS": {
-                    "max_amount": "0x2710",
-                    "max_price_per_unit": "0x2d79883d20000"
-                }
-            },
-            "tip": "0x0",
-            "calldata": [
-                "0x1",
-                "0x4ed90820844c31bbec1995996767f3e3f2a78f0bbb3289ee381f8efe40d80b2",
-                "0x2468d193cd15b621b24c2a602b8dbcfa5eaa14f88416c40c09d7fd12592cb4b",
-                "0x0"
-            ],
-            "sender_address": "0x352057331d5ad77465315d30b98135ddb815b86aa485d659dfeef59a904f88d",
-            "nonce": "0x2dc88d",
-            "signature": [
-                "0x3ff77a14422c44f03510b0ea71c4d0c3816d779e1fa8d8a93fca171910987b2",
-                "0x1a4010147747cb66acb0be0307ca15e3339bfb1d9eeac9f8ad866b8464f3ef9"
-            ],
-            "nonce_data_availability_mode": 0,
-            "fee_data_availability_mode": 0,
-            "paymaster_data": [],
-            "account_deployment_data": [],
-            "transaction_hash": "0x42cba529ecbeb42e26018d83e360f8faae55541a5e9f9d56b4dc8374059371c",
-            "version": "0x3"
-        }
-    ],
-    "transaction_receipts": [
-        {
-            "transaction_index": 0,
-            "transaction_hash": "0x51188824aab8a9d7213d7e359538c0513c6d3e63d214dca076b34c5895a4ee8",
-            "l2_to_l1_messages": [],
-            "events": [
-                {
-                    "from_address": "0x352057331d5ad77465315d30b98135ddb815b86aa485d659dfeef59a904f88d",
-                    "keys": [
-                        "0x15bd0500dc9d7e69ab9577f73a8d753e8761bed10f25ba0f124254dc4edb8b4"
-                    ],
-                    "data": [
-                        "0x25b019aa77b0c2b8d1c8039e145993e761eb466c683899821361ef5cca79045",
-                        "0x3",
-                        "0x525f6c2f38ca502b110f75ee2fbd9c90b5fe249590331c2fe2107c88bc3c3bf",
-                        "0x302e4cd1e8c5b26c0df536e4039373b761cf035125cc2761d21603a12c4f9c5",
-                        "0x57cdc35ae42f4afcac71b308658aabc375ef852be5c4a8c7e37e474510a966b"
-                    ]
-                }
-            ],
-            "execution_resources": {
-                "n_steps": 4929,
-                "builtin_instance_counter": {
-                    "range_check_builtin": 158,
-                    "poseidon_builtin": 22,
-                    "pedersen_builtin": 4
-                },
-                "n_memory_holes": 0,
-                "data_availability": {
-                    "l1_gas": 0,
-                    "l1_data_gas": 128,
-                    "l2_gas": 0
-                },
-                "total_gas_consumed": {
-                    "l1_gas": 0,
-                    "l1_data_gas": 128,
-                    "l2_gas": 1023436
-                }
-            },
-            "actual_fee": "0x17d4295b80",
-            "execution_status": "SUCCEEDED"
-        },
-		null
-    ],
-    "transaction_state_diffs": [
-        {
-            "storage_diffs": {
-                "0x4718f5a0fc34cc1af16a1cdee98ffb20c31f5cd61d6ab07201858f4287c938d": [
-                    {
-                        "key": "0x5496768776e3db30053404f18067d81a6e06f5a2b0de326e21298fd9d569a9a",
-                        "value": "0x1cfb4c453de6b9fe6054"
-                    },
-                    {
-                        "key": "0x3c204dd68b8e800b4f42e438d9ed4ccbba9f8e436518758cd36553715c1d6ab",
-                        "value": "0x154a0b181701af533d0"
-                    }
-                ]
-            },
-            "deployed_contracts": [],
-            "declared_classes": [],
-            "old_declared_contracts": [],
-            "nonces": {
-                "0x352057331d5ad77465315d30b98135ddb815b86aa485d659dfeef59a904f88d": "0x2dc88d"
-            },
-            "replaced_classes": []
-        },
-		null
-    ]
-}`
-
-	preConfirmedlock := new(starknet.PreConfirmedBlock)
-	require.NoError(t, json.Unmarshal([]byte(preConfirmedJSONStr), preConfirmedlock))
-	adaptedPreConfirmed, err := sn2core.AdaptPreConfirmedBlock(preConfirmedlock, 0)
-	require.NoError(t, err)
-	return adaptedPreConfirmed
 }

--- a/rpc/v9/transaction_test.go
+++ b/rpc/v9/transaction_test.go
@@ -5,9 +5,11 @@ import (
 	"encoding/json"
 	"errors"
 	"math/rand"
+	"strconv"
 	"testing"
 	"time"
 
+	"github.com/NethermindEth/juno/adapters/sn2core"
 	"github.com/NethermindEth/juno/clients/feeder"
 	"github.com/NethermindEth/juno/clients/gateway"
 	"github.com/NethermindEth/juno/core"
@@ -45,7 +47,7 @@ func TestTransactionByHashNotFound(t *testing.T) {
 	assert.Equal(t, rpccore.ErrTxnHashNotFound, rpcErr)
 }
 
-func TestTransactionByHashNotFoundInPendingBlock(t *testing.T) {
+func TestTransactionByHashNotFoundInPreConfirmedBlock(t *testing.T) {
 	mockCtrl := gomock.NewController(t)
 	t.Cleanup(mockCtrl.Finish)
 	mockReader := mocks.NewMockReader(mockCtrl)
@@ -54,21 +56,20 @@ func TestTransactionByHashNotFoundInPendingBlock(t *testing.T) {
 	searchTxHash := utils.HexToFelt(t, "0x123456")
 
 	otherTxHash := utils.HexToFelt(t, "0x789abc")
-	pendingTx := &core.InvokeTransaction{
+	preConfirmedTx := &core.InvokeTransaction{
 		TransactionHash: otherTxHash,
 		Version:         new(core.TransactionVersion).SetUint64(1),
 	}
 
-	mockReader.EXPECT().TransactionByHash(searchTxHash).Return(nil, db.ErrKeyNotFound)
-
-	pendingBlock := &core.Block{
-		Transactions: []core.Transaction{pendingTx},
+	preConfirmed := &core.PreConfirmed{
+		Block: &core.Block{
+			Transactions: []core.Transaction{preConfirmedTx},
+		},
+		CandidateTxs: []core.Transaction{},
 	}
-	pending := sync.NewPending(pendingBlock, nil, nil)
-	mockSyncReader.EXPECT().PendingData().Return(
-		&pending,
-		nil,
-	)
+	mockReader.EXPECT().TransactionByHash(searchTxHash).Return(nil, db.ErrKeyNotFound)
+	mockSyncReader.EXPECT().PendingData().Return(&preConfirmed, nil)
+
 	handler := rpc.New(mockReader, mockSyncReader, nil, nil)
 
 	tx, rpcErr := handler.TransactionByHash(*searchTxHash)
@@ -451,6 +452,41 @@ func TestTransactionByHash(t *testing.T) {
 	}
 }
 
+func TestTransactionByHash_PreConfirmedBlock(t *testing.T) {
+	gw := feeder.NewTestClient(t, &utils.SepoliaIntegration)
+
+	mockCtrl := gomock.NewController(t)
+	t.Cleanup(mockCtrl.Finish)
+	mockReader := mocks.NewMockReader(mockCtrl)
+	mockSyncReader := mocks.NewMockSyncReader(mockCtrl)
+	blockNumber := uint64(1204672)
+	preConfirmedBlockWithCandidates, err := gw.PreConfirmedBlock(t.Context(), strconv.FormatUint(blockNumber, 10))
+	require.NoError(t, err)
+
+	adaptedPreConfirmed, err := sn2core.AdaptPreConfirmedBlock(preConfirmedBlockWithCandidates, blockNumber)
+	require.NoError(t, err)
+	mockSyncReader.EXPECT().PendingData().Return(&adaptedPreConfirmed, nil).Times(2)
+	handler := rpc.New(mockReader, mockSyncReader, nil, nil)
+
+	t.Run("Transaction found in pre_confirmed block", func(t *testing.T) {
+		searchTxn := adaptedPreConfirmed.Block.Transactions[0]
+		mockReader.EXPECT().TransactionByHash(searchTxn.Hash()).Return(nil, db.ErrKeyNotFound)
+
+		foundTxn, err := handler.TransactionByHash(*searchTxn.Hash())
+		require.Nil(t, err)
+		require.Equal(t, searchTxn.Hash(), foundTxn.Hash)
+	})
+
+	t.Run("Transaction found in pre_confirmed block - Candidate transactions", func(t *testing.T) {
+		searchTxn := adaptedPreConfirmed.CandidateTxs[0]
+		mockReader.EXPECT().TransactionByHash(searchTxn.Hash()).Return(nil, db.ErrKeyNotFound)
+
+		foundTxn, err := handler.TransactionByHash(*searchTxn.Hash())
+		require.Nil(t, err)
+		require.Equal(t, searchTxn.Hash(), foundTxn.Hash)
+	})
+}
+
 func TestTransactionByBlockIdAndIndex(t *testing.T) {
 	mockCtrl := gomock.NewController(t)
 	t.Cleanup(mockCtrl.Finish)
@@ -581,14 +617,14 @@ func TestTransactionByBlockIdAndIndex(t *testing.T) {
 		assert.Equal(t, txn1, txn2)
 	})
 
-	t.Run("blockID - pending", func(t *testing.T) {
+	t.Run("blockID - pre_confirmed", func(t *testing.T) {
 		index := rand.Intn(int(latestBlock.TransactionCount))
 
 		latestBlock.Hash = nil
 		latestBlock.GlobalStateRoot = nil
-		pending := sync.NewPending(latestBlock, nil, nil)
+		preConfirmed := core.NewPreConfirmed(latestBlock, nil, nil, nil)
 		mockSyncReader.EXPECT().PendingData().Return(
-			&pending,
+			&preConfirmed,
 			nil,
 		)
 		mockReader.EXPECT().TransactionByHash(latestBlock.Transactions[index].Hash()).DoAndReturn(
@@ -596,7 +632,7 @@ func TestTransactionByBlockIdAndIndex(t *testing.T) {
 				return latestBlock.Transactions[index], nil
 			})
 
-		blockID := blockIDPending(t)
+		blockID := blockIDPreConfirmed(t)
 		txn1, rpcErr := handler.TransactionByBlockIDAndIndex(&blockID, index)
 		require.Nil(t, rpcErr)
 
@@ -714,13 +750,13 @@ func TestTransactionReceiptByHash(t *testing.T) {
 		})
 	}
 
-	t.Run("pending receipt", func(t *testing.T) {
+	t.Run("pre_confirmed receipt", func(t *testing.T) {
 		i := 2
 		expected := `{
 					"type": "INVOKE",
 					"transaction_hash": "0xce54bbc5647e1c1ea4276c01a708523f740db0ff5474c77734f73beec2624",
 					"actual_fee": {"amount": "0x0", "unit": "WEI"},
-					"finality_status": "ACCEPTED_ON_L2",
+					"finality_status": "PRE_CONFIRMED",
 					"execution_status": "SUCCEEDED",
 					"messages_sent": [
 						{
@@ -742,11 +778,12 @@ func TestTransactionReceiptByHash(t *testing.T) {
 
 		txHash := block0.Transactions[i].Hash()
 		mockReader.EXPECT().TransactionByHash(txHash).Return(nil, db.ErrKeyNotFound)
-		pending := sync.NewPending(block0, nil, nil)
+		preConfirmed := core.NewPreConfirmed(block0, nil, nil, nil)
 		mockSyncReader.EXPECT().PendingData().Return(
-			&pending,
+			&preConfirmed,
 			nil,
-		)
+		).Times(2)
+
 		checkTxReceipt(t, txHash, expected)
 	})
 
@@ -1373,9 +1410,9 @@ func TestTransactionStatus(t *testing.T) {
 					}
 					status, rpcErr := handler.TransactionStatus(ctx, *tx.Hash())
 					require.Nil(t, rpcErr)
-					require.Equal(t, want, status)
+					require.Equal(t, *want, status)
 				})
-				t.Run("verified", func(t *testing.T) { //nolint:dupl
+				t.Run("verified", func(t *testing.T) {
 					mockReader := mocks.NewMockReader(mockCtrl)
 					mockReader.EXPECT().TransactionByHash(tx.Hash()).Return(tx, nil)
 					mockReader.EXPECT().Receipt(tx.Hash()).Return(block.Receipts[0], block.Hash, block.Number, nil)
@@ -1391,9 +1428,9 @@ func TestTransactionStatus(t *testing.T) {
 					}
 					status, rpcErr := handler.TransactionStatus(ctx, *tx.Hash())
 					require.Nil(t, rpcErr)
-					require.Equal(t, want, status)
+					require.Equal(t, *want, status)
 				})
-				t.Run("verified v0.7.0", func(t *testing.T) { //nolint:dupl
+				t.Run("verified v0.7.0", func(t *testing.T) {
 					mockReader := mocks.NewMockReader(mockCtrl)
 					mockReader.EXPECT().TransactionByHash(tx.Hash()).Return(tx, nil)
 					mockReader.EXPECT().Receipt(tx.Hash()).Return(block.Receipts[0], block.Hash, block.Number, nil)
@@ -1432,8 +1469,8 @@ func TestTransactionStatus(t *testing.T) {
 						mockReader := mocks.NewMockReader(mockCtrl)
 						mockSyncReader := mocks.NewMockSyncReader(mockCtrl)
 						mockReader.EXPECT().TransactionByHash(notFoundTest.hash).Return(nil, db.ErrKeyNotFound).Times(2)
-						mockSyncReader.EXPECT().PendingData().Return(nil, sync.ErrPendingBlockNotFound).Times(2)
-						mockReader.EXPECT().HeadsHeader().Return(nil, db.ErrKeyNotFound).Times(2)
+						mockSyncReader.EXPECT().PendingData().Return(nil, sync.ErrPendingBlockNotFound).Times(4)
+						mockReader.EXPECT().HeadsHeader().Return(nil, db.ErrKeyNotFound).Times(4)
 						handler := rpc.New(mockReader, mockSyncReader, nil, log)
 						_, err := handler.TransactionStatus(ctx, *notFoundTest.hash)
 						require.Equal(t, rpccore.ErrTxnHashNotFound.Code, err.Code)
@@ -1451,34 +1488,66 @@ func TestTransactionStatus(t *testing.T) {
 				mockReader := mocks.NewMockReader(mockCtrl)
 				mockSyncReader := mocks.NewMockSyncReader(mockCtrl)
 				mockReader.EXPECT().TransactionByHash(test.notFoundTxHash).Return(nil, db.ErrKeyNotFound)
-				mockSyncReader.EXPECT().PendingData().Return(nil, sync.ErrPendingBlockNotFound)
-				mockReader.EXPECT().HeadsHeader().Return(nil, db.ErrKeyNotFound)
+				mockSyncReader.EXPECT().PendingData().Return(nil, sync.ErrPendingBlockNotFound).Times(2)
+				mockReader.EXPECT().HeadsHeader().Return(nil, db.ErrKeyNotFound).Times(2)
 				handler := rpc.New(mockReader, mockSyncReader, nil, log).WithFeeder(client)
 
 				_, err := handler.TransactionStatus(ctx, *test.notFoundTxHash)
 				require.NotNil(t, err)
 				require.Equal(t, err, rpccore.ErrTxnHashNotFound)
 			})
+
+			t.Run("transaction found in preconfirmed block", func(t *testing.T) {
+				mockReader := mocks.NewMockReader(mockCtrl)
+				mockSyncReader := mocks.NewMockSyncReader(mockCtrl)
+
+				preConfirmed := getTestPreConfirmed(t)
+				preConfirmedTx := preConfirmed.Block.Transactions[0].Hash()
+				mockReader.EXPECT().TransactionByHash(preConfirmedTx).Return(nil, db.ErrKeyNotFound)
+				mockSyncReader.EXPECT().PendingData().Return(&preConfirmed, nil).Times(2)
+				handler := rpc.New(mockReader, mockSyncReader, nil, log).WithFeeder(client)
+
+				status, err := handler.TransactionStatus(ctx, *preConfirmedTx)
+				require.Nil(t, err)
+				require.Equal(t, rpc.TxnStatusPreConfirmed, status.Finality)
+				require.Equal(t, rpc.TxnSuccess, status.Execution)
+			})
+
+			t.Run("transaction found in preconfirmed block candidates", func(t *testing.T) {
+				mockReader := mocks.NewMockReader(mockCtrl)
+				mockSyncReader := mocks.NewMockSyncReader(mockCtrl)
+
+				preConfirmed := getTestPreConfirmed(t)
+				for _, candidateTx := range preConfirmed.CandidateTxs {
+					mockReader.EXPECT().TransactionByHash(candidateTx.Hash()).Return(nil, db.ErrKeyNotFound)
+					mockSyncReader.EXPECT().PendingData().Return(&preConfirmed, nil).Times(2)
+					handler := rpc.New(mockReader, mockSyncReader, nil, log).WithFeeder(client)
+
+					status, err := handler.TransactionStatus(ctx, *candidateTx.Hash())
+					require.Nil(t, err)
+					require.Equal(t, rpc.TxnStatusCandidate, status.Finality)
+					require.Equal(t, rpc.UnknownExecution, status.Execution)
+				}
+			})
+		})
+
+		t.Run("Rejected historical tx found in feeder", func(t *testing.T) {
+			mockReader := mocks.NewMockReader(mockCtrl)
+			mockSyncReader := mocks.NewMockSyncReader(mockCtrl)
+			client := feeder.NewTestClient(t, &utils.SepoliaIntegration)
+			txHash, err := new(felt.Felt).SetString("0x1111")
+			require.NoError(t, err)
+
+			handler := rpc.New(mockReader, mockSyncReader, nil, log).WithFeeder(client)
+			mockReader.EXPECT().TransactionByHash(txHash).Return(nil, db.ErrKeyNotFound)
+			mockSyncReader.EXPECT().PendingData().Return(nil, sync.ErrPendingBlockNotFound).Times(2)
+			mockReader.EXPECT().HeadsHeader().Return(nil, db.ErrKeyNotFound).Times(2)
+
+			status, rpcErr := handler.TransactionStatus(t.Context(), *txHash)
+			require.Equal(t, rpcErr, rpccore.ErrTxnHashNotFound)
+			require.Empty(t, status)
 		})
 	}
-
-	t.Run("Rejected transaction found in feeder", func(t *testing.T) {
-		mockReader := mocks.NewMockReader(mockCtrl)
-		mockSyncReader := mocks.NewMockSyncReader(mockCtrl)
-		client := feeder.NewTestClient(t, &utils.SepoliaIntegration)
-		txHash, err := new(felt.Felt).SetString("0x1111")
-		require.NoError(t, err)
-
-		handler := rpc.New(mockReader, mockSyncReader, nil, log).WithFeeder(client)
-		mockReader.EXPECT().TransactionByHash(txHash).Return(nil, db.ErrKeyNotFound)
-		mockSyncReader.EXPECT().PendingData().Return(nil, sync.ErrPendingBlockNotFound)
-		mockReader.EXPECT().HeadsHeader().Return(nil, db.ErrKeyNotFound)
-
-		status, rpcErr := handler.TransactionStatus(t.Context(), *txHash)
-		require.Nil(t, rpcErr)
-		require.Equal(t, status.Finality, rpc.TxnStatusRejected)
-		require.Equal(t, status.FailureReason, "some error")
-	})
 }
 
 func TestResourceMarshalText(t *testing.T) {
@@ -1931,11 +2000,13 @@ func TestSubmittedTransactionsCache(t *testing.T) {
 		res, err := handler.AddTransaction(ctx, *broadcastedTxn)
 		require.Nil(t, err)
 		mockReader.EXPECT().TransactionByHash(res.TransactionHash).Return(nil, db.ErrKeyNotFound)
-		mockSyncReader.EXPECT().PendingData().Return(nil, sync.ErrPendingBlockNotFound)
-		mockReader.EXPECT().HeadsHeader().Return(nil, db.ErrKeyNotFound)
+		mockSyncReader.EXPECT().PendingData().Return(nil, sync.ErrPendingBlockNotFound).Times(2)
+		mockReader.EXPECT().HeadsHeader().Return(nil, db.ErrKeyNotFound).Times(2)
+
 		status, err := handler.TransactionStatus(ctx, *res.TransactionHash)
 		require.Nil(t, err)
 		require.Equal(t, rpc.TxnStatusReceived, status.Finality)
+		require.Equal(t, rpc.UnknownExecution, status.Execution)
 	})
 
 	t.Run("transaction not found in db and feeder, found in cache but expired", func(t *testing.T) {
@@ -1949,12 +2020,194 @@ func TestSubmittedTransactionsCache(t *testing.T) {
 		res, err := handler.AddTransaction(ctx, *broadcastedTxn)
 		require.Nil(t, err)
 		mockReader.EXPECT().TransactionByHash(res.TransactionHash).Return(nil, db.ErrKeyNotFound)
-		mockSyncReader.EXPECT().PendingData().Return(nil, sync.ErrPendingBlockNotFound)
-		mockReader.EXPECT().HeadsHeader().Return(nil, db.ErrKeyNotFound)
+		mockSyncReader.EXPECT().PendingData().Return(nil, sync.ErrPendingBlockNotFound).Times(2)
+		mockReader.EXPECT().HeadsHeader().Return(nil, db.ErrKeyNotFound).Times(2)
+
 		// Expire cache entry
 		time.Sleep(cacheEntryTimeOut)
 		status, err := handler.TransactionStatus(ctx, *res.TransactionHash)
 		require.Equal(t, rpccore.ErrTxnHashNotFound, err)
-		require.Nil(t, status)
+		require.Empty(t, status)
 	})
+}
+
+func getTestPreConfirmed(t *testing.T) core.PreConfirmed {
+	t.Helper()
+
+	preConfirmedJSONStr := `{
+    "status": "PRE_CONFIRMED",
+    "starknet_version": "0.14.0",
+    "l1_da_mode": "BLOB",
+    "l1_gas_price": {
+        "price_in_fri": "0xe8d4a51000",
+        "price_in_wei": "0x3b9aca00"
+    },
+    "l1_data_gas_price": {
+        "price_in_fri": "0x3e8",
+        "price_in_wei": "0x1"
+    },
+    "l2_gas_price": {
+        "price_in_fri": "0x186a0",
+        "price_in_wei": "0x64"
+    },
+    "timestamp": 1750157184,
+    "sequencer_address": "0x1176a1bd84444c89232ec27754698e5d2e7e1a7f1539f12027f28b23ec9f3d8",
+    "transactions": [
+        {
+            "type": "INVOKE_FUNCTION",
+            "resource_bounds": {
+                "L1_GAS": {
+                    "max_amount": "0x11170",
+                    "max_price_per_unit": "0x2d79883d20000"
+                },
+                "L2_GAS": {
+                    "max_amount": "0x5f5e100",
+                    "max_price_per_unit": "0xba43b7400"
+                },
+                "L1_DATA_GAS": {
+                    "max_amount": "0x2710",
+                    "max_price_per_unit": "0x2d79883d20000"
+                }
+            },
+            "tip": "0x0",
+            "calldata": [
+                "0x2",
+                "0x4ed90820844c31bbec1995996767f3e3f2a78f0bbb3289ee381f8efe40d80b2",
+                "0x2468d193cd15b621b24c2a602b8dbcfa5eaa14f88416c40c09d7fd12592cb4b",
+                "0x0",
+                "0x4ed90820844c31bbec1995996767f3e3f2a78f0bbb3289ee381f8efe40d80b2",
+                "0x31aafc75f498fdfa7528880ad27246b4c15af4954f96228c9a132b328de1c92",
+                "0x6",
+                "0x25b019aa77b0c2b8d1c8039e145993e761eb466c683899821361ef5cca79045",
+                "0x3",
+                "0x525f6c2f38ca502b110f75ee2fbd9c90b5fe249590331c2fe2107c88bc3c3bf",
+                "0x302e4cd1e8c5b26c0df536e4039373b761cf035125cc2761d21603a12c4f9c5",
+                "0x57cdc35ae42f4afcac71b308658aabc375ef852be5c4a8c7e37e474510a966b",
+                "0x7f3f817b69bf989b100f4e194b939edbe7b2049a05695fce9cab4a83b6d5f0d"
+            ],
+            "sender_address": "0x352057331d5ad77465315d30b98135ddb815b86aa485d659dfeef59a904f88d",
+            "nonce": "0x2dc88c",
+            "signature": [
+                "0xac616ba95b63b87ac84e23dae4a68730716b32daee0bf1a23941ee43fd7fe3",
+                "0x34fbea4bccfd668de816fa8ca2f7fea6c16a1d3749ebb68bf058edd5a139c3c"
+            ],
+            "nonce_data_availability_mode": 0,
+            "fee_data_availability_mode": 0,
+            "paymaster_data": [],
+            "account_deployment_data": [],
+            "transaction_hash": "0x51188824aab8a9d7213d7e359538c0513c6d3e63d214dca076b34c5895a4ee8",
+            "version": "0x3"
+        },
+        {
+            "type": "INVOKE_FUNCTION",
+            "resource_bounds": {
+                "L1_GAS": {
+                    "max_amount": "0x11170",
+                    "max_price_per_unit": "0x2d79883d20000"
+                },
+                "L2_GAS": {
+                    "max_amount": "0x5f5e100",
+                    "max_price_per_unit": "0xba43b7400"
+                },
+                "L1_DATA_GAS": {
+                    "max_amount": "0x2710",
+                    "max_price_per_unit": "0x2d79883d20000"
+                }
+            },
+            "tip": "0x0",
+            "calldata": [
+                "0x1",
+                "0x4ed90820844c31bbec1995996767f3e3f2a78f0bbb3289ee381f8efe40d80b2",
+                "0x2468d193cd15b621b24c2a602b8dbcfa5eaa14f88416c40c09d7fd12592cb4b",
+                "0x0"
+            ],
+            "sender_address": "0x352057331d5ad77465315d30b98135ddb815b86aa485d659dfeef59a904f88d",
+            "nonce": "0x2dc88d",
+            "signature": [
+                "0x3ff77a14422c44f03510b0ea71c4d0c3816d779e1fa8d8a93fca171910987b2",
+                "0x1a4010147747cb66acb0be0307ca15e3339bfb1d9eeac9f8ad866b8464f3ef9"
+            ],
+            "nonce_data_availability_mode": 0,
+            "fee_data_availability_mode": 0,
+            "paymaster_data": [],
+            "account_deployment_data": [],
+            "transaction_hash": "0x42cba529ecbeb42e26018d83e360f8faae55541a5e9f9d56b4dc8374059371c",
+            "version": "0x3"
+        }
+    ],
+    "transaction_receipts": [
+        {
+            "transaction_index": 0,
+            "transaction_hash": "0x51188824aab8a9d7213d7e359538c0513c6d3e63d214dca076b34c5895a4ee8",
+            "l2_to_l1_messages": [],
+            "events": [
+                {
+                    "from_address": "0x352057331d5ad77465315d30b98135ddb815b86aa485d659dfeef59a904f88d",
+                    "keys": [
+                        "0x15bd0500dc9d7e69ab9577f73a8d753e8761bed10f25ba0f124254dc4edb8b4"
+                    ],
+                    "data": [
+                        "0x25b019aa77b0c2b8d1c8039e145993e761eb466c683899821361ef5cca79045",
+                        "0x3",
+                        "0x525f6c2f38ca502b110f75ee2fbd9c90b5fe249590331c2fe2107c88bc3c3bf",
+                        "0x302e4cd1e8c5b26c0df536e4039373b761cf035125cc2761d21603a12c4f9c5",
+                        "0x57cdc35ae42f4afcac71b308658aabc375ef852be5c4a8c7e37e474510a966b"
+                    ]
+                }
+            ],
+            "execution_resources": {
+                "n_steps": 4929,
+                "builtin_instance_counter": {
+                    "range_check_builtin": 158,
+                    "poseidon_builtin": 22,
+                    "pedersen_builtin": 4
+                },
+                "n_memory_holes": 0,
+                "data_availability": {
+                    "l1_gas": 0,
+                    "l1_data_gas": 128,
+                    "l2_gas": 0
+                },
+                "total_gas_consumed": {
+                    "l1_gas": 0,
+                    "l1_data_gas": 128,
+                    "l2_gas": 1023436
+                }
+            },
+            "actual_fee": "0x17d4295b80",
+            "execution_status": "SUCCEEDED"
+        },
+		null
+    ],
+    "transaction_state_diffs": [
+        {
+            "storage_diffs": {
+                "0x4718f5a0fc34cc1af16a1cdee98ffb20c31f5cd61d6ab07201858f4287c938d": [
+                    {
+                        "key": "0x5496768776e3db30053404f18067d81a6e06f5a2b0de326e21298fd9d569a9a",
+                        "value": "0x1cfb4c453de6b9fe6054"
+                    },
+                    {
+                        "key": "0x3c204dd68b8e800b4f42e438d9ed4ccbba9f8e436518758cd36553715c1d6ab",
+                        "value": "0x154a0b181701af533d0"
+                    }
+                ]
+            },
+            "deployed_contracts": [],
+            "declared_classes": [],
+            "old_declared_contracts": [],
+            "nonces": {
+                "0x352057331d5ad77465315d30b98135ddb815b86aa485d659dfeef59a904f88d": "0x2dc88d"
+            },
+            "replaced_classes": []
+        },
+		null
+    ]
+}`
+
+	preConfirmedlock := new(starknet.PreConfirmedBlock)
+	require.NoError(t, json.Unmarshal([]byte(preConfirmedJSONStr), preConfirmedlock))
+	adaptedPreConfirmed, err := sn2core.AdaptPreConfirmedBlock(preConfirmedlock, 0)
+	require.NoError(t, err)
+	return adaptedPreConfirmed
 }

--- a/starknet/transaction.go
+++ b/starknet/transaction.go
@@ -37,6 +37,8 @@ const (
 	AcceptedOnL1
 	NotReceived
 	Received
+	PreConfirmed
+	Candidate
 )
 
 func (fs *FinalityStatus) UnmarshalText(data []byte) error {
@@ -49,6 +51,10 @@ func (fs *FinalityStatus) UnmarshalText(data []byte) error {
 		*fs = NotReceived
 	case "RECEIVED":
 		*fs = Received
+	case "PRE_CONFIRMED":
+		*fs = PreConfirmed
+	case "CANDIDATE":
+		*fs = Candidate
 	default:
 		return fmt.Errorf("unknown FinalityStatus %q", str)
 	}

--- a/starknet/transaction_test.go
+++ b/starknet/transaction_test.go
@@ -34,6 +34,8 @@ func TestUnmarshalFinalityStatus(t *testing.T) {
 		"ACCEPTED_ON_L1": starknet.AcceptedOnL1,
 		"NOT_RECEIVED":   starknet.NotReceived,
 		"RECEIVED":       starknet.Received,
+		"CANDIDATE":      starknet.Candidate,
+		"PRE_CONFIRMED":  starknet.PreConfirmed,
 	}
 	for str, expected := range cases {
 		quotedStr := `"` + str + `"`


### PR DESCRIPTION
This PR introduces new Block and TransactionStatuses introduced in RPCv9.

Also partially implements `ws` endpoints. For transaction status subscription, we return the new statuses but for the rest of the methods we do not use data from `pre_confirmed` block