### PR TITLE
fix: CI skip declare test cases with old casm hash

### DIFF
--- a/.github/workflows/starknet-rs-tests.yml
+++ b/.github/workflows/starknet-rs-tests.yml
@@ -26,7 +26,9 @@ jobs:
       - name: Run jsonrpc tests
         run: |
           cd starknet-providers && cargo test jsonrpc -- --skip jsonrpc_get_block_with_receipts
-          cd ../starknet-accounts && cargo test jsonrpc -- \
+          cd ../starknet-accounts
+          # TODO: Once SDK is updated, remove ignore for declare tests
+          cargo test jsonrpc -- \
             --skip can_declare_cairo0_contract_with_jsonrpc \
             --skip can_estimate_declare_v3_fee_with_jsonrpc \
             --skip can_declare_cairo1_contract_v3_with_jsonrpc


### PR DESCRIPTION
Since sepolia upgraded to v0.14.1, rpc test cases that are declaring transactions with poseidon class hash will constantly fails. This PR skips them, however, they would be useful again when starknet.rs releases version which uses blake2s hash for declared classes