### PR TITLE
feat: rpcv9 ws endpoints

### DIFF
--- a/.github/workflows/deploy-and-test.yaml
+++ b/.github/workflows/deploy-and-test.yaml
@@ -153,7 +153,7 @@ jobs:
     needs: [deploy]
     uses: ./.github/workflows/starknet-go-tests.yml
     with:
-      ref: 2229570c51b95617c2e708f7ba4ee050d91f63dc
+      ref: 4e939e80b7dccbde007b997c11e88bc025eea7eb
       rpc_version: v0_9
     secrets:
       TEST_RPC_URL: ${{ secrets.RPC_URL }}

--- a/.github/workflows/deploy-and-test.yaml
+++ b/.github/workflows/deploy-and-test.yaml
@@ -153,7 +153,7 @@ jobs:
     needs: [deploy]
     uses: ./.github/workflows/starknet-go-tests.yml
     with:
-      ref: 4e939e80b7dccbde007b997c11e88bc025eea7eb
+      ref: 103d20c44ad4e07586a933e63564ae9505463959
       rpc_version: v0_9
     secrets:
       TEST_RPC_URL: ${{ secrets.RPC_URL }}

--- a/.github/workflows/deploy-and-test.yaml
+++ b/.github/workflows/deploy-and-test.yaml
@@ -153,7 +153,7 @@ jobs:
     needs: [deploy]
     uses: ./.github/workflows/starknet-go-tests.yml
     with:
-      ref: 5f5517021c173741e06a552dd81d6bd8a477713c
+      ref: 2229570c51b95617c2e708f7ba4ee050d91f63dc
       rpc_version: v0_9
     secrets:
       TEST_RPC_URL: ${{ secrets.RPC_URL }}

--- a/blockchain/event_matcher.go
+++ b/blockchain/event_matcher.go
@@ -34,7 +34,7 @@ func makeKeysMaps(filterKeys [][]felt.Felt) []map[felt.Felt]struct{} {
 	return filterKeysMaps
 }
 
-func (e *EventMatcher) matchesEventKeys(eventKeys []*felt.Felt) bool {
+func (e *EventMatcher) MatchesEventKeys(eventKeys []*felt.Felt) bool {
 	// short circuit if event doest have enough keys
 	for i := len(eventKeys); i < len(e.keysMap); i++ {
 		if len(e.keysMap[i]) > 0 {
@@ -148,7 +148,8 @@ func (e *EventMatcher) AppendBlockEvents(matchedEventsSofar []*FilteredEvent, he
 		for i, event := range receipt.Events {
 			var blockNumber *uint64
 			// if header.Hash == nil it's a pending block
-			if header.Hash != nil {
+			// if header.Hash == nil and header.ParentHash is nil preconfirmed block
+			if header.Hash != nil || header.ParentHash == nil {
 				blockNumber = &header.Number
 			}
 
@@ -164,7 +165,7 @@ func (e *EventMatcher) AppendBlockEvents(matchedEventsSofar []*FilteredEvent, he
 				continue
 			}
 
-			if !e.matchesEventKeys(event.Keys) {
+			if !e.MatchesEventKeys(event.Keys) {
 				processedEvents++
 				continue
 			}

--- a/rpc/handlers.go
+++ b/rpc/handlers.go
@@ -254,9 +254,19 @@ func (h *Handler) MethodsV0_9() ([]jsonrpc.Method, string) { //nolint:funlen
 			Handler: h.rpcv9Handler.SpecVersion,
 		},
 		{
-			Name:    "starknet_subscribeEvents",
-			Params:  []jsonrpc.Parameter{{Name: "from_address", Optional: true}, {Name: "keys", Optional: true}, {Name: "block_id", Optional: true}},
+			Name: "starknet_subscribeEvents",
+			Params: []jsonrpc.Parameter{
+				{Name: "from_address", Optional: true},
+				{Name: "keys", Optional: true},
+				{Name: "block_id", Optional: true},
+				{Name: "finality_status", Optional: true},
+			},
 			Handler: h.rpcv9Handler.SubscribeEvents,
+		},
+		{
+			Name:    "starknet_subscribeNewTransactionReceipts",
+			Params:  []jsonrpc.Parameter{{Name: "sender_address", Optional: true}, {Name: "finality_status", Optional: true}},
+			Handler: h.rpcv9Handler.SubscribeNewTransactionReceipts,
 		},
 		{
 			Name:    "starknet_subscribeNewHeads",
@@ -269,9 +279,9 @@ func (h *Handler) MethodsV0_9() ([]jsonrpc.Method, string) { //nolint:funlen
 			Handler: h.rpcv9Handler.SubscribeTransactionStatus,
 		},
 		{
-			Name:    "starknet_subscribePendingTransactions",
-			Params:  []jsonrpc.Parameter{{Name: "transaction_details", Optional: true}, {Name: "sender_address", Optional: true}},
-			Handler: h.rpcv9Handler.SubscribePendingTxs,
+			Name:    "starknet_subscribeNewTransactions",
+			Params:  []jsonrpc.Parameter{{Name: "finality_status", Optional: true}, {Name: "sender_address", Optional: true}},
+			Handler: h.rpcv9Handler.SubscribeNewTransactions,
 		},
 		{
 			Name:    "starknet_unsubscribe",

--- a/rpc/v8/block.go
+++ b/rpc/v8/block.go
@@ -55,6 +55,12 @@ func BlockIDFromHash(blockHash *felt.Felt) BlockID {
 	}
 }
 
+func BlockIDPending() BlockID {
+	return BlockID{
+		typeID: pending,
+	}
+}
+
 func (b *BlockID) Type() blockIDType {
 	return b.typeID
 }

--- a/rpc/v8/subscriptions.go
+++ b/rpc/v8/subscriptions.go
@@ -375,40 +375,34 @@ func (h *Handler) processEvents(
 ) error {
 	filter, err := h.bcReader.EventFilter(fromAddr, keys, h.PendingBlock)
 	if err != nil {
-		h.log.Warnw("Error creating event filter", "err", err)
 		return err
 	}
 
-	defer h.callAndLogErr(filter.Close, "Error closing event filter in events subscription")
+	defer h.callAndLogErr(filter.Close, "error closing event filter in events subscription")
 
 	err = setEventFilterRange(filter, from, to, height)
 	if err != nil {
-		h.log.Warnw("Error setting event filter range", "err", err)
 		return err
 	}
 
 	filteredEvents, cToken, err := filter.Events(nil, subscribeEventsChunkSize)
 	if err != nil {
-		h.log.Warnw("Error filtering events", "err", err)
 		return err
 	}
 
 	err = sendEvents(ctx, w, filteredEvents, eventsPreviouslySent, id)
 	if err != nil {
-		h.log.Warnw("Error sending events", "err", err)
 		return err
 	}
 
 	for cToken != nil {
 		filteredEvents, cToken, err = filter.Events(cToken, subscribeEventsChunkSize)
 		if err != nil {
-			h.log.Warnw("Error filtering events", "err", err)
 			return err
 		}
 
 		err = sendEvents(ctx, w, filteredEvents, eventsPreviouslySent, id)
 		if err != nil {
-			h.log.Warnw("Error sending events", "err", err)
 			return err
 		}
 	}

--- a/rpc/v8/subscriptions.go
+++ b/rpc/v8/subscriptions.go
@@ -202,7 +202,7 @@ func (h *Handler) SubscribeEvents(
 
 	nextBlock := headHeader.Number + 1
 	eventsPreviouslySent := make(map[SentEvent]struct{})
-	pendingID := &BlockID{typeID: pending}
+	pendingID := BlockIDPending()
 	subscriber := subscriber{
 		onStart: func(ctx context.Context, id string, _ *subscription, _ any) error {
 			fromB := BlockIDFromNumber(requestedHeader.Number)
@@ -241,8 +241,8 @@ func (h *Handler) SubscribeEvents(
 				ctx,
 				w,
 				id,
-				pendingID,
-				pendingID,
+				&pendingID,
+				&pendingID,
 				fromAddr,
 				keys,
 				eventsPreviouslySent,

--- a/rpc/v8/subscriptions.go
+++ b/rpc/v8/subscriptions.go
@@ -335,7 +335,7 @@ func (h *Handler) checkTxStatus(
 		return lastStatus, errorTxnHashNotFound{*txHash}
 	}
 
-	if status.Finality <= lastStatus {
+	if status.Finality == lastStatus {
 		return lastStatus, nil
 	}
 

--- a/rpc/v9/block.go
+++ b/rpc/v9/block.go
@@ -83,6 +83,12 @@ func BlockIDFromHash(blockHash *felt.Felt) BlockID {
 	}
 }
 
+func BlockIDPreConfirmed() BlockID {
+	return BlockID{
+		typeID: preConfirmed,
+	}
+}
+
 func (b *BlockID) Type() blockIDType {
 	return b.typeID
 }

--- a/rpc/v9/handlers.go
+++ b/rpc/v9/handlers.go
@@ -288,9 +288,19 @@ func (h *Handler) methods() ([]jsonrpc.Method, string) { //nolint: funlen
 			Handler: h.SpecVersion,
 		},
 		{
-			Name:    "starknet_subscribeEvents",
-			Params:  []jsonrpc.Parameter{{Name: "from_address", Optional: true}, {Name: "keys", Optional: true}, {Name: "block_id", Optional: true}},
+			Name: "starknet_subscribeEvents",
+			Params: []jsonrpc.Parameter{
+				{Name: "from_address", Optional: true},
+				{Name: "keys", Optional: true},
+				{Name: "block_id", Optional: true},
+				{Name: "finality_status", Optional: true},
+			},
 			Handler: h.SubscribeEvents,
+		},
+		{
+			Name:    "starknet_subscribeNewTransactionReceipts",
+			Params:  []jsonrpc.Parameter{{Name: "sender_address", Optional: true}, {Name: "finality_status", Optional: true}},
+			Handler: h.SubscribeNewTransactionReceipts,
 		},
 		{
 			Name:    "starknet_subscribeNewHeads",
@@ -303,9 +313,9 @@ func (h *Handler) methods() ([]jsonrpc.Method, string) { //nolint: funlen
 			Handler: h.SubscribeTransactionStatus,
 		},
 		{
-			Name:    "starknet_subscribePendingTransactions",
-			Params:  []jsonrpc.Parameter{{Name: "transaction_details", Optional: true}, {Name: "sender_address", Optional: true}},
-			Handler: h.SubscribePendingTxs,
+			Name:    "starknet_subscribeNewTransactions",
+			Params:  []jsonrpc.Parameter{{Name: "finality_status", Optional: true}, {Name: "sender_address", Optional: true}},
+			Handler: h.SubscribeNewTransactions,
 		},
 		{
 			Name:    "starknet_unsubscribe",

--- a/rpc/v9/subscriptions.go
+++ b/rpc/v9/subscriptions.go
@@ -307,8 +307,16 @@ func (h *Handler) SubscribeEvents(
 }
 
 // processEvents queries database for events and stream filtered events.
-func (h *Handler) processEvents(ctx context.Context, w jsonrpc.Conn, id string, from, to *BlockID, fromAddr *felt.Felt,
-	keys [][]felt.Felt, eventsPreviouslySent map[SentEvent]TxnFinalityStatusWithoutL1, height uint64, finalityStatus TxnFinalityStatusWithoutL1,
+func (h *Handler) processEvents(
+	ctx context.Context,
+	w jsonrpc.Conn,
+	id string,
+	from, to *BlockID,
+	fromAddr *felt.Felt,
+	keys [][]felt.Felt,
+	eventsPreviouslySent map[SentEvent]TxnFinalityStatusWithoutL1,
+	height uint64,
+	finalityStatus TxnFinalityStatusWithoutL1,
 ) error {
 	filter, err := h.bcReader.EventFilter(fromAddr, keys, h.PendingBlock)
 	if err != nil {

--- a/rpc/v9/subscriptions.go
+++ b/rpc/v9/subscriptions.go
@@ -246,7 +246,7 @@ func (h *Handler) SubscribeEvents(
 			}
 
 			if *finalityStatus == TxnFinalityStatusWithoutL1(TxnPreConfirmed) {
-				preConfirmedID := BlockID{typeID: preConfirmed}
+				preConfirmedID := BlockIDPreConfirmed()
 				return h.processEvents(
 					ctx,
 					w,

--- a/rpc/v9/subscriptions.go
+++ b/rpc/v9/subscriptions.go
@@ -962,8 +962,6 @@ func (h *Handler) SubscribeNewTransactions(
 
 	if len(finalityStatus) == 0 {
 		finalityStatus = []TxnStatusWithoutL1{
-			TxnStatusWithoutL1(TxnStatusCandidate),
-			TxnStatusWithoutL1(TxnStatusPreConfirmed),
 			TxnStatusWithoutL1(TxnStatusAcceptedOnL2),
 		}
 	} else {

--- a/rpc/v9/subscriptions.go
+++ b/rpc/v9/subscriptions.go
@@ -789,9 +789,6 @@ func (h *Handler) SubscribeNewTransactionReceipts(
 	lastBlockNumber := uint64(0)
 
 	subscriber := subscriber{
-		onReorg: func(ctx context.Context, id string, _ *subscription, reorg *sync.ReorgBlockRange) error {
-			return sendReorg(w, reorg, id)
-		},
 		onNewHead: func(ctx context.Context, id string, _ *subscription, head *core.Block) error {
 			if !slices.Contains(finalityStatuses, TxnFinalityStatusWithoutL1(TxnAcceptedOnL2)) {
 				return nil

--- a/rpc/v9/subscriptions.go
+++ b/rpc/v9/subscriptions.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"slices"
 	"time"
 
 	"github.com/NethermindEth/juno/blockchain"
@@ -15,6 +16,7 @@ import (
 	"github.com/NethermindEth/juno/rpc/rpccore"
 	rpcv6 "github.com/NethermindEth/juno/rpc/v6"
 	"github.com/NethermindEth/juno/sync"
+	"github.com/NethermindEth/juno/utils"
 )
 
 const subscribeEventsChunkSize = 1024
@@ -24,7 +26,7 @@ const subscribeEventsChunkSize = 1024
 // as arguments, and they can be modified in the test to make them run faster.
 var (
 	subscribeTxStatusTimeout        = 5 * time.Minute
-	subscribeTxStatusTickerDuration = 5 * time.Second
+	subscribeTxStatusTickerDuration = time.Second
 )
 
 type SubscriptionResponse struct {
@@ -176,6 +178,11 @@ func (h *Handler) subscribe(
 	return SubscriptionID(id), nil
 }
 
+type SubscriptionEmittedEvent struct {
+	rpcv6.EmittedEvent
+	FinalityStatus TxnFinalityStatusWithoutL1 `json:"finality_status"`
+}
+
 // Currently the order of transactions is deterministic, so the transaction always execute on a deterministic state
 // Therefore, the emitted events are deterministic and we can use the transaction hash and event index to identify.
 type SentEvent struct {
@@ -184,8 +191,15 @@ type SentEvent struct {
 }
 
 // SubscribeEvents creates a WebSocket stream which will fire events for new Starknet events with applied filters
+//
+// It follows the specification defined here:
+// https://github.com/starkware-libs/starknet-specs/blob/c2e93098b9c2ca0423b7f4d15b201f52f22d8c36/api/starknet_ws_api.json#L59
 func (h *Handler) SubscribeEvents(
-	ctx context.Context, fromAddr *felt.Felt, keys [][]felt.Felt, blockID *SubscriptionBlockID,
+	ctx context.Context,
+	fromAddr *felt.Felt,
+	keys [][]felt.Felt,
+	blockID *SubscriptionBlockID,
+	finalityStatus *TxnFinalityStatusWithoutL1,
 ) (SubscriptionID, *jsonrpc.Error) {
 	w, ok := jsonrpc.ConnFromContext(ctx)
 	if !ok {
@@ -204,50 +218,266 @@ func (h *Handler) SubscribeEvents(
 	if rpcErr != nil {
 		return "", rpcErr
 	}
+	// default to ACCEPTED_ON_L2
+	if finalityStatus == nil {
+		finalityStatus = utils.HeapPtr(TxnFinalityStatusWithoutL1(TxnAcceptedOnL2))
+	}
 
-	nextBlock := headHeader.Number + 1
-	eventsPreviouslySent := make(map[SentEvent]struct{})
-
+	eventsPreviouslySent := make(map[SentEvent]TxnFinalityStatusWithoutL1)
+	eventMatcher := blockchain.NewEventMatcher(fromAddr, keys)
 	subscriber := subscriber{
 		onStart: func(ctx context.Context, id string, _ *subscription, _ any) error {
-			return h.processEvents(
-				ctx, w, id, requestedHeader.Number, headHeader.Number, fromAddr, keys, nil,
-			)
-		},
-		onReorg: func(ctx context.Context, id string, _ *subscription, reorg *sync.ReorgBlockRange) error {
-			if err := sendReorg(w, reorg, id); err != nil {
+			fromBlock := BlockIDFromNumber(requestedHeader.Number)
+			toBlock := BlockIDFromNumber(headHeader.Number)
+
+			if err := h.processEvents(
+				ctx,
+				w,
+				id,
+				&fromBlock,
+				&toBlock,
+				fromAddr,
+				keys,
+				eventsPreviouslySent,
+				headHeader.Number,
+				TxnFinalityStatusWithoutL1(TxnAcceptedOnL2),
+			); err != nil {
 				return err
-			}
-			nextBlock = reorg.StartBlockNum
-			return nil
-		},
-		onNewHead: func(ctx context.Context, id string, _ *subscription, head *core.Block) error {
-			err := h.processEvents(
-				ctx, w, id, nextBlock, head.Number, fromAddr, keys, eventsPreviouslySent,
-			)
-			if err != nil {
-				return err
-			}
-			nextBlock = head.Number + 1
-			return nil
-		},
-		onPendingData: func(ctx context.Context, id string, _ *subscription, pending core.PendingData) error {
-			// We should only return `ACCEPTED_ON_L2` events in this stream.
-			if pending == nil || pending.Variant() != core.PendingBlockVariant {
-				return nil
 			}
 
-			return h.processEvents(
-				ctx, w, id, nextBlock, nextBlock, fromAddr, keys, eventsPreviouslySent,
+			if *finalityStatus == TxnFinalityStatusWithoutL1(TxnPreConfirmed) {
+				preConfirmedID := BlockID{typeID: preConfirmed}
+				return h.processEvents(
+					ctx,
+					w,
+					id,
+					&preConfirmedID,
+					&preConfirmedID,
+					fromAddr,
+					keys,
+					eventsPreviouslySent,
+					headHeader.Number,
+					TxnFinalityStatusWithoutL1(TxnPreConfirmed),
+				)
+			}
+			return nil
+		},
+		onReorg: func(ctx context.Context, id string, _ *subscription, reorg *sync.ReorgBlockRange) error {
+			return sendReorg(w, reorg, id)
+		},
+		onNewHead: func(ctx context.Context, id string, _ *subscription, head *core.Block) error {
+			return processBlockEvents(
+				ctx,
+				w,
+				id,
+				head,
+				fromAddr,
+				&eventMatcher,
+				eventsPreviouslySent,
+				TxnFinalityStatusWithoutL1(TxnAcceptedOnL2),
+			)
+		},
+		onPendingData: func(ctx context.Context, id string, _ *subscription, pending core.PendingData) error {
+			var blockFinalityStatus TxnFinalityStatusWithoutL1
+			switch v := pending.Variant(); v {
+			case core.PendingBlockVariant:
+				blockFinalityStatus = TxnFinalityStatusWithoutL1(TxnAcceptedOnL2)
+			case core.PreConfirmedBlockVariant:
+				if *finalityStatus != TxnFinalityStatusWithoutL1(TxnPreConfirmed) {
+					return nil
+				}
+				blockFinalityStatus = TxnFinalityStatusWithoutL1(TxnPreConfirmed)
+			default:
+				return fmt.Errorf("unknown pending variant %v", v)
+			}
+
+			return processBlockEvents(
+				ctx,
+				w,
+				id,
+				pending.GetBlock(),
+				fromAddr,
+				&eventMatcher,
+				eventsPreviouslySent,
+				blockFinalityStatus,
 			)
 		},
 	}
 	return h.subscribe(ctx, w, subscriber)
 }
 
+// processEvents queries database for events and stream filtered events.
+func (h *Handler) processEvents(ctx context.Context, w jsonrpc.Conn, id string, from, to *BlockID, fromAddr *felt.Felt,
+	keys [][]felt.Felt, eventsPreviouslySent map[SentEvent]TxnFinalityStatusWithoutL1, height uint64, finalityStatus TxnFinalityStatusWithoutL1,
+) error {
+	filter, err := h.bcReader.EventFilter(fromAddr, keys, h.PendingBlock)
+	if err != nil {
+		h.log.Warnw("Error creating event filter", "err", err)
+		return err
+	}
+
+	defer h.callAndLogErr(filter.Close, "Error closing event filter in events subscription")
+
+	err = setEventFilterRange(filter, from, to, height)
+	if err != nil {
+		h.log.Warnw("Error setting event filter range", "err", err)
+		return err
+	}
+
+	filteredEvents, cToken, err := filter.Events(nil, subscribeEventsChunkSize)
+	if err != nil {
+		h.log.Warnw("Error filtering events", "err", err)
+		return err
+	}
+
+	err = sendEvents(ctx, w, filteredEvents, eventsPreviouslySent, id, finalityStatus)
+	if err != nil {
+		h.log.Warnw("Error sending events", "err", err)
+		return err
+	}
+
+	for cToken != nil {
+		filteredEvents, cToken, err = filter.Events(cToken, subscribeEventsChunkSize)
+		if err != nil {
+			h.log.Warnw("Error filtering events", "err", err)
+			return err
+		}
+
+		err = sendEvents(ctx, w, filteredEvents, eventsPreviouslySent, id, finalityStatus)
+		if err != nil {
+			h.log.Warnw("Error sending events", "err", err)
+			return err
+		}
+	}
+	return nil
+}
+
+// processBlockEvents, extract events from block and stream filtered events.
+func processBlockEvents(
+	ctx context.Context,
+	w jsonrpc.Conn,
+	id string,
+	block *core.Block,
+	fromAddr *felt.Felt,
+	eventMatcher *blockchain.EventMatcher,
+	eventsPreviouslySent map[SentEvent]TxnFinalityStatusWithoutL1,
+	finalityStatus TxnFinalityStatusWithoutL1,
+) error {
+	if isMatch := eventMatcher.TestBloom(block.EventsBloom); !isMatch {
+		return nil
+	}
+
+	var blockNumber *uint64
+	// if header.Hash == nil and parentHash != nil it's a pending block
+	// if header.Hash == nil and parentHash == nil it's a pre_confirmed block
+	if block.Hash != nil || block.ParentHash == nil {
+		blockNumber = &block.Number
+	}
+
+	for _, receipt := range block.Receipts {
+		for i, event := range receipt.Events {
+			select {
+			case <-ctx.Done():
+				return ctx.Err()
+			default:
+			}
+
+			if fromAddr != nil && !event.From.Equal(fromAddr) {
+				continue
+			}
+
+			if !eventMatcher.MatchesEventKeys(event.Keys) {
+				continue
+			}
+
+			event := blockchain.FilteredEvent{
+				BlockNumber:     blockNumber,
+				BlockHash:       block.Hash,
+				TransactionHash: receipt.TransactionHash,
+				EventIndex:      i,
+				Event:           event,
+			}
+
+			if err := sendEventWithoutDuplicate(w, &event, eventsPreviouslySent, id, finalityStatus); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+// sendEvents streams filtered events, does not stream last sent status multiple times
+func sendEvents(ctx context.Context, w jsonrpc.Conn, events []*blockchain.FilteredEvent,
+	eventsPreviouslySent map[SentEvent]TxnFinalityStatusWithoutL1, id string, finalityStatus TxnFinalityStatusWithoutL1,
+) error {
+	for _, event := range events {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		default:
+			if err := sendEventWithoutDuplicate(w, event, eventsPreviouslySent, id, finalityStatus); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+// sendEventWithoutDuplicate streams event if status is changed
+func sendEventWithoutDuplicate(
+	w jsonrpc.Conn,
+	event *blockchain.FilteredEvent,
+	eventsPreviouslySent map[SentEvent]TxnFinalityStatusWithoutL1,
+	id string,
+	finalityStatus TxnFinalityStatusWithoutL1,
+) error {
+	if eventsPreviouslySent != nil {
+		sentEvent := SentEvent{
+			TransactionHash: *event.TransactionHash,
+			EventIndex:      event.EventIndex,
+		}
+		if status := eventsPreviouslySent[sentEvent]; status == finalityStatus {
+			return nil
+		}
+		// This describe the lifecycle of SentEvent.
+		// It's added when the event is sent.
+		// It's deleted when new pending/pre_confirmed block for different head arrives.
+		if isPreConfirmed := event.BlockHash == nil; isPreConfirmed {
+			eventsPreviouslySent[sentEvent] = finalityStatus
+		} else {
+			delete(eventsPreviouslySent, sentEvent)
+		}
+	}
+
+	emittedEvent := rpcv6.EmittedEvent{
+		BlockNumber:     event.BlockNumber,
+		BlockHash:       event.BlockHash,
+		TransactionHash: event.TransactionHash,
+		Event: &rpcv6.Event{
+			From: event.From,
+			Keys: event.Keys,
+			Data: event.Data,
+		},
+	}
+
+	response := &SubscriptionEmittedEvent{
+		EmittedEvent:   emittedEvent,
+		FinalityStatus: finalityStatus,
+	}
+
+	return sendEvent(w, response, id)
+}
+
+type SubscriptionTransactionStatus struct {
+	TransactionHash *felt.Felt        `json:"transaction_hash"`
+	Status          TransactionStatus `json:"status"`
+}
+
 // SubscribeTransactionStatus subscribes to status changes of a transaction. It checks for updates each time a new block is added.
 // Later updates are sent only when the transaction status changes.
-// The optional block_id parameter is ignored, as status changes are not stored and historical data cannot be sent.
+//
+// It follows the specification defined here:
+// https://github.com/starkware-libs/starknet-specs/blob/c2e93098b9c2ca0423b7f4d15b201f52f22d8c36/api/starknet_ws_api.json#L151
 func (h *Handler) SubscribeTransactionStatus(ctx context.Context, txHash *felt.Felt) (SubscriptionID, *jsonrpc.Error) {
 	w, ok := jsonrpc.ConnFromContext(ctx)
 	if !ok {
@@ -295,7 +525,7 @@ func (h *Handler) SubscribeTransactionStatus(ctx context.Context, txHash *felt.F
 
 // If the error is transaction not found that means the transaction has not been submitted to the feeder gateway,
 // therefore, we need to wait for a specified time and at regular interval check if the transaction has been found.
-// If the transaction is found during the timout expiry, then we continue to keep track of its status otherwise the
+// If the transaction is found during the timeout expiry, then we continue to keep track of its status otherwise the
 // websocket connection is closed after the expiry.
 func (h *Handler) getInitialTxStatus(ctx context.Context, sub *subscription, id string, txHash *felt.Felt) (TxnStatus, error) {
 	var lastStatus TxnStatus
@@ -350,99 +580,10 @@ func (h *Handler) checkTxStatus(
 	return status.Finality, nil
 }
 
-func (h *Handler) processEvents(ctx context.Context, w jsonrpc.Conn, id string, from, to uint64, fromAddr *felt.Felt,
-	keys [][]felt.Felt, eventsPreviouslySent map[SentEvent]struct{},
-) error {
-	filter, err := h.bcReader.EventFilter(fromAddr, keys, h.PendingBlock)
-	if err != nil {
-		h.log.Warnw("Error creating event filter", "err", err)
-		return err
-	}
-
-	defer h.callAndLogErr(filter.Close, "Error closing event filter in events subscription")
-
-	fromBlockID := BlockIDFromNumber(from)
-	toBlockID := BlockIDFromNumber(to)
-	err = setEventFilterRange(filter, &fromBlockID, &toBlockID, to)
-	if err != nil {
-		h.log.Warnw("Error setting event filter range", "err", err)
-		return err
-	}
-
-	filteredEvents, cToken, err := filter.Events(nil, subscribeEventsChunkSize)
-	if err != nil {
-		h.log.Warnw("Error filtering events", "err", err)
-		return err
-	}
-
-	err = sendEvents(ctx, w, filteredEvents, eventsPreviouslySent, id)
-	if err != nil {
-		h.log.Warnw("Error sending events", "err", err)
-		return err
-	}
-
-	for cToken != nil {
-		filteredEvents, cToken, err = filter.Events(cToken, subscribeEventsChunkSize)
-		if err != nil {
-			h.log.Warnw("Error filtering events", "err", err)
-			return err
-		}
-
-		err = sendEvents(ctx, w, filteredEvents, eventsPreviouslySent, id)
-		if err != nil {
-			h.log.Warnw("Error sending events", "err", err)
-			return err
-		}
-	}
-	return nil
-}
-
-func sendEvents(ctx context.Context, w jsonrpc.Conn, events []*blockchain.FilteredEvent,
-	eventsPreviouslySent map[SentEvent]struct{}, id string,
-) error {
-	for _, event := range events {
-		select {
-		case <-ctx.Done():
-			return ctx.Err()
-		default:
-			if eventsPreviouslySent != nil {
-				sentEvent := SentEvent{
-					TransactionHash: *event.TransactionHash,
-					EventIndex:      event.EventIndex,
-				}
-				if _, ok := eventsPreviouslySent[sentEvent]; ok {
-					continue
-				}
-				// This describe the lifecycle of SentEvent.
-				// It's added when the event is received from a pre_confirmed block.
-				// It's deleted when the event is received from a head block.
-				if isPreConfirmed := event.BlockHash == nil; isPreConfirmed {
-					eventsPreviouslySent[sentEvent] = struct{}{}
-				} else {
-					delete(eventsPreviouslySent, sentEvent)
-				}
-			}
-
-			emittedEvent := &rpcv6.EmittedEvent{
-				BlockNumber:     event.BlockNumber, // This always be filled as subscribeEvents cannot be called on pending/pre_confirmed block
-				BlockHash:       event.BlockHash,
-				TransactionHash: event.TransactionHash,
-				Event: &rpcv6.Event{
-					From: event.From,
-					Keys: event.Keys,
-					Data: event.Data,
-				},
-			}
-
-			if err := sendResponse("starknet_subscriptionEvents", w, id, emittedEvent); err != nil {
-				return err
-			}
-		}
-	}
-	return nil
-}
-
 // SubscribeNewHeads creates a WebSocket stream which will fire events when a new block header is added.
+//
+// It follows the specification defined here:
+// https://github.com/starkware-libs/starknet-specs/blob/c2e93098b9c2ca0423b7f4d15b201f52f22d8c36/api/starknet_ws_api.json#L10
 func (h *Handler) SubscribeNewHeads(ctx context.Context, blockID *SubscriptionBlockID) (SubscriptionID, *jsonrpc.Error) {
 	w, ok := jsonrpc.ConnFromContext(ctx)
 	if !ok {
@@ -468,128 +609,11 @@ func (h *Handler) SubscribeNewHeads(ctx context.Context, blockID *SubscriptionBl
 	return h.subscribe(ctx, w, subscriber)
 }
 
-// SubscribePendingTxs creates a WebSocket stream which will fire events when a new pending transaction is added.
-// The getDetails flag controls if the response will contain the transaction details or just the transaction hashes.
-// The senderAddr flag is used to filter the transactions by sender address.
-func (h *Handler) SubscribePendingTxs(ctx context.Context, getDetails bool, senderAddr []felt.Felt) (SubscriptionID, *jsonrpc.Error) {
-	w, ok := jsonrpc.ConnFromContext(ctx)
-	if !ok {
-		return "", jsonrpc.Err(jsonrpc.MethodNotFound, nil)
-	}
-
-	if len(senderAddr) > rpccore.MaxEventFilterKeys {
-		return "", rpccore.ErrTooManyAddressesInFilter
-	}
-
-	sentTxHashes := make(map[felt.Felt]struct{})
-	lastParentHash := felt.Zero
-
-	subscriber := subscriber{
-		onStart: func(ctx context.Context, id string, _ *subscription, _ any) error {
-			if pending := h.PendingBlock(); pending != nil {
-				return h.onPendingBlock(id, w, getDetails, senderAddr, pending, &lastParentHash, sentTxHashes)
-			}
-			return nil
-		},
-		onPendingData: func(ctx context.Context, id string, _ *subscription, pending core.PendingData) error {
-			// We should only return `ACCEPTED_ON_L2` txs in this stream.
-			if pending == nil || pending.Variant() != core.PendingBlockVariant {
-				return nil
-			}
-
-			return h.onPendingBlock(id, w, getDetails, senderAddr, pending.GetBlock(), &lastParentHash, sentTxHashes)
-		},
-	}
-	return h.subscribe(ctx, w, subscriber)
-}
-
-// If getDetails is true, response will contain the transaction details.
-// If getDetails is false, response will only contain the transaction hashes.
-func (h *Handler) onPendingBlock(
-	id string,
-	w jsonrpc.Conn,
-	getDetails bool,
-	senderAddr []felt.Felt,
-	pending *core.Block,
-	lastParentHash *felt.Felt,
-	sentTxHashes map[felt.Felt]struct{},
-) error {
-	if !pending.ParentHash.Equal(lastParentHash) {
-		clear(sentTxHashes)
-		*lastParentHash = *pending.ParentHash
-	}
-
-	var toResult func(txn core.Transaction) any
-	if getDetails {
-		toResult = toFullTx
-	} else {
-		toResult = toHash
-	}
-
-	for _, txn := range pending.Transactions {
-		if _, exist := sentTxHashes[*txn.Hash()]; !exist {
-			if h.filterTxBySender(txn, senderAddr) {
-				if err := sendPendingTxs(w, toResult(txn), id); err != nil {
-					return err
-				}
-			}
-			sentTxHashes[*txn.Hash()] = struct{}{}
-		}
-	}
-	return nil
-}
-
-// If getDetails is true, response will contain the transaction details.
-// If getDetails is false, response will only contain the transaction hashes.
-//
-//nolint:unused // retained for future use in 0.9.0-rc3, currently unused
-func (h *Handler) onPreConfirmedBlock(
-	id string,
-	w jsonrpc.Conn,
-	getDetails bool,
-	senderAddr []felt.Felt,
-	preConfirmed *core.Block,
-	lastBlockNumber *uint64,
-	sentTxHashes map[felt.Felt]struct{},
-) error {
-	if preConfirmed.Number != *lastBlockNumber {
-		clear(sentTxHashes)
-		*lastBlockNumber = preConfirmed.Number
-	}
-
-	var toResult func(txn core.Transaction) any
-	if getDetails {
-		toResult = toFullTx
-	} else {
-		toResult = toHash
-	}
-
-	for _, txn := range preConfirmed.Transactions {
-		if _, exist := sentTxHashes[*txn.Hash()]; !exist {
-			if h.filterTxBySender(txn, senderAddr) {
-				if err := sendPendingTxs(w, toResult(txn), id); err != nil {
-					return err
-				}
-			}
-			sentTxHashes[*txn.Hash()] = struct{}{}
-		}
-	}
-	return nil
-}
-
-func toFullTx(txn core.Transaction) any {
-	return AdaptTransaction(txn)
-}
-
-func toHash(txn core.Transaction) any {
-	return txn.Hash()
-}
-
 // filterTxBySender checks if the transaction is included in the sender address list.
 // If the sender address list is empty, it will return true by default.
 // If the sender address list is not empty, it will check if the transaction is an Invoke or Declare transaction
 // and if the sender address is in the list. For other transaction types, it will by default return false.
-func (h *Handler) filterTxBySender(txn core.Transaction, senderAddr []felt.Felt) bool {
+func filterTxBySender(txn core.Transaction, senderAddr []felt.Felt) bool {
 	if len(senderAddr) == 0 {
 		return true
 	}
@@ -610,10 +634,6 @@ func (h *Handler) filterTxBySender(txn core.Transaction, senderAddr []felt.Felt)
 	}
 
 	return false
-}
-
-func sendPendingTxs(w jsonrpc.Conn, result any, id string) error {
-	return sendResponse("starknet_subscriptionPendingTransactions", w, id, result)
 }
 
 // resolveBlockRange returns the start and latest headers based on the blockID.
@@ -676,25 +696,11 @@ func (h *Handler) sendHistoricalHeaders(
 	}
 }
 
-// sendHeader creates a request and sends it to the client
-func sendHeader(w jsonrpc.Conn, header *core.Header, id string) error {
-	return sendResponse("starknet_subscriptionNewHeads", w, id, adaptBlockHeader(header))
-}
-
 type ReorgEvent struct {
 	StartBlockHash *felt.Felt `json:"starting_block_hash"`
 	StartBlockNum  uint64     `json:"starting_block_number"`
 	EndBlockHash   *felt.Felt `json:"ending_block_hash"`
 	EndBlockNum    uint64     `json:"ending_block_number"`
-}
-
-func sendReorg(w jsonrpc.Conn, reorg *sync.ReorgBlockRange, id string) error {
-	return sendResponse("starknet_subscriptionReorg", w, id, &ReorgEvent{
-		StartBlockHash: reorg.StartBlockHash,
-		StartBlockNum:  reorg.StartBlockNum,
-		EndBlockHash:   reorg.EndBlockHash,
-		EndBlockNum:    reorg.EndBlockNum,
-	})
 }
 
 func (h *Handler) Unsubscribe(ctx context.Context, id string) (bool, *jsonrpc.Error) {
@@ -718,14 +724,406 @@ func (h *Handler) Unsubscribe(ctx context.Context, id string) (bool, *jsonrpc.Er
 	return true, nil
 }
 
-type SubscriptionTransactionStatus struct {
-	TransactionHash *felt.Felt        `json:"transaction_hash"`
-	Status          TransactionStatus `json:"status"`
+type TxnFinalityStatusWithoutL1 TxnFinalityStatus
+
+func (s *TxnFinalityStatusWithoutL1) UnmarshalText(text []byte) error {
+	switch string(text) {
+	case "PRE_CONFIRMED":
+		*s = TxnFinalityStatusWithoutL1(TxnPreConfirmed)
+		return nil
+	case "ACCEPTED_ON_L2":
+		*s = TxnFinalityStatusWithoutL1(TxnAcceptedOnL2)
+		return nil
+	default:
+		return fmt.Errorf("invalid TxnStatus: %s;", text)
+	}
+}
+
+func (s TxnFinalityStatusWithoutL1) MarshalText() ([]byte, error) {
+	switch s {
+	case TxnFinalityStatusWithoutL1(TxnPreConfirmed):
+		return []byte("PRE_CONFIRMED"), nil
+	case TxnFinalityStatusWithoutL1(TxnAcceptedOnL2):
+		return []byte("ACCEPTED_ON_L2"), nil
+	default:
+		return nil, fmt.Errorf("unknown TxnFinalityStatusWithoutL1 %v", s)
+	}
+}
+
+type SentReceipt struct {
+	TransactionHash  felt.Felt
+	TransactionIndex int
+	BlockNumber      uint64
+}
+
+// SubscribeTransactionReceipts creates a WebSocket stream which will fire events when new transaction receipts are created.
+// The endpoint receives a vector of finality statuses. An event is fired for each finality status update.
+// It is possible for receipts for pre-confirmed transactions to be received multiple times, or not at all.
+//
+// It follows the specification defined here:
+// https://github.com/starkware-libs/starknet-specs/blob/4e98e3684b50ee9e63b7eeea9412b6a2ed7494ec/api/starknet_ws_api.json#L186
+func (h *Handler) SubscribeNewTransactionReceipts(
+	ctx context.Context,
+	senderAddress []felt.Felt,
+	finalityStatuses []TxnFinalityStatusWithoutL1,
+) (SubscriptionID, *jsonrpc.Error) {
+	w, ok := jsonrpc.ConnFromContext(ctx)
+	if !ok {
+		return "", jsonrpc.Err(jsonrpc.MethodNotFound, nil)
+	}
+
+	if len(senderAddress) > rpccore.MaxEventFilterKeys {
+		return "", rpccore.ErrTooManyAddressesInFilter
+	}
+
+	if len(finalityStatuses) == 0 {
+		finalityStatuses = []TxnFinalityStatusWithoutL1{TxnFinalityStatusWithoutL1(TxnAcceptedOnL2)}
+	} else {
+		finalityStatuses = utils.Set(finalityStatuses)
+	}
+
+	receiptsPreviouslySent := make(map[SentReceipt]TxnFinalityStatusWithoutL1)
+	lastParentHash := felt.Zero
+	lastBlockNumber := uint64(0)
+
+	subscriber := subscriber{
+		onReorg: func(ctx context.Context, id string, _ *subscription, reorg *sync.ReorgBlockRange) error {
+			return sendReorg(w, reorg, id)
+		},
+		onNewHead: func(ctx context.Context, id string, _ *subscription, head *core.Block) error {
+			if !slices.Contains(finalityStatuses, TxnFinalityStatusWithoutL1(TxnAcceptedOnL2)) {
+				return nil
+			}
+
+			return processBlockReceipts(
+				id,
+				w,
+				senderAddress,
+				head,
+				receiptsPreviouslySent,
+				TxnFinalityStatusWithoutL1(TxnAcceptedOnL2),
+			)
+		},
+		onPendingData: func(ctx context.Context, id string, sub *subscription, pending core.PendingData) error {
+			if pending == nil {
+				return nil
+			}
+			block := pending.GetBlock()
+			switch pending.Variant() {
+			case core.PendingBlockVariant:
+				if !slices.Contains(finalityStatuses, TxnFinalityStatusWithoutL1(TxnAcceptedOnL2)) {
+					return nil
+				}
+
+				parentHash := block.ParentHash
+				if !parentHash.Equal(&lastParentHash) {
+					clear(receiptsPreviouslySent)
+					lastParentHash = *parentHash
+				}
+
+				return processBlockReceipts(
+					id,
+					w,
+					senderAddress,
+					block,
+					receiptsPreviouslySent,
+					TxnFinalityStatusWithoutL1(TxnAcceptedOnL2),
+				)
+			case core.PreConfirmedBlockVariant:
+				if !slices.Contains(finalityStatuses, TxnFinalityStatusWithoutL1(TxnPreConfirmed)) {
+					return nil
+				}
+
+				blockNumber := block.Number
+				if blockNumber != lastBlockNumber {
+					clear(receiptsPreviouslySent)
+					lastBlockNumber = blockNumber
+				}
+
+				return processBlockReceipts(
+					id,
+					w,
+					senderAddress,
+					block,
+					receiptsPreviouslySent,
+					TxnFinalityStatusWithoutL1(TxnPreConfirmed),
+				)
+			}
+			return nil
+		},
+	}
+	return h.subscribe(ctx, w, subscriber)
+}
+
+// processBlockReceipts streams block events to subscriber
+func processBlockReceipts(
+	id string,
+	w jsonrpc.Conn,
+	senderAddress []felt.Felt,
+	block *core.Block,
+	receiptsPreviouslySent map[SentReceipt]TxnFinalityStatusWithoutL1,
+	finalityStatus TxnFinalityStatusWithoutL1,
+) error {
+	for i, txn := range block.Transactions {
+		if !filterTxBySender(txn, senderAddress) {
+			continue
+		}
+
+		adaptedReceipt := AdaptReceipt(block.Receipts[i], txn, TxnFinalityStatus(finalityStatus), block.Hash, block.Number)
+
+		if receiptsPreviouslySent != nil {
+			sentReceipt := SentReceipt{
+				TransactionHash:  *adaptedReceipt.Hash,
+				TransactionIndex: i,
+				BlockNumber:      block.Number,
+			}
+			if sentStatus := receiptsPreviouslySent[sentReceipt]; sentStatus == finalityStatus {
+				continue
+			}
+			receiptsPreviouslySent[sentReceipt] = finalityStatus
+		}
+
+		if err := sendTransactionReceipt(w, adaptedReceipt, id); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+type TxnStatusWithoutL1 TxnStatus
+
+func (s *TxnStatusWithoutL1) UnmarshalText(text []byte) error {
+	switch string(text) {
+	case "RECEIVED":
+		*s = TxnStatusWithoutL1(TxnStatusReceived)
+		return nil
+	case "CANDIDATE":
+		*s = TxnStatusWithoutL1(TxnStatusCandidate)
+		return nil
+	case "PRE_CONFIRMED":
+		*s = TxnStatusWithoutL1(TxnStatusPreConfirmed)
+		return nil
+	case "ACCEPTED_ON_L2":
+		*s = TxnStatusWithoutL1(TxnStatusAcceptedOnL2)
+		return nil
+	default:
+		return fmt.Errorf("invalid TxnStatus: %s;", text)
+	}
+}
+
+func (s TxnStatusWithoutL1) MarshalText() ([]byte, error) {
+	switch s {
+	case TxnStatusWithoutL1(TxnStatusReceived):
+		return []byte("RECEIVED"), nil
+	case TxnStatusWithoutL1(TxnStatusCandidate):
+		return []byte("CANDIDATE"), nil
+	case TxnStatusWithoutL1(TxnStatusPreConfirmed):
+		return []byte("PRE_CONFIRMED"), nil
+	case TxnStatusWithoutL1(TxnStatusAcceptedOnL2):
+		return []byte("ACCEPTED_ON_L2"), nil
+	default:
+		return nil, fmt.Errorf("unknown TxnFinalityStatusWithoutL1 %v", s)
+	}
+}
+
+type SentTransaction struct {
+	BlockNumber uint64
+	Hash        felt.Felt
+	Index       uint
+}
+
+type SubscriptionNewTransaction struct {
+	Transaction
+	FinalityStatus TxnStatusWithoutL1 `json:"finality_status"`
+}
+
+// SubscribeNewTransactions Creates a WebSocket stream which will fire events when new transaction are created.
+//
+// The endpoint receives a vector of finality statuses. An event is fired for each finality status update.
+// It is possible for events for pre-confirmed and candidate transactions to be received multiple times, or not at all.
+//
+// It follows the specification defined here:
+// https://github.com/starkware-libs/starknet-specs/blob/4e98e3684b50ee9e63b7eeea9412b6a2ed7494ec/api/starknet_ws_api.json#L257
+func (h *Handler) SubscribeNewTransactions(
+	ctx context.Context,
+	finalityStatus []TxnStatusWithoutL1,
+	senderAddr []felt.Felt,
+) (SubscriptionID, *jsonrpc.Error) {
+	w, ok := jsonrpc.ConnFromContext(ctx)
+	if !ok {
+		return "", jsonrpc.Err(jsonrpc.MethodNotFound, nil)
+	}
+
+	if len(senderAddr) > rpccore.MaxEventFilterKeys {
+		return "", rpccore.ErrTooManyAddressesInFilter
+	}
+
+	if len(finalityStatus) == 0 {
+		finalityStatus = []TxnStatusWithoutL1{
+			TxnStatusWithoutL1(TxnStatusCandidate),
+			TxnStatusWithoutL1(TxnStatusPreConfirmed),
+			TxnStatusWithoutL1(TxnStatusAcceptedOnL2),
+		}
+	} else {
+		finalityStatus = utils.Set(finalityStatus)
+	}
+
+	sentTransactions := make(map[SentTransaction]TxnStatusWithoutL1)
+	lastParentHash := felt.Zero
+	lastBlockNumber := uint64(0)
+
+	subscriber := subscriber{
+		onStart: func(ctx context.Context, id string, _ *subscription, _ any) error {
+			return nil
+		},
+		onReorg: func(ctx context.Context, id string, _ *subscription, reorg *sync.ReorgBlockRange) error {
+			if err := sendReorg(w, reorg, id); err != nil {
+				return err
+			}
+			return nil
+		},
+		onNewHead: func(ctx context.Context, id string, _ *subscription, head *core.Block) error {
+			if !slices.Contains(finalityStatus, TxnStatusWithoutL1(TxnStatusAcceptedOnL2)) {
+				return nil
+			}
+			return processBlockTransactions(id, w, senderAddr, head, sentTransactions, TxnStatusWithoutL1(TxnStatusAcceptedOnL2))
+		},
+		onPendingData: func(ctx context.Context, id string, _ *subscription, pending core.PendingData) error {
+			if pending == nil {
+				return nil
+			}
+
+			switch pending.Variant() {
+			case core.PendingBlockVariant:
+				if slices.Contains(finalityStatus, TxnStatusWithoutL1(TxnStatusAcceptedOnL2)) {
+					parentHash := pending.GetBlock().ParentHash
+					if !parentHash.Equal(&lastParentHash) {
+						clear(sentTransactions)
+						lastParentHash = *parentHash
+					}
+					return processBlockTransactions(id, w, senderAddr, pending.GetBlock(), sentTransactions, TxnStatusWithoutL1(TxnStatusAcceptedOnL2))
+				}
+
+			case core.PreConfirmedBlockVariant:
+				blockNumber := pending.GetBlock().Number
+				if blockNumber != lastBlockNumber {
+					clear(sentTransactions)
+					lastBlockNumber = blockNumber
+				}
+
+				if slices.Contains(finalityStatus, TxnStatusWithoutL1(TxnStatusPreConfirmed)) {
+					err := processBlockTransactions(id, w, senderAddr, pending.GetBlock(), sentTransactions, TxnStatusWithoutL1(TxnStatusPreConfirmed))
+					if err != nil {
+						return err
+					}
+				}
+
+				if slices.Contains(finalityStatus, TxnStatusWithoutL1(TxnStatusCandidate)) {
+					return processCandidateTransactions(id, w, senderAddr, pending, sentTransactions)
+				}
+			}
+			return nil
+		},
+	}
+	return h.subscribe(ctx, w, subscriber)
+}
+
+// processBlockTransactions streams given block transactions without duplicates
+func processBlockTransactions(
+	id string,
+	w jsonrpc.Conn,
+	senderAddr []felt.Felt,
+	b *core.Block,
+	sentTransactions map[SentTransaction]TxnStatusWithoutL1,
+	status TxnStatusWithoutL1,
+) error {
+	for i, txn := range b.Transactions {
+		sentTxn := SentTransaction{
+			BlockNumber: b.Number,
+			Hash:        *txn.Hash(),
+			Index:       uint(i),
+		}
+
+		response := SubscriptionNewTransaction{
+			Transaction:    *AdaptTransaction(txn),
+			FinalityStatus: status,
+		}
+		if sentStatus := sentTransactions[sentTxn]; sentStatus != status {
+			if filterTxBySender(txn, senderAddr) {
+				if err := sendTransaction(w, &response, id); err != nil {
+					return err
+				}
+			}
+			sentTransactions[sentTxn] = status
+		}
+	}
+	return nil
+}
+
+// processCandidateTransactions streams 'CANDIDATE' transactions
+func processCandidateTransactions(
+	id string,
+	w jsonrpc.Conn,
+	senderAddr []felt.Felt,
+	preConfirmed core.PendingData,
+	sentTransactions map[SentTransaction]TxnStatusWithoutL1,
+) error {
+	preconfirmedCount := uint(len(preConfirmed.GetTransactions()))
+	for i, txn := range preConfirmed.GetCandidateTransaction() {
+		sentTxn := SentTransaction{
+			BlockNumber: preConfirmed.GetBlock().Number,
+			Hash:        *txn.Hash(),
+			Index:       uint(i) + preconfirmedCount,
+		}
+
+		response := SubscriptionNewTransaction{
+			Transaction:    *AdaptTransaction(txn),
+			FinalityStatus: TxnStatusWithoutL1(TxnStatusCandidate),
+		}
+		if status := sentTransactions[sentTxn]; status != TxnStatusWithoutL1(TxnStatusCandidate) {
+			if filterTxBySender(txn, senderAddr) {
+				if err := sendTransaction(w, &response, id); err != nil {
+					return err
+				}
+			}
+			sentTransactions[sentTxn] = TxnStatusWithoutL1(TxnStatusCandidate)
+		}
+	}
+	return nil
+}
+
+// sendTransaction creates a response and sends it to the client
+func sendTransaction(w jsonrpc.Conn, result *SubscriptionNewTransaction, id string) error {
+	return sendResponse("starknet_subscriptionNewTransactions", w, id, result)
 }
 
 // sendTxnStatus creates a response and sends it to the client
 func sendTxnStatus(w jsonrpc.Conn, status SubscriptionTransactionStatus, id string) error {
 	return sendResponse("starknet_subscriptionTransactionStatus", w, id, status)
+}
+
+// sendTransactionReceipt creates a response and sends it to the client
+func sendTransactionReceipt(w jsonrpc.Conn, receipt *TransactionReceipt, id string) error {
+	return sendResponse("starknet_subscriptionNewTransactionReceipts", w, id, receipt)
+}
+
+// sendEvent creates a response and sends it to the client
+func sendEvent(w jsonrpc.Conn, event *SubscriptionEmittedEvent, id string) error {
+	return sendResponse("starknet_subscriptionEvents", w, id, event)
+}
+
+// sendHeader creates a request and sends it to the client
+func sendHeader(w jsonrpc.Conn, header *core.Header, id string) error {
+	return sendResponse("starknet_subscriptionNewHeads", w, id, adaptBlockHeader(header))
+}
+
+func sendReorg(w jsonrpc.Conn, reorg *sync.ReorgBlockRange, id string) error {
+	return sendResponse("starknet_subscriptionReorg", w, id, &ReorgEvent{
+		StartBlockHash: reorg.StartBlockHash,
+		StartBlockNum:  reorg.StartBlockNum,
+		EndBlockHash:   reorg.EndBlockHash,
+		EndBlockNum:    reorg.EndBlockNum,
+	})
 }
 
 func sendResponse(method string, w jsonrpc.Conn, id string, result any) error {

--- a/rpc/v9/subscriptions.go
+++ b/rpc/v9/subscriptions.go
@@ -1096,7 +1096,7 @@ func processCandidateTransactions(
 
 // sendTransaction creates a response and sends it to the client
 func sendTransaction(w jsonrpc.Conn, result *SubscriptionNewTransaction, id string) error {
-	return sendResponse("starknet_subscriptionNewTransactions", w, id, result)
+	return sendResponse("starknet_subscriptionNewTransaction", w, id, result)
 }
 
 // sendTxnStatus creates a response and sends it to the client

--- a/rpc/v9/subscriptions.go
+++ b/rpc/v9/subscriptions.go
@@ -978,12 +978,6 @@ func (h *Handler) SubscribeNewTransactions(
 		onStart: func(ctx context.Context, id string, _ *subscription, _ any) error {
 			return nil
 		},
-		onReorg: func(ctx context.Context, id string, _ *subscription, reorg *sync.ReorgBlockRange) error {
-			if err := sendReorg(w, reorg, id); err != nil {
-				return err
-			}
-			return nil
-		},
 		onNewHead: func(ctx context.Context, id string, _ *subscription, head *core.Block) error {
 			if !slices.Contains(finalityStatus, TxnStatusWithoutL1(TxnStatusAcceptedOnL2)) {
 				return nil

--- a/rpc/v9/subscriptions.go
+++ b/rpc/v9/subscriptions.go
@@ -320,40 +320,34 @@ func (h *Handler) processEvents(
 ) error {
 	filter, err := h.bcReader.EventFilter(fromAddr, keys, h.PendingBlock)
 	if err != nil {
-		h.log.Warnw("Error creating event filter", "err", err)
 		return err
 	}
 
-	defer h.callAndLogErr(filter.Close, "Error closing event filter in events subscription")
+	defer h.callAndLogErr(filter.Close, "error closing event filter in events subscription")
 
 	err = setEventFilterRange(filter, from, to, height)
 	if err != nil {
-		h.log.Warnw("Error setting event filter range", "err", err)
 		return err
 	}
 
 	filteredEvents, cToken, err := filter.Events(nil, subscribeEventsChunkSize)
 	if err != nil {
-		h.log.Warnw("Error filtering events", "err", err)
 		return err
 	}
 
 	err = sendEvents(ctx, w, filteredEvents, eventsPreviouslySent, id, finalityStatus)
 	if err != nil {
-		h.log.Warnw("Error sending events", "err", err)
 		return err
 	}
 
 	for cToken != nil {
 		filteredEvents, cToken, err = filter.Events(cToken, subscribeEventsChunkSize)
 		if err != nil {
-			h.log.Warnw("Error filtering events", "err", err)
 			return err
 		}
 
 		err = sendEvents(ctx, w, filteredEvents, eventsPreviouslySent, id, finalityStatus)
 		if err != nil {
-			h.log.Warnw("Error sending events", "err", err)
 			return err
 		}
 	}

--- a/rpc/v9/subscriptions.go
+++ b/rpc/v9/subscriptions.go
@@ -372,7 +372,7 @@ func processBlockEvents(
 	var blockNumber *uint64
 	// if header.Hash == nil and parentHash != nil it's a pending block
 	// if header.Hash == nil and parentHash == nil it's a pre_confirmed block
-	if block.Hash != nil || block.ParentHash == nil {
+	if isNotPending := block.Hash != nil || block.ParentHash == nil; isNotPending {
 		blockNumber = &block.Number
 	}
 

--- a/rpc/v9/subscriptions.go
+++ b/rpc/v9/subscriptions.go
@@ -839,8 +839,7 @@ func (h *Handler) SubscribeNewTransactionReceipts(
 				blockFinalityStatus = TxnFinalityStatusWithoutL1(TxnPreConfirmed)
 
 			default:
-				h.log.Errorw("unexptected pending_data variant %v", v)
-				return nil
+				return fmt.Errorf("unknown pending variant %v", v)
 			}
 
 			return processBlockReceipts(

--- a/rpc/v9/subscriptions.go
+++ b/rpc/v9/subscriptions.go
@@ -335,7 +335,7 @@ func (h *Handler) checkTxStatus(
 		return lastStatus, errorTxnHashNotFound{*txHash}
 	}
 
-	if status.Finality <= lastStatus {
+	if status.Finality == lastStatus {
 		return lastStatus, nil
 	}
 

--- a/rpc/v9/subscriptions_test.go
+++ b/rpc/v9/subscriptions_test.go
@@ -48,7 +48,52 @@ func (fc *fakeConn) Equal(other jsonrpc.Conn) bool {
 	return fc.w == fc2.w
 }
 
-func TestSubscribeEvents(t *testing.T) {
+type fakeSyncer struct {
+	newHeads    *feed.Feed[*core.Block]
+	reorgs      *feed.Feed[*sync.ReorgBlockRange]
+	pendingData *feed.Feed[core.PendingData]
+}
+
+func newFakeSyncer() *fakeSyncer {
+	return &fakeSyncer{
+		newHeads:    feed.New[*core.Block](),
+		reorgs:      feed.New[*sync.ReorgBlockRange](),
+		pendingData: feed.New[core.PendingData](),
+	}
+}
+
+func (fs *fakeSyncer) SubscribeNewHeads() sync.NewHeadSubscription {
+	return sync.NewHeadSubscription{Subscription: fs.newHeads.Subscribe()}
+}
+
+func (fs *fakeSyncer) SubscribeReorg() sync.ReorgSubscription {
+	return sync.ReorgSubscription{Subscription: fs.reorgs.Subscribe()}
+}
+
+func (fs *fakeSyncer) SubscribePendingData() sync.PendingDataSubscription {
+	return sync.PendingDataSubscription{Subscription: fs.pendingData.Subscribe()}
+}
+
+func (fs *fakeSyncer) StartingBlockNumber() (uint64, error) {
+	return 0, nil
+}
+
+func (fs *fakeSyncer) HighestBlockHeader() *core.Header {
+	return nil
+}
+
+func (fs *fakeSyncer) PendingData() (core.PendingData, error) {
+	return nil, sync.ErrPendingBlockNotFound
+}
+func (fs *fakeSyncer) PendingBlock() *core.Block { return nil }
+
+func (fs *fakeSyncer) PendingState() (core.StateReader, func() error, error) { return nil, nil, nil }
+
+func (fs *fakeSyncer) PendingStateBeforeIndex(index int) (core.StateReader, func() error, error) {
+	return nil, nil, nil
+}
+
+func TestSubscribeEventsInvalidInputs(t *testing.T) {
 	log := utils.NewNopZapLogger()
 
 	t.Run("Return error if too many keys in filter", func(t *testing.T) {
@@ -69,7 +114,7 @@ func TestSubscribeEvents(t *testing.T) {
 
 		subCtx := context.WithValue(t.Context(), jsonrpc.ConnKey{}, &fakeConn{w: serverConn})
 
-		id, rpcErr := handler.SubscribeEvents(subCtx, fromAddr, keys, nil)
+		id, rpcErr := handler.SubscribeEvents(subCtx, fromAddr, keys, nil, nil)
 		assert.Zero(t, id)
 		assert.Equal(t, rpccore.ErrTooManyKeysInFilter, rpcErr)
 	})
@@ -102,7 +147,7 @@ func TestSubscribeEvents(t *testing.T) {
 			mockChain.EXPECT().BlockHeaderByNumber(blockID.Number()).
 				Return(&core.Header{Number: 0}, nil)
 
-			id, rpcErr := handler.SubscribeEvents(subCtx, fromAddr, keys, &blockID)
+			id, rpcErr := handler.SubscribeEvents(subCtx, fromAddr, keys, &blockID, nil)
 			assert.Zero(t, id)
 			assert.Equal(t, rpccore.ErrTooManyBlocksBack, rpcErr)
 		})
@@ -112,11 +157,15 @@ func TestSubscribeEvents(t *testing.T) {
 			mockChain.EXPECT().BlockHeaderByNumber(blockID.Number()).
 				Return(&core.Header{Number: 0}, nil)
 
-			id, rpcErr := handler.SubscribeEvents(subCtx, fromAddr, keys, &blockID)
+			id, rpcErr := handler.SubscribeEvents(subCtx, fromAddr, keys, &blockID, nil)
 			assert.Zero(t, id)
 			assert.Equal(t, rpccore.ErrTooManyBlocksBack, rpcErr)
 		})
 	})
+}
+
+func TestSubscribeEvents(t *testing.T) {
+	log := utils.NewNopZapLogger()
 
 	n := &utils.Sepolia
 	client := feeder.NewTestClient(t, n)
@@ -128,126 +177,442 @@ func TestSubscribeEvents(t *testing.T) {
 	b2, err := gw.BlockByNumber(t.Context(), 56378)
 	require.NoError(t, err)
 
-	pending1 := createTestPendingBlock(t, b2, 3)
-	pending2 := createTestPendingBlock(t, b2, 6)
+	b1Filtered, b1Emitted := createTestEvents(
+		t,
+		b1,
+		nil,
+		nil,
+		TxnFinalityStatusWithoutL1(TxnAcceptedOnL2),
+	)
+	b2Filtered, b2Emitted := createTestEvents(
+		t,
+		b2,
+		nil,
+		nil,
+		TxnFinalityStatusWithoutL1(TxnAcceptedOnL2),
+	)
 
-	fromAddr := new(felt.Felt).SetBytes([]byte("some address"))
-	keys := [][]felt.Felt{{*new(felt.Felt).SetBytes([]byte("key1"))}}
+	pendingB := createTestPendingBlock(t, b2, 6)
+	pending := sync.NewPending(pendingB, nil, nil)
+	_, pendingEmitted := createTestEvents(
+		t,
+		pendingB,
+		nil,
+		nil,
+		TxnFinalityStatusWithoutL1(TxnAcceptedOnL2),
+	)
+	pendingB2 := createTestPendingBlock(t, b2, 10)
 
-	b1Filtered, b1Emitted := createTestEvents(t, b1)
-	b2Filtered, b2Emitted := createTestEvents(t, b2)
-	pending1Filtered, pending1Emitted := createTestEvents(t, pending1)
-	pending2Filtered, pending2Emitted := createTestEvents(t, pending2)
+	pending2 := sync.NewPending(pendingB2, nil, nil)
+	_, pending2Emitted := createTestEvents(
+		t,
+		pendingB2,
+		nil,
+		nil,
+		TxnFinalityStatusWithoutL1(TxnAcceptedOnL2),
+	)
+	preConfirmed1 := createTestPreConfirmed(t, b2, 3)
+	preConfirmed2 := createTestPreConfirmed(t, b2, 6)
 
-	t.Run("Events from new blocks", func(t *testing.T) {
-		mockCtrl := gomock.NewController(t)
-		t.Cleanup(mockCtrl.Finish)
+	preConfirmed1Filtered, preConfirmed1Emitted := createTestEvents(
+		t,
+		preConfirmed1.Block,
+		nil,
+		nil,
+		TxnFinalityStatusWithoutL1(TxnPreConfirmed),
+	)
+	_, preConfirmed2Emitted := createTestEvents(
+		t,
+		preConfirmed2.Block,
+		nil,
+		nil,
+		TxnFinalityStatusWithoutL1(TxnPreConfirmed),
+	)
 
-		mockChain := mocks.NewMockReader(mockCtrl)
-		mockSyncer := mocks.NewMockSyncReader(mockCtrl)
-		mockEventFilterer := mocks.NewMockEventFilterer(mockCtrl)
+	mockCtrl := gomock.NewController(t)
+	t.Cleanup(mockCtrl.Finish)
 
-		handler := New(mockChain, mockSyncer, nil, log)
+	mockChain := mocks.NewMockReader(mockCtrl)
+	mockSyncer := mocks.NewMockSyncReader(mockCtrl)
+	mockEventFilterer := mocks.NewMockEventFilterer(mockCtrl)
 
-		mockChain.EXPECT().HeadsHeader().Return(b1.Header, nil)
-		mockChain.EXPECT().EventFilter(gomock.Any(), gomock.Any(), gomock.Any()).
-			Return(mockEventFilterer, nil).AnyTimes()
-		mockChain.EXPECT().BlockByNumber(gomock.Any()).Return(b1, nil).AnyTimes()
-		mockEventFilterer.EXPECT().SetRangeEndBlockByNumber(gomock.Any(), gomock.Any()).
-			Return(nil).AnyTimes()
-		mockEventFilterer.EXPECT().Events(gomock.Any(), gomock.Any()).Return(b1Filtered, nil, nil)
-		mockEventFilterer.EXPECT().Close().AnyTimes()
+	handler := New(mockChain, mockSyncer, nil, log)
 
-		id, clientConn := createTestEventsWebsocket(t, handler, fromAddr, keys, nil)
+	type stepInfo struct {
+		description string
+		setupMocks  func()
+		notify      func()
+		expect      [][]*SubscriptionEmittedEvent
+	}
 
-		assertNextEvents(t, clientConn, id, b1Emitted)
+	type testCase struct {
+		description    string
+		blockID        *SubscriptionBlockID
+		finalityStatus *TxnFinalityStatusWithoutL1
+		keys           [][]felt.Felt
+		fromAddr       *felt.Felt
+		steps          []stepInfo
+		setupMocks     func()
+	}
 
-		mockEventFilterer.EXPECT().Events(gomock.Any(), gomock.Any()).Return(b2Filtered, nil, nil)
-		handler.newHeads.Send(b2)
-		assertNextEvents(t, clientConn, id, b2Emitted)
-	})
+	preStarknet0_14_0basicSubscription := testCase{
+		description: "Events from new blocks - default status, Starknet version < 0.14.0",
+		blockID:     nil,
+		keys:        nil,
+		fromAddr:    nil,
+		setupMocks: func() {
+			mockChain.EXPECT().HeadsHeader().Return(b1.Header, nil).Times(1)
+			mockChain.EXPECT().EventFilter(gomock.Any(), gomock.Any(), gomock.Any()).
+				Return(mockEventFilterer, nil)
+			mockEventFilterer.EXPECT().SetRangeEndBlockByNumber(gomock.Any(), gomock.Any()).
+				Return(nil).Times(2)
+			mockEventFilterer.EXPECT().Events(gomock.Any(), gomock.Any()).Return(b1Filtered, nil, nil)
+			mockEventFilterer.EXPECT().Close()
+		},
+		steps: []stepInfo{
+			{
+				description: "events from latest on start",
+				expect:      [][]*SubscriptionEmittedEvent{b1Emitted},
+			},
+			{
+				description: "on pending block",
+				notify: func() {
+					handler.pendingData.Send(&pending)
+				},
+				expect: [][]*SubscriptionEmittedEvent{pendingEmitted},
+			},
+			{
+				description: "on pending block update, without duplicates",
+				notify: func() {
+					handler.pendingData.Send(&pending2)
+				},
+				expect: [][]*SubscriptionEmittedEvent{pending2Emitted[len(pendingEmitted):]},
+			},
+			{
+				description: "on new head, without duplicates",
+				notify: func() {
+					handler.newHeads.Send(b2)
+				},
+				expect: [][]*SubscriptionEmittedEvent{b2Emitted[len(pending2Emitted):]},
+			},
+		},
+	}
 
-	t.Run("Events from old blocks", func(t *testing.T) {
-		mockCtrl := gomock.NewController(t)
-		t.Cleanup(mockCtrl.Finish)
+	basicSubscription := testCase{
+		description: "Events from new blocks - default status",
+		blockID:     nil,
+		keys:        nil,
+		fromAddr:    nil,
+		setupMocks: func() {
+			mockChain.EXPECT().HeadsHeader().Return(b1.Header, nil)
+			mockChain.EXPECT().EventFilter(gomock.Any(), gomock.Any(), gomock.Any()).
+				Return(mockEventFilterer, nil)
+			mockEventFilterer.EXPECT().SetRangeEndBlockByNumber(gomock.Any(), gomock.Any()).
+				Return(nil).Times(2)
+			mockEventFilterer.EXPECT().Events(gomock.Any(), gomock.Any()).Return(b1Filtered, nil, nil)
+			mockEventFilterer.EXPECT().Close()
+		},
+		steps: []stepInfo{
+			{
+				description: "events from latest on start",
+				expect:      [][]*SubscriptionEmittedEvent{b1Emitted},
+			},
+			{
+				description: "on pre_confirmed block",
+				notify: func() {
+					handler.pendingData.Send(&preConfirmed1)
+				},
+				expect: [][]*SubscriptionEmittedEvent{},
+			},
+			{
+				description: "on pre_confirmed block update, without duplicates",
+				notify: func() {
+					handler.pendingData.Send(&preConfirmed2)
+				},
+				expect: [][]*SubscriptionEmittedEvent{},
+			},
+			{
+				description: "on new head",
+				notify: func() {
+					handler.newHeads.Send(b2)
+				},
+				expect: [][]*SubscriptionEmittedEvent{b2Emitted},
+			},
+		},
+	}
 
-		mockChain := mocks.NewMockReader(mockCtrl)
-		mockSyncer := mocks.NewMockSyncReader(mockCtrl)
-		mockEventFilterer := mocks.NewMockEventFilterer(mockCtrl)
-		handler := New(mockChain, mockSyncer, nil, log)
+	basicSubscriptionWithPreConfirmed := testCase{
+		description:    "Events from new blocks - status PRE_CONFIRMED",
+		finalityStatus: utils.HeapPtr(TxnFinalityStatusWithoutL1(TxnPreConfirmed)),
+		blockID:        nil,
+		keys:           nil,
+		fromAddr:       nil,
+		setupMocks: func() {
+			mockChain.EXPECT().HeadsHeader().Return(b1.Header, nil)
+			mockChain.EXPECT().EventFilter(gomock.Any(), gomock.Any(), gomock.Any()).
+				Return(mockEventFilterer, nil).Times(2)
+			mockEventFilterer.EXPECT().SetRangeEndBlockByNumber(gomock.Any(), gomock.Any()).
+				Return(nil).Times(4)
+			mockEventFilterer.EXPECT().Events(gomock.Any(), gomock.Any()).Return(b1Filtered, nil, nil)
+			mockEventFilterer.EXPECT().Events(gomock.Any(), gomock.Any()).Return(preConfirmed1Filtered, nil, nil)
+			mockEventFilterer.EXPECT().Close().Times(2)
+		},
+		steps: []stepInfo{
+			{
+				description: "events from latest and preconfirmed",
+				expect:      [][]*SubscriptionEmittedEvent{append(b1Emitted, preConfirmed1Emitted...)},
+			},
+			{
+				description: "on pre_confirmed block update, without duplicates",
+				notify: func() {
+					handler.pendingData.Send(&preConfirmed2)
+				},
+				expect: [][]*SubscriptionEmittedEvent{preConfirmed2Emitted[len(preConfirmed1Emitted):]},
+			},
+			{
+				description: "on new head",
+				notify: func() {
+					handler.newHeads.Send(b2)
+				},
+				expect: [][]*SubscriptionEmittedEvent{b2Emitted},
+			},
+		},
+	}
 
-		mockChain.EXPECT().HeadsHeader().Return(b1.Header, nil)
-		mockChain.EXPECT().BlockHeaderByNumber(b1.Number).Return(b1.Header, nil)
-		mockChain.EXPECT().EventFilter(fromAddr, keys, gomock.Any()).Return(mockEventFilterer, nil)
+	eventsFromHistoricalBlocks := testCase{
+		description: "Events from historical blocks - default status",
+		blockID:     utils.HeapPtr(SubscriptionBlockID(BlockIDFromNumber(b1.Number))),
+		keys:        nil,
+		fromAddr:    nil,
+		setupMocks: func() {
+			mockChain.EXPECT().HeadsHeader().Return(b2.Header, nil)
+			mockChain.EXPECT().EventFilter(gomock.Any(), gomock.Any(), gomock.Any()).
+				Return(mockEventFilterer, nil)
+			mockChain.EXPECT().BlockHeaderByNumber(b1.Number).Return(b1.Header, nil)
+			mockEventFilterer.EXPECT().SetRangeEndBlockByNumber(gomock.Any(), gomock.Any()).
+				Return(nil).Times(2)
+			mockEventFilterer.EXPECT().Events(gomock.Any(), gomock.Any()).Return(append(b1Filtered, b2Filtered...), nil, nil)
+			mockEventFilterer.EXPECT().Close()
+		},
+		steps: []stepInfo{
+			{
+				description: "events from last 2 blocks",
+				expect:      [][]*SubscriptionEmittedEvent{append(b1Emitted, b2Emitted...)},
+			},
+		},
+	}
 
-		mockEventFilterer.EXPECT().SetRangeEndBlockByNumber(gomock.Any(), gomock.Any()).Return(nil).MaxTimes(2)
-		mockEventFilterer.EXPECT().Events(gomock.Any(), gomock.Any()).Return(b1Filtered, nil, nil)
-		mockEventFilterer.EXPECT().Close().AnyTimes()
+	eventsWithContinuationToken := testCase{
+		description: "Events with continuation token - default status",
+		blockID:     utils.HeapPtr(SubscriptionBlockID(BlockIDFromNumber(b1.Number))),
+		keys:        nil,
+		fromAddr:    nil,
+		setupMocks: func() {
+			mockChain.EXPECT().HeadsHeader().Return(b2.Header, nil)
+			mockChain.EXPECT().EventFilter(gomock.Any(), gomock.Any(), gomock.Any()).
+				Return(mockEventFilterer, nil)
+			mockChain.EXPECT().BlockHeaderByNumber(b1.Number).Return(b1.Header, nil)
 
-		id, clientConn := createTestEventsWebsocket(t, handler, fromAddr, keys, &b1.Number)
+			cToken := new(blockchain.ContinuationToken)
+			mockEventFilterer.EXPECT().SetRangeEndBlockByNumber(gomock.Any(), gomock.Any()).Return(nil).Times(2)
+			mockEventFilterer.EXPECT().Events(gomock.Any(), gomock.Any()).Return(b1Filtered, cToken, nil)
+			mockEventFilterer.EXPECT().Events(gomock.Any(), gomock.Any()).Return(b2Filtered, nil, nil)
+			mockEventFilterer.EXPECT().Close()
+		},
+		steps: []stepInfo{
+			{
+				description: "events from last 2 blocks with continuation token",
+				expect:      [][]*SubscriptionEmittedEvent{append(b1Emitted, b2Emitted...)},
+			},
+		},
+	}
+	targetAddress, err := new(felt.Felt).SetString("0x246ff8c7b475ddfb4cb5035867cba76025f08b22938e5684c18c2ab9d9f36d3")
+	require.NoError(t, err)
+	b1FilteredBySenders, b1EmittedFiltered := createTestEvents(
+		t,
+		b1,
+		targetAddress,
+		nil,
+		TxnFinalityStatusWithoutL1(TxnAcceptedOnL2),
+	)
 
-		assertNextEvents(t, clientConn, id, b1Emitted)
-	})
+	preConfirmedFilteredBySenders, preConfirmedEmittedFiltered := createTestEvents(
+		t,
+		preConfirmed1.Block,
+		targetAddress,
+		nil,
+		TxnFinalityStatusWithoutL1(TxnPreConfirmed),
+	)
 
-	t.Run("Events when continuation token is not nil", func(t *testing.T) {
-		mockCtrl := gomock.NewController(t)
-		t.Cleanup(mockCtrl.Finish)
+	_, preConfirmed2EmittedFiltered := createTestEvents(
+		t,
+		preConfirmed2.Block,
+		targetAddress,
+		nil,
+		TxnFinalityStatusWithoutL1(TxnPreConfirmed),
+	)
 
-		mockChain := mocks.NewMockReader(mockCtrl)
-		mockSyncer := mocks.NewMockSyncReader(mockCtrl)
-		mockEventFilterer := mocks.NewMockEventFilterer(mockCtrl)
-		handler := New(mockChain, mockSyncer, nil, log)
+	_, b2EmittedFiltered := createTestEvents(
+		t,
+		b2,
+		targetAddress,
+		nil,
+		TxnFinalityStatusWithoutL1(TxnAcceptedOnL2),
+	)
 
-		mockChain.EXPECT().HeadsHeader().Return(b1.Header, nil)
-		mockChain.EXPECT().BlockHeaderByNumber(b1.Number).Return(b1.Header, nil)
-		mockChain.EXPECT().EventFilter(fromAddr, keys, gomock.Any()).Return(mockEventFilterer, nil)
+	eventsWithFromAddressAndPreConfirmed := testCase{
+		description:    "Events with from_address filter, finality PRE_CONFIRMED",
+		blockID:        nil,
+		finalityStatus: utils.HeapPtr(TxnFinalityStatusWithoutL1(TxnPreConfirmed)),
+		fromAddr:       targetAddress,
+		keys:           nil,
+		setupMocks: func() {
+			mockChain.EXPECT().HeadsHeader().Return(b1.Header, nil)
+			mockChain.EXPECT().EventFilter(gomock.Any(), gomock.Any(), gomock.Any()).
+				Return(mockEventFilterer, nil).Times(2)
+			mockEventFilterer.EXPECT().SetRangeEndBlockByNumber(gomock.Any(), gomock.Any()).
+				Return(nil).Times(4)
+			mockEventFilterer.EXPECT().Events(gomock.Any(), gomock.Any()).Return(b1FilteredBySenders, nil, nil)
+			mockEventFilterer.EXPECT().Events(gomock.Any(), gomock.Any()).Return(preConfirmedFilteredBySenders, nil, nil)
+			mockEventFilterer.EXPECT().Close().Times(2)
+		},
+		steps: []stepInfo{
+			{
+				description: "events from latest and preconfirmed",
+				expect:      [][]*SubscriptionEmittedEvent{append(b1EmittedFiltered, preConfirmedEmittedFiltered...)},
+			},
+			{
+				description: "on pre_confirmed block update, without duplicates",
+				notify: func() {
+					handler.pendingData.Send(&preConfirmed2)
+				},
+				expect: [][]*SubscriptionEmittedEvent{preConfirmed2EmittedFiltered[len(preConfirmedEmittedFiltered):]},
+			},
+			{
+				description: "on new head",
+				notify: func() {
+					handler.newHeads.Send(b2)
+				},
+				expect: [][]*SubscriptionEmittedEvent{b2EmittedFiltered},
+			},
+		},
+	}
 
-		cToken := new(blockchain.ContinuationToken)
-		mockEventFilterer.EXPECT().SetRangeEndBlockByNumber(gomock.Any(), gomock.Any()).Return(nil).MaxTimes(2)
-		mockEventFilterer.EXPECT().Events(gomock.Any(), gomock.Any()).Return(b1Filtered, cToken, nil)
-		mockEventFilterer.EXPECT().Events(gomock.Any(), gomock.Any()).Return(b2Filtered, nil, nil)
-		mockEventFilterer.EXPECT().Close().AnyTimes()
+	targetKey, err := new(felt.Felt).SetString("0x1dcde06aabdbca2f80aa51392b345d7549d7757aa855f7e37f5d335ac8243b1")
+	require.NoError(t, err)
+	keys := [][]felt.Felt{{*targetKey}}
 
-		id, clientConn := createTestEventsWebsocket(t, handler, fromAddr, keys, &b1.Number)
+	b1FilteredByFromAddressAndKey, b1EmittedWFilters := createTestEvents(
+		t,
+		b1,
+		targetAddress,
+		keys,
+		TxnFinalityStatusWithoutL1(TxnAcceptedOnL2),
+	)
 
-		assertNextEvents(t, clientConn, id, b1Emitted)
-	})
+	preConfirmedFilteredBySendersAndKey, preConfirmedEmittedWFilters := createTestEvents(
+		t,
+		preConfirmed1.Block,
+		targetAddress,
+		keys,
+		TxnFinalityStatusWithoutL1(TxnPreConfirmed),
+	)
 
-	t.Run("Events from pending block without duplicates", func(t *testing.T) {
-		mockCtrl := gomock.NewController(t)
-		t.Cleanup(mockCtrl.Finish)
+	_, preConfirmed2EmittedWFilters := createTestEvents(
+		t,
+		preConfirmed2.Block,
+		targetAddress,
+		keys,
+		TxnFinalityStatusWithoutL1(TxnPreConfirmed),
+	)
 
-		mockChain := mocks.NewMockReader(mockCtrl)
-		mockSyncer := mocks.NewMockSyncReader(mockCtrl)
-		mockEventFilterer := mocks.NewMockEventFilterer(mockCtrl)
+	_, b2EmittedWFilters := createTestEvents(
+		t,
+		b2,
+		targetAddress,
+		keys,
+		TxnFinalityStatusWithoutL1(TxnAcceptedOnL2),
+	)
 
-		handler := New(mockChain, mockSyncer, nil, log)
+	eventsWithAllFilterAndPreConfirmed := testCase{
+		description:    "Events with from_address and key, finality PRE_CONFIRMED",
+		blockID:        nil,
+		finalityStatus: utils.HeapPtr(TxnFinalityStatusWithoutL1(TxnPreConfirmed)),
+		fromAddr:       targetAddress,
+		keys:           keys,
+		setupMocks: func() {
+			mockChain.EXPECT().HeadsHeader().Return(b1.Header, nil)
+			mockChain.EXPECT().EventFilter(gomock.Any(), gomock.Any(), gomock.Any()).
+				Return(mockEventFilterer, nil).Times(2)
+			mockEventFilterer.EXPECT().SetRangeEndBlockByNumber(gomock.Any(), gomock.Any()).
+				Return(nil).Times(4)
+			mockEventFilterer.EXPECT().Events(gomock.Any(), gomock.Any()).Return(b1FilteredByFromAddressAndKey, nil, nil)
+			mockEventFilterer.EXPECT().Events(gomock.Any(), gomock.Any()).Return(preConfirmedFilteredBySendersAndKey, nil, nil)
+			mockEventFilterer.EXPECT().Close().Times(2)
+		},
+		steps: []stepInfo{
+			{
+				description: "events from latest and preconfirmed on start",
+				expect:      [][]*SubscriptionEmittedEvent{append(b1EmittedWFilters, preConfirmedEmittedWFilters...)},
+			},
+			{
+				description: "on pre_confirmed block update, without duplicates",
+				notify: func() {
+					handler.pendingData.Send(&preConfirmed2)
+				},
+				expect: [][]*SubscriptionEmittedEvent{preConfirmed2EmittedWFilters[len(preConfirmedEmittedWFilters):]},
+			},
+			{
+				description: "on new head",
+				notify: func() {
+					handler.newHeads.Send(b2)
+				},
+				expect: [][]*SubscriptionEmittedEvent{b2EmittedWFilters},
+			},
+		},
+	}
 
-		mockChain.EXPECT().EventFilter(fromAddr, keys, gomock.Any()).Return(mockEventFilterer, nil).AnyTimes()
-		mockEventFilterer.EXPECT().SetRangeEndBlockByNumber(gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
-		mockEventFilterer.EXPECT().Close().AnyTimes()
+	testCases := []testCase{
+		preStarknet0_14_0basicSubscription,
+		basicSubscription,
+		basicSubscriptionWithPreConfirmed,
+		eventsFromHistoricalBlocks,
+		eventsWithContinuationToken,
+		eventsWithFromAddressAndPreConfirmed,
+		eventsWithAllFilterAndPreConfirmed,
+	}
 
-		mockChain.EXPECT().HeadsHeader().Return(b1.Header, nil)
-		mockEventFilterer.EXPECT().Events(gomock.Any(), gomock.Any()).Return(b1Filtered, nil, nil)
+	for _, tc := range testCases {
+		t.Run(tc.description, func(t *testing.T) {
+			if tc.setupMocks != nil {
+				tc.setupMocks()
+			}
+			subID, conn := createTestEventsWebsocket(
+				t,
+				handler,
+				tc.fromAddr,
+				tc.keys,
+				tc.blockID,
+				tc.finalityStatus,
+			)
 
-		id, clientConn := createTestEventsWebsocket(t, handler, fromAddr, keys, nil)
+			for _, step := range tc.steps {
+				t.Run(step.description, func(t *testing.T) {
+					if step.setupMocks != nil {
+						step.setupMocks()
+					}
 
-		assertNextEvents(t, clientConn, id, b1Emitted)
+					if step.notify != nil {
+						step.notify()
+					}
 
-		mockEventFilterer.EXPECT().Events(gomock.Any(), gomock.Any()).Return(pending1Filtered, nil, nil)
-		pendingData1 := sync.NewPending(pending1, nil, nil)
-		handler.pendingData.Send(&pendingData1)
-		assertNextEvents(t, clientConn, id, pending1Emitted)
-
-		mockEventFilterer.EXPECT().Events(gomock.Any(), gomock.Any()).Return(pending2Filtered, nil, nil)
-		pendingData2 := sync.NewPending(pending2, nil, nil)
-		handler.pendingData.Send(&pendingData2)
-		assertNextEvents(t, clientConn, id, pending2Emitted[len(pending1Emitted):])
-
-		mockEventFilterer.EXPECT().Events(gomock.Any(), gomock.Any()).Return(b2Filtered, nil, nil)
-		handler.newHeads.Send(b2)
-		assertNextEvents(t, clientConn, id, b2Emitted[len(pending2Emitted):])
-	})
+					for _, expectedEvents := range step.expect {
+						assertNextEvents(t, conn, subID, expectedEvents)
+					}
+				})
+			}
+		})
+	}
 }
 
 func TestSubscribeTxnStatus(t *testing.T) {
@@ -416,53 +781,10 @@ func TestSubscribeTxnStatus(t *testing.T) {
 	})
 }
 
-type fakeSyncer struct {
-	newHeads    *feed.Feed[*core.Block]
-	reorgs      *feed.Feed[*sync.ReorgBlockRange]
-	pendingData *feed.Feed[core.PendingData]
-}
-
-func newFakeSyncer() *fakeSyncer {
-	return &fakeSyncer{
-		newHeads:    feed.New[*core.Block](),
-		reorgs:      feed.New[*sync.ReorgBlockRange](),
-		pendingData: feed.New[core.PendingData](),
-	}
-}
-
-func (fs *fakeSyncer) SubscribeNewHeads() sync.NewHeadSubscription {
-	return sync.NewHeadSubscription{Subscription: fs.newHeads.Subscribe()}
-}
-
-func (fs *fakeSyncer) SubscribeReorg() sync.ReorgSubscription {
-	return sync.ReorgSubscription{Subscription: fs.reorgs.Subscribe()}
-}
-
-func (fs *fakeSyncer) SubscribePendingData() sync.PendingDataSubscription {
-	return sync.PendingDataSubscription{Subscription: fs.pendingData.Subscribe()}
-}
-
-func (fs *fakeSyncer) StartingBlockNumber() (uint64, error) {
-	return 0, nil
-}
-
-func (fs *fakeSyncer) HighestBlockHeader() *core.Header {
-	return nil
-}
-
-func (fs *fakeSyncer) PendingData() (core.PendingData, error) {
-	return nil, sync.ErrPendingBlockNotFound
-}
-func (fs *fakeSyncer) PendingBlock() *core.Block                             { return nil }
-func (fs *fakeSyncer) PendingState() (core.StateReader, func() error, error) { return nil, nil, nil }
-func (fs *fakeSyncer) PendingStateBeforeIndex(index int) (core.StateReader, func() error, error) {
-	return nil, nil, nil
-}
-
 func TestSubscribeNewHeads(t *testing.T) {
 	log := utils.NewNopZapLogger()
 
-	t.Run("Return error if block is too far back", func(t *testing.T) {
+	t.Run("BlockID - Number, Invalid Input", func(t *testing.T) {
 		mockCtrl := gomock.NewController(t)
 		t.Cleanup(mockCtrl.Finish)
 
@@ -479,7 +801,7 @@ func TestSubscribeNewHeads(t *testing.T) {
 
 		subCtx := context.WithValue(t.Context(), jsonrpc.ConnKey{}, &fakeConn{w: serverConn})
 
-		t.Run("head is 1024", func(t *testing.T) {
+		t.Run("BlockID head is 1024", func(t *testing.T) {
 			mockChain.EXPECT().HeadsHeader().Return(&core.Header{Number: 1024}, nil)
 			mockChain.EXPECT().BlockHeaderByNumber(blockID.Number()).
 				Return(&core.Header{Number: 0}, nil)
@@ -737,7 +1059,7 @@ func TestSubscriptionReorg(t *testing.T) {
 	}
 }
 
-func TestSubscribePendingTxs(t *testing.T) {
+func TestSubscribeNewTransactions(t *testing.T) {
 	ctx, cancel := context.WithCancel(t.Context())
 	t.Cleanup(cancel)
 
@@ -745,167 +1067,298 @@ func TestSubscribePendingTxs(t *testing.T) {
 	t.Cleanup(mockCtrl.Finish)
 
 	mockChain := mocks.NewMockReader(mockCtrl)
+	syncer := newFakeSyncer()
 	l1Feed := feed.New[*core.L1Head]()
 	mockChain.EXPECT().SubscribeL1Head().Return(blockchain.L1HeadSubscription{Subscription: l1Feed.Subscribe()})
-	mockChain.EXPECT().HeadsHeader().Return(nil, db.ErrKeyNotFound).Times(3)
-	syncer := newFakeSyncer()
-	handler, server := setupRPC(t, ctx, mockChain, syncer)
+	handler, _ := setupRPC(t, ctx, mockChain, syncer)
 
-	t.Run("Basic subscription", func(t *testing.T) {
-		conn := createWsConn(t, ctx, server)
+	n := &utils.Sepolia
+	client := feeder.NewTestClient(t, n)
+	gw := adaptfeeder.New(client)
 
-		subMsg := `{"jsonrpc":"2.0","id":"1","method":"starknet_subscribePendingTransactions"}`
-		id := "1"
-		handler.WithIDGen(func() string { return id })
-		got := sendWsMessage(t, ctx, conn, subMsg)
-		require.Equal(t, subResp(id), got)
+	newHead1, err := gw.BlockByNumber(t.Context(), 56377)
+	require.NoError(t, err)
 
-		parentHash := new(felt.Felt).SetUint64(1)
+	newHead2, err := gw.BlockByNumber(t.Context(), 56378)
+	require.NoError(t, err)
 
-		hash1 := new(felt.Felt).SetUint64(1)
-		addr1 := new(felt.Felt).SetUint64(11)
-
-		hash2 := new(felt.Felt).SetUint64(2)
-		addr2 := new(felt.Felt).SetUint64(22)
-
-		hash3 := new(felt.Felt).SetUint64(3)
-		hash4 := new(felt.Felt).SetUint64(4)
-		hash5 := new(felt.Felt).SetUint64(5)
-
-		syncer.pendingData.Send(&sync.Pending{
-			Block: &core.Block{
-				Header: &core.Header{
-					ParentHash: parentHash,
-				},
-				Transactions: []core.Transaction{
-					&core.InvokeTransaction{TransactionHash: hash1, SenderAddress: addr1},
-					&core.DeclareTransaction{TransactionHash: hash2, SenderAddress: addr2},
-					&core.DeployTransaction{TransactionHash: hash3},
-					&core.DeployAccountTransaction{DeployTransaction: core.DeployTransaction{TransactionHash: hash4}},
-					&core.L1HandlerTransaction{TransactionHash: hash5},
-				},
-			},
-		})
-
-		for _, expectedResult := range []string{"0x1", "0x2", "0x3", "0x4", "0x5"} {
-			want := `{"jsonrpc":"2.0","method":"starknet_subscriptionPendingTransactions","params":{"result":"%s","subscription_id":"%s"}}`
-			want = fmt.Sprintf(want, expectedResult, id)
-			_, pendingTxsGot, err := conn.Read(ctx)
-			require.NoError(t, err)
-			require.Equal(t, want, string(pendingTxsGot))
+	toTransactionsWithFinalityStatus := func(txs []core.Transaction, finalityStatus TxnStatusWithoutL1) []*SubscriptionNewTransaction {
+		txsWithStatus := make([]*SubscriptionNewTransaction, len(txs))
+		for i, txn := range txs {
+			txsWithStatus[i] = &SubscriptionNewTransaction{
+				Transaction:    *AdaptTransaction(txn),
+				FinalityStatus: finalityStatus,
+			}
 		}
-	})
+		return txsWithStatus
+	}
 
-	t.Run("Filtered subscription", func(t *testing.T) {
-		conn := createWsConn(t, ctx, server)
+	pendingBlockTxCount := 6
+	pendingBlock := createTestPendingBlock(t, newHead2, pendingBlockTxCount)
+	pending := sync.NewPending(pendingBlock, nil, nil)
 
-		subMsg := `{"jsonrpc":"2.0","id":"1","method":"starknet_subscribePendingTransactions", "params":{"sender_address":["0xb", "0x16"]}}`
-		id := "1"
-		handler.WithIDGen(func() string { return id })
-		got := sendWsMessage(t, ctx, conn, subMsg)
-		require.Equal(t, subResp(id), got)
+	initialPreconfirmedCount := 3
+	secondPreConfirmedCount := 6
+	thirdPreConfirmedCount := len(newHead2.Transactions)
 
-		parentHash := new(felt.Felt).SetUint64(1)
+	type stepInfo struct {
+		description string
+		notify      func()
+		expect      [][]*SubscriptionNewTransaction
+	}
 
-		hash1 := new(felt.Felt).SetUint64(1)
-		addr1 := new(felt.Felt).SetUint64(11)
+	type testCase struct {
+		description   string
+		statuses      []TxnStatusWithoutL1
+		senderAddress []felt.Felt
+		steps         []stepInfo
+	}
 
-		hash2 := new(felt.Felt).SetUint64(2)
-		addr2 := new(felt.Felt).SetUint64(22)
-
-		hash3 := new(felt.Felt).SetUint64(3)
-		hash4 := new(felt.Felt).SetUint64(4)
-		hash5 := new(felt.Felt).SetUint64(5)
-
-		hash6 := new(felt.Felt).SetUint64(6)
-		addr6 := new(felt.Felt).SetUint64(66)
-
-		hash7 := new(felt.Felt).SetUint64(7)
-		addr7 := new(felt.Felt).SetUint64(77)
-
-		syncer.pendingData.Send(&sync.Pending{
-			Block: &core.Block{
-				Header: &core.Header{
-					ParentHash: parentHash,
+	preStarknet0_14_0DefaultFinality := testCase{
+		description:   "Basic subcription - default finality status. Starknet version < 0.14.0, Pending txs without duplicates",
+		statuses:      nil,
+		senderAddress: nil,
+		steps: []stepInfo{
+			{
+				description: "onNewHead",
+				notify: func() {
+					syncer.newHeads.Send(newHead1)
 				},
-				Transactions: []core.Transaction{
-					&core.InvokeTransaction{TransactionHash: hash1, SenderAddress: addr1},
-					&core.DeclareTransaction{TransactionHash: hash2, SenderAddress: addr2},
-					&core.DeployTransaction{TransactionHash: hash3},
-					&core.DeployAccountTransaction{DeployTransaction: core.DeployTransaction{TransactionHash: hash4}},
-					&core.L1HandlerTransaction{TransactionHash: hash5},
-					&core.InvokeTransaction{TransactionHash: hash6, SenderAddress: addr6},
-					&core.DeclareTransaction{TransactionHash: hash7, SenderAddress: addr7},
+				expect: [][]*SubscriptionNewTransaction{
+					toTransactionsWithFinalityStatus(newHead1.Transactions, TxnStatusWithoutL1(TxnStatusAcceptedOnL2)),
 				},
 			},
-		})
+			{
+				description: "onPendingBLock",
+				notify: func() {
+					syncer.pendingData.Send(&pending)
+				},
+				expect: [][]*SubscriptionNewTransaction{
+					toTransactionsWithFinalityStatus(pendingBlock.Transactions, TxnStatusWithoutL1(TxnStatusAcceptedOnL2)),
+				},
+			},
+			{
+				description: "pending becomes new head without duplicates",
+				notify: func() {
+					syncer.newHeads.Send(newHead2)
+				},
+				expect: [][]*SubscriptionNewTransaction{
+					toTransactionsWithFinalityStatus(newHead2.Transactions[pendingBlockTxCount:], TxnStatusWithoutL1(TxnAcceptedOnL2)),
+				},
+			},
+		},
+	}
 
-		for _, expectedResult := range []string{"0x1", "0x2"} {
-			want := `{"jsonrpc":"2.0","method":"starknet_subscriptionPendingTransactions","params":{"result":"%s","subscription_id":"%s"}}`
-			want = fmt.Sprintf(want, expectedResult, id)
-			_, pendingTxsGot, err := conn.Read(ctx)
-			require.NoError(t, err)
-			require.Equal(t, want, string(pendingTxsGot))
+	defaultFinality := testCase{
+		description:   "Basic subcription - default finality status. Starknet version >= 0.14.0, Transactions from pre_confirmed block",
+		statuses:      nil,
+		senderAddress: nil,
+		steps: []stepInfo{
+			{
+				description: "on new head receive all txs with ACCEPTED_ON_L2",
+				notify: func() {
+					syncer.newHeads.Send(newHead1)
+				},
+				expect: [][]*SubscriptionNewTransaction{
+					toTransactionsWithFinalityStatus(newHead1.Transactions, TxnStatusWithoutL1(TxnStatusAcceptedOnL2)),
+				},
+			},
+			{
+				description: "on new pre_confirmed receive PRE_CONFIRMED and CANDIDATE txs",
+				notify: func() {
+					syncer.pendingData.Send(utils.HeapPtr(createTestPreConfirmed(t, newHead2, initialPreconfirmedCount)))
+				},
+				expect: [][]*SubscriptionNewTransaction{
+					toTransactionsWithFinalityStatus(newHead2.Transactions[:initialPreconfirmedCount], TxnStatusWithoutL1(TxnStatusPreConfirmed)),
+					toTransactionsWithFinalityStatus(newHead2.Transactions[initialPreconfirmedCount:], TxnStatusWithoutL1(TxnStatusCandidate)),
+				},
+			},
+			{
+				description: "on pre_confirmed update subset of candidates moved to PRE_CONFIRMED, without dup.",
+				notify: func() {
+					syncer.pendingData.Send(utils.HeapPtr(createTestPreConfirmed(t, newHead2, secondPreConfirmedCount)))
+				},
+				expect: [][]*SubscriptionNewTransaction{
+					toTransactionsWithFinalityStatus(newHead2.Transactions[initialPreconfirmedCount:secondPreConfirmedCount], TxnStatusWithoutL1(TxnStatusPreConfirmed)),
+				},
+			},
+			{
+				description: "on pre_confirmed update all candidates moved to PRE_CONFIRMED, without dup.",
+				notify: func() {
+					syncer.pendingData.Send(utils.HeapPtr(createTestPreConfirmed(t, newHead2, thirdPreConfirmedCount)))
+				},
+				expect: [][]*SubscriptionNewTransaction{
+					toTransactionsWithFinalityStatus(newHead2.Transactions[secondPreConfirmedCount:], TxnStatusWithoutL1(TxnStatusPreConfirmed)),
+				},
+			},
+			{
+				description: "pre_confirmed become new head",
+				notify: func() {
+					syncer.newHeads.Send(newHead2)
+				},
+				expect: [][]*SubscriptionNewTransaction{
+					toTransactionsWithFinalityStatus(newHead2.Transactions, TxnStatusWithoutL1(TxnAcceptedOnL2)),
+				},
+			},
+		},
+	}
+
+	onlyAcceptedOnL2 := testCase{
+		description:   "Basic subcription - only ACCEPTED_ON_L2",
+		statuses:      []TxnStatusWithoutL1{TxnStatusWithoutL1(TxnStatusAcceptedOnL2)},
+		senderAddress: nil,
+		steps: []stepInfo{
+			{
+				description: "on new head receive all txs with ACCEPTED_ON_L2",
+				notify: func() {
+					syncer.newHeads.Send(newHead1)
+				},
+				expect: [][]*SubscriptionNewTransaction{
+					toTransactionsWithFinalityStatus(newHead1.Transactions, TxnStatusWithoutL1(TxnStatusAcceptedOnL2)),
+				},
+			},
+			{
+				description: "on new pre_confirmed no stream",
+				notify: func() {
+					syncer.pendingData.Send(utils.HeapPtr(createTestPreConfirmed(t, newHead2, initialPreconfirmedCount)))
+				},
+				expect: [][]*SubscriptionNewTransaction{},
+			},
+			{
+				description: "pre_confirmed become new head",
+				notify: func() {
+					syncer.newHeads.Send(newHead2)
+				},
+				expect: [][]*SubscriptionNewTransaction{
+					toTransactionsWithFinalityStatus(newHead2.Transactions, TxnStatusWithoutL1(TxnAcceptedOnL2)),
+				},
+			},
+		},
+	}
+
+	allStatuses := testCase{
+		description: "Basic Subscription- all statuses",
+		statuses: []TxnStatusWithoutL1{
+			TxnStatusWithoutL1(TxnStatusReceived),
+			TxnStatusWithoutL1(TxnStatusCandidate),
+			TxnStatusWithoutL1(TxnStatusPreConfirmed),
+			TxnStatusWithoutL1(TxnStatusAcceptedOnL2),
+		},
+		senderAddress: nil,
+		steps: []stepInfo{
+			// {
+			// 	description: "on receiving new transaction",
+			// 	notify: func() {
+			// 		handler.receivedTxFeed.Send(newHead2.Transactions[0])
+			// 	},
+			// 	expect: [][]*NewTransactionSubscriptionResponse{
+			// 		toTransactionsWithFinalityStatus(newHead2.Transactions[:1], TxnStatusWithoutL1(TxnStatusReceived)),
+			// 	},
+			// },
+			{
+				description: "on new pre_confirmed with candidates",
+				notify: func() {
+					syncer.pendingData.Send(utils.HeapPtr(createTestPreConfirmed(t, newHead2, secondPreConfirmedCount)))
+				},
+				expect: [][]*SubscriptionNewTransaction{
+					toTransactionsWithFinalityStatus(newHead2.Transactions[:secondPreConfirmedCount], TxnStatusWithoutL1(TxnStatusPreConfirmed)),
+					toTransactionsWithFinalityStatus(newHead2.Transactions[secondPreConfirmedCount:], TxnStatusWithoutL1(TxnStatusCandidate)),
+				},
+			},
+			{
+				description: "pre_confirmed becomes new head",
+				notify: func() {
+					syncer.newHeads.Send(newHead2)
+				},
+				expect: [][]*SubscriptionNewTransaction{
+					toTransactionsWithFinalityStatus(newHead2.Transactions, TxnStatusWithoutL1(TxnAcceptedOnL2)),
+				},
+			},
+		},
+	}
+
+	senderAddress := AdaptTransaction(newHead2.Transactions[0]).SenderAddress
+	senderFilter := []felt.Felt{*senderAddress}
+	senderTransactions := make([]core.Transaction, 0)
+	for _, txn := range newHead2.Transactions {
+		if filterTxBySender(txn, senderFilter) {
+			senderTransactions = append(senderTransactions, txn)
 		}
-	})
+	}
 
-	t.Run("Full details subscription", func(t *testing.T) {
-		conn := createWsConn(t, ctx, server)
-
-		subMsg := `{"jsonrpc":"2.0","id":"1","method":"starknet_subscribePendingTransactions", "params":{"transaction_details": true}}`
-		id := "1"
-		handler.WithIDGen(func() string { return id })
-		got := sendWsMessage(t, ctx, conn, subMsg)
-		require.Equal(t, subResp(id), got)
-
-		parentHash := new(felt.Felt).SetUint64(1)
-		syncer.pendingData.Send(&sync.Pending{
-			Block: &core.Block{
-				Header: &core.Header{
-					ParentHash: parentHash,
+	allStatusesWithFilter := testCase{
+		description: "Subscription with sender filter - all statuses",
+		statuses: []TxnStatusWithoutL1{
+			TxnStatusWithoutL1(TxnStatusReceived),
+			TxnStatusWithoutL1(TxnStatusCandidate),
+			TxnStatusWithoutL1(TxnStatusPreConfirmed),
+			TxnStatusWithoutL1(TxnStatusAcceptedOnL2),
+		},
+		senderAddress: []felt.Felt{*senderAddress},
+		steps: []stepInfo{
+			//  {
+			//  	description: "on receiving new transaction",
+			//  	notify: func() {
+			//  		handler.receivedTxFeed.Send(newHead2.Transactions[0])
+			//  	},
+			//  	expect: [][]*NewTransactionSubscriptionResponse{
+			//  		toTransactionsWithFinalityStatus(newHead2.Transactions[:1], TxnStatusWithoutL1(TxnStatusReceived)),
+			//  	},
+			//  },
+			{
+				description: "on new pre_confirmed full of candidates",
+				notify: func() {
+					syncer.pendingData.Send(utils.HeapPtr(createTestPreConfirmed(t, newHead2, 0)))
 				},
-				Transactions: []core.Transaction{
-					&core.InvokeTransaction{
-						TransactionHash:      new(felt.Felt).SetUint64(1),
-						CallData:             []*felt.Felt{new(felt.Felt).SetUint64(2)},
-						TransactionSignature: []*felt.Felt{new(felt.Felt).SetUint64(3)},
-						MaxFee:               new(felt.Felt).SetUint64(4),
-						ContractAddress:      new(felt.Felt).SetUint64(5),
-						Version:              new(core.TransactionVersion).SetUint64(3),
-						EntryPointSelector:   new(felt.Felt).SetUint64(6),
-						Nonce:                new(felt.Felt).SetUint64(7),
-						SenderAddress:        new(felt.Felt).SetUint64(8),
-						ResourceBounds: map[core.Resource]core.ResourceBounds{
-							core.ResourceL1Gas: {
-								MaxAmount:       1,
-								MaxPricePerUnit: new(felt.Felt).SetUint64(1),
-							},
-							core.ResourceL2Gas: {
-								MaxAmount:       1,
-								MaxPricePerUnit: new(felt.Felt).SetUint64(1),
-							},
-							core.ResourceL1DataGas: {
-								MaxAmount:       1,
-								MaxPricePerUnit: new(felt.Felt).SetUint64(1),
-							},
-						},
-						Tip:                   9,
-						PaymasterData:         []*felt.Felt{new(felt.Felt).SetUint64(10)},
-						AccountDeploymentData: []*felt.Felt{new(felt.Felt).SetUint64(11)},
-					},
+				expect: [][]*SubscriptionNewTransaction{
+					toTransactionsWithFinalityStatus(senderTransactions, TxnStatusWithoutL1(TxnStatusCandidate)),
 				},
 			},
-		})
+			{
+				description: "on new pre_confirmed full of preconfirmed",
+				notify: func() {
+					syncer.pendingData.Send(utils.HeapPtr(createTestPreConfirmed(t, newHead2, len(newHead2.Transactions))))
+				},
+				expect: [][]*SubscriptionNewTransaction{
+					toTransactionsWithFinalityStatus(senderTransactions, TxnStatusWithoutL1(TxnStatusPreConfirmed)),
+				},
+			},
+			{
+				description: "pre_confirmed becomes new head",
+				notify: func() {
+					syncer.newHeads.Send(newHead2)
+				},
+				expect: [][]*SubscriptionNewTransaction{
+					toTransactionsWithFinalityStatus(senderTransactions, TxnStatusWithoutL1(TxnAcceptedOnL2)),
+				},
+			},
+		},
+	}
 
-		want := `{"jsonrpc":"2.0","method":"starknet_subscriptionPendingTransactions","params":{"result":{"transaction_hash":"0x1","type":"INVOKE","version":"0x3","nonce":"0x7","max_fee":"0x4","contract_address":"0x5","sender_address":"0x8","signature":["0x3"],"calldata":["0x2"],"entry_point_selector":"0x6","resource_bounds":{"l1_gas":{"max_amount":"0x1","max_price_per_unit":"0x1"},"l2_gas":{"max_amount":"0x1","max_price_per_unit":"0x1"},"l1_data_gas":{"max_amount":"0x1","max_price_per_unit":"0x1"}},"tip":"0x9","paymaster_data":["0xa"],"account_deployment_data":["0xb"],"nonce_data_availability_mode":"L1","fee_data_availability_mode":"L1"},"subscription_id":"%s"}}`
-		want = fmt.Sprintf(want, id)
-		_, pendingTxsGot, err := conn.Read(ctx)
-		require.NoError(t, err)
-		require.Equal(t, want, string(pendingTxsGot))
-	})
+	testCases := []testCase{
+		preStarknet0_14_0DefaultFinality,
+		defaultFinality,
+		onlyAcceptedOnL2,
+		allStatuses,
+		allStatusesWithFilter,
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.description, func(t *testing.T) {
+			subID, conn := createTestNewTransactionsWebsocket(t, handler, tc.statuses, tc.senderAddress)
+			for _, step := range tc.steps {
+				t.Run(step.description, func(t *testing.T) {
+					step.notify()
+					for _, expectedTransactions := range step.expect {
+						assertNextTransactions(t, conn, subID, expectedTransactions)
+					}
+				})
+			}
+		})
+	}
 
 	t.Run("Return error if too many addresses in filter", func(t *testing.T) {
-		addresses := make([]felt.Felt, 1024+1)
+		addresses := make([]felt.Felt, rpccore.MaxEventFilterKeys+1)
 
 		serverConn, _ := net.Pipe()
 		t.Cleanup(func() {
@@ -914,7 +1367,295 @@ func TestSubscribePendingTxs(t *testing.T) {
 
 		subCtx := context.WithValue(t.Context(), jsonrpc.ConnKey{}, &fakeConn{w: serverConn})
 
-		id, rpcErr := handler.SubscribePendingTxs(subCtx, false, addresses)
+		id, rpcErr := handler.SubscribeNewTransactions(subCtx, nil, addresses)
+		assert.Zero(t, id)
+		assert.Equal(t, rpccore.ErrTooManyAddressesInFilter, rpcErr)
+	})
+}
+
+func TestSubscribeTransactionReceipts(t *testing.T) {
+	ctx, cancel := context.WithCancel(t.Context())
+	t.Cleanup(cancel)
+
+	mockCtrl := gomock.NewController(t)
+	t.Cleanup(mockCtrl.Finish)
+
+	mockChain := mocks.NewMockReader(mockCtrl)
+	syncer := newFakeSyncer()
+	l1Feed := feed.New[*core.L1Head]()
+	mockChain.EXPECT().SubscribeL1Head().Return(blockchain.L1HeadSubscription{Subscription: l1Feed.Subscribe()})
+	handler, _ := setupRPC(t, ctx, mockChain, syncer)
+
+	n := &utils.Sepolia
+	client := feeder.NewTestClient(t, n)
+	gw := adaptfeeder.New(client)
+
+	newHead1, err := gw.BlockByNumber(t.Context(), 56377)
+	require.NoError(t, err)
+
+	newHead2, err := gw.BlockByNumber(t.Context(), 56378)
+	require.NoError(t, err)
+
+	type stepInfo struct {
+		description string
+		notify      func()
+		expect      [][]*TransactionReceipt
+	}
+
+	type testCase struct {
+		description   string
+		statuses      []TxnFinalityStatusWithoutL1
+		senderAddress []felt.Felt
+		steps         []stepInfo
+	}
+
+	toAdaptedReceiptsWithFilter := func(b *core.Block, senderAddress []felt.Felt, finalityStatus TxnFinalityStatus) []*TransactionReceipt {
+		receipts := make([]*TransactionReceipt, 0)
+		for i, receipt := range b.Receipts {
+			txn := b.Transactions[i]
+			if filterTxBySender(txn, senderAddress) {
+				receipts = append(receipts, AdaptReceipt(receipt, txn, finalityStatus, b.Hash, b.Number))
+			}
+		}
+		return receipts
+	}
+
+	pendingB1TxCount := 3
+	pendingB2TxCount := 6
+	pendingBlock1 := createTestPendingBlock(t, newHead2, pendingB1TxCount)
+	pendingBlock2 := createTestPendingBlock(t, newHead2, pendingB2TxCount)
+
+	preStarknet0_14_0defaultFinalityStatus := testCase{
+		description: "Basic subscription with default finality status, starknet version < 0.14.0",
+		statuses:    nil,
+		steps: []stepInfo{
+			{
+				description: "on new head",
+				notify: func() {
+					syncer.newHeads.Send(newHead1)
+				},
+				expect: [][]*TransactionReceipt{
+					toAdaptedReceiptsWithFilter(newHead1, nil, TxnAcceptedOnL2),
+				},
+			},
+			{
+				description: "on pending",
+				notify: func() {
+					syncer.pendingData.Send(utils.HeapPtr(sync.NewPending(pendingBlock1, nil, nil)))
+				},
+				expect: [][]*TransactionReceipt{toAdaptedReceiptsWithFilter(pendingBlock1, nil, TxnAcceptedOnL2)},
+			},
+			{
+				description: "on pending block update, without duplicates",
+				notify: func() {
+					syncer.pendingData.Send(utils.HeapPtr(sync.NewPending(pendingBlock2, nil, nil)))
+				},
+				expect: [][]*TransactionReceipt{toAdaptedReceiptsWithFilter(pendingBlock2, nil, TxnAcceptedOnL2)[pendingB1TxCount:]},
+			},
+			{
+				description: "on next head, without duplicates",
+				notify: func() {
+					syncer.newHeads.Send(newHead2)
+				},
+				expect: [][]*TransactionReceipt{
+					toAdaptedReceiptsWithFilter(newHead2, nil, TxnAcceptedOnL2)[pendingB2TxCount:],
+				},
+			},
+		},
+	}
+
+	preConfirmedB1TxCount := 3
+	preConfirmedB2TxCount := 6
+	preConfirmed1 := createTestPreConfirmed(t, newHead2, preConfirmedB1TxCount)
+	preConfirmed2 := createTestPreConfirmed(t, newHead2, preConfirmedB2TxCount)
+
+	defaultFinalityStatus := testCase{
+		description: "Basic subscription with default finality status",
+		statuses:    nil,
+		steps: []stepInfo{
+			{
+				description: "on new head",
+				notify: func() {
+					syncer.newHeads.Send(newHead1)
+				},
+				expect: [][]*TransactionReceipt{
+					toAdaptedReceiptsWithFilter(newHead1, nil, TxnAcceptedOnL2),
+				},
+			},
+			{
+				description: "on pre_confirmed",
+				notify: func() {
+					syncer.pendingData.Send(utils.HeapPtr(createTestPreConfirmed(t, newHead2, len(newHead2.Transactions))))
+				},
+				expect: [][]*TransactionReceipt{},
+			},
+			{
+				description: "on next head",
+				notify: func() {
+					syncer.newHeads.Send(newHead2)
+				},
+				expect: [][]*TransactionReceipt{
+					toAdaptedReceiptsWithFilter(newHead2, nil, TxnAcceptedOnL2),
+				},
+			},
+		},
+	}
+
+	onlyPreConfirmed := testCase{
+		description: "Basic subscription with only PRE_CONFIRMED status",
+		statuses:    []TxnFinalityStatusWithoutL1{TxnFinalityStatusWithoutL1(TxnPreConfirmed)},
+		steps: []stepInfo{
+			{
+				description: "on new head, no response",
+				notify: func() {
+					syncer.newHeads.Send(newHead1)
+				},
+				expect: [][]*TransactionReceipt{},
+			},
+			{
+				description: "on pre_confirmed",
+				notify: func() {
+					syncer.pendingData.Send(&preConfirmed1)
+				},
+				expect: [][]*TransactionReceipt{
+					toAdaptedReceiptsWithFilter(preConfirmed1.GetBlock(), nil, TxnPreConfirmed),
+				},
+			},
+			{
+				description: "on pre_confirmed update, without duplicates",
+				notify: func() {
+					syncer.pendingData.Send(&preConfirmed2)
+				},
+				expect: [][]*TransactionReceipt{
+					toAdaptedReceiptsWithFilter(preConfirmed2.GetBlock(), nil, TxnPreConfirmed)[preConfirmedB1TxCount:],
+				},
+			},
+			{
+				description: "on next head, no response",
+				notify: func() {
+					syncer.newHeads.Send(newHead2)
+				},
+				expect: [][]*TransactionReceipt{},
+			},
+		},
+	}
+
+	allStatuses := testCase{
+		description: "Basic subscription with all statuses",
+		statuses:    []TxnFinalityStatusWithoutL1{TxnFinalityStatusWithoutL1(TxnPreConfirmed), TxnFinalityStatusWithoutL1(TxnAcceptedOnL2)},
+		steps: []stepInfo{
+			{
+				description: "on new head",
+				notify: func() {
+					syncer.newHeads.Send(newHead1)
+				},
+				expect: [][]*TransactionReceipt{
+					toAdaptedReceiptsWithFilter(newHead1, nil, TxnAcceptedOnL2),
+				},
+			},
+			{
+				description: "on pre_confirmed",
+				notify: func() {
+					syncer.pendingData.Send(&preConfirmed1)
+				},
+				expect: [][]*TransactionReceipt{
+					toAdaptedReceiptsWithFilter(preConfirmed1.GetBlock(), nil, TxnPreConfirmed),
+				},
+			},
+			{
+				description: "on pre_confirmed update, without duplicates",
+				notify: func() {
+					syncer.pendingData.Send(&preConfirmed2)
+				},
+				expect: [][]*TransactionReceipt{
+					toAdaptedReceiptsWithFilter(preConfirmed2.GetBlock(), nil, TxnPreConfirmed)[preConfirmedB1TxCount:],
+				},
+			},
+			{
+				description: "on next head",
+				notify: func() {
+					syncer.newHeads.Send(newHead2)
+				},
+				expect: [][]*TransactionReceipt{
+					toAdaptedReceiptsWithFilter(newHead2, nil, TxnAcceptedOnL2),
+				},
+			},
+		},
+	}
+
+	preConfirmed3 := createTestPreConfirmed(t, newHead2, len(newHead2.Transactions))
+	senderAddress := AdaptTransaction(newHead2.Transactions[0]).SenderAddress
+	senderFilter := []felt.Felt{*senderAddress}
+	preConfirmed1FilteredReceipts := toAdaptedReceiptsWithFilter(preConfirmed1.GetBlock(), senderFilter, TxnPreConfirmed)
+
+	allStatusesWithFilter := testCase{
+		description:   "subscription with filter and all statuses",
+		senderAddress: senderFilter,
+		statuses:      []TxnFinalityStatusWithoutL1{TxnFinalityStatusWithoutL1(TxnPreConfirmed), TxnFinalityStatusWithoutL1(TxnAcceptedOnL2)},
+		steps: []stepInfo{
+			{
+				description: "on pre_confirmed",
+				notify: func() {
+					syncer.pendingData.Send(&preConfirmed1)
+				},
+				expect: [][]*TransactionReceipt{
+					preConfirmed1FilteredReceipts,
+				},
+			},
+			{
+				description: "on pre_confirmed update, without duplicates",
+				notify: func() {
+					syncer.pendingData.Send(&preConfirmed3)
+				},
+				expect: [][]*TransactionReceipt{
+					toAdaptedReceiptsWithFilter(preConfirmed3.GetBlock(), senderFilter, TxnPreConfirmed)[len(preConfirmed1FilteredReceipts):],
+				},
+			},
+			{
+				description: "on next head",
+				notify: func() {
+					syncer.newHeads.Send(newHead2)
+				},
+				expect: [][]*TransactionReceipt{
+					toAdaptedReceiptsWithFilter(newHead2, senderFilter, TxnAcceptedOnL2),
+				},
+			},
+		},
+	}
+
+	testCases := []testCase{
+		defaultFinalityStatus,
+		preStarknet0_14_0defaultFinalityStatus,
+		allStatuses,
+		allStatusesWithFilter,
+		onlyPreConfirmed,
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.description, func(t *testing.T) {
+			subID, conn := createTestTransactionReceiptsWebsocket(t, handler, tc.senderAddress, tc.statuses)
+			for _, step := range tc.steps {
+				t.Run(step.description, func(t *testing.T) {
+					step.notify()
+					for _, expectedReceipts := range step.expect {
+						assertNextReceipts(t, conn, subID, expectedReceipts)
+					}
+				})
+			}
+		})
+	}
+
+	t.Run("Returns error if to many address in filter", func(t *testing.T) {
+		addresses := make([]felt.Felt, rpccore.MaxEventFilterKeys+1)
+
+		serverConn, _ := net.Pipe()
+		t.Cleanup(func() {
+			require.NoError(t, serverConn.Close())
+		})
+
+		subCtx := context.WithValue(t.Context(), jsonrpc.ConnKey{}, &fakeConn{w: serverConn})
+
+		id, rpcErr := handler.SubscribeNewTransactionReceipts(subCtx, addresses, nil)
 		assert.Zero(t, id)
 		assert.Equal(t, rpccore.ErrTooManyAddressesInFilter, rpcErr)
 	})
@@ -1127,7 +1868,7 @@ func assertNextTxnStatus(t *testing.T, conn net.Conn, id SubscriptionID, txHash 
 	})
 }
 
-func assertNextEvents(t *testing.T, conn net.Conn, id SubscriptionID, emittedEvents []*rpcv6.EmittedEvent) {
+func assertNextEvents(t *testing.T, conn net.Conn, id SubscriptionID, emittedEvents []*SubscriptionEmittedEvent) {
 	t.Helper()
 
 	for _, emitted := range emittedEvents {
@@ -1135,82 +1876,135 @@ func assertNextEvents(t *testing.T, conn net.Conn, id SubscriptionID, emittedEve
 	}
 }
 
+func assertNextReceipts(t *testing.T, conn net.Conn, id SubscriptionID, receipts []*TransactionReceipt) {
+	t.Helper()
+
+	for _, receipt := range receipts {
+		assertNextMessage(t, conn, id, "starknet_subscriptionNewTransactionReceipts", receipt)
+	}
+}
+
+func assertNextTransactions(t *testing.T, conn net.Conn, id SubscriptionID, transactions []*SubscriptionNewTransaction) {
+	t.Helper()
+
+	for _, txn := range transactions {
+		assertNextMessage(t, conn, id, "starknet_subscriptionNewTransactions", txn)
+	}
+}
+
 func createTestPendingBlock(t *testing.T, b *core.Block, txCount int) *core.Block {
 	t.Helper()
 
-	pending := *b
-	pending.Header.Number = 0
-	pending.Header.Hash = nil
-	pending.Hash = nil
-	pending.Transactions = pending.Transactions[:txCount]
-	pending.Receipts = pending.Receipts[:txCount]
+	pending := core.Block{
+		Header: &core.Header{
+			// Pending block does not have number but we internaly set it
+			Number:           b.Number,
+			ParentHash:       b.ParentHash,
+			SequencerAddress: b.SequencerAddress,
+		},
+	}
+
+	pending.Transactions = b.Transactions[:txCount]
+	pending.Receipts = b.Receipts[:txCount]
 	return &pending
 }
 
-//nolint:unused // retained for future use in 0.9.0-rc3, currently unused
-func createTestPreConfirmed(t *testing.T, b *core.Block, preConfirmedCount int) *core.PreConfirmed {
+func createTestPreConfirmed(t *testing.T, b *core.Block, preConfirmedCount int) core.PreConfirmed {
 	t.Helper()
 
 	actualTxCount := len(b.Transactions)
 	var preConfirmed core.PreConfirmed
 	if candidateCount := actualTxCount - preConfirmedCount; candidateCount > 0 {
-		preConfirmed.CandidateTxs = make([]core.Transaction, 0, candidateCount)
-		for i := actualTxCount - candidateCount; i < actualTxCount; i++ {
-			preConfirmed.CandidateTxs = append(preConfirmed.CandidateTxs, b.Transactions[i])
+		preConfirmed.CandidateTxs = make([]core.Transaction, candidateCount)
+		candidateIndex := actualTxCount - candidateCount
+		for i := range candidateCount {
+			preConfirmed.CandidateTxs[i] = b.Transactions[candidateIndex]
+			candidateIndex += 1
 		}
 	}
 
-	preConfirmedBlock := *b
-	preConfirmedBlock.Header.Number = 0
-	preConfirmedBlock.Header.Hash = nil
-	preConfirmedBlock.Hash = nil
-	preConfirmedBlock.Transactions = preConfirmedBlock.Transactions[:preConfirmedCount]
-	preConfirmedBlock.Receipts = preConfirmedBlock.Receipts[:preConfirmedCount]
+	preConfirmedBlock := core.Block{
+		Header: &core.Header{
+			Hash:             nil,
+			ParentHash:       nil,
+			Number:           b.Number,
+			GlobalStateRoot:  b.GlobalStateRoot,
+			SequencerAddress: b.SequencerAddress,
+			TransactionCount: uint64(preConfirmedCount),
+		},
+	}
 
+	preConfirmedBlock.Transactions = b.Transactions[:preConfirmedCount]
+	preConfirmedBlock.Receipts = b.Receipts[:preConfirmedCount]
+	preConfirmedBlock.EventsBloom = core.EventsBloom(preConfirmedBlock.Receipts)
 	preConfirmed.Block = &preConfirmedBlock
-	return &preConfirmed
+	return preConfirmed
 }
 
-func createTestEvents(t *testing.T, b *core.Block) ([]*blockchain.FilteredEvent, []*rpcv6.EmittedEvent) {
+func createTestEvents(
+	t *testing.T,
+	b *core.Block,
+	fromAddress *felt.Felt,
+	keys [][]felt.Felt,
+	finalityStatus TxnFinalityStatusWithoutL1,
+) ([]*blockchain.FilteredEvent, []*SubscriptionEmittedEvent) {
 	t.Helper()
-
+	var blockNumber *uint64
+	// if header.Hash == nil and parentHash != nil it's a pending block
+	// if header.Hash == nil and parentHash == nil it's a pre_confirmed block
+	if b.Hash != nil || b.ParentHash == nil {
+		blockNumber = &b.Number
+	}
+	eventMatcher := blockchain.NewEventMatcher(fromAddress, keys)
 	var filtered []*blockchain.FilteredEvent
-	var emitted []*rpcv6.EmittedEvent
+	var responses []*SubscriptionEmittedEvent
 	for _, receipt := range b.Receipts {
 		for i, event := range receipt.Events {
+			if fromAddress != nil && !event.From.Equal(fromAddress) {
+				continue
+			}
+
+			if !eventMatcher.MatchesEventKeys(event.Keys) {
+				continue
+			}
+
 			filtered = append(filtered, &blockchain.FilteredEvent{
 				Event:           event,
-				BlockNumber:     &b.Number,
+				BlockNumber:     blockNumber,
 				BlockHash:       b.Hash,
 				TransactionHash: receipt.TransactionHash,
 				EventIndex:      i,
 			})
-			emitted = append(emitted, &rpcv6.EmittedEvent{
-				Event: &rpcv6.Event{
-					From: event.From,
-					Keys: event.Keys,
-					Data: event.Data,
+			responses = append(responses, &SubscriptionEmittedEvent{
+				EmittedEvent: rpcv6.EmittedEvent{
+					Event: &rpcv6.Event{
+						From: event.From,
+						Keys: event.Keys,
+						Data: event.Data,
+					},
+					BlockNumber:     blockNumber,
+					BlockHash:       b.Hash,
+					TransactionHash: receipt.TransactionHash,
 				},
-				BlockNumber:     &b.Number,
-				BlockHash:       b.Hash,
-				TransactionHash: receipt.TransactionHash,
+				FinalityStatus: finalityStatus,
 			})
 		}
 	}
-	return filtered, emitted
+	return filtered, responses
 }
 
 func createTestEventsWebsocket(
-	t *testing.T, h *Handler, fromAddr *felt.Felt, keys [][]felt.Felt, startBlock *uint64,
+	t *testing.T,
+	h *Handler,
+	fromAddr *felt.Felt,
+	keys [][]felt.Felt,
+	blockID *SubscriptionBlockID,
+	finalityStatus *TxnFinalityStatusWithoutL1,
 ) (SubscriptionID, net.Conn) {
 	t.Helper()
 
 	return createTestWebsocket(t, func(ctx context.Context) (SubscriptionID, *jsonrpc.Error) {
-		if startBlock != nil {
-			blockID := SubscriptionBlockID(BlockIDFromNumber(*startBlock))
-			return h.SubscribeEvents(ctx, fromAddr, keys, &blockID)
-		}
-		return h.SubscribeEvents(ctx, fromAddr, keys, nil)
+		return h.SubscribeEvents(ctx, fromAddr, keys, blockID, finalityStatus)
 	})
 }
 
@@ -1221,6 +2015,26 @@ func createTestTxStatusWebsocket(
 
 	return createTestWebsocket(t, func(ctx context.Context) (SubscriptionID, *jsonrpc.Error) {
 		return h.SubscribeTransactionStatus(ctx, txHash)
+	})
+}
+
+func createTestNewTransactionsWebsocket(
+	t *testing.T, h *Handler, finalityStatus []TxnStatusWithoutL1, senderAddress []felt.Felt,
+) (SubscriptionID, net.Conn) {
+	t.Helper()
+
+	return createTestWebsocket(t, func(ctx context.Context) (SubscriptionID, *jsonrpc.Error) {
+		return h.SubscribeNewTransactions(ctx, finalityStatus, senderAddress)
+	})
+}
+
+func createTestTransactionReceiptsWebsocket(
+	t *testing.T, h *Handler, senderAddress []felt.Felt, finalityStatus []TxnFinalityStatusWithoutL1,
+) (SubscriptionID, net.Conn) {
+	t.Helper()
+
+	return createTestWebsocket(t, func(ctx context.Context) (SubscriptionID, *jsonrpc.Error) {
+		return h.SubscribeNewTransactionReceipts(ctx, senderAddress, finalityStatus)
 	})
 }
 

--- a/rpc/v9/subscriptions_test.go
+++ b/rpc/v9/subscriptions_test.go
@@ -1859,7 +1859,7 @@ func assertNextTransactions(t *testing.T, conn net.Conn, id SubscriptionID, tran
 	t.Helper()
 
 	for _, txn := range transactions {
-		assertNextMessage(t, conn, id, "starknet_subscriptionNewTransactions", txn)
+		assertNextMessage(t, conn, id, "starknet_subscriptionNewTransaction", txn)
 	}
 }
 

--- a/rpc/v9/transaction.go
+++ b/rpc/v9/transaction.go
@@ -926,7 +926,7 @@ func AdaptReceipt(receipt *core.TransactionReceipt, txn core.Transaction, finali
 	var receiptBlockNumber *uint64
 
 	// Do not return block number for pending block
-	// Return block number for canonical blocks and pending block
+	// Return block number for canonical blocks and pre_confirmed block
 	if blockHash != nil || finalityStatus == TxnPreConfirmed {
 		receiptBlockNumber = &blockNumber
 	}

--- a/rpc/v9/transaction.go
+++ b/rpc/v9/transaction.go
@@ -95,7 +95,7 @@ func (s TxnStatus) MarshalText() ([]byte, error) {
 	case TxnStatusPreConfirmed:
 		return []byte("PRE_CONFIRMED"), nil
 	default:
-		return nil, fmt.Errorf("unknown ExecutionStatus %v", s)
+		return nil, fmt.Errorf("unknown TxnStatus %v", s)
 	}
 }
 
@@ -924,10 +924,10 @@ func AdaptReceipt(receipt *core.TransactionReceipt, txn core.Transaction, finali
 	}
 
 	var receiptBlockNumber *uint64
-	// TODO(Ege): case for preconfirmed blocks: they don't have blockHash
-	// but they do have block number, so far we were not returning blocknumber for pending block
-	// pending block didnt had blocknumber, clarify whether we need to return number or not
-	if blockHash != nil {
+
+	// Do not return block number for pending block
+	// Return block number for canonical blocks and pending block
+	if blockHash != nil || finalityStatus == TxnPreConfirmed {
 		receiptBlockNumber = &blockNumber
 	}
 

--- a/rpc/v9/transaction_test.go
+++ b/rpc/v9/transaction_test.go
@@ -787,6 +787,7 @@ func TestTransactionReceiptByHash(t *testing.T) {
 					"type": "INVOKE",
 					"transaction_hash": "0xce54bbc5647e1c1ea4276c01a708523f740db0ff5474c77734f73beec2624",
 					"actual_fee": {"amount": "0x0", "unit": "WEI"},
+					"block_number": 0,
 					"finality_status": "PRE_CONFIRMED",
 					"execution_status": "SUCCEEDED",
 					"messages_sent": [


### PR DESCRIPTION
This PR implements, rpc 0.9.0 ws endpoints defined [here](https://github.com/starkware-libs/starknet-specs/tree/v0.9.0)

Fixes pending block event access in rpcv8 which is an issue started after bounding out of upper bound block number to latest.

**Notice**: does not support received tx stream on `starknet_subscribeNewTransactions`, this will be enabled in follow up PR