### PR TITLE
update(feeder): reduce wait times in Feeder client

### DIFF
--- a/clients/feeder/feeder.go
+++ b/clients/feeder/feeder.go
@@ -100,8 +100,8 @@ func NewClient(clientURL string) *Client {
 		client:     http.DefaultClient,
 		backoff:    ExponentialBackoff,
 		maxRetries: 10, // ~40 secs with default backoff and maxWait (block time on mainnet is 20 seconds on average)
-		maxWait:    4 * time.Second,
-		minWait:    time.Second,
+		maxWait:    2 * time.Second,
+		minWait:    500 * time.Millisecond,
 		log:        utils.NewNopZapLogger(),
 		listener:   &SelectiveListener{},
 	}


### PR DESCRIPTION
Current feeder's min/max wait times are suboptimal for pre_confirmed polling (default to 0.5 s) as currently, we are polling every 1-4 sec (depending on possible failure responses from the gateway). 

The solution is quite simple, we would want to poll for `pre_confirmed` as often as possible, but not hit rate limiting from the feeder gateway. 

In practice, it's a bit complicated, as:
- we query `get_state_update?blockNumber=$ID&includeBlock=true` every 0.5 sec (by default) to get the next `pre_confirmed` block,  and if it's not ready yet, we'd get a 400 response, which then would be retried after some wait (exponential backoff) 
- Feeder client has a `retry` mechanism, which will retry up to 10 times before giving up. 
- minWait/maxWait and backoff mechanism are the same for both syncing (from behind) and for following the chain.


So in the best case, we'll get a new state every 0.5s, and in the worst case, 4s. 

Reducing the `minWait` time will slow down the backoff wait growth, while reducing `maxWait` will reduce overall delay between the new state becoming available in the feeder and us getting it.  

**Some test results:**

`minWait = 1s` / `maxWait = 2s`
- synced_block: same=91% juno=1% pf=8%
- pre_confirmed: same=93% juno=2% pf=5%

`minWait = 0.5s` / `maxWait = 2s`
- synced_block: same=91% juno=1% pf=9%
- pre_confirmed: same=93% juno=2% pf=5%

`minWait = 0.2s` / `maxWait = 2s`
- synced_block: same=98% juno=1% pf=1%
- pre_confirmed: same=98% juno=1% pf=1%