### PR TITLE
fix(jsonrpc): Gracefully handle panics from handler calls

### DIFF
--- a/jsonrpc/server.go
+++ b/jsonrpc/server.go
@@ -457,19 +457,17 @@ func isNilOrEmpty(i any) (bool, error) {
 	}
 }
 
-// TODO: add recover() to catch panics from handlers/validators and return a JSON-RPC internal error
-// instead of crashing the HTTP connection
-func (s *Server) handleRequest(ctx context.Context, req *Request) (*response, http.Header, error) {
+func (s *Server) handleRequest(ctx context.Context, req *Request) (res *response, header http.Header, err error) {
 	// todo(rdr): have a way of representing a `req` so the structured logger has a way of showing it
 	s.log.Trace("Received request", zap.Any("req", req))
 
-	header := http.Header{}
+	header = http.Header{}
 	if err := req.isSane(); err != nil {
 		s.log.Trace("Request sanity check failed", zap.Error(err))
 		return nil, header, err
 	}
 
-	res := &response{
+	res = &response{
 		Version: "2.0",
 		ID:      req.ID,
 	}
@@ -483,15 +481,28 @@ func (s *Server) handleRequest(ctx context.Context, req *Request) (*response, ht
 
 	handlerTimer := time.Now()
 	s.listener.OnNewRequest(req.Method)
+	defer func() {
+		if r := recover(); r != nil {
+			s.log.Error("Panic during RPC request handling",
+				zap.String("method", req.Method),
+				zap.Any("panic", r),
+				zap.Stack("stack"),
+			)
+			s.listener.OnRequestFailed(req.Method, Err(InternalError, nil))
+			res.Error = Err(InternalError, "internal error")
+			// Clear err so the caller uses the JSON-RPC error response
+			// instead of treating this as a transport-level failure.
+			err = nil
+		}
+		s.listener.OnRequestHandled(req.Method, time.Since(handlerTimer))
+	}()
+
 	args, err := s.buildArguments(ctx, req.Params, calledMethod)
 	if err != nil {
 		res.Error = Err(InvalidParams, err.Error())
 		s.log.Trace("Error building arguments for RPC call", zap.Error(err))
 		return res, header, nil
 	}
-	defer func() {
-		s.listener.OnRequestHandled(req.Method, time.Since(handlerTimer))
-	}()
 
 	tuple := reflect.ValueOf(calledMethod.Handler).Call(args)
 	if res.ID == nil { // notification

--- a/jsonrpc/server.go
+++ b/jsonrpc/server.go
@@ -457,7 +457,14 @@ func isNilOrEmpty(i any) (bool, error) {
 	}
 }
 
-func (s *Server) handleRequest(ctx context.Context, req *Request) (res *response, header http.Header, err error) {
+func (s *Server) handleRequest(
+	ctx context.Context,
+	req *Request,
+) (
+	res *response,
+	header http.Header,
+	err error,
+) {
 	// todo(rdr): have a way of representing a `req` so the structured logger has a way of showing it
 	s.log.Trace("Received request", zap.Any("req", req))
 

--- a/jsonrpc/server.go
+++ b/jsonrpc/server.go
@@ -482,26 +482,27 @@ func (s *Server) handleRequest(
 	calledMethod, found := s.methods[req.Method]
 	if !found {
 		res.Error = Err(MethodNotFound, nil)
-		s.log.Trace("Method not found in request", zap.String("method", req.Method))
+		s.log.Trace("Method not found in request", zap.String("method", sanitizeForLog(req.Method)))
 		return res, header, nil
 	}
 
 	handlerTimer := time.Now()
-	s.listener.OnNewRequest(req.Method)
+	methodName := calledMethod.Name
+	s.listener.OnNewRequest(methodName)
 	defer func() {
 		if r := recover(); r != nil {
 			s.log.Error("Panic during RPC request handling",
-				zap.String("method", req.Method),
+				zap.String("method", methodName),
 				zap.Any("panic", r),
 				zap.Stack("stack"),
 			)
-			s.listener.OnRequestFailed(req.Method, Err(InternalError, nil))
+			s.listener.OnRequestFailed(methodName, Err(InternalError, nil))
 			res.Error = Err(InternalError, "internal error")
 			// Clear err so the caller uses the JSON-RPC error response
 			// instead of treating this as a transport-level failure.
 			err = nil
 		}
-		s.listener.OnRequestHandled(req.Method, time.Since(handlerTimer))
+		s.listener.OnRequestHandled(methodName, time.Since(handlerTimer))
 	}()
 
 	args, err := s.buildArguments(ctx, req.Params, calledMethod)
@@ -655,6 +656,11 @@ func (s *Server) parseParam(param any, t reflect.Type) (reflect.Value, error) {
 	}
 
 	return elem, nil
+}
+
+func sanitizeForLog(value string) string {
+	value = strings.ReplaceAll(value, "\n", "")
+	return strings.ReplaceAll(value, "\r", "")
 }
 
 func (s *Server) validateParam(param reflect.Value) error {

--- a/jsonrpc/server_test.go
+++ b/jsonrpc/server_test.go
@@ -174,6 +174,13 @@ func TestHandle(t *testing.T) {
 			},
 		},
 		{
+			Name:   "panics",
+			Params: []jsonrpc.Parameter{},
+			Handler: func() (int, *jsonrpc.Error) {
+				panic("test panic")
+			},
+		},
+		{
 			Name:   "singleOptionalParam",
 			Params: []jsonrpc.Parameter{{Name: "param", Optional: true}},
 			Handler: func(param *int) (int, *jsonrpc.Error) {
@@ -484,6 +491,10 @@ func TestHandle(t *testing.T) {
 			req:              `{"jsonrpc": "2.0", "method": "errorsInternally", "params": {}, "id": 1}`,
 			res:              `{"jsonrpc":"2.0","error":{"code":-32603,"message":"Internal error"},"id":1}`,
 			checkFailedEvent: true,
+		},
+		"handler panic returns internal error": {
+			req: `{"jsonrpc": "2.0", "method": "panics", "params": {}, "id": 1}`,
+			res: `{"jsonrpc":"2.0","error":{"code":-32603,"message":"Internal error","data":"internal error"},"id":1}`,
 		},
 		"empty optional param": {
 			req: `{"jsonrpc": "2.0", "method": "singleOptionalParam", "params": {}, "id": 1}`,

--- a/jsonrpc/server_test.go
+++ b/jsonrpc/server_test.go
@@ -494,7 +494,11 @@ func TestHandle(t *testing.T) {
 		},
 		"handler panic returns internal error": {
 			req: `{"jsonrpc": "2.0", "method": "panics", "params": {}, "id": 1}`,
-			res: `{"jsonrpc":"2.0","error":{"code":-32603,"message":"Internal error","data":"internal error"},"id":1}`,
+			res: `{
+			"jsonrpc":"2.0",
+			"error":{"code":-32603,"message":"Internal error","data":"internal error"},
+			"id":1
+			}`,
 		},
 		"empty optional param": {
 			req: `{"jsonrpc": "2.0", "method": "singleOptionalParam", "params": {}, "id": 1}`,


### PR DESCRIPTION
The server could panic when the underlying handler function panics. The original panic happened due to the type mismatch in the v10 JSON validator handler. We were using v9 handler (and v10 validator), and some of the underlying types are different. 

This PR adds graceful handling for panics in the request handling code on the server level. It does not feel ideal, as the actual issue is related to the lack of type-safety in our RPC handler definitions (meaning we could mix up the handlers, and it won't be detected unless we do a runtime check). 