### PR TITLE
refactor: move subscription cache to rpccore

### DIFF
--- a/rpc/rpccore/subscription_cache.go
+++ b/rpc/rpccore/subscription_cache.go
@@ -1,4 +1,4 @@
-package rpcv9
+package rpccore
 
 import "sync"
 

--- a/rpc/rpccore/subscription_cache_test.go
+++ b/rpc/rpccore/subscription_cache_test.go
@@ -1,9 +1,9 @@
-package rpcv9_test
+package rpccore_test
 
 import (
 	"testing"
 
-	rpcv9 "github.com/NethermindEth/juno/rpc/v9"
+	"github.com/NethermindEth/juno/rpc/rpccore"
 	"github.com/stretchr/testify/require"
 )
 
@@ -16,7 +16,7 @@ func TestSubscriptionCache_BasicOperations(t *testing.T) {
 	val3 := 3
 	t.Run("block zero", func(t *testing.T) {
 		t.Run("should handle basic operations with block zero", func(t *testing.T) {
-			cache := rpcv9.NewSubscriptionCache[string, int]()
+			cache := rpccore.NewSubscriptionCache[string, int]()
 
 			// Test with block 0
 			cache.Put(0, &key1, &val1)
@@ -25,7 +25,7 @@ func TestSubscriptionCache_BasicOperations(t *testing.T) {
 		})
 
 		t.Run("should prefer empty slots over eviction", func(t *testing.T) {
-			cache := rpcv9.NewSubscriptionCache[string, int]()
+			cache := rpccore.NewSubscriptionCache[string, int]()
 
 			cache.Put(0, &key1, &val1)
 			cache.Put(1, &key1, &val2) // Should use empty slot, not evict block 0
@@ -34,7 +34,7 @@ func TestSubscriptionCache_BasicOperations(t *testing.T) {
 	})
 
 	t.Run("block non-zero", func(t *testing.T) {
-		cache := rpcv9.NewSubscriptionCache[string, int]()
+		cache := rpccore.NewSubscriptionCache[string, int]()
 
 		require.True(t, cache.ShouldSend(100, &key1, &val1))
 
@@ -48,7 +48,7 @@ func TestSubscriptionCache_BasicOperations(t *testing.T) {
 	})
 
 	t.Run("should update existing value", func(t *testing.T) {
-		cache := rpcv9.NewSubscriptionCache[string, int]()
+		cache := rpccore.NewSubscriptionCache[string, int]()
 
 		cache.Put(100, &key1, &val1)
 		cache.Put(100, &key1, &val2)
@@ -68,7 +68,7 @@ func TestSubscriptionCache_Eviction(t *testing.T) {
 	val3 := 3
 	val4 := 4
 	t.Run("should evict lowest block number", func(t *testing.T) {
-		cache := rpcv9.NewSubscriptionCache[string, int]()
+		cache := rpccore.NewSubscriptionCache[string, int]()
 
 		// Fill cache to capacity
 		cache.Put(100, &key1, &val1)
@@ -89,7 +89,7 @@ func TestSubscriptionCache_Eviction(t *testing.T) {
 	})
 
 	t.Run("should not leak keys across eviction", func(t *testing.T) {
-		cache := rpcv9.NewSubscriptionCache[string, int]()
+		cache := rpccore.NewSubscriptionCache[string, int]()
 
 		keyLeak := "leak"
 		val42 := 42
@@ -105,7 +105,7 @@ func TestSubscriptionCache_Eviction(t *testing.T) {
 }
 
 func TestSubscriptionCache_ClearResetsAllData(t *testing.T) {
-	cache := rpcv9.NewSubscriptionCache[string, int]()
+	cache := rpccore.NewSubscriptionCache[string, int]()
 	key := "k"
 	val := 1
 
@@ -118,7 +118,7 @@ func TestSubscriptionCache_ClearResetsAllData(t *testing.T) {
 }
 
 func BenchmarkSubscriptionCache_Put(b *testing.B) {
-	cache := rpcv9.NewSubscriptionCache[string, int]()
+	cache := rpccore.NewSubscriptionCache[string, int]()
 
 	key := "key"
 	b.ResetTimer()
@@ -128,7 +128,7 @@ func BenchmarkSubscriptionCache_Put(b *testing.B) {
 }
 
 func BenchmarkSubscriptionCache_ShouldSend(b *testing.B) {
-	cache := rpcv9.NewSubscriptionCache[string, int]()
+	cache := rpccore.NewSubscriptionCache[string, int]()
 
 	key := "key"
 	// Pre-populate cache
@@ -143,7 +143,7 @@ func BenchmarkSubscriptionCache_ShouldSend(b *testing.B) {
 }
 
 func BenchmarkSubscriptionCache_MixedOperations(b *testing.B) {
-	cache := rpcv9.NewSubscriptionCache[string, int]()
+	cache := rpccore.NewSubscriptionCache[string, int]()
 	key := "k"
 	for i := range 3 {
 		cache.Put(uint64(i), &key, &i)

--- a/rpc/v9/subscriptions.go
+++ b/rpc/v9/subscriptions.go
@@ -236,7 +236,7 @@ func (h *Handler) SubscribeEvents(
 	}
 
 	l1HeadNumber := l1Head.BlockNumber
-	sentCache := NewSubscriptionCache[SentEvent, TxnFinalityStatus]()
+	sentCache := rpccore.NewSubscriptionCache[SentEvent, TxnFinalityStatus]()
 	eventMatcher := blockchain.NewEventMatcher(fromAddr, keys)
 	subscriber := subscriber{
 		onStart: func(ctx context.Context, id string, _ *subscription, _ any) error {
@@ -334,7 +334,7 @@ func (h *Handler) processHistoricalEvents(
 	from, to *BlockID,
 	fromAddr *felt.Felt,
 	keys [][]felt.Felt,
-	sentCache *SubscriptionCache[SentEvent, TxnFinalityStatus],
+	sentCache *rpccore.SubscriptionCache[SentEvent, TxnFinalityStatus],
 	height uint64,
 	l1Head uint64,
 ) error {
@@ -382,7 +382,7 @@ func processBlockEvents(
 	block *core.Block,
 	fromAddr *felt.Felt,
 	eventMatcher *blockchain.EventMatcher,
-	sentCache *SubscriptionCache[SentEvent, TxnFinalityStatus],
+	sentCache *rpccore.SubscriptionCache[SentEvent, TxnFinalityStatus],
 	finalityStatus TxnFinalityStatus,
 	isPreLatest bool,
 ) error {
@@ -443,7 +443,7 @@ func sendEvents(
 	ctx context.Context,
 	w jsonrpc.Conn,
 	events []blockchain.FilteredEvent,
-	sentCache *SubscriptionCache[SentEvent, TxnFinalityStatus],
+	sentCache *rpccore.SubscriptionCache[SentEvent, TxnFinalityStatus],
 	id string,
 	height uint64,
 	l1Head uint64,
@@ -488,7 +488,7 @@ func sendEvents(
 func sendEventWithoutDuplicate(
 	w jsonrpc.Conn,
 	event *blockchain.FilteredEvent,
-	sentCache *SubscriptionCache[SentEvent, TxnFinalityStatus],
+	sentCache *rpccore.SubscriptionCache[SentEvent, TxnFinalityStatus],
 	id string,
 	finalityStatus TxnFinalityStatus,
 	blockNum *uint64,
@@ -854,7 +854,7 @@ func (h *Handler) SubscribeNewTransactionReceipts(
 		finalityStatuses = utils.Set(finalityStatuses)
 	}
 
-	sentCache := NewSubscriptionCache[SentReceipt, TxnFinalityStatusWithoutL1]()
+	sentCache := rpccore.NewSubscriptionCache[SentReceipt, TxnFinalityStatusWithoutL1]()
 
 	subscriber := subscriber{
 		onNewHead: func(ctx context.Context, id string, _ *subscription, head *core.Block) error {
@@ -941,7 +941,7 @@ func processBlockReceipts(
 	w jsonrpc.Conn,
 	senderAddress []felt.Felt,
 	block *core.Block,
-	sentCache *SubscriptionCache[SentReceipt, TxnFinalityStatusWithoutL1],
+	sentCache *rpccore.SubscriptionCache[SentReceipt, TxnFinalityStatusWithoutL1],
 	finalityStatus TxnFinalityStatusWithoutL1,
 	isPreLatest bool,
 ) error {
@@ -1047,7 +1047,7 @@ func (h *Handler) SubscribeNewTransactions(
 		finalityStatus = utils.Set(finalityStatus)
 	}
 
-	sentCache := NewSubscriptionCache[felt.TransactionHash, TxnStatusWithoutL1]()
+	sentCache := rpccore.NewSubscriptionCache[felt.TransactionHash, TxnStatusWithoutL1]()
 	subscriber := subscriber{
 		onReorg: func(ctx context.Context, id string, _ *subscription, reorg *sync.ReorgBlockRange) error {
 			sentCache.Clear()
@@ -1133,7 +1133,7 @@ func processBlockTransactions(
 	w jsonrpc.Conn,
 	senderAddr []felt.Felt,
 	b *core.Block,
-	sentCache *SubscriptionCache[felt.TransactionHash, TxnStatusWithoutL1],
+	sentCache *rpccore.SubscriptionCache[felt.TransactionHash, TxnStatusWithoutL1],
 	status TxnStatusWithoutL1,
 ) error {
 	for _, txn := range b.Transactions {
@@ -1161,7 +1161,7 @@ func processCandidateTransactions(
 	w jsonrpc.Conn,
 	senderAddr []felt.Felt,
 	preConfirmed core.PendingData,
-	sentCache *SubscriptionCache[felt.TransactionHash, TxnStatusWithoutL1],
+	sentCache *rpccore.SubscriptionCache[felt.TransactionHash, TxnStatusWithoutL1],
 ) error {
 	for _, txn := range preConfirmed.GetCandidateTransaction() {
 		if !filterTxBySender(txn, senderAddr) {
@@ -1186,7 +1186,7 @@ func processCandidateTransactions(
 // and sends the transaction if it hasn't been sent before with the same finality status
 func sendTransactionWithoutDuplicate(
 	w jsonrpc.Conn,
-	sentCache *SubscriptionCache[felt.TransactionHash, TxnStatusWithoutL1],
+	sentCache *rpccore.SubscriptionCache[felt.TransactionHash, TxnStatusWithoutL1],
 	blockNumber uint64,
 	txn core.Transaction,
 	finalityStatus TxnStatusWithoutL1,


### PR DESCRIPTION
Moves subscription cache to rpccore to be able to reuse in rpcv10. This cache is not meant to be used by RPC versions less than 9