### PR TITLE
WIP: Test passed because memory DB doesn't behave similar to pebble DB

### DIFF
--- a/core/trie/trie_test.go
+++ b/core/trie/trie_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/NethermindEth/juno/core/trie"
 	"github.com/NethermindEth/juno/db"
 	"github.com/NethermindEth/juno/db/memory"
+	"github.com/NethermindEth/juno/db/pebblev2"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -442,8 +443,10 @@ func BenchmarkTriePut(b *testing.B) {
 // can handle concurrent reads when updateChildTriesConcurrently
 // is called.
 func TestTrie_Hash_ConcurrentReadsWithinHash(t *testing.T) {
-	memDB := memory.New()
-	txn := memDB.NewIndexedBatch()
+	db, err := pebblev2.New(t.TempDir())
+	require.NoError(t, err)
+
+	txn := db.NewIndexedBatch()
 	prefix := []byte("test")
 
 	trieInstance, err := trie.NewTriePedersen(txn, prefix, 8)


### PR DESCRIPTION
This test is currently using memory DB. Inside the test, we call `(*batch).Write()` before calling `(*Trie).Hash()`. The problem is that memory DB allows write after batch write, while pebble will panic:
```
panic: pebble: batch already committing [recovered, repanicked]
```

This means that the behaviour here works because memory DB doesn't behave similarly to pebble DB, which in my opinion can cause confusion. I also double checked and can see that we do initialize the trie with pebble DB instead of always using memory DB.

This WIP PR is replacing `memory.New()` by `pebblev2.New()` in order to demostrate the issue.