### PR TITLE
refactor: Use function from the standard library

### DIFF
--- a/core/trie2/triedb/hashdb/database_test.go
+++ b/core/trie2/triedb/hashdb/database_test.go
@@ -1,6 +1,7 @@
 package hashdb
 
 import (
+	"maps"
 	"math"
 	"sync"
 	"testing"
@@ -13,7 +14,6 @@ import (
 	"github.com/NethermindEth/juno/db/memory"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"golang.org/x/exp/maps"
 )
 
 var (


### PR DESCRIPTION
`maps.Copy` has been moved to the standard library and can provide better performance with the new version.