### PR TITLE
fix:  pending block number

### DIFF
--- a/sync/sync.go
+++ b/sync/sync.go
@@ -579,6 +579,7 @@ func (s *Synchronizer) fetchAndStorePending(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
+	pending.Block.Number = head.Number + 1
 
 	blockVer, err = core.ParseBlockVersion(pending.Block.ProtocolVersion)
 	if err != nil {


### PR DESCRIPTION
Mistakenly I removed the line that assigns block number to pending block in another PR([here](https://github.com/NethermindEth/juno/pull/2952/files#r2226181076)) while adapting changes 0.14.0-beta to main