### PR TITLE
fix: Unwind Rust panic on FFI boundary

### DIFF
--- a/vm/rust/src/entrypoint/call/call.rs
+++ b/vm/rust/src/entrypoint/call/call.rs
@@ -13,7 +13,6 @@ use blockifier::{
     transaction::objects::{DeprecatedTransactionInfo, TransactionInfo},
 };
 use once_cell::sync::Lazy;
-use serde_json::json;
 use starknet_api::{
     contract_class::EntryPointType,
     core::{ClassHash, ContractAddress},
@@ -129,12 +128,11 @@ pub fn cairo_vm_call(
             );
             match e {
                 CallError::ContractError(revert_error, error_stack) => {
-                    let err_string = if structured_err_stack {
-                        error_stack_frames_to_json(error_stack).to_string()
+                    if structured_err_stack {
+                        JunoError::json_error(error_stack_frames_to_json(error_stack), None)
                     } else {
-                        json!(revert_error).to_string()
-                    };
-                    JunoError::block_error(err_string)
+                        JunoError::block_error(revert_error)
+                    }
                 }
                 CallError::Internal(e) | CallError::Custom(e) => JunoError::block_error(e),
             }

--- a/vm/rust/src/entrypoint/execute/execute.rs
+++ b/vm/rust/src/entrypoint/execute/execute.rs
@@ -18,7 +18,6 @@ use crate::{
     state_reader::{state_reader::BlockHeight, JunoStateReader},
 };
 use serde::Deserialize;
-use serde_json::json;
 use std::{
     collections::VecDeque,
     ffi::{c_char, c_uchar},
@@ -138,15 +137,14 @@ pub fn cairo_vm_execute(
         )
         .map_err(|e| match e {
             ExecutionError::ExecutionError { error, error_stack } => {
-                let err_string = if err_stack {
-                    error_stack_frames_to_json(error_stack).to_string()
+                if err_stack {
+                    JunoError::json_error(error_stack_frames_to_json(error_stack), Some(txn_index))
                 } else {
-                    json!(error).to_string()
-                };
-                JunoError::tx_non_execution_error(err_string, txn_index)
+                    JunoError::tx_non_execution_error(error, txn_index)
+                }
             }
             ExecutionError::Internal(e) | ExecutionError::Custom(e) => {
-                JunoError::tx_non_execution_error(json!(e), txn_index)
+                JunoError::tx_non_execution_error(e, txn_index)
             }
         })?;
 

--- a/vm/rust/src/error/juno.rs
+++ b/vm/rust/src/error/juno.rs
@@ -1,3 +1,5 @@
+use serde_json::{json, Value};
+
 pub struct JunoError {
     pub msg: String,
     pub txn_index: i64,
@@ -5,9 +7,17 @@ pub struct JunoError {
 }
 
 impl JunoError {
-    pub fn block_error<E: ToString>(err: E) -> Self {
+    pub fn json_error(err: Value, txn_index: Option<usize>) -> Self {
         Self {
             msg: err.to_string(),
+            txn_index: txn_index.map(|idx| idx as i64).unwrap_or(-1),
+            execution_failed: false,
+        }
+    }
+
+    pub fn block_error<E: ToString>(err: E) -> Self {
+        Self {
+            msg: json!(err.to_string()).to_string(),
             txn_index: -1,
             execution_failed: false,
         }
@@ -15,7 +25,7 @@ impl JunoError {
 
     pub fn tx_non_execution_error<E: ToString>(err: E, txn_index: usize) -> Self {
         Self {
-            msg: err.to_string(),
+            msg: json!(err.to_string()).to_string(),
             txn_index: txn_index as i64,
             execution_failed: false,
         }


### PR DESCRIPTION
According to [Rustonomicon](https://doc.rust-lang.org/nomicon/unwinding.html):
> Rust's unwinding strategy is not specified to be fundamentally compatible with any other language's unwinding. As such, unwinding into Rust from another language, or unwinding into another language from Rust is Undefined Behavior. You must absolutely catch any panics at the FFI boundary! What you do at that point is up to you, but something must be done. If you fail to do this, at best, your application will crash and burn. At worst, your application won't crash and burn, and will proceed with completely clobbered state.

This PR does 2 things:
- `panic::catch_unwind` in the top-level function at FFI boundary.
- The current error handling behaviour on the Go side requires the error to be a JSON, so any string error must be wrap by double quotes.