### PR TITLE
fix:  `TransactionByBlockIDAndIndex` error when txIndex equal `block.TransactionCount`

### DIFF
--- a/rpc/v6/transaction.go
+++ b/rpc/v6/transaction.go
@@ -494,7 +494,7 @@ func (h *Handler) TransactionByBlockIDAndIndex(id BlockID, txIndex int) (*Transa
 			return nil, rpccore.ErrBlockNotFound
 		}
 
-		if uint64(txIndex) > pending.GetBlock().TransactionCount {
+		if uint64(txIndex) >= pending.GetBlock().TransactionCount {
 			return nil, rpccore.ErrInvalidTxIndex
 		}
 

--- a/rpc/v7/transaction.go
+++ b/rpc/v7/transaction.go
@@ -402,7 +402,7 @@ func (h *Handler) TransactionByBlockIDAndIndex(id BlockID, txIndex int) (*Transa
 			return nil, rpccore.ErrBlockNotFound
 		}
 
-		if uint64(txIndex) > pending.GetBlock().TransactionCount {
+		if uint64(txIndex) >= pending.GetBlock().TransactionCount {
 			return nil, rpccore.ErrInvalidTxIndex
 		}
 

--- a/rpc/v8/transaction.go
+++ b/rpc/v8/transaction.go
@@ -514,7 +514,7 @@ func (h *Handler) TransactionByBlockIDAndIndex(
 			return nil, rpccore.ErrBlockNotFound
 		}
 
-		if uint64(txIndex) > pending.GetBlock().TransactionCount {
+		if uint64(txIndex) >= pending.GetBlock().TransactionCount {
 			return nil, rpccore.ErrInvalidTxIndex
 		}
 

--- a/rpc/v9/transaction.go
+++ b/rpc/v9/transaction.go
@@ -528,7 +528,7 @@ func (h *Handler) TransactionByBlockIDAndIndex(
 			return nil, rpccore.ErrBlockNotFound
 		}
 
-		if uint64(txIndex) > pending.GetBlock().TransactionCount {
+		if uint64(txIndex) >= pending.GetBlock().TransactionCount {
 			return nil, rpccore.ErrInvalidTxIndex
 		}
 


### PR DESCRIPTION
TxIndex should be [0, block.TransactionCount). 