### PR TITLE
refactor(compiler): add Compiler interface and thread through call sites

### DIFF
--- a/adapters/consensus2p2p/consensus_p2p_adapters_test.go
+++ b/adapters/consensus2p2p/consensus_p2p_adapters_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/NethermindEth/juno/adapters/consensus2p2p/testutils"
 	"github.com/NethermindEth/juno/adapters/p2p2consensus"
 	transactiontestutils "github.com/NethermindEth/juno/adapters/testutils"
+	"github.com/NethermindEth/juno/starknet/compiler"
 	"github.com/NethermindEth/juno/utils"
 	"github.com/stretchr/testify/require"
 )
@@ -56,7 +57,9 @@ func TestAdaptProposalTransaction(t *testing.T) {
 			require.NoError(t, err)
 			require.Equal(t, p2pTransactions[i], convertedP2PTransaction)
 
-			convertedConsensusTransaction, err := p2p2consensus.AdaptTransaction(convertedP2PTransaction, &utils.Mainnet)
+			convertedConsensusTransaction, err := p2p2consensus.AdaptTransaction(
+				t.Context(), compiler.NewUnsafe(), convertedP2PTransaction, &utils.Mainnet,
+			)
 			require.NoError(t, err)
 
 			transactiontestutils.StripCompilerFields(t, consensusTransactions[i].Class)
@@ -70,7 +73,9 @@ func TestAdaptProposalTransaction(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, p2pTransactions, convertedP2PTransactions.Transactions)
 
-		convertedConsensusTransactions, err := p2p2consensus.AdaptProposalTransaction(&convertedP2PTransactions, &utils.Mainnet)
+		convertedConsensusTransactions, err := p2p2consensus.AdaptProposalTransaction(
+			t.Context(), compiler.NewUnsafe(), &convertedP2PTransactions, &utils.Mainnet,
+		)
 		require.NoError(t, err)
 		for i := range consensusTransactions {
 			transactiontestutils.StripCompilerFields(t, consensusTransactions[i].Class)

--- a/adapters/mempool2p2p/mempool_p2p_adapters_test.go
+++ b/adapters/mempool2p2p/mempool_p2p_adapters_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/NethermindEth/juno/adapters/mempool2p2p/testutils"
 	"github.com/NethermindEth/juno/adapters/p2p2mempool"
 	transactiontestutils "github.com/NethermindEth/juno/adapters/testutils"
+	"github.com/NethermindEth/juno/starknet/compiler"
 	"github.com/NethermindEth/juno/utils"
 	"github.com/stretchr/testify/require"
 )
@@ -27,7 +28,9 @@ func TestAdaptTransaction(t *testing.T) {
 			require.NoError(t, err)
 			require.Equal(t, p2pTransactions[i], convertedP2PTransaction)
 
-			convertedmempoolTransaction, err := p2p2mempool.AdaptTransaction(convertedP2PTransaction, &utils.Sepolia)
+			convertedmempoolTransaction, err := p2p2mempool.AdaptTransaction(
+				t.Context(), compiler.NewUnsafe(), convertedP2PTransaction, &utils.Sepolia,
+			)
 			require.NoError(t, err)
 
 			transactiontestutils.StripCompilerFields(t, mempoolTransactions[i].DeclaredClass)

--- a/adapters/p2p2consensus/p2p_consensus_adapters_test.go
+++ b/adapters/p2p2consensus/p2p_consensus_adapters_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/NethermindEth/juno/adapters/consensus2p2p/testutils"
 	"github.com/NethermindEth/juno/adapters/p2p2consensus"
 	transactiontestutils "github.com/NethermindEth/juno/adapters/testutils"
+	"github.com/NethermindEth/juno/starknet/compiler"
 	"github.com/NethermindEth/juno/utils"
 	"github.com/starknet-io/starknet-p2pspecs/p2p/proto/consensus/consensus"
 	"github.com/stretchr/testify/require"
@@ -53,7 +54,9 @@ func TestAdaptProposalTransaction(t *testing.T) {
 
 	for i := range consensusTransactions {
 		t.Run(fmt.Sprintf("%T", consensusTransactions[i].Transaction), func(t *testing.T) {
-			convertedConsensusTransaction, err := p2p2consensus.AdaptTransaction(p2pTransactions[i], &utils.Mainnet)
+			convertedConsensusTransaction, err := p2p2consensus.AdaptTransaction(
+				t.Context(), compiler.NewUnsafe(), p2pTransactions[i], &utils.Mainnet,
+			)
 			require.NoError(t, err)
 
 			transactiontestutils.StripCompilerFields(t, consensusTransactions[i].Class)
@@ -70,7 +73,9 @@ func TestAdaptProposalTransaction(t *testing.T) {
 		transactionBatch := consensus.TransactionBatch{
 			Transactions: p2pTransactions,
 		}
-		convertedConsensusTransactions, err := p2p2consensus.AdaptProposalTransaction(&transactionBatch, &utils.Mainnet)
+		convertedConsensusTransactions, err := p2p2consensus.AdaptProposalTransaction(
+			t.Context(), compiler.NewUnsafe(), &transactionBatch, &utils.Mainnet,
+		)
 		require.NoError(t, err)
 
 		for i := range consensusTransactions {

--- a/adapters/p2p2consensus/proposal.go
+++ b/adapters/p2p2consensus/proposal.go
@@ -1,11 +1,14 @@
 package p2p2consensus
 
 import (
+	"context"
+
 	"github.com/Masterminds/semver/v3"
 	"github.com/NethermindEth/juno/adapters/p2p2core"
 	consensus "github.com/NethermindEth/juno/consensus/types"
 	"github.com/NethermindEth/juno/core"
 	"github.com/NethermindEth/juno/core/felt"
+	"github.com/NethermindEth/juno/starknet/compiler"
 	"github.com/NethermindEth/juno/utils"
 	p2pconsensus "github.com/starknet-io/starknet-p2pspecs/p2p/proto/consensus/consensus"
 )
@@ -55,11 +58,16 @@ func AdaptBlockInfo(msg *p2pconsensus.BlockInfo) (consensus.BlockInfo, error) {
 	}, nil
 }
 
-func AdaptProposalTransaction(msg *p2pconsensus.TransactionBatch, network *utils.Network) ([]consensus.Transaction, error) {
+func AdaptProposalTransaction(
+	ctx context.Context,
+	compiler compiler.Compiler,
+	msg *p2pconsensus.TransactionBatch,
+	network *utils.Network,
+) ([]consensus.Transaction, error) {
 	var err error
 	txns := make([]consensus.Transaction, len(msg.Transactions))
 	for i := range msg.Transactions {
-		if txns[i], err = AdaptTransaction(msg.Transactions[i], network); err != nil {
+		if txns[i], err = AdaptTransaction(ctx, compiler, msg.Transactions[i], network); err != nil {
 			return nil, err
 		}
 	}

--- a/adapters/p2p2consensus/transaction.go
+++ b/adapters/p2p2consensus/transaction.go
@@ -1,17 +1,24 @@
 package p2p2consensus
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/NethermindEth/juno/adapters/p2p2core"
 	consensus "github.com/NethermindEth/juno/consensus/types"
 	"github.com/NethermindEth/juno/core"
 	"github.com/NethermindEth/juno/core/felt"
+	"github.com/NethermindEth/juno/starknet/compiler"
 	"github.com/NethermindEth/juno/utils"
 	p2pconsensus "github.com/starknet-io/starknet-p2pspecs/p2p/proto/consensus/consensus"
 )
 
-func AdaptTransaction(t *p2pconsensus.ConsensusTransaction, network *utils.Network) (consensus.Transaction, error) {
+func AdaptTransaction(
+	ctx context.Context,
+	compiler compiler.Compiler,
+	t *p2pconsensus.ConsensusTransaction,
+	network *utils.Network,
+) (consensus.Transaction, error) {
 	if err := validateConsensusTransaction(t); err != nil {
 		return consensus.Transaction{}, err
 	}
@@ -25,7 +32,10 @@ func AdaptTransaction(t *p2pconsensus.ConsensusTransaction, network *utils.Netwo
 
 	switch t.Txn.(type) {
 	case *p2pconsensus.ConsensusTransaction_DeclareV3:
-		if tx, class, err = p2p2core.AdaptDeclareV3WithClass(t.GetDeclareV3(), t.TransactionHash); err != nil {
+		tx, class, err = p2p2core.AdaptDeclareV3WithClass(
+			ctx, compiler, t.GetDeclareV3(), t.TransactionHash,
+		)
+		if err != nil {
 			return consensus.Transaction{}, err
 		}
 	case *p2pconsensus.ConsensusTransaction_DeployAccountV3:

--- a/adapters/p2p2core/state.go
+++ b/adapters/p2p2core/state.go
@@ -1,12 +1,14 @@
 package p2p2core
 
 import (
+	"context"
 	"errors"
 	"fmt"
 
 	"github.com/NethermindEth/juno/core"
 	"github.com/NethermindEth/juno/core/felt"
 	"github.com/NethermindEth/juno/db"
+	"github.com/NethermindEth/juno/starknet/compiler"
 	"github.com/NethermindEth/juno/utils"
 	"github.com/starknet-io/starknet-p2pspecs/p2p/proto/class"
 	"github.com/starknet-io/starknet-p2pspecs/p2p/proto/common"
@@ -14,6 +16,8 @@ import (
 )
 
 func AdaptStateDiff(
+	ctx context.Context,
+	compiler compiler.Compiler,
 	reader core.StateReader,
 	contractDiffs []*state.ContractDiff,
 	classes []*class.Class,
@@ -24,7 +28,7 @@ func AdaptStateDiff(
 	)
 
 	for _, cls := range classes {
-		class, err := AdaptClass(cls)
+		class, err := AdaptClass(ctx, compiler, cls)
 		if err != nil {
 			return nil, fmt.Errorf("unsupported class: %w", err)
 		}

--- a/adapters/p2p2core/transaction.go
+++ b/adapters/p2p2core/transaction.go
@@ -1,10 +1,12 @@
 package p2p2core
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/NethermindEth/juno/core"
 	"github.com/NethermindEth/juno/core/felt"
+	"github.com/NethermindEth/juno/starknet/compiler"
 	"github.com/NethermindEth/juno/utils"
 	"github.com/starknet-io/starknet-p2pspecs/p2p/proto/common"
 	synctransaction "github.com/starknet-io/starknet-p2pspecs/p2p/proto/sync/transaction"
@@ -12,10 +14,12 @@ import (
 )
 
 func AdaptDeclareV3WithClass(
+	ctx context.Context,
+	compiler compiler.Compiler,
 	tx *transaction.DeclareV3WithClass,
 	txnHash *common.Hash,
 ) (*core.DeclareTransaction, *core.SierraClass, error) {
-	class, err := AdaptSierraClass(tx.Class)
+	class, err := AdaptSierraClass(ctx, compiler, tx.Class)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/adapters/p2p2mempool/p2p_mempool_adapters_test.go
+++ b/adapters/p2p2mempool/p2p_mempool_adapters_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/NethermindEth/juno/adapters/mempool2p2p/testutils"
 	"github.com/NethermindEth/juno/adapters/p2p2mempool"
 	transactiontestutils "github.com/NethermindEth/juno/adapters/testutils"
+	"github.com/NethermindEth/juno/starknet/compiler"
 	"github.com/NethermindEth/juno/utils"
 	"github.com/stretchr/testify/require"
 )
@@ -23,7 +24,9 @@ func TestAdaptProposalTransaction(t *testing.T) {
 
 	for i := range mempoolTransactions {
 		t.Run(fmt.Sprintf("%T", mempoolTransactions[i].Transaction), func(t *testing.T) {
-			convertedmempoolTransaction, err := p2p2mempool.AdaptTransaction(p2pTransactions[i], &utils.Sepolia)
+			convertedmempoolTransaction, err := p2p2mempool.AdaptTransaction(
+				t.Context(), compiler.NewUnsafe(), p2pTransactions[i], &utils.Sepolia,
+			)
 			require.NoError(t, err)
 
 			transactiontestutils.StripCompilerFields(t, mempoolTransactions[i].DeclaredClass)

--- a/adapters/p2p2mempool/transaction.go
+++ b/adapters/p2p2mempool/transaction.go
@@ -1,12 +1,14 @@
 package p2p2mempool
 
 import (
+	"context"
 	"errors"
 	"fmt"
 
 	"github.com/NethermindEth/juno/adapters/p2p2core"
 	"github.com/NethermindEth/juno/core"
 	"github.com/NethermindEth/juno/mempool"
+	"github.com/NethermindEth/juno/starknet/compiler"
 	"github.com/NethermindEth/juno/utils"
 	mempooltransaction "github.com/starknet-io/starknet-p2pspecs/p2p/proto/mempool/transaction"
 )
@@ -25,7 +27,12 @@ func validateMempoolTransaction(t *mempooltransaction.MempoolTransaction) error 
 	return nil
 }
 
-func AdaptTransaction(t *mempooltransaction.MempoolTransaction, network *utils.Network) (mempool.BroadcastedTransaction, error) {
+func AdaptTransaction(
+	ctx context.Context,
+	compiler compiler.Compiler,
+	t *mempooltransaction.MempoolTransaction,
+	network *utils.Network,
+) (mempool.BroadcastedTransaction, error) {
 	if err := validateMempoolTransaction(t); err != nil {
 		return mempool.BroadcastedTransaction{}, err
 	}
@@ -38,7 +45,10 @@ func AdaptTransaction(t *mempooltransaction.MempoolTransaction, network *utils.N
 
 	switch t.Txn.(type) {
 	case *mempooltransaction.MempoolTransaction_DeclareV3:
-		if tx, class, err = p2p2core.AdaptDeclareV3WithClass(t.GetDeclareV3(), t.TransactionHash); err != nil {
+		tx, class, err = p2p2core.AdaptDeclareV3WithClass(
+			ctx, compiler, t.GetDeclareV3(), t.TransactionHash,
+		)
+		if err != nil {
 			return mempool.BroadcastedTransaction{}, err
 		}
 	case *mempooltransaction.MempoolTransaction_DeployAccountV3:

--- a/cmd/juno/juno_test.go
+++ b/cmd/juno/juno_test.go
@@ -71,7 +71,6 @@ func TestConfigPrecedence(t *testing.T) {
 	defaultGwTimeout := "5s"
 	defaultSubmittedTransactionsCacheSize := uint(10_000)
 	defaultSubmittedTransactionsCacheEntryTTL := 5 * time.Minute
-
 	expectedConfig1 := node.Config{
 		LogLevel:                           "debug",
 		HTTP:                               defaultHTTP,

--- a/consensus/consensus.go
+++ b/consensus/consensus.go
@@ -19,6 +19,7 @@ import (
 	"github.com/NethermindEth/juno/core/felt"
 	"github.com/NethermindEth/juno/db"
 	"github.com/NethermindEth/juno/p2p/sync"
+	"github.com/NethermindEth/juno/starknet/compiler"
 	"github.com/NethermindEth/juno/utils"
 	"github.com/NethermindEth/juno/vm"
 	"github.com/libp2p/go-libp2p/core/host"
@@ -43,6 +44,7 @@ func Init(
 	validators votecounter.Validators[starknet.Address],
 	timeoutFn driver.TimeoutFn,
 	bootstrapPeersFn func() []peer.AddrInfo,
+	compiler compiler.Compiler,
 ) (ConsensusServices, error) {
 	chainHeight, err := blockchain.Height()
 	if err != nil && !errors.Is(err, db.ErrKeyNotFound) {
@@ -59,7 +61,16 @@ func Init(
 	proposer := proposer.New(logger, &builder, &proposalStore, *nodeAddress, toValue)
 	stateMachine := tendermint.New(logger, *nodeAddress, proposer, validators, currentHeight)
 
-	p2p := p2p.New(host, logger, &builder, &proposalStore, currentHeight, &config.DefaultBufferSizes, bootstrapPeersFn)
+	p2p := p2p.New(
+		host,
+		logger,
+		&builder,
+		&proposalStore,
+		currentHeight,
+		&config.DefaultBufferSizes,
+		bootstrapPeersFn,
+		compiler,
+	)
 
 	commitListener := driver.NewCommitListener(logger, &proposalStore, proposer, p2p)
 

--- a/consensus/p2p/p2p.go
+++ b/consensus/p2p/p2p.go
@@ -16,6 +16,7 @@ import (
 	"github.com/NethermindEth/juno/p2p/pubsub"
 	"github.com/NethermindEth/juno/p2p/starknetp2p"
 	"github.com/NethermindEth/juno/service"
+	"github.com/NethermindEth/juno/starknet/compiler"
 	"github.com/NethermindEth/juno/utils"
 	libp2p "github.com/libp2p/go-libp2p-pubsub"
 	"github.com/libp2p/go-libp2p/core/host"
@@ -62,6 +63,7 @@ func New(
 	currentHeight types.Height,
 	bufferSizeConfig *config.BufferSizes,
 	bootstrapPeersFn func() []peer.AddrInfo,
+	compiler compiler.Compiler,
 ) P2P[starknet.Value, starknet.Hash, starknet.Address] {
 	commitNotifier := make(chan types.Height, bufferSizeConfig.ProposalCommitNotifier)
 
@@ -86,7 +88,7 @@ func New(
 	proposalStream := validator.NewProposalStreamDemux(
 		log,
 		proposalStore,
-		validator.NewTransition(builder),
+		validator.NewTransition(builder, compiler),
 		bufferSizeConfig,
 		commitNotifier,
 		currentHeight,

--- a/consensus/p2p/validator/proposal_stream_demux_test.go
+++ b/consensus/p2p/validator/proposal_stream_demux_test.go
@@ -54,7 +54,7 @@ func TestProposalStreamDemux(t *testing.T) {
 	database := memory.New()
 	bc := blockchain.New(database, network)
 	builder := builder.New(bc, executor)
-	transition := NewTransition(&builder)
+	transition := NewTransition(&builder, nil)
 	proposalStore := proposal.ProposalStore[starknet.Hash]{}
 	demux := NewProposalStreamDemux(logger, &proposalStore, transition, &config.DefaultBufferSizes, commitNotifier, block1)
 

--- a/consensus/p2p/validator/proposal_stream_test.go
+++ b/consensus/p2p/validator/proposal_stream_test.go
@@ -81,7 +81,13 @@ func buildMessage(t *testing.T, sequenceNumber uint64, proposalPart *consensus.P
 func testProposalStreamStart(t *testing.T, expectedHeight types.Height, expectedErrorMsg string, message *consensus.StreamMessage) {
 	t.Helper()
 	proposalStore := proposal.ProposalStore[starknet.Hash]{}
-	stream := newSingleProposalStream(utils.NewNopZapLogger(), &proposalStore, NewTransition(nil), 0, nil)
+	stream := newSingleProposalStream(
+		utils.NewNopZapLogger(),
+		&proposalStore,
+		NewTransition(nil, nil),
+		0,
+		nil,
+	)
 	height, err := stream.start(t.Context(), message)
 	assert.Equal(t, expectedHeight, height)
 	if expectedErrorMsg != "" {
@@ -307,7 +313,13 @@ func TestProposalStream_ProcessMessage(t *testing.T) {
 func testProposalStreamProcessMessage(t *testing.T, builder *builder.Builder, proposalInit *consensus.ProposalPart, steps []step) {
 	outputs := make(chan *starknet.Proposal, 1)
 	proposalStore := proposal.ProposalStore[starknet.Hash]{}
-	stream := newSingleProposalStream(utils.NewNopZapLogger(), &proposalStore, NewTransition(builder), 0, outputs)
+	stream := newSingleProposalStream(
+		utils.NewNopZapLogger(),
+		&proposalStore,
+		NewTransition(builder, nil),
+		0,
+		outputs,
+	)
 	_, err := stream.start(t.Context(), buildMessage(t, 1, proposalInit))
 	require.NoError(t, err)
 

--- a/consensus/p2p/validator/state_machine.go
+++ b/consensus/p2p/validator/state_machine.go
@@ -84,7 +84,9 @@ func (s *ReceivingTransactionsState) OnEvent(
 ) (ProposalStateMachine, error) {
 	switch part := part.GetMessages().(type) {
 	case *consensus.ProposalPart_Transactions:
-		transactions, err := p2p2consensus.AdaptProposalTransaction(part.Transactions, transition.Network())
+		transactions, err := p2p2consensus.AdaptProposalTransaction(
+			ctx, transition.Compiler(), part.Transactions, transition.Network(),
+		)
 		if err != nil {
 			return nil, err
 		}

--- a/consensus/p2p/validator/state_machine_test.go
+++ b/consensus/p2p/validator/state_machine_test.go
@@ -122,7 +122,7 @@ func runNonEmptyProposalStream(t *testing.T, testCase validator.TestCase) {
 
 func runTestSteps(t *testing.T, builder *builder.Builder, steps []validTransitionTestStep) {
 	var err error
-	transition := validator.NewTransition(builder)
+	transition := validator.NewTransition(builder, nil)
 	var state validator.ProposalStateMachine = &validator.InitialState{}
 
 	for _, step := range steps {
@@ -191,7 +191,7 @@ func TestProposalStateMachine_InvalidTransitions(t *testing.T) {
 		},
 	}
 
-	transition := validator.NewTransition(nil)
+	transition := validator.NewTransition(nil, nil)
 	for _, step := range steps {
 		t.Run(fmt.Sprintf("State %T", step.state), func(t *testing.T) {
 			for _, event := range step.events {

--- a/consensus/p2p/validator/transition.go
+++ b/consensus/p2p/validator/transition.go
@@ -11,6 +11,7 @@ import (
 	"github.com/NethermindEth/juno/core"
 	"github.com/NethermindEth/juno/core/felt"
 	"github.com/NethermindEth/juno/mempool"
+	"github.com/NethermindEth/juno/starknet/compiler"
 	"github.com/NethermindEth/juno/utils"
 )
 
@@ -18,6 +19,7 @@ var errHashMismatch = errors.New("hash mismatch")
 
 type Transition interface {
 	Network() *utils.Network
+	Compiler() compiler.Compiler
 	OnProposalInit(
 		context.Context,
 		*InitialState,
@@ -51,17 +53,25 @@ type Transition interface {
 }
 
 type transition struct {
-	builder *builder.Builder
+	builder  *builder.Builder
+	compiler compiler.Compiler
 }
 
-func NewTransition(builder *builder.Builder) Transition {
+func NewTransition(
+	builder *builder.Builder, compiler compiler.Compiler,
+) Transition {
 	return &transition{
-		builder: builder,
+		builder:  builder,
+		compiler: compiler,
 	}
 }
 
 func (t *transition) Network() *utils.Network {
 	return t.builder.Network()
+}
+
+func (t *transition) Compiler() compiler.Compiler {
+	return t.compiler
 }
 
 func (t *transition) OnProposalInit(

--- a/consensus/p2p/validator/transition_test.go
+++ b/consensus/p2p/validator/transition_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/NethermindEth/juno/genesis"
 	"github.com/NethermindEth/juno/mempool"
 	"github.com/NethermindEth/juno/sequencer"
+	"github.com/NethermindEth/juno/starknet/compiler"
 	"github.com/NethermindEth/juno/utils"
 	"github.com/NethermindEth/juno/vm"
 	"github.com/consensys/gnark-crypto/ecc/stark-curve/ecdsa"
@@ -49,11 +50,13 @@ func getBuilder(t *testing.T, seqAddr *felt.Felt) (*builder.Builder, *core.Heade
 		FeeTokenAddresses: feeTokens,
 	}
 	diff, classes, err := genesis.GenesisStateDiff(
+		t.Context(),
 		genesisConfig,
 		vm.New(&chainInfo, false, log),
 		bc.Network(),
 		vm.DefaultMaxSteps,
 		vm.DefaultMaxGas,
+		compiler.NewUnsafe(),
 	)
 	require.NoError(t, err)
 	require.NoError(t, bc.StoreGenesis(&diff, classes))
@@ -74,7 +77,7 @@ func TestEmptyProposal(t *testing.T) {
 	testBuilder, head := getBuilder(t, proposerAddr)
 
 	initialState := InitialState{}
-	transition := NewTransition(testBuilder)
+	transition := NewTransition(testBuilder, nil)
 
 	// Step 1: ProposalInit
 	proposalInit := types.ProposalInit{
@@ -119,7 +122,7 @@ func TestEmptyProposal(t *testing.T) {
 func TestProposal(t *testing.T) {
 	proposerAddr := felt.NewUnsafeFromString[felt.Felt]("0xDEADBEEF")
 	b, head := getBuilder(t, proposerAddr)
-	transition := NewTransition(b)
+	transition := NewTransition(b, nil)
 	initialState := InitialState{}
 
 	l2GasPriceFri := uint64(10)

--- a/consensus/proposer/proposer_test.go
+++ b/consensus/proposer/proposer_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/NethermindEth/juno/db/memory"
 	"github.com/NethermindEth/juno/genesis"
 	"github.com/NethermindEth/juno/mempool"
+	"github.com/NethermindEth/juno/starknet/compiler"
 	"github.com/NethermindEth/juno/utils"
 	"github.com/NethermindEth/juno/vm"
 	"github.com/sourcegraph/conc"
@@ -200,11 +201,13 @@ func getBuilder(t *testing.T, log utils.Logger, bc *blockchain.Blockchain) *buil
 		FeeTokenAddresses: feeTokens,
 	}
 	diff, classes, err := genesis.GenesisStateDiff(
+		t.Context(),
 		genesisConfig,
 		vm.New(&chainInfo, false, log),
 		bc.Network(),
 		vm.DefaultMaxSteps,
 		vm.DefaultMaxGas,
+		compiler.NewUnsafe(),
 	)
 	require.NoError(t, err)
 	require.NoError(t, bc.StoreGenesis(&diff, classes))

--- a/genesis/genesis.go
+++ b/genesis/genesis.go
@@ -1,6 +1,7 @@
 package genesis
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -96,11 +97,13 @@ func (g *GenesisConfig) Validate() error {
 
 // GenesisStateDiff builds the genesis state given the genesis-config data.
 func GenesisStateDiff(
+	ctx context.Context,
 	config *GenesisConfig,
 	v vm.VM,
 	network *utils.Network,
 	maxSteps uint64,
 	maxGas uint64,
+	compiler compiler.Compiler,
 ) (core.StateDiff, map[felt.Felt]core.ClassDefinition, error) {
 	initialStateDiff := core.EmptyStateDiff()
 	memDB := memory.New()
@@ -110,7 +113,7 @@ func GenesisStateDiff(
 		core.NewState(memDB.NewIndexedBatch()),
 	)
 
-	if err := declareClasses(config, &genesisState); err != nil {
+	if err := declareClasses(ctx, config, &genesisState, compiler); err != nil {
 		return core.StateDiff{}, nil, err
 	}
 
@@ -131,10 +134,12 @@ func GenesisStateDiff(
 }
 
 func declareClasses(
+	ctx context.Context,
 	config *GenesisConfig,
 	genesisState *core.PendingStateWriter,
+	compiler compiler.Compiler,
 ) error {
-	newClasses, err := loadClasses(config.Classes)
+	newClasses, err := loadClasses(ctx, config.Classes, compiler)
 	if err != nil {
 		return err
 	}
@@ -373,7 +378,11 @@ func adaptResourceBounds(rb *rpc.ResourceBoundsMap) map[core.Resource]core.Resou
 	}
 }
 
-func loadClasses(classes []string) (map[felt.Felt]core.ClassDefinition, error) {
+func loadClasses(
+	ctx context.Context,
+	classes []string,
+	compiler compiler.Compiler,
+) (map[felt.Felt]core.ClassDefinition, error) {
 	classMap := make(map[felt.Felt]core.ClassDefinition, len(classes))
 	for _, classPath := range classes {
 		bytes, err := os.ReadFile(classPath)
@@ -388,15 +397,20 @@ func loadClasses(classes []string) (map[felt.Felt]core.ClassDefinition, error) {
 
 		var class core.ClassDefinition
 		if response.DeprecatedCairo != nil {
-			if class, err = sn2core.AdaptDeprecatedCairoClass(response.DeprecatedCairo); err != nil {
+			if class, err = sn2core.AdaptDeprecatedCairoClass(
+				response.DeprecatedCairo,
+			); err != nil {
 				return nil, err
 			}
 		} else {
 			var casmClass *starknet.CasmClass
-			if casmClass, err = compiler.Compile(response.Sierra); err != nil {
+			casmClass, err = compiler.Compile(ctx, response.Sierra)
+			if err != nil {
 				return nil, err
 			}
-			if class, err = sn2core.AdaptSierraClass(response.Sierra, casmClass); err != nil {
+			if class, err = sn2core.AdaptSierraClass(
+				response.Sierra, casmClass,
+			); err != nil {
 				return nil, err
 			}
 		}

--- a/genesis/genesis_test.go
+++ b/genesis/genesis_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/NethermindEth/juno/core/felt"
 	"github.com/NethermindEth/juno/genesis"
+	"github.com/NethermindEth/juno/starknet/compiler"
 	"github.com/NethermindEth/juno/utils"
 	"github.com/NethermindEth/juno/vm"
 	"github.com/stretchr/testify/require"
@@ -22,11 +23,13 @@ func TestGenesisStateDiff(t *testing.T) {
 		}
 		genesisConfig := genesis.GenesisConfig{}
 		_, _, err := genesis.GenesisStateDiff(
+			t.Context(),
 			&genesisConfig,
 			vm.New(&chainInfo, false, log),
 			network,
 			vm.DefaultMaxSteps,
 			vm.DefaultMaxGas,
+			nil,
 		)
 		require.NoError(t, err)
 	})
@@ -44,11 +47,13 @@ func TestGenesisStateDiff(t *testing.T) {
 			FeeTokenAddresses: feeTokens,
 		}
 		stateDiff, newClasses, err := genesis.GenesisStateDiff(
+			t.Context(),
 			genesisConfig,
 			vm.New(&chainInfo, false, log),
 			network,
 			vm.DefaultMaxSteps,
 			vm.DefaultMaxGas,
+			compiler.NewUnsafe(),
 		)
 		require.NoError(t, err)
 		require.Equal(t, 2, len(stateDiff.DeclaredV1Classes))

--- a/mempool/p2p/p2p.go
+++ b/mempool/p2p/p2p.go
@@ -10,6 +10,7 @@ import (
 	"github.com/NethermindEth/juno/mempool"
 	"github.com/NethermindEth/juno/p2p/pubsub"
 	"github.com/NethermindEth/juno/p2p/starknetp2p"
+	"github.com/NethermindEth/juno/starknet/compiler"
 	"github.com/NethermindEth/juno/utils"
 	"github.com/libp2p/go-libp2p/core/host"
 	"github.com/libp2p/go-libp2p/core/peer"
@@ -40,6 +41,7 @@ func New(
 	pool mempool.Pool,
 	config *config.BufferSizes,
 	bootstrapPeersFn func() []peer.AddrInfo,
+	compiler compiler.Compiler,
 ) *P2P {
 	return &P2P{
 		host:             host,
@@ -47,7 +49,7 @@ func New(
 		network:          network,
 		pool:             pool,
 		broadcaster:      NewTransactionBroadcaster(log, config.MempoolBroadcaster, config.RetryInterval),
-		listener:         NewTransactionListener(network, log, pool, config.MempoolListener),
+		listener:         NewTransactionListener(network, log, pool, config.MempoolListener, compiler),
 		config:           config,
 		bootstrapPeersFn: bootstrapPeersFn,
 	}

--- a/mempool/p2p/p2p_broadcasters_listeners_test.go
+++ b/mempool/p2p/p2p_broadcasters_listeners_test.go
@@ -67,7 +67,15 @@ func TestMempoolBroadcastersAndListeners(t *testing.T) {
 		received := make(chan *mempool.BroadcastedTransaction, txCount)
 		pool := mockMempool(received)
 
-		p2p := p2p.New(&utils.Mainnet, node.Host, logger, &pool, &config.DefaultBufferSizes, node.GetBootstrapPeers)
+		p2p := p2p.New(
+			&utils.Mainnet,
+			node.Host,
+			logger,
+			&pool,
+			&config.DefaultBufferSizes,
+			node.GetBootstrapPeers,
+			nil,
+		)
 
 		peerWait.Go(func() {
 			require.NoError(t, p2p.Run(t.Context()))

--- a/mempool/p2p/transaction_listener.go
+++ b/mempool/p2p/transaction_listener.go
@@ -6,6 +6,7 @@ import (
 	"github.com/NethermindEth/juno/adapters/p2p2mempool"
 	"github.com/NethermindEth/juno/consensus/p2p/buffered"
 	"github.com/NethermindEth/juno/mempool"
+	"github.com/NethermindEth/juno/starknet/compiler"
 	"github.com/NethermindEth/juno/utils"
 	pubsub "github.com/libp2p/go-libp2p-pubsub"
 	mempooltransaction "github.com/starknet-io/starknet-p2pspecs/p2p/proto/mempool/transaction"
@@ -18,6 +19,7 @@ func NewTransactionListener(
 	log utils.Logger,
 	pool mempool.Pool,
 	bufferSize int,
+	compiler compiler.Compiler,
 ) buffered.TopicSubscription {
 	onMessage := func(ctx context.Context, msg *pubsub.Message) {
 		var p2pTransaction mempooltransaction.MempoolTransaction
@@ -26,7 +28,9 @@ func NewTransactionListener(
 			return
 		}
 
-		transaction, err := p2p2mempool.AdaptTransaction(&p2pTransaction, network)
+		transaction, err := p2p2mempool.AdaptTransaction(
+			ctx, compiler, &p2pTransaction, network,
+		)
 		if err != nil {
 			log.Error("unable to convert transaction message to transaction", zap.Error(err))
 			return

--- a/node/genesis.go
+++ b/node/genesis.go
@@ -1,6 +1,7 @@
 package node
 
 import (
+	"context"
 	"errors"
 
 	"github.com/NethermindEth/juno/blockchain"
@@ -8,15 +9,18 @@ import (
 	"github.com/NethermindEth/juno/core/felt"
 	"github.com/NethermindEth/juno/db"
 	"github.com/NethermindEth/juno/genesis"
+	"github.com/NethermindEth/juno/starknet/compiler"
 	"github.com/NethermindEth/juno/vm"
 )
 
 func buildGenesis(
+	ctx context.Context,
 	genesisPath string,
 	bc *blockchain.Blockchain,
 	v vm.VM,
 	maxSteps uint64,
 	maxGas uint64,
+	compiler compiler.Compiler,
 ) error {
 	if _, err := bc.Height(); !errors.Is(err, db.ErrKeyNotFound) {
 		return err
@@ -32,11 +36,13 @@ func buildGenesis(
 		}
 
 		diff, classes, err = genesis.GenesisStateDiff(
+			ctx,
 			genesisConfig,
 			v,
 			bc.Network(),
 			maxSteps,
 			maxGas,
+			compiler,
 		)
 		if err != nil {
 			return err

--- a/p2p/p2p_test.go
+++ b/p2p/p2p_test.go
@@ -24,6 +24,7 @@ func TestInvalidKey(t *testing.T) {
 		&utils.Integration,
 		utils.NewNopZapLogger(),
 		nil,
+		nil,
 	)
 
 	require.Error(t, err)
@@ -59,6 +60,7 @@ func TestLoadAndPersistPeers(t *testing.T) {
 		&utils.Integration,
 		utils.NewNopZapLogger(),
 		testDB,
+		nil,
 	)
 	require.NoError(t, err)
 }

--- a/rpc/handlers.go
+++ b/rpc/handlers.go
@@ -13,6 +13,7 @@ import (
 	rpcv7 "github.com/NethermindEth/juno/rpc/v7"
 	rpcv8 "github.com/NethermindEth/juno/rpc/v8"
 	rpcv9 "github.com/NethermindEth/juno/rpc/v9"
+	"github.com/NethermindEth/juno/starknet/compiler"
 	"github.com/NethermindEth/juno/sync"
 	"github.com/NethermindEth/juno/utils"
 	"github.com/NethermindEth/juno/vm"
@@ -45,6 +46,15 @@ func New(bcReader blockchain.Reader, syncReader sync.Reader, virtualMachine vm.V
 		rpcv10Handler: handlerv10,
 		version:       version,
 	}
+}
+
+func (h *Handler) WithCompiler(compiler compiler.Compiler) *Handler {
+	h.rpcv6Handler.WithCompiler(compiler)
+	h.rpcv7Handler.WithCompiler(compiler)
+	h.rpcv8Handler.WithCompiler(compiler)
+	h.rpcv9Handler.WithCompiler(compiler)
+	h.rpcv10Handler.WithCompiler(compiler)
+	return h
 }
 
 // WithFilterLimit sets the maximum number of blocks to scan in a single call for event filtering.

--- a/rpc/v10/estimate_fee.go
+++ b/rpc/v10/estimate_fee.go
@@ -1,6 +1,7 @@
 package rpcv10
 
 import (
+	"context"
 	"net/http"
 
 	"github.com/NethermindEth/juno/core/felt"
@@ -18,6 +19,7 @@ import (
 ****************************************************
 */
 func (h *Handler) EstimateFee(
+	ctx context.Context,
 	broadcastedTxns BroadcastedTransactionInputs,
 	estimateFlags []EstimateFlag,
 	id *rpcv9.BlockID,
@@ -32,6 +34,7 @@ func (h *Handler) EstimateFee(
 	}
 
 	txnResults, httpHeader, err := h.simulateTransactions(
+		ctx,
 		id,
 		broadcastedTxns.Data,
 		append(simulationFlags, SkipFeeChargeFlag),
@@ -52,7 +55,7 @@ func (h *Handler) EstimateFee(
 }
 
 func (h *Handler) EstimateMessageFee(
-	msg *rpcv6.MsgFromL1, id *rpcv9.BlockID,
+	ctx context.Context, msg *rpcv6.MsgFromL1, id *rpcv9.BlockID,
 ) (rpcv9.FeeEstimate, http.Header, *jsonrpc.Error) {
 	calldata := make([]*felt.Felt, len(msg.Payload)+1)
 	// msg.From needs to be the first element
@@ -87,6 +90,7 @@ func (h *Handler) EstimateMessageFee(
 
 	bcTxn := [1]rpcv9.BroadcastedTransaction{tx}
 	estimates, httpHeader, err := h.EstimateFee(
+		ctx,
 		rpccore.LimitSlice[rpcv9.BroadcastedTransaction, rpccore.SimulationLimit]{Data: bcTxn[:]},
 		nil,
 		id,

--- a/rpc/v10/estimate_fee_test.go
+++ b/rpc/v10/estimate_fee_test.go
@@ -56,6 +56,7 @@ func TestEstimateFee(t *testing.T) {
 			}, nil)
 
 		_, httpHeader, err := handler.EstimateFee(
+			t.Context(),
 			rpcv10.BroadcastedTransactionInputs{},
 			[]rpcv10.EstimateFlag{},
 			&blockID,
@@ -86,6 +87,7 @@ func TestEstimateFee(t *testing.T) {
 			)
 
 		_, httpHeader, err := handler.EstimateFee(
+			t.Context(),
 			rpcv10.BroadcastedTransactionInputs{},
 			[]rpcv10.EstimateFlag{
 				rpcv10.EstimateSkipValidateFlag,
@@ -112,6 +114,7 @@ func TestEstimateFee(t *testing.T) {
 			})
 
 		_, httpHeader, err := handler.EstimateFee(
+			t.Context(),
 			rpcv10.BroadcastedTransactionInputs{},
 			[]rpcv10.EstimateFlag{rpcv10.EstimateSkipValidateFlag},
 			&blockID,
@@ -142,6 +145,7 @@ func TestEstimateFee(t *testing.T) {
 			ContractClass: json.RawMessage(`{}`),
 		}
 		_, _, err := handler.EstimateFee(
+			t.Context(),
 			rpcv10.BroadcastedTransactionInputs{Data: []rpcv9.BroadcastedTransaction{invalidTx}},
 			[]rpcv10.EstimateFlag{},
 			&blockID,

--- a/rpc/v10/handlers.go
+++ b/rpc/v10/handlers.go
@@ -17,6 +17,7 @@ import (
 	"github.com/NethermindEth/juno/l1/contract"
 	"github.com/NethermindEth/juno/mempool"
 	"github.com/NethermindEth/juno/rpc/rpccore"
+	"github.com/NethermindEth/juno/starknet/compiler"
 	"github.com/NethermindEth/juno/sync"
 	"github.com/NethermindEth/juno/utils"
 	"github.com/NethermindEth/juno/vm"
@@ -52,6 +53,8 @@ type Handler struct {
 	filterLimit  uint
 	callMaxSteps uint64
 	callMaxGas   uint64
+
+	compiler compiler.Compiler
 
 	l1Client        rpccore.L1Client
 	coreContractABI abi.ABI
@@ -97,6 +100,11 @@ func New(
 		filterLimit:     math.MaxUint,
 		coreContractABI: contractABI,
 	}
+}
+
+func (h *Handler) WithCompiler(compiler compiler.Compiler) *Handler {
+	h.compiler = compiler
+	return h
 }
 
 func (h *Handler) WithMempool(memPool mempool.Pool) *Handler {

--- a/rpc/v10/handlers_test.go
+++ b/rpc/v10/handlers_test.go
@@ -44,6 +44,7 @@ func TestThrottledVMError(t *testing.T) {
 
 		blockID := rpcv9.BlockIDLatest()
 		_, httpHeader, rpcErr := handler.SimulateTransactions(
+			t.Context(),
 			&blockID,
 			rpcv9.BroadcastedTransactionInputs{},
 			[]rpcv10.SimulationFlag{rpcv10.SkipFeeChargeFlag},

--- a/rpc/v10/simulation_test.go
+++ b/rpc/v10/simulation_test.go
@@ -163,6 +163,7 @@ func TestSimulateTransactions(t *testing.T) {
 
 			blockID := rpcv9.BlockIDLatest()
 			simulatedTxs, httpHeader, err := handler.SimulateTransactions(
+				t.Context(),
 				&blockID,
 				rpcv9.BroadcastedTransactionInputs{},
 				test.simulationFlags,
@@ -305,6 +306,7 @@ func TestSimulateTransactionsShouldErrorWithoutSenderAddressOrResourceBounds(t *
 
 			blockID := rpcv9.BlockIDLatest()
 			_, _, err := handler.SimulateTransactions(
+				t.Context(),
 				&blockID,
 				rpcv9.BroadcastedTransactionInputs{Data: test.transactions},
 				[]rpcv10.SimulationFlag{},
@@ -467,6 +469,7 @@ func TestSimulateTransactionsWithReturnInitialReads(t *testing.T) {
 
 			blockID := rpcv9.BlockIDLatest()
 			simulatedTxs, _, err := handler.SimulateTransactions(
+				t.Context(),
 				&blockID,
 				rpcv9.BroadcastedTransactionInputs{Data: broadcastedTxns},
 				test.simulationFlags,

--- a/rpc/v6/class.go
+++ b/rpc/v6/class.go
@@ -1,6 +1,7 @@
 package rpcv6
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 
@@ -44,7 +45,11 @@ type FunctionCall struct {
 	Calldata           CalldataInputs `json:"calldata"`
 }
 
-func adaptDeclaredClass(declaredClass json.RawMessage) (core.ClassDefinition, error) {
+func adaptDeclaredClass(
+	ctx context.Context,
+	compiler compiler.Compiler,
+	declaredClass json.RawMessage,
+) (core.ClassDefinition, error) {
 	var feederClass starknet.ClassDefinition
 	err := json.Unmarshal(declaredClass, &feederClass)
 	if err != nil {
@@ -53,7 +58,7 @@ func adaptDeclaredClass(declaredClass json.RawMessage) (core.ClassDefinition, er
 
 	switch {
 	case feederClass.Sierra != nil:
-		compiledClass, cErr := compiler.Compile(feederClass.Sierra)
+		compiledClass, cErr := compiler.Compile(ctx, feederClass.Sierra)
 		if cErr != nil {
 			return nil, cErr
 		}

--- a/rpc/v6/estimate_fee_test.go
+++ b/rpc/v6/estimate_fee_test.go
@@ -37,7 +37,7 @@ func TestEstimateMessageFee(t *testing.T) {
 
 	t.Run("block not found", func(t *testing.T) {
 		mockReader.EXPECT().HeadState().Return(nil, nil, db.ErrKeyNotFound)
-		_, err := handler.EstimateMessageFee(msg, rpc.BlockID{Latest: true})
+		_, err := handler.EstimateMessageFee(t.Context(), msg, rpc.BlockID{Latest: true})
 		require.Equal(t, rpccore.ErrBlockNotFound, err)
 	})
 
@@ -95,7 +95,7 @@ func TestEstimateMessageFee(t *testing.T) {
 		},
 	)
 
-	estimateFee, err := handler.EstimateMessageFee(msg, rpc.BlockID{Latest: true})
+	estimateFee, err := handler.EstimateMessageFee(t.Context(), msg, rpc.BlockID{Latest: true})
 	require.Nil(t, err)
 	feeUnit := rpc.WEI
 	require.Equal(t, expectedGasConsumed, estimateFee.GasConsumed)

--- a/rpc/v6/handlers.go
+++ b/rpc/v6/handlers.go
@@ -15,6 +15,7 @@ import (
 	"github.com/NethermindEth/juno/jsonrpc"
 	"github.com/NethermindEth/juno/mempool"
 	rpccore "github.com/NethermindEth/juno/rpc/rpccore"
+	"github.com/NethermindEth/juno/starknet/compiler"
 	"github.com/NethermindEth/juno/sync"
 	"github.com/NethermindEth/juno/utils"
 	"github.com/NethermindEth/juno/vm"
@@ -32,6 +33,7 @@ type Handler struct {
 	gatewayClient rpccore.Gateway
 	feederClient  *feeder.Client
 	vm            vm.VM
+	compiler      compiler.Compiler
 	idgen         func() uint64
 	subscriptions stdsync.Map // map[uint64]*subscription
 	newHeads      *feed.Feed[*core.Block]
@@ -71,6 +73,11 @@ func New(bcReader blockchain.Reader, syncReader sync.Reader, virtualMachine vm.V
 		blockTraceCache: lru.NewCache[traceCacheKey, []TracedBlockTransaction](rpccore.TraceCacheSize),
 		filterLimit:     math.MaxUint,
 	}
+}
+
+func (h *Handler) WithCompiler(compiler compiler.Compiler) *Handler {
+	h.compiler = compiler
+	return h
 }
 
 func (h *Handler) WithMempool(memPool mempool.Pool) *Handler {

--- a/rpc/v6/handlers_test.go
+++ b/rpc/v6/handlers_test.go
@@ -48,6 +48,7 @@ func TestThrottledVMError(t *testing.T) {
 		mockReader.EXPECT().HeadState().Return(mockState, nopCloser, nil)
 		mockReader.EXPECT().HeadsHeader().Return(&core.Header{}, nil)
 		_, rpcErr := handler.SimulateTransactions(
+			t.Context(),
 			rpc.BlockID{Latest: true},
 			rpc.BroadcastedTransactionInputs{},
 			[]rpc.SimulationFlag{rpc.SkipFeeChargeFlag},

--- a/rpc/v6/simulation_test.go
+++ b/rpc/v6/simulation_test.go
@@ -49,6 +49,7 @@ func TestSimulateTransactions(t *testing.T) {
 			}, nil)
 
 		_, err := handler.SimulateTransactions(
+			t.Context(),
 			rpc.BlockID{Latest: true},
 			rpc.BroadcastedTransactionInputs{},
 			[]rpc.SimulationFlag{rpc.SkipFeeChargeFlag},
@@ -69,6 +70,7 @@ func TestSimulateTransactions(t *testing.T) {
 			}, nil)
 
 		_, err := handler.SimulateTransactions(
+			t.Context(),
 			rpc.BlockID{Latest: true},
 			rpc.BroadcastedTransactionInputs{},
 			[]rpc.SimulationFlag{rpc.SkipValidateFlag},
@@ -86,6 +88,7 @@ func TestSimulateTransactions(t *testing.T) {
 			})
 
 		_, err := handler.SimulateTransactions(
+			t.Context(),
 			rpc.BlockID{Latest: true},
 			rpc.BroadcastedTransactionInputs{},
 			[]rpc.SimulationFlag{rpc.SkipValidateFlag},
@@ -104,6 +107,7 @@ func TestSimulateTransactions(t *testing.T) {
 			})
 
 		_, err = handler.SimulateTransactions(
+			t.Context(),
 			rpc.BlockID{Latest: true},
 			rpc.BroadcastedTransactionInputs{},
 			[]rpc.SimulationFlag{rpc.SkipValidateFlag},
@@ -127,6 +131,7 @@ func TestSimulateTransactions(t *testing.T) {
 			}, nil)
 
 		_, err := handler.SimulateTransactions(
+			t.Context(),
 			rpc.BlockID{Latest: true},
 			rpc.BroadcastedTransactionInputs{},
 			[]rpc.SimulationFlag{rpc.SkipValidateFlag},
@@ -243,6 +248,7 @@ func TestSimulateTransactionsShouldErrorWithoutSenderAddressOrResourceBounds(t *
 			handler := rpc.New(mockReader, nil, mockVM, n, utils.NewNopZapLogger())
 
 			_, err := handler.SimulateTransactions(
+				t.Context(),
 				rpc.BlockID{Latest: true},
 				rpc.BroadcastedTransactionInputs{Data: test.transactions},
 				[]rpc.SimulationFlag{},

--- a/rpc/v6/transaction.go
+++ b/rpc/v6/transaction.go
@@ -16,6 +16,7 @@ import (
 	"github.com/NethermindEth/juno/mempool"
 	rpccore "github.com/NethermindEth/juno/rpc/rpccore"
 	"github.com/NethermindEth/juno/starknet"
+	"github.com/NethermindEth/juno/starknet/compiler"
 	"github.com/NethermindEth/juno/utils"
 	"github.com/ethereum/go-ethereum/common"
 	"go.uber.org/zap"
@@ -318,7 +319,10 @@ type BroadcastedTransaction struct {
 	PaidFeeOnL1   *felt.Felt      `json:"paid_fee_on_l1,omitempty" validate:"required_if=Transaction.Type L1_HANDLER"`
 }
 
-func AdaptBroadcastedTransaction(broadcastedTxn *BroadcastedTransaction,
+func AdaptBroadcastedTransaction(
+	ctx context.Context,
+	compiler compiler.Compiler,
+	broadcastedTxn *BroadcastedTransaction,
 	network *utils.Network,
 ) (core.Transaction, core.ClassDefinition, *felt.Felt, error) {
 	// RPCv6 requests must set l2_gas to zero
@@ -340,7 +344,9 @@ func AdaptBroadcastedTransaction(broadcastedTxn *BroadcastedTransaction,
 
 	var declaredClass core.ClassDefinition
 	if len(broadcastedTxn.ContractClass) != 0 {
-		declaredClass, err = adaptDeclaredClass(broadcastedTxn.ContractClass)
+		declaredClass, err = adaptDeclaredClass(
+			ctx, compiler, broadcastedTxn.ContractClass,
+		)
 		if err != nil {
 			return nil, nil, nil, err
 		}
@@ -620,7 +626,9 @@ func (h *Handler) AddTransaction(
 }
 
 func (h *Handler) addToMempool(ctx context.Context, tx *BroadcastedTransaction) (AddTxResponse, *jsonrpc.Error) {
-	userTxn, userClass, paidFeeOnL1, err := AdaptBroadcastedTransaction(tx, h.bcReader.Network())
+	userTxn, userClass, paidFeeOnL1, err := AdaptBroadcastedTransaction(
+		ctx, h.compiler, tx, h.bcReader.Network(),
+	)
 	if err != nil {
 		return AddTxResponse{}, rpccore.ErrInternal.CloneWithData(err.Error())
 	}

--- a/rpc/v6/transaction_test.go
+++ b/rpc/v6/transaction_test.go
@@ -1659,7 +1659,10 @@ func TestAdaptBroadcastedTransaction(t *testing.T) {
 	txnNonZeroL2Gas := rpc.BroadcastedTransaction{}
 	require.NoError(t, json.Unmarshal([]byte(txnNonZeroL2GasData), &txnNonZeroL2Gas))
 
-	tx, _, _, err := rpc.AdaptBroadcastedTransaction(&txnNonZeroL2Gas, &utils.Sepolia)
+	tx, _, _, err := rpc.AdaptBroadcastedTransaction(
+		t.Context(), nil,
+		&txnNonZeroL2Gas, &utils.Sepolia,
+	)
 	require.NoError(t, err)
 	resultTxn, ok := (tx).(*core.DeployAccountTransaction)
 	require.True(t, ok)

--- a/rpc/v7/class.go
+++ b/rpc/v7/class.go
@@ -1,6 +1,7 @@
 package rpcv7
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 
@@ -22,7 +23,11 @@ type FunctionCall struct {
 	Calldata           CalldataInputs `json:"calldata"`
 }
 
-func adaptDeclaredClass(declaredClass json.RawMessage) (core.ClassDefinition, error) {
+func adaptDeclaredClass(
+	ctx context.Context,
+	compiler compiler.Compiler,
+	declaredClass json.RawMessage,
+) (core.ClassDefinition, error) {
 	var feederClass starknet.ClassDefinition
 	err := json.Unmarshal(declaredClass, &feederClass)
 	if err != nil {
@@ -31,7 +36,7 @@ func adaptDeclaredClass(declaredClass json.RawMessage) (core.ClassDefinition, er
 
 	switch {
 	case feederClass.Sierra != nil:
-		compiledClass, cErr := compiler.Compile(feederClass.Sierra)
+		compiledClass, cErr := compiler.Compile(ctx, feederClass.Sierra)
 		if cErr != nil {
 			return nil, cErr
 		}

--- a/rpc/v7/estimate_fee_test.go
+++ b/rpc/v7/estimate_fee_test.go
@@ -53,6 +53,7 @@ func TestEstimateFee(t *testing.T) {
 			}, nil)
 
 		_, httpHeader, err := handler.EstimateFee(
+			t.Context(),
 			rpcv7.BroadcastedTransactionInputs{},
 			[]rpcv6.SimulationFlag{},
 			rpcv7.BlockID{Latest: true},
@@ -79,6 +80,7 @@ func TestEstimateFee(t *testing.T) {
 			}, nil)
 
 		_, httpHeader, err := handler.EstimateFee(
+			t.Context(),
 			rpcv7.BroadcastedTransactionInputs{},
 			[]rpcv6.SimulationFlag{rpcv6.SkipValidateFlag},
 			rpcv7.BlockID{Latest: true},
@@ -103,6 +105,7 @@ func TestEstimateFee(t *testing.T) {
 			})
 
 		_, httpHeader, err := handler.EstimateFee(
+			t.Context(),
 			rpcv7.BroadcastedTransactionInputs{},
 			[]rpcv6.SimulationFlag{rpcv6.SkipValidateFlag},
 			rpcv7.BlockID{Latest: true},
@@ -132,6 +135,7 @@ func TestEstimateFee(t *testing.T) {
 			ContractClass: json.RawMessage(`{}`),
 		}
 		_, _, err := handler.EstimateFee(
+			t.Context(),
 			rpcv7.BroadcastedTransactionInputs{Data: []rpcv7.BroadcastedTransaction{invalidTx}},
 			[]rpcv6.SimulationFlag{},
 			rpcv7.BlockID{Latest: true},

--- a/rpc/v7/handlers.go
+++ b/rpc/v7/handlers.go
@@ -14,6 +14,7 @@ import (
 	"github.com/NethermindEth/juno/feed"
 	"github.com/NethermindEth/juno/jsonrpc"
 	"github.com/NethermindEth/juno/rpc/rpccore"
+	"github.com/NethermindEth/juno/starknet/compiler"
 	"github.com/NethermindEth/juno/sync"
 	"github.com/NethermindEth/juno/utils"
 	"github.com/NethermindEth/juno/vm"
@@ -39,6 +40,7 @@ type Handler struct {
 	gatewayClient rpccore.Gateway
 	feederClient  *feeder.Client
 	vm            vm.VM
+	compiler      compiler.Compiler
 	log           utils.Logger
 
 	newHeads *feed.Feed[*core.Block]
@@ -79,6 +81,11 @@ func New(bcReader blockchain.Reader, syncReader sync.Reader, virtualMachine vm.V
 		blockTraceCache: lru.NewCache[traceCacheKey, []TracedBlockTransaction](traceCacheSize),
 		filterLimit:     math.MaxUint,
 	}
+}
+
+func (h *Handler) WithCompiler(compiler compiler.Compiler) *Handler {
+	h.compiler = compiler
+	return h
 }
 
 // WithFilterLimit sets the maximum number of blocks to scan in a single call for event filtering.

--- a/rpc/v7/handlers_test.go
+++ b/rpc/v7/handlers_test.go
@@ -49,6 +49,7 @@ func TestThrottledVMError(t *testing.T) {
 		mockReader.EXPECT().HeadState().Return(mockState, nopCloser, nil)
 		mockReader.EXPECT().HeadsHeader().Return(&core.Header{}, nil)
 		_, httpHeader, rpcErr := handler.SimulateTransactions(
+			t.Context(),
 			rpcv7.BlockID{Latest: true},
 			rpcv7.BroadcastedTransactionInputs{},
 			[]rpcv6.SimulationFlag{rpcv6.SkipFeeChargeFlag},

--- a/rpc/v7/simulation.go
+++ b/rpc/v7/simulation.go
@@ -1,6 +1,7 @@
 package rpcv7
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -39,15 +40,21 @@ type BroadcastedTransactionInputs = rpccore.LimitSlice[
 *****************************************************/
 
 func (h *Handler) SimulateTransactions(
+	ctx context.Context,
 	id BlockID,
 	transactions BroadcastedTransactionInputs,
 	simulationFlags []rpcv6.SimulationFlag,
 ) ([]SimulatedTransaction, http.Header, *jsonrpc.Error) {
-	return h.simulateTransactions(id, transactions.Data, simulationFlags, false, false)
+	return h.simulateTransactions(ctx, id, transactions.Data, simulationFlags, false, false)
 }
 
-func (h *Handler) simulateTransactions(id BlockID, transactions []BroadcastedTransaction,
-	simulationFlags []rpcv6.SimulationFlag, errOnRevert bool, isEstimateFee bool,
+func (h *Handler) simulateTransactions(
+	ctx context.Context,
+	id BlockID,
+	transactions []BroadcastedTransaction,
+	simulationFlags []rpcv6.SimulationFlag,
+	errOnRevert bool,
+	isEstimateFee bool,
 ) ([]SimulatedTransaction, http.Header, *jsonrpc.Error) {
 	skipFeeCharge := slices.Contains(simulationFlags, rpcv6.SkipFeeChargeFlag)
 	skipValidate := slices.Contains(simulationFlags, rpcv6.SkipValidateFlag)
@@ -69,7 +76,9 @@ func (h *Handler) simulateTransactions(id BlockID, transactions []BroadcastedTra
 
 	network := h.bcReader.Network()
 
-	txns, classes, paidFeesOnL1, rpcErr := prepareTransactions(transactions, network)
+	txns, classes, paidFeesOnL1, rpcErr := h.prepareTransactions(
+		ctx, transactions, network,
+	)
 	if rpcErr != nil {
 		return nil, httpHeader, rpcErr
 	}
@@ -127,7 +136,9 @@ func checkTxHasResourceBounds(tx *BroadcastedTransaction) bool {
 		tx.Transaction.ResourceBounds == nil
 }
 
-func prepareTransactions(transactions []BroadcastedTransaction, network *utils.Network) (
+func (h *Handler) prepareTransactions(
+	ctx context.Context, transactions []BroadcastedTransaction, network *utils.Network,
+) (
 	[]core.Transaction, []core.ClassDefinition, []*felt.Felt, *jsonrpc.Error,
 ) {
 	txns := make([]core.Transaction, len(transactions))
@@ -149,7 +160,12 @@ func prepareTransactions(transactions []BroadcastedTransaction, network *utils.N
 			return nil, nil, nil, jsonrpc.Err(jsonrpc.InvalidParams, "resource_bounds is required for this transaction type")
 		}
 
-		txn, declaredClass, paidFeeOnL1, aErr := AdaptBroadcastedTransaction(&transactions[idx], network)
+		txn, declaredClass, paidFeeOnL1, aErr := AdaptBroadcastedTransaction(
+			ctx,
+			h.compiler,
+			&transactions[idx],
+			network,
+		)
 		if aErr != nil {
 			return nil, nil, nil, jsonrpc.Err(jsonrpc.InvalidParams, aErr.Error())
 		}

--- a/rpc/v7/simulation_test.go
+++ b/rpc/v7/simulation_test.go
@@ -51,6 +51,7 @@ func TestSimulateTransactions(t *testing.T) {
 			}, nil)
 
 		_, httpHeader, err := handler.SimulateTransactions(
+			t.Context(),
 			rpcv7.BlockID{Latest: true},
 			rpcv7.BroadcastedTransactionInputs{},
 			[]rpcv6.SimulationFlag{rpcv6.SkipFeeChargeFlag},
@@ -72,6 +73,7 @@ func TestSimulateTransactions(t *testing.T) {
 			}, nil)
 
 		_, httpHeader, err := handler.SimulateTransactions(
+			t.Context(),
 			rpcv7.BlockID{Latest: true},
 			rpcv7.BroadcastedTransactionInputs{},
 			[]rpcv6.SimulationFlag{rpcv6.SkipValidateFlag},
@@ -91,6 +93,7 @@ func TestSimulateTransactions(t *testing.T) {
 				})
 
 			_, httpHeader, err := handler.SimulateTransactions(
+				t.Context(),
 				rpcv7.BlockID{Latest: true},
 				rpcv7.BroadcastedTransactionInputs{},
 				[]rpcv6.SimulationFlag{rpcv6.SkipValidateFlag},
@@ -116,6 +119,7 @@ func TestSimulateTransactions(t *testing.T) {
 			}, nil)
 
 		_, httpHeader, err := handler.SimulateTransactions(
+			t.Context(),
 			rpcv7.BlockID{Latest: true},
 			rpcv7.BroadcastedTransactionInputs{},
 			[]rpcv6.SimulationFlag{rpcv6.SkipValidateFlag},
@@ -233,6 +237,7 @@ func TestSimulateTransactionsShouldErrorWithoutSenderAddressOrResourceBounds(t *
 			handler := rpcv7.New(mockReader, nil, mockVM, n, utils.NewNopZapLogger())
 
 			_, _, err := handler.SimulateTransactions(
+				t.Context(),
 				rpcv7.BlockID{Latest: true},
 				rpcv7.BroadcastedTransactionInputs{Data: test.transactions},
 				[]rpcv6.SimulationFlag{},

--- a/rpc/v7/transaction.go
+++ b/rpc/v7/transaction.go
@@ -15,6 +15,7 @@ import (
 	"github.com/NethermindEth/juno/rpc/rpccore"
 	rpcv6 "github.com/NethermindEth/juno/rpc/v6"
 	"github.com/NethermindEth/juno/starknet"
+	"github.com/NethermindEth/juno/starknet/compiler"
 	"github.com/NethermindEth/juno/utils"
 	"github.com/ethereum/go-ethereum/common"
 	"go.uber.org/zap"
@@ -256,7 +257,10 @@ type BroadcastedTransaction struct {
 	PaidFeeOnL1   *felt.Felt      `json:"paid_fee_on_l1,omitempty" validate:"required_if=Transaction.Type L1_HANDLER"`
 }
 
-func AdaptBroadcastedTransaction(broadcastedTxn *BroadcastedTransaction,
+func AdaptBroadcastedTransaction(
+	ctx context.Context,
+	compiler compiler.Compiler,
+	broadcastedTxn *BroadcastedTransaction,
 	network *utils.Network,
 ) (core.Transaction, core.ClassDefinition, *felt.Felt, error) {
 	// RPCv7 requests must set l2_gas to zero
@@ -277,7 +281,9 @@ func AdaptBroadcastedTransaction(broadcastedTxn *BroadcastedTransaction,
 	}
 	var declaredClass core.ClassDefinition
 	if len(broadcastedTxn.ContractClass) != 0 {
-		declaredClass, err = adaptDeclaredClass(broadcastedTxn.ContractClass)
+		declaredClass, err = adaptDeclaredClass(
+			ctx, compiler, broadcastedTxn.ContractClass,
+		)
 		if err != nil {
 			return nil, nil, nil, err
 		}

--- a/rpc/v7/transaction_test.go
+++ b/rpc/v7/transaction_test.go
@@ -1046,7 +1046,12 @@ func TestAdaptBroadcastedTransaction(t *testing.T) {
 	txnNonZeroL2Gas := rpc.BroadcastedTransaction{}
 	require.NoError(t, json.Unmarshal([]byte(txnNonZeroL2GasData), &txnNonZeroL2Gas))
 
-	tx, _, _, err := rpc.AdaptBroadcastedTransaction(&txnNonZeroL2Gas, &utils.Sepolia)
+	tx, _, _, err := rpc.AdaptBroadcastedTransaction(
+		t.Context(),
+		nil,
+		&txnNonZeroL2Gas,
+		&utils.Sepolia,
+	)
 	require.NoError(t, err)
 	resultTxn, ok := (tx).(*core.DeployAccountTransaction)
 	require.True(t, ok)

--- a/rpc/v8/class.go
+++ b/rpc/v8/class.go
@@ -1,6 +1,7 @@
 package rpcv8
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 
@@ -22,7 +23,11 @@ type FunctionCall struct {
 	Calldata           CalldataInputs `json:"calldata"`
 }
 
-func adaptDeclaredClass(declaredClass json.RawMessage) (core.ClassDefinition, error) {
+func adaptDeclaredClass(
+	ctx context.Context,
+	compiler compiler.Compiler,
+	declaredClass json.RawMessage,
+) (core.ClassDefinition, error) {
 	var feederClass starknet.ClassDefinition
 	err := json.Unmarshal(declaredClass, &feederClass)
 	if err != nil {
@@ -31,7 +36,7 @@ func adaptDeclaredClass(declaredClass json.RawMessage) (core.ClassDefinition, er
 
 	switch {
 	case feederClass.Sierra != nil:
-		compiledClass, cErr := compiler.Compile(feederClass.Sierra)
+		compiledClass, cErr := compiler.Compile(ctx, feederClass.Sierra)
 		if cErr != nil {
 			return nil, cErr
 		}

--- a/rpc/v8/estimate_fee.go
+++ b/rpc/v8/estimate_fee.go
@@ -1,6 +1,7 @@
 package rpcv8
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -259,11 +260,13 @@ curl --location 'http://localhost:6060/rpc/v0_8' \
 */
 
 func (h *Handler) EstimateFee(
+	ctx context.Context,
 	broadcastedTxns BroadcastedTransactionInputs,
 	simulationFlags []rpcv6.SimulationFlag,
 	id *BlockID,
 ) ([]FeeEstimate, http.Header, *jsonrpc.Error) {
 	txnResults, httpHeader, err := h.simulateTransactions(
+		ctx,
 		id,
 		broadcastedTxns.Data,
 		append(simulationFlags, rpcv6.SkipFeeChargeFlag),
@@ -283,7 +286,9 @@ func (h *Handler) EstimateFee(
 }
 
 func (h *Handler) EstimateMessageFee(
-	msg *rpcv6.MsgFromL1, id *BlockID,
+	ctx context.Context,
+	msg *rpcv6.MsgFromL1,
+	id *BlockID,
 ) (FeeEstimate, http.Header, *jsonrpc.Error) {
 	calldata := make([]*felt.Felt, len(msg.Payload)+1)
 	// msg.From needs to be the first element
@@ -307,6 +312,7 @@ func (h *Handler) EstimateMessageFee(
 
 	bcTxn := [1]BroadcastedTransaction{tx}
 	estimates, httpHeader, err := h.EstimateFee(
+		ctx,
 		BroadcastedTransactionInputs{Data: bcTxn[:]},
 		nil,
 		id,

--- a/rpc/v8/estimate_fee_test.go
+++ b/rpc/v8/estimate_fee_test.go
@@ -59,6 +59,7 @@ func TestEstimateFee(t *testing.T) {
 			)
 
 		_, httpHeader, err := handler.EstimateFee(
+			t.Context(),
 			rpc.BroadcastedTransactionInputs{},
 			[]rpcv6.SimulationFlag{},
 			&blockID,
@@ -86,6 +87,7 @@ func TestEstimateFee(t *testing.T) {
 			}, nil)
 
 		_, httpHeader, err := handler.EstimateFee(
+			t.Context(),
 			rpc.BroadcastedTransactionInputs{},
 			[]rpcv6.SimulationFlag{rpcv6.SkipValidateFlag},
 			&blockID,
@@ -113,6 +115,7 @@ func TestEstimateFee(t *testing.T) {
 			)
 
 		_, httpHeader, err := handler.EstimateFee(
+			t.Context(),
 			rpc.BroadcastedTransactionInputs{},
 			[]rpcv6.SimulationFlag{rpcv6.SkipValidateFlag},
 			&blockID,
@@ -142,6 +145,7 @@ func TestEstimateFee(t *testing.T) {
 			ContractClass: json.RawMessage(`{}`),
 		}
 		_, _, err := handler.EstimateFee(
+			t.Context(),
 			rpc.BroadcastedTransactionInputs{Data: []rpc.BroadcastedTransaction{invalidTx}},
 			[]rpcv6.SimulationFlag{},
 			&blockID,

--- a/rpc/v8/handlers.go
+++ b/rpc/v8/handlers.go
@@ -17,6 +17,7 @@ import (
 	"github.com/NethermindEth/juno/l1/contract"
 	"github.com/NethermindEth/juno/mempool"
 	"github.com/NethermindEth/juno/rpc/rpccore"
+	"github.com/NethermindEth/juno/starknet/compiler"
 	"github.com/NethermindEth/juno/sync"
 	"github.com/NethermindEth/juno/utils"
 	"github.com/NethermindEth/juno/vm"
@@ -31,6 +32,7 @@ type Handler struct {
 	gatewayClient rpccore.Gateway
 	feederClient  *feeder.Client
 	vm            vm.VM
+	compiler      compiler.Compiler
 	log           utils.Logger
 	memPool       mempool.Pool
 
@@ -86,6 +88,11 @@ func New(bcReader blockchain.Reader, syncReader sync.Reader, virtualMachine vm.V
 		filterLimit:     math.MaxUint,
 		coreContractABI: contractABI,
 	}
+}
+
+func (h *Handler) WithCompiler(compiler compiler.Compiler) *Handler {
+	h.compiler = compiler
+	return h
 }
 
 func (h *Handler) WithMempool(memPool mempool.Pool) *Handler {

--- a/rpc/v8/handlers_test.go
+++ b/rpc/v8/handlers_test.go
@@ -53,6 +53,7 @@ func TestThrottledVMError(t *testing.T) {
 
 		blockID := blockIDLatest(t)
 		_, httpHeader, rpcErr := handler.SimulateTransactions(
+			t.Context(),
 			&blockID,
 			rpcv8.BroadcastedTransactionInputs{},
 			[]rpcv6.SimulationFlag{rpcv6.SkipFeeChargeFlag},

--- a/rpc/v8/simulation.go
+++ b/rpc/v8/simulation.go
@@ -1,6 +1,7 @@
 package rpcv8
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -39,15 +40,20 @@ type BroadcastedTransactionInputs = rpccore.LimitSlice[
 *****************************************************/
 
 func (h *Handler) SimulateTransactions(
+	ctx context.Context,
 	id *BlockID,
 	transactions BroadcastedTransactionInputs,
 	simulationFlags []rpcv6.SimulationFlag,
 ) ([]SimulatedTransaction, http.Header, *jsonrpc.Error) {
-	return h.simulateTransactions(id, transactions.Data, simulationFlags, false, false)
+	return h.simulateTransactions(ctx, id, transactions.Data, simulationFlags, false, false)
 }
 
-func (h *Handler) simulateTransactions(id *BlockID, transactions []BroadcastedTransaction,
-	simulationFlags []rpcv6.SimulationFlag, errOnRevert bool,
+func (h *Handler) simulateTransactions(
+	ctx context.Context,
+	id *BlockID,
+	transactions []BroadcastedTransaction,
+	simulationFlags []rpcv6.SimulationFlag,
+	errOnRevert bool,
 	isEstimateFee bool,
 ) ([]SimulatedTransaction, http.Header, *jsonrpc.Error) {
 	skipFeeCharge := slices.Contains(simulationFlags, rpcv6.SkipFeeChargeFlag)
@@ -68,7 +74,9 @@ func (h *Handler) simulateTransactions(id *BlockID, transactions []BroadcastedTr
 	}
 
 	network := h.bcReader.Network()
-	txns, classes, paidFeesOnL1, rpcErr := prepareTransactions(transactions, network)
+	txns, classes, paidFeesOnL1, rpcErr := h.prepareTransactions(
+		ctx, transactions, network,
+	)
 	if rpcErr != nil {
 		return nil, httpHeader, rpcErr
 	}
@@ -117,7 +125,9 @@ func checkTxHasResourceBounds(tx *BroadcastedTransaction) bool {
 		tx.Transaction.ResourceBounds == nil
 }
 
-func prepareTransactions(transactions []BroadcastedTransaction, network *utils.Network) (
+func (h *Handler) prepareTransactions(
+	ctx context.Context, transactions []BroadcastedTransaction, network *utils.Network,
+) (
 	[]core.Transaction, []core.ClassDefinition, []*felt.Felt, *jsonrpc.Error,
 ) {
 	txns := make([]core.Transaction, len(transactions))
@@ -139,7 +149,12 @@ func prepareTransactions(transactions []BroadcastedTransaction, network *utils.N
 			return nil, nil, nil, jsonrpc.Err(jsonrpc.InvalidParams, "resource_bounds is required for this transaction type")
 		}
 
-		txn, declaredClass, paidFeeOnL1, aErr := AdaptBroadcastedTransaction(&transactions[idx], network)
+		txn, declaredClass, paidFeeOnL1, aErr := AdaptBroadcastedTransaction(
+			ctx,
+			h.compiler,
+			&transactions[idx],
+			network,
+		)
 		if aErr != nil {
 			return nil, nil, nil, jsonrpc.Err(jsonrpc.InvalidParams, aErr.Error())
 		}

--- a/rpc/v8/simulation_test.go
+++ b/rpc/v8/simulation_test.go
@@ -142,6 +142,7 @@ func TestSimulateTransactions(t *testing.T) {
 
 			blockID := blockIDLatest(t)
 			simulatedTxs, httpHeader, err := handler.SimulateTransactions(
+				t.Context(),
 				&blockID,
 				rpc.BroadcastedTransactionInputs{},
 				test.simulationFlags,
@@ -269,6 +270,7 @@ func TestSimulateTransactionsShouldErrorWithoutSenderAddressOrResourceBounds(t *
 
 			blockID := blockIDLatest(t)
 			_, _, err := handler.SimulateTransactions(
+				t.Context(),
 				&blockID,
 				rpc.BroadcastedTransactionInputs{Data: test.transactions},
 				[]rpcv6.SimulationFlag{},

--- a/rpc/v8/transaction.go
+++ b/rpc/v8/transaction.go
@@ -17,6 +17,7 @@ import (
 	"github.com/NethermindEth/juno/mempool"
 	"github.com/NethermindEth/juno/rpc/rpccore"
 	"github.com/NethermindEth/juno/starknet"
+	"github.com/NethermindEth/juno/starknet/compiler"
 	"github.com/NethermindEth/juno/utils"
 	"github.com/ethereum/go-ethereum/common"
 	"go.uber.org/zap"
@@ -327,7 +328,10 @@ type BroadcastedTransaction struct {
 	PaidFeeOnL1   *felt.Felt      `json:"paid_fee_on_l1,omitempty" validate:"required_if=Transaction.Type L1_HANDLER"`
 }
 
-func AdaptBroadcastedTransaction(broadcastedTxn *BroadcastedTransaction,
+func AdaptBroadcastedTransaction(
+	ctx context.Context,
+	compiler compiler.Compiler,
+	broadcastedTxn *BroadcastedTransaction,
 	network *utils.Network,
 ) (core.Transaction, core.ClassDefinition, *felt.Felt, error) {
 	feederTxn := adaptRPCTxToFeederTx(&broadcastedTxn.Transaction)
@@ -339,7 +343,9 @@ func AdaptBroadcastedTransaction(broadcastedTxn *BroadcastedTransaction,
 
 	var declaredClass core.ClassDefinition
 	if len(broadcastedTxn.ContractClass) != 0 {
-		declaredClass, err = adaptDeclaredClass(broadcastedTxn.ContractClass)
+		declaredClass, err = adaptDeclaredClass(
+			ctx, compiler, broadcastedTxn.ContractClass,
+		)
 		if err != nil {
 			return nil, nil, nil, err
 		}
@@ -640,7 +646,9 @@ func (h *Handler) AddTransaction(ctx context.Context, tx *BroadcastedTransaction
 }
 
 func (h *Handler) addToMempool(ctx context.Context, tx *BroadcastedTransaction) (AddTxResponse, *jsonrpc.Error) {
-	userTxn, userClass, paidFeeOnL1, err := AdaptBroadcastedTransaction(tx, h.bcReader.Network())
+	userTxn, userClass, paidFeeOnL1, err := AdaptBroadcastedTransaction(
+		ctx, h.compiler, tx, h.bcReader.Network(),
+	)
 	if err != nil {
 		return AddTxResponse{}, rpccore.ErrInternal.CloneWithData(err.Error())
 	}

--- a/rpc/v8/transaction_test.go
+++ b/rpc/v8/transaction_test.go
@@ -1837,7 +1837,9 @@ func TestAdaptBroadcastedTransaction(t *testing.T) {
 	txnNonZeroL2Gas := rpc.BroadcastedTransaction{}
 	require.NoError(t, json.Unmarshal([]byte(txnNonZeroL2GasData), &txnNonZeroL2Gas))
 
-	tx, _, _, err := rpc.AdaptBroadcastedTransaction(&txnNonZeroL2Gas, &utils.Sepolia)
+	tx, _, _, err := rpc.AdaptBroadcastedTransaction(
+		t.Context(), nil, &txnNonZeroL2Gas, &utils.Sepolia,
+	)
 	require.NoError(t, err)
 	resultTxn, ok := (tx).(*core.DeployAccountTransaction)
 

--- a/rpc/v9/class.go
+++ b/rpc/v9/class.go
@@ -1,6 +1,7 @@
 package rpcv9
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 
@@ -24,7 +25,11 @@ type FunctionCall struct {
 	Calldata           CalldataInputs `json:"calldata"`
 }
 
-func adaptDeclaredClass(declaredClass json.RawMessage) (core.ClassDefinition, error) {
+func adaptDeclaredClass(
+	ctx context.Context,
+	compiler compiler.Compiler,
+	declaredClass json.RawMessage,
+) (core.ClassDefinition, error) {
 	var feederClass starknet.ClassDefinition
 	err := json.Unmarshal(declaredClass, &feederClass)
 	if err != nil {
@@ -33,7 +38,7 @@ func adaptDeclaredClass(declaredClass json.RawMessage) (core.ClassDefinition, er
 
 	switch {
 	case feederClass.Sierra != nil:
-		compiledClass, cErr := compiler.Compile(feederClass.Sierra)
+		compiledClass, cErr := compiler.Compile(ctx, feederClass.Sierra)
 		if cErr != nil {
 			return nil, cErr
 		}

--- a/rpc/v9/estimate_fee.go
+++ b/rpc/v9/estimate_fee.go
@@ -1,6 +1,7 @@
 package rpcv9
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -271,11 +272,13 @@ curl --location 'http://localhost:6060/rpc/v0_8' \
 */
 
 func (h *Handler) EstimateFee(
+	ctx context.Context,
 	broadcastedTxns BroadcastedTransactionInputs,
 	simulationFlags []rpcv6.SimulationFlag,
 	id *BlockID,
 ) ([]FeeEstimate, http.Header, *jsonrpc.Error) {
 	txnResults, httpHeader, err := h.simulateTransactions(
+		ctx,
 		id,
 		broadcastedTxns.Data,
 		append(simulationFlags, rpcv6.SkipFeeChargeFlag),
@@ -295,7 +298,7 @@ func (h *Handler) EstimateFee(
 }
 
 func (h *Handler) EstimateMessageFee(
-	msg *rpcv6.MsgFromL1, id *BlockID,
+	ctx context.Context, msg *rpcv6.MsgFromL1, id *BlockID,
 ) (FeeEstimate, http.Header, *jsonrpc.Error) {
 	calldata := make([]*felt.Felt, len(msg.Payload)+1)
 	// msg.From needs to be the first element
@@ -319,6 +322,7 @@ func (h *Handler) EstimateMessageFee(
 
 	bcTxn := [1]BroadcastedTransaction{tx}
 	estimates, httpHeader, err := h.EstimateFee(
+		ctx,
 		rpccore.LimitSlice[BroadcastedTransaction, rpccore.SimulationLimit]{Data: bcTxn[:]},
 		nil,
 		id,

--- a/rpc/v9/estimate_fee_test.go
+++ b/rpc/v9/estimate_fee_test.go
@@ -56,6 +56,7 @@ func TestEstimateFee(t *testing.T) {
 			}, nil)
 
 		_, httpHeader, err := handler.EstimateFee(
+			t.Context(),
 			rpc.BroadcastedTransactionInputs{},
 			[]rpcv6.SimulationFlag{},
 			&blockID,
@@ -86,6 +87,7 @@ func TestEstimateFee(t *testing.T) {
 			)
 
 		_, httpHeader, err := handler.EstimateFee(
+			t.Context(),
 			rpc.BroadcastedTransactionInputs{},
 			[]rpcv6.SimulationFlag{rpcv6.SkipValidateFlag},
 			&blockID,
@@ -110,6 +112,7 @@ func TestEstimateFee(t *testing.T) {
 			})
 
 		_, httpHeader, err := handler.EstimateFee(
+			t.Context(),
 			rpc.BroadcastedTransactionInputs{},
 			[]rpcv6.SimulationFlag{rpcv6.SkipValidateFlag},
 			&blockID,
@@ -139,6 +142,7 @@ func TestEstimateFee(t *testing.T) {
 			ContractClass: json.RawMessage(`{}`),
 		}
 		_, _, err := handler.EstimateFee(
+			t.Context(),
 			rpc.BroadcastedTransactionInputs{Data: []rpc.BroadcastedTransaction{invalidTx}},
 			[]rpcv6.SimulationFlag{},
 			&blockID,

--- a/rpc/v9/handlers.go
+++ b/rpc/v9/handlers.go
@@ -17,6 +17,7 @@ import (
 	"github.com/NethermindEth/juno/l1/contract"
 	"github.com/NethermindEth/juno/mempool"
 	"github.com/NethermindEth/juno/rpc/rpccore"
+	"github.com/NethermindEth/juno/starknet/compiler"
 	"github.com/NethermindEth/juno/sync"
 	"github.com/NethermindEth/juno/utils"
 	"github.com/NethermindEth/juno/vm"
@@ -31,6 +32,7 @@ type Handler struct {
 	gatewayClient rpccore.Gateway
 	feederClient  *feeder.Client
 	vm            vm.VM
+	compiler      compiler.Compiler
 	log           utils.Logger
 	memPool       mempool.Pool
 
@@ -94,6 +96,11 @@ func New(bcReader blockchain.Reader, syncReader sync.Reader, virtualMachine vm.V
 		filterLimit:     math.MaxUint,
 		coreContractABI: contractABI,
 	}
+}
+
+func (h *Handler) WithCompiler(compiler compiler.Compiler) *Handler {
+	h.compiler = compiler
+	return h
 }
 
 func (h *Handler) WithMempool(memPool mempool.Pool) *Handler {

--- a/rpc/v9/handlers_test.go
+++ b/rpc/v9/handlers_test.go
@@ -53,6 +53,7 @@ func TestThrottledVMError(t *testing.T) {
 
 		blockID := blockIDLatest(t)
 		_, httpHeader, rpcErr := handler.SimulateTransactions(
+			t.Context(),
 			&blockID,
 			rpcv9.BroadcastedTransactionInputs{},
 			[]rpcv6.SimulationFlag{rpcv6.SkipFeeChargeFlag},

--- a/rpc/v9/simulation_test.go
+++ b/rpc/v9/simulation_test.go
@@ -142,6 +142,7 @@ func TestSimulateTransactions(t *testing.T) {
 
 			blockID := blockIDLatest(t)
 			simulatedTxs, httpHeader, err := handler.SimulateTransactions(
+				t.Context(),
 				&blockID,
 				rpc.BroadcastedTransactionInputs{},
 				test.simulationFlags,
@@ -269,6 +270,7 @@ func TestSimulateTransactionsShouldErrorWithoutSenderAddressOrResourceBounds(t *
 
 			blockID := blockIDLatest(t)
 			_, _, err := handler.SimulateTransactions(
+				t.Context(),
 				&blockID,
 				rpc.BroadcastedTransactionInputs{Data: test.transactions},
 				[]rpcv6.SimulationFlag{},

--- a/rpc/v9/transaction_test.go
+++ b/rpc/v9/transaction_test.go
@@ -2121,7 +2121,9 @@ func TestAdaptBroadcastedTransaction(t *testing.T) {
 	txnNonZeroL2Gas := rpc.BroadcastedTransaction{}
 	require.NoError(t, json.Unmarshal([]byte(txnNonZeroL2GasData), &txnNonZeroL2Gas))
 
-	tx, _, _, err := rpc.AdaptBroadcastedTransaction(&txnNonZeroL2Gas, &utils.Sepolia)
+	tx, _, _, err := rpc.AdaptBroadcastedTransaction(
+		t.Context(), nil, &txnNonZeroL2Gas, &utils.Sepolia,
+	)
 	require.NoError(t, err)
 	resultTxn, ok := (tx).(*core.DeployAccountTransaction)
 

--- a/sequencer/sequencer_test.go
+++ b/sequencer/sequencer_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/NethermindEth/juno/mocks"
 	rpc "github.com/NethermindEth/juno/rpc/v8"
 	"github.com/NethermindEth/juno/sequencer"
+	"github.com/NethermindEth/juno/starknet/compiler"
 	"github.com/NethermindEth/juno/utils"
 	"github.com/NethermindEth/juno/vm"
 	"github.com/consensys/gnark-crypto/ecc/stark-curve/ecdsa"
@@ -122,11 +123,13 @@ func getGenesisSequencer(
 		FeeTokenAddresses: feeTokens,
 	}
 	diff, classes, err := genesis.GenesisStateDiff(
+		t.Context(),
 		genesisConfig,
 		vm.New(&chainInfo, false, log),
 		bc.Network(),
 		vm.DefaultMaxSteps,
 		vm.DefaultMaxGas,
+		compiler.NewUnsafe(),
 	)
 	require.NoError(t, err)
 	require.NoError(t, bc.StoreGenesis(&diff, classes))

--- a/starknet/compiler/compile_ffi.go
+++ b/starknet/compiler/compile_ffi.go
@@ -1,0 +1,58 @@
+package compiler
+
+/*
+#include <stdint.h>
+#include <stdlib.h>
+#include <stddef.h>
+
+// Extern function declarations from Rust
+extern char compileSierraToCasm(char* sierra_json, char** result);
+extern void freeCstr(char* ptr);
+
+// Linker flags for Rust shared library
+#cgo vm_debug  LDFLAGS: -L./rust/target/debug   -ljuno_starknet_compiler_rs
+#cgo !vm_debug LDFLAGS: -L./rust/target/release -ljuno_starknet_compiler_rs
+*/
+import "C"
+
+import (
+	"encoding/json"
+	"errors"
+	"unsafe"
+
+	"github.com/NethermindEth/juno/starknet"
+)
+
+// CompileFFI performs Sierra-to-CASM compilation via direct CGo FFI.
+func CompileFFI(sierra *starknet.SierraClass) (*starknet.CasmClass, error) {
+	sierraJSON, err := json.Marshal(starknet.SierraClass{
+		EntryPoints: sierra.EntryPoints,
+		Program:     sierra.Program,
+		Version:     sierra.Version,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	sierraJSONCstr := C.CString(string(sierraJSON))
+	defer C.free(unsafe.Pointer(sierraJSONCstr))
+
+	var result *C.char
+
+	//nolint:gocritic // false positive. It can be either 0 or 1
+	success := C.compileSierraToCasm(sierraJSONCstr, &result) == 1
+	defer C.freeCstr(result)
+
+	if !success {
+		return nil, errors.New(C.GoString(result))
+	}
+
+	casmJSON := C.GoString(result)
+
+	var casmClass starknet.CasmClass
+	if err := json.Unmarshal([]byte(casmJSON), &casmClass); err != nil {
+		return nil, err
+	}
+
+	return &casmClass, nil
+}

--- a/starknet/compiler/compiler.go
+++ b/starknet/compiler/compiler.go
@@ -1,56 +1,31 @@
 package compiler
 
-/*
-#include <stdint.h>
-#include <stdlib.h>
-#include <stddef.h>
-
-// Extern function declarations from Rust
-extern char compileSierraToCasm(char* sierra_json, char** result);
-extern void freeCstr(char* ptr);
-
-// Linker flags for Rust shared library
-#cgo vm_debug  LDFLAGS: -L./rust/target/debug   -ljuno_starknet_compiler_rs
-#cgo !vm_debug LDFLAGS: -L./rust/target/release -ljuno_starknet_compiler_rs
-*/
-import "C"
-
 import (
-	"encoding/json"
-	"errors"
-	"unsafe"
+	"context"
 
 	"github.com/NethermindEth/juno/starknet"
 )
 
-func Compile(sierra *starknet.SierraClass) (*starknet.CasmClass, error) {
-	sierraJSON, err := json.Marshal(starknet.SierraClass{
-		EntryPoints: sierra.EntryPoints,
-		Program:     sierra.Program,
-		Version:     sierra.Version,
-	})
-	if err != nil {
-		return nil, err
-	}
+// Compiler compiles Sierra classes to CASM.
+type Compiler interface {
+	Compile(ctx context.Context, sierra *starknet.SierraClass) (
+		*starknet.CasmClass, error,
+	)
+}
 
-	sierraJSONCstr := C.CString(string(sierraJSON))
-	defer C.free(unsafe.Pointer(sierraJSONCstr))
+type inProcessCompiler struct{}
 
-	var result *C.char
+// NewUnsafe returns a Compiler that compiles in the same process Juno is running.
+// It can be unsafe if the compilation process get stuck.
+func NewUnsafe() Compiler {
+	return &inProcessCompiler{}
+}
 
-	success := C.compileSierraToCasm(sierraJSONCstr, &result) == 1 //nolint:gocritic
-	defer C.freeCstr(result)
-
-	if !success {
-		return nil, errors.New(C.GoString(result))
-	}
-
-	casmJSON := C.GoString(result)
-
-	var casmClass starknet.CasmClass
-	if err := json.Unmarshal([]byte(casmJSON), &casmClass); err != nil {
-		return nil, err
-	}
-
-	return &casmClass, nil
+// Compile runs Sierra-to-CASM compilation as a process thread
+// If there were to be a bug in the compilation process, such as an infinite loop
+// it opens a vector for a DoS attack.
+func (r *inProcessCompiler) Compile(
+	_ context.Context, sierra *starknet.SierraClass,
+) (*starknet.CasmClass, error) {
+	return CompileFFI(sierra)
 }

--- a/starknet/compiler/compiler_test.go
+++ b/starknet/compiler/compiler_test.go
@@ -17,15 +17,17 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestCompile(t *testing.T) {
+func TestCompileFFI(t *testing.T) {
 	t.Run("zero sierra", func(t *testing.T) {
-		_, err := compiler.Compile(&starknet.SierraClass{})
+		_, err := compiler.CompileFFI(&starknet.SierraClass{})
 		require.Error(t, err)
 	})
 
 	t.Run("ok", func(t *testing.T) {
 		cl := feeder.NewTestClient(t, &utils.Integration)
-		classHash := felt.NewUnsafeFromString[felt.Felt]("0xc6c634d10e2cc7b1db6b4403b477f05e39cb4900fd5ea0156d1721dbb6c59b")
+		classHash := felt.NewUnsafeFromString[felt.Felt](
+			"0xc6c634d10e2cc7b1db6b4403b477f05e39cb4900fd5ea0156d1721dbb6c59b",
+		)
 
 		classDef, err := cl.ClassDefinition(t.Context(), classHash)
 		require.NoError(t, err)
@@ -35,7 +37,7 @@ func TestCompile(t *testing.T) {
 		expectedCompiled, err := sn2core.AdaptCompiledClass(compiledDef)
 		require.NoError(t, err)
 
-		res, err := compiler.Compile(classDef.Sierra)
+		res, err := compiler.CompileFFI(classDef.Sierra)
 		require.NoError(t, err)
 
 		gotCompiled, err := sn2core.AdaptCompiledClass(res)
@@ -51,7 +53,7 @@ func TestCompile(t *testing.T) {
 		// tests https://github.com/NethermindEth/juno/issues/1748
 		definition := loadTestData[starknet.SierraClass](t, "declare_cairo2_definition.json")
 
-		_, err := compiler.Compile(&definition)
+		_, err := compiler.CompileFFI(&definition)
 		require.NoError(t, err)
 	})
 }

--- a/sync/reorg_test.go
+++ b/sync/reorg_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/NethermindEth/juno/core/felt"
 	"github.com/NethermindEth/juno/db/memory"
 	"github.com/NethermindEth/juno/genesis"
+	"github.com/NethermindEth/juno/starknet/compiler"
 	"github.com/NethermindEth/juno/sync"
 	"github.com/NethermindEth/juno/utils"
 	"github.com/NethermindEth/juno/vm"
@@ -107,11 +108,13 @@ func initGenesis(t *testing.T) (*memory.Database, sync.CommittedBlock) {
 		FeeTokenAddresses: feeTokens,
 	}
 	diff, classes, err := genesis.GenesisStateDiff(
+		t.Context(),
 		genesisConfig,
 		vm.New(&chainInfo, false, utils.NewNopZapLogger()),
 		bc.Network(),
 		vm.DefaultMaxGas,
 		vm.DefaultMaxGas,
+		compiler.NewUnsafe(),
 	)
 	require.NoError(t, err)
 	require.NoError(t, bc.StoreGenesis(&diff, classes))


### PR DESCRIPTION
Update the architecture to, instead of having a `Compile` function inside the compiler package, having a `Compiler` interface with a `Compile` method. Juno aspects that require compilation were updated to receive this interface:
1. RPC
2. P2P
3. Sequencer

Among the architectural changes is that `Compile` will now receive a context, this is meant to make the compilation process "stop-able" in the future when the context gets cancelled. 

**Note** that there shouldn't be any behaviour change after this commit, since functionality remains the same, the only thing that is changing is how we call the `Compile` function/method. 
