### PR TITLE
refactor: use the built-in max/min to simplify the code

### DIFF
--- a/clients/feeder/feeder.go
+++ b/clients/feeder/feeder.go
@@ -157,10 +157,7 @@ func (c *Client) get(ctx context.Context, queryURL string) (io.ReadCloser, error
 			if wait < c.minWait {
 				wait = c.minWait
 			}
-			wait = c.backoff(wait)
-			if wait > c.maxWait {
-				wait = c.maxWait
-			}
+			wait = min(c.backoff(wait), c.maxWait)
 
 			currentTimeout := timeouts.GetCurrentTimeout()
 			if currentTimeout >= mediumGrowThreshold {

--- a/core/trie2/trieutils/bitarray.go
+++ b/core/trie2/trieutils/bitarray.go
@@ -151,10 +151,7 @@ func (b *BitArray) EqualMSBs(x *BitArray) bool {
 	}
 
 	// Compare only the first min(b.len, x.len) bits
-	minLen := b.len
-	if x.len < minLen {
-		minLen = x.len
-	}
+	minLen := min(x.len, b.len)
 
 	return new(BitArray).MSBs(b, minLen).Equal(new(BitArray).MSBs(x, minLen))
 }

--- a/utils/sign.go
+++ b/utils/sign.go
@@ -18,10 +18,7 @@ func Sign(privKey *ecdsa.PrivateKey) BlockSignFunc {
 		}
 		sig := make([]*felt.Felt, 0)
 		for start := 0; start < len(signatureBytes); {
-			step := len(signatureBytes[start:])
-			if step > felt.Bytes {
-				step = felt.Bytes
-			}
+			step := min(len(signatureBytes[start:]), felt.Bytes)
 			sig = append(sig, new(felt.Felt).SetBytes(signatureBytes[start:step]))
 			start += step
 		}


### PR DESCRIPTION

In Go 1.21, the standard library includes built-in [max/min](https://pkg.go.dev/builtin@go1.21.0#max) function, which can greatly simplify the code.