### PR TITLE
fix: use ETH/wei fields in ProposalBlockInfo for L1 gas and L1 data gas

### DIFF
--- a/consensus/p2p/proposer/proposer_adapter.go
+++ b/consensus/p2p/proposer/proposer_adapter.go
@@ -40,8 +40,8 @@ func (a *starknetProposerAdapter) ProposalBlockInfo(buildResult *builder.BuildRe
 		Builder:           *buildResult.Preconfirmed.Block.SequencerAddress,
 		Timestamp:         buildResult.Preconfirmed.Block.Timestamp,
 		L2GasPriceFRI:     *buildResult.Preconfirmed.Block.L2GasPrice.PriceInFri,
-		L1GasPriceWEI:     *buildResult.Preconfirmed.Block.L1GasPriceSTRK,
-		L1DataGasPriceWEI: *buildResult.Preconfirmed.Block.L1DataGasPrice.PriceInFri,
+		L1GasPriceWEI:     *buildResult.Preconfirmed.Block.L1GasPriceETH,
+		L1DataGasPriceWEI: *buildResult.Preconfirmed.Block.L1DataGasPrice.PriceInWei,
 		EthToStrkRate:     felt.One, // TODO: Double check if this is used
 		L1DAMode:          buildResult.Preconfirmed.Block.L1DAMode,
 	}, nil


### PR DESCRIPTION
Problem: ProposalBlockInfo() populated L1GasPriceWEI from Header.L1GasPriceSTRK and L1DataGasPriceWEI from Header.L1DataGasPrice.PriceInFri, mixing fri/STRK fields into wei fields.
Fix: Use Header.L1GasPriceETH for L1GasPriceWEI and Header.L1DataGasPrice.PriceInWei for L1DataGasPriceWEI, aligning with the rest of the codebase (P2P adapters and builder) which expects wei for L1 fields.