### PR TITLE
feat: l1 accepted block tag

### DIFF
--- a/blockchain/event_filter.go
+++ b/blockchain/event_filter.go
@@ -20,6 +20,7 @@ type EventFilterer interface {
 	Events(cToken *ContinuationToken, chunkSize uint64) ([]*FilteredEvent, *ContinuationToken, error)
 	SetRangeEndBlockByNumber(filterRange EventFilterRange, blockNumber uint64) error
 	SetRangeEndBlockByHash(filterRange EventFilterRange, blockHash *felt.Felt) error
+	SetRangeEndBlockToL1Head(filterRange EventFilterRange) error
 	WithLimit(limit uint) *EventFilter
 }
 
@@ -87,6 +88,15 @@ func (e *EventFilter) SetRangeEndBlockByHash(filterRange EventFilterRange, block
 		return err
 	}
 	return e.SetRangeEndBlockByNumber(filterRange, header.Number)
+}
+
+// SetRangeEndBlockToL1Head sets an end of the block range to latest `l1_accepted` block
+func (e *EventFilter) SetRangeEndBlockToL1Head(filterRange EventFilterRange) error {
+	l1Head, err := core.GetL1Head(e.txn)
+	if err != nil {
+		return err
+	}
+	return e.SetRangeEndBlockByNumber(filterRange, l1Head.BlockNumber)
 }
 
 // Close closes the underlying database transaction that provides the blockchain snapshot

--- a/mocks/mock_event_filterer.go
+++ b/mocks/mock_event_filterer.go
@@ -21,6 +21,7 @@ import (
 type MockEventFilterer struct {
 	ctrl     *gomock.Controller
 	recorder *MockEventFiltererMockRecorder
+	isgomock struct{}
 }
 
 // MockEventFiltererMockRecorder is the mock recorder for MockEventFilterer.
@@ -55,9 +56,9 @@ func (mr *MockEventFiltererMockRecorder) Close() *gomock.Call {
 }
 
 // Events mocks base method.
-func (m *MockEventFilterer) Events(arg0 *blockchain.ContinuationToken, arg1 uint64) ([]*blockchain.FilteredEvent, *blockchain.ContinuationToken, error) {
+func (m *MockEventFilterer) Events(cToken *blockchain.ContinuationToken, chunkSize uint64) ([]*blockchain.FilteredEvent, *blockchain.ContinuationToken, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Events", arg0, arg1)
+	ret := m.ctrl.Call(m, "Events", cToken, chunkSize)
 	ret0, _ := ret[0].([]*blockchain.FilteredEvent)
 	ret1, _ := ret[1].(*blockchain.ContinuationToken)
 	ret2, _ := ret[2].(error)
@@ -65,49 +66,63 @@ func (m *MockEventFilterer) Events(arg0 *blockchain.ContinuationToken, arg1 uint
 }
 
 // Events indicates an expected call of Events.
-func (mr *MockEventFiltererMockRecorder) Events(arg0, arg1 any) *gomock.Call {
+func (mr *MockEventFiltererMockRecorder) Events(cToken, chunkSize any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Events", reflect.TypeOf((*MockEventFilterer)(nil).Events), arg0, arg1)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Events", reflect.TypeOf((*MockEventFilterer)(nil).Events), cToken, chunkSize)
 }
 
 // SetRangeEndBlockByHash mocks base method.
-func (m *MockEventFilterer) SetRangeEndBlockByHash(arg0 blockchain.EventFilterRange, arg1 *felt.Felt) error {
+func (m *MockEventFilterer) SetRangeEndBlockByHash(filterRange blockchain.EventFilterRange, blockHash *felt.Felt) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "SetRangeEndBlockByHash", arg0, arg1)
+	ret := m.ctrl.Call(m, "SetRangeEndBlockByHash", filterRange, blockHash)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // SetRangeEndBlockByHash indicates an expected call of SetRangeEndBlockByHash.
-func (mr *MockEventFiltererMockRecorder) SetRangeEndBlockByHash(arg0, arg1 any) *gomock.Call {
+func (mr *MockEventFiltererMockRecorder) SetRangeEndBlockByHash(filterRange, blockHash any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetRangeEndBlockByHash", reflect.TypeOf((*MockEventFilterer)(nil).SetRangeEndBlockByHash), arg0, arg1)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetRangeEndBlockByHash", reflect.TypeOf((*MockEventFilterer)(nil).SetRangeEndBlockByHash), filterRange, blockHash)
 }
 
 // SetRangeEndBlockByNumber mocks base method.
-func (m *MockEventFilterer) SetRangeEndBlockByNumber(arg0 blockchain.EventFilterRange, arg1 uint64) error {
+func (m *MockEventFilterer) SetRangeEndBlockByNumber(filterRange blockchain.EventFilterRange, blockNumber uint64) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "SetRangeEndBlockByNumber", arg0, arg1)
+	ret := m.ctrl.Call(m, "SetRangeEndBlockByNumber", filterRange, blockNumber)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // SetRangeEndBlockByNumber indicates an expected call of SetRangeEndBlockByNumber.
-func (mr *MockEventFiltererMockRecorder) SetRangeEndBlockByNumber(arg0, arg1 any) *gomock.Call {
+func (mr *MockEventFiltererMockRecorder) SetRangeEndBlockByNumber(filterRange, blockNumber any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetRangeEndBlockByNumber", reflect.TypeOf((*MockEventFilterer)(nil).SetRangeEndBlockByNumber), arg0, arg1)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetRangeEndBlockByNumber", reflect.TypeOf((*MockEventFilterer)(nil).SetRangeEndBlockByNumber), filterRange, blockNumber)
+}
+
+// SetRangeEndBlockToL1Head mocks base method.
+func (m *MockEventFilterer) SetRangeEndBlockToL1Head(filterRange blockchain.EventFilterRange) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "SetRangeEndBlockToL1Head", filterRange)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// SetRangeEndBlockToL1Head indicates an expected call of SetRangeEndBlockToL1Head.
+func (mr *MockEventFiltererMockRecorder) SetRangeEndBlockToL1Head(filterRange any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetRangeEndBlockToL1Head", reflect.TypeOf((*MockEventFilterer)(nil).SetRangeEndBlockToL1Head), filterRange)
 }
 
 // WithLimit mocks base method.
-func (m *MockEventFilterer) WithLimit(arg0 uint) *blockchain.EventFilter {
+func (m *MockEventFilterer) WithLimit(limit uint) *blockchain.EventFilter {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "WithLimit", arg0)
+	ret := m.ctrl.Call(m, "WithLimit", limit)
 	ret0, _ := ret[0].(*blockchain.EventFilter)
 	return ret0
 }
 
 // WithLimit indicates an expected call of WithLimit.
-func (mr *MockEventFiltererMockRecorder) WithLimit(arg0 any) *gomock.Call {
+func (mr *MockEventFiltererMockRecorder) WithLimit(limit any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WithLimit", reflect.TypeOf((*MockEventFilterer)(nil).WithLimit), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WithLimit", reflect.TypeOf((*MockEventFilterer)(nil).WithLimit), limit)
 }

--- a/rpc/v9/block.go
+++ b/rpc/v9/block.go
@@ -43,6 +43,7 @@ const (
 	latest
 	hash
 	number
+	l1Accepted
 )
 
 func (b *blockIDType) String() string {
@@ -51,6 +52,8 @@ func (b *blockIDType) String() string {
 		return "pre_confirmed"
 	case latest:
 		return "latest"
+	case l1Accepted:
+		return "l1_accepted"
 	case hash:
 		return "hash"
 	case number:
@@ -100,6 +103,10 @@ func (b *BlockID) IsNumber() bool {
 	return b.typeID == number
 }
 
+func (b *BlockID) IsL1Accepted() bool {
+	return b.typeID == l1Accepted
+}
+
 func (b *BlockID) Hash() *felt.Felt {
 	if b.typeID != hash {
 		panic(fmt.Sprintf("Trying to get hash from block id with type %s", b.typeID.String()))
@@ -122,6 +129,8 @@ func (b *BlockID) UnmarshalJSON(data []byte) error {
 			b.typeID = latest
 		case "pre_confirmed":
 			b.typeID = preConfirmed
+		case "l1_accepted":
+			b.typeID = l1Accepted
 		default:
 			return fmt.Errorf("unknown block tag '%s'", blockTag)
 		}

--- a/rpc/v9/class_test.go
+++ b/rpc/v9/class_test.go
@@ -229,6 +229,24 @@ func TestClassHashAt(t *testing.T) {
 		require.Nil(t, rpcErr)
 		assert.Equal(t, expectedClassHash, classHash)
 	})
+
+	t.Run("blockID - l1_accepted", func(t *testing.T) {
+		l1HeadBlockNumber := uint64(10)
+		mockReader.EXPECT().L1Head().Return(
+			&core.L1Head{
+				BlockNumber: l1HeadBlockNumber,
+				BlockHash:   &felt.Zero,
+				StateRoot:   &felt.Zero,
+			},
+			nil,
+		)
+		mockReader.EXPECT().StateAtBlockNumber(l1HeadBlockNumber).Return(mockState, nopCloser, nil)
+		mockState.EXPECT().ContractClassHash(gomock.Any()).Return(expectedClassHash, nil)
+		l1AcceptedID := blockIDL1Accepted(t)
+		classHash, rpcErr := handler.ClassHashAt(&l1AcceptedID, &felt.Zero)
+		require.Nil(t, rpcErr)
+		assert.Equal(t, expectedClassHash, classHash)
+	})
 }
 
 func assertEqualCairo0Class(t *testing.T, cairo0Class *core.Cairo0Class, class *rpcv6.Class) {

--- a/rpc/v9/events.go
+++ b/rpc/v9/events.go
@@ -45,6 +45,8 @@ func setEventFilterRange(filter blockchain.EventFilterer, from, to *BlockID, lat
 				return filter.SetRangeEndBlockByNumber(filterRange, min(blockID.Number(), latestHeight))
 			}
 			return filter.SetRangeEndBlockByNumber(filterRange, blockID.Number())
+		case l1Accepted:
+			return filter.SetRangeEndBlockToL1Head(filterRange)
 		default:
 			panic("Unknown block id type")
 		}

--- a/rpc/v9/events_test.go
+++ b/rpc/v9/events_test.go
@@ -301,11 +301,11 @@ func TestEvents(t *testing.T) {
 		block, err := gw.BlockByNumber(t.Context(), 4)
 		require.NoError(t, err)
 
-		chain.SetL1Head(&core.L1Head{
+		require.NoError(t, chain.SetL1Head(&core.L1Head{
 			BlockNumber: block.Number,
 			BlockHash:   block.Hash,
 			StateRoot:   block.GlobalStateRoot,
-		})
+		}))
 
 		expectedEvents := []*core.Event{}
 

--- a/rpc/v9/helpers.go
+++ b/rpc/v9/helpers.go
@@ -46,6 +46,13 @@ func (h *Handler) blockByID(blockID *BlockID) (*core.Block, *jsonrpc.Error) {
 		block, err = h.bcReader.Head()
 	case hash:
 		block, err = h.bcReader.BlockByHash(blockID.Hash())
+	case l1Accepted:
+		var l1Head *core.L1Head
+		l1Head, err = h.bcReader.L1Head()
+		if err != nil {
+			break
+		}
+		block, err = h.bcReader.BlockByNumber(l1Head.BlockNumber)
 	default:
 		block, err = h.bcReader.BlockByNumber(blockID.Number())
 	}
@@ -78,6 +85,13 @@ func (h *Handler) blockHeaderByID(blockID *BlockID) (*core.Header, *jsonrpc.Erro
 		header, err = h.bcReader.BlockHeaderByHash(blockID.Hash())
 	case number:
 		header, err = h.bcReader.BlockHeaderByNumber(blockID.Number())
+	case l1Accepted:
+		var l1Head *core.L1Head
+		l1Head, err = h.bcReader.L1Head()
+		if err != nil {
+			break
+		}
+		header, err = h.bcReader.BlockHeaderByNumber(l1Head.BlockNumber)
 	default:
 		panic("unknown block type id")
 	}
@@ -150,6 +164,13 @@ func (h *Handler) stateByBlockID(blockID *BlockID) (core.StateReader, blockchain
 		reader, closer, err = h.bcReader.StateAtBlockHash(blockID.Hash())
 	case number:
 		reader, closer, err = h.bcReader.StateAtBlockNumber(blockID.Number())
+	case l1Accepted:
+		var l1Head *core.L1Head
+		l1Head, err = h.bcReader.L1Head()
+		if err != nil {
+			break
+		}
+		reader, closer, err = h.bcReader.StateAtBlockNumber(l1Head.BlockNumber)
 	default:
 		panic("unknown block id type")
 	}

--- a/rpc/v9/nonce_test.go
+++ b/rpc/v9/nonce_test.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"testing"
 
+	"github.com/NethermindEth/juno/core"
 	"github.com/NethermindEth/juno/core/felt"
 	"github.com/NethermindEth/juno/db"
 	"github.com/NethermindEth/juno/mocks"
@@ -100,6 +101,26 @@ func TestNonce(t *testing.T) {
 
 		preConfirmedBlockID := blockIDPreConfirmed(t)
 		nonce, rpcErr := handler.Nonce(&preConfirmedBlockID, &felt.Zero)
+		require.Nil(t, rpcErr)
+		assert.Equal(t, expectedNonce, nonce)
+	})
+
+	t.Run("blockID - l1_accepted", func(t *testing.T) {
+		l1AcceptedBlockNumber := uint64(10)
+
+		mockReader.EXPECT().L1Head().Return(
+			&core.L1Head{
+				BlockNumber: l1AcceptedBlockNumber,
+				BlockHash:   &felt.One,
+				StateRoot:   &felt.One,
+			},
+			nil,
+		)
+		mockReader.EXPECT().StateAtBlockNumber(l1AcceptedBlockNumber).Return(mockState, nopCloser, nil)
+		mockState.EXPECT().ContractNonce(&felt.Zero).Return(expectedNonce, nil)
+
+		l1AcceptedID := blockIDL1Accepted(t)
+		nonce, rpcErr := handler.Nonce(&l1AcceptedID, &felt.Zero)
 		require.Nil(t, rpcErr)
 		assert.Equal(t, expectedNonce, nonce)
 	})

--- a/rpc/v9/state_update.go
+++ b/rpc/v9/state_update.go
@@ -119,6 +119,12 @@ func (h *Handler) stateUpdateByID(id *BlockID) (*core.StateUpdate, error) {
 		return h.bcReader.StateUpdateByHash(id.Hash())
 	case number:
 		return h.bcReader.StateUpdateByNumber(id.Number())
+	case l1Accepted:
+		l1Head, err := h.bcReader.L1Head()
+		if err != nil {
+			return nil, err
+		}
+		return h.bcReader.StateUpdateByNumber(l1Head.BlockNumber)
 	default:
 		panic("unknown block type id")
 	}

--- a/rpc/v9/state_update_test.go
+++ b/rpc/v9/state_update_test.go
@@ -26,6 +26,7 @@ func TestStateUpdate(t *testing.T) {
 		"pre_confirmed": blockIDPreConfirmed(t),
 		"hash":          blockIDHash(t, &felt.One),
 		"number":        blockIDNumber(t, 1),
+		"l1_accepted":   blockIDL1Accepted(t),
 	}
 	mockCtrl := gomock.NewController(t)
 	t.Cleanup(mockCtrl.Finish)
@@ -143,6 +144,22 @@ func TestStateUpdate(t *testing.T) {
 				checkUpdate(t, gwUpdate, &update)
 			})
 		}
+	})
+
+	t.Run("l1_accepted", func(t *testing.T) {
+		mockReader.EXPECT().L1Head().Return(
+			&core.L1Head{
+				BlockNumber: uint64(21656),
+				BlockHash:   update21656.BlockHash,
+				StateRoot:   update21656.NewRoot,
+			},
+			nil,
+		)
+		mockReader.EXPECT().StateUpdateByNumber(uint64(21656)).Return(update21656, nil)
+		l1AcceptedID := blockIDL1Accepted(t)
+		update, rpcErr := handler.StateUpdate(&l1AcceptedID)
+		require.Nil(t, rpcErr)
+		checkUpdate(t, update21656, &update)
 	})
 
 	t.Run("pre_confirmed", func(t *testing.T) {

--- a/rpc/v9/storage.go
+++ b/rpc/v9/storage.go
@@ -192,6 +192,8 @@ func (h *Handler) isBlockSupported(blockID *BlockID, chainHeight uint64) *jsonrp
 		blockNumber = header.Number
 	case blockID.IsNumber():
 		blockNumber = blockID.Number()
+	case blockID.IsL1Accepted():
+		return rpccore.ErrStorageProofNotSupported
 	default:
 		panic(fmt.Sprintf("invalid block id type %d", blockID.Type()))
 	}

--- a/rpc/v9/storage_test.go
+++ b/rpc/v9/storage_test.go
@@ -141,6 +141,26 @@ func TestStorageAt(t *testing.T) {
 		require.Nil(t, rpcErr)
 		assert.Equal(t, expectedStorage, storageValue)
 	})
+
+	t.Run("blockID - l1_accepted", func(t *testing.T) {
+		l1HeadBlockNumber := uint64(10)
+		mockReader.EXPECT().L1Head().Return(
+			&core.L1Head{
+				BlockNumber: l1HeadBlockNumber,
+				BlockHash:   &felt.Zero,
+				StateRoot:   &felt.Zero,
+			},
+			nil,
+		)
+		mockReader.EXPECT().StateAtBlockNumber(l1HeadBlockNumber).Return(mockState, nopCloser, nil)
+		mockState.EXPECT().ContractClassHash(&felt.Zero).Return(nil, nil)
+		mockState.EXPECT().ContractStorage(gomock.Any(), gomock.Any()).Return(expectedStorage, nil)
+
+		blockID := blockIDL1Accepted(t)
+		storageValue, rpcErr := handler.StorageAt(&felt.Zero, &felt.Zero, &blockID)
+		require.Nil(t, rpcErr)
+		assert.Equal(t, expectedStorage, storageValue)
+	})
 }
 
 func TestStorageProof(t *testing.T) {

--- a/rpc/v9/subscriptions.go
+++ b/rpc/v9/subscriptions.go
@@ -41,7 +41,7 @@ func (e errorTxnHashNotFound) Error() string {
 	return fmt.Sprintf("transaction %v not found", e.txHash)
 }
 
-// As per the spec, this is the same as BlockID, but without `pre_confirmed`
+// As per the spec, this is the same as BlockID, but without `pre_confirmed` and `l1_accepted`
 type SubscriptionBlockID BlockID
 
 func (b *SubscriptionBlockID) Type() blockIDType {
@@ -77,6 +77,10 @@ func (b *SubscriptionBlockID) UnmarshalJSON(data []byte) error {
 
 	if blockID.IsPreConfirmed() {
 		return errors.New("subscription block id cannot be pre_confirmed")
+	}
+
+	if blockID.IsL1Accepted() {
+		return errors.New("subscription block id cannot be l1_accepted")
 	}
 
 	return nil

--- a/rpc/v9/trace_test.go
+++ b/rpc/v9/trace_test.go
@@ -683,6 +683,7 @@ func TestTraceBlockTransactions(t *testing.T) {
 		"hash":          blockIDHash(t, new(felt.Felt).SetUint64(1)),
 		"number":        blockIDNumber(t, 2),
 		"pre_confirmed": blockIDPreConfirmed(t),
+		"l1_accepted":   blockIDL1Accepted(t),
 	}
 
 	for description, blockID := range errTests {


### PR DESCRIPTION
This PR introduces new block tag `l1_accepted`, which comes with rpc `0.9.0-rc2` [ref](https://github.com/starkware-libs/starknet-specs/blob/9264a4eec76ccb7cbc24624bb13d243518cda6e6/api/starknet_api_openrpc.json#L1233).