### PR TITLE
feat: rpcv9 fee units in estimation

### DIFF
--- a/rpc/v9/simulation.go
+++ b/rpc/v9/simulation.go
@@ -192,7 +192,7 @@ func createSimulatedTransactions(
 
 	simulatedTransactions := make([]SimulatedTransaction, len(overallFees))
 	for i, overallFee := range overallFees {
-		// Adapt transaction trace to rpc v8 trace
+		// Adapt transaction trace to rpc v9 trace
 		trace := utils.HeapPtr(AdaptVMTransactionTrace(&traces[i]))
 
 		// Add root level execution resources
@@ -206,7 +206,16 @@ func createSimulatedTransactions(
 
 		// Compute data for FeeEstimate
 		var l1GasPrice, l2GasPrice, l1DataGasPrice *felt.Felt
-		feeUnit := feeUnit(txns[i])
+
+		// estimateFee only allows FRI as unit
+		// https://github.com/starkware-libs/starknet-specs/blob/0bf403bfafbfbe0eaa52103a9c7df545bec8f73b/api/starknet_api_openrpc.json#L3586
+		feeUnit := FRI
+		// estimateMessageFee only allow WEI as unit
+		// https://github.com/starkware-libs/starknet-specs/blob/0bf403bfafbfbe0eaa52103a9c7df545bec8f73b/api/starknet_api_openrpc.json#L3605
+		if traces[i].Type == vm.TxnL1Handler {
+			feeUnit = WEI
+		}
+
 		switch feeUnit {
 		case WEI:
 			l1GasPrice = l1GasPriceWei

--- a/rpc/v9/simulation_pkg_test.go
+++ b/rpc/v9/simulation_pkg_test.go
@@ -14,7 +14,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-//nolint:dupl
 func TestCreateSimulatedTransactions(t *testing.T) {
 	executionResults := vm.ExecutionResults{
 		OverallFees: []*felt.Felt{new(felt.Felt).SetUint64(10), new(felt.Felt).SetUint64(20)},
@@ -26,13 +25,13 @@ func TestCreateSimulatedTransactions(t *testing.T) {
 			{L1Gas: 100, L1DataGas: 50, L2Gas: 200},
 			{L1Gas: 150, L1DataGas: 70, L2Gas: 250},
 		},
-		Traces:   []vm.TransactionTrace{{}, {}},
+		Traces:   []vm.TransactionTrace{{Type: vm.TxnL1Handler}, {}},
 		NumSteps: 0,
 	}
 
 	txns := []core.Transaction{
-		&core.InvokeTransaction{
-			Version: new(core.TransactionVersion).SetUint64(1),
+		&core.L1HandlerTransaction{
+			Version: new(core.TransactionVersion).SetUint64(3),
 		},
 		&core.InvokeTransaction{
 			Version: new(core.TransactionVersion).SetUint64(3),
@@ -59,6 +58,7 @@ func TestCreateSimulatedTransactions(t *testing.T) {
 	expected := []SimulatedTransaction{
 		{
 			TransactionTrace: &TransactionTrace{
+				Type: TransactionType(vm.TxnL1Handler),
 				ExecutionResources: &ExecutionResources{
 					InnerExecutionResources: InnerExecutionResources{
 						L1Gas: 100,


### PR DESCRIPTION

- estimateFee only allows FRI as unit -[ref](https://github.com/starkware-libs/starknet-specs/blob/0bf403bfafbfbe0eaa52103a9c7df545bec8f73b/api/starknet_api_openrpc.json#L3586)
- estimateMessageFee only allow WEI as unit - [ref](https://github.com/starkware-libs/starknet-specs/blob/0bf403bfafbfbe0eaa52103a9c7df545bec8f73b/api/starknet_api_openrpc.json#L3605)