### PR TITLE
fix(ci): Tag `latest` docker image only for releases

### DIFF
--- a/.github/workflows/release-published.yml
+++ b/.github/workflows/release-published.yml
@@ -19,7 +19,7 @@ jobs:
 
   tag-official-latest:
     name: Tag Official Image as Latest
-    if: github.repository_owner == 'NethermindEth'
+    if: github.repository_owner == 'NethermindEth' && !github.event.release.prerelease
     needs: [build-official-docker-image]
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
We don't want to tag pre-release docker images as latest. This PR addresses that. 