### PR TITLE
rpcv10: fee estimations and simulations uses default value as 1 for L…

### DIFF
--- a/rpc/v10/simulation.go
+++ b/rpc/v10/simulation.go
@@ -213,10 +213,10 @@ func createSimulatedTransactions(
 
 	l1GasPriceWei := header.L1GasPriceETH
 	l1GasPriceStrk := header.L1GasPriceSTRK
-	l2GasPriceWei := &felt.Zero
-	l2GasPriceStrk := &felt.Zero
-	l1DataGasPriceWei := &felt.Zero
-	l1DataGasPriceStrk := &felt.Zero
+	l2GasPriceWei := &felt.One
+	l2GasPriceStrk := &felt.One
+	l1DataGasPriceWei := &felt.One
+	l1DataGasPriceStrk := &felt.One
 
 	if gasPrice := header.L2GasPrice; gasPrice != nil {
 		l2GasPriceWei = gasPrice.PriceInWei


### PR DESCRIPTION
**Problem**: Juno is returning `L2GasPrice` as `0x0` for older blocks where `L2GasPrice` is not a thing, similar for `L1DataGasPrice`, default for `L1Gas` remains `0x0`.

See this FGW query: https://feeder.alpha-mainnet.starknet.io/feeder_gateway/get_block?blockNumber=500

FGW returns those fields as `0x1`. Node re-synced with new behaviour of FGW, should already be returning `0x1`. This only changes these values for older blocks and should not affect estimations & simulation on up to date blocks. 