### PR TITLE
fix: misuse of jsonrpc.Err(...)

### DIFF
--- a/rpc/v8/l1.go
+++ b/rpc/v8/l1.go
@@ -67,7 +67,7 @@ func (h *Handler) GetMessageStatus(ctx context.Context, l1TxnHash *common.Hash) 
 		if err != nil {
 			return nil, jsonrpc.Err(
 				jsonrpc.InternalError,
-				fmt.Sprintf("failed to retrieve L1 handler txn hash. msgHash %s, err %v",
+				fmt.Sprintf("failed to retrieve L1 handler txn hash. msgHash %s, err: %v",
 					msgHash.Hex(),
 					err,
 				),
@@ -106,7 +106,7 @@ func (h *Handler) messageToL2Logs(ctx context.Context, txHash *common.Hash) ([]*
 		if err != nil {
 			return nil, jsonrpc.Err(
 				jsonrpc.InternalError,
-				fmt.Sprintf("failed to unpack log, l1 txn hash %s, logIndex %d err %v",
+				fmt.Sprintf("failed to unpack log, l1 txn hash %s, logIndex %d err: %v",
 					txHash.Hex(),
 					i,
 					err,

--- a/rpc/v9/l1.go
+++ b/rpc/v9/l1.go
@@ -68,7 +68,7 @@ func (h *Handler) GetMessageStatus(ctx context.Context, l1TxnHash *common.Hash) 
 		if err != nil {
 			return nil, jsonrpc.Err(
 				jsonrpc.InternalError,
-				fmt.Sprintf("failed to retrieve L1 handler txn hash. msgHash %s, err %v",
+				fmt.Sprintf("failed to retrieve L1 handler txn hash. msgHash %s, err: %v",
 					msgHash.Hex(),
 					err,
 				),
@@ -115,7 +115,7 @@ func (h *Handler) messageToL2Logs(ctx context.Context, txHash *common.Hash) ([]*
 		if err != nil {
 			return nil, jsonrpc.Err(
 				jsonrpc.InternalError,
-				fmt.Sprintf("failed to unpack log, l1 txn hash %s, logIndex %d err %v",
+				fmt.Sprintf("failed to unpack log, l1 txn hash %s, logIndex %d err: %v",
 					txHash.Hex(),
 					i,
 					err,


### PR DESCRIPTION
Passing error into jsonrpc.Err(errCode, error) was resulting in error being serialized as empty struct {}, which resulting in hiding the data field. Fixed by passing string instead as it has been done in the rest of the codebase