### PR TITLE
refactor(triedb): add clean cache to the rawDB engine

### DIFF
--- a/core/trie2/triedb/database.go
+++ b/core/trie2/triedb/database.go
@@ -10,6 +10,12 @@ import (
 	"github.com/NethermindEth/juno/db"
 )
 
+const (
+	PathScheme string = "path"
+	HashScheme string = "hash"
+	RawScheme  string = "raw"
+)
+
 type Config struct {
 	PathConfig *pathdb.Config
 	HashConfig *hashdb.Config
@@ -19,13 +25,13 @@ type Config struct {
 func New(disk db.KeyValueStore, config *Config) (database.TrieDB, error) {
 	// Default to raw config if not provided
 	if config == nil {
-		return rawdb.New(disk), nil
+		return rawdb.New(disk, nil), nil
 	} else if config.PathConfig != nil {
 		return pathdb.New(disk, config.PathConfig)
 	} else if config.HashConfig != nil {
 		return hashdb.New(disk, config.HashConfig), nil
 	} else if config.RawConfig != nil {
-		return rawdb.New(disk), nil
+		return rawdb.New(disk, config.RawConfig), nil
 	}
 	return nil, fmt.Errorf("invalid config")
 }

--- a/core/trie2/triedb/rawdb/cache.go
+++ b/core/trie2/triedb/rawdb/cache.go
@@ -1,0 +1,60 @@
+package rawdb
+
+import (
+	"math"
+
+	"github.com/NethermindEth/juno/core/felt"
+	"github.com/NethermindEth/juno/core/trie2/trieutils"
+	"github.com/VictoriaMetrics/fastcache"
+)
+
+const nodeCacheSize = ownerSize + trieutils.PathSize + 1
+
+type trieType byte
+
+const (
+	contract trieType = iota
+	class
+)
+
+// Stores committed trie nodes in memory
+type cleanCache struct {
+	cache *fastcache.Cache // map[nodeKey]node
+}
+
+// Creates a new clean cache with the given size.
+// The size is the maximum size of the cache in bytes.
+func newCleanCache(size uint64) cleanCache {
+	if size > uint64(math.MaxInt) {
+		panic("cache size too large: uint64 to int conversion would overflow")
+	}
+	return cleanCache{
+		cache: fastcache.New(int(size)),
+	}
+}
+
+func (c *cleanCache) putNode(owner *felt.Address, path *trieutils.Path, isClass bool, blob []byte) {
+	c.cache.Set(nodeKey(owner, path, isClass), blob)
+}
+
+func (c *cleanCache) getNode(owner *felt.Address, path *trieutils.Path, isClass bool) []byte {
+	return c.cache.Get(nil, nodeKey(owner, path, isClass))
+}
+
+func (c *cleanCache) deleteNode(owner *felt.Address, path *trieutils.Path, isClass bool) {
+	c.cache.Del(nodeKey(owner, path, isClass))
+}
+
+// key = owner (32 bytes) + path (20 bytes) + trie type (1 byte)
+func nodeKey(owner *felt.Address, path *trieutils.Path, isClass bool) []byte {
+	key := make([]byte, nodeCacheSize)
+	ownerBytes := owner.Bytes()
+	copy(key[:felt.Bytes], ownerBytes[:])
+	copy(key[felt.Bytes:felt.Bytes+trieutils.PathSize], path.EncodedBytes())
+
+	if isClass {
+		key[nodeCacheSize-1] = byte(class)
+	}
+
+	return key
+}

--- a/core/trie2/triedb/rawdb/database_test.go
+++ b/core/trie2/triedb/rawdb/database_test.go
@@ -108,13 +108,13 @@ func verifyNode(
 func TestRawDB(t *testing.T) {
 	t.Run("New creates database", func(t *testing.T) {
 		memDB := memory.New()
-		database := New(memDB)
+		database := New(memDB, nil)
 		require.NotNil(t, database)
 	})
 
 	t.Run("Update with all node types", func(t *testing.T) {
 		memDB := memory.New()
-		database := New(memDB)
+		database := New(memDB, nil)
 
 		contractHash := felt.NewFromUint64[felt.Felt](210)
 		contractPath := trieutils.NewBitArray(1, 0x01)
@@ -171,7 +171,7 @@ func TestRawDB(t *testing.T) {
 
 	t.Run("Update with deleted nodes", func(t *testing.T) {
 		memDB := memory.New()
-		database := New(memDB)
+		database := New(memDB, nil)
 
 		err := database.Update(
 			&felt.StateRootHash{},
@@ -215,7 +215,7 @@ func TestRawDB(t *testing.T) {
 
 	t.Run("NodeReader returns correct reader", func(t *testing.T) {
 		memDB := memory.New()
-		database := New(memDB)
+		database := New(memDB, nil)
 
 		err := database.Update(
 			&felt.StateRootHash{},
@@ -245,7 +245,7 @@ func TestRawDB(t *testing.T) {
 
 	t.Run("Multiple updates", func(t *testing.T) {
 		memDB := memory.New()
-		database := New(memDB)
+		database := New(memDB, nil)
 
 		err := database.Update(
 			&felt.StateRootHash{},
@@ -286,7 +286,7 @@ func TestRawDB(t *testing.T) {
 
 	t.Run("Concurrent reads", func(t *testing.T) {
 		memDB := memory.New()
-		database := New(memDB)
+		database := New(memDB, nil)
 
 		err := database.Update(
 			&felt.StateRootHash{},

--- a/core/trie2/triedb/rawdb/types.go
+++ b/core/trie2/triedb/rawdb/types.go
@@ -11,3 +11,5 @@ type (
 	contractNodesMap        = map[trieutils.Path]trienode.TrieNode
 	contractStorageNodesMap = map[felt.Address]map[trieutils.Path]trienode.TrieNode
 )
+
+const ownerSize = felt.Bytes


### PR DESCRIPTION
This PR introduces a clean cache layer for the rawDB. The state is meant to read from this layer before the direct PebbleDB hit. We write to clean cache on read miss and also when flushing the nodes to the DB.