### PR TITLE
fix(tests): fix a bug in tests for transactions in rpc v6, v8 and v9

### DIFF
--- a/rpc/v6/transaction_test.go
+++ b/rpc/v6/transaction_test.go
@@ -1173,15 +1173,15 @@ func TestAdaptTransaction(t *testing.T) {
 func TestAddTransaction(t *testing.T) {
 	n := &utils.Integration
 	gw := adaptfeeder.New(feeder.NewTestClient(t, n))
-	txWithoutClass := func(hash string) *rpc.BroadcastedTransaction {
+	txWithoutClass := func(hash string) rpc.BroadcastedTransaction {
 		tx, err := gw.Transaction(t.Context(), utils.HexToFelt(t, hash))
 		require.NoError(t, err)
-		return &rpc.BroadcastedTransaction{
+		return rpc.BroadcastedTransaction{
 			Transaction: *rpc.AdaptTransaction(tx),
 		}
 	}
 	tests := map[string]struct {
-		txn          *rpc.BroadcastedTransaction
+		txn          rpc.BroadcastedTransaction
 		expectedJSON string
 	}{
 		"invoke v0": {
@@ -1300,7 +1300,7 @@ func TestAddTransaction(t *testing.T) {
 			  }`,
 		},
 		"declare v2": {
-			txn: func() *rpc.BroadcastedTransaction {
+			txn: func() rpc.BroadcastedTransaction {
 				tx := txWithoutClass("0x44b971f7eface29b185f86dd7b3b70acb1e48e0ad459e3a41e06fc42937aaa4")
 				tx.ContractClass = json.RawMessage([]byte(`{"sierra_program": {}}`))
 				return tx
@@ -1316,7 +1316,7 @@ func TestAddTransaction(t *testing.T) {
 				"nonce": "0x11",
 				"class_hash": "0x7cb013a4139335cefce52adc2ac342c0110811353e7992baefbe547200223c7",
 				"contract_class": {
-					"sierra_program": "H4sIAAAAAAAA/1LyMCn2dIQCfbPCUqfAQEfHAH39QHPt3PxysJStEiAAAP//Pys9fyYAAAA="
+					"sierra_program": "H4sIAAAAAAAA/6quBQQAAP//Q7+mowIAAAA="
 				},
 				"compiled_class_hash": "0x67f7deab53a3ba70500bdafe66fb3038bbbaadb36a6dd1a7a5fc5b094e9d724",
 				"sender_address": "0x3bb81d22ecd0e0a6f3138bdc5c072ff5726c5add02bcfd5b81cd657a6ae10a8",
@@ -1324,7 +1324,7 @@ func TestAddTransaction(t *testing.T) {
 			  }`,
 		},
 		"declare v3": {
-			txn: func() *rpc.BroadcastedTransaction {
+			txn: func() rpc.BroadcastedTransaction {
 				tx := txWithoutClass("0x41d1f5206ef58a443e7d3d1ca073171ec25fa75313394318fc83a074a6631c3")
 				tx.ContractClass = json.RawMessage([]byte(`{"sierra_program": {}}`))
 				return tx
@@ -1357,7 +1357,7 @@ func TestAddTransaction(t *testing.T) {
 				"account_deployment_data": [],
 				"type": "DECLARE",
 				"contract_class": {
-					"sierra_program": "H4sIAAAAAAAA/1LyMCn2dIQCfbPCUqfAQEfHAH39QHPt3PxysJStEiAAAP//Pys9fyYAAAA="
+					"sierra_program": "H4sIAAAAAAAA/6quBQQAAP//Q7+mowIAAAA="
 				}
 			  }`,
 		},
@@ -1438,11 +1438,11 @@ func TestAddTransaction(t *testing.T) {
 				Times(1)
 
 			handler := rpc.New(nil, nil, nil, n, utils.NewNopZapLogger())
-			_, rpcErr := handler.AddTransaction(t.Context(), test.txn)
+			_, rpcErr := handler.AddTransaction(t.Context(), utils.HeapPtr(test.txn))
 			require.Equal(t, rpcErr.Code, rpccore.ErrInternal.Code)
 
 			handler = handler.WithGateway(mockGateway)
-			got, rpcErr := handler.AddTransaction(t.Context(), test.txn)
+			got, rpcErr := handler.AddTransaction(t.Context(), utils.HeapPtr(test.txn))
 			require.Nil(t, rpcErr)
 			require.Equal(
 				t,

--- a/rpc/v9/transaction.go
+++ b/rpc/v9/transaction.go
@@ -675,7 +675,6 @@ func (h *Handler) pushToFeederGateway(
 		}
 
 		sierraProgBytes, errIn := json.Marshal(sierraProg)
-		println("sierraProgBytes", string(sierraProgBytes))
 		if errIn != nil {
 			return AddTxResponse{}, jsonrpc.Err(jsonrpc.InternalError, errIn.Error())
 		}
@@ -684,14 +683,12 @@ func (h *Handler) pushToFeederGateway(
 		if errIn != nil {
 			return AddTxResponse{}, jsonrpc.Err(jsonrpc.InternalError, errIn.Error())
 		}
-		println("gwsierraProgBytes", gwSierraProg)
 
 		contractClass["sierra_program"] = gwSierraProg
 		newContractClass, err := json.Marshal(contractClass)
 		if err != nil {
 			return AddTxResponse{}, rpccore.ErrInternal.CloneWithData(fmt.Sprintf("marshal revised contract class: %v", err))
 		}
-		println("newcontractclass", string(newContractClass))
 		tx.ContractClass = newContractClass
 	}
 

--- a/rpc/v9/transaction.go
+++ b/rpc/v9/transaction.go
@@ -675,6 +675,7 @@ func (h *Handler) pushToFeederGateway(
 		}
 
 		sierraProgBytes, errIn := json.Marshal(sierraProg)
+		println("sierraProgBytes", string(sierraProgBytes))
 		if errIn != nil {
 			return AddTxResponse{}, jsonrpc.Err(jsonrpc.InternalError, errIn.Error())
 		}
@@ -683,12 +684,14 @@ func (h *Handler) pushToFeederGateway(
 		if errIn != nil {
 			return AddTxResponse{}, jsonrpc.Err(jsonrpc.InternalError, errIn.Error())
 		}
+		println("gwsierraProgBytes", gwSierraProg)
 
 		contractClass["sierra_program"] = gwSierraProg
 		newContractClass, err := json.Marshal(contractClass)
 		if err != nil {
 			return AddTxResponse{}, rpccore.ErrInternal.CloneWithData(fmt.Sprintf("marshal revised contract class: %v", err))
 		}
+		println("newcontractclass", string(newContractClass))
 		tx.ContractClass = newContractClass
 	}
 


### PR DESCRIPTION
Fix a bug where tests were sharing an object and the first test was modifying this object. Then the second test used the modified object assuming it was the original one. 