### PR TITLE
fix: wrong status for prelatest events in subscription on start

### DIFF
--- a/blockchain/event_filter.go
+++ b/blockchain/event_filter.go
@@ -131,8 +131,14 @@ func (c *ContinuationToken) FromString(str string) error {
 
 type FilteredEvent struct {
 	*core.Event
-	BlockNumber     *uint64
-	BlockHash       *felt.Felt
+	BlockNumber *uint64
+	BlockHash   *felt.Felt
+	// BlockParentHash is used to distinguish pre_latest from pre_confirmed blocks
+	// when assigning finality status.
+	// If BlockNumber > latest_canonical_block_number or block hash is nil:
+	//   - BlockParentHash == nil indicates pre_confirmed block
+	//   - BlockParentHash != nil indicates pre_latest block
+	BlockParentHash *felt.Felt
 	TransactionHash *felt.Felt
 	EventIndex      int
 }

--- a/blockchain/event_matcher.go
+++ b/blockchain/event_matcher.go
@@ -180,6 +180,7 @@ func (e *EventMatcher) AppendBlockEvents(
 				matchedEventsSofar = append(matchedEventsSofar, FilteredEvent{
 					BlockNumber:     blockNumber,
 					BlockHash:       header.Hash,
+					BlockParentHash: header.ParentHash,
 					TransactionHash: receipt.TransactionHash,
 					EventIndex:      i,
 					Event:           event,

--- a/rpc/v9/subscriptions.go
+++ b/rpc/v9/subscriptions.go
@@ -457,8 +457,12 @@ func sendEvents(
 			switch {
 			case event.BlockNumber == nil: // pending block
 				finalityStatus = TxnAcceptedOnL2
-			case *event.BlockNumber > height: // pre_confirmed block
-				finalityStatus = TxnPreConfirmed
+			case *event.BlockNumber > height: // pre_confirmed or pre_latest block
+				if event.BlockParentHash == nil {
+					finalityStatus = TxnPreConfirmed
+				} else {
+					finalityStatus = TxnAcceptedOnL2
+				}
 			case *event.BlockNumber <= l1Head:
 				finalityStatus = TxnAcceptedOnL1
 			default: // Canonical block not finalised on L1


### PR DESCRIPTION
`FilteredEvent` currently includes block hash and number which we use to determine event finality status in rpcv9 subscription. However, this limited block context isnt enough to distinguish between pre_latest and pre_confirmed events.

This PR adds the block parent hash to `FilteredEvent`. If the parent hash is non-nil, it indicates the event belongs to a pre_latest block.