### PR TITLE
chore: Fix linter

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -77,13 +77,6 @@ linters:
     govet:
       enable:
         - nilness
-      settings:
-        printf:
-          funcs:
-            - (github.com/golangci/golangci-lint/pkg/logutils.Log).Infof
-            - (github.com/golangci/golangci-lint/pkg/logutils.Log).Warnf
-            - (github.com/golangci/golangci-lint/pkg/logutils.Log).Errorf
-            - (github.com/golangci/golangci-lint/pkg/logutils.Log).Fatalf
     lll:
       line-length: 140 # todo(rdr): change this to 100
     misspell:
@@ -104,8 +97,6 @@ linters:
         - "16"
         - "24"
         - "32"
-      ignored-functions:
-        - strings.SplitN
     nolintlint:
       allow-unused: false
       require-explanation: false # todo(rdr): this should be switched to true for non test files
@@ -141,45 +132,11 @@ linters:
       - linters:
           - lll
         source: '^//go:generate '
-      - path: pkg/golinters/errcheck.go
-        text: 'SA1019: errCfg.Exclude is deprecated: use ExcludeFunctions instead'
-      - path: pkg/commands/run.go
-        text: 'SA1019: lsc.Errcheck.Exclude is deprecated: use ExcludeFunctions instead'
-      - path: pkg/commands/run.go
-        text: 'SA1019: e.cfg.Run.Deadline is deprecated: Deadline exists for historical compatibility and should not be used.'
-      - path: pkg/golinters/gofumpt.go
-        text: 'SA1019: settings.LangVersion is deprecated: use the global `run.go` instead.'
-      - path: pkg/golinters/staticcheck_common.go
-        text: 'SA1019: settings.GoVersion is deprecated: use the global `run.go` instead.'
-      - path: pkg/lint/lintersdb/manager.go
-        text: 'SA1019: (.+).(GoVersion|LangVersion) is deprecated: use the global `run.go` instead.'
-      - path: pkg/golinters/unused.go
-        text: 'rangeValCopy: each iteration copies 160 bytes \(consider pointers or indexing\)'
-    paths:
-      - test/testdata_etc
-      - internal/cache
-      - internal/renameio
-      - internal/robustio
-      - third_party$
-      - builtin$
-      - examples$
 formatters:
   enable:
     - gci
     - gofumpt
-  settings:
-    goimports:
-      local-prefixes:
-        - github.com/golangci/golangci-lint
   exclusions:
     generated: lax
-    paths:
-      - test/testdata_etc
-      - internal/cache
-      - internal/renameio
-      - internal/robustio
-      - third_party$
-      - builtin$
-      - examples$
 run:
   timeout: 10m

--- a/rpc/v10/simulation_test.go
+++ b/rpc/v10/simulation_test.go
@@ -143,7 +143,7 @@ func TestSimulateTransactions(t *testing.T) {
 			},
 			simulationFlags: []rpcv6.SimulationFlag{rpcv6.SkipValidateFlag},
 			err: rpccore.ErrInternal.CloneWithData(errors.New(
-				"inconsistent lengths: 1 overall fees, 1 traces, 1 gas consumed, 2 data availability, 0 txns", //nolint:lll // test data
+				"inconsistent lengths: 1 overall fees, 1 traces, 1 gas consumed, 2 data availability, 0 txns",
 			)),
 		},
 	}

--- a/rpc/v10/subscriptions.go
+++ b/rpc/v10/subscriptions.go
@@ -160,9 +160,9 @@ type SentEvent struct {
 // new Starknet events with applied filters
 //
 // It follows the specification defined here:
-// https://github.com/starkware-libs/starknet-specs/blob/c2e93098b9c2ca0423b7f4d15b201f52f22d8c36/api/starknet_ws_api.json#L59 //nolint:lll
+// https://github.com/starkware-libs/starknet-specs/blob/c2e93098b9c2ca0423b7f4d15b201f52f22d8c36/api/starknet_ws_api.json#L59
 //
-//nolint:lll,funlen // URL exceeds line limit but should remain intact for reference
+//nolint:funlen // URL exceeds line limit but should remain intact for reference
 func (h *Handler) SubscribeEvents(
 	ctx context.Context,
 	fromAddr *felt.Felt,
@@ -511,8 +511,6 @@ func sendEventWithoutDuplicate(
 //
 // It follows the specification defined here:
 // https://github.com/starkware-libs/starknet-specs/blob/c2e93098b9c2ca0423b7f4d15b201f52f22d8c36/api/starknet_ws_api.json#L151
-//
-//nolint:lll // URL exceeds line limit but should remain intact for reference
 func (h *Handler) SubscribeTransactionStatus(
 	ctx context.Context,
 	txHash *felt.Felt,
@@ -683,9 +681,7 @@ func (h *Handler) checkTxStatus(
 // a new block header is added.
 //
 // It follows the specification defined here:
-// https://github.com/starkware-libs/starknet-specs/blob/c2e93098b9c2ca0423b7f4d15b201f52f22d8c36/api/starknet_ws_api.json#L10 //nolint:lll
-//
-//nolint:lll // URL exceeds line limit but should remain intact for reference
+// https://github.com/starkware-libs/starknet-specs/blob/c2e93098b9c2ca0423b7f4d15b201f52f22d8c36/api/starknet_ws_api.json#L10
 func (h *Handler) SubscribeNewHeads(
 	ctx context.Context,
 	blockID *rpcv9.SubscriptionBlockID,
@@ -848,9 +844,7 @@ func (h *Handler) Unsubscribe(ctx context.Context, id string) (bool, *jsonrpc.Er
 // or not at all.
 //
 // It follows the specification defined here:
-// https://github.com/starkware-libs/starknet-specs/blob/4e98e3684b50ee9e63b7eeea9412b6a2ed7494ec/api/starknet_ws_api.json#L186 //nolint:lll
-//
-//nolint:lll // URL exceeds line limit but should remain intact for reference
+// https://github.com/starkware-libs/starknet-specs/blob/4e98e3684b50ee9e63b7eeea9412b6a2ed7494ec/api/starknet_ws_api.json#L186
 func (h *Handler) SubscribeNewTransactionReceipts(
 	ctx context.Context,
 	senderAddress []felt.Felt,
@@ -1016,9 +1010,7 @@ func processBlockReceipts(
 // or not at all.
 //
 // It follows the specification defined here:
-// https://github.com/starkware-libs/starknet-specs/blob/4e98e3684b50ee9e63b7eeea9412b6a2ed7494ec/api/starknet_ws_api.json#L257 //nolint:lll
-//
-//nolint:lll // URL exceeds line limit but should remain intact for reference
+// https://github.com/starkware-libs/starknet-specs/blob/4e98e3684b50ee9e63b7eeea9412b6a2ed7494ec/api/starknet_ws_api.json#L257
 func (h *Handler) SubscribeNewTransactions(
 	ctx context.Context,
 	finalityStatus []rpcv9.TxnStatusWithoutL1,

--- a/rpc/v10/subscriptions_test.go
+++ b/rpc/v10/subscriptions_test.go
@@ -1385,12 +1385,12 @@ func TestSubscribeNewHeadsHistorical(t *testing.T) {
 	id := "1"
 	handler.WithIDGen(func() string { return id })
 
-	subMsg := `{"jsonrpc":"2.0","id":"1","method":"starknet_subscribeNewHeads", "params":{"block_id":{"block_number":0}}}` //nolint:lll // test data
+	subMsg := `{"jsonrpc":"2.0","id":"1","method":"starknet_subscribeNewHeads", "params":{"block_id":{"block_number":0}}}`
 	got := sendWsMessage(t, ctx, conn, subMsg)
 	require.Equal(t, subResp(id), got)
 
 	// Check block 0 content
-	want := `{"jsonrpc":"2.0","method":"starknet_subscriptionNewHeads","params":{"result":{"block_hash":"0x47c3637b57c2b079b93c61539950c17e868a28f46cdef28f88521067f21e943","parent_hash":"0x0","block_number":0,"new_root":"0x21870ba80540e7831fb21c591ee93481f5ae1bb71ff85a86ddd465be4eddee6","timestamp":1637069048,"sequencer_address":"0x0","l1_gas_price":{"price_in_fri":"0x0","price_in_wei":"0x0"},"l1_data_gas_price":{"price_in_fri":"0x0","price_in_wei":"0x0"},"l1_da_mode":"CALLDATA","starknet_version":"","l2_gas_price":{"price_in_fri":"0x0","price_in_wei":"0x0"}},"subscription_id":"%s"}}` //nolint:lll // test data
+	want := `{"jsonrpc":"2.0","method":"starknet_subscriptionNewHeads","params":{"result":{"block_hash":"0x47c3637b57c2b079b93c61539950c17e868a28f46cdef28f88521067f21e943","parent_hash":"0x0","block_number":0,"new_root":"0x21870ba80540e7831fb21c591ee93481f5ae1bb71ff85a86ddd465be4eddee6","timestamp":1637069048,"sequencer_address":"0x0","l1_gas_price":{"price_in_fri":"0x0","price_in_wei":"0x0"},"l1_data_gas_price":{"price_in_fri":"0x0","price_in_wei":"0x0"},"l1_da_mode":"CALLDATA","starknet_version":"","l2_gas_price":{"price_in_fri":"0x0","price_in_wei":"0x0"}},"subscription_id":"%s"}}`
 	want = fmt.Sprintf(want, id)
 	_, block0Got, err := conn.Read(ctx)
 	require.NoError(t, err)
@@ -1568,7 +1568,7 @@ func TestSubscriptionReorg(t *testing.T) {
 			})
 
 			// Receive reorg event
-			expectedRes := `{"jsonrpc":"2.0","method":"starknet_subscriptionReorg","params":{"result":{"starting_block_hash":"0x4e1f77f39545afe866ac151ac908bd1a347a2a8a7d58bef1276db4f06fdf2f6","starting_block_number":0,"ending_block_hash":"0x34e815552e42c5eb5233b99de2d3d7fd396e575df2719bf98e7ed2794494f86","ending_block_number":2},"subscription_id":"%s"}}` //nolint:lll // test data
+			expectedRes := `{"jsonrpc":"2.0","method":"starknet_subscriptionReorg","params":{"result":{"starting_block_hash":"0x4e1f77f39545afe866ac151ac908bd1a347a2a8a7d58bef1276db4f06fdf2f6","starting_block_number":0,"ending_block_hash":"0x34e815552e42c5eb5233b99de2d3d7fd396e575df2719bf98e7ed2794494f86","ending_block_number":2},"subscription_id":"%s"}}`
 			want := fmt.Sprintf(expectedRes, id)
 			_, reorgGot, err := conn.Read(ctx)
 			require.NoError(t, err)
@@ -2860,7 +2860,7 @@ func testHeadBlock(t *testing.T) *core.Block {
 }
 
 func newHeadsResponse(id string) string {
-	return fmt.Sprintf(`{"jsonrpc":"2.0","method":"starknet_subscriptionNewHeads","params":{"result":{"block_hash":"0x609e8ffabfdca05b5a2e7c1bd99fc95a757e7b4ef9186aeb1f301f3741458ce","parent_hash":"0x5d5e7c03c7ef4419c0847d7ae1d1079b6f91fa952ebdb20b74ca2e621017f02","block_number":56377,"new_root":"0x2a899e1200baa9b843cbfb65d63f4f746cec27f8edb42f8446ae349b532f8b3","timestamp":1712213818,"sequencer_address":"0x1176a1bd84444c89232ec27754698e5d2e7e1a7f1539f12027f28b23ec9f3d8","l1_gas_price":{"price_in_fri":"0x1d1a94a20000","price_in_wei":"0x4a817c800"},"l1_data_gas_price":{"price_in_fri":"0x2dfb78bf913d","price_in_wei":"0x6b85dda55"},"l1_da_mode":"BLOB","starknet_version":"0.13.1","l2_gas_price":{"price_in_fri":"0x0","price_in_wei":"0x0"}},"subscription_id":%q}}`, id) //nolint:lll // test data
+	return fmt.Sprintf(`{"jsonrpc":"2.0","method":"starknet_subscriptionNewHeads","params":{"result":{"block_hash":"0x609e8ffabfdca05b5a2e7c1bd99fc95a757e7b4ef9186aeb1f301f3741458ce","parent_hash":"0x5d5e7c03c7ef4419c0847d7ae1d1079b6f91fa952ebdb20b74ca2e621017f02","block_number":56377,"new_root":"0x2a899e1200baa9b843cbfb65d63f4f746cec27f8edb42f8446ae349b532f8b3","timestamp":1712213818,"sequencer_address":"0x1176a1bd84444c89232ec27754698e5d2e7e1a7f1539f12027f28b23ec9f3d8","l1_gas_price":{"price_in_fri":"0x1d1a94a20000","price_in_wei":"0x4a817c800"},"l1_data_gas_price":{"price_in_fri":"0x2dfb78bf913d","price_in_wei":"0x6b85dda55"},"l1_da_mode":"BLOB","starknet_version":"0.13.1","l2_gas_price":{"price_in_fri":"0x0","price_in_wei":"0x0"}},"subscription_id":%q}}`, id)
 }
 
 // setupRPC creates a RPC handler that runs in a goroutine and


### PR DESCRIPTION
`.golangci.yaml` is enforcing line length 140 while `.golangci_diff.yaml` is enforcing line length 100.

We have a line (containing an URL) with length 120, so:
- Not adding `nolint` will be complained by `.golangci_diff.yaml`
- Adding `nolint` will be complained by `.golangci.yaml`

The temporary workaround is to get this forced merged to `main`, because `.golangci.yaml` always checks while `.golangci_diff.yaml` only checks PR changes.