### PR TITLE
fix: Fail to close database due to iterator leak

### DIFF
--- a/db/pebble/batch.go
+++ b/db/pebble/batch.go
@@ -63,11 +63,8 @@ func (b *batch) Get(key []byte, cb func(value []byte) error) error {
 		return err
 	}
 
-	if err := cb(val); err != nil {
-		return err
-	}
-
-	return closer.Close()
+	err = cb(val)
+	return errors.Join(err, closer.Close())
 }
 
 func (b *batch) Has(key []byte) (bool, error) {

--- a/db/pebble/db.go
+++ b/db/pebble/db.go
@@ -127,11 +127,8 @@ func (d *DB) Get(key []byte, cb func(value []byte) error) error {
 		return err
 	}
 
-	if err := cb(val); err != nil {
-		return err
-	}
-
-	return closer.Close()
+	err = cb(val)
+	return errors.Join(err, closer.Close())
 }
 
 func (d *DB) Put(key, val []byte) error {

--- a/db/pebblev2/batch.go
+++ b/db/pebblev2/batch.go
@@ -63,11 +63,8 @@ func (b *batch) Get(key []byte, cb func(value []byte) error) error {
 		return err
 	}
 
-	if err := cb(val); err != nil {
-		return err
-	}
-
-	return closer.Close()
+	err = cb(val)
+	return errors.Join(err, closer.Close())
 }
 
 func (b *batch) Has(key []byte) (bool, error) {

--- a/db/pebblev2/db.go
+++ b/db/pebblev2/db.go
@@ -134,11 +134,8 @@ func (d *DB) Get(key []byte, cb func(value []byte) error) error {
 		return err
 	}
 
-	if err := cb(val); err != nil {
-		return err
-	}
-
-	return closer.Close()
+	err = cb(val)
+	return errors.Join(err, closer.Close())
 }
 
 func (d *DB) Put(key, val []byte) error {


### PR DESCRIPTION
The current implementation doesn't call `closer` if the callback fails.