### PR TITLE
ci: add golden tests

### DIFF
--- a/.github/workflows/deploy-and-test.yaml
+++ b/.github/workflows/deploy-and-test.yaml
@@ -185,11 +185,7 @@ jobs:
         uses: actions/checkout@v5
         with:
           repository: NethermindEth/starknet-golden-tests
-
-      - name: Install dependencies
-        run: |
-          sudo apt-get update -qq
-          sudo apt-get install -y curl jq
+          ref: "fix/linux-issue"
 
       - name: Run golden tests
         env:


### PR DESCRIPTION
adds a workflow to run golden tests.

This PR depends on https://github.com/NethermindEth/starknet-golden-tests/pull/24 and https://github.com/NethermindEth/starknet-golden-tests/pull/25
