### PR TITLE
migration: better error message on optout attempt

### DIFF
--- a/cmd/juno/juno.go
+++ b/cmd/juno/juno.go
@@ -101,7 +101,7 @@ const (
 	dbCompactionConcurrencyF            = "db-compaction-concurrency"
 	dbMemtableSizeF                     = "db-memtable-size"
 	dbCompressionF                      = "db-compression"
-	transactionCombinedLayoutF          = "transaction-combined-layout"
+	transactionCombinedLayoutF          = node.FlagTransactionCombinedLayout
 
 	defaultConfig                             = ""
 	defaultHost                               = "localhost"

--- a/node/migration.go
+++ b/node/migration.go
@@ -16,7 +16,11 @@ import (
 // config variables from cfg to determine if they should be enabled.
 func registerMigrations(cfg *Config) *migration.Registry {
 	registry := migration.NewRegistry().
-		WithOptional(&blocktransactions.Migrator{}, cfg.TransactionCombinedLayout)
+		WithOptional(
+			&blocktransactions.Migrator{},
+			cfg.TransactionCombinedLayout,
+			FlagTransactionCombinedLayout,
+		)
 
 	return registry
 }
@@ -44,8 +48,7 @@ func migrateIfNeeded(
 		// Run new migrations
 		registry := registerMigrations(config)
 		runner, err := migration.NewRunner(
-			registry.Entries(),
-			registry.TargetVersion(),
+			registry,
 			db,
 			&config.Network,
 			log,

--- a/node/node.go
+++ b/node/node.go
@@ -46,11 +46,12 @@ import (
 )
 
 const (
-	upgraderDelay    = 5 * time.Minute
-	mempoolLimit     = 1024
-	githubAPIUrl     = "https://api.github.com/repos/NethermindEth/juno/releases/latest"
-	latestReleaseURL = "https://github.com/NethermindEth/juno/releases/latest"
-	sequencerAddress = 1337
+	upgraderDelay                 = 5 * time.Minute
+	mempoolLimit                  = 1024
+	githubAPIUrl                  = "https://api.github.com/repos/NethermindEth/juno/releases/latest"
+	latestReleaseURL              = "https://github.com/NethermindEth/juno/releases/latest"
+	sequencerAddress              = 1337
+	FlagTransactionCombinedLayout = "transaction-combined-layout"
 )
 
 // Config is the top-level juno configuration.


### PR DESCRIPTION
Now returned error is in the following format

>Error while running migrations	{"err": "create migration runner: cannot opt out of previously enabled migrations: [--transaction-combined-layout] (set these flags to enable)"}