### PR TITLE
CI: Improve pipeline stability

### DIFF
--- a/.github/workflows/deploy-and-test.yaml
+++ b/.github/workflows/deploy-and-test.yaml
@@ -120,7 +120,7 @@ jobs:
       STARKNET_RPC: ${{ secrets.RPC_URL }}/v0_8?apikey=${{ secrets.AUTH_TOKEN }}
 
   starknet-rs-rpcv09:
-    needs: [deploy]
+    needs: [deploy, starknet-rs-rpcv08]
     uses: ./.github/workflows/starknet-rs-tests.yml
     with:
       ref: starknet/v0.17.0
@@ -128,7 +128,7 @@ jobs:
       STARKNET_RPC: ${{ secrets.RPC_URL }}/v0_9?apikey=${{ secrets.AUTH_TOKEN }}
 
   starknet-rust-rpcv10:
-    needs: [deploy]
+    needs: [deploy, starknet-rs-rpcv09]
     uses: ./.github/workflows/starknet-rust-tests.yml
     with:
       # Latest master commit. Switch to 0.19.0 once released

--- a/jsonrpc/server.go
+++ b/jsonrpc/server.go
@@ -457,6 +457,8 @@ func isNilOrEmpty(i any) (bool, error) {
 	}
 }
 
+// TODO: add recover() to catch panics from handlers/validators and return a JSON-RPC internal error
+// instead of crashing the HTTP connection
 func (s *Server) handleRequest(ctx context.Context, req *Request) (*response, http.Header, error) {
 	// todo(rdr): have a way of representing a `req` so the structured logger has a way of showing it
 	s.log.Trace("Received request", zap.Any("req", req))

--- a/rpc/handlers.go
+++ b/rpc/handlers.go
@@ -244,12 +244,12 @@ func (h *Handler) MethodsV0_10() ([]jsonrpc.Method, string) {
 		{
 			Name:    "starknet_addDeployAccountTransaction",
 			Params:  []jsonrpc.Parameter{{Name: "deploy_account_transaction"}},
-			Handler: h.rpcv9Handler.AddTransaction,
+			Handler: h.rpcv10Handler.AddTransaction,
 		},
 		{
 			Name:    "starknet_addDeclareTransaction",
 			Params:  []jsonrpc.Parameter{{Name: "declare_transaction"}},
-			Handler: h.rpcv9Handler.AddTransaction,
+			Handler: h.rpcv10Handler.AddTransaction,
 		},
 		{
 			Name:    "starknet_getEvents",

--- a/rpc/handlers.go
+++ b/rpc/handlers.go
@@ -244,12 +244,12 @@ func (h *Handler) MethodsV0_10() ([]jsonrpc.Method, string) {
 		{
 			Name:    "starknet_addDeployAccountTransaction",
 			Params:  []jsonrpc.Parameter{{Name: "deploy_account_transaction"}},
-			Handler: h.rpcv10Handler.AddTransaction,
+			Handler: h.rpcv9Handler.AddTransaction,
 		},
 		{
 			Name:    "starknet_addDeclareTransaction",
 			Params:  []jsonrpc.Parameter{{Name: "declare_transaction"}},
-			Handler: h.rpcv10Handler.AddTransaction,
+			Handler: h.rpcv9Handler.AddTransaction,
 		},
 		{
 			Name:    "starknet_getEvents",

--- a/sync/sync_test.go
+++ b/sync/sync_test.go
@@ -178,7 +178,24 @@ func TestReorg(t *testing.T) {
 		dataSource := sync.NewFeederGatewayDataSource(bc, mainGw)
 		synchronizer = sync.New(bc, dataSource, utils.NewNopZapLogger(), 0, 0, false, testDB)
 		sub := synchronizer.SubscribeReorg()
-		ctx, cancel = context.WithTimeout(t.Context(), timeout)
+		// Use a generous timeout with early cancellation once the expected block is stored.
+		// The reorg flow (detect mismatch → revert → re-sync 3 blocks) needs more than 1s on slow CI.
+		ctx, cancel = context.WithTimeout(t.Context(), 30*time.Second)
+		go func() {
+			ticker := time.NewTicker(10 * time.Millisecond)
+			defer ticker.Stop()
+			for {
+				select {
+				case <-ctx.Done():
+					return
+				case <-ticker.C:
+					if h, err := bc.Height(); err == nil && h >= 2 {
+						cancel()
+						return
+					}
+				}
+			}
+		}()
 		require.NoError(t, synchronizer.Run(ctx))
 		cancel()
 


### PR DESCRIPTION
This PR addresses a few things:
- starknet-rs tests are sharing the same account, which was causing nonce desync -> made them sequential. That's not ideal, but since they are taking less time than JS jobs, that will not affect overall workflow time.
- v0_10 JS tests were causing panics due to failing JSON validation because we were using v0_9 handlers.
-  increased timeout used in re-org sync test. Sometimes 1 sec is not always enough to sync + reorg on (presumably slow) macos runner. 