### PR TITLE
feat: update snapshots to tar.zst format with streaming extraction

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,50 +114,46 @@ If you are looking to become a **Starknet Validator**, follow our guide [here](h
 
 Use the provided snapshots to quickly sync your Juno node with the current state of the network. Fresh snapshots are automatically uploaded once a week and are available under the links below.
 
+**Note**: Snapshots are now provided in compressed `.tar.zst` format for faster downloads and reduced storage requirements. You can stream the download and extraction process without requiring double disk space.
+
 #### Mainnet
 
 | Version | Download Link |
 | ------- | ------------- |
-| **>=v0.13.0**  | [**juno_mainnet.tar**](https://juno-snapshots.nethermind.io/files/mainnet/latest) |
+| **>=v0.13.0**  | [**juno_mainnet.tar.zst**](https://juno-snapshots.nethermind.io/files/mainnet/latest) |
 
 #### Sepolia
 
 | Version | Download Link |
 | ------- | ------------- |
-| **>=v0.13.0** | [**juno_sepolia.tar**](https://juno-snapshots.nethermind.io/files/sepolia/latest) |
+| **>=v0.13.0** | [**juno_sepolia.tar.zst**](https://juno-snapshots.nethermind.io/files/sepolia/latest) |
 
 #### Sepolia-Integration
 
 | Version | Download Link |
 | ------- | ------------- |
-| **>=v0.13.0** | [**juno_sepolia_integration.tar**](https://juno-snapshots.nethermind.io/files/sepolia-integration/latest) |
+| **>=v0.13.0** | [**juno_sepolia_integration.tar.zst**](https://juno-snapshots.nethermind.io/files/sepolia-integration/latest) |
 
 ### Getting the size for each snapshot
 ```console
 $date
-Thu  1 Aug 2024 09:49:30 BST
+Mon 28 Jul 2025 08:24:59 GMT
 
 $curl -s -I -L https://juno-snapshots.nethermind.io/files/mainnet/latest | gawk -v IGNORECASE=1 '/^Content-Length/ { printf "%.2f GB\n", $2/1024/1024/1024 }'
-172.47 GB
+186.23 GB
 
 $curl -s -I -L https://juno-snapshots.nethermind.io/files/sepolia/latest | gawk -v IGNORECASE=1 '/^Content-Length/ { printf "%.2f GB\n", $2/1024/1024/1024 }'
-5.67 GB
+30.45 GB
 
 $curl -s -I -L https://juno-snapshots.nethermind.io/files/sepolia-integration/latest | gawk -v IGNORECASE=1 '/^Content-Length/ { printf "%.2f GB\n", $2/1024/1024/1024 }'
-2.4 GB
+6.14 GB
 ```
 
 ### Run Juno Using Snapshot
 
-1. **Download Snapshot**
+This method downloads and extracts the snapshot in one step without requiring double disk space:
 
-   Fetch the snapshot from the provided URL:
-
-   ```bash
-   wget -O juno_mainnet.tar https://juno-snapshots.nethermind.io/files/mainnet/latest
-   ```
-
-2. **Prepare Directory**
+1. **Prepare Directory**
 
    Ensure you have a directory at `$HOME/snapshots`. If it doesn't exist yet, create it:
 
@@ -165,23 +161,44 @@ $curl -s -I -L https://juno-snapshots.nethermind.io/files/sepolia-integration/la
    mkdir -p $HOME/snapshots
    ```
 
-3. **Extract Tarball**
+2. **Install zstd**
 
-   Extract the contents of the `.tar` file:
+   [zstd (Zstandard)](https://github.com/facebook/zstd) is required to decompress and directly stream the snapshots into your system without requiring temporary storage. zstd provides significantly better compression ratios and faster decompression speeds compared to traditional tar compression.
 
    ```bash
-   tar -xvf juno_mainnet.tar -C $HOME/snapshots
+   # On Ubuntu/Debian
+   sudo apt-get install zstd
+   
+   # On macOS
+   brew install zstd
+   
+   # On RHEL/CentOS/Fedora
+   sudo dnf install zstd  # or yum install zstd
    ```
+
+3. **Stream Download and Extract**
+
+   Download and extract the snapshot directly to your target directory:
+
+   ```bash
+   # For Mainnet
+   curl -s -L https://juno-snapshots.nethermind.io/files/mainnet/latest \
+   | zstd -d | tar -xvf - -C $HOME/snapshots
+   ```
+
+   For other networks, replace the URL:
+   - **Sepolia**: `https://juno-snapshots.nethermind.io/files/sepolia/latest`
+   - **Sepolia-Integration**: `https://juno-snapshots.nethermind.io/files/sepolia-integration/latest`
 
 4. **Run Juno**
 
-   Execute the Docker command to run Juno, ensuring that you're using the correct snapshot path `$HOME/snapshots/juno_mainnet`:
+   Execute the Docker command to run Juno:
 
    ```bash
    docker run -d \
      --name juno \
      -p 6060:6060 \
-     -v $HOME/snapshots/juno_mainnet:/var/lib/juno \
+     -v $HOME/snapshots:/var/lib/juno \
      nethermind/juno \
      --http \
      --http-port 6060 \
@@ -189,6 +206,8 @@ $curl -s -I -L https://juno-snapshots.nethermind.io/files/sepolia-integration/la
      --db-path /var/lib/juno \
      --eth-node <YOUR-ETH-NODE>
    ```
+
+   Replace `<YOUR-ETH-NODE>` with your Ethereum node WebSocket URL (e.g., `wss://mainnet.infura.io/ws/v3/your-project-id`).
 
 After following these steps, Juno should be up and running on your machine, utilizing the provided snapshot.
 

--- a/docs/docs/snapshots.md
+++ b/docs/docs/snapshots.md
@@ -6,51 +6,47 @@ title: Database Snapshots
 
 You can download a snapshot of the Juno database to reduce the network syncing time. Only the blocks created after the snapshot will be synced when you run the node. Fresh snapshots are automatically uploaded once a week and are available under the links below.
 
+**Note**: Snapshots are now provided in compressed `.tar.zst` format for faster downloads and reduced storage requirements. You can stream the download and extraction process without requiring double disk space.
+
 ## Mainnet
 
 | Version | Download Link |
 | ------- | ------------- |
-| **>=v0.13.0**  | [**juno_mainnet.tar**](https://juno-snapshots.nethermind.io/files/mainnet/latest) |
+| **>=v0.13.0**  | [**juno_mainnet.tar.zst**](https://juno-snapshots.nethermind.io/files/mainnet/latest) |
 
 ## Sepolia
 
 | Version | Download Link |
 | ------- | ------------- |
-| **>=v0.13.0** | [**juno_sepolia.tar**](https://juno-snapshots.nethermind.io/files/sepolia/latest) |
+| **>=v0.13.0** | [**juno_sepolia.tar.zst**](https://juno-snapshots.nethermind.io/files/sepolia/latest) |
 
 ## Sepolia-Integration
 
 | Version | Download Link |
 | ------- | ------------- |
-| **>=v0.13.0** | [**juno_sepolia_integration.tar**](https://juno-snapshots.nethermind.io/files/sepolia-integration/latest) |
+| **>=v0.13.0** | [**juno_sepolia_integration.tar.zst**](https://juno-snapshots.nethermind.io/files/sepolia-integration/latest) |
 
 ## Getting snapshot sizes
 
 ```console
 $date
-Thu  1 Aug 2024 09:49:30 BST
+Mon 28 Jul 2025 08:24:59 GMT
 
 $curl -s -I -L https://juno-snapshots.nethermind.io/files/mainnet/latest | gawk -v IGNORECASE=1 '/^Content-Length/ { printf "%.2f GB\n", $2/1024/1024/1024 }'
-172.47 GB
+186.23 GB
 
 $curl -s -I -L https://juno-snapshots.nethermind.io/files/sepolia/latest | gawk -v IGNORECASE=1 '/^Content-Length/ { printf "%.2f GB\n", $2/1024/1024/1024 }'
-5.67 GB
+30.45 GB
 
 $curl -s -I -L https://juno-snapshots.nethermind.io/files/sepolia-integration/latest | gawk -v IGNORECASE=1 '/^Content-Length/ { printf "%.2f GB\n", $2/1024/1024/1024 }'
-2.4 GB
+6.14 GB
 ```
 
 ## Run Juno with a snapshot
 
-### 1. Download the snapshot
+This method downloads and extracts the snapshot in one step without requiring double disk space:
 
-First, download a snapshot from one of the provided URLs:
-
-```bash
-wget -O juno_mainnet.tar https://juno-snapshots.nethermind.io/files/mainnet/latest
-```
-
-### 2. Prepare a directory
+### 1. Prepare a directory
 
 Ensure you have a directory to store the snapshots. We will use the `$HOME/snapshots` directory:
 
@@ -58,31 +54,75 @@ Ensure you have a directory to store the snapshots. We will use the `$HOME/snaps
 mkdir -p $HOME/snapshots
 ```
 
-### 3. Extract the snapshot
+### 2. Install zstd
 
-Extract the contents of the downloaded `.tar` file into the directory:
+[zstd (Zstandard)](https://github.com/facebook/zstd) is required to decompress and directly stream the snapshots into your system without requiring temporary storage. zstd provides significantly better compression ratios and faster decompression speeds compared to traditional tar compression.
 
 ```bash
-tar -xvf juno_mainnet.tar -C $HOME/snapshots
+# On Ubuntu/Debian
+sudo apt-get install zstd
+
+# On macOS
+brew install zstd
+
+# On RHEL/CentOS/Fedora
+sudo dnf install zstd  # or yum install zstd
 ```
 
-### 4. Run Juno
+### 3. Stream download and extract
 
-Run the Docker command to start Juno and provide the path to the snapshot using the `db-path` option:
+Download and extract the snapshot directly to your target directory:
+
+```bash
+# For Mainnet
+curl -s -L https://juno-snapshots.nethermind.io/files/mainnet/latest \
+| zstd -d | tar -xvf - -C $HOME/snapshots
+```
+
+For other networks, replace the URL with:
+- **Sepolia**: `https://juno-snapshots.nethermind.io/files/sepolia/latest`
+- **Sepolia-Integration**: `https://juno-snapshots.nethermind.io/files/sepolia-integration/latest`
+
+#### Alternative method: Download then extract
+
+If you prefer the traditional two-step approach or have limited bandwidth, you can download the snapshot first and extract it later:
+
+##### 1. Download the snapshot
+
+```bash
+# For Mainnet
+wget -O juno_mainnet.tar.zst https://juno-snapshots.nethermind.io/files/mainnet/latest
+
+# Or using curl
+curl -L https://juno-snapshots.nethermind.io/files/mainnet/latest -o juno_mainnet.tar.zst
+```
+
+##### 2. Extract the snapshot
+
+```bash
+# Extract to your snapshots directory
+zstd -d juno_mainnet.tar.zst -c | tar -xvf - -C $HOME/snapshots
+```
+
+## Running Juno with snapshots
+
+### 1. Run Juno
+
+Run the Docker command to start Juno:
 
 ```bash
 docker run -d \
   --name juno \
   -p 6060:6060 \
-  -v $HOME/snapshots/juno_mainnet:/snapshots/juno_mainnet \
+  -v $HOME/snapshots:/var/lib/juno \
   nethermind/juno \
   --http \
   --http-port 6060 \
   --http-host 0.0.0.0 \
-  --db-path /snapshots/juno_mainnet \
-  --eth-node <YOUR ETH NODE>
+  --db-path /var/lib/juno \
+  --eth-node <YOUR-ETH-NODE>
 ```
 
 :::info
-Replace \<YOUR ETH NODE\> with the WebSocket endpoint of your Ethereum node. For Infura users, your address should be: `wss://mainnet.infura.io/ws/v3/your-infura-project-id`. Ensure you use the WebSocket URL (`ws`/`wss`) instead of the HTTP URL (`http`/`https`).
+Replace `<YOUR-ETH-NODE>` with your Ethereum node WebSocket URL (e.g., `wss://mainnet.infura.io/ws/v3/your-project-id`). Ensure you use the WebSocket URL (`ws`/`wss`) instead of the HTTP URL (`http`/`https`).
 :::

--- a/docs/versioned_docs/version-0.15.0/snapshots.md
+++ b/docs/versioned_docs/version-0.15.0/snapshots.md
@@ -6,51 +6,47 @@ title: Database Snapshots
 
 You can download a snapshot of the Juno database to reduce the network syncing time. Only the blocks created after the snapshot will be synced when you run the node. Fresh snapshots are automatically uploaded once a week and are available under the links below.
 
+**Note**: Snapshots are now provided in compressed `.tar.zst` format for faster downloads and reduced storage requirements. You can stream the download and extraction process without requiring double disk space.
+
 ## Mainnet
 
 | Version | Download Link |
 | ------- | ------------- |
-| **>=v0.13.0**  | [**juno_mainnet.tar**](https://juno-snapshots.nethermind.io/files/mainnet/latest) |
+| **>=v0.13.0**  | [**juno_mainnet.tar.zst**](https://juno-snapshots.nethermind.io/files/mainnet/latest) |
 
 ## Sepolia
 
 | Version | Download Link |
 | ------- | ------------- |
-| **>=v0.13.0** | [**juno_sepolia.tar**](https://juno-snapshots.nethermind.io/files/sepolia/latest) |
+| **>=v0.13.0** | [**juno_sepolia.tar.zst**](https://juno-snapshots.nethermind.io/files/sepolia/latest) |
 
 ## Sepolia-Integration
 
 | Version | Download Link |
 | ------- | ------------- |
-| **>=v0.13.0** | [**juno_sepolia_integration.tar**](https://juno-snapshots.nethermind.io/files/sepolia-integration/latest) |
+| **>=v0.13.0** | [**juno_sepolia_integration.tar.zst**](https://juno-snapshots.nethermind.io/files/sepolia-integration/latest) |
 
 ## Getting snapshot sizes
 
 ```console
 $date
-Thu  1 Aug 2024 09:49:30 BST
+Mon 28 Jul 2025 08:24:59 GMT
 
 $curl -s -I -L https://juno-snapshots.nethermind.io/files/mainnet/latest | gawk -v IGNORECASE=1 '/^Content-Length/ { printf "%.2f GB\n", $2/1024/1024/1024 }'
-172.47 GB
+186.23 GB
 
 $curl -s -I -L https://juno-snapshots.nethermind.io/files/sepolia/latest | gawk -v IGNORECASE=1 '/^Content-Length/ { printf "%.2f GB\n", $2/1024/1024/1024 }'
-5.67 GB
+30.45 GB
 
 $curl -s -I -L https://juno-snapshots.nethermind.io/files/sepolia-integration/latest | gawk -v IGNORECASE=1 '/^Content-Length/ { printf "%.2f GB\n", $2/1024/1024/1024 }'
-2.4 GB
+6.14 GB
 ```
 
 ## Run Juno with a snapshot
 
-### 1. Download the snapshot
+This method downloads and extracts the snapshot in one step without requiring double disk space:
 
-First, download a snapshot from one of the provided URLs:
-
-```bash
-wget -O juno_mainnet.tar https://juno-snapshots.nethermind.io/files/mainnet/latest
-```
-
-### 2. Prepare a directory
+### 1. Prepare a directory
 
 Ensure you have a directory to store the snapshots. We will use the `$HOME/snapshots` directory:
 
@@ -58,31 +54,75 @@ Ensure you have a directory to store the snapshots. We will use the `$HOME/snaps
 mkdir -p $HOME/snapshots
 ```
 
-### 3. Extract the snapshot
+### 2. Install zstd
 
-Extract the contents of the downloaded `.tar` file into the directory:
+[zstd (Zstandard)](https://github.com/facebook/zstd) is required to decompress and directly stream the snapshots into your system without requiring temporary storage. zstd provides significantly better compression ratios and faster decompression speeds compared to traditional tar compression.
 
 ```bash
-tar -xvf juno_mainnet.tar -C $HOME/snapshots
+# On Ubuntu/Debian
+sudo apt-get install zstd
+
+# On macOS
+brew install zstd
+
+# On RHEL/CentOS/Fedora
+sudo dnf install zstd  # or yum install zstd
 ```
 
-### 4. Run Juno
+### 3. Stream download and extract
 
-Run the Docker command to start Juno and provide the path to the snapshot using the `db-path` option:
+Download and extract the snapshot directly to your target directory:
+
+```bash
+# For Mainnet
+curl -s -L https://juno-snapshots.nethermind.io/files/mainnet/latest \
+| zstd -d | tar -xvf - -C $HOME/snapshots
+```
+
+For other networks, replace the URL with:
+- **Sepolia**: `https://juno-snapshots.nethermind.io/files/sepolia/latest`
+- **Sepolia-Integration**: `https://juno-snapshots.nethermind.io/files/sepolia-integration/latest`
+
+#### Alternative method: Download then extract
+
+If you prefer the traditional two-step approach or have limited bandwidth, you can download the snapshot first and extract it later:
+
+##### 1. Download the snapshot
+
+```bash
+# For Mainnet
+wget -O juno_mainnet.tar.zst https://juno-snapshots.nethermind.io/files/mainnet/latest
+
+# Or using curl
+curl -L https://juno-snapshots.nethermind.io/files/mainnet/latest -o juno_mainnet.tar.zst
+```
+
+##### 2. Extract the snapshot
+
+```bash
+# Extract to your snapshots directory
+zstd -d juno_mainnet.tar.zst -c | tar -xvf - -C $HOME/snapshots
+```
+
+## Running Juno with snapshots
+
+### 1. Run Juno
+
+Run the Docker command to start Juno:
 
 ```bash
 docker run -d \
   --name juno \
   -p 6060:6060 \
-  -v $HOME/snapshots/juno_mainnet:/snapshots/juno_mainnet \
+  -v $HOME/snapshots:/var/lib/juno \
   nethermind/juno \
   --http \
   --http-port 6060 \
   --http-host 0.0.0.0 \
-  --db-path /snapshots/juno_mainnet \
-  --eth-node <YOUR ETH NODE>
+  --db-path /var/lib/juno \
+  --eth-node <YOUR-ETH-NODE>
 ```
 
 :::info
-Replace \<YOUR ETH NODE\> with the WebSocket endpoint of your Ethereum node. For Infura users, your address should be: `wss://mainnet.infura.io/ws/v3/your-infura-project-id`. Ensure you use the WebSocket URL (`ws`/`wss`) instead of the HTTP URL (`http`/`https`).
+Replace `<YOUR-ETH-NODE>` with your Ethereum node WebSocket URL (e.g., `wss://mainnet.infura.io/ws/v3/your-project-id`). Ensure you use the WebSocket URL (`ws`/`wss`) instead of the HTTP URL (`http`/`https`).
 :::


### PR DESCRIPTION
- Change snapshot format from .tar to .tar.zst for better compression
- Replace wget method with curl streaming extraction
- Eliminate need for double disk space during extraction
- Update snapshot sizes and documentation across README and docs