### PR TITLE
fix: simulate deploy account tx

### DIFF
--- a/rpc/v9/simulation.go
+++ b/rpc/v9/simulation.go
@@ -81,8 +81,18 @@ func (h *Handler) simulateTransactions(id *BlockID, transactions []BroadcastedTr
 		BlockHashToBeRevealed: blockHashToBeRevealed,
 	}
 
-	executionResults, err := h.vm.Execute(txns, classes, paidFeesOnL1, &blockInfo,
-		state, skipFeeCharge, skipValidate, errOnRevert, true, true)
+	executionResults, err := h.vm.Execute(
+		txns,
+		classes,
+		paidFeesOnL1,
+		&blockInfo,
+		state,
+		skipFeeCharge,
+		skipValidate,
+		errOnRevert,
+		true,
+		true,
+	)
 	if err != nil {
 		return nil, httpHeader, handleExecutionError(err)
 	}

--- a/vm/rust/src/execution.rs
+++ b/vm/rust/src/execution.rs
@@ -417,12 +417,6 @@ where
 
     match tx {
         Transaction::Account(account_transaction) => {
-            // DEPLOY_ACCOUNT: Normal logic calculates max gas based on account balance, but account doesn't exist yet (balance = 0).
-            // This would set gas limit to zero, causing immediate "out of gas". Use max gas limit from versioned constants instead.
-            if is_deploy_account_transaction(tx) {
-                return Ok(get_default_max_sierra_gas_limit(block_context));
-            }
-
             // Retrieve the fee token address.
             let fee_token_address = block_context
                 .chain_info()


### PR DESCRIPTION
When calling `starknet_simulateTransaction` without the `SKIP_FEE_CHARGE` flag, the execution charges the fee upfront based on gas limits defined by the transaction’s maximum gas usage. For account transactions, except for `DEPLOY_ACCOUNT`, we set gas limits according to the maximum L2 gas that the account balance can cover.

However, a previous fix in PR #2862 changed `DEPLOY_ACCOUNT` transactions to use a fixed maximum gas limit from versioned constants instead. This was meant to address the case where the account does not yet exist (and thus has a zero balance), preventing an immediate "out of gas" error. The relevant comment in the code reads:
```go
// DEPLOY_ACCOUNT: Normal logic calculates max gas based on account balance, but account doesn't exist yet (balance = 0).
// This would set gas limit to zero, causing immediate "out of gas". Use max gas limit from versioned constants instead.
if is_deploy_account_transaction(tx) {
    let max_sierra_gas_limit = block_context.versioned_constants().os_constants.validate_max_sierra_gas.0;
    return Ok(GasAmount::from(max_sierra_gas_limit));
}
```
However, this approach was applied in a code path where actual fee charging happens. Using the max gas limit here caused the charged fee to be much higher than the account’s balance, resulting in an execution failure with an insufficient balance error.

This PR fixes the issue by making DEPLOY_ACCOUNT transactions use the account balance to calculate gas limits—consistent with the logic used for other transaction types—thus preventing excessive fee charging and execution failures.