### PR TITLE
feat: Add metrics for write stall

### DIFF
--- a/db/event_listener.go
+++ b/db/event_listener.go
@@ -9,11 +9,13 @@ type Listener interface {
 type EventListener interface {
 	OnIO(write bool, start time.Time)
 	OnCommit(start time.Time)
+	OnWriteStall(isL0 bool, duration time.Duration)
 }
 
 type SelectiveListener struct {
-	OnIOCb     func(write bool, duration time.Duration)
-	OnCommitCb func(duration time.Duration)
+	OnIOCb         func(write bool, duration time.Duration)
+	OnCommitCb     func(duration time.Duration)
+	OnWriteStallCb func(isL0 bool, duration time.Duration)
 }
 
 func (l *SelectiveListener) OnIO(write bool, start time.Time) {
@@ -25,5 +27,11 @@ func (l *SelectiveListener) OnIO(write bool, start time.Time) {
 func (l *SelectiveListener) OnCommit(start time.Time) {
 	if l.OnCommitCb != nil {
 		l.OnCommitCb(time.Since(start))
+	}
+}
+
+func (l *SelectiveListener) OnWriteStall(isL0 bool, duration time.Duration) {
+	if l.OnWriteStallCb != nil {
+		l.OnWriteStallCb(isL0, duration)
 	}
 }

--- a/db/event_listener_test.go
+++ b/db/event_listener_test.go
@@ -11,10 +11,12 @@ import (
 type op string
 
 const (
-	delay       = 100 * time.Millisecond
-	opRead   op = "OnIO Read"
-	opWrite  op = "OnIO Write"
-	opCommit op = "OnCommit"
+	delay                   = 100 * time.Millisecond
+	opRead               op = "OnIO Read"
+	opWrite              op = "OnIO Write"
+	opCommit             op = "OnCommit"
+	opWriteStallL0       op = "OnWriteStall L0"
+	opWriteStallMemtable op = "OnWriteStall Memtable"
 )
 
 type eventListenerTestCase struct {
@@ -45,6 +47,18 @@ func TestEventListener(t *testing.T) {
 				time.Sleep(delay)
 			},
 		},
+		{
+			op: opWriteStallL0,
+			fn: func(listener db.EventListener) {
+				listener.OnWriteStall(true, delay)
+			},
+		},
+		{
+			op: opWriteStallMemtable,
+			fn: func(listener db.EventListener) {
+				listener.OnWriteStall(false, delay)
+			},
+		},
 	}
 
 	for _, testCase := range testCases {
@@ -63,6 +77,14 @@ func TestEventListener(t *testing.T) {
 				},
 				OnCommitCb: func(duration time.Duration) {
 					actualOp = opCommit
+					actualDuration = duration
+				},
+				OnWriteStallCb: func(isL0 bool, duration time.Duration) {
+					if isL0 {
+						actualOp = opWriteStallL0
+					} else {
+						actualOp = opWriteStallMemtable
+					}
 					actualDuration = duration
 				},
 			}

--- a/db/pebble/batch.go
+++ b/db/pebble/batch.go
@@ -142,6 +142,14 @@ func (b *batch) Write() error {
 		return err
 	}
 
+	metrics := b.batch.CommitStats()
+	if metrics.L0ReadAmpWriteStallDuration > 0 {
+		b.listener.OnWriteStall(true, metrics.L0ReadAmpWriteStallDuration)
+	}
+	if metrics.MemTableWriteStallDuration > 0 {
+		b.listener.OnWriteStall(false, metrics.MemTableWriteStallDuration)
+	}
+
 	return b.Close()
 }
 

--- a/db/pebblev2/batch.go
+++ b/db/pebblev2/batch.go
@@ -142,6 +142,14 @@ func (b *batch) Write() error {
 		return err
 	}
 
+	metrics := b.batch.CommitStats()
+	if metrics.L0ReadAmpWriteStallDuration > 0 {
+		b.listener.OnWriteStall(true, metrics.L0ReadAmpWriteStallDuration)
+	}
+	if metrics.MemTableWriteStallDuration > 0 {
+		b.listener.OnWriteStall(false, metrics.MemTableWriteStallDuration)
+	}
+
 	return b.Close()
 }
 

--- a/node/metrics.go
+++ b/node/metrics.go
@@ -55,8 +55,13 @@ func makeDBMetrics() db.EventListener {
 		Name:      "commit_latency",
 		Help:      "Database transaction commit latency in seconds",
 	})
+	writeStall := prometheus.NewHistogramVec(prometheus.HistogramOpts{
+		Namespace: "db",
+		Name:      "write_stall",
+		Help:      "Database write stall latency in seconds",
+	}, []string{"type"})
 
-	prometheus.MustRegister(readLatencyHistogram, writeLatencyHistogram, commitLatency)
+	prometheus.MustRegister(readLatencyHistogram, writeLatencyHistogram, commitLatency, writeStall)
 	return &db.SelectiveListener{
 		OnIOCb: func(write bool, duration time.Duration) {
 			if write {
@@ -67,6 +72,13 @@ func makeDBMetrics() db.EventListener {
 		},
 		OnCommitCb: func(duration time.Duration) {
 			commitLatency.Observe(duration.Seconds())
+		},
+		OnWriteStallCb: func(isL0 bool, duration time.Duration) {
+			if isL0 {
+				writeStall.WithLabelValues("l0").Observe(duration.Seconds())
+			} else {
+				writeStall.WithLabelValues("memtable").Observe(duration.Seconds())
+			}
 		},
 	}
 }


### PR DESCRIPTION
When we have a write stall, the db is in trouble. It’s not recorded in Metrics() but after batch commit, so I added another histogram to track this if we get any write stall.