### PR TITLE
refactor(l1): implement universal types for `l1`

### DIFF
--- a/adapters/core2p2p/receipt.go
+++ b/adapters/core2p2p/receipt.go
@@ -94,9 +94,9 @@ func adaptPriceUnit(unit core.FeeUnit) receipt.PriceUnit {
 
 func AdaptMessageToL1(mL1 *core.L2ToL1Message) *receipt.MessageToL1 {
 	return &receipt.MessageToL1{
-		FromAddress: AdaptFelt(mL1.From),
+		FromAddress: AdaptFelt((*felt.Felt)(mL1.From)),
 		Payload:     utils.Map(mL1.Payload, AdaptFelt),
-		ToAddress:   &receipt.EthereumAddress{Elements: mL1.To.Bytes()},
+		ToAddress:   &receipt.EthereumAddress{Elements: mL1.To.Marshal()},
 	}
 }
 

--- a/adapters/p2p2core/felt.go
+++ b/adapters/p2p2core/felt.go
@@ -5,9 +5,7 @@ import (
 
 	"github.com/NethermindEth/juno/core/felt"
 	"github.com/NethermindEth/juno/utils"
-	ethcommon "github.com/ethereum/go-ethereum/common"
 	"github.com/starknet-io/starknet-p2pspecs/p2p/proto/common"
-	"github.com/starknet-io/starknet-p2pspecs/p2p/proto/sync/receipt"
 )
 
 func AdaptHash(h *common.Hash) *felt.Felt {
@@ -16,10 +14,6 @@ func AdaptHash(h *common.Hash) *felt.Felt {
 
 func AdaptAddress(h *common.Address) *felt.Felt {
 	return adapt(h)
-}
-
-func AdaptEthAddress(h *receipt.EthereumAddress) ethcommon.Address {
-	return ethcommon.BytesToAddress(h.Elements)
 }
 
 func AdaptFelt(f *common.Felt252) *felt.Felt {

--- a/adapters/p2p2core/receipt.go
+++ b/adapters/p2p2core/receipt.go
@@ -3,6 +3,7 @@ package p2p2core
 import (
 	"github.com/NethermindEth/juno/core"
 	"github.com/NethermindEth/juno/core/felt"
+	"github.com/NethermindEth/juno/l1/types"
 	"github.com/NethermindEth/juno/utils"
 	"github.com/starknet-io/starknet-p2pspecs/p2p/proto/common"
 	"github.com/starknet-io/starknet-p2pspecs/p2p/proto/sync/receipt"
@@ -73,9 +74,14 @@ func adaptExecutionResources(er *receipt.Receipt_ExecutionResources) *core.Execu
 }
 
 func adaptMessageToL1(m *receipt.MessageToL1) *core.L2ToL1Message {
+	from := (*felt.Address)(AdaptFelt(m.FromAddress))
+	var to *types.L1Address
+	if m.ToAddress != nil {
+		to = types.NewFromBytes[types.L1Address](m.ToAddress.GetElements())
+	}
 	return &core.L2ToL1Message{
-		From:    AdaptFelt(m.FromAddress),
-		To:      AdaptEthAddress(m.ToAddress),
+		From:    from,
+		To:      to,
 		Payload: utils.Map(m.Payload, AdaptFelt),
 	}
 }

--- a/adapters/p2p2core/receipt.go
+++ b/adapters/p2p2core/receipt.go
@@ -75,13 +75,11 @@ func adaptExecutionResources(er *receipt.Receipt_ExecutionResources) *core.Execu
 
 func adaptMessageToL1(m *receipt.MessageToL1) *core.L2ToL1Message {
 	from := (*felt.Address)(AdaptFelt(m.FromAddress))
-	var to *types.L1Address
-	if m.ToAddress != nil {
-		to = types.NewFromBytes[types.L1Address](m.ToAddress.GetElements())
-	}
 	return &core.L2ToL1Message{
-		From:    from,
-		To:      to,
+		From: from,
+		To: types.FromBytes[types.L1Address](
+			m.ToAddress.GetElements(),
+		),
 		Payload: utils.Map(m.Payload, AdaptFelt),
 	}
 }

--- a/adapters/sn2core/sn2core.go
+++ b/adapters/sn2core/sn2core.go
@@ -126,9 +126,9 @@ func AdaptL1ToL2Message(response *starknet.L1ToL2Message) *core.L1ToL2Message {
 	if response == nil {
 		return nil
 	}
-
+	fromBytes := []byte(response.From)
 	return &core.L1ToL2Message{
-		From:     types.NewUnsafeFromString[types.L1Address](response.From),
+		From:     types.FromBytes[types.L1Address](fromBytes),
 		Nonce:    response.Nonce,
 		Payload:  response.Payload,
 		Selector: response.Selector,
@@ -141,10 +141,11 @@ func AdaptL2ToL1Message(response *starknet.L2ToL1Message) *core.L2ToL1Message {
 		return nil
 	}
 
+	toBytes := []byte(response.To)
 	return &core.L2ToL1Message{
 		From:    (*felt.Address)(response.From),
 		Payload: response.Payload,
-		To:      types.NewUnsafeFromString[types.L1Address](response.To),
+		To:      types.FromBytes[types.L1Address](toBytes),
 	}
 }
 

--- a/adapters/sn2core/sn2core.go
+++ b/adapters/sn2core/sn2core.go
@@ -8,9 +8,9 @@ import (
 	"github.com/NethermindEth/juno/core"
 	"github.com/NethermindEth/juno/core/crypto"
 	"github.com/NethermindEth/juno/core/felt"
+	"github.com/NethermindEth/juno/l1/types"
 	"github.com/NethermindEth/juno/starknet"
 	"github.com/NethermindEth/juno/utils"
-	"github.com/ethereum/go-ethereum/common"
 )
 
 func AdaptBlock(response *starknet.Block, sig *starknet.Signature) (*core.Block, error) {
@@ -128,11 +128,11 @@ func AdaptL1ToL2Message(response *starknet.L1ToL2Message) *core.L1ToL2Message {
 	}
 
 	return &core.L1ToL2Message{
-		From:     common.HexToAddress(response.From),
+		From:     types.NewUnsafeFromString[types.L1Address](response.From),
 		Nonce:    response.Nonce,
 		Payload:  response.Payload,
 		Selector: response.Selector,
-		To:       response.To,
+		To:       (*felt.Address)(response.To),
 	}
 }
 
@@ -142,9 +142,9 @@ func AdaptL2ToL1Message(response *starknet.L2ToL1Message) *core.L2ToL1Message {
 	}
 
 	return &core.L2ToL1Message{
-		From:    response.From,
+		From:    (*felt.Address)(response.From),
 		Payload: response.Payload,
-		To:      common.HexToAddress(response.To),
+		To:      types.NewUnsafeFromString[types.L1Address](response.To),
 	}
 }
 

--- a/adapters/sn2core/sn2core.go
+++ b/adapters/sn2core/sn2core.go
@@ -126,9 +126,8 @@ func AdaptL1ToL2Message(response *starknet.L1ToL2Message) *core.L1ToL2Message {
 	if response == nil {
 		return nil
 	}
-	fromBytes := []byte(response.From)
 	return &core.L1ToL2Message{
-		From:     types.FromBytes[types.L1Address](fromBytes),
+		From:     types.UnsafeFromString[types.L1Address](response.From),
 		Nonce:    response.Nonce,
 		Payload:  response.Payload,
 		Selector: response.Selector,
@@ -141,11 +140,10 @@ func AdaptL2ToL1Message(response *starknet.L2ToL1Message) *core.L2ToL1Message {
 		return nil
 	}
 
-	toBytes := []byte(response.To)
 	return &core.L2ToL1Message{
 		From:    (*felt.Address)(response.From),
 		Payload: response.Payload,
-		To:      types.FromBytes[types.L1Address](toBytes),
+		To:      types.UnsafeFromString[types.L1Address](response.To),
 	}
 }
 

--- a/adapters/testutils/core_test_utils.go
+++ b/adapters/testutils/core_test_utils.go
@@ -35,10 +35,10 @@ func randomSliceT[T any](t *testing.T, size int, generator func(t *testing.T) T)
 	return items
 }
 
-func randomL1Address(t *testing.T) *types.L1Address {
+func randomL1Address(t *testing.T) types.L1Address {
 	t.Helper()
 	addr := types.Random[types.L1Address]()
-	return &addr
+	return addr
 }
 
 func randomEvent() *core.Event {

--- a/adapters/testutils/core_test_utils.go
+++ b/adapters/testutils/core_test_utils.go
@@ -8,9 +8,8 @@ import (
 
 	"github.com/NethermindEth/juno/core"
 	"github.com/NethermindEth/juno/core/felt"
+	"github.com/NethermindEth/juno/l1/types"
 	"github.com/NethermindEth/juno/utils"
-	"github.com/ethereum/go-ethereum/common"
-	"github.com/stretchr/testify/require"
 )
 
 const sliceLen = 5
@@ -36,13 +35,10 @@ func randomSliceT[T any](t *testing.T, size int, generator func(t *testing.T) T)
 	return items
 }
 
-func randomL1Address(t *testing.T) common.Address {
+func randomL1Address(t *testing.T) *types.L1Address {
 	t.Helper()
-	var l1Address common.Address
-	read, err := cryptorand.Read(l1Address[:])
-	require.Equal(t, len(l1Address), read)
-	require.NoError(t, err)
-	return l1Address
+	addr := types.Random[types.L1Address]()
+	return &addr
 }
 
 func randomEvent() *core.Event {
@@ -90,14 +86,14 @@ func randomL1ToL2Message(t *testing.T) *core.L1ToL2Message {
 		Nonce:    felt.NewRandom[felt.Felt](),
 		Payload:  randomSlice(sliceLen, felt.NewRandom[felt.Felt]),
 		Selector: felt.NewRandom[felt.Felt](),
-		To:       felt.NewRandom[felt.Felt](),
+		To:       felt.NewRandom[felt.Address](),
 	}
 }
 
 func randomL2ToL1Message(t *testing.T) *core.L2ToL1Message {
 	t.Helper()
 	return &core.L2ToL1Message{
-		From:    felt.NewRandom[felt.Felt](),
+		From:    felt.NewRandom[felt.Address](),
 		Payload: randomSlice(sliceLen, felt.NewRandom[felt.Felt]),
 		To:      randomL1Address(t),
 	}

--- a/adapters/vm2core/vm2core.go
+++ b/adapters/vm2core/vm2core.go
@@ -22,7 +22,7 @@ func AdaptOrderedEvent(event vm.OrderedEvent) *core.Event {
 // todo(rdr): this is function definition is twice wrong:
 //   - the parameters should be received by reference
 //   - the output param should be return by value
-func AdaptOrderedMessageToL1(message vm.OrderedL2toL1Message) *core.L2ToL1Message {
+func AdaptOrderedMessageToL1(message *vm.OrderedL2toL1Message) *core.L2ToL1Message {
 	var to *types.L1Address
 	if message.To != nil {
 		bits := (*felt.Felt)(message.To).Bits()
@@ -45,7 +45,7 @@ func AdaptOrderedMessagesToL1(messages []vm.OrderedL2toL1Message) []*core.L2ToL1
 	out := make([]*core.L2ToL1Message, len(messages))
 	for i := range messages {
 		m := AdaptOrderedMessageToL1(&messages[i])
-		out[i] = &m
+		out[i] = m
 	}
 	return out
 }

--- a/adapters/vm2core/vm2core.go
+++ b/adapters/vm2core/vm2core.go
@@ -23,12 +23,16 @@ func AdaptOrderedEvent(event vm.OrderedEvent) *core.Event {
 //   - the parameters should be received by reference
 //   - the output param should be return by value
 func AdaptOrderedMessageToL1(message *vm.OrderedL2toL1Message) *core.L2ToL1Message {
-	messageBytes := message.From.Marshal()
+	var to types.L1Address
+	if message.To != nil {
+		toBytes := message.To.Marshal()
+		to = types.FromBytes[types.L1Address](toBytes)
+	}
 	return &core.L2ToL1Message{
 		// todo: remove this cast
 		From:    (*felt.Address)(message.From),
 		Payload: message.Payload,
-		To:      types.FromBytes[types.L1Address](messageBytes),
+		To:      to,
 	}
 }
 

--- a/adapters/vm2core/vm2core.go
+++ b/adapters/vm2core/vm2core.go
@@ -23,17 +23,12 @@ func AdaptOrderedEvent(event vm.OrderedEvent) *core.Event {
 //   - the parameters should be received by reference
 //   - the output param should be return by value
 func AdaptOrderedMessageToL1(message *vm.OrderedL2toL1Message) *core.L2ToL1Message {
-	var to *types.L1Address
-	if message.To != nil {
-		bits := (*felt.Felt)(message.To).Bits()
-		u256 := types.U256(bits)
-		to = (*types.L1Address)(&u256)
-	}
+	messageBytes := message.From.Marshal()
 	return &core.L2ToL1Message{
 		// todo: remove this cast
 		From:    (*felt.Address)(message.From),
 		Payload: message.Payload,
-		To:      to,
+		To:      types.FromBytes[types.L1Address](messageBytes),
 	}
 }
 

--- a/adapters/vm2core/vm2core_test.go
+++ b/adapters/vm2core/vm2core_test.go
@@ -42,7 +42,7 @@ func TestAdaptOrderedEvents(t *testing.T) {
 func TestAdaptOrderedMessageToL1(t *testing.T) {
 	require.Equal(t, &core.L2ToL1Message{
 		From:    felt.NewFromUint64[felt.Address](2),
-		To:      types.NewFromUint64[types.L1Address](3),
+		To:      types.FromUint64[types.L1Address](3),
 		Payload: []*felt.Felt{new(felt.Felt).SetUint64(4)},
 	}, vm2core.AdaptOrderedMessageToL1(&vm.OrderedL2toL1Message{
 		Order:   1,

--- a/adapters/vm2core/vm2core_test.go
+++ b/adapters/vm2core/vm2core_test.go
@@ -6,9 +6,9 @@ import (
 	"github.com/NethermindEth/juno/adapters/vm2core"
 	"github.com/NethermindEth/juno/core"
 	"github.com/NethermindEth/juno/core/felt"
+	"github.com/NethermindEth/juno/l1/types"
 	"github.com/NethermindEth/juno/utils"
 	"github.com/NethermindEth/juno/vm"
-	"github.com/ethereum/go-ethereum/common"
 	"github.com/stretchr/testify/require"
 )
 
@@ -41,9 +41,9 @@ func TestAdaptOrderedEvents(t *testing.T) {
 }
 
 func TestAdaptOrderedMessageToL1(t *testing.T) {
-	require.Equal(t, core.L2ToL1Message{
-		From:    felt.NewFromUint64[felt.Felt](2),
-		To:      common.HexToAddress("0x3"),
+	require.Equal(t, &core.L2ToL1Message{
+		From:    felt.NewFromUint64[felt.Address](2),
+		To:      types.NewFromUint64[types.L1Address](3),
 		Payload: []*felt.Felt{new(felt.Felt).SetUint64(4)},
 	}, vm2core.AdaptOrderedMessageToL1(&vm.OrderedL2toL1Message{
 		Order:   1,

--- a/adapters/vm2core/vm2core_test.go
+++ b/adapters/vm2core/vm2core_test.go
@@ -7,7 +7,6 @@ import (
 	"github.com/NethermindEth/juno/core"
 	"github.com/NethermindEth/juno/core/felt"
 	"github.com/NethermindEth/juno/l1/types"
-	"github.com/NethermindEth/juno/utils"
 	"github.com/NethermindEth/juno/vm"
 	"github.com/stretchr/testify/require"
 )
@@ -60,10 +59,10 @@ func TestAdaptOrderedMessagesToL1(t *testing.T) {
 		messages = append(messages, vm.OrderedL2toL1Message{Order: uint64(i)})
 	}
 	require.Equal(t, []*core.L2ToL1Message{
-		utils.HeapPtr(vm2core.AdaptOrderedMessageToL1(&messages[4])),
-		utils.HeapPtr(vm2core.AdaptOrderedMessageToL1(&messages[3])),
-		utils.HeapPtr(vm2core.AdaptOrderedMessageToL1(&messages[2])),
-		utils.HeapPtr(vm2core.AdaptOrderedMessageToL1(&messages[1])),
-		utils.HeapPtr(vm2core.AdaptOrderedMessageToL1(&messages[0])),
+		vm2core.AdaptOrderedMessageToL1(&messages[4]),
+		vm2core.AdaptOrderedMessageToL1(&messages[3]),
+		vm2core.AdaptOrderedMessageToL1(&messages[2]),
+		vm2core.AdaptOrderedMessageToL1(&messages[1]),
+		vm2core.AdaptOrderedMessageToL1(&messages[0]),
 	}, vm2core.AdaptOrderedMessagesToL1(messages))
 }

--- a/blockchain/blockchain.go
+++ b/blockchain/blockchain.go
@@ -9,8 +9,8 @@ import (
 	"github.com/NethermindEth/juno/db"
 	"github.com/NethermindEth/juno/db/memory"
 	"github.com/NethermindEth/juno/feed"
+	"github.com/NethermindEth/juno/l1/types"
 	"github.com/NethermindEth/juno/utils"
-	"github.com/ethereum/go-ethereum/common"
 )
 
 type L1HeadSubscription struct {
@@ -46,7 +46,7 @@ type Reader interface {
 
 	StateUpdateByNumber(number uint64) (update *core.StateUpdate, err error)
 	StateUpdateByHash(hash *felt.Felt) (update *core.StateUpdate, err error)
-	L1HandlerTxnHash(msgHash *common.Hash) (l1HandlerTxnHash felt.Felt, err error)
+	L1HandlerTxnHash(msgHash *types.L1Hash) (l1HandlerTxnHash felt.Felt, err error)
 
 	HeadState() (core.StateReader, StateCloser, error)
 	StateAtBlockHash(blockHash *felt.Felt) (core.StateReader, StateCloser, error)
@@ -209,9 +209,9 @@ func (b *Blockchain) StateUpdateByHash(hash *felt.Felt) (*core.StateUpdate, erro
 	return core.GetStateUpdateByHash(b.database, hash)
 }
 
-func (b *Blockchain) L1HandlerTxnHash(msgHash *common.Hash) (felt.Felt, error) {
+func (b *Blockchain) L1HandlerTxnHash(msgHash *types.L1Hash) (felt.Felt, error) {
 	b.listener.OnRead("L1HandlerTxnHash")
-	return core.GetL1HandlerTxnHashByMsgHash(b.database, msgHash.Bytes())
+	return core.GetL1HandlerTxnHashByMsgHash(b.database, msgHash.Marshal())
 }
 
 // TransactionByBlockNumberAndIndex gets the transaction for a given block number and index.

--- a/blockchain/blockchain_test.go
+++ b/blockchain/blockchain_test.go
@@ -10,9 +10,9 @@ import (
 	"github.com/NethermindEth/juno/core/felt"
 	"github.com/NethermindEth/juno/db"
 	"github.com/NethermindEth/juno/db/memory"
+	types "github.com/NethermindEth/juno/l1/types"
 	adaptfeeder "github.com/NethermindEth/juno/starknetdata/feeder"
 	"github.com/NethermindEth/juno/utils"
-	"github.com/ethereum/go-ethereum/common"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -304,8 +304,8 @@ func TestStoreL1HandlerTxnHash(t *testing.T) {
 		require.NoError(t, err)
 		require.NoError(t, chain.Store(block, &emptyCommitments, stateUpdate, nil))
 	}
-	l1HandlerMsgHash := common.HexToHash("0x42e76df4e3d5255262929c27132bd0d295a8d3db2cfe63d2fcd061c7a7a7ab34")
-	l1HandlerTxnHash, err := chain.L1HandlerTxnHash(&l1HandlerMsgHash)
+	l1HandlerMsgHash := types.NewUnsafeFromString[types.L1Hash]("0x42e76df4e3d5255262929c27132bd0d295a8d3db2cfe63d2fcd061c7a7a7ab34")
+	l1HandlerTxnHash, err := chain.L1HandlerTxnHash(l1HandlerMsgHash)
 	require.NoError(t, err)
 	expectedHash := felt.UnsafeFromString[felt.Felt](
 		"0x785c2ada3f53fbc66078d47715c27718f92e6e48b96372b36e5197de69b82b5",

--- a/cmd/juno/juno.go
+++ b/cmd/juno/juno.go
@@ -15,10 +15,10 @@ import (
 
 	_ "github.com/NethermindEth/juno/encoder/registry"
 	_ "github.com/NethermindEth/juno/jemalloc"
+	"github.com/NethermindEth/juno/l1/types"
 	"github.com/NethermindEth/juno/node"
 	"github.com/NethermindEth/juno/utils"
 	"github.com/NethermindEth/juno/vm"
-	"github.com/ethereum/go-ethereum/common"
 	"github.com/mitchellh/mapstructure"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
@@ -353,7 +353,7 @@ func NewCmd(config *node.Config, run func(*cobra.Command, []string) error) *cobr
 				GatewayURL:          v.GetString(cnGatewayURLF),
 				L1ChainID:           l1ChainID,
 				L2ChainID:           v.GetString(cnL2ChainIDF),
-				CoreContractAddress: common.HexToAddress(v.GetString(cnCoreContractAddressF)),
+				CoreContractAddress: types.UnsafeFromString[types.L1Address](v.GetString(cnCoreContractAddressF)),
 				BlockHashMetaInfo: &utils.BlockHashMetaInfo{
 					First07Block:      0,
 					UnverifiableRange: []uint64{uint64(unverifRange[0]), uint64(unverifRange[1])},

--- a/cmd/juno/juno_test.go
+++ b/cmd/juno/juno_test.go
@@ -11,9 +11,9 @@ import (
 	"time"
 
 	juno "github.com/NethermindEth/juno/cmd/juno"
+	"github.com/NethermindEth/juno/l1/types"
 	"github.com/NethermindEth/juno/node"
 	"github.com/NethermindEth/juno/utils"
-	"github.com/ethereum/go-ethereum/common"
 	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -35,7 +35,8 @@ func TestConfigPrecedence(t *testing.T) {
 	defaultWS := false
 	defaultWSPort := uint16(6061)
 	defaultDBPath := filepath.Join(pwd, "juno")
-	defaultCoreContractAddress := common.HexToAddress("0xc662c410C0ECf747543f5bA90660f6ABeBD9C8c4")
+	defaultCoreContractAddress, err := types.FromString[types.L1Address]("0xc662c410C0ECf747543f5bA90660f6ABeBD9C8c4")
+	require.NoError(t, err)
 	defaultNetwork := utils.Mainnet
 	defaultCustomNetwork := utils.Network{
 		Name:                "custom",

--- a/core/receipt.go
+++ b/core/receipt.go
@@ -59,9 +59,10 @@ func messagesSentHash(messages []*L2ToL1Message) felt.Felt {
 		felt.NewFromUint64[felt.Felt](uint64(len(messages))),
 	}
 	for _, msg := range messages {
-		msgTo := felt.FromBytes[felt.Felt](msg.To.Bytes())
+		toBytes := msg.To.Bytes()
+		msgTo := felt.FromBytes[felt.Felt](toBytes[:])
 		payloadSize := felt.FromUint64[felt.Felt](uint64(len(msg.Payload)))
-		chain = append(chain, msg.From, &msgTo, &payloadSize)
+		chain = append(chain, (*felt.Felt)(msg.From), &msgTo, &payloadSize)
 		chain = append(chain, msg.Payload...)
 	}
 

--- a/core/transaction.go
+++ b/core/transaction.go
@@ -85,7 +85,7 @@ type Event struct {
 }
 
 type L1ToL2Message struct {
-	From     *types.L1Address
+	From     types.L1Address
 	Nonce    *felt.Felt
 	Payload  []*felt.Felt
 	Selector *felt.Felt
@@ -95,7 +95,7 @@ type L1ToL2Message struct {
 type L2ToL1Message struct {
 	From    *felt.Address
 	Payload []*felt.Felt
-	To      *types.L1Address
+	To      types.L1Address
 }
 
 type ExecutionResources struct {

--- a/core/transaction.go
+++ b/core/transaction.go
@@ -11,9 +11,9 @@ import (
 	"github.com/NethermindEth/juno/core/crypto"
 	"github.com/NethermindEth/juno/core/felt"
 	"github.com/NethermindEth/juno/core/trie"
+	"github.com/NethermindEth/juno/l1/types"
 	"github.com/NethermindEth/juno/utils"
 	"github.com/bits-and-blooms/bloom/v3"
-	"github.com/ethereum/go-ethereum/common"
 	"github.com/fxamacker/cbor/v2"
 	"golang.org/x/crypto/sha3"
 )
@@ -85,21 +85,17 @@ type Event struct {
 }
 
 type L1ToL2Message struct {
-	// todo(rdr): Starknet from 0.14.1 has dropped the assumption that we use an EthAddress
-	//            here. We should change this to felt.Address
-	From     common.Address
+	From     *types.L1Address
 	Nonce    *felt.Felt
 	Payload  []*felt.Felt
 	Selector *felt.Felt
-	To       *felt.Felt
+	To       *felt.Address
 }
 
 type L2ToL1Message struct {
-	From    *felt.Felt
+	From    *felt.Address
 	Payload []*felt.Felt
-	// todo(rdr): Starknet from 0.14.1 has dropped the assumption that we use an EthAddress
-	//            here. We should change this to felt.Address
-	To common.Address
+	To      *types.L1Address
 }
 
 type ExecutionResources struct {

--- a/l1/l1.go
+++ b/l1/l1.go
@@ -10,9 +10,9 @@ import (
 	"github.com/NethermindEth/juno/core"
 	"github.com/NethermindEth/juno/core/felt"
 	"github.com/NethermindEth/juno/l1/contract"
+	l1types "github.com/NethermindEth/juno/l1/types"
 	"github.com/NethermindEth/juno/service"
 	"github.com/NethermindEth/juno/utils"
-	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/event"
 	"go.uber.org/zap"
@@ -24,7 +24,7 @@ type Subscriber interface {
 	LatestHeight(ctx context.Context) (uint64, error)
 	WatchLogStateUpdate(ctx context.Context, sink chan<- *contract.StarknetLogStateUpdate) (event.Subscription, error)
 	ChainID(ctx context.Context) (*big.Int, error)
-	TransactionReceipt(ctx context.Context, txHash common.Hash) (*types.Receipt, error)
+	TransactionReceipt(ctx context.Context, txHash *l1types.L1Hash) (*types.Receipt, error)
 
 	Close()
 }

--- a/l1/l1_test.go
+++ b/l1/l1_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/NethermindEth/juno/db/memory"
 	"github.com/NethermindEth/juno/l1"
 	"github.com/NethermindEth/juno/l1/contract"
+	l1types "github.com/NethermindEth/juno/l1/types"
 	"github.com/NethermindEth/juno/mocks"
 	"github.com/NethermindEth/juno/utils"
 	"github.com/ethereum/go-ethereum/common"
@@ -286,7 +287,7 @@ func testEthSubscriberHeight(t *testing.T, tests map[string]struct {
 			server, listener := startServer("127.0.0.1:0", test.service)
 			defer server.Stop()
 
-			subscriber, err := l1.NewEthSubscriber("ws://"+listener.Addr().String(), common.Address{})
+			subscriber, err := l1.NewEthSubscriber("ws://"+listener.Addr().String(), &l1types.L1Address{})
 			require.NoError(t, err)
 			defer subscriber.Close()
 

--- a/l1/types/address.go
+++ b/l1/types/address.go
@@ -1,0 +1,85 @@
+package types
+
+import (
+	"github.com/fxamacker/cbor/v2"
+	"github.com/holiman/uint256"
+)
+
+type L1Address U256
+
+// Bytes returns the 32-byte big-endian representation.
+func (a *L1Address) Bytes() [32]byte {
+	return (*U256)(a).Bytes32()
+}
+
+// String returns hex representation with "0x" prefix.
+func (a *L1Address) String() string {
+	return (*U256)(a).String()
+}
+
+// Marshal returns the 32-byte big-endian representation as a slice.
+func (a *L1Address) Marshal() []byte {
+	b := (*U256)(a).Bytes32()
+	return b[:]
+}
+
+// Unmarshal sets the value from big-endian bytes (left-padded if < 32 bytes).
+func (a *L1Address) Unmarshal(e []byte) {
+	if len(e) > 32 {
+		e = e[len(e)-32:]
+	}
+	(*uint256.Int)((*U256)(a)).SetBytes(e)
+}
+
+// MarshalJSON encodes as a hex string with "0x" prefix.
+func (a *L1Address) MarshalJSON() ([]byte, error) {
+	return (*U256)(a).MarshalJSON()
+}
+
+// UnmarshalJSON decodes from hex string or decimal string.
+func (a *L1Address) UnmarshalJSON(data []byte) error {
+	return (*U256)(a).UnmarshalJSON(data)
+}
+
+// SetBytesCanonical accepts up to 32 bytes big-endian and left-pads to 32.
+func (a *L1Address) SetBytesCanonical(data []byte) error {
+	if len(data) > 32 {
+		return errU256TooLarge
+	}
+	(*uint256.Int)((*U256)(a)).SetBytes(data)
+	return nil
+}
+
+// MarshalCBOR marshals a L1Address to CBOR.
+// For Ethereum addresses (first 12 bytes are zero), it marshals only the last 20 bytes
+// to maintain compatibility with the old format. It first checks if this
+// is an Ethereum address (first 12 bytes are zero) and if so, it marshals only the last 20 bytes.
+// Otherwise, it marshals all 32 bytes.
+func (a *L1Address) MarshalCBOR() ([]byte, error) {
+	bytes := a.Bytes()
+
+	isEthAddress := true
+	for i := range 12 {
+		if bytes[i] != 0 {
+			isEthAddress = false
+			break
+		}
+	}
+
+	if isEthAddress {
+		return cbor.Marshal(bytes[12:])
+	}
+
+	return cbor.Marshal(bytes[:])
+}
+
+// UnmarshalCBOR unmarshals a CBOR-encoded L1Address.
+func (a *L1Address) UnmarshalCBOR(data []byte) error {
+	var b []byte
+	if err := cbor.Unmarshal(data, &b); err != nil {
+		return err
+	}
+
+	(*uint256.Int)((*U256)(a)).SetBytes(b)
+	return nil
+}

--- a/l1/types/ctors.go
+++ b/l1/types/ctors.go
@@ -1,6 +1,8 @@
 package types
 
 import (
+	"crypto/rand"
+
 	"github.com/holiman/uint256"
 )
 
@@ -58,5 +60,16 @@ func UnsafeFromString[T U256Like](value string) T {
 	if err != nil {
 		panic(err)
 	}
+	return T(*u)
+}
+
+// Creates a new random U256 based type
+func Random[T U256Like]() T {
+	var b [32]byte
+	if _, err := rand.Read(b[:]); err != nil {
+		panic(err)
+	}
+	u := new(U256)
+	(*uint256.Int)(u).SetBytes(b[:])
 	return T(*u)
 }

--- a/l1/types/ctors.go
+++ b/l1/types/ctors.go
@@ -1,0 +1,62 @@
+package types
+
+import (
+	"github.com/holiman/uint256"
+)
+
+type U256Like interface {
+	~[4]uint64
+}
+
+func NewFromUint64[T U256Like](num uint64) *T {
+	v := FromUint64[T](num)
+	return &v
+}
+
+func NewFromString[T U256Like](val string) (*T, error) {
+	v, err := FromString[T](val)
+	if err != nil {
+		return nil, err
+	}
+	return &v, nil
+}
+
+func NewUnsafeFromString[T U256Like](val string) *T {
+	v := UnsafeFromString[T](val)
+	return &v
+}
+
+func NewFromBytes[T U256Like](val []byte) *T {
+	v := FromBytes[T](val)
+	return &v
+}
+
+func FromUint64[T U256Like](num uint64) T {
+	u := uint256.NewInt(num)
+	return T(*u)
+}
+
+func FromBytes[T U256Like](value []byte) T {
+	u := new(U256)
+	if err := u.SetBytesCanonical(value); err != nil {
+		panic(err)
+	}
+	return T(*u)
+}
+
+func FromString[T U256Like](value string) (T, error) {
+	u, err := u256FromString(value)
+	if err != nil {
+		var zero T
+		return zero, err
+	}
+	return T(*u), nil
+}
+
+func UnsafeFromString[T U256Like](value string) T {
+	u, err := u256FromString(value)
+	if err != nil {
+		panic(err)
+	}
+	return T(*u)
+}

--- a/l1/types/go_ethereum.go
+++ b/l1/types/go_ethereum.go
@@ -1,0 +1,31 @@
+package types
+
+import (
+	"github.com/ethereum/go-ethereum/common"
+)
+
+func L1AddressFromEth(addr common.Address) L1Address {
+	var result L1Address
+	var padded [32]byte
+	copy(padded[12:], addr[:])
+	_ = result.SetBytesCanonical(padded[:])
+	return result
+}
+
+func (a L1Address) ToEthAddress() common.Address {
+	bytes := a.Bytes()
+	var addr common.Address
+	copy(addr[:], bytes[12:])
+	return addr
+}
+
+func L1HashFromEth(hash common.Hash) L1Hash {
+	var result L1Hash
+	_ = result.SetBytesCanonical(hash[:])
+	return result
+}
+
+func (h L1Hash) ToEthHash() common.Hash {
+	bytes := h.Bytes()
+	return common.BytesToHash(bytes[:])
+}

--- a/l1/types/go_ethereum_test.go
+++ b/l1/types/go_ethereum_test.go
@@ -1,0 +1,220 @@
+package types_test
+
+import (
+	"testing"
+
+	"github.com/NethermindEth/juno/l1/types"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/fxamacker/cbor/v2"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestEthereumAddressRoundTrip(t *testing.T) {
+	tests := []struct {
+		name string
+		addr string
+	}{
+		{
+			name: "mainnet core contract",
+			addr: "0xc662c410C0ECf747543f5bA90660f6ABeBD9C8c4",
+		},
+		{
+			name: "zero address",
+			addr: "0x0000000000000000000000000000000000000000",
+		},
+		{
+			name: "all ones",
+			addr: "0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF",
+		},
+		{
+			name: "mixed",
+			addr: "0x1234567890123456789012345678901234567890",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			original := common.HexToAddress(tt.addr)
+			l1Addr := types.L1AddressFromEth(original)
+			converted := l1Addr.ToEthAddress()
+			require.Equal(t, original, converted, "Round-trip conversion failed")
+		})
+	}
+}
+
+func TestEthereumHashRoundTrip(t *testing.T) {
+	tests := []struct {
+		name string
+		hash string
+	}{
+		{
+			name: "typical transaction hash",
+			hash: "0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef",
+		},
+		{
+			name: "zero hash",
+			hash: "0x0000000000000000000000000000000000000000000000000000000000000000",
+		},
+		{
+			name: "all ones",
+			hash: "0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+		},
+		{
+			name: "mixed",
+			hash: "0x123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			original := common.HexToHash(tt.hash)
+
+			l1Hash := types.L1HashFromEth(original)
+			converted := l1Hash.ToEthHash()
+			require.Equal(t, original, converted, "Round-trip conversion failed")
+		})
+	}
+}
+
+// TestEthereumAddressPadding verifies that Ethereum addresses (20 bytes)
+// are correctly left-padded with 12 zero bytes when stored as L1Address (32 bytes).
+func TestEthereumAddressPadding(t *testing.T) {
+	addr := common.HexToAddress("0x1234567890123456789012345678901234567890")
+	l1Addr := types.L1AddressFromEth(addr)
+
+	bytes := l1Addr.Bytes()
+
+	for i := range 12 {
+		assert.Zero(t, bytes[i], "Expected zero padding at byte %d", i)
+	}
+
+	assert.Equal(t, addr[:], bytes[12:], "Address bytes don't match")
+}
+
+// TestCBORBackwardCompatibility ensures that L1Address CBOR encoding
+// maintains backward compatibility by:
+// 1. Encoding Ethereum addresses as compact 20-byte format (new behavior)
+// 2. Still being able to decode old 32-byte padded format
+func TestCBORBackwardCompatibility(t *testing.T) {
+	ethAddr := common.HexToAddress("0xc662c410C0ECf747543f5bA90660f6ABeBD9C8c4")
+
+	t.Run("New compact encoding", func(t *testing.T) {
+		l1Addr := types.L1AddressFromEth(ethAddr)
+		newCBOR, err := l1Addr.MarshalCBOR()
+		require.NoError(t, err)
+
+		expectedCompact, err := cbor.Marshal(ethAddr[:])
+		require.NoError(t, err)
+
+		assert.Equal(t, expectedCompact, newCBOR, "Should encode Ethereum address as compact 20-byte format")
+	})
+
+	t.Run("Can decode old 32-byte format", func(t *testing.T) {
+		var oldPadded [32]byte
+		copy(oldPadded[12:], ethAddr[:])
+		oldCBOR, err := cbor.Marshal(oldPadded[:])
+		require.NoError(t, err)
+
+		var decoded types.L1Address
+		err = decoded.UnmarshalCBOR(oldCBOR)
+		require.NoError(t, err)
+
+		l1Addr := types.L1AddressFromEth(ethAddr)
+		assert.True(t, types.Equal(&l1Addr, &decoded), "Failed to decode old 32-byte CBOR format")
+	})
+
+	t.Run("Can decode new 20-byte format", func(t *testing.T) {
+		// New compact encoding
+		l1Addr := types.L1AddressFromEth(ethAddr)
+		compactCBOR, err := l1Addr.MarshalCBOR()
+		require.NoError(t, err)
+
+		var decoded types.L1Address
+		err = decoded.UnmarshalCBOR(compactCBOR)
+		require.NoError(t, err)
+
+		assert.True(t, types.Equal(&l1Addr, &decoded), "Failed to decode new 20-byte CBOR format")
+		assert.Equal(t, ethAddr, decoded.ToEthAddress(), "Round-trip failed")
+	})
+}
+
+// TestCBORHashBackwardCompatibility ensures that L1Hash CBOR encoding
+// is compatible with the previous go-ethereum-based implementation.
+func TestCBORHashBackwardCompatibility(t *testing.T) {
+	ethHash := common.HexToHash("0x123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0")
+
+	oldCBOR, err := cbor.Marshal(ethHash[:])
+	require.NoError(t, err)
+
+	l1Hash := types.L1HashFromEth(ethHash)
+	newCBOR, err := l1Hash.MarshalCBOR()
+	require.NoError(t, err)
+
+	assert.Equal(t, oldCBOR, newCBOR, "CBOR encoding changed - backward compatibility broken!")
+
+	var decoded types.L1Hash
+	err = decoded.UnmarshalCBOR(oldCBOR)
+	require.NoError(t, err)
+	assert.True(t, types.Equal(&l1Hash, &decoded), "Failed to decode old CBOR format")
+}
+
+// TestJSONCompatibility verifies JSON marshaling/unmarshaling works correctly.
+func TestJSONCompatibility(t *testing.T) {
+	t.Run("L1Address", func(t *testing.T) {
+		ethAddr := common.HexToAddress("0x1234567890123456789012345678901234567890")
+		l1Addr := types.L1AddressFromEth(ethAddr)
+
+		jsonData, err := l1Addr.MarshalJSON()
+		require.NoError(t, err)
+
+		var decoded types.L1Address
+		err = decoded.UnmarshalJSON(jsonData)
+		require.NoError(t, err)
+
+		assert.True(t, types.Equal(&l1Addr, &decoded), "JSON round-trip failed")
+	})
+
+	t.Run("L1Hash", func(t *testing.T) {
+		ethHash := common.HexToHash("0x123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0")
+		l1Hash := types.L1HashFromEth(ethHash)
+
+		jsonData, err := l1Hash.MarshalJSON()
+		require.NoError(t, err)
+
+		var decoded types.L1Hash
+		err = decoded.UnmarshalJSON(jsonData)
+		require.NoError(t, err)
+
+		assert.True(t, types.Equal(&l1Hash, &decoded), "JSON round-trip failed")
+	})
+}
+
+// TestStringRepresentation verifies string conversion is correct.
+func TestStringRepresentation(t *testing.T) {
+	t.Run("L1Address", func(t *testing.T) {
+		ethAddr := common.HexToAddress("0xc662c410C0ECf747543f5bA90660f6ABeBD9C8c4")
+		l1Addr := types.L1AddressFromEth(ethAddr)
+
+		str := l1Addr.String()
+		assert.NotEmpty(t, str)
+		assert.Contains(t, str, "0x")
+
+		parsed, err := types.NewFromString[types.L1Address](str)
+		require.NoError(t, err)
+		assert.True(t, types.Equal(&l1Addr, parsed))
+	})
+
+	t.Run("L1Hash", func(t *testing.T) {
+		ethHash := common.HexToHash("0x123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0")
+		l1Hash := types.L1HashFromEth(ethHash)
+
+		str := l1Hash.String()
+		assert.NotEmpty(t, str)
+		assert.Contains(t, str, "0x")
+
+		parsed, err := types.NewFromString[types.L1Hash](str)
+		require.NoError(t, err)
+		assert.True(t, types.Equal(&l1Hash, parsed))
+	})
+}

--- a/l1/types/go_ethereum_test.go
+++ b/l1/types/go_ethereum_test.go
@@ -107,7 +107,12 @@ func TestCBORBackwardCompatibility(t *testing.T) {
 		expectedCompact, err := cbor.Marshal(ethAddr[:])
 		require.NoError(t, err)
 
-		assert.Equal(t, expectedCompact, newCBOR, "Should encode Ethereum address as compact 20-byte format")
+		assert.Equal(
+			t,
+			expectedCompact,
+			newCBOR,
+			"Should encode Ethereum address as compact 20-byte format",
+		)
 	})
 
 	t.Run("Can decode old 32-byte format", func(t *testing.T) {

--- a/l1/types/hash.go
+++ b/l1/types/hash.go
@@ -1,0 +1,60 @@
+package types
+
+import "github.com/holiman/uint256"
+
+type L1Hash U256
+
+// Bytes returns the 32-byte big-endian representation.
+func (h *L1Hash) Bytes() [32]byte {
+	return (*U256)(h).Bytes32()
+}
+
+// String returns hex representation with "0x" prefix.
+func (h *L1Hash) String() string {
+	return (*U256)(h).String()
+}
+
+// Marshal returns the 32-byte big-endian representation as a slice.
+func (h *L1Hash) Marshal() []byte {
+	b := (*U256)(h).Bytes32()
+	return b[:]
+}
+
+// Unmarshal sets the value from big-endian bytes (right-truncated if > 32 bytes).
+func (h *L1Hash) Unmarshal(e []byte) {
+	if len(e) > 32 {
+		e = e[len(e)-32:]
+	}
+	(*uint256.Int)((*U256)(h)).SetBytes(e)
+}
+
+// MarshalJSON encodes as a hex string with "0x" prefix.
+func (h *L1Hash) MarshalJSON() ([]byte, error) {
+	return (*U256)(h).MarshalJSON()
+}
+
+// UnmarshalJSON decodes from hex string or decimal string.
+func (h *L1Hash) UnmarshalJSON(data []byte) error {
+	return (*U256)(h).UnmarshalJSON(data)
+}
+
+// MarshalCBOR marshals the 32-byte value to CBOR.
+func (h *L1Hash) MarshalCBOR() ([]byte, error) {
+	u := (*U256)(h)
+	return u.MarshalCBOR()
+}
+
+// UnmarshalCBOR unmarshals a CBOR-encoded 32-byte value.
+func (h *L1Hash) UnmarshalCBOR(data []byte) error {
+	u := (*U256)(h)
+	return u.UnmarshalCBOR(data)
+}
+
+// SetBytesCanonical accepts up to 32 bytes big-endian and sets the value.
+func (h *L1Hash) SetBytesCanonical(data []byte) error {
+	if len(data) > 32 {
+		return errU256TooLarge
+	}
+	(*uint256.Int)((*U256)(h)).SetBytes(data)
+	return nil
+}

--- a/l1/types/u256.go
+++ b/l1/types/u256.go
@@ -1,0 +1,148 @@
+package types
+
+import (
+	"crypto/rand"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"math/big"
+	"strings"
+
+	"github.com/fxamacker/cbor/v2"
+	"github.com/holiman/uint256"
+)
+
+// U256 is a 256-bit unsigned integer (wraps holiman/uint256.Int).
+type U256 uint256.Int
+
+var (
+	errU256TooLarge = errors.New("value exceeds 32 bytes")
+	errU256BadHex   = errors.New("invalid hex string")
+)
+
+// Bytes32 returns the 32-byte big-endian representation.
+func (u *U256) Bytes32() [32]byte {
+	return (*uint256.Int)(u).Bytes32()
+}
+
+// Equal reports whether u and other represent the same value.
+func (u *U256) Equal(other *U256) bool {
+	if other == nil {
+		return false
+	}
+	return (*uint256.Int)(u).Eq((*uint256.Int)(other))
+}
+
+// String returns hex representation with "0x" prefix.
+func (u *U256) String() string {
+	return (*uint256.Int)(u).Hex()
+}
+
+// Marshal returns the 32-byte big-endian representation as a slice.
+func (u *U256) Marshal() []byte {
+	b := u.Bytes32()
+	return b[:]
+}
+
+// Unmarshal sets the value from big-endian bytes (right-truncated if > 32 bytes).
+func (u *U256) Unmarshal(e []byte) {
+	if len(e) > 32 {
+		e = e[len(e)-32:]
+	}
+	(*uint256.Int)(u).SetBytes(e)
+}
+
+// MarshalJSON encodes as a hex string with "0x" prefix.
+func (u *U256) MarshalJSON() ([]byte, error) {
+	hexStr := (*uint256.Int)(u).Hex()
+	return json.Marshal(hexStr)
+}
+
+// UnmarshalJSON decodes from hex string or decimal string.
+func (u *U256) UnmarshalJSON(data []byte) error {
+	var s string
+	if err := json.Unmarshal(data, &s); err != nil {
+		return err
+	}
+	v, err := u256FromString(s)
+	if err != nil {
+		return err
+	}
+	*u = U256(*v)
+	return nil
+}
+
+// MarshalCBOR marshals the 32-byte value to CBOR.
+func (u *U256) MarshalCBOR() ([]byte, error) {
+	return cbor.Marshal(u.Marshal())
+}
+
+// UnmarshalCBOR unmarshals a CBOR-encoded byte slice into u.
+func (u *U256) UnmarshalCBOR(data []byte) error {
+	var b []byte
+	if err := cbor.Unmarshal(data, &b); err != nil {
+		return err
+	}
+	u.Unmarshal(b)
+	return nil
+}
+
+// SetBytesCanonical accepts up to 32 bytes big-endian and sets the value.
+func (u *U256) SetBytesCanonical(data []byte) error {
+	if len(data) > 32 {
+		return errU256TooLarge
+	}
+	(*uint256.Int)(u).SetBytes(data)
+	return nil
+}
+
+// SetBytes32 sets the value from exactly 32 big-endian bytes.
+func (u *U256) SetBytes32(b [32]byte) error {
+	(*uint256.Int)(u).SetBytes(b[:])
+	return nil
+}
+
+func u256FromString(value string) (*U256, error) {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return nil, errU256BadHex
+	}
+	if strings.HasPrefix(value, "0x") || strings.HasPrefix(value, "0X") {
+		return u256FromHex(value[2:])
+	}
+	return u256FromDecimal(value)
+}
+
+func u256FromHex(hexPart string) (*U256, error) {
+	hexPart = strings.TrimLeft(hexPart, "0")
+	if hexPart == "" {
+		hexPart = "0"
+	}
+	val, err := uint256.FromHex("0x" + hexPart)
+	if err != nil {
+		return nil, fmt.Errorf("%w: %v", errU256BadHex, err)
+	}
+	return (*U256)(val), nil
+}
+
+func u256FromDecimal(s string) (*U256, error) {
+	val, err := uint256.FromDecimal(s)
+	if err != nil {
+		if bi, ok := new(big.Int).SetString(s, 10); ok && bi.BitLen() > 256 {
+			return nil, errU256TooLarge
+		}
+		return nil, fmt.Errorf("%w: %v", errU256BadHex, err)
+	}
+	return (*U256)(val), nil
+}
+
+// RandomU256 returns a random U256 value.
+func RandomU256() (*U256, error) {
+	var b [32]byte
+	if _, err := rand.Read(b[:]); err != nil {
+		return nil, err
+	}
+	u := new(U256)
+	(*uint256.Int)(u).SetBytes(b[:])
+	return u, nil
+}

--- a/l1/types/u256.go
+++ b/l1/types/u256.go
@@ -1,7 +1,6 @@
 package types
 
 import (
-	"crypto/rand"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -134,15 +133,4 @@ func u256FromDecimal(s string) (*U256, error) {
 		return nil, fmt.Errorf("%w: %v", errU256BadHex, err)
 	}
 	return (*U256)(val), nil
-}
-
-// RandomU256 returns a random U256 value.
-func RandomU256() (*U256, error) {
-	var b [32]byte
-	if _, err := rand.Read(b[:]); err != nil {
-		return nil, err
-	}
-	u := new(U256)
-	(*uint256.Int)(u).SetBytes(b[:])
-	return u, nil
 }

--- a/l1/types/utils.go
+++ b/l1/types/utils.go
@@ -1,0 +1,7 @@
+package types
+
+func Equal[T U256Like](a, b *T) bool {
+	fa := U256(*a)
+	fb := U256(*b)
+	return fa.Equal(&fb)
+}

--- a/mocks/mock_blockchain.go
+++ b/mocks/mock_blockchain.go
@@ -151,37 +151,6 @@ func (mr *MockReaderMockRecorder) BlockNumberByHash(hash any) *gomock.Call {
 }
 
 // EventFilter mocks base method.
-func (m *MockReader) EventFilter(from *felt.Felt, keys [][]felt.Felt, pendingDataFn func() (core.PendingData, error)) (blockchain.EventFilterer, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "BlockNumberAndIndexByTxHash", hash)
-	ret0, _ := ret[0].(uint64)
-	ret1, _ := ret[1].(uint64)
-	ret2, _ := ret[2].(error)
-	return ret0, ret1, ret2
-}
-
-// BlockNumberAndIndexByTxHash indicates an expected call of BlockNumberAndIndexByTxHash.
-func (mr *MockReaderMockRecorder) BlockNumberAndIndexByTxHash(hash any) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BlockNumberAndIndexByTxHash", reflect.TypeOf((*MockReader)(nil).BlockNumberAndIndexByTxHash), hash)
-}
-
-// BlockNumberByHash mocks base method.
-func (m *MockReader) BlockNumberByHash(hash *felt.Felt) (uint64, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "BlockNumberByHash", hash)
-	ret0, _ := ret[0].(uint64)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// BlockNumberByHash indicates an expected call of BlockNumberByHash.
-func (mr *MockReaderMockRecorder) BlockNumberByHash(hash any) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BlockNumberByHash", reflect.TypeOf((*MockReader)(nil).BlockNumberByHash), hash)
-}
-
-// EventFilter mocks base method.
 func (m *MockReader) EventFilter(addresses []felt.Address, keys [][]felt.Felt, pendingDataFn func() (core.PendingData, error)) (blockchain.EventFilterer, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "EventFilter", addresses, keys, pendingDataFn)

--- a/mocks/mock_blockchain.go
+++ b/mocks/mock_blockchain.go
@@ -15,8 +15,8 @@ import (
 	blockchain "github.com/NethermindEth/juno/blockchain"
 	core "github.com/NethermindEth/juno/core"
 	felt "github.com/NethermindEth/juno/core/felt"
+	types "github.com/NethermindEth/juno/l1/types"
 	utils "github.com/NethermindEth/juno/utils"
-	common "github.com/ethereum/go-ethereum/common"
 	gomock "go.uber.org/mock/gomock"
 )
 
@@ -151,6 +151,37 @@ func (mr *MockReaderMockRecorder) BlockNumberByHash(hash any) *gomock.Call {
 }
 
 // EventFilter mocks base method.
+func (m *MockReader) EventFilter(from *felt.Felt, keys [][]felt.Felt, pendingDataFn func() (core.PendingData, error)) (blockchain.EventFilterer, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "BlockNumberAndIndexByTxHash", hash)
+	ret0, _ := ret[0].(uint64)
+	ret1, _ := ret[1].(uint64)
+	ret2, _ := ret[2].(error)
+	return ret0, ret1, ret2
+}
+
+// BlockNumberAndIndexByTxHash indicates an expected call of BlockNumberAndIndexByTxHash.
+func (mr *MockReaderMockRecorder) BlockNumberAndIndexByTxHash(hash any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BlockNumberAndIndexByTxHash", reflect.TypeOf((*MockReader)(nil).BlockNumberAndIndexByTxHash), hash)
+}
+
+// BlockNumberByHash mocks base method.
+func (m *MockReader) BlockNumberByHash(hash *felt.Felt) (uint64, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "BlockNumberByHash", hash)
+	ret0, _ := ret[0].(uint64)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// BlockNumberByHash indicates an expected call of BlockNumberByHash.
+func (mr *MockReaderMockRecorder) BlockNumberByHash(hash any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BlockNumberByHash", reflect.TypeOf((*MockReader)(nil).BlockNumberByHash), hash)
+}
+
+// EventFilter mocks base method.
 func (m *MockReader) EventFilter(addresses []felt.Address, keys [][]felt.Felt, pendingDataFn func() (core.PendingData, error)) (blockchain.EventFilterer, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "EventFilter", addresses, keys, pendingDataFn)
@@ -227,7 +258,7 @@ func (mr *MockReaderMockRecorder) Height() *gomock.Call {
 }
 
 // L1HandlerTxnHash mocks base method.
-func (m *MockReader) L1HandlerTxnHash(msgHash *common.Hash) (felt.Felt, error) {
+func (m *MockReader) L1HandlerTxnHash(msgHash *types.L1Hash) (felt.Felt, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "L1HandlerTxnHash", msgHash)
 	ret0, _ := ret[0].(felt.Felt)

--- a/mocks/mock_subscriber.go
+++ b/mocks/mock_subscriber.go
@@ -15,8 +15,8 @@ import (
 	reflect "reflect"
 
 	contract "github.com/NethermindEth/juno/l1/contract"
-	common "github.com/ethereum/go-ethereum/common"
-	types "github.com/ethereum/go-ethereum/core/types"
+	types "github.com/NethermindEth/juno/l1/types"
+	types0 "github.com/ethereum/go-ethereum/core/types"
 	event "github.com/ethereum/go-ethereum/event"
 	gomock "go.uber.org/mock/gomock"
 )
@@ -103,10 +103,10 @@ func (mr *MockSubscriberMockRecorder) LatestHeight(ctx any) *gomock.Call {
 }
 
 // TransactionReceipt mocks base method.
-func (m *MockSubscriber) TransactionReceipt(ctx context.Context, txHash common.Hash) (*types.Receipt, error) {
+func (m *MockSubscriber) TransactionReceipt(ctx context.Context, txHash *types.L1Hash) (*types0.Receipt, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "TransactionReceipt", ctx, txHash)
-	ret0, _ := ret[0].(*types.Receipt)
+	ret0, _ := ret[0].(*types0.Receipt)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }

--- a/node/node.go
+++ b/node/node.go
@@ -486,7 +486,7 @@ func newL1Client(
 	network := chain.Network()
 
 	var ethSubscriber *l1.EthSubscriber
-	ethSubscriber, err = l1.NewEthSubscriber(ethNode, network.CoreContractAddress)
+	ethSubscriber, err = l1.NewEthSubscriber(ethNode, &network.CoreContractAddress)
 	if err != nil {
 		return nil, fmt.Errorf("set up ethSubscriber: %w", err)
 	}

--- a/rpc/rpccore/rpccore.go
+++ b/rpc/rpccore/rpccore.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/NethermindEth/juno/core/felt"
 	"github.com/NethermindEth/juno/jsonrpc"
-	"github.com/ethereum/go-ethereum/common"
+	l1types "github.com/NethermindEth/juno/l1/types"
 	"github.com/ethereum/go-ethereum/core/types"
 )
 
@@ -27,7 +27,7 @@ type Gateway interface {
 }
 
 type L1Client interface {
-	TransactionReceipt(ctx context.Context, txHash common.Hash) (*types.Receipt, error)
+	TransactionReceipt(ctx context.Context, txHash *l1types.L1Hash) (*types.Receipt, error)
 }
 
 type TraceCacheKey struct {

--- a/rpc/v10/estimate_fee.go
+++ b/rpc/v10/estimate_fee.go
@@ -46,7 +46,7 @@ func (h *Handler) EstimateMessageFee(
 ) (rpcv9.FeeEstimate, http.Header, *jsonrpc.Error) {
 	calldata := make([]*felt.Felt, len(msg.Payload)+1)
 	// msg.From needs to be the first element
-	calldata[0] = felt.NewFromBytes[felt.Felt](msg.From.Bytes())
+	calldata[0] = felt.NewFromBytes[felt.Felt](msg.From.Marshal())
 	for i := range msg.Payload {
 		calldata[i+1] = &msg.Payload[i]
 	}
@@ -57,14 +57,16 @@ func (h *Handler) EstimateMessageFee(
 	}
 	defer h.callAndLogErr(closer, "Failed to close state in starknet_estimateMessageFee")
 
-	if _, err := state.ContractClassHash(&msg.To); err != nil {
+	// todo: remove the felt cast
+	if _, err := state.ContractClassHash((*felt.Felt)(&msg.To)); err != nil {
 		return rpcv9.FeeEstimate{}, nil, rpccore.ErrContractNotFound
 	}
 
 	tx := rpcv9.BroadcastedTransaction{
 		Transaction: rpcv9.Transaction{
-			Type:               rpcv9.TxnL1Handler,
-			ContractAddress:    &msg.To,
+			Type: rpcv9.TxnL1Handler,
+			// todo: remove the felt cast
+			ContractAddress:    (*felt.Felt)(&msg.To),
 			EntryPointSelector: &msg.Selector,
 			CallData:           &calldata,
 			Version:            &felt.Zero, // Needed for transaction hash calculation.

--- a/rpc/v6/estimate_fee.go
+++ b/rpc/v6/estimate_fee.go
@@ -77,7 +77,7 @@ type estimateFeeHandler func(
 func (h *Handler) estimateMessageFee(msg MsgFromL1, id BlockID, f estimateFeeHandler) (*FeeEstimate, *jsonrpc.Error) { //nolint:gocritic
 	calldata := make([]*felt.Felt, 0, len(msg.Payload)+1)
 	// The order of the calldata parameters matters. msg.From must be prepended.
-	calldata = append(calldata, (*felt.Felt)(&msg.From))
+	calldata = append(calldata, felt.NewFromBytes[felt.Felt](msg.From.Marshal()))
 	for payloadIdx := range msg.Payload {
 		calldata = append(calldata, &msg.Payload[payloadIdx])
 	}

--- a/rpc/v6/estimate_fee.go
+++ b/rpc/v6/estimate_fee.go
@@ -77,14 +77,15 @@ type estimateFeeHandler func(
 func (h *Handler) estimateMessageFee(msg MsgFromL1, id BlockID, f estimateFeeHandler) (*FeeEstimate, *jsonrpc.Error) { //nolint:gocritic
 	calldata := make([]*felt.Felt, 0, len(msg.Payload)+1)
 	// The order of the calldata parameters matters. msg.From must be prepended.
-	calldata = append(calldata, new(felt.Felt).SetBytes(msg.From.Bytes()))
+	calldata = append(calldata, (*felt.Felt)(&msg.From))
 	for payloadIdx := range msg.Payload {
 		calldata = append(calldata, &msg.Payload[payloadIdx])
 	}
 	tx := BroadcastedTransaction{
 		Transaction: Transaction{
-			Type:               TxnL1Handler,
-			ContractAddress:    &msg.To,
+			Type: TxnL1Handler,
+			// todo: remove the felt cast
+			ContractAddress:    (*felt.Felt)(&msg.To),
 			EntryPointSelector: &msg.Selector,
 			CallData:           &calldata,
 			Version:            &felt.Zero, // Needed for transaction hash calculation.

--- a/rpc/v6/estimate_fee_test.go
+++ b/rpc/v6/estimate_fee_test.go
@@ -7,12 +7,12 @@ import (
 	"github.com/NethermindEth/juno/core"
 	"github.com/NethermindEth/juno/core/felt"
 	"github.com/NethermindEth/juno/db"
+	"github.com/NethermindEth/juno/l1/types"
 	"github.com/NethermindEth/juno/mocks"
 	rpccore "github.com/NethermindEth/juno/rpc/rpccore"
 	rpc "github.com/NethermindEth/juno/rpc/v6"
 	"github.com/NethermindEth/juno/utils"
 	"github.com/NethermindEth/juno/vm"
-	"github.com/ethereum/go-ethereum/common"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
@@ -29,10 +29,10 @@ func TestEstimateMessageFee(t *testing.T) {
 
 	handler := rpc.New(mockReader, nil, mockVM, n, utils.NewNopZapLogger())
 	msg := rpc.MsgFromL1{
-		From:     common.HexToAddress("0xDEADBEEF"),
-		To:       *new(felt.Felt).SetUint64(1337),
-		Payload:  []felt.Felt{*new(felt.Felt).SetUint64(1), *new(felt.Felt).SetUint64(2)},
-		Selector: *new(felt.Felt).SetUint64(44),
+		From:     types.FromBytes[types.L1Address]([]byte("0xDEADBEEF")),
+		To:       felt.FromUint64[felt.Address](1337),
+		Payload:  []felt.Felt{felt.FromUint64[felt.Felt](1), felt.FromUint64[felt.Felt](2)},
+		Selector: felt.FromUint64[felt.Felt](44),
 	}
 
 	t.Run("block not found", func(t *testing.T) {

--- a/rpc/v6/estimate_fee_test.go
+++ b/rpc/v6/estimate_fee_test.go
@@ -28,8 +28,10 @@ func TestEstimateMessageFee(t *testing.T) {
 	mockVM := mocks.NewMockVM(mockCtrl)
 
 	handler := rpc.New(mockReader, nil, mockVM, n, utils.NewNopZapLogger())
+	from, err := types.FromString[types.L1Address]("0xDEADBEEF")
+	require.NoError(t, err)
 	msg := rpc.MsgFromL1{
-		From:     types.FromBytes[types.L1Address]([]byte("0xDEADBEEF")),
+		From:     from,
 		To:       felt.FromUint64[felt.Address](1337),
 		Payload:  []felt.Felt{felt.FromUint64[felt.Felt](1), felt.FromUint64[felt.Felt](2)},
 		Selector: felt.FromUint64[felt.Felt](44),
@@ -94,8 +96,8 @@ func TestEstimateMessageFee(t *testing.T) {
 		},
 	)
 
-	estimateFee, err := handler.EstimateMessageFee(msg, rpc.BlockID{Latest: true})
-	require.Nil(t, err)
+	estimateFee, rpcErr := handler.EstimateMessageFee(msg, rpc.BlockID{Latest: true})
+	require.Nil(t, rpcErr)
 	feeUnit := rpc.WEI
 	require.Equal(t, expectedGasConsumed, estimateFee.GasConsumed)
 	require.Equal(t, latestHeader.L1GasPriceETH, estimateFee.GasPrice)

--- a/rpc/v6/transaction.go
+++ b/rpc/v6/transaction.go
@@ -253,9 +253,9 @@ type MsgFromL1 struct {
 }
 
 type MsgToL1 struct {
-	From    *felt.Address    `json:"from_address,omitempty"`
-	To      *types.L1Address `json:"to_address"`
-	Payload []*felt.Felt     `json:"payload"`
+	From    *felt.Address   `json:"from_address,omitempty"`
+	To      types.L1Address `json:"to_address"`
+	Payload []*felt.Felt    `json:"payload"`
 }
 
 type ComputationResources struct {

--- a/rpc/v6/transaction.go
+++ b/rpc/v6/transaction.go
@@ -13,11 +13,11 @@ import (
 	"github.com/NethermindEth/juno/core/felt"
 	"github.com/NethermindEth/juno/db"
 	"github.com/NethermindEth/juno/jsonrpc"
+	"github.com/NethermindEth/juno/l1/types"
 	"github.com/NethermindEth/juno/mempool"
 	rpccore "github.com/NethermindEth/juno/rpc/rpccore"
 	"github.com/NethermindEth/juno/starknet"
 	"github.com/NethermindEth/juno/utils"
-	"github.com/ethereum/go-ethereum/common"
 	"go.uber.org/zap"
 )
 
@@ -244,18 +244,18 @@ type TransactionStatus struct {
 
 type MsgFromL1 struct {
 	// The address of the L1 contract sending the message.
-	From common.Address `json:"from_address" validate:"required"`
+	From types.L1Address `json:"from_address" validate:"required"`
 	// The address of the L2 contract receiving the message.
-	To felt.Felt `json:"to_address" validate:"required"`
+	To felt.Address `json:"to_address" validate:"required"`
 	// The payload of the message.
 	Payload  []felt.Felt `json:"payload" validate:"required"`
 	Selector felt.Felt   `json:"entry_point_selector" validate:"required"`
 }
 
 type MsgToL1 struct {
-	From    *felt.Felt     `json:"from_address,omitempty"`
-	To      common.Address `json:"to_address"`
-	Payload []*felt.Felt   `json:"payload"`
+	From    *felt.Address    `json:"from_address,omitempty"`
+	To      *types.L1Address `json:"to_address"`
+	Payload []*felt.Felt     `json:"payload"`
 }
 
 type ComputationResources struct {

--- a/rpc/v7/estimate_fee.go
+++ b/rpc/v7/estimate_fee.go
@@ -80,14 +80,14 @@ func (h *Handler) estimateMessageFee(msg rpcv6.MsgFromL1, id BlockID, f estimate
 ) {
 	calldata := make([]*felt.Felt, 0, len(msg.Payload)+1)
 	// The order of the calldata parameters matters. msg.From must be prepended.
-	calldata = append(calldata, new(felt.Felt).SetBytes(msg.From.Bytes()))
+	calldata = append(calldata, new(felt.Felt).SetBytes(msg.From.Marshal()))
 	for payloadIdx := range msg.Payload {
 		calldata = append(calldata, &msg.Payload[payloadIdx])
 	}
 	tx := BroadcastedTransaction{
 		Transaction: Transaction{
 			Type:               TxnL1Handler,
-			ContractAddress:    &msg.To,
+			ContractAddress:    (*felt.Felt)(&msg.To),
 			EntryPointSelector: &msg.Selector,
 			CallData:           &calldata,
 			Version:            &felt.Zero, // Needed for transaction hash calculation.

--- a/rpc/v7/estimate_fee.go
+++ b/rpc/v7/estimate_fee.go
@@ -80,7 +80,7 @@ func (h *Handler) estimateMessageFee(msg rpcv6.MsgFromL1, id BlockID, f estimate
 ) {
 	calldata := make([]*felt.Felt, 0, len(msg.Payload)+1)
 	// The order of the calldata parameters matters. msg.From must be prepended.
-	calldata = append(calldata, new(felt.Felt).SetBytes(msg.From.Marshal()))
+	calldata = append(calldata, felt.NewFromBytes[felt.Felt](msg.From.Marshal()))
 	for payloadIdx := range msg.Payload {
 		calldata = append(calldata, &msg.Payload[payloadIdx])
 	}

--- a/rpc/v7/transaction.go
+++ b/rpc/v7/transaction.go
@@ -12,11 +12,11 @@ import (
 	"github.com/NethermindEth/juno/core/felt"
 	"github.com/NethermindEth/juno/db"
 	"github.com/NethermindEth/juno/jsonrpc"
+	"github.com/NethermindEth/juno/l1/types"
 	"github.com/NethermindEth/juno/rpc/rpccore"
 	rpcv6 "github.com/NethermindEth/juno/rpc/v6"
 	"github.com/NethermindEth/juno/starknet"
 	"github.com/NethermindEth/juno/utils"
-	"github.com/ethereum/go-ethereum/common"
 	"go.uber.org/zap"
 )
 
@@ -193,9 +193,9 @@ type TransactionStatus struct {
 }
 
 type MsgToL1 struct {
-	From    *felt.Felt     `json:"from_address,omitempty"`
-	To      common.Address `json:"to_address"`
-	Payload []*felt.Felt   `json:"payload"`
+	From    *felt.Address   `json:"from_address,omitempty"`
+	To      types.L1Address `json:"to_address"`
+	Payload []*felt.Felt    `json:"payload"`
 }
 
 type ComputationResources struct {
@@ -608,7 +608,7 @@ func AdaptReceipt(receipt *core.TransactionReceipt, txn core.Transaction,
 	messages := make([]*MsgToL1, len(receipt.L2ToL1Message))
 	for idx, msg := range receipt.L2ToL1Message {
 		messages[idx] = &MsgToL1{
-			To:      msg.To,
+			To:      *msg.To,
 			Payload: msg.Payload,
 			From:    msg.From,
 		}

--- a/rpc/v7/transaction.go
+++ b/rpc/v7/transaction.go
@@ -608,7 +608,7 @@ func AdaptReceipt(receipt *core.TransactionReceipt, txn core.Transaction,
 	messages := make([]*MsgToL1, len(receipt.L2ToL1Message))
 	for idx, msg := range receipt.L2ToL1Message {
 		messages[idx] = &MsgToL1{
-			To:      *msg.To,
+			To:      msg.To,
 			Payload: msg.Payload,
 			From:    msg.From,
 		}

--- a/rpc/v8/estimate_fee.go
+++ b/rpc/v8/estimate_fee.go
@@ -287,7 +287,7 @@ func (h *Handler) EstimateMessageFee(
 ) (FeeEstimate, http.Header, *jsonrpc.Error) {
 	calldata := make([]*felt.Felt, len(msg.Payload)+1)
 	// msg.From needs to be the first element
-	calldata[0] = new(felt.Felt).SetBytes(msg.From.Marshal())
+	calldata[0] = felt.NewFromBytes[felt.Felt](msg.From.Marshal())
 	for i := range msg.Payload {
 		calldata[i+1] = &msg.Payload[i]
 	}

--- a/rpc/v8/estimate_fee.go
+++ b/rpc/v8/estimate_fee.go
@@ -287,14 +287,15 @@ func (h *Handler) EstimateMessageFee(
 ) (FeeEstimate, http.Header, *jsonrpc.Error) {
 	calldata := make([]*felt.Felt, len(msg.Payload)+1)
 	// msg.From needs to be the first element
-	calldata[0] = new(felt.Felt).SetBytes(msg.From.Bytes())
+	calldata[0] = new(felt.Felt).SetBytes(msg.From.Marshal())
 	for i := range msg.Payload {
 		calldata[i+1] = &msg.Payload[i]
 	}
 	tx := BroadcastedTransaction{
 		Transaction: Transaction{
-			Type:               TxnL1Handler,
-			ContractAddress:    &msg.To,
+			Type: TxnL1Handler,
+			// todo: this shouldn't have to be casted
+			ContractAddress:    (*felt.Felt)(&msg.To),
 			EntryPointSelector: &msg.Selector,
 			CallData:           &calldata,
 			Version:            &felt.Zero, // Needed for transaction hash calculation.

--- a/rpc/v8/l1.go
+++ b/rpc/v8/l1.go
@@ -7,15 +7,15 @@ import (
 
 	"github.com/NethermindEth/juno/core/felt"
 	"github.com/NethermindEth/juno/jsonrpc"
+	"github.com/NethermindEth/juno/l1/types"
 	"github.com/NethermindEth/juno/rpc/rpccore"
-	"github.com/ethereum/go-ethereum/common"
 	"golang.org/x/crypto/sha3"
 )
 
-var logMsgToL2SigHash = common.HexToHash("0xdb80dd488acf86d17c747445b0eabb5d57c541d3bd7b6b87af987858e5066b2b")
+var logMsgToL2SigHash = types.UnsafeFromString[types.L1Hash]("0xdb80dd488acf86d17c747445b0eabb5d57c541d3bd7b6b87af987858e5066b2b")
 
 type logMessageToL2 struct {
-	FromAddress *common.Address
+	FromAddress *types.L1Address
 	ToAddress   *big.Int
 	Nonce       *big.Int
 	Selector    *big.Int
@@ -23,7 +23,7 @@ type logMessageToL2 struct {
 	Fee         *big.Int
 }
 
-func (l *logMessageToL2) hashMessage() *common.Hash {
+func (l *logMessageToL2) hashMessage() types.L1Hash {
 	hash := sha3.NewLegacyKeccak256()
 
 	writeUint256 := func(value *big.Int) {
@@ -32,9 +32,8 @@ func (l *logMessageToL2) hashMessage() *common.Hash {
 		hash.Write(bytes)
 	}
 
-	// Pad FromAddress to 32 bytes
-	hash.Write(make([]byte, 12)) //nolint:mnd
-	hash.Write(l.FromAddress.Bytes())
+	fromBytes := l.FromAddress.Bytes()
+	hash.Write(fromBytes[:])
 	writeUint256(l.ToAddress)
 	writeUint256(l.Nonce)
 	writeUint256(l.Selector)
@@ -44,8 +43,8 @@ func (l *logMessageToL2) hashMessage() *common.Hash {
 		writeUint256(elem)
 	}
 
-	tmp := common.BytesToHash(hash.Sum(nil))
-	return &tmp
+	eventHash := hash.Sum(nil)
+	return types.FromBytes[types.L1Hash](eventHash)
 }
 
 type MsgStatus struct {
@@ -54,7 +53,7 @@ type MsgStatus struct {
 	FailureReason  string     `json:"failure_reason,omitempty"`
 }
 
-func (h *Handler) GetMessageStatus(ctx context.Context, l1TxnHash *common.Hash) ([]MsgStatus, *jsonrpc.Error) {
+func (h *Handler) GetMessageStatus(ctx context.Context, l1TxnHash *types.L1Hash) ([]MsgStatus, *jsonrpc.Error) {
 	// l1 txn hash -> (l1 handler) msg hashes
 	msgHashes, rpcErr := h.messageToL2Logs(ctx, l1TxnHash)
 	if rpcErr != nil {
@@ -67,10 +66,8 @@ func (h *Handler) GetMessageStatus(ctx context.Context, l1TxnHash *common.Hash) 
 		if err != nil {
 			return nil, jsonrpc.Err(
 				jsonrpc.InternalError,
-				fmt.Sprintf("failed to retrieve L1 handler txn hash. msgHash %s, err: %v",
-					msgHash.Hex(),
-					err,
-				),
+				fmt.Errorf("failed to retrieve L1 handler txn %v",
+					err),
 			)
 		}
 		status, rpcErr := h.TransactionStatus(ctx, hash)
@@ -86,40 +83,41 @@ func (h *Handler) GetMessageStatus(ctx context.Context, l1TxnHash *common.Hash) 
 	return results, nil
 }
 
-func (h *Handler) messageToL2Logs(ctx context.Context, txHash *common.Hash) ([]*common.Hash, *jsonrpc.Error) {
+func (h *Handler) messageToL2Logs(ctx context.Context, txHash *types.L1Hash) ([]*types.L1Hash, *jsonrpc.Error) {
 	if h.l1Client == nil {
 		return nil, jsonrpc.Err(jsonrpc.InternalError, "L1 client not found")
 	}
 
-	receipt, err := h.l1Client.TransactionReceipt(ctx, *txHash)
+	receipt, err := h.l1Client.TransactionReceipt(ctx, txHash)
 	if err != nil {
 		return nil, rpccore.ErrTxnHashNotFound
 	}
 
-	messageHashes := make([]*common.Hash, 0, len(receipt.Logs))
-	for i, vLog := range receipt.Logs {
-		if common.HexToHash(vLog.Topics[0].Hex()).Cmp(logMsgToL2SigHash) != 0 {
+	messageHashes := make([]*types.L1Hash, 0, len(receipt.Logs))
+	for _, vLog := range receipt.Logs {
+		topic0Hash, err := types.FromString[types.L1Hash](vLog.Topics[0].Hex())
+		if err != nil {
+			return nil, jsonrpc.Err(rpccore.ErrInternal.Code, fmt.Errorf("failed to parse topic 0 hash %v", err))
+		}
+		if !types.Equal(&topic0Hash, &logMsgToL2SigHash) {
 			continue
 		}
 		var event logMessageToL2
 		err = h.coreContractABI.UnpackIntoInterface(&event, "LogMessageToL2", vLog.Data)
 		if err != nil {
-			return nil, jsonrpc.Err(
-				jsonrpc.InternalError,
-				fmt.Sprintf("failed to unpack log, l1 txn hash %s, logIndex %d err: %v",
-					txHash.Hex(),
-					i,
-					err,
-				),
-			)
+			return nil, jsonrpc.Err(rpccore.ErrInternal.Code, fmt.Errorf("failed to unpack log %v", err))
 		}
 		// Extract indexed fields from topics
-		fromAddress := common.HexToAddress(vLog.Topics[1].Hex())
+		fromAddress, err := types.FromString[types.L1Address](vLog.Topics[1].Hex())
+		if err != nil {
+			return nil, jsonrpc.Err(rpccore.ErrInternal.Code, fmt.Errorf("failed to parse from address %v", err))
+		}
 		event.ToAddress = new(big.Int).SetBytes(vLog.Topics[2].Bytes())
 		selector := new(big.Int).SetBytes(vLog.Topics[3].Bytes())
 		event.FromAddress = &fromAddress
 		event.Selector = selector
-		messageHashes = append(messageHashes, event.hashMessage())
+		eventHash := event.hashMessage()
+		messageHashes = append(messageHashes, &eventHash)
 	}
 	return messageHashes, nil
 }

--- a/rpc/v8/l1_test.go
+++ b/rpc/v8/l1_test.go
@@ -7,11 +7,11 @@ import (
 	"github.com/NethermindEth/juno/clients/feeder"
 	"github.com/NethermindEth/juno/core"
 	"github.com/NethermindEth/juno/core/felt"
+	l1types "github.com/NethermindEth/juno/l1/types"
 	"github.com/NethermindEth/juno/mocks"
 	rpc "github.com/NethermindEth/juno/rpc/v8"
 	adaptfeeder "github.com/NethermindEth/juno/starknetdata/feeder"
 	"github.com/NethermindEth/juno/utils"
-	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
@@ -35,35 +35,36 @@ func TestGetMessageStatus(t *testing.T) {
 
 	tests := map[string]struct {
 		network        utils.Network
-		l1TxnHash      common.Hash
+		l1TxnHash      l1types.L1Hash
 		msgs           []rpc.MsgStatus
-		msgHashes      []common.Hash
+		msgHashes      []l1types.L1Hash
 		l1TxnReceipt   types.Receipt
 		blockNum       uint
 		l1HeadBlockNum uint
 	}{
 		"mainnet 0.13.2.1": {
 			network:   utils.Mainnet,
-			l1TxnHash: common.HexToHash("0x5780c6fe46f958a7ebf9308e6db16d819ff9e06b1e88f9e718c50cde10898f38"),
+			l1TxnHash: l1types.UnsafeFromString[l1types.L1Hash]("0x5780c6fe46f958a7ebf9308e6db16d819ff9e06b1e88f9e718c50cde10898f38"),
 			msgs: []rpc.MsgStatus{{
 				L1HandlerHash:  felt.NewUnsafeFromString[felt.Felt]("0xc470e30f97f64255a62215633e35a7c6ae10332a9011776dde1143ab0202c3"),
 				FinalityStatus: rpc.TxnStatusAcceptedOnL1,
 				FailureReason:  "",
 			}},
-			msgHashes:      []common.Hash{common.HexToHash("0xd8824a75a588f0726d7d83b3e9560810c763043e979fdb77b11c1a51a991235d")},
+			msgHashes: []l1types.L1Hash{
+				l1types.UnsafeFromString[l1types.L1Hash]("0xd8824a75a588f0726d7d83b3e9560810c763043e979fdb77b11c1a51a991235d")},
 			l1TxnReceipt:   l1TxnReceipt,
 			blockNum:       763497,
 			l1HeadBlockNum: 763498,
 		},
 		"sepolia 0.13.4": {
 			network:   utils.Sepolia,
-			l1TxnHash: common.HexToHash("0xeafadb9958437ef43ce7ed19f8ac0c8071c18f4a55fd778cecc23d8b6f86026f"),
+			l1TxnHash: l1types.UnsafeFromString[l1types.L1Hash]("0xeafadb9958437ef43ce7ed19f8ac0c8071c18f4a55fd778cecc23d8b6f86026f"),
 			msgs: []rpc.MsgStatus{{
 				L1HandlerHash:  felt.NewUnsafeFromString[felt.Felt]("0x304c78cccf0569159d4b2aff2117f060509b7c6d590ae740d2031d1eb507b10"),
 				FinalityStatus: rpc.TxnStatusAcceptedOnL2,
 				FailureReason:  "",
 			}},
-			msgHashes:      []common.Hash{common.HexToHash("0x162e74b4ccf7e350a1668de856f892057e0da112e1ad2262603306ee5dffb158")},
+			msgHashes:      []l1types.L1Hash{l1types.UnsafeFromString[l1types.L1Hash]("0x162e74b4ccf7e350a1668de856f892057e0da112e1ad2262603306ee5dffb158")},
 			l1TxnReceipt:   l1TxnReceiptSepolia,
 			blockNum:       469719,
 			l1HeadBlockNum: 469718,
@@ -110,7 +111,7 @@ func TestGetMessageStatus(t *testing.T) {
 
 	t.Run("l1 client not found", func(t *testing.T) {
 		handler := rpc.New(nil, nil, nil, nil).WithL1Client(nil)
-		msgStatuses, rpcErr := handler.GetMessageStatus(t.Context(), &common.Hash{})
+		msgStatuses, rpcErr := handler.GetMessageStatus(t.Context(), &l1types.L1Hash{})
 		require.Nil(t, msgStatuses)
 		require.NotNil(t, rpcErr)
 	})

--- a/rpc/v8/transaction.go
+++ b/rpc/v8/transaction.go
@@ -886,7 +886,7 @@ func AdaptReceipt(receipt *core.TransactionReceipt, txn core.Transaction, finali
 	messages := make([]*MsgToL1, len(receipt.L2ToL1Message))
 	for idx, msg := range receipt.L2ToL1Message {
 		messages[idx] = &MsgToL1{
-			To:      *msg.To,
+			To:      msg.To,
 			Payload: msg.Payload,
 			From:    msg.From,
 		}

--- a/rpc/v8/transaction.go
+++ b/rpc/v8/transaction.go
@@ -14,11 +14,11 @@ import (
 	"github.com/NethermindEth/juno/core/felt"
 	"github.com/NethermindEth/juno/db"
 	"github.com/NethermindEth/juno/jsonrpc"
+	"github.com/NethermindEth/juno/l1/types"
 	"github.com/NethermindEth/juno/mempool"
 	"github.com/NethermindEth/juno/rpc/rpccore"
 	"github.com/NethermindEth/juno/starknet"
 	"github.com/NethermindEth/juno/utils"
-	"github.com/ethereum/go-ethereum/common"
 	"go.uber.org/zap"
 )
 
@@ -264,9 +264,9 @@ type TransactionStatus struct {
 }
 
 type MsgToL1 struct {
-	From    *felt.Felt     `json:"from_address,omitempty"`
-	To      common.Address `json:"to_address"`
-	Payload []*felt.Felt   `json:"payload"`
+	From    *felt.Address   `json:"from_address,omitempty"`
+	To      types.L1Address `json:"to_address"`
+	Payload []*felt.Felt    `json:"payload"`
 }
 
 type ComputationResources struct {
@@ -886,7 +886,7 @@ func AdaptReceipt(receipt *core.TransactionReceipt, txn core.Transaction, finali
 	messages := make([]*MsgToL1, len(receipt.L2ToL1Message))
 	for idx, msg := range receipt.L2ToL1Message {
 		messages[idx] = &MsgToL1{
-			To:      msg.To,
+			To:      *msg.To,
 			Payload: msg.Payload,
 			From:    msg.From,
 		}

--- a/rpc/v9/estimate_fee.go
+++ b/rpc/v9/estimate_fee.go
@@ -299,14 +299,15 @@ func (h *Handler) EstimateMessageFee(
 ) (FeeEstimate, http.Header, *jsonrpc.Error) {
 	calldata := make([]*felt.Felt, len(msg.Payload)+1)
 	// msg.From needs to be the first element
-	calldata[0] = felt.NewFromBytes[felt.Felt](msg.From.Bytes())
+	calldata[0] = felt.NewFromBytes[felt.Felt](msg.From.Marshal())
 	for i := range msg.Payload {
 		calldata[i+1] = &msg.Payload[i]
 	}
 	tx := BroadcastedTransaction{
 		Transaction: Transaction{
-			Type:               TxnL1Handler,
-			ContractAddress:    &msg.To,
+			Type: TxnL1Handler,
+			// todo: remove the felt cast
+			ContractAddress:    (*felt.Felt)(&msg.To),
 			EntryPointSelector: &msg.Selector,
 			CallData:           &calldata,
 			Version:            &felt.Zero, // Needed for transaction hash calculation.

--- a/rpc/v9/l1.go
+++ b/rpc/v9/l1.go
@@ -65,7 +65,13 @@ func (h *Handler) GetMessageStatus(ctx context.Context, l1TxnHash *types.L1Hash)
 	for i, msgHash := range msgHashes {
 		hash, err := h.bcReader.L1HandlerTxnHash(msgHash)
 		if err != nil {
-			return nil, jsonrpc.Err(jsonrpc.InternalError, fmt.Errorf("failed to retrieve L1 handler txn %v", err))
+			return nil, jsonrpc.Err(
+				jsonrpc.InternalError,
+				fmt.Sprintf("failed to retrieve L1 handler txn hash. msgHash %s, err: %v",
+					msgHash.String(),
+					err,
+				),
+			)
 		}
 		status, rpcErr := h.TransactionStatus(ctx, &hash)
 		if rpcErr != nil {

--- a/rpc/v9/l1_test.go
+++ b/rpc/v9/l1_test.go
@@ -7,11 +7,11 @@ import (
 	"github.com/NethermindEth/juno/clients/feeder"
 	"github.com/NethermindEth/juno/core"
 	"github.com/NethermindEth/juno/core/felt"
+	l1types "github.com/NethermindEth/juno/l1/types"
 	"github.com/NethermindEth/juno/mocks"
 	rpc "github.com/NethermindEth/juno/rpc/v9"
 	adaptfeeder "github.com/NethermindEth/juno/starknetdata/feeder"
 	"github.com/NethermindEth/juno/utils"
-	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
@@ -36,37 +36,37 @@ func TestGetMessageStatus(t *testing.T) {
 
 	tests := map[string]struct {
 		network        utils.Network
-		l1TxnHash      common.Hash
+		l1TxnHash      l1types.L1Hash
 		msgs           []rpc.MsgStatus
-		msgHashes      []common.Hash
+		msgHashes      []l1types.L1Hash
 		l1TxnReceipt   types.Receipt
 		blockNum       uint64
 		l1HeadBlockNum uint64
 	}{
 		"mainnet 0.13.2.1": {
 			network:   utils.Mainnet,
-			l1TxnHash: common.HexToHash("0x5780c6fe46f958a7ebf9308e6db16d819ff9e06b1e88f9e718c50cde10898f38"),
+			l1TxnHash: l1types.UnsafeFromString[l1types.L1Hash]("0x5780c6fe46f958a7ebf9308e6db16d819ff9e06b1e88f9e718c50cde10898f38"),
 			msgs: []rpc.MsgStatus{{
 				L1HandlerHash:   felt.NewUnsafeFromString[felt.Felt]("0xc470e30f97f64255a62215633e35a7c6ae10332a9011776dde1143ab0202c3"),
 				FinalityStatus:  rpc.TxnStatusAcceptedOnL1,
 				FailureReason:   "",
 				ExecutionStatus: rpc.TxnSuccess,
 			}},
-			msgHashes:      []common.Hash{common.HexToHash("0xd8824a75a588f0726d7d83b3e9560810c763043e979fdb77b11c1a51a991235d")},
+			msgHashes:      []l1types.L1Hash{l1types.UnsafeFromString[l1types.L1Hash]("0xd8824a75a588f0726d7d83b3e9560810c763043e979fdb77b11c1a51a991235d")},
 			l1TxnReceipt:   l1TxnReceipt,
 			blockNum:       763497,
 			l1HeadBlockNum: 763498,
 		},
 		"sepolia 0.13.4": {
 			network:   utils.Sepolia,
-			l1TxnHash: common.HexToHash("0xeafadb9958437ef43ce7ed19f8ac0c8071c18f4a55fd778cecc23d8b6f86026f"),
+			l1TxnHash: l1types.UnsafeFromString[l1types.L1Hash]("0xeafadb9958437ef43ce7ed19f8ac0c8071c18f4a55fd778cecc23d8b6f86026f"),
 			msgs: []rpc.MsgStatus{{
 				L1HandlerHash:   felt.NewUnsafeFromString[felt.Felt]("0x304c78cccf0569159d4b2aff2117f060509b7c6d590ae740d2031d1eb507b10"),
 				FinalityStatus:  rpc.TxnStatusAcceptedOnL2,
 				FailureReason:   "",
 				ExecutionStatus: rpc.TxnSuccess,
 			}},
-			msgHashes:      []common.Hash{common.HexToHash("0x162e74b4ccf7e350a1668de856f892057e0da112e1ad2262603306ee5dffb158")},
+			msgHashes:      []l1types.L1Hash{l1types.UnsafeFromString[l1types.L1Hash]("0x162e74b4ccf7e350a1668de856f892057e0da112e1ad2262603306ee5dffb158")},
 			l1TxnReceipt:   l1TxnReceiptSepolia,
 			blockNum:       469719,
 			l1HeadBlockNum: 469718,
@@ -122,7 +122,7 @@ func TestGetMessageStatus(t *testing.T) {
 
 	t.Run("l1 client not found", func(t *testing.T) {
 		handler := rpc.New(nil, nil, nil, nil).WithL1Client(nil)
-		msgStatuses, rpcErr := handler.GetMessageStatus(t.Context(), &common.Hash{})
+		msgStatuses, rpcErr := handler.GetMessageStatus(t.Context(), &l1types.L1Hash{})
 		require.Nil(t, msgStatuses)
 		require.NotNil(t, rpcErr)
 	})

--- a/rpc/v9/transaction.go
+++ b/rpc/v9/transaction.go
@@ -975,7 +975,7 @@ func AdaptReceipt(
 	messages := make([]*MsgToL1, len(receipt.L2ToL1Message))
 	for idx, msg := range receipt.L2ToL1Message {
 		messages[idx] = &MsgToL1{
-			To:      *msg.To,
+			To:      msg.To,
 			Payload: msg.Payload,
 			From:    msg.From,
 		}

--- a/rpc/v9/transaction.go
+++ b/rpc/v9/transaction.go
@@ -14,12 +14,12 @@ import (
 	"github.com/NethermindEth/juno/core/felt"
 	"github.com/NethermindEth/juno/db"
 	"github.com/NethermindEth/juno/jsonrpc"
+	"github.com/NethermindEth/juno/l1/types"
 	"github.com/NethermindEth/juno/mempool"
 	"github.com/NethermindEth/juno/rpc/rpccore"
 	rpcv6 "github.com/NethermindEth/juno/rpc/v6"
 	"github.com/NethermindEth/juno/starknet"
 	"github.com/NethermindEth/juno/utils"
-	"github.com/ethereum/go-ethereum/common"
 	"go.uber.org/zap"
 )
 
@@ -300,9 +300,9 @@ type TransactionStatus struct {
 }
 
 type MsgToL1 struct {
-	From    *felt.Felt     `json:"from_address,omitempty"`
-	To      common.Address `json:"to_address"`
-	Payload []*felt.Felt   `json:"payload"`
+	From    *felt.Address   `json:"from_address,omitempty"`
+	To      types.L1Address `json:"to_address"`
+	Payload []*felt.Felt    `json:"payload"`
 }
 
 type ComputationResources struct {
@@ -975,7 +975,7 @@ func AdaptReceipt(
 	messages := make([]*MsgToL1, len(receipt.L2ToL1Message))
 	for idx, msg := range receipt.L2ToL1Message {
 		messages[idx] = &MsgToL1{
-			To:      msg.To,
+			To:      *msg.To,
 			Payload: msg.Payload,
 			From:    msg.From,
 		}

--- a/utils/network.go
+++ b/utils/network.go
@@ -7,8 +7,8 @@ import (
 	"strings"
 
 	"github.com/NethermindEth/juno/core/felt"
+	"github.com/NethermindEth/juno/l1/types"
 	"github.com/NethermindEth/juno/starknet"
-	"github.com/ethereum/go-ethereum/common"
 	"github.com/spf13/pflag"
 )
 
@@ -50,7 +50,7 @@ type Network struct {
 	GatewayURL          string             `json:"gateway_url" validate:"required"`
 	L1ChainID           *big.Int           `json:"l1_chain_id" validate:"required"`
 	L2ChainID           string             `json:"l2_chain_id" validate:"required"`
-	CoreContractAddress common.Address     `json:"core_contract_address" validate:"required"`
+	CoreContractAddress types.L1Address    `json:"core_contract_address" validate:"required"`
 	BlockHashMetaInfo   *BlockHashMetaInfo `json:"block_hash_meta_info"`
 }
 
@@ -77,7 +77,7 @@ var (
 		GatewayURL:          "https://alpha-mainnet.starknet.io/gateway/",
 		L2ChainID:           "SN_MAIN",
 		L1ChainID:           big.NewInt(1),
-		CoreContractAddress: common.HexToAddress("0xc662c410C0ECf747543f5bA90660f6ABeBD9C8c4"),
+		CoreContractAddress: types.UnsafeFromString[types.L1Address]("0xc662c410C0ECf747543f5bA90660f6ABeBD9C8c4"),
 		BlockHashMetaInfo: &BlockHashMetaInfo{
 			First07Block:             833,
 			FallBackSequencerAddress: fallBackSequencerAddressMainnet,
@@ -90,7 +90,7 @@ var (
 		L2ChainID:  "SN_GOERLI",
 		//nolint:mnd
 		L1ChainID:           big.NewInt(5),
-		CoreContractAddress: common.HexToAddress("0xde29d060D45901Fb19ED6C6e959EB22d8626708e"),
+		CoreContractAddress: types.UnsafeFromString[types.L1Address]("0xde29d060D45901Fb19ED6C6e959EB22d8626708e"),
 		BlockHashMetaInfo: &BlockHashMetaInfo{
 			First07Block:             47028,
 			UnverifiableRange:        []uint64{119802, 148428},
@@ -104,7 +104,7 @@ var (
 		L2ChainID:  "SN_GOERLI2",
 		//nolint:mnd
 		L1ChainID:           big.NewInt(5),
-		CoreContractAddress: common.HexToAddress("0xa4eD3aD27c294565cB0DCc993BDdCC75432D498c"),
+		CoreContractAddress: types.UnsafeFromString[types.L1Address]("0xa4eD3aD27c294565cB0DCc993BDdCC75432D498c"),
 		BlockHashMetaInfo: &BlockHashMetaInfo{
 			First07Block:             0,
 			FallBackSequencerAddress: fallBackSequencerAddress,
@@ -117,7 +117,7 @@ var (
 		L2ChainID:  "SN_GOERLI",
 		//nolint:mnd
 		L1ChainID:           big.NewInt(5),
-		CoreContractAddress: common.HexToAddress("0xd5c325D183C592C94998000C5e0EED9e6655c020"),
+		CoreContractAddress: types.UnsafeFromString[types.L1Address]("0xd5c325D183C592C94998000C5e0EED9e6655c020"),
 		BlockHashMetaInfo: &BlockHashMetaInfo{
 			First07Block:             110511,
 			UnverifiableRange:        []uint64{0, 110511},
@@ -131,7 +131,7 @@ var (
 		L2ChainID:  "SN_SEPOLIA",
 		//nolint:mnd
 		L1ChainID:           big.NewInt(11155111),
-		CoreContractAddress: common.HexToAddress("0xE2Bb56ee936fd6433DC0F6e7e3b8365C906AA057"),
+		CoreContractAddress: types.UnsafeFromString[types.L1Address]("0xE2Bb56ee936fd6433DC0F6e7e3b8365C906AA057"),
 		BlockHashMetaInfo: &BlockHashMetaInfo{
 			First07Block:             0,
 			FallBackSequencerAddress: fallBackSequencerAddress,
@@ -144,7 +144,7 @@ var (
 		L2ChainID:  "SN_INTEGRATION_SEPOLIA",
 		//nolint:mnd
 		L1ChainID:           big.NewInt(11155111),
-		CoreContractAddress: common.HexToAddress("0x4737c0c1B4D5b1A687B42610DdabEE781152359c"),
+		CoreContractAddress: types.UnsafeFromString[types.L1Address]("0x4737c0c1B4D5b1A687B42610DdabEE781152359c"),
 		BlockHashMetaInfo: &BlockHashMetaInfo{
 			First07Block:             0,
 			FallBackSequencerAddress: fallBackSequencerAddress,

--- a/utils/network_test.go
+++ b/utils/network_test.go
@@ -8,8 +8,8 @@ import (
 	"testing"
 
 	"github.com/NethermindEth/juno/core/felt"
+	"github.com/NethermindEth/juno/l1/types"
 	"github.com/NethermindEth/juno/utils"
-	"github.com/ethereum/go-ethereum/common"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -141,13 +141,13 @@ func TestNetworkType(t *testing.T) {
 }
 
 func TestCoreContractAddress(t *testing.T) {
-	addresses := map[utils.Network]common.Address{
-		utils.Mainnet:            common.HexToAddress("0xc662c410C0ECf747543f5bA90660f6ABeBD9C8c4"),
-		utils.Goerli:             common.HexToAddress("0xde29d060D45901Fb19ED6C6e959EB22d8626708e"),
-		utils.Goerli2:            common.HexToAddress("0xa4eD3aD27c294565cB0DCc993BDdCC75432D498c"),
-		utils.Integration:        common.HexToAddress("0xd5c325D183C592C94998000C5e0EED9e6655c020"),
-		utils.Sepolia:            common.HexToAddress("0xE2Bb56ee936fd6433DC0F6e7e3b8365C906AA057"),
-		utils.SepoliaIntegration: common.HexToAddress("0x4737c0c1B4D5b1A687B42610DdabEE781152359c"),
+	addresses := map[utils.Network]types.L1Address{
+		utils.Mainnet:            types.UnsafeFromString[types.L1Address]("0xc662c410C0ECf747543f5bA90660f6ABeBD9C8c4"),
+		utils.Goerli:             types.UnsafeFromString[types.L1Address]("0xde29d060D45901Fb19ED6C6e959EB22d8626708e"),
+		utils.Goerli2:            types.UnsafeFromString[types.L1Address]("0xa4eD3aD27c294565cB0DCc993BDdCC75432D498c"),
+		utils.Integration:        types.UnsafeFromString[types.L1Address]("0xd5c325D183C592C94998000C5e0EED9e6655c020"),
+		utils.Sepolia:            types.UnsafeFromString[types.L1Address]("0xE2Bb56ee936fd6433DC0F6e7e3b8365C906AA057"),
+		utils.SepoliaIntegration: types.UnsafeFromString[types.L1Address]("0x4737c0c1B4D5b1A687B42610DdabEE781152359c"),
 	}
 
 	for n := range networkStrings {


### PR DESCRIPTION
This PR introduces new universal l1 types:
- l1hash
- l1address
That are meant to replace the types from `go-ethereum/common` package. They are based on `holiman/uint256` package and are fully backward compatible.

This PR already includes the integration of the new types with Juno.