### PR TITLE
chore(ci): Disable deploy-test workflow when label is present

### DIFF
--- a/.github/workflows/deploy-dev-and-test.yml
+++ b/.github/workflows/deploy-dev-and-test.yml
@@ -16,7 +16,7 @@ permissions:
 
 jobs:
   build:
-    # Skip for PRs from forks as they don't have access to secrets. Also skip for non-fork PRs with `disable-deploy-test` label
+    # Skip for PRs from forks as they don't have access to secrets. Also skip for non-fork PRs with "disable-deploy-test" label
     if: github.event_name != 'pull_request' || (!github.event.pull_request.head.repo.fork && !contains(github.event.pull_request.labels.*.name, 'disable-deploy-test'))
     permissions:
       actions: write


### PR DESCRIPTION
from https://github.com/orgs/community/discussions/39062:
> github.event.pull_request.labels contains the labels at the time the pull_request event was triggered. Modifications made during the workflow won't show up there.

which means that simply re-running the workflow manually won't make it run. to make it work, one need to push a commit or trigger it manually, which seems like ok-ish