### PR TITLE
fix: ProposalStreamDemux flaky test

### DIFF
--- a/consensus/p2p/validator/proposal_stream_demux_test.go
+++ b/consensus/p2p/validator/proposal_stream_demux_test.go
@@ -126,8 +126,8 @@ func TestProposalStreamDemux(t *testing.T) {
 	})
 
 	t.Run("commit block 1", func(t *testing.T) {
-		commitNotifier <- block1
 		SetChainHeight(t, database, block1)
+		commitNotifier <- block1
 		assertExpectedProposal(t, outputs, &proposal2a)
 	})
 


### PR DESCRIPTION
Writing the committed block to DB is supposed to synchronize before notifying all other dependencies about the commit.
This is to fix the flaky test here: https://github.com/NethermindEth/juno/actions/runs/18395147946/job/52416432571