### PR TITLE
refactor(blockchain): replace method chaining with functional options

### DIFF
--- a/blockchain/blockchain.go
+++ b/blockchain/blockchain.go
@@ -81,7 +81,38 @@ type Blockchain struct {
 	transactionLayout core.TransactionLayout
 }
 
-func New(database db.KeyValueStore, network *utils.Network) *Blockchain {
+// options holds configuration for constructing a Blockchain.
+type options struct {
+	listener          EventListener
+	transactionLayout core.TransactionLayout
+}
+
+// Option is a functional option for configuring Blockchain options.
+type Option func(*options)
+
+// WithTransactionLayout sets the transaction storage layout.
+func WithTransactionLayout(layout core.TransactionLayout) Option {
+	return func(o *options) {
+		o.transactionLayout = layout
+	}
+}
+
+// WithListener sets the event listener for the blockchain.
+func WithListener(listener EventListener) Option {
+	return func(o *options) {
+		o.listener = listener
+	}
+}
+
+func New(database db.KeyValueStore, network *utils.Network, opts ...Option) *Blockchain {
+	o := options{
+		listener:          &SelectiveListener{},
+		transactionLayout: core.TransactionLayoutCombined,
+	}
+	for _, opt := range opts {
+		opt(&o)
+	}
+
 	cachedFilters := NewAggregatedBloomCache(AggregatedBloomFilterCacheSize)
 	fallback := func(key EventFiltersCacheKey) (core.AggregatedBloomFilter, error) {
 		return core.GetAggregatedBloomFilter(database, key.fromBlock, key.toBlock)
@@ -93,33 +124,17 @@ func New(database db.KeyValueStore, network *utils.Network) *Blockchain {
 	return &Blockchain{
 		database:          database,
 		network:           network,
-		listener:          &SelectiveListener{},
+		listener:          o.listener,
 		l1HeadFeed:        feed.New[*core.L1Head](),
 		cachedFilters:     &cachedFilters,
 		runningFilter:     runningFilter,
-		transactionLayout: core.TransactionLayoutCombined,
+		transactionLayout: o.transactionLayout,
 	}
-}
-
-// WithTransactionLayout sets the transaction storage layout.
-// If combined is true, uses combined (per-block) layout; otherwise uses per-tx layout.
-func (b *Blockchain) WithTransactionLayout(combined bool) *Blockchain {
-	if combined {
-		b.transactionLayout = core.TransactionLayoutCombined
-	} else {
-		b.transactionLayout = core.TransactionLayoutPerTx
-	}
-	return b
 }
 
 // TransactionLayout returns the transaction storage layout used by this blockchain
 func (b *Blockchain) TransactionLayout() core.TransactionLayout {
 	return b.transactionLayout
-}
-
-func (b *Blockchain) WithListener(listener EventListener) *Blockchain {
-	b.listener = listener
-	return b
 }
 
 func (b *Blockchain) Network() *utils.Network {

--- a/deprecatedmigration/migration_pkg_test.go
+++ b/deprecatedmigration/migration_pkg_test.go
@@ -190,7 +190,11 @@ func TestChangeTrieNodeEncoding(t *testing.T) {
 
 func TestCalculateBlockCommitments(t *testing.T) {
 	testdb := memory.New()
-	chain := blockchain.New(testdb, &utils.Mainnet).WithTransactionLayout(false)
+	chain := blockchain.New(
+		testdb,
+		&utils.Mainnet,
+		blockchain.WithTransactionLayout(core.TransactionLayoutPerTx),
+	)
 	client := feeder.NewTestClient(t, &utils.Mainnet)
 	gw := adaptfeeder.New(client)
 
@@ -214,7 +218,11 @@ func TestCalculateBlockCommitments(t *testing.T) {
 
 func TestL1HandlerTxns(t *testing.T) {
 	testdb := memory.New()
-	chain := blockchain.New(testdb, &utils.Sepolia).WithTransactionLayout(false)
+	chain := blockchain.New(
+		testdb,
+		&utils.Sepolia,
+		blockchain.WithTransactionLayout(core.TransactionLayoutPerTx),
+	)
 	client := feeder.NewTestClient(t, &utils.Sepolia)
 	gw := adaptfeeder.New(client)
 

--- a/node/node.go
+++ b/node/node.go
@@ -194,7 +194,7 @@ func New(cfg *Config, version string, logLevel *utils.LogLevel) (*Node, error) {
 	services := make([]service.Service, 0)
 	earlyServices := make([]service.Service, 0)
 
-	var opts []blockchain.Option
+	opts := make([]blockchain.Option, 0, 1)
 	if cfg.Metrics {
 		opts = append(opts, blockchain.WithListener(makeBlockchainMetrics()))
 	}

--- a/node/node.go
+++ b/node/node.go
@@ -194,7 +194,11 @@ func New(cfg *Config, version string, logLevel *utils.LogLevel) (*Node, error) {
 	services := make([]service.Service, 0)
 	earlyServices := make([]service.Service, 0)
 
-	chain := blockchain.New(database, &cfg.Network)
+	var opts []blockchain.Option
+	if cfg.Metrics {
+		opts = append(opts, blockchain.WithListener(makeBlockchainMetrics()))
+	}
+	chain := blockchain.New(database, &cfg.Network, opts...)
 
 	// Verify that cfg.Network is compatible with the database.
 	head, err := chain.Head()
@@ -461,7 +465,6 @@ func New(cfg *Config, version string, logLevel *utils.LogLevel) (*Node, error) {
 		makeJeMallocMetrics()
 		makeVMThrottlerMetrics(throttledVM)
 		makePebbleMetrics(database)
-		chain.WithListener(makeBlockchainMetrics())
 		makeJunoMetrics(version)
 		database.WithListener(makeDBMetrics())
 		rpcMetrics := makeRPCMetrics(pathV10, pathV09, pathV08)


### PR DESCRIPTION
Method-chaining setters stay on the public API, so a fully constructed Blockchain can be reconfigured at any time. When options depend on each other, a setter must cascade updates to everything that was already configured based on a now-stale value. Each setter ends up needing to know about every other option. 

Functional options collect configuration before construction; the returned value has no setters, blockchain is immutable after construction.