### PR TITLE
fix(db/memory): correct iterator Prev behaviour

### DIFF
--- a/db/memory/iterator.go
+++ b/db/memory/iterator.go
@@ -39,16 +39,13 @@ func (i *iterator) Prev() bool {
 		panic(errIteratorClosed)
 	}
 
-	if i.curInd == 0 {
-		return false
-	}
-
 	if i.curInd == -1 {
-		return i.First()
+		i.curInd = 0
+		return i.Valid()
 	}
 
 	i.curInd--
-	return true
+	return i.Valid()
 }
 
 func (i *iterator) Next() bool {


### PR DESCRIPTION
Why were these changes needed?
The in-memory iterator implementation returned false from Prev() when called on the first element but left the cursor on that element and kept the iterator valid. This behavior was inconsistent with the Iterator interface contract, asymmetric with Next(), and diverged from the pebble-backed iterators, which make the iterator invalid when moving past the beginning. Code that relies on the boolean return of Prev() to detect end-of-range could mistakenly continue reading a stale key.

What does this change do?
This change updates the memory iterator's Prev() to always move the internal index and to return the same value as Valid() after the move. From an unpositioned state, Prev() now positions the iterator at the first key, mirroring the pebble iterators. When called on the first element, Prev() now moves the cursor before the first key so that the iterator becomes invalid and Prev() returns false, aligning the in-memory behavior with the other backends and with the intended Iterator contract.