### PR TITLE
refactor(rpc): make v8 self contained

### DIFF
--- a/rpc/handlers.go
+++ b/rpc/handlers.go
@@ -588,7 +588,7 @@ func (h *Handler) MethodsV0_8() ([]jsonrpc.Method, string) { //nolint:funlen
 	return []jsonrpc.Method{
 		{
 			Name:    "starknet_chainId",
-			Handler: h.rpcv6Handler.ChainID,
+			Handler: h.rpcv8Handler.ChainID,
 		},
 		{
 			Name:    "starknet_blockNumber",

--- a/rpc/handlers.go
+++ b/rpc/handlers.go
@@ -650,17 +650,17 @@ func (h *Handler) MethodsV0_8() ([]jsonrpc.Method, string) { //nolint:funlen
 		{
 			Name:    "starknet_getClassHashAt",
 			Params:  []jsonrpc.Parameter{{Name: "block_id"}, {Name: "contract_address"}},
-			Handler: h.rpcv6Handler.ClassHashAt,
+			Handler: h.rpcv8Handler.ClassHashAt,
 		},
 		{
 			Name:    "starknet_getClass",
 			Params:  []jsonrpc.Parameter{{Name: "block_id"}, {Name: "class_hash"}},
-			Handler: h.rpcv6Handler.Class,
+			Handler: h.rpcv8Handler.Class,
 		},
 		{
 			Name:    "starknet_getClassAt",
 			Params:  []jsonrpc.Parameter{{Name: "block_id"}, {Name: "contract_address"}},
-			Handler: h.rpcv6Handler.ClassAt,
+			Handler: h.rpcv8Handler.ClassAt,
 		},
 		{
 			Name:    "starknet_addInvokeTransaction",

--- a/rpc/handlers.go
+++ b/rpc/handlers.go
@@ -640,7 +640,7 @@ func (h *Handler) MethodsV0_8() ([]jsonrpc.Method, string) { //nolint:funlen
 		{
 			Name:    "starknet_getNonce",
 			Params:  []jsonrpc.Parameter{{Name: "block_id"}, {Name: "contract_address"}},
-			Handler: h.rpcv6Handler.Nonce,
+			Handler: h.rpcv8Handler.Nonce,
 		},
 		{
 			Name:    "starknet_getStorageAt",

--- a/rpc/handlers.go
+++ b/rpc/handlers.go
@@ -635,7 +635,7 @@ func (h *Handler) MethodsV0_8() ([]jsonrpc.Method, string) { //nolint:funlen
 		},
 		{
 			Name:    "starknet_syncing",
-			Handler: h.rpcv6Handler.Syncing,
+			Handler: h.rpcv8Handler.Syncing,
 		},
 		{
 			Name:    "starknet_getNonce",

--- a/rpc/handlers.go
+++ b/rpc/handlers.go
@@ -631,7 +631,7 @@ func (h *Handler) MethodsV0_8() ([]jsonrpc.Method, string) { //nolint:funlen
 		{
 			Name:    "starknet_getStateUpdate",
 			Params:  []jsonrpc.Parameter{{Name: "block_id"}},
-			Handler: h.rpcv6Handler.StateUpdate,
+			Handler: h.rpcv8Handler.StateUpdate,
 		},
 		{
 			Name:    "starknet_syncing",

--- a/rpc/handlers.go
+++ b/rpc/handlers.go
@@ -680,7 +680,7 @@ func (h *Handler) MethodsV0_8() ([]jsonrpc.Method, string) { //nolint:funlen
 		{
 			Name:    "starknet_getEvents",
 			Params:  []jsonrpc.Parameter{{Name: "filter"}},
-			Handler: h.rpcv6Handler.Events,
+			Handler: h.rpcv8Handler.Events,
 		},
 		{
 			Name:    "juno_version",

--- a/rpc/handlers.go
+++ b/rpc/handlers.go
@@ -592,11 +592,11 @@ func (h *Handler) MethodsV0_8() ([]jsonrpc.Method, string) { //nolint:funlen
 		},
 		{
 			Name:    "starknet_blockNumber",
-			Handler: h.rpcv6Handler.BlockNumber,
+			Handler: h.rpcv8Handler.BlockNumber,
 		},
 		{
 			Name:    "starknet_blockHashAndNumber",
-			Handler: h.rpcv6Handler.BlockHashAndNumber,
+			Handler: h.rpcv8Handler.BlockHashAndNumber,
 		},
 		{
 			Name:    "starknet_getBlockWithTxHashes",

--- a/rpc/handlers.go
+++ b/rpc/handlers.go
@@ -621,7 +621,7 @@ func (h *Handler) MethodsV0_8() ([]jsonrpc.Method, string) { //nolint:funlen
 		{
 			Name:    "starknet_getBlockTransactionCount",
 			Params:  []jsonrpc.Parameter{{Name: "block_id"}},
-			Handler: h.rpcv6Handler.BlockTransactionCount,
+			Handler: h.rpcv8Handler.BlockTransactionCount,
 		},
 		{
 			Name:    "starknet_getTransactionByBlockIdAndIndex",

--- a/rpc/v8/adapters.go
+++ b/rpc/v8/adapters.go
@@ -4,7 +4,6 @@ import (
 	"errors"
 
 	"github.com/NethermindEth/juno/core/felt"
-	rpcv6 "github.com/NethermindEth/juno/rpc/v6"
 	"github.com/NethermindEth/juno/starknet"
 	"github.com/NethermindEth/juno/utils"
 	"github.com/NethermindEth/juno/vm"
@@ -98,11 +97,11 @@ func adaptVMFunctionInvocation(vmFnInvocation *vm.FunctionInvocation) FunctionIn
 	}
 
 	// Adapt events
-	adaptedEvents := make([]rpcv6.OrderedEvent, len(vmFnInvocation.Events))
+	adaptedEvents := make([]OrderedEvent, len(vmFnInvocation.Events))
 	for index := range vmFnInvocation.Events {
 		vmEvent := &vmFnInvocation.Events[index]
 
-		adaptedEvents[index] = rpcv6.OrderedEvent{
+		adaptedEvents[index] = OrderedEvent{
 			Order: vmEvent.Order,
 			Keys:  vmEvent.Keys,
 			Data:  vmEvent.Data,
@@ -110,11 +109,11 @@ func adaptVMFunctionInvocation(vmFnInvocation *vm.FunctionInvocation) FunctionIn
 	}
 
 	// Adapt messages
-	adaptedMessages := make([]rpcv6.OrderedL2toL1Message, len(vmFnInvocation.Messages))
+	adaptedMessages := make([]OrderedL2toL1Message, len(vmFnInvocation.Messages))
 	for index := range vmFnInvocation.Messages {
 		vmMessage := &vmFnInvocation.Messages[index]
 
-		adaptedMessages[index] = rpcv6.OrderedL2toL1Message{
+		adaptedMessages[index] = OrderedL2toL1Message{
 			Order: vmMessage.Order,
 			From:  vmMessage.From,
 			// todo(rdr): This is not the rigth fix, this casting should be unnecessary but the
@@ -303,11 +302,11 @@ func adaptFeederFunctionInvocation(snFnInvocation *starknet.FunctionInvocation) 
 	}
 
 	// Adapt events
-	adaptedEvents := make([]rpcv6.OrderedEvent, len(snFnInvocation.Events))
+	adaptedEvents := make([]OrderedEvent, len(snFnInvocation.Events))
 	for index := range snFnInvocation.Events {
 		snEvent := &snFnInvocation.Events[index]
 
-		adaptedEvents[index] = rpcv6.OrderedEvent{
+		adaptedEvents[index] = OrderedEvent{
 			Order: snEvent.Order,
 			Keys:  utils.Map(snEvent.Keys, utils.HeapPtr[felt.Felt]),
 			Data:  utils.Map(snEvent.Data, utils.HeapPtr[felt.Felt]),
@@ -315,13 +314,13 @@ func adaptFeederFunctionInvocation(snFnInvocation *starknet.FunctionInvocation) 
 	}
 
 	// Adapt messages
-	adaptedMessages := make([]rpcv6.OrderedL2toL1Message, len(snFnInvocation.Messages))
+	adaptedMessages := make([]OrderedL2toL1Message, len(snFnInvocation.Messages))
 	for index := range snFnInvocation.Messages {
 		snMessage := &snFnInvocation.Messages[index]
 
 		toAddr, _ := new(felt.Felt).SetString(snMessage.ToAddr)
 
-		adaptedMessages[index] = rpcv6.OrderedL2toL1Message{
+		adaptedMessages[index] = OrderedL2toL1Message{
 			Order:   snMessage.Order,
 			From:    &snFnInvocation.ContractAddress,
 			To:      toAddr,
@@ -369,13 +368,13 @@ func DefaultL1HandlerFunctionInvocation() FunctionInvocation {
 		ContractAddress:    felt.Zero,
 		EntryPointSelector: &felt.Zero,
 		EntryPointType:     "L1_HANDLER",
-		Events:             []rpcv6.OrderedEvent{},
+		Events:             []OrderedEvent{},
 		ExecutionResources: &InnerExecutionResources{
 			L1Gas: 0,
 			L2Gas: 0,
 		},
 		IsReverted: true,
-		Messages:   []rpcv6.OrderedL2toL1Message{},
+		Messages:   []OrderedL2toL1Message{},
 		Result:     []felt.Felt{},
 	}
 }

--- a/rpc/v8/adapters.go
+++ b/rpc/v8/adapters.go
@@ -54,15 +54,15 @@ func AdaptVMTransactionTrace(trace *vm.TransactionTrace) TransactionTrace {
 		resources = utils.HeapPtr(adaptVMExecutionResources(trace.ExecutionResources))
 	}
 
-	var stateDiff *rpcv6.StateDiff
+	var stateDiff *StateDiff
 	if trace.StateDiff != nil {
-		stateDiff = utils.HeapPtr(rpcv6.AdaptVMStateDiff(trace.StateDiff))
+		stateDiff = utils.HeapPtr(AdaptVMStateDiff(trace.StateDiff))
 	}
 
 	traceType := TransactionType(trace.Type)
 	if traceType == TxnDeploy {
 		// There is no DEPLOY_TXN_TRACE thus we need to convert the type to `DEPLOY_ACCOUNT`
-		// see https://github.com/starkware-libs/starknet-specs/blob/a2d10fc6cbaddbe2d3cf6ace5174dd0a306f4885/api/starknet_trace_api_openrpc.json#L150
+		// see https://github.com/starkware-libs/starknet-specs/blob/v0.8.1/api/starknet_trace_api_openrpc.json#L150
 		traceType = TxnDeployAccount
 	}
 
@@ -157,6 +157,83 @@ func adaptVMExecutionResources(r *vm.ExecutionResources) ExecutionResources {
 			L2Gas: r.L2Gas,
 		},
 		L1DataGas: r.L1DataGas,
+	}
+}
+
+func AdaptVMStateDiff(vmStateDiff *vm.StateDiff) StateDiff {
+	// Adapt storage diffs
+	adaptedStorageDiffs := make([]StorageDiff, len(vmStateDiff.StorageDiffs))
+	for index := range vmStateDiff.StorageDiffs {
+		vmStorageDiff := &vmStateDiff.StorageDiffs[index]
+
+		// Adapt storage entries
+		adaptedEntries := make([]Entry, len(vmStorageDiff.StorageEntries))
+		for entryIndex := range vmStorageDiff.StorageEntries {
+			vmEntry := &vmStorageDiff.StorageEntries[entryIndex]
+
+			adaptedEntries[entryIndex] = Entry{
+				Key:   vmEntry.Key,
+				Value: vmEntry.Value,
+			}
+		}
+
+		adaptedStorageDiffs[index] = StorageDiff{
+			Address:        vmStorageDiff.Address,
+			StorageEntries: adaptedEntries,
+		}
+	}
+
+	// Adapt nonces
+	adaptedNonces := make([]Nonce, len(vmStateDiff.Nonces))
+	for index := range vmStateDiff.Nonces {
+		vmNonce := &vmStateDiff.Nonces[index]
+
+		adaptedNonces[index] = Nonce{
+			ContractAddress: vmNonce.ContractAddress,
+			Nonce:           vmNonce.Nonce,
+		}
+	}
+
+	// Adapt deployed contracts
+	adaptedDeployedContracts := make([]DeployedContract, len(vmStateDiff.DeployedContracts))
+	for index := range vmStateDiff.DeployedContracts {
+		vmDeployedContract := &vmStateDiff.DeployedContracts[index]
+
+		adaptedDeployedContracts[index] = DeployedContract{
+			Address:   vmDeployedContract.Address,
+			ClassHash: vmDeployedContract.ClassHash,
+		}
+	}
+
+	// Adapt declared classes
+	adaptedDeclaredClasses := make([]DeclaredClass, len(vmStateDiff.DeclaredClasses))
+	for index := range vmStateDiff.DeclaredClasses {
+		vmDeclaredClass := &vmStateDiff.DeclaredClasses[index]
+
+		adaptedDeclaredClasses[index] = DeclaredClass{
+			ClassHash:         vmDeclaredClass.ClassHash,
+			CompiledClassHash: vmDeclaredClass.CompiledClassHash,
+		}
+	}
+
+	// Adapt replaced classes
+	adaptedReplacedClasses := make([]ReplacedClass, len(vmStateDiff.ReplacedClasses))
+	for index := range vmStateDiff.ReplacedClasses {
+		vmReplacedClass := &vmStateDiff.ReplacedClasses[index]
+
+		adaptedReplacedClasses[index] = ReplacedClass{
+			ContractAddress: vmReplacedClass.ContractAddress,
+			ClassHash:       vmReplacedClass.ClassHash,
+		}
+	}
+
+	return StateDiff{
+		StorageDiffs:              adaptedStorageDiffs,
+		Nonces:                    adaptedNonces,
+		DeployedContracts:         adaptedDeployedContracts,
+		DeprecatedDeclaredClasses: vmStateDiff.DeprecatedDeclaredClasses,
+		DeclaredClasses:           adaptedDeclaredClasses,
+		ReplacedClasses:           adaptedReplacedClasses,
 	}
 }
 

--- a/rpc/v8/block.go
+++ b/rpc/v8/block.go
@@ -9,7 +9,6 @@ import (
 	"github.com/NethermindEth/juno/core/felt"
 	"github.com/NethermindEth/juno/jsonrpc"
 	"github.com/NethermindEth/juno/rpc/rpccore"
-	rpcv6 "github.com/NethermindEth/juno/rpc/v6"
 )
 
 type blockIDType uint8
@@ -42,7 +41,7 @@ type BlockHashAndNumber struct {
 	Number uint64     `json:"block_number"`
 }
 
-// https://github.com/starkware-libs/starknet-specs/blob/a789ccc3432c57777beceaa53a34a7ae2f25fda0/api/starknet_api_openrpc.json#L814
+// https://github.com/starkware-libs/starknet-specs/blob/v0.8.1/api/starknet_api_openrpc.json#L1190
 type BlockID struct {
 	typeID blockIDType
 	data   felt.Felt
@@ -135,22 +134,78 @@ func (b *BlockID) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
-// https://github.com/starkware-libs/starknet-specs/blob/a789ccc3432c57777beceaa53a34a7ae2f25fda0/api/starknet_api_openrpc.json#L1072
+// https://github.com/starkware-libs/starknet-specs/blob/v0.8.1/api/starknet_api_openrpc.json#L1544
 type BlockHeader struct {
-	rpcv6.BlockHeader
-	L2GasPrice *rpcv6.ResourcePrice `json:"l2_gas_price"`
+	Hash             *felt.Felt     `json:"block_hash,omitempty"`
+	ParentHash       *felt.Felt     `json:"parent_hash"`
+	Number           *uint64        `json:"block_number,omitempty"`
+	NewRoot          *felt.Felt     `json:"new_root,omitempty"`
+	Timestamp        uint64         `json:"timestamp"`
+	SequencerAddress *felt.Felt     `json:"sequencer_address,omitempty"`
+	L1GasPrice       *ResourcePrice `json:"l1_gas_price"`
+	L1DataGasPrice   *ResourcePrice `json:"l1_data_gas_price,omitempty"`
+	L2GasPrice       *ResourcePrice `json:"l2_gas_price"`
+	L1DAMode         *L1DAMode      `json:"l1_da_mode,omitempty"`
+	StarknetVersion  string         `json:"starknet_version"`
 }
 
-// https://github.com/starkware-libs/starknet-specs/blob/a789ccc3432c57777beceaa53a34a7ae2f25fda0/api/starknet_api_openrpc.json#L1131
+type ResourcePrice struct {
+	InFri *felt.Felt `json:"price_in_fri"`
+	InWei *felt.Felt `json:"price_in_wei"`
+}
+type L1DAMode uint8
+
+const (
+	Blob L1DAMode = iota
+	Calldata
+)
+
+func (l L1DAMode) MarshalText() ([]byte, error) {
+	switch l {
+	case Blob:
+		return []byte("BLOB"), nil
+	case Calldata:
+		return []byte("CALLDATA"), nil
+	default:
+		return nil, fmt.Errorf("unknown L1DAMode value = %v", l)
+	}
+}
+
+// https://github.com/starkware-libs/starknet-specs/blob/v0.8.1/api/starknet_api_openrpc.json#L3129
+type BlockStatus uint8
+
+const (
+	BlockPending BlockStatus = iota
+	BlockAcceptedL2
+	BlockAcceptedL1
+	BlockRejected
+)
+
+func (s BlockStatus) MarshalText() ([]byte, error) {
+	switch s {
+	case BlockPending:
+		return []byte("PENDING"), nil
+	case BlockAcceptedL2:
+		return []byte("ACCEPTED_ON_L2"), nil
+	case BlockAcceptedL1:
+		return []byte("ACCEPTED_ON_L1"), nil
+	case BlockRejected:
+		return []byte("REJECTED"), nil
+	default:
+		return nil, fmt.Errorf("unknown block status %v", s)
+	}
+}
+
+// https://github.com/starkware-libs/starknet-specs/blob/v0.8.1/api/starknet_api_openrpc.json#L1705
 type BlockWithTxs struct {
-	Status rpcv6.BlockStatus `json:"status,omitempty"`
+	Status BlockStatus `json:"status,omitempty"`
 	BlockHeader
 	Transactions []*Transaction `json:"transactions"`
 }
 
-// https://github.com/starkware-libs/starknet-specs/blob/a789ccc3432c57777beceaa53a34a7ae2f25fda0/api/starknet_api_openrpc.json#L1109
+// https://github.com/starkware-libs/starknet-specs/blob/v0.8.1/api/starknet_api_openrpc.json#L1680
 type BlockWithTxHashes struct {
-	Status rpcv6.BlockStatus `json:"status,omitempty"`
+	Status BlockStatus `json:"status,omitempty"`
 	BlockHeader
 	TxnHashes []*felt.Felt `json:"transactions"`
 }
@@ -161,7 +216,7 @@ type TransactionWithReceipt struct {
 }
 
 type BlockWithReceipts struct {
-	Status rpcv6.BlockStatus `json:"status,omitempty"`
+	Status BlockStatus `json:"status,omitempty"`
 	BlockHeader
 	Transactions []TransactionWithReceipt `json:"transactions"`
 }
@@ -197,7 +252,7 @@ func (h *Handler) BlockHashAndNumber() (*BlockHashAndNumber, *jsonrpc.Error) {
 // BlockWithTxHashes returns the block information with transaction hashes given a block ID.
 //
 // It follows the specification defined here:
-// https://github.com/starkware-libs/starknet-specs/blob/a789ccc3432c57777beceaa53a34a7ae2f25fda0/api/starknet_api_openrpc.json#L11
+// https://github.com/starkware-libs/starknet-specs/blob/v0.8.1/api/starknet_api_openrpc.json#L25
 func (h *Handler) BlockWithTxHashes(id *BlockID) (*BlockWithTxHashes, *jsonrpc.Error) {
 	header, rpcErr := h.blockHeaderByID(id)
 	if rpcErr != nil {
@@ -245,9 +300,9 @@ func (h *Handler) BlockWithReceipts(id *BlockID) (*BlockWithReceipts, *jsonrpc.E
 
 	var finalityStatus TxnFinalityStatus
 	switch blockStatus {
-	case rpcv6.BlockAcceptedL1:
+	case BlockAcceptedL1:
 		finalityStatus = TxnAcceptedOnL1
-	case rpcv6.BlockPending:
+	case BlockPending:
 		finalityStatus = TxnPending
 	default:
 		finalityStatus = TxnAcceptedOnL2
@@ -276,7 +331,7 @@ func (h *Handler) BlockWithReceipts(id *BlockID) (*BlockWithReceipts, *jsonrpc.E
 // BlockWithTxs returns the block information with full transactions given a block ID.
 //
 // It follows the specification defined here:
-// https://github.com/starkware-libs/starknet-specs/blob/a789ccc3432c57777beceaa53a34a7ae2f25fda0/api/starknet_api_openrpc.json#L44
+// https://github.com/starkware-libs/starknet-specs/blob/v0.8.1/api/starknet_api_openrpc.json#L62
 func (h *Handler) BlockWithTxs(blockID *BlockID) (*BlockWithTxs, *jsonrpc.Error) {
 	header, rpcErr := h.blockHeaderByID(blockID)
 	if rpcErr != nil {
@@ -311,17 +366,17 @@ func (h *Handler) BlockWithTxs(blockID *BlockID) (*BlockWithTxs, *jsonrpc.Error)
 	}, nil
 }
 
-func (h *Handler) blockStatus(id *BlockID, blockNumber uint64) (rpcv6.BlockStatus, *jsonrpc.Error) {
+func (h *Handler) blockStatus(id *BlockID, blockNumber uint64) (BlockStatus, *jsonrpc.Error) {
 	l1H, jsonErr := h.l1Head()
 	if jsonErr != nil {
 		return 0, jsonErr
 	}
 
-	status := rpcv6.BlockAcceptedL2
+	status := BlockAcceptedL2
 	if id.IsPending() {
-		status = rpcv6.BlockPending
+		status = BlockPending
 	} else if isL1Verified(blockNumber, l1H) {
-		status = rpcv6.BlockAcceptedL1
+		status = BlockAcceptedL1
 	}
 
 	return status, nil
@@ -339,57 +394,55 @@ func adaptBlockHeader(header *core.Header) BlockHeader {
 		sequencerAddress = &felt.Zero
 	}
 
-	var l1DAMode rpcv6.L1DAMode
+	var l1DAMode L1DAMode
 	switch header.L1DAMode {
 	case core.Blob:
-		l1DAMode = rpcv6.Blob
+		l1DAMode = Blob
 	case core.Calldata:
-		l1DAMode = rpcv6.Calldata
+		l1DAMode = Calldata
 	}
 
-	var l1DataGasPrice rpcv6.ResourcePrice
+	var l1DataGasPrice ResourcePrice
 	if header.L1DataGasPrice != nil {
-		l1DataGasPrice = rpcv6.ResourcePrice{
+		l1DataGasPrice = ResourcePrice{
 			InWei: nilToZero(header.L1DataGasPrice.PriceInWei),
 			InFri: nilToZero(header.L1DataGasPrice.PriceInFri),
 		}
 	} else {
-		l1DataGasPrice = rpcv6.ResourcePrice{
+		l1DataGasPrice = ResourcePrice{
 			InWei: &felt.Zero,
 			InFri: &felt.Zero,
 		}
 	}
 
-	var l2GasPrice rpcv6.ResourcePrice
+	var l2GasPrice ResourcePrice
 	if header.L2GasPrice != nil {
-		l2GasPrice = rpcv6.ResourcePrice{
+		l2GasPrice = ResourcePrice{
 			InWei: nilToZero(header.L2GasPrice.PriceInWei),
 			InFri: nilToZero(header.L2GasPrice.PriceInFri),
 		}
 	} else {
-		l2GasPrice = rpcv6.ResourcePrice{
+		l2GasPrice = ResourcePrice{
 			InWei: &felt.Zero,
 			InFri: &felt.Zero,
 		}
 	}
 
 	return BlockHeader{
-		BlockHeader: rpcv6.BlockHeader{
-			Hash:             header.Hash,
-			ParentHash:       header.ParentHash,
-			Number:           blockNumber,
-			NewRoot:          header.GlobalStateRoot,
-			Timestamp:        header.Timestamp,
-			SequencerAddress: sequencerAddress,
-			L1GasPrice: &rpcv6.ResourcePrice{
-				InWei: header.L1GasPriceETH,
-				InFri: nilToZero(header.L1GasPriceSTRK),
-			},
-			L1DataGasPrice:  &l1DataGasPrice,
-			L1DAMode:        &l1DAMode,
-			StarknetVersion: header.ProtocolVersion,
+		Hash:             header.Hash,
+		ParentHash:       header.ParentHash,
+		Number:           blockNumber,
+		NewRoot:          header.GlobalStateRoot,
+		Timestamp:        header.Timestamp,
+		SequencerAddress: sequencerAddress,
+		L1GasPrice: &ResourcePrice{
+			InWei: header.L1GasPriceETH,
+			InFri: nilToZero(header.L1GasPriceSTRK),
 		},
-		L2GasPrice: &l2GasPrice,
+		L1DataGasPrice:  &l1DataGasPrice,
+		L2GasPrice:      &l2GasPrice,
+		L1DAMode:        &l1DAMode,
+		StarknetVersion: header.ProtocolVersion,
 	}
 }
 

--- a/rpc/v8/block.go
+++ b/rpc/v8/block.go
@@ -144,9 +144,9 @@ type BlockHeader struct {
 	SequencerAddress *felt.Felt     `json:"sequencer_address,omitempty"`
 	L1GasPrice       *ResourcePrice `json:"l1_gas_price"`
 	L1DataGasPrice   *ResourcePrice `json:"l1_data_gas_price,omitempty"`
-	L2GasPrice       *ResourcePrice `json:"l2_gas_price"`
 	L1DAMode         *L1DAMode      `json:"l1_da_mode,omitempty"`
 	StarknetVersion  string         `json:"starknet_version"`
+	L2GasPrice       *ResourcePrice `json:"l2_gas_price"`
 }
 
 type ResourcePrice struct {

--- a/rpc/v8/block.go
+++ b/rpc/v8/block.go
@@ -366,6 +366,19 @@ func (h *Handler) BlockWithTxs(blockID *BlockID) (*BlockWithTxs, *jsonrpc.Error)
 	}, nil
 }
 
+// BlockTransactionCount returns the number of transactions in a block
+// identified by the given BlockID.
+//
+// It follows the specification defined here:
+// https://github.com/starkware-libs/starknet-specs/blob/v0.8.1/api/starknet_api_openrpc.json#L531
+func (h *Handler) BlockTransactionCount(id BlockID) (uint64, *jsonrpc.Error) {
+	header, rpcErr := h.blockHeaderByID(&id)
+	if rpcErr != nil {
+		return 0, rpcErr
+	}
+	return header.TransactionCount, nil
+}
+
 func (h *Handler) blockStatus(id *BlockID, blockNumber uint64) (BlockStatus, *jsonrpc.Error) {
 	l1H, jsonErr := h.l1Head()
 	if jsonErr != nil {

--- a/rpc/v8/block.go
+++ b/rpc/v8/block.go
@@ -8,6 +8,7 @@ import (
 	"github.com/NethermindEth/juno/core"
 	"github.com/NethermindEth/juno/core/felt"
 	"github.com/NethermindEth/juno/jsonrpc"
+	"github.com/NethermindEth/juno/rpc/rpccore"
 	rpcv6 "github.com/NethermindEth/juno/rpc/v6"
 )
 
@@ -33,6 +34,12 @@ func (b *blockIDType) String() string {
 	default:
 		panic(fmt.Sprintf("Unknown blockIdType: %d", b))
 	}
+}
+
+// https://github.com/starkware-libs/starknet-specs/blob/v0.8.1/api/starknet_api_openrpc.json#L733-L751
+type BlockHashAndNumber struct {
+	Hash   *felt.Felt `json:"block_hash"`
+	Number uint64     `json:"block_number"`
 }
 
 // https://github.com/starkware-libs/starknet-specs/blob/a789ccc3432c57777beceaa53a34a7ae2f25fda0/api/starknet_api_openrpc.json#L814
@@ -162,6 +169,30 @@ type BlockWithReceipts struct {
 /****************************************************
 		Block Handlers
 *****************************************************/
+// BlockNumber returns the latest synced block number.
+//
+// It follows the specification defined here:
+// https://github.com/starkware-libs/starknet-specs/blob/v0.8.1/api/starknet_api_openrpc.json#L712
+func (h *Handler) BlockNumber() (uint64, *jsonrpc.Error) {
+	num, err := h.bcReader.Height()
+	if err != nil {
+		return 0, rpccore.ErrNoBlock
+	}
+
+	return num, nil
+}
+
+// BlockHashAndNumber returns the block hash and number of the latest synced block.
+//
+// It follows the specification defined here:
+// https://github.com/starkware-libs/starknet-specs/blob/v0.8.1/api/starknet_api_openrpc.json#L730
+func (h *Handler) BlockHashAndNumber() (*BlockHashAndNumber, *jsonrpc.Error) {
+	block, err := h.bcReader.Head()
+	if err != nil {
+		return nil, rpccore.ErrNoBlock
+	}
+	return &BlockHashAndNumber{Number: block.Number, Hash: block.Hash}, nil
+}
 
 // BlockWithTxHashes returns the block information with transaction hashes given a block ID.
 //

--- a/rpc/v8/block_test.go
+++ b/rpc/v8/block_test.go
@@ -151,6 +151,98 @@ func TestBlockHashAndNumber(t *testing.T) {
 	})
 }
 
+func TestBlockTransactionCount(t *testing.T) {
+	mockCtrl := gomock.NewController(t)
+	t.Cleanup(mockCtrl.Finish)
+	mockSyncReader := mocks.NewMockSyncReader(mockCtrl)
+	n := utils.HeapPtr(utils.Sepolia)
+	mockReader := mocks.NewMockReader(mockCtrl)
+	handler := rpc.New(mockReader, mockSyncReader, nil, nil)
+
+	client := feeder.NewTestClient(t, n)
+	gw := adaptfeeder.New(client)
+
+	latestBlockNumber := uint64(56377)
+	latestBlock, err := gw.BlockByNumber(t.Context(), latestBlockNumber)
+	require.NoError(t, err)
+	latestBlockHash := latestBlock.Hash
+	expectedCount := latestBlock.TransactionCount
+
+	t.Run("empty blockchain", func(t *testing.T) {
+		mockReader.EXPECT().HeadsHeader().Return(nil, db.ErrKeyNotFound)
+
+		count, rpcErr := handler.BlockTransactionCount(blockIDLatest(t))
+		assert.Equal(t, uint64(0), count)
+		assert.Equal(t, rpccore.ErrBlockNotFound, rpcErr)
+	})
+
+	t.Run("non-existent block hash", func(t *testing.T) {
+		mockReader.EXPECT().BlockHeaderByHash(gomock.Any()).Return(nil, db.ErrKeyNotFound)
+
+		count, rpcErr := handler.BlockTransactionCount(blockIDHash(t, new(felt.Felt).SetBytes([]byte("random"))))
+		assert.Equal(t, uint64(0), count)
+		assert.Equal(t, rpccore.ErrBlockNotFound, rpcErr)
+	})
+
+	t.Run("non-existent pending block", func(t *testing.T) {
+		latestBlock.Hash = nil
+		latestBlock.GlobalStateRoot = nil
+		mockReader.EXPECT().HeadsHeader().Return(nil, db.ErrKeyNotFound)
+
+		count, rpcErr := handler.BlockTransactionCount(blockIDPending(t))
+		require.Equal(t, rpccore.ErrBlockNotFound, rpcErr)
+		assert.Equal(t, uint64(0), count)
+	})
+
+	t.Run("non-existent block number", func(t *testing.T) {
+		mockReader.EXPECT().BlockHeaderByNumber(gomock.Any()).Return(nil, db.ErrKeyNotFound)
+
+		count, rpcErr := handler.BlockTransactionCount(blockIDNumber(t, uint64(328476)))
+		assert.Equal(t, uint64(0), count)
+		assert.Equal(t, rpccore.ErrBlockNotFound, rpcErr)
+	})
+
+	t.Run("blockID - latest", func(t *testing.T) {
+		mockReader.EXPECT().HeadsHeader().Return(latestBlock.Header, nil)
+
+		count, rpcErr := handler.BlockTransactionCount(blockIDLatest(t))
+		require.Nil(t, rpcErr)
+		assert.Equal(t, expectedCount, count)
+	})
+
+	t.Run("blockID - hash", func(t *testing.T) {
+		mockReader.EXPECT().BlockHeaderByHash(latestBlockHash).Return(latestBlock.Header, nil)
+
+		count, rpcErr := handler.BlockTransactionCount(blockIDHash(t, latestBlockHash))
+		require.Nil(t, rpcErr)
+		assert.Equal(t, expectedCount, count)
+	})
+
+	t.Run("blockID - number", func(t *testing.T) {
+		mockReader.EXPECT().BlockHeaderByNumber(latestBlockNumber).Return(latestBlock.Header, nil)
+
+		count, rpcErr := handler.BlockTransactionCount(blockIDNumber(t, latestBlockNumber))
+		require.Nil(t, rpcErr)
+		assert.Equal(t, expectedCount, count)
+	})
+
+	t.Run("blockID - pending", func(t *testing.T) {
+		latestBlock.Hash = nil
+		latestBlock.GlobalStateRoot = nil
+		blockToRegisterHash := core.Header{
+			Hash:   felt.NewUnsafeFromString[felt.Felt]("0xFFFF"),
+			Number: latestBlock.Number + 1 - 10,
+		}
+		mockReader.EXPECT().BlockHeaderByNumber(blockToRegisterHash.Number).
+			Return(&blockToRegisterHash, nil)
+		mockReader.EXPECT().HeadsHeader().Return(latestBlock.Header, nil)
+		expectedCount := uint64(0)
+		count, rpcErr := handler.BlockTransactionCount(blockIDPending(t))
+		require.Nil(t, rpcErr)
+		assert.Equal(t, expectedCount, count)
+	})
+}
+
 func TestBlockWithTxHashes(t *testing.T) {
 	errTests := map[string]rpc.BlockID{
 		"latest":  blockIDLatest(t),

--- a/rpc/v8/block_test.go
+++ b/rpc/v8/block_test.go
@@ -13,7 +13,6 @@ import (
 	"github.com/NethermindEth/juno/db/memory"
 	"github.com/NethermindEth/juno/mocks"
 	"github.com/NethermindEth/juno/rpc/rpccore"
-	rpcv6 "github.com/NethermindEth/juno/rpc/v6"
 	rpc "github.com/NethermindEth/juno/rpc/v8"
 	adaptfeeder "github.com/NethermindEth/juno/starknetdata/feeder"
 	"github.com/NethermindEth/juno/utils"
@@ -209,7 +208,7 @@ func TestBlockWithTxHashes(t *testing.T) {
 			assert.Equal(t, latestBlock.Number, *b.Number)
 		} else {
 			assert.Nil(t, b.Number)
-			assert.Equal(t, rpcv6.BlockPending, b.Status)
+			assert.Equal(t, rpc.BlockPending, b.Status)
 		}
 		checkBlock(t, b)
 	}
@@ -267,7 +266,7 @@ func TestBlockWithTxHashes(t *testing.T) {
 		block, rpcErr := handler.BlockWithTxHashes(&number)
 		require.Nil(t, rpcErr)
 
-		assert.Equal(t, rpcv6.BlockAcceptedL1, block.Status)
+		assert.Equal(t, rpc.BlockAcceptedL1, block.Status)
 		checkBlock(t, block)
 	})
 	//nolint:dupl,lll // BlockWithTxHashes and BlockWithTxs share the same pending block setup but differ in return type
@@ -290,18 +289,16 @@ func TestBlockWithTxHashes(t *testing.T) {
 		require.Equal(t, latestBlock.Hash, header.ParentHash)
 
 		assert.Equal(t, &rpc.BlockWithTxHashes{
-			Status: rpcv6.BlockPending,
+			Status: rpc.BlockPending,
 			BlockHeader: rpc.BlockHeader{
-				BlockHeader: rpcv6.BlockHeader{
-					ParentHash:       header.ParentHash,
-					Timestamp:        header.Timestamp,
-					SequencerAddress: header.SequencerAddress,
-					L1GasPrice:       header.L1GasPrice,
-					StarknetVersion:  header.StarknetVersion,
-					L1DataGasPrice:   header.L1DataGasPrice,
-					L1DAMode:         header.L1DAMode,
-				},
-				L2GasPrice: header.L2GasPrice,
+				ParentHash:       header.ParentHash,
+				Timestamp:        header.Timestamp,
+				SequencerAddress: header.SequencerAddress,
+				L1GasPrice:       header.L1GasPrice,
+				StarknetVersion:  header.StarknetVersion,
+				L1DataGasPrice:   header.L1DataGasPrice,
+				L1DAMode:         header.L1DAMode,
+				L2GasPrice:       header.L2GasPrice,
 			},
 			TxnHashes: []*felt.Felt{},
 		}, blockWTxHashes)
@@ -502,18 +499,16 @@ func TestBlockWithTxs(t *testing.T) {
 		require.Equal(t, latestBlock.Hash, header.ParentHash)
 
 		assert.Equal(t, &rpc.BlockWithTxs{
-			Status: rpcv6.BlockPending,
+			Status: rpc.BlockPending,
 			BlockHeader: rpc.BlockHeader{
-				BlockHeader: rpcv6.BlockHeader{
-					ParentHash:       header.ParentHash,
-					Timestamp:        header.Timestamp,
-					SequencerAddress: header.SequencerAddress,
-					L1GasPrice:       header.L1GasPrice,
-					StarknetVersion:  header.StarknetVersion,
-					L1DataGasPrice:   header.L1DataGasPrice,
-					L1DAMode:         header.L1DAMode,
-				},
-				L2GasPrice: header.L2GasPrice,
+				ParentHash:       header.ParentHash,
+				Timestamp:        header.Timestamp,
+				SequencerAddress: header.SequencerAddress,
+				L1GasPrice:       header.L1GasPrice,
+				StarknetVersion:  header.StarknetVersion,
+				L1DataGasPrice:   header.L1DataGasPrice,
+				L1DAMode:         header.L1DAMode,
+				L2GasPrice:       header.L2GasPrice,
 			},
 			Transactions: []*rpc.Transaction{},
 		}, blockWithTxs)
@@ -581,30 +576,28 @@ func TestBlockWithTxHashesV013(t *testing.T) {
 
 	require.Equal(t, &rpc.BlockWithTxs{
 		BlockHeader: rpc.BlockHeader{
-			BlockHeader: rpcv6.BlockHeader{
-				Hash:            coreBlock.Hash,
-				StarknetVersion: coreBlock.ProtocolVersion,
-				NewRoot:         coreBlock.GlobalStateRoot,
-				Number:          &coreBlock.Number,
-				ParentHash:      coreBlock.ParentHash,
-				L1DAMode:        utils.HeapPtr(rpcv6.Blob),
-				L1GasPrice: &rpcv6.ResourcePrice{
-					InFri: felt.NewUnsafeFromString[felt.Felt]("0x17882b6aa74"),
-					InWei: felt.NewUnsafeFromString[felt.Felt]("0x3b9aca10"),
-				},
-				L1DataGasPrice: &rpcv6.ResourcePrice{
-					InFri: felt.NewUnsafeFromString[felt.Felt]("0x2cc6d7f596e1"),
-					InWei: felt.NewUnsafeFromString[felt.Felt]("0x716a8f6dd"),
-				},
-				SequencerAddress: coreBlock.SequencerAddress,
-				Timestamp:        coreBlock.Timestamp,
+			Hash:            coreBlock.Hash,
+			StarknetVersion: coreBlock.ProtocolVersion,
+			NewRoot:         coreBlock.GlobalStateRoot,
+			Number:          &coreBlock.Number,
+			ParentHash:      coreBlock.ParentHash,
+			L1DAMode:        utils.HeapPtr(rpc.Blob),
+			L1GasPrice: &rpc.ResourcePrice{
+				InFri: felt.NewUnsafeFromString[felt.Felt]("0x17882b6aa74"),
+				InWei: felt.NewUnsafeFromString[felt.Felt]("0x3b9aca10"),
 			},
-			L2GasPrice: &rpcv6.ResourcePrice{
+			L1DataGasPrice: &rpc.ResourcePrice{
+				InFri: felt.NewUnsafeFromString[felt.Felt]("0x2cc6d7f596e1"),
+				InWei: felt.NewUnsafeFromString[felt.Felt]("0x716a8f6dd"),
+			},
+			SequencerAddress: coreBlock.SequencerAddress,
+			Timestamp:        coreBlock.Timestamp,
+			L2GasPrice: &rpc.ResourcePrice{
 				InFri: &felt.One,
 				InWei: &felt.One,
 			},
 		},
-		Status: rpcv6.BlockAcceptedL2,
+		Status: rpc.BlockAcceptedL2,
 		Transactions: []*rpc.Transaction{
 			{
 				Hash:               tx.Hash(),
@@ -689,18 +682,16 @@ func TestBlockWithReceipts(t *testing.T) {
 		header := resp.BlockHeader
 
 		assert.Equal(t, &rpc.BlockWithReceipts{
-			Status: rpcv6.BlockPending,
+			Status: rpc.BlockPending,
 			BlockHeader: rpc.BlockHeader{
-				BlockHeader: rpcv6.BlockHeader{
-					ParentHash:       block0.Hash,
-					Timestamp:        header.Timestamp,
-					SequencerAddress: header.SequencerAddress,
-					L1GasPrice:       header.L1GasPrice,
-					StarknetVersion:  header.StarknetVersion,
-					L1DataGasPrice:   header.L1DataGasPrice,
-					L1DAMode:         header.L1DAMode,
-				},
-				L2GasPrice: header.L2GasPrice,
+				ParentHash:       block0.Hash,
+				Timestamp:        header.Timestamp,
+				SequencerAddress: header.SequencerAddress,
+				L1GasPrice:       header.L1GasPrice,
+				StarknetVersion:  header.StarknetVersion,
+				L1DataGasPrice:   header.L1DataGasPrice,
+				L1DAMode:         header.L1DAMode,
+				L2GasPrice:       header.L2GasPrice,
 			},
 			Transactions: []rpc.TransactionWithReceipt{},
 		}, resp)
@@ -734,21 +725,19 @@ func TestBlockWithReceipts(t *testing.T) {
 
 		assert.Nil(t, rpcErr)
 		assert.Equal(t, &rpc.BlockWithReceipts{
-			Status: rpcv6.BlockAcceptedL1,
+			Status: rpc.BlockAcceptedL1,
 			BlockHeader: rpc.BlockHeader{
-				BlockHeader: rpcv6.BlockHeader{
-					Hash:             header.Hash,
-					ParentHash:       header.ParentHash,
-					Number:           header.Number,
-					NewRoot:          header.NewRoot,
-					Timestamp:        header.Timestamp,
-					SequencerAddress: header.SequencerAddress,
-					L1DAMode:         header.L1DAMode,
-					L1GasPrice:       header.L1GasPrice,
-					L1DataGasPrice:   header.L1DataGasPrice,
-					StarknetVersion:  header.StarknetVersion,
-				},
-				L2GasPrice: header.L2GasPrice,
+				Hash:             header.Hash,
+				ParentHash:       header.ParentHash,
+				Number:           header.Number,
+				NewRoot:          header.NewRoot,
+				Timestamp:        header.Timestamp,
+				SequencerAddress: header.SequencerAddress,
+				L1DAMode:         header.L1DAMode,
+				L1GasPrice:       header.L1GasPrice,
+				L1DataGasPrice:   header.L1DataGasPrice,
+				StarknetVersion:  header.StarknetVersion,
+				L2GasPrice:       header.L2GasPrice,
 			},
 			Transactions: transactions,
 		}, resp)

--- a/rpc/v8/block_test.go
+++ b/rpc/v8/block_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/NethermindEth/juno/mocks"
 	"github.com/NethermindEth/juno/rpc/rpccore"
 	rpcv6 "github.com/NethermindEth/juno/rpc/v6"
-	rpcv8 "github.com/NethermindEth/juno/rpc/v8"
+	rpc "github.com/NethermindEth/juno/rpc/v8"
 	adaptfeeder "github.com/NethermindEth/juno/starknetdata/feeder"
 	"github.com/NethermindEth/juno/utils"
 	"github.com/stretchr/testify/assert"
@@ -26,29 +26,29 @@ func TestBlockIDMarshalling(t *testing.T) {
 	t.Parallel()
 	tests := map[string]struct {
 		blockIDJSON string
-		checkFunc   func(*rpcv8.BlockID) bool
+		checkFunc   func(*rpc.BlockID) bool
 	}{
 		"latest": {
 			blockIDJSON: `"latest"`,
-			checkFunc: func(blockID *rpcv8.BlockID) bool {
+			checkFunc: func(blockID *rpc.BlockID) bool {
 				return blockID.IsLatest()
 			},
 		},
 		"pending": {
 			blockIDJSON: `"pending"`,
-			checkFunc: func(blockID *rpcv8.BlockID) bool {
+			checkFunc: func(blockID *rpc.BlockID) bool {
 				return blockID.IsPending()
 			},
 		},
 		"number": {
 			blockIDJSON: `{ "block_number" : 123123 }`,
-			checkFunc: func(blockID *rpcv8.BlockID) bool {
+			checkFunc: func(blockID *rpc.BlockID) bool {
 				return blockID.IsNumber() && blockID.Number() == 123123
 			},
 		},
 		"hash": {
 			blockIDJSON: `{ "block_hash" : "0x123" }`,
-			checkFunc: func(blockID *rpcv8.BlockID) bool {
+			checkFunc: func(blockID *rpc.BlockID) bool {
 				return blockID.IsHash() && *blockID.Hash() == felt.FromUint64[felt.Felt](0x123)
 			},
 		},
@@ -56,7 +56,7 @@ func TestBlockIDMarshalling(t *testing.T) {
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
-			var blockID rpcv8.BlockID
+			var blockID rpc.BlockID
 			require.NoError(t, blockID.UnmarshalJSON([]byte(test.blockIDJSON)))
 			assert.True(t, test.checkFunc(&blockID))
 		})
@@ -84,14 +84,76 @@ func TestBlockIDMarshalling(t *testing.T) {
 	for name, test := range failingTests {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
-			var blockID rpcv8.BlockID
+			var blockID rpc.BlockID
 			assert.Error(t, blockID.UnmarshalJSON([]byte(test.blockIDJSON)))
 		})
 	}
 }
 
+func TestBlockNumber(t *testing.T) {
+	mockCtrl := gomock.NewController(t)
+	t.Cleanup(mockCtrl.Finish)
+
+	mockReader := mocks.NewMockReader(mockCtrl)
+	handler := rpc.New(mockReader, nil, nil, nil)
+
+	t.Run("empty blockchain", func(t *testing.T) {
+		expectedHeight := uint64(0)
+		mockReader.EXPECT().Height().Return(expectedHeight, errors.New("empty blockchain"))
+
+		num, err := handler.BlockNumber()
+		assert.Equal(t, expectedHeight, num)
+		assert.Equal(t, rpccore.ErrNoBlock, err)
+	})
+
+	t.Run("blockchain height is 21", func(t *testing.T) {
+		expectedHeight := uint64(21)
+		mockReader.EXPECT().Height().Return(expectedHeight, nil)
+
+		num, err := handler.BlockNumber()
+		require.Nil(t, err)
+		assert.Equal(t, expectedHeight, num)
+	})
+}
+
+func TestBlockHashAndNumber(t *testing.T) {
+	mockCtrl := gomock.NewController(t)
+	t.Cleanup(mockCtrl.Finish)
+
+	n := &utils.Mainnet
+	mockReader := mocks.NewMockReader(mockCtrl)
+	handler := rpc.New(mockReader, nil, nil, nil)
+
+	t.Run("empty blockchain", func(t *testing.T) {
+		mockReader.EXPECT().Head().Return(nil, errors.New("empty blockchain"))
+
+		block, err := handler.BlockHashAndNumber()
+		assert.Nil(t, block)
+		assert.Equal(t, rpccore.ErrNoBlock, err)
+	})
+
+	t.Run("blockchain height is 147", func(t *testing.T) {
+		client := feeder.NewTestClient(t, n)
+		gw := adaptfeeder.New(client)
+
+		expectedBlock, err := gw.BlockByNumber(t.Context(), 147)
+		require.NoError(t, err)
+
+		expectedBlockHashAndNumber := &rpc.BlockHashAndNumber{
+			Hash:   expectedBlock.Hash,
+			Number: expectedBlock.Number,
+		}
+
+		mockReader.EXPECT().Head().Return(expectedBlock, nil)
+
+		hashAndNum, rpcErr := handler.BlockHashAndNumber()
+		require.Nil(t, rpcErr)
+		assert.Equal(t, expectedBlockHashAndNumber, hashAndNum)
+	})
+}
+
 func TestBlockWithTxHashes(t *testing.T) {
-	errTests := map[string]rpcv8.BlockID{
+	errTests := map[string]rpc.BlockID{
 		"latest":  blockIDLatest(t),
 		"pending": blockIDPending(t),
 		"hash":    blockIDHash(t, &felt.One),
@@ -109,7 +171,7 @@ func TestBlockWithTxHashes(t *testing.T) {
 			n := &utils.Mainnet
 			chain := blockchain.New(memory.New(), n)
 
-			handler := rpcv8.New(chain, mockSyncReader, nil, log)
+			handler := rpc.New(chain, mockSyncReader, nil, log)
 
 			block, rpcErr := handler.BlockWithTxHashes(&id)
 			assert.Nil(t, block)
@@ -118,7 +180,7 @@ func TestBlockWithTxHashes(t *testing.T) {
 	}
 
 	n := &utils.Sepolia
-	handler := rpcv8.New(mockReader, mockSyncReader, nil, nil)
+	handler := rpc.New(mockReader, mockSyncReader, nil, nil)
 
 	client := feeder.NewTestClient(t, n)
 	gw := adaptfeeder.New(client)
@@ -128,7 +190,7 @@ func TestBlockWithTxHashes(t *testing.T) {
 	require.NoError(t, err)
 	latestBlockHash := latestBlock.Hash
 
-	checkBlock := func(t *testing.T, b *rpcv8.BlockWithTxHashes) {
+	checkBlock := func(t *testing.T, b *rpc.BlockWithTxHashes) {
 		t.Helper()
 		assert.Equal(t, latestBlock.Hash, b.Hash)
 		assert.Equal(t, latestBlock.GlobalStateRoot, b.NewRoot)
@@ -141,7 +203,7 @@ func TestBlockWithTxHashes(t *testing.T) {
 		}
 	}
 
-	checkLatestBlock := func(t *testing.T, b *rpcv8.BlockWithTxHashes) {
+	checkLatestBlock := func(t *testing.T, b *rpc.BlockWithTxHashes) {
 		t.Helper()
 		if latestBlock.Hash != nil {
 			assert.Equal(t, latestBlock.Number, *b.Number)
@@ -227,9 +289,9 @@ func TestBlockWithTxHashes(t *testing.T) {
 		header := blockWTxHashes.BlockHeader
 		require.Equal(t, latestBlock.Hash, header.ParentHash)
 
-		assert.Equal(t, &rpcv8.BlockWithTxHashes{
+		assert.Equal(t, &rpc.BlockWithTxHashes{
 			Status: rpcv6.BlockPending,
-			BlockHeader: rpcv8.BlockHeader{
+			BlockHeader: rpc.BlockHeader{
 				BlockHeader: rpcv6.BlockHeader{
 					ParentHash:       header.ParentHash,
 					Timestamp:        header.Timestamp,
@@ -254,7 +316,7 @@ func TestBlockWithTxHashes_TxnsFetchError(t *testing.T) {
 		mockCtrl := gomock.NewController(t)
 		t.Cleanup(mockCtrl.Finish)
 		mockReader := mocks.NewMockReader(mockCtrl)
-		handler := rpcv8.New(mockReader, nil, nil, nil)
+		handler := rpc.New(mockReader, nil, nil, nil)
 
 		id := blockIDNumber(t, blockNumber)
 		mockReader.EXPECT().BlockHeaderByNumber(blockNumber).Return(header, nil)
@@ -269,7 +331,7 @@ func TestBlockWithTxHashes_TxnsFetchError(t *testing.T) {
 		mockCtrl := gomock.NewController(t)
 		t.Cleanup(mockCtrl.Finish)
 		mockReader := mocks.NewMockReader(mockCtrl)
-		handler := rpcv8.New(mockReader, nil, nil, nil)
+		handler := rpc.New(mockReader, nil, nil, nil)
 
 		id := blockIDNumber(t, blockNumber)
 		internalErr := errors.New("some internal error")
@@ -283,7 +345,7 @@ func TestBlockWithTxHashes_TxnsFetchError(t *testing.T) {
 }
 
 func TestBlockWithTxs(t *testing.T) {
-	errTests := map[string]rpcv8.BlockID{
+	errTests := map[string]rpc.BlockID{
 		"latest":  blockIDLatest(t),
 		"pending": blockIDPending(t),
 		"hash":    blockIDHash(t, &felt.One),
@@ -302,7 +364,7 @@ func TestBlockWithTxs(t *testing.T) {
 			n := &utils.Mainnet
 			chain := blockchain.New(memory.New(), n)
 
-			handler := rpcv8.New(chain, mockSyncReader, nil, log)
+			handler := rpc.New(chain, mockSyncReader, nil, log)
 
 			block, rpcErr := handler.BlockWithTxs(&id)
 			assert.Nil(t, block)
@@ -311,7 +373,7 @@ func TestBlockWithTxs(t *testing.T) {
 	}
 
 	n := &utils.Mainnet
-	handler := rpcv8.New(mockReader, mockSyncReader, nil, nil)
+	handler := rpc.New(mockReader, mockSyncReader, nil, nil)
 
 	client := feeder.NewTestClient(t, n)
 	gw := adaptfeeder.New(client)
@@ -321,7 +383,7 @@ func TestBlockWithTxs(t *testing.T) {
 	require.NoError(t, err)
 	latestBlockHash := latestBlock.Hash
 
-	checkLatestBlock := func(t *testing.T, blockWithTxHashes *rpcv8.BlockWithTxHashes, blockWithTxs *rpcv8.BlockWithTxs) {
+	checkLatestBlock := func(t *testing.T, blockWithTxHashes *rpc.BlockWithTxHashes, blockWithTxs *rpc.BlockWithTxs) {
 		t.Helper()
 		assert.Equal(t, blockWithTxHashes.BlockHeader, blockWithTxs.BlockHeader)
 		assert.Equal(t, len(blockWithTxHashes.TxnHashes), len(blockWithTxs.Transactions))
@@ -439,9 +501,9 @@ func TestBlockWithTxs(t *testing.T) {
 		header := blockWithTxs.BlockHeader
 		require.Equal(t, latestBlock.Hash, header.ParentHash)
 
-		assert.Equal(t, &rpcv8.BlockWithTxs{
+		assert.Equal(t, &rpc.BlockWithTxs{
 			Status: rpcv6.BlockPending,
-			BlockHeader: rpcv8.BlockHeader{
+			BlockHeader: rpc.BlockHeader{
 				BlockHeader: rpcv6.BlockHeader{
 					ParentHash:       header.ParentHash,
 					Timestamp:        header.Timestamp,
@@ -453,7 +515,7 @@ func TestBlockWithTxs(t *testing.T) {
 				},
 				L2GasPrice: header.L2GasPrice,
 			},
-			Transactions: []*rpcv8.Transaction{},
+			Transactions: []*rpc.Transaction{},
 		}, blockWithTxs)
 	})
 }
@@ -466,7 +528,7 @@ func TestBlockWithTxs_TxnsFetchError(t *testing.T) {
 		mockCtrl := gomock.NewController(t)
 		t.Cleanup(mockCtrl.Finish)
 		mockReader := mocks.NewMockReader(mockCtrl)
-		handler := rpcv8.New(mockReader, nil, nil, nil)
+		handler := rpc.New(mockReader, nil, nil, nil)
 
 		id := blockIDNumber(t, blockNumber)
 		mockReader.EXPECT().BlockHeaderByNumber(blockNumber).Return(header, nil)
@@ -481,7 +543,7 @@ func TestBlockWithTxs_TxnsFetchError(t *testing.T) {
 		mockCtrl := gomock.NewController(t)
 		t.Cleanup(mockCtrl.Finish)
 		mockReader := mocks.NewMockReader(mockCtrl)
-		handler := rpcv8.New(mockReader, nil, nil, nil)
+		handler := rpc.New(mockReader, nil, nil, nil)
 
 		id := blockIDNumber(t, blockNumber)
 		internalErr := errors.New("some internal error")
@@ -499,7 +561,7 @@ func TestBlockWithTxHashesV013(t *testing.T) {
 	mockCtrl := gomock.NewController(t)
 	t.Cleanup(mockCtrl.Finish)
 	mockReader := mocks.NewMockReader(mockCtrl)
-	handler := rpcv8.New(mockReader, nil, nil, nil)
+	handler := rpc.New(mockReader, nil, nil, nil)
 
 	blockNumber := uint64(16350)
 	gw := adaptfeeder.New(feeder.NewTestClient(t, n))
@@ -517,8 +579,8 @@ func TestBlockWithTxHashesV013(t *testing.T) {
 	require.Nil(t, rpcErr)
 	got.Transactions = got.Transactions[:1]
 
-	require.Equal(t, &rpcv8.BlockWithTxs{
-		BlockHeader: rpcv8.BlockHeader{
+	require.Equal(t, &rpc.BlockWithTxs{
+		BlockHeader: rpc.BlockHeader{
 			BlockHeader: rpcv6.BlockHeader{
 				Hash:            coreBlock.Hash,
 				StarknetVersion: coreBlock.ProtocolVersion,
@@ -543,10 +605,10 @@ func TestBlockWithTxHashesV013(t *testing.T) {
 			},
 		},
 		Status: rpcv6.BlockAcceptedL2,
-		Transactions: []*rpcv8.Transaction{
+		Transactions: []*rpc.Transaction{
 			{
 				Hash:               tx.Hash(),
-				Type:               rpcv8.TxnInvoke,
+				Type:               rpc.TxnInvoke,
 				Version:            tx.Version.AsFelt(),
 				Nonce:              tx.Nonce,
 				MaxFee:             tx.MaxFee,
@@ -555,16 +617,16 @@ func TestBlockWithTxHashesV013(t *testing.T) {
 				Signature:          &tx.TransactionSignature,
 				CallData:           &tx.CallData,
 				EntryPointSelector: tx.EntryPointSelector,
-				ResourceBounds: &rpcv8.ResourceBoundsMap{
-					L1Gas: &rpcv8.ResourceBounds{
+				ResourceBounds: &rpc.ResourceBoundsMap{
+					L1Gas: &rpc.ResourceBounds{
 						MaxAmount:       new(felt.Felt).SetUint64(tx.ResourceBounds[core.ResourceL1Gas].MaxAmount),
 						MaxPricePerUnit: tx.ResourceBounds[core.ResourceL1Gas].MaxPricePerUnit,
 					},
-					L2Gas: &rpcv8.ResourceBounds{
+					L2Gas: &rpc.ResourceBounds{
 						MaxAmount:       new(felt.Felt).SetUint64(tx.ResourceBounds[core.ResourceL2Gas].MaxAmount),
 						MaxPricePerUnit: tx.ResourceBounds[core.ResourceL2Gas].MaxPricePerUnit,
 					},
-					L1DataGas: &rpcv8.ResourceBounds{
+					L1DataGas: &rpc.ResourceBounds{
 						MaxAmount:       &felt.Zero,
 						MaxPricePerUnit: &felt.Zero,
 					},
@@ -572,8 +634,8 @@ func TestBlockWithTxHashesV013(t *testing.T) {
 				Tip:                   new(felt.Felt).SetUint64(tx.Tip),
 				PaymasterData:         &tx.PaymasterData,
 				AccountDeploymentData: &tx.AccountDeploymentData,
-				NonceDAMode:           utils.HeapPtr(rpcv8.DataAvailabilityMode(tx.NonceDAMode)),
-				FeeDAMode:             utils.HeapPtr(rpcv8.DataAvailabilityMode(tx.FeeDAMode)),
+				NonceDAMode:           utils.HeapPtr(rpc.DataAvailabilityMode(tx.NonceDAMode)),
+				FeeDAMode:             utils.HeapPtr(rpc.DataAvailabilityMode(tx.FeeDAMode)),
 			},
 		},
 	}, got)
@@ -586,7 +648,7 @@ func TestBlockWithReceipts(t *testing.T) {
 	n := utils.HeapPtr(utils.Mainnet)
 	mockReader := mocks.NewMockReader(mockCtrl)
 	mockSyncReader := mocks.NewMockSyncReader(mockCtrl)
-	handler := rpcv8.New(mockReader, mockSyncReader, nil, nil)
+	handler := rpc.New(mockReader, mockSyncReader, nil, nil)
 
 	t.Run("transaction not found", func(t *testing.T) {
 		blockID := blockIDNumber(t, 777)
@@ -626,9 +688,9 @@ func TestBlockWithReceipts(t *testing.T) {
 		assert.Nil(t, rpcErr)
 		header := resp.BlockHeader
 
-		assert.Equal(t, &rpcv8.BlockWithReceipts{
+		assert.Equal(t, &rpc.BlockWithReceipts{
 			Status: rpcv6.BlockPending,
-			BlockHeader: rpcv8.BlockHeader{
+			BlockHeader: rpc.BlockHeader{
 				BlockHeader: rpcv6.BlockHeader{
 					ParentHash:       block0.Hash,
 					Timestamp:        header.Timestamp,
@@ -640,7 +702,7 @@ func TestBlockWithReceipts(t *testing.T) {
 				},
 				L2GasPrice: header.L2GasPrice,
 			},
-			Transactions: []rpcv8.TransactionWithReceipt{},
+			Transactions: []rpc.TransactionWithReceipt{},
 		}, resp)
 	})
 
@@ -658,22 +720,22 @@ func TestBlockWithReceipts(t *testing.T) {
 		resp, rpcErr := handler.BlockWithReceipts(&blockID)
 		header := resp.BlockHeader
 
-		transactions := make([]rpcv8.TransactionWithReceipt, len(block1.Transactions))
+		transactions := make([]rpc.TransactionWithReceipt, len(block1.Transactions))
 		for i, tx := range block1.Transactions {
 			receipt := block1.Receipts[i]
-			adaptedTx := rpcv8.AdaptTransaction(tx)
+			adaptedTx := rpc.AdaptTransaction(tx)
 			adaptedTx.Hash = nil
 
-			transactions[i] = rpcv8.TransactionWithReceipt{
+			transactions[i] = rpc.TransactionWithReceipt{
 				Transaction: adaptedTx,
-				Receipt:     rpcv8.AdaptReceipt(receipt, tx, rpcv8.TxnAcceptedOnL1, nil, 0),
+				Receipt:     rpc.AdaptReceipt(receipt, tx, rpc.TxnAcceptedOnL1, nil, 0),
 			}
 		}
 
 		assert.Nil(t, rpcErr)
-		assert.Equal(t, &rpcv8.BlockWithReceipts{
+		assert.Equal(t, &rpc.BlockWithReceipts{
 			Status: rpcv6.BlockAcceptedL1,
-			BlockHeader: rpcv8.BlockHeader{
+			BlockHeader: rpc.BlockHeader{
 				BlockHeader: rpcv6.BlockHeader{
 					Hash:             header.Hash,
 					ParentHash:       header.ParentHash,
@@ -699,7 +761,7 @@ func TestRpcBlockAdaptation(t *testing.T) {
 
 	n := utils.HeapPtr(utils.Sepolia)
 	mockReader := mocks.NewMockReader(mockCtrl)
-	handler := rpcv8.New(mockReader, nil, nil, nil)
+	handler := rpc.New(mockReader, nil, nil, nil)
 
 	client := feeder.NewTestClient(t, n)
 	gw := adaptfeeder.New(client)
@@ -725,26 +787,26 @@ func TestRpcBlockAdaptation(t *testing.T) {
 	})
 }
 
-func blockIDPending(t *testing.T) rpcv8.BlockID {
+func blockIDPending(t *testing.T) rpc.BlockID {
 	t.Helper()
 
-	blockID := rpcv8.BlockID{}
+	blockID := rpc.BlockID{}
 	require.NoError(t, blockID.UnmarshalJSON([]byte(`"pending"`)))
 	return blockID
 }
 
-func blockIDLatest(t *testing.T) rpcv8.BlockID {
+func blockIDLatest(t *testing.T) rpc.BlockID {
 	t.Helper()
 
-	blockID := rpcv8.BlockID{}
+	blockID := rpc.BlockID{}
 	require.NoError(t, blockID.UnmarshalJSON([]byte(`"latest"`)))
 	return blockID
 }
 
-func blockIDHash(t *testing.T, val *felt.Felt) rpcv8.BlockID {
+func blockIDHash(t *testing.T, val *felt.Felt) rpc.BlockID {
 	t.Helper()
 
-	blockID := rpcv8.BlockID{}
+	blockID := rpc.BlockID{}
 	require.NoError(
 		t,
 		blockID.UnmarshalJSON(
@@ -754,10 +816,10 @@ func blockIDHash(t *testing.T, val *felt.Felt) rpcv8.BlockID {
 	return blockID
 }
 
-func blockIDNumber(t *testing.T, val uint64) rpcv8.BlockID {
+func blockIDNumber(t *testing.T, val uint64) rpc.BlockID {
 	t.Helper()
 
-	blockID := rpcv8.BlockID{}
+	blockID := rpc.BlockID{}
 	require.NoError(t,
 		blockID.UnmarshalJSON([]byte(fmt.Sprintf(`{ "block_number" : %d}`, val))),
 	)

--- a/rpc/v8/block_test.go
+++ b/rpc/v8/block_test.go
@@ -179,7 +179,9 @@ func TestBlockTransactionCount(t *testing.T) {
 	t.Run("non-existent block hash", func(t *testing.T) {
 		mockReader.EXPECT().BlockHeaderByHash(gomock.Any()).Return(nil, db.ErrKeyNotFound)
 
-		count, rpcErr := handler.BlockTransactionCount(blockIDHash(t, new(felt.Felt).SetBytes([]byte("random"))))
+		count, rpcErr := handler.BlockTransactionCount(
+			blockIDHash(t, new(felt.Felt).SetBytes([]byte("random"))),
+		)
 		assert.Equal(t, uint64(0), count)
 		assert.Equal(t, rpccore.ErrBlockNotFound, rpcErr)
 	})
@@ -472,7 +474,11 @@ func TestBlockWithTxs(t *testing.T) {
 	require.NoError(t, err)
 	latestBlockHash := latestBlock.Hash
 
-	checkLatestBlock := func(t *testing.T, blockWithTxHashes *rpc.BlockWithTxHashes, blockWithTxs *rpc.BlockWithTxs) {
+	checkLatestBlock := func(
+		t *testing.T,
+		blockWithTxHashes *rpc.BlockWithTxHashes,
+		blockWithTxs *rpc.BlockWithTxs,
+	) {
 		t.Helper()
 		assert.Equal(t, blockWithTxHashes.BlockHeader, blockWithTxs.BlockHeader)
 		assert.Equal(t, len(blockWithTxHashes.TxnHashes), len(blockWithTxs.Transactions))

--- a/rpc/v8/chain.go
+++ b/rpc/v8/chain.go
@@ -1,0 +1,18 @@
+package rpcv8
+
+import (
+	"github.com/NethermindEth/juno/core/felt"
+	"github.com/NethermindEth/juno/jsonrpc"
+)
+
+/****************************************************
+		Chain Handlers
+*****************************************************/
+
+// ChainID returns the chain ID of the currently configured network.
+//
+// It follows the specification defined here:
+// https://github.com/starkware-libs/starknet-specs/blob/v0.8.1/api/starknet_api_openrpc.json#L759
+func (h *Handler) ChainID() (*felt.Felt, *jsonrpc.Error) {
+	return h.bcReader.Network().L2ChainIDFelt(), nil
+}

--- a/rpc/v8/chain_test.go
+++ b/rpc/v8/chain_test.go
@@ -1,0 +1,31 @@
+package rpcv8_test
+
+import (
+	"testing"
+
+	"github.com/NethermindEth/juno/mocks"
+	rpc "github.com/NethermindEth/juno/rpc/v8"
+	"github.com/NethermindEth/juno/utils"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+)
+
+func TestChainId(t *testing.T) {
+	for _, n := range []utils.Network{
+		utils.Mainnet, utils.Sepolia, utils.SepoliaIntegration,
+	} {
+		t.Run(n.String(), func(t *testing.T) {
+			mockCtrl := gomock.NewController(t)
+			t.Cleanup(mockCtrl.Finish)
+
+			mockReader := mocks.NewMockReader(mockCtrl)
+			mockReader.EXPECT().Network().Return(&n)
+			handler := rpc.New(mockReader, nil, nil, nil)
+
+			cID, err := handler.ChainID()
+			require.Nil(t, err)
+			assert.Equal(t, n.L2ChainIDFelt(), cID)
+		})
+	}
+}

--- a/rpc/v8/class.go
+++ b/rpc/v8/class.go
@@ -8,20 +8,35 @@ import (
 	"github.com/NethermindEth/juno/adapters/sn2core"
 	"github.com/NethermindEth/juno/core"
 	"github.com/NethermindEth/juno/core/felt"
+	"github.com/NethermindEth/juno/jsonrpc"
 	"github.com/NethermindEth/juno/rpc/rpccore"
 	"github.com/NethermindEth/juno/starknet"
 	"github.com/NethermindEth/juno/starknet/compiler"
 	"github.com/NethermindEth/juno/utils"
 )
 
-type CalldataInputs = rpccore.LimitSlice[felt.Felt, rpccore.FunctionCalldataLimit]
-
-// https://github.com/starkware-libs/starknet-specs/blob/v0.3.0/api/starknet_api_openrpc.json#L2344
-type FunctionCall struct {
-	ContractAddress    felt.Felt      `json:"contract_address"`
-	EntryPointSelector felt.Felt      `json:"entry_point_selector"`
-	Calldata           CalldataInputs `json:"calldata"`
+// https://github.com/starkware-libs/starknet-specs/blob/v0.8.1/api/starknet_api_openrpc.json#L3159
+type Class struct {
+	SierraProgram        []*felt.Felt `json:"sierra_program,omitempty"`
+	Program              string       `json:"program,omitempty"`
+	ContractClassVersion string       `json:"contract_class_version,omitempty"`
+	EntryPoints          EntryPoints  `json:"entry_points_by_type"`
+	Abi                  any          `json:"abi"`
 }
+
+type EntryPoints struct {
+	Constructor []EntryPoint `json:"CONSTRUCTOR"`
+	External    []EntryPoint `json:"EXTERNAL"`
+	L1Handler   []EntryPoint `json:"L1_HANDLER"`
+}
+
+type EntryPoint struct {
+	Index    *uint64    `json:"function_idx,omitempty"`
+	Offset   *felt.Felt `json:"offset,omitempty"`
+	Selector *felt.Felt `json:"selector"`
+}
+
+type CalldataInputs = rpccore.LimitSlice[felt.Felt, rpccore.FunctionCalldataLimit]
 
 func adaptDeclaredClass(
 	ctx context.Context,
@@ -59,4 +74,105 @@ func adaptDeclaredClass(
 	default:
 		return nil, errors.New("empty class")
 	}
+}
+
+/****************************************************
+		Class Handlers
+*****************************************************/
+
+// Class gets the contract class definition in the given block associated with the given hash
+//
+// It follows the specification defined here:
+// https://github.com/starkware-libs/starknet-specs/blob/v0.8.1/api/starknet_api_openrpc.json#L393
+func (h *Handler) Class(id BlockID, classHash felt.Felt) (*Class, *jsonrpc.Error) {
+	state, stateCloser, rpcErr := h.stateByBlockID(&id)
+	if rpcErr != nil {
+		return nil, rpcErr
+	}
+	defer h.callAndLogErr(stateCloser, "Error closing state reader in getClass")
+
+	declared, err := state.Class(&classHash)
+	if err != nil {
+		return nil, rpccore.ErrClassHashNotFound
+	}
+
+	var rpcClass *Class
+	switch c := declared.Class.(type) {
+	case *core.DeprecatedCairoClass:
+		adaptEntryPoint := func(ep core.DeprecatedEntryPoint) EntryPoint {
+			return EntryPoint{
+				Offset:   ep.Offset,
+				Selector: ep.Selector,
+			}
+		}
+
+		rpcClass = &Class{
+			Abi:     c.Abi,
+			Program: c.Program,
+			EntryPoints: EntryPoints{
+				// Note that utils.Map returns nil if provided slice is nil
+				// but this is not the case here, because we rely on sn2core adapters that will set it to empty slice
+				// if it's nil. In the API spec these fields are required.
+				Constructor: utils.Map(c.Constructors, adaptEntryPoint),
+				External:    utils.Map(c.Externals, adaptEntryPoint),
+				L1Handler:   utils.Map(c.L1Handlers, adaptEntryPoint),
+			},
+		}
+	case *core.SierraClass:
+		adaptEntryPoint := func(ep core.SierraEntryPoint) EntryPoint {
+			return EntryPoint{
+				Index:    &ep.Index,
+				Selector: ep.Selector,
+			}
+		}
+
+		rpcClass = &Class{
+			Abi:                  c.Abi,
+			SierraProgram:        c.Program,
+			ContractClassVersion: c.SemanticVersion,
+			EntryPoints: EntryPoints{
+				// Note that utils.Map returns nil if provided slice is nil
+				// but this is not the case here, because we rely on sn2core adapters that will set it to empty slice
+				// if it's nil. In the API spec these fields are required.
+				Constructor: utils.Map(c.EntryPoints.Constructor, adaptEntryPoint),
+				External:    utils.Map(c.EntryPoints.External, adaptEntryPoint),
+				L1Handler:   utils.Map(c.EntryPoints.L1Handler, adaptEntryPoint),
+			},
+		}
+	default:
+		return nil, rpccore.ErrClassHashNotFound
+	}
+
+	return rpcClass, nil
+}
+
+// ClassAt gets the contract class definition in the given block instantiated by the given contract address
+//
+// It follows the specification defined here:
+// https://github.com/starkware-libs/starknet-specs/blob/v0.8.1/api/starknet_api_openrpc.json#L482
+func (h *Handler) ClassAt(id BlockID, address felt.Felt) (*Class, *jsonrpc.Error) {
+	classHash, err := h.ClassHashAt(id, address)
+	if err != nil {
+		return nil, err
+	}
+	return h.Class(id, *classHash)
+}
+
+// ClassHashAt gets the class hash for the contract deployed at the given address in the given block.
+//
+// It follows the specification defined here:
+// https://github.com/starkware-libs/starknet-specs/blob/v0.8.1/api/starknet_api_openrpc.json#L442
+func (h *Handler) ClassHashAt(id BlockID, address felt.Felt) (*felt.Felt, *jsonrpc.Error) {
+	stateReader, stateCloser, rpcErr := h.stateByBlockID(&id)
+	if rpcErr != nil {
+		return nil, rpcErr
+	}
+	defer h.callAndLogErr(stateCloser, "Error closing state reader in getClassHashAt")
+
+	classHash, err := stateReader.ContractClassHash(&address)
+	if err != nil {
+		return nil, rpccore.ErrContractNotFound
+	}
+
+	return &classHash, nil
 }

--- a/rpc/v8/class.go
+++ b/rpc/v8/class.go
@@ -111,7 +111,8 @@ func (h *Handler) Class(id BlockID, classHash felt.Felt) (*Class, *jsonrpc.Error
 			Program: c.Program,
 			EntryPoints: EntryPoints{
 				// Note that utils.Map returns nil if provided slice is nil
-				// but this is not the case here, because we rely on sn2core adapters that will set it to empty slice
+				// but this is not the case here, because we rely on sn2core adapters
+				// that will set it to empty slice if it's nil. In the API spec these fields are required.
 				// if it's nil. In the API spec these fields are required.
 				Constructor: utils.Map(c.Constructors, adaptEntryPoint),
 				External:    utils.Map(c.Externals, adaptEntryPoint),
@@ -132,7 +133,8 @@ func (h *Handler) Class(id BlockID, classHash felt.Felt) (*Class, *jsonrpc.Error
 			ContractClassVersion: c.SemanticVersion,
 			EntryPoints: EntryPoints{
 				// Note that utils.Map returns nil if provided slice is nil
-				// but this is not the case here, because we rely on sn2core adapters that will set it to empty slice
+				// but this is not the case here, because we rely on sn2core adapters
+				// that will set it to empty slice if it's nil. In the API spec these fields are required.
 				// if it's nil. In the API spec these fields are required.
 				Constructor: utils.Map(c.EntryPoints.Constructor, adaptEntryPoint),
 				External:    utils.Map(c.EntryPoints.External, adaptEntryPoint),
@@ -146,7 +148,8 @@ func (h *Handler) Class(id BlockID, classHash felt.Felt) (*Class, *jsonrpc.Error
 	return rpcClass, nil
 }
 
-// ClassAt gets the contract class definition in the given block instantiated by the given contract address
+// ClassAt gets the contract class definition in the given block instantiated by
+// the given contract address
 //
 // It follows the specification defined here:
 // https://github.com/starkware-libs/starknet-specs/blob/v0.8.1/api/starknet_api_openrpc.json#L482
@@ -158,7 +161,8 @@ func (h *Handler) ClassAt(id BlockID, address felt.Felt) (*Class, *jsonrpc.Error
 	return h.Class(id, *classHash)
 }
 
-// ClassHashAt gets the class hash for the contract deployed at the given address in the given block.
+// ClassHashAt gets the class hash for the contract deployed at the given address
+// in the given block.
 //
 // It follows the specification defined here:
 // https://github.com/starkware-libs/starknet-specs/blob/v0.8.1/api/starknet_api_openrpc.json#L442

--- a/rpc/v8/class_test.go
+++ b/rpc/v8/class_test.go
@@ -1,0 +1,368 @@
+package rpcv8_test
+
+import (
+	"encoding/json"
+	"errors"
+	"testing"
+
+	"github.com/NethermindEth/juno/clients/feeder"
+	"github.com/NethermindEth/juno/core"
+	"github.com/NethermindEth/juno/core/felt"
+	"github.com/NethermindEth/juno/db"
+	"github.com/NethermindEth/juno/mocks"
+	rpccore "github.com/NethermindEth/juno/rpc/rpccore"
+	rpc "github.com/NethermindEth/juno/rpc/v8"
+	adaptfeeder "github.com/NethermindEth/juno/starknetdata/feeder"
+	"github.com/NethermindEth/juno/utils"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+)
+
+func TestClass(t *testing.T) {
+	n := &utils.Integration
+	integrationClient := feeder.NewTestClient(t, n)
+	integGw := adaptfeeder.New(integrationClient)
+
+	mockCtrl := gomock.NewController(t)
+	t.Cleanup(mockCtrl.Finish)
+
+	mockReader := mocks.NewMockReader(mockCtrl)
+	mockState := mocks.NewMockStateReader(mockCtrl)
+
+	mockState.EXPECT().Class(
+		gomock.Any()).DoAndReturn(func(
+		classHash *felt.Felt,
+	) (*core.DeclaredClassDefinition, error) {
+		class, err := integGw.Class(t.Context(), classHash)
+		return &core.DeclaredClassDefinition{Class: class, At: 0}, err
+	}).AnyTimes()
+	mockReader.EXPECT().HeadState().Return(mockState, func() error {
+		return nil
+	}, nil).AnyTimes()
+	mockReader.EXPECT().HeadsHeader().Return(new(core.Header), nil).AnyTimes()
+	handler := rpc.New(mockReader, nil, nil, utils.NewNopZapLogger())
+
+	latest := blockIDLatest(t)
+
+	t.Run("sierra class", func(t *testing.T) {
+		hash := felt.NewUnsafeFromString[felt.Felt](
+			"0x1cd2edfb485241c4403254d550de0a097fa76743cd30696f714a491a454bad5",
+		)
+
+		coreClass, err := integGw.Class(t.Context(), hash)
+		require.NoError(t, err)
+
+		class, rpcErr := handler.Class(latest, *hash)
+		require.Nil(t, rpcErr)
+		sierraClass := coreClass.(*core.SierraClass)
+		assertEqualSierraClass(t, sierraClass, class)
+	})
+
+	t.Run("casm class", func(t *testing.T) {
+		hash := felt.NewUnsafeFromString[felt.Felt](
+			"0x4631b6b3fa31e140524b7d21ba784cea223e618bffe60b5bbdca44a8b45be04",
+		)
+
+		coreClass, err := integGw.Class(t.Context(), hash)
+		require.NoError(t, err)
+
+		class, rpcErr := handler.Class(latest, *hash)
+		require.Nil(t, rpcErr)
+
+		deprecatedCairoClass := coreClass.(*core.DeprecatedCairoClass)
+		assertEqualDeprecatedCairoClass(t, deprecatedCairoClass, class)
+	})
+
+	t.Run("state by id error", func(t *testing.T) {
+		mockReader := mocks.NewMockReader(mockCtrl)
+		handler := rpc.New(mockReader, nil, nil, utils.NewNopZapLogger())
+
+		mockReader.EXPECT().HeadState().Return(nil, nil, db.ErrKeyNotFound)
+
+		_, rpcErr := handler.Class(latest, felt.Zero)
+		require.NotNil(t, rpcErr)
+		require.Equal(t, rpccore.ErrBlockNotFound, rpcErr)
+	})
+
+	t.Run("class hash not found error", func(t *testing.T) {
+		mockReader := mocks.NewMockReader(mockCtrl)
+		mockState := mocks.NewMockStateReader(mockCtrl)
+		handler := rpc.New(mockReader, nil, nil, utils.NewNopZapLogger())
+
+		mockReader.EXPECT().HeadState().Return(mockState, func() error {
+			return nil
+		}, nil)
+		mockState.EXPECT().Class(gomock.Any()).Return(nil, errors.New("class hash not found"))
+
+		_, rpcErr := handler.Class(latest, felt.Zero)
+		require.NotNil(t, rpcErr)
+		require.Equal(t, rpccore.ErrClassHashNotFound, rpcErr)
+	})
+}
+
+func TestClassAt(t *testing.T) {
+	n := &utils.Integration
+	integrationClient := feeder.NewTestClient(t, n)
+	integGw := adaptfeeder.New(integrationClient)
+
+	mockCtrl := gomock.NewController(t)
+	t.Cleanup(mockCtrl.Finish)
+
+	mockReader := mocks.NewMockReader(mockCtrl)
+	mockState := mocks.NewMockStateReader(mockCtrl)
+
+	deprecatedCairoContractAddress := felt.NewRandom[felt.Felt]()
+	deprecatedCairoClassHash := felt.NewUnsafeFromString[felt.Felt](
+		"0x4631b6b3fa31e140524b7d21ba784cea223e618bffe60b5bbdca44a8b45be04",
+	)
+	mockState.EXPECT().
+		ContractClassHash(deprecatedCairoContractAddress).
+		Return(*deprecatedCairoClassHash, nil)
+
+	cairo1ContractAddress := felt.NewRandom[felt.Felt]()
+	sierraClassHash := felt.NewUnsafeFromString[felt.Felt](
+		"0x1cd2edfb485241c4403254d550de0a097fa76743cd30696f714a491a454bad5",
+	)
+	mockState.EXPECT().ContractClassHash(cairo1ContractAddress).Return(*sierraClassHash, nil)
+
+	mockState.EXPECT().Class(gomock.Any()).
+		DoAndReturn(func(classHash *felt.Felt) (*core.DeclaredClassDefinition, error) {
+			class, err := integGw.Class(t.Context(), classHash)
+			return &core.DeclaredClassDefinition{Class: class, At: 0}, err
+		}).AnyTimes()
+	mockReader.EXPECT().HeadState().Return(mockState, func() error {
+		return nil
+	}, nil).AnyTimes()
+	mockReader.EXPECT().HeadsHeader().Return(new(core.Header), nil).AnyTimes()
+	handler := rpc.New(mockReader, nil, nil, utils.NewNopZapLogger())
+
+	latest := blockIDLatest(t)
+
+	t.Run("sierra class", func(t *testing.T) {
+		coreClass, err := integGw.Class(t.Context(), sierraClassHash)
+		require.NoError(t, err)
+
+		class, rpcErr := handler.ClassAt(latest, *cairo1ContractAddress)
+		require.Nil(t, rpcErr)
+		sierraClass := coreClass.(*core.SierraClass)
+		assertEqualSierraClass(t, sierraClass, class)
+	})
+
+	t.Run("casm class", func(t *testing.T) {
+		coreClass, err := integGw.Class(t.Context(), deprecatedCairoClassHash)
+		require.NoError(t, err)
+
+		class, rpcErr := handler.ClassAt(latest, *deprecatedCairoContractAddress)
+		require.Nil(t, rpcErr)
+
+		deprecatedCairoClass := coreClass.(*core.DeprecatedCairoClass)
+		assertEqualDeprecatedCairoClass(t, deprecatedCairoClass, class)
+	})
+}
+
+func TestClassHashAt(t *testing.T) {
+	mockCtrl := gomock.NewController(t)
+	t.Cleanup(mockCtrl.Finish)
+
+	mockReader := mocks.NewMockReader(mockCtrl)
+	mockSyncReader := mocks.NewMockSyncReader(mockCtrl)
+	log := utils.NewNopZapLogger()
+	handler := rpc.New(mockReader, mockSyncReader, nil, log)
+
+	latestID := blockIDLatest(t)
+	targetAddress := felt.FromUint64[felt.Felt](1234)
+	t.Run("empty blockchain", func(t *testing.T) {
+		mockReader.EXPECT().HeadState().Return(nil, nil, db.ErrKeyNotFound)
+
+		classHash, rpcErr := handler.ClassHashAt(latestID, targetAddress)
+		require.Nil(t, classHash)
+		assert.Equal(t, rpccore.ErrBlockNotFound, rpcErr)
+	})
+
+	t.Run("non-existent block hash", func(t *testing.T) {
+		mockReader.EXPECT().StateAtBlockHash(&felt.Zero).Return(nil, nil, db.ErrKeyNotFound)
+
+		classHash, rpcErr := handler.ClassHashAt(
+			blockIDHash(t, &felt.Zero),
+			targetAddress,
+		)
+		require.Nil(t, classHash)
+		assert.Equal(t, rpccore.ErrBlockNotFound, rpcErr)
+	})
+
+	t.Run("non-existent block number", func(t *testing.T) {
+		mockReader.EXPECT().StateAtBlockNumber(uint64(0)).Return(nil, nil, db.ErrKeyNotFound)
+
+		classHash, rpcErr := handler.ClassHashAt(
+			blockIDNumber(t, 0),
+			targetAddress,
+		)
+		require.Nil(t, classHash)
+		assert.Equal(t, rpccore.ErrBlockNotFound, rpcErr)
+	})
+
+	mockState := mocks.NewMockStateReader(mockCtrl)
+
+	t.Run("non-existent contract", func(t *testing.T) {
+		mockReader.EXPECT().HeadState().Return(mockState, nopCloser, nil)
+		mockState.EXPECT().ContractClassHash(&targetAddress).
+			Return(felt.Felt{}, errors.New("non-existent contract"))
+
+		classHash, rpcErr := handler.ClassHashAt(latestID, targetAddress)
+		require.Nil(t, classHash)
+		assert.Equal(t, rpccore.ErrContractNotFound, rpcErr)
+	})
+
+	expectedClassHash := new(felt.Felt).SetUint64(3)
+
+	t.Run("blockID - latest", func(t *testing.T) {
+		mockReader.EXPECT().HeadState().Return(mockState, nopCloser, nil)
+		mockState.EXPECT().ContractClassHash(&targetAddress).
+			Return(*expectedClassHash, nil)
+
+		classHash, rpcErr := handler.ClassHashAt(latestID, targetAddress)
+		require.Nil(t, rpcErr)
+		assert.Equal(t, expectedClassHash, classHash)
+	})
+
+	t.Run("blockID - hash", func(t *testing.T) {
+		mockReader.EXPECT().StateAtBlockHash(&felt.Zero).Return(mockState, nopCloser, nil)
+		mockState.EXPECT().ContractClassHash(&targetAddress).Return(*expectedClassHash, nil)
+
+		classHash, rpcErr := handler.ClassHashAt(
+			blockIDHash(t, &felt.Zero),
+			targetAddress,
+		)
+		require.Nil(t, rpcErr)
+		assert.Equal(t, expectedClassHash, classHash)
+	})
+
+	t.Run("blockID - number", func(t *testing.T) {
+		mockReader.EXPECT().StateAtBlockNumber(uint64(0)).Return(mockState, nopCloser, nil)
+		mockState.EXPECT().ContractClassHash(&targetAddress).Return(*expectedClassHash, nil)
+
+		classHash, rpcErr := handler.ClassHashAt(
+			blockIDNumber(t, 0),
+			targetAddress,
+		)
+		require.Nil(t, rpcErr)
+		assert.Equal(t, expectedClassHash, classHash)
+	})
+
+	t.Run("blockID - pending", func(t *testing.T) {
+		mockReader.EXPECT().HeadState().Return(mockState, nopCloser, nil)
+		mockState.EXPECT().ContractClassHash(&targetAddress).Return(*expectedClassHash, nil)
+
+		classHash, rpcErr := handler.ClassHashAt(
+			blockIDPending(t),
+			targetAddress,
+		)
+		require.Nil(t, rpcErr)
+		assert.Equal(t, expectedClassHash, classHash)
+	})
+}
+
+func assertEqualDeprecatedCairoClass(
+	t *testing.T,
+	deprecatedCairoClass *core.DeprecatedCairoClass,
+	class *rpc.Class,
+) {
+	assert.Equal(t, deprecatedCairoClass.Program, class.Program)
+	assert.Equal(t, deprecatedCairoClass.Abi, class.Abi.(json.RawMessage))
+
+	require.Equal(t, len(deprecatedCairoClass.L1Handlers), len(class.EntryPoints.L1Handler))
+	for idx := range deprecatedCairoClass.L1Handlers {
+		assert.Nil(t, class.EntryPoints.L1Handler[idx].Index)
+		assert.Equal(
+			t,
+			deprecatedCairoClass.L1Handlers[idx].Offset,
+			class.EntryPoints.L1Handler[idx].Offset,
+		)
+		assert.Equal(
+			t,
+			deprecatedCairoClass.L1Handlers[idx].Selector,
+			class.EntryPoints.L1Handler[idx].Selector,
+		)
+	}
+
+	require.Equal(t, len(deprecatedCairoClass.Constructors), len(class.EntryPoints.Constructor))
+	for idx := range deprecatedCairoClass.Constructors {
+		assert.Nil(t, class.EntryPoints.Constructor[idx].Index)
+		assert.Equal(
+			t,
+			deprecatedCairoClass.Constructors[idx].Offset,
+			class.EntryPoints.Constructor[idx].Offset,
+		)
+		assert.Equal(
+			t,
+			deprecatedCairoClass.Constructors[idx].Selector,
+			class.EntryPoints.Constructor[idx].Selector,
+		)
+	}
+
+	require.Equal(t, len(deprecatedCairoClass.Externals), len(class.EntryPoints.External))
+	for idx := range deprecatedCairoClass.Externals {
+		assert.Nil(t, class.EntryPoints.External[idx].Index)
+		assert.Equal(
+			t,
+			deprecatedCairoClass.Externals[idx].Offset,
+			class.EntryPoints.External[idx].Offset,
+		)
+		assert.Equal(t,
+			deprecatedCairoClass.Externals[idx].Selector,
+			class.EntryPoints.External[idx].Selector,
+		)
+	}
+}
+
+func assertEqualSierraClass(t *testing.T, sierraClass *core.SierraClass, class *rpc.Class) {
+	assert.Equal(t, sierraClass.Program, class.SierraProgram)
+	assert.Equal(t, sierraClass.Abi, class.Abi.(string))
+	assert.Equal(t, sierraClass.SemanticVersion, class.ContractClassVersion)
+
+	require.Equal(t, len(sierraClass.EntryPoints.L1Handler), len(class.EntryPoints.L1Handler))
+	for idx := range sierraClass.EntryPoints.L1Handler {
+		assert.Nil(t, class.EntryPoints.L1Handler[idx].Offset)
+		assert.Equal(
+			t,
+			sierraClass.EntryPoints.L1Handler[idx].Index,
+			*class.EntryPoints.L1Handler[idx].Index,
+		)
+		assert.Equal(
+			t,
+			sierraClass.EntryPoints.L1Handler[idx].Selector,
+			class.EntryPoints.L1Handler[idx].Selector,
+		)
+	}
+
+	require.Equal(t, len(sierraClass.EntryPoints.Constructor), len(class.EntryPoints.Constructor))
+	for idx := range sierraClass.EntryPoints.Constructor {
+		assert.Nil(t, class.EntryPoints.Constructor[idx].Offset)
+		assert.Equal(
+			t,
+			sierraClass.EntryPoints.Constructor[idx].Index,
+			*class.EntryPoints.Constructor[idx].Index,
+		)
+		assert.Equal(
+			t,
+			sierraClass.EntryPoints.Constructor[idx].Selector,
+			class.EntryPoints.Constructor[idx].Selector,
+		)
+	}
+
+	require.Equal(t, len(sierraClass.EntryPoints.External), len(class.EntryPoints.External))
+	for idx := range sierraClass.EntryPoints.External {
+		assert.Nil(t, class.EntryPoints.External[idx].Offset)
+		assert.Equal(
+			t,
+			sierraClass.EntryPoints.External[idx].Index,
+			*class.EntryPoints.External[idx].Index,
+		)
+		assert.Equal(
+			t,
+			sierraClass.EntryPoints.External[idx].Selector,
+			class.EntryPoints.External[idx].Selector,
+		)
+	}
+}

--- a/rpc/v8/estimate_fee.go
+++ b/rpc/v8/estimate_fee.go
@@ -9,7 +9,7 @@ import (
 	"github.com/NethermindEth/juno/core/felt"
 	"github.com/NethermindEth/juno/jsonrpc"
 	"github.com/NethermindEth/juno/rpc/rpccore"
-	rpcv6 "github.com/NethermindEth/juno/rpc/v6"
+	"github.com/ethereum/go-ethereum/common"
 )
 
 type FeeUnit byte
@@ -39,6 +39,16 @@ type FeeEstimate struct {
 	L1DataGasPrice    *felt.Felt `json:"l1_data_gas_price,omitempty"`
 	OverallFee        *felt.Felt `json:"overall_fee"`
 	Unit              *FeeUnit   `json:"unit,omitempty"`
+}
+
+type MsgFromL1 struct {
+	// The address of the L1 contract sending the message.
+	From common.Address `json:"from_address" validate:"required"`
+	// The address of the L2 contract receiving the message.
+	To felt.Felt `json:"to_address" validate:"required"`
+	// The payload of the message.
+	Payload  []felt.Felt `json:"payload" validate:"required"`
+	Selector felt.Felt   `json:"entry_point_selector" validate:"required"`
 }
 
 /****************************************************
@@ -262,14 +272,14 @@ curl --location 'http://localhost:6060/rpc/v0_8' \
 func (h *Handler) EstimateFee(
 	ctx context.Context,
 	broadcastedTxns BroadcastedTransactionInputs,
-	simulationFlags []rpcv6.SimulationFlag,
+	simulationFlags []SimulationFlag,
 	id *BlockID,
 ) ([]FeeEstimate, http.Header, *jsonrpc.Error) {
 	txnResults, httpHeader, err := h.simulateTransactions(
 		ctx,
 		id,
 		broadcastedTxns.Data,
-		append(simulationFlags, rpcv6.SkipFeeChargeFlag),
+		append(simulationFlags, SkipFeeChargeFlag),
 		true,
 		true,
 	)
@@ -287,7 +297,7 @@ func (h *Handler) EstimateFee(
 
 func (h *Handler) EstimateMessageFee(
 	ctx context.Context,
-	msg *rpcv6.MsgFromL1,
+	msg *MsgFromL1,
 	id *BlockID,
 ) (FeeEstimate, http.Header, *jsonrpc.Error) {
 	calldata := make([]*felt.Felt, len(msg.Payload)+1)

--- a/rpc/v8/estimate_fee_test.go
+++ b/rpc/v8/estimate_fee_test.go
@@ -9,7 +9,6 @@ import (
 	"github.com/NethermindEth/juno/jsonrpc"
 	"github.com/NethermindEth/juno/mocks"
 	"github.com/NethermindEth/juno/rpc/rpccore"
-	rpcv6 "github.com/NethermindEth/juno/rpc/v6"
 	rpc "github.com/NethermindEth/juno/rpc/v8"
 	"github.com/NethermindEth/juno/utils"
 	"github.com/NethermindEth/juno/vm"
@@ -61,7 +60,7 @@ func TestEstimateFee(t *testing.T) {
 		_, httpHeader, err := handler.EstimateFee(
 			t.Context(),
 			rpc.BroadcastedTransactionInputs{},
-			[]rpcv6.SimulationFlag{},
+			[]rpc.SimulationFlag{},
 			&blockID,
 		)
 		require.Nil(t, err)
@@ -89,7 +88,7 @@ func TestEstimateFee(t *testing.T) {
 		_, httpHeader, err := handler.EstimateFee(
 			t.Context(),
 			rpc.BroadcastedTransactionInputs{},
-			[]rpcv6.SimulationFlag{rpcv6.SkipValidateFlag},
+			[]rpc.SimulationFlag{rpc.SkipValidateFlag},
 			&blockID,
 		)
 		require.Nil(t, err)
@@ -117,7 +116,7 @@ func TestEstimateFee(t *testing.T) {
 		_, httpHeader, err := handler.EstimateFee(
 			t.Context(),
 			rpc.BroadcastedTransactionInputs{},
-			[]rpcv6.SimulationFlag{rpcv6.SkipValidateFlag},
+			[]rpc.SimulationFlag{rpc.SkipValidateFlag},
 			&blockID,
 		)
 		require.Equal(t, rpccore.ErrTransactionExecutionError.CloneWithData(rpc.TransactionExecutionErrorData{
@@ -144,7 +143,7 @@ func TestEstimateFee(t *testing.T) {
 		_, _, err := handler.EstimateFee(
 			t.Context(),
 			rpc.BroadcastedTransactionInputs{Data: []rpc.BroadcastedTransaction{invalidTx}},
-			[]rpcv6.SimulationFlag{},
+			[]rpc.SimulationFlag{},
 			&blockID,
 		)
 		expectedErr := &jsonrpc.Error{

--- a/rpc/v8/events.go
+++ b/rpc/v8/events.go
@@ -73,7 +73,7 @@ func (h *Handler) Events(args EventsArg) (*EventsChunk, *jsonrpc.Error) {
 	if args.EventFilter.Address != nil {
 		addresses = []felt.Address{felt.Address(*args.EventFilter.Address)}
 	}
-	// rpc/v6 builds its pending block via MakeEmptyPendingForParent, which returns the deprecated
+	// rpc/v8 builds its pending block via MakeEmptyPendingForParent, which returns the deprecated
 	// *core.Pending type and carries no events. EventFilter requires *core.PreConfirmed, so a
 	// no-op is passed here — the result is identical since there are no pending events to emit.
 	filter, err := h.bcReader.EventFilter(

--- a/rpc/v8/events.go
+++ b/rpc/v8/events.go
@@ -2,10 +2,28 @@ package rpcv8
 
 import (
 	"github.com/NethermindEth/juno/blockchain"
+	"github.com/NethermindEth/juno/core"
 	"github.com/NethermindEth/juno/core/felt"
+	"github.com/NethermindEth/juno/jsonrpc"
+	"github.com/NethermindEth/juno/rpc/rpccore"
 )
 
-type SubscriptionID string
+type EventsArg struct {
+	EventFilter
+	ResultPageRequest
+}
+
+type EventFilter struct {
+	FromBlock *BlockID      `json:"from_block"`
+	ToBlock   *BlockID      `json:"to_block"`
+	Address   *felt.Felt    `json:"address"`
+	Keys      [][]felt.Felt `json:"keys"`
+}
+
+type ResultPageRequest struct {
+	ContinuationToken string `json:"continuation_token"`
+	ChunkSize         uint64 `json:"chunk_size" validate:"min=1"`
+}
 
 type Event struct {
 	From *felt.Felt   `json:"from_address,omitempty"`
@@ -20,9 +38,100 @@ type EmittedEvent struct {
 	TransactionHash *felt.Felt `json:"transaction_hash"`
 }
 
-func (h *Handler) unsubscribe(sub *subscription, id string) {
-	sub.cancel()
-	h.subscriptions.Delete(id)
+type EventsChunk struct {
+	Events            []EmittedEvent `json:"events"`
+	ContinuationToken string         `json:"continuation_token,omitempty"`
+}
+
+/****************************************************
+		Events Handlers
+*****************************************************/
+
+// Events gets the events matching a filter
+//
+// It follows the specification defined here:
+// https://github.com/starkware-libs/starknet-specs/blob/v0.8.1/api/starknet_api_openrpc.json#L796
+func (h *Handler) Events(args EventsArg) (*EventsChunk, *jsonrpc.Error) {
+	if args.ChunkSize > rpccore.MaxEventChunkSize {
+		return nil, rpccore.ErrPageSizeTooBig
+	} else {
+		lenKeys := len(args.Keys)
+		for _, keys := range args.Keys {
+			lenKeys += len(keys)
+		}
+		if lenKeys > rpccore.MaxEventFilterKeys {
+			return nil, rpccore.ErrTooManyKeysInFilter
+		}
+	}
+
+	height, err := h.bcReader.Height()
+	if err != nil {
+		return nil, rpccore.ErrInternal
+	}
+
+	var addresses []felt.Address
+	if args.EventFilter.Address != nil {
+		addresses = []felt.Address{felt.Address(*args.EventFilter.Address)}
+	}
+	// rpc/v6 builds its pending block via MakeEmptyPendingForParent, which returns the deprecated
+	// *core.Pending type and carries no events. EventFilter requires *core.PreConfirmed, so a
+	// no-op is passed here — the result is identical since there are no pending events to emit.
+	filter, err := h.bcReader.EventFilter(
+		addresses,
+		args.EventFilter.Keys,
+		func() (*core.PreConfirmed, error) { return nil, core.ErrPreConfirmedNotFound },
+	)
+	if err != nil {
+		return nil, rpccore.ErrInternal
+	}
+	filter = filter.WithLimit(h.filterLimit)
+	defer h.callAndLogErr(filter.Close, "Error closing event filter in events")
+
+	var cToken *blockchain.ContinuationToken
+	if args.ContinuationToken != "" {
+		cToken = new(blockchain.ContinuationToken)
+		if err = cToken.FromString(args.ContinuationToken); err != nil {
+			return nil, rpccore.ErrInvalidContinuationToken
+		}
+	}
+
+	if err = setEventFilterRange(
+		filter,
+		args.EventFilter.FromBlock,
+		args.EventFilter.ToBlock,
+		height,
+	); err != nil {
+		return nil, rpccore.ErrBlockNotFound
+	}
+
+	filteredEvents, cTokenValue, err := filter.Events(cToken, args.ChunkSize)
+	if err != nil {
+		return nil, rpccore.ErrInternal
+	}
+
+	emittedEvents := make([]EmittedEvent, len(filteredEvents))
+	for i, fEvent := range filteredEvents {
+		var blockNumber *uint64
+		if fEvent.BlockHash != nil {
+			blockNumber = fEvent.BlockNumber
+		}
+		emittedEvents[i] = EmittedEvent{
+			BlockNumber:     blockNumber,
+			BlockHash:       fEvent.BlockHash,
+			TransactionHash: fEvent.TransactionHash,
+			Event: &Event{
+				From: fEvent.From,
+				Keys: fEvent.Keys,
+				Data: fEvent.Data,
+			},
+		}
+	}
+
+	cTokenStr := ""
+	if !cTokenValue.IsEmpty() {
+		cTokenStr = cTokenValue.String()
+	}
+	return &EventsChunk{Events: emittedEvents, ContinuationToken: cTokenStr}, nil
 }
 
 func setEventFilterRange(filter blockchain.EventFilterer, from, to *BlockID, latestHeight uint64) error {

--- a/rpc/v8/events_test.go
+++ b/rpc/v8/events_test.go
@@ -1,0 +1,238 @@
+package rpcv8_test
+
+import (
+	"testing"
+
+	"github.com/NethermindEth/juno/blockchain"
+	"github.com/NethermindEth/juno/clients/feeder"
+	"github.com/NethermindEth/juno/core"
+	"github.com/NethermindEth/juno/core/felt"
+	"github.com/NethermindEth/juno/db/memory"
+	"github.com/NethermindEth/juno/mocks"
+	"github.com/NethermindEth/juno/rpc/rpccore"
+	rpc "github.com/NethermindEth/juno/rpc/v8"
+	adaptfeeder "github.com/NethermindEth/juno/starknetdata/feeder"
+	"github.com/NethermindEth/juno/utils"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+)
+
+func TestEvents(t *testing.T) {
+	testDB := memory.New()
+	n := &utils.Sepolia
+	chain := blockchain.New(testDB, n)
+
+	mockCtrl := gomock.NewController(t)
+	t.Cleanup(mockCtrl.Finish)
+
+	mockSyncReader := mocks.NewMockSyncReader(mockCtrl)
+
+	client := feeder.NewTestClient(t, n)
+	gw := adaptfeeder.New(client)
+	for i := range 7 {
+		b, err := gw.BlockByNumber(t.Context(), uint64(i))
+		require.NoError(t, err)
+		s, err := gw.StateUpdate(t.Context(), uint64(i))
+		require.NoError(t, err)
+
+		if b.Number < 6 {
+			require.NoError(t, chain.Store(b, &core.BlockCommitments{}, s, nil))
+		}
+	}
+
+	handler := rpc.New(chain, mockSyncReader, nil, utils.NewNopZapLogger())
+	from := felt.NewUnsafeFromString[felt.Felt](
+		"0x49d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7",
+	)
+	args := rpc.EventsArg{
+		EventFilter: rpc.EventFilter{
+			FromBlock: utils.HeapPtr(rpc.BlockIDFromNumber(0)),
+			ToBlock:   utils.HeapPtr(blockIDLatest(t)),
+			Address:   from,
+			Keys:      [][]felt.Felt{},
+		},
+		ResultPageRequest: rpc.ResultPageRequest{
+			ChunkSize:         100,
+			ContinuationToken: "",
+		},
+	}
+
+	t.Run("filter non-existent", func(t *testing.T) {
+		t.Run("block number - bound to latest", func(t *testing.T) {
+			args.ToBlock = utils.HeapPtr(rpc.BlockIDFromNumber(55))
+			events, err := handler.Events(args)
+			require.Nil(t, err)
+			require.Len(t, events.Events, 4)
+		})
+
+		t.Run("block hash", func(t *testing.T) {
+			args.ToBlock = utils.HeapPtr(rpc.BlockIDFromHash(felt.NewFromUint64[felt.Felt](55)))
+			_, err := handler.Events(args)
+			require.Equal(t, rpccore.ErrBlockNotFound, err)
+		})
+	})
+
+	t.Run("filter with no from_block", func(t *testing.T) {
+		args.FromBlock = nil
+		args.ToBlock = utils.HeapPtr(blockIDLatest(t))
+		_, err := handler.Events(args)
+		require.Nil(t, err)
+	})
+
+	t.Run("filter with no to_block", func(t *testing.T) {
+		args.FromBlock = utils.HeapPtr(rpc.BlockIDFromNumber(0))
+		args.ToBlock = nil
+		_, err := handler.Events(args)
+		require.Nil(t, err)
+	})
+
+	t.Run("filter with from_block > to_block", func(t *testing.T) {
+		fArgs := rpc.EventsArg{
+			EventFilter: rpc.EventFilter{
+				FromBlock: utils.HeapPtr(rpc.BlockIDFromNumber(1)),
+				ToBlock:   utils.HeapPtr(rpc.BlockIDFromNumber(0)),
+			},
+			ResultPageRequest: rpc.ResultPageRequest{
+				ChunkSize:         100,
+				ContinuationToken: "",
+			},
+		}
+
+		events, err := handler.Events(fArgs)
+		require.Nil(t, err)
+		require.Empty(t, events.Events)
+	})
+
+	t.Run("filter with no address", func(t *testing.T) {
+		args.ToBlock = utils.HeapPtr(blockIDLatest(t))
+		args.Address = nil
+		_, err := handler.Events(args)
+		require.Nil(t, err)
+	})
+
+	t.Run("filter with no keys", func(t *testing.T) {
+		var allEvents []rpc.EmittedEvent
+		t.Run("get canonical events without pagination", func(t *testing.T) {
+			args.ToBlock = utils.HeapPtr(blockIDLatest(t))
+			args.Address = from
+			events, err := handler.Events(args)
+			require.Nil(t, err)
+			require.Len(t, events.Events, 4)
+			require.Empty(t, events.ContinuationToken)
+			allEvents = events.Events
+		})
+
+		t.Run("accumulate events with pagination", func(t *testing.T) {
+			var accEvents []rpc.EmittedEvent
+			args.ChunkSize = 1
+
+			for range len(allEvents) + 1 {
+				events, err := handler.Events(args)
+				require.Nil(t, err)
+				accEvents = append(accEvents, events.Events...)
+				args.ContinuationToken = events.ContinuationToken
+				if args.ContinuationToken == "" {
+					break
+				}
+			}
+			require.Equal(t, allEvents, accEvents)
+		})
+	})
+
+	t.Run("filter with keys", func(t *testing.T) {
+		key := felt.NewUnsafeFromString[felt.Felt](
+			"0x2e8a4ec40a36a027111fafdb6a46746ff1b0125d5067fbaebd8b5f227185a1e",
+		)
+
+		t.Run("get all events without pagination", func(t *testing.T) {
+			args.ChunkSize = 100
+			args.Keys = append(args.Keys, []felt.Felt{*key})
+			events, err := handler.Events(args)
+			require.Nil(t, err)
+			require.Len(t, events.Events, 1)
+			require.Empty(t, events.ContinuationToken)
+
+			require.Equal(t, from, events.Events[0].From)
+			require.Equal(t, []*felt.Felt{key}, events.Events[0].Keys)
+			require.Equal(t, []*felt.Felt{
+				felt.NewUnsafeFromString[felt.Felt](
+					"0x23be95f90bf41685e18a4356e57b0cfdc1da22bf382ead8b64108353915c1e5",
+				),
+				felt.NewUnsafeFromString[felt.Felt]("0x0"),
+				felt.NewUnsafeFromString[felt.Felt]("0x4"),
+				felt.NewUnsafeFromString[felt.Felt]("0x4574686572"),
+				felt.NewUnsafeFromString[felt.Felt]("0x455448"),
+				felt.NewUnsafeFromString[felt.Felt]("0x12"),
+				felt.NewUnsafeFromString[felt.Felt](
+					"0x4c5772d1914fe6ce891b64eb35bf3522aeae1315647314aac58b01137607f3f",
+				),
+				felt.NewUnsafeFromString[felt.Felt]("0x0"),
+			}, events.Events[0].Data)
+			require.Equal(t, uint64(4), *events.Events[0].BlockNumber)
+			require.Equal(t,
+				felt.NewUnsafeFromString[felt.Felt](
+					"0x445152a69e628774b0f78a952e6f9ba0ffcda1374724b314140928fd2f31f4c",
+				),
+				events.Events[0].BlockHash,
+			)
+			require.Equal(t,
+				felt.NewUnsafeFromString[felt.Felt](
+					"0x3c9dfcd3fe66be18b661ee4ebb62520bb4f13d4182b040b3c2be9a12dbcc09b",
+				),
+				events.Events[0].TransactionHash,
+			)
+		})
+	})
+
+	t.Run("large page size", func(t *testing.T) {
+		args.ChunkSize = 10240 + 1
+		events, err := handler.Events(args)
+		require.Equal(t, rpccore.ErrPageSizeTooBig, err)
+		require.Nil(t, events)
+	})
+
+	t.Run("too many keys", func(t *testing.T) {
+		args.ChunkSize = 2
+		args.Keys = make([][]felt.Felt, 1024+1)
+		events, err := handler.Events(args)
+		require.Equal(t, rpccore.ErrTooManyKeysInFilter, err)
+		require.Nil(t, events)
+	})
+
+	t.Run("filter with limit", func(t *testing.T) {
+		handler = handler.WithFilterLimit(1)
+		args.Address = felt.NewUnsafeFromString[felt.Felt](
+			"0x49d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7",
+		)
+		args.ChunkSize = 100
+		args.Keys = make([][]felt.Felt, 0)
+
+		events, err := handler.Events(args)
+		require.Nil(t, err)
+		require.Equal(t, "4-0", events.ContinuationToken)
+		require.NotEmpty(t, events.Events)
+
+		handler = handler.WithFilterLimit(7)
+		events, err = handler.Events(args)
+		require.Nil(t, err)
+		require.Empty(t, events.ContinuationToken)
+		require.NotEmpty(t, events.Events)
+	})
+
+	t.Run("pending block always empty", func(t *testing.T) {
+		args = rpc.EventsArg{
+			EventFilter: rpc.EventFilter{
+				FromBlock: utils.HeapPtr(blockIDPending(t)),
+				ToBlock:   utils.HeapPtr(blockIDPending(t)),
+			},
+			ResultPageRequest: rpc.ResultPageRequest{
+				ChunkSize:         100,
+				ContinuationToken: "",
+			},
+		}
+		events, err := handler.Events(args)
+		require.Nil(t, err)
+		require.Len(t, events.Events, 0)
+		require.Empty(t, events.ContinuationToken)
+	})
+}

--- a/rpc/v8/handlers_test.go
+++ b/rpc/v8/handlers_test.go
@@ -7,7 +7,6 @@ import (
 	"github.com/NethermindEth/juno/core/felt"
 	"github.com/NethermindEth/juno/mocks"
 	"github.com/NethermindEth/juno/node"
-	rpcv6 "github.com/NethermindEth/juno/rpc/v6"
 	rpcv8 "github.com/NethermindEth/juno/rpc/v8"
 	"github.com/NethermindEth/juno/utils"
 	"github.com/stretchr/testify/assert"
@@ -56,7 +55,7 @@ func TestThrottledVMError(t *testing.T) {
 			t.Context(),
 			&blockID,
 			rpcv8.BroadcastedTransactionInputs{},
-			[]rpcv6.SimulationFlag{rpcv6.SkipFeeChargeFlag},
+			[]rpcv8.SimulationFlag{rpcv8.SkipFeeChargeFlag},
 		)
 		assert.Equal(t, throttledErr, rpcErr.Data)
 		assert.NotEmpty(t, httpHeader.Get(rpcv8.ExecutionStepsHeader))

--- a/rpc/v8/nonce.go
+++ b/rpc/v8/nonce.go
@@ -1,0 +1,30 @@
+package rpcv8
+
+import (
+	"github.com/NethermindEth/juno/core/felt"
+	"github.com/NethermindEth/juno/jsonrpc"
+	"github.com/NethermindEth/juno/rpc/rpccore"
+)
+
+/****************************************************
+		Contract Handlers
+*****************************************************/
+
+// Nonce returns the nonce associated with the given address in the given block number
+//
+// It follows the specification defined here:
+// https://github.com/starkware-libs/starknet-specs/blob/v0.8.1/api/starknet_api_openrpc.json#L843
+func (h *Handler) Nonce(id BlockID, address felt.Felt) (*felt.Felt, *jsonrpc.Error) {
+	stateReader, stateCloser, rpcErr := h.stateByBlockID(&id)
+	if rpcErr != nil {
+		return nil, rpcErr
+	}
+	defer h.callAndLogErr(stateCloser, "Error closing state reader in getNonce")
+
+	nonce, err := stateReader.ContractNonce(&address)
+	if err != nil {
+		return nil, rpccore.ErrContractNotFound
+	}
+
+	return &nonce, nil
+}

--- a/rpc/v8/nonce_test.go
+++ b/rpc/v8/nonce_test.go
@@ -1,0 +1,124 @@
+package rpcv8_test
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/NethermindEth/juno/core/felt"
+	"github.com/NethermindEth/juno/db"
+	"github.com/NethermindEth/juno/mocks"
+	"github.com/NethermindEth/juno/rpc/rpccore"
+	rpc "github.com/NethermindEth/juno/rpc/v8"
+	"github.com/NethermindEth/juno/utils"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+)
+
+func TestNonce(t *testing.T) {
+	mockCtrl := gomock.NewController(t)
+	t.Cleanup(mockCtrl.Finish)
+
+	mockReader := mocks.NewMockReader(mockCtrl)
+	mockSyncReader := mocks.NewMockSyncReader(mockCtrl)
+	log := utils.NewNopZapLogger()
+	handler := rpc.New(mockReader, mockSyncReader, nil, log)
+
+	targetAddress := felt.FromUint64[felt.Felt](1234)
+	t.Run("empty blockchain", func(t *testing.T) {
+		mockReader.EXPECT().HeadState().Return(nil, nil, db.ErrKeyNotFound)
+
+		nonce, rpcErr := handler.Nonce(
+			blockIDLatest(t),
+			targetAddress,
+		)
+		require.Nil(t, nonce)
+		assert.Equal(t, rpccore.ErrBlockNotFound, rpcErr)
+	})
+
+	t.Run("non-existent block hash", func(t *testing.T) {
+		mockReader.EXPECT().StateAtBlockHash(&felt.Zero).Return(nil, nil, db.ErrKeyNotFound)
+
+		nonce, rpcErr := handler.Nonce(
+			blockIDHash(t, &felt.Zero),
+			targetAddress,
+		)
+		require.Nil(t, nonce)
+		assert.Equal(t, rpccore.ErrBlockNotFound, rpcErr)
+	})
+
+	t.Run("non-existent block number", func(t *testing.T) {
+		mockReader.EXPECT().StateAtBlockNumber(uint64(0)).Return(nil, nil, db.ErrKeyNotFound)
+
+		nonce, rpcErr := handler.Nonce(
+			blockIDNumber(t, 0),
+			targetAddress,
+		)
+		require.Nil(t, nonce)
+		assert.Equal(t, rpccore.ErrBlockNotFound, rpcErr)
+	})
+
+	mockState := mocks.NewMockStateReader(mockCtrl)
+
+	t.Run("non-existent contract", func(t *testing.T) {
+		mockReader.EXPECT().HeadState().Return(mockState, nopCloser, nil)
+		mockState.EXPECT().ContractNonce(&targetAddress).
+			Return(felt.Felt{}, errors.New("non-existent contract"))
+
+		nonce, rpcErr := handler.Nonce(
+			blockIDLatest(t),
+			targetAddress,
+		)
+		require.Nil(t, nonce)
+		assert.Equal(t, rpccore.ErrContractNotFound, rpcErr)
+	})
+
+	expectedNonce := new(felt.Felt).SetUint64(1)
+
+	t.Run("blockID - latest", func(t *testing.T) {
+		mockReader.EXPECT().HeadState().Return(mockState, nopCloser, nil)
+		mockState.EXPECT().ContractNonce(&targetAddress).Return(*expectedNonce, nil)
+
+		nonce, rpcErr := handler.Nonce(
+			blockIDLatest(t),
+			targetAddress,
+		)
+		require.Nil(t, rpcErr)
+		assert.Equal(t, expectedNonce, nonce)
+	})
+
+	t.Run("blockID - hash", func(t *testing.T) {
+		mockReader.EXPECT().StateAtBlockHash(&felt.Zero).Return(mockState, nopCloser, nil)
+		mockState.EXPECT().ContractNonce(&targetAddress).Return(*expectedNonce, nil)
+
+		nonce, rpcErr := handler.Nonce(
+			blockIDHash(t, &felt.Zero),
+			targetAddress,
+		)
+		require.Nil(t, rpcErr)
+		assert.Equal(t, expectedNonce, nonce)
+	})
+
+	t.Run("blockID - number", func(t *testing.T) {
+		mockReader.EXPECT().StateAtBlockNumber(uint64(0)).Return(mockState, nopCloser, nil)
+		mockState.EXPECT().ContractNonce(&targetAddress).Return(*expectedNonce, nil)
+
+		nonce, rpcErr := handler.Nonce(
+			blockIDNumber(t, 0),
+			targetAddress,
+		)
+		require.Nil(t, rpcErr)
+		assert.Equal(t, expectedNonce, nonce)
+	})
+	t.Run("blockID - pending", func(t *testing.T) {
+		mockReader.EXPECT().HeadState().Return(mockState, nopCloser, nil)
+		mockState.EXPECT().ContractNonce(&targetAddress).Return(*expectedNonce, nil)
+
+		nonce, rpcErr := handler.Nonce(
+			blockIDPending(t),
+			targetAddress,
+		)
+		require.Nil(t, rpcErr)
+		assert.Equal(t, expectedNonce, nonce)
+	})
+}

--- a/rpc/v8/simulation.go
+++ b/rpc/v8/simulation.go
@@ -13,9 +13,9 @@ import (
 	"github.com/NethermindEth/juno/core/felt"
 	"github.com/NethermindEth/juno/jsonrpc"
 	"github.com/NethermindEth/juno/rpc/rpccore"
-	rpcv6 "github.com/NethermindEth/juno/rpc/v6"
 	"github.com/NethermindEth/juno/utils"
 	"github.com/NethermindEth/juno/vm"
+	"github.com/consensys/gnark-crypto/ecc/stark-curve/fp"
 )
 
 const ExecutionStepsHeader string = "X-Cairo-Steps"
@@ -35,6 +35,35 @@ type BroadcastedTransactionInputs = rpccore.LimitSlice[
 	rpccore.SimulationLimit,
 ]
 
+type SimulationFlag int
+
+const (
+	SkipValidateFlag SimulationFlag = iota + 1
+	SkipFeeChargeFlag
+)
+
+var RPCVersion3Value = felt.Felt(fp.Element(
+	[4]uint64{
+		18446744073709551521,
+		18446744073709551615,
+		18446744073709551615,
+		576460752303421872,
+	},
+))
+
+func (s *SimulationFlag) UnmarshalJSON(bytes []byte) (err error) {
+	switch flag := string(bytes); flag {
+	case `"SKIP_VALIDATE"`:
+		*s = SkipValidateFlag
+	case `"SKIP_FEE_CHARGE"`:
+		*s = SkipFeeChargeFlag
+	default:
+		err = fmt.Errorf("unknown simulation flag %q", flag)
+	}
+
+	return err
+}
+
 /****************************************************
 		Simulate Handlers
 *****************************************************/
@@ -43,7 +72,7 @@ func (h *Handler) SimulateTransactions(
 	ctx context.Context,
 	id *BlockID,
 	transactions BroadcastedTransactionInputs,
-	simulationFlags []rpcv6.SimulationFlag,
+	simulationFlags []SimulationFlag,
 ) ([]SimulatedTransaction, http.Header, *jsonrpc.Error) {
 	return h.simulateTransactions(ctx, id, transactions.Data, simulationFlags, false, false)
 }
@@ -52,12 +81,12 @@ func (h *Handler) simulateTransactions(
 	ctx context.Context,
 	id *BlockID,
 	transactions []BroadcastedTransaction,
-	simulationFlags []rpcv6.SimulationFlag,
+	simulationFlags []SimulationFlag,
 	errOnRevert bool,
 	isEstimateFee bool,
 ) ([]SimulatedTransaction, http.Header, *jsonrpc.Error) {
-	skipFeeCharge := slices.Contains(simulationFlags, rpcv6.SkipFeeChargeFlag)
-	skipValidate := slices.Contains(simulationFlags, rpcv6.SkipValidateFlag)
+	skipFeeCharge := slices.Contains(simulationFlags, SkipFeeChargeFlag)
+	skipValidate := slices.Contains(simulationFlags, SkipValidateFlag)
 
 	httpHeader := http.Header{}
 	httpHeader.Set(ExecutionStepsHeader, "0")

--- a/rpc/v8/simulation_test.go
+++ b/rpc/v8/simulation_test.go
@@ -11,7 +11,6 @@ import (
 	"github.com/NethermindEth/juno/jsonrpc"
 	"github.com/NethermindEth/juno/mocks"
 	"github.com/NethermindEth/juno/rpc/rpccore"
-	rpcv6 "github.com/NethermindEth/juno/rpc/v6"
 	rpc "github.com/NethermindEth/juno/rpc/v8"
 	"github.com/NethermindEth/juno/utils"
 	"github.com/NethermindEth/juno/vm"
@@ -54,7 +53,7 @@ func TestSimulateTransactions(t *testing.T) {
 			mockVM *mocks.MockVM,
 			mockState *mocks.MockStateReader,
 		)
-		simulationFlags []rpcv6.SimulationFlag
+		simulationFlags []rpc.SimulationFlag
 		simulatedTxs    []rpc.SimulatedTransaction
 	}{
 		{ //nolint:dupl
@@ -77,7 +76,7 @@ func TestSimulateTransactions(t *testing.T) {
 						NumSteps:         uint64(123),
 					}, nil)
 			},
-			simulationFlags: []rpcv6.SimulationFlag{rpcv6.SkipFeeChargeFlag},
+			simulationFlags: []rpc.SimulationFlag{rpc.SkipFeeChargeFlag},
 			simulatedTxs:    []rpc.SimulatedTransaction{},
 		},
 		{ //nolint:dupl
@@ -100,7 +99,7 @@ func TestSimulateTransactions(t *testing.T) {
 						NumSteps:         uint64(123),
 					}, nil)
 			},
-			simulationFlags: []rpcv6.SimulationFlag{rpcv6.SkipValidateFlag},
+			simulationFlags: []rpc.SimulationFlag{rpc.SkipValidateFlag},
 			simulatedTxs:    []rpc.SimulatedTransaction{},
 		},
 		{
@@ -119,7 +118,7 @@ func TestSimulateTransactions(t *testing.T) {
 						Cause: json.RawMessage("oops"),
 					})
 			},
-			simulationFlags: []rpcv6.SimulationFlag{rpcv6.SkipValidateFlag},
+			simulationFlags: []rpc.SimulationFlag{rpc.SkipValidateFlag},
 			err: rpccore.ErrTransactionExecutionError.CloneWithData(rpc.TransactionExecutionErrorData{
 				TransactionIndex: 44,
 				ExecutionError:   json.RawMessage("oops"),
@@ -144,7 +143,7 @@ func TestSimulateTransactions(t *testing.T) {
 						NumSteps:         uint64(0),
 					}, nil)
 			},
-			simulationFlags: []rpcv6.SimulationFlag{rpcv6.SkipValidateFlag},
+			simulationFlags: []rpc.SimulationFlag{rpc.SkipValidateFlag},
 			err: rpccore.ErrInternal.CloneWithData(errors.New(
 				"inconsistent lengths: 1 overall fees, 1 traces, 1 gas consumed, 2 data availability, 0 txns",
 			)),
@@ -297,7 +296,7 @@ func TestSimulateTransactionsShouldErrorWithoutSenderAddressOrResourceBounds(t *
 				t.Context(),
 				&blockID,
 				rpc.BroadcastedTransactionInputs{Data: test.transactions},
-				[]rpcv6.SimulationFlag{},
+				[]rpc.SimulationFlag{},
 			)
 			if test.err != nil {
 				require.Equal(t, test.err, err)

--- a/rpc/v8/state_update.go
+++ b/rpc/v8/state_update.go
@@ -1,0 +1,153 @@
+package rpcv8
+
+import (
+	"errors"
+
+	"github.com/NethermindEth/juno/core"
+	"github.com/NethermindEth/juno/core/felt"
+	"github.com/NethermindEth/juno/db"
+	"github.com/NethermindEth/juno/jsonrpc"
+	"github.com/NethermindEth/juno/rpc/rpccore"
+)
+
+// https://github.com/starkware-libs/starknet-specs/blob/v0.8.1/api/starknet_api_openrpc.json#L1416
+type StateUpdate struct {
+	BlockHash *felt.Felt `json:"block_hash,omitempty"`
+	NewRoot   *felt.Felt `json:"new_root,omitempty"`
+	OldRoot   *felt.Felt `json:"old_root"`
+	StateDiff *StateDiff `json:"state_diff"`
+}
+
+type StateDiff struct {
+	StorageDiffs              []StorageDiff      `json:"storage_diffs"`
+	Nonces                    []Nonce            `json:"nonces"`
+	DeployedContracts         []DeployedContract `json:"deployed_contracts"`
+	DeprecatedDeclaredClasses []*felt.Felt       `json:"deprecated_declared_classes"`
+	DeclaredClasses           []DeclaredClass    `json:"declared_classes"`
+	ReplacedClasses           []ReplacedClass    `json:"replaced_classes"`
+}
+
+type Nonce struct {
+	ContractAddress felt.Felt `json:"contract_address"`
+	Nonce           felt.Felt `json:"nonce"`
+}
+
+type StorageDiff struct {
+	Address        felt.Felt `json:"address"`
+	StorageEntries []Entry   `json:"storage_entries"`
+}
+
+type Entry struct {
+	Key   felt.Felt `json:"key"`
+	Value felt.Felt `json:"value"`
+}
+
+type DeployedContract struct {
+	Address   felt.Felt `json:"address"`
+	ClassHash felt.Felt `json:"class_hash"`
+}
+
+type ReplacedClass struct {
+	ContractAddress felt.Felt `json:"contract_address"`
+	ClassHash       felt.Felt `json:"class_hash"`
+}
+
+type DeclaredClass struct {
+	ClassHash         felt.Felt `json:"class_hash"`
+	CompiledClassHash felt.Felt `json:"compiled_class_hash"`
+}
+
+/****************************************************
+		StateUpdate Handlers
+*****************************************************/
+
+// StateUpdate returns the state update identified by the given BlockID.
+//
+// It follows the specification defined here:
+// https://github.com/starkware-libs/starknet-specs/blob/v0.8.1/api/starknet_api_openrpc.json#L136
+func (h *Handler) StateUpdate(id BlockID) (*StateUpdate, *jsonrpc.Error) {
+	var update *core.StateUpdate
+	var err error
+	if id.IsLatest() {
+		if height, heightErr := h.bcReader.Height(); heightErr != nil {
+			err = heightErr
+		} else {
+			update, err = h.bcReader.StateUpdateByNumber(height)
+		}
+	} else if id.IsPending() {
+		var pending *core.Pending
+		pending, err = h.Pending()
+		if err == nil {
+			update = pending.GetStateUpdate()
+		}
+	} else if id.Hash() != nil {
+		update, err = h.bcReader.StateUpdateByHash(id.Hash())
+	} else {
+		update, err = h.bcReader.StateUpdateByNumber(id.Number())
+	}
+	if err != nil {
+		if errors.Is(err, db.ErrKeyNotFound) {
+			return nil, rpccore.ErrBlockNotFound
+		}
+		return nil, rpccore.ErrInternal.CloneWithData(err)
+	}
+
+	nonces := make([]Nonce, 0, len(update.StateDiff.Nonces))
+	for addr, nonce := range update.StateDiff.Nonces {
+		nonces = append(nonces, Nonce{ContractAddress: addr, Nonce: *nonce})
+	}
+
+	storageDiffs := make([]StorageDiff, 0, len(update.StateDiff.StorageDiffs))
+	for addr, diffs := range update.StateDiff.StorageDiffs {
+		entries := make([]Entry, 0, len(diffs))
+		for key, value := range diffs {
+			entries = append(entries, Entry{
+				Key:   key,
+				Value: *value,
+			})
+		}
+
+		storageDiffs = append(storageDiffs, StorageDiff{
+			Address:        addr,
+			StorageEntries: entries,
+		})
+	}
+
+	deployedContracts := make([]DeployedContract, 0, len(update.StateDiff.DeployedContracts))
+	for addr, classHash := range update.StateDiff.DeployedContracts {
+		deployedContracts = append(deployedContracts, DeployedContract{
+			Address:   addr,
+			ClassHash: *classHash,
+		})
+	}
+
+	declaredClasses := make([]DeclaredClass, 0, len(update.StateDiff.DeclaredV1Classes))
+	for classHash, compiledClassHash := range update.StateDiff.DeclaredV1Classes {
+		declaredClasses = append(declaredClasses, DeclaredClass{
+			ClassHash:         classHash,
+			CompiledClassHash: *compiledClassHash,
+		})
+	}
+
+	replacedClasses := make([]ReplacedClass, 0, len(update.StateDiff.ReplacedClasses))
+	for addr, classHash := range update.StateDiff.ReplacedClasses {
+		replacedClasses = append(replacedClasses, ReplacedClass{
+			ClassHash:       *classHash,
+			ContractAddress: addr,
+		})
+	}
+
+	return &StateUpdate{
+		BlockHash: update.BlockHash,
+		OldRoot:   update.OldRoot,
+		NewRoot:   update.NewRoot,
+		StateDiff: &StateDiff{
+			DeprecatedDeclaredClasses: update.StateDiff.DeclaredV0Classes,
+			DeclaredClasses:           declaredClasses,
+			ReplacedClasses:           replacedClasses,
+			Nonces:                    nonces,
+			StorageDiffs:              storageDiffs,
+			DeployedContracts:         deployedContracts,
+		},
+	}, nil
+}

--- a/rpc/v8/state_update.go
+++ b/rpc/v8/state_update.go
@@ -75,6 +75,7 @@ func (h *Handler) StateUpdate(id BlockID) (*StateUpdate, *jsonrpc.Error) {
 			update, err = h.bcReader.StateUpdateByNumber(height)
 		}
 	} else if id.IsPending() {
+		//nolint:staticcheck // Necessary for v8
 		var pending *core.Pending
 		pending, err = h.Pending()
 		if err == nil {

--- a/rpc/v8/state_update.go
+++ b/rpc/v8/state_update.go
@@ -80,7 +80,7 @@ func (h *Handler) StateUpdate(id BlockID) (*StateUpdate, *jsonrpc.Error) {
 		if err == nil {
 			update = pending.GetStateUpdate()
 		}
-	} else if id.Hash() != nil {
+	} else if id.IsHash() {
 		update, err = h.bcReader.StateUpdateByHash(id.Hash())
 	} else {
 		update, err = h.bcReader.StateUpdateByNumber(id.Number())

--- a/rpc/v8/state_update_test.go
+++ b/rpc/v8/state_update_test.go
@@ -1,0 +1,200 @@
+package rpcv8_test
+
+import (
+	"testing"
+
+	"github.com/NethermindEth/juno/blockchain"
+	"github.com/NethermindEth/juno/clients/feeder"
+	"github.com/NethermindEth/juno/core"
+	"github.com/NethermindEth/juno/core/felt"
+	"github.com/NethermindEth/juno/db/memory"
+	"github.com/NethermindEth/juno/mocks"
+	"github.com/NethermindEth/juno/rpc/rpccore"
+	rpc "github.com/NethermindEth/juno/rpc/v8"
+	adaptfeeder "github.com/NethermindEth/juno/starknetdata/feeder"
+	"github.com/NethermindEth/juno/sync"
+	"github.com/NethermindEth/juno/utils"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+)
+
+func TestStateUpdate(t *testing.T) {
+	errTests := map[string]rpc.BlockID{
+		"latest":  blockIDLatest(t),
+		"pending": blockIDPending(t),
+		"hash":    blockIDHash(t, &felt.One),
+		"number":  blockIDNumber(t, 1),
+	}
+	mockCtrl := gomock.NewController(t)
+	t.Cleanup(mockCtrl.Finish)
+	var mockSyncReader *mocks.MockSyncReader
+
+	n := &utils.Mainnet
+	for description, id := range errTests {
+		t.Run(description, func(t *testing.T) {
+			chain := blockchain.New(memory.New(), n)
+
+			handler := rpc.New(chain, mockSyncReader, nil, nil)
+
+			update, rpcErr := handler.StateUpdate(id)
+			assert.Nil(t, update)
+			assert.Equal(t, rpccore.ErrBlockNotFound, rpcErr)
+		})
+	}
+
+	mockReader := mocks.NewMockReader(mockCtrl)
+	handler := rpc.New(mockReader, mockSyncReader, nil, nil)
+	client := feeder.NewTestClient(t, n)
+	mainnetGw := adaptfeeder.New(client)
+
+	update21656, err := mainnetGw.StateUpdate(t.Context(), 21656)
+	require.NoError(t, err)
+
+	checkUpdate := func(t *testing.T, coreUpdate *core.StateUpdate, rpcUpdate *rpc.StateUpdate) {
+		t.Helper()
+		require.Equal(t, coreUpdate.BlockHash, rpcUpdate.BlockHash)
+		require.Equal(t, coreUpdate.NewRoot, rpcUpdate.NewRoot)
+		require.Equal(t, coreUpdate.OldRoot, rpcUpdate.OldRoot)
+
+		require.Equal(t,
+			len(coreUpdate.StateDiff.StorageDiffs),
+			len(rpcUpdate.StateDiff.StorageDiffs),
+		)
+		for _, diff := range rpcUpdate.StateDiff.StorageDiffs {
+			coreDiffs := coreUpdate.StateDiff.StorageDiffs[diff.Address]
+			require.Equal(t, len(coreDiffs), len(diff.StorageEntries))
+			for _, entry := range diff.StorageEntries {
+				require.Equal(t, *coreDiffs[entry.Key], entry.Value)
+			}
+		}
+
+		require.Equal(t, len(coreUpdate.StateDiff.Nonces), len(rpcUpdate.StateDiff.Nonces))
+		for _, nonce := range rpcUpdate.StateDiff.Nonces {
+			require.Equal(t, *coreUpdate.StateDiff.Nonces[nonce.ContractAddress], nonce.Nonce)
+		}
+
+		require.Equal(
+			t,
+			len(coreUpdate.StateDiff.DeployedContracts),
+			len(rpcUpdate.StateDiff.DeployedContracts),
+		)
+		for _, deployedContract := range rpcUpdate.StateDiff.DeployedContracts {
+			require.Equal(
+				t,
+				*coreUpdate.StateDiff.DeployedContracts[deployedContract.Address],
+				deployedContract.ClassHash,
+			)
+		}
+
+		require.Equal(
+			t,
+			coreUpdate.StateDiff.DeclaredV0Classes,
+			rpcUpdate.StateDiff.DeprecatedDeclaredClasses,
+		)
+
+		require.Equal(
+			t,
+			len(coreUpdate.StateDiff.ReplacedClasses),
+			len(rpcUpdate.StateDiff.ReplacedClasses),
+		)
+		for index := range rpcUpdate.StateDiff.ReplacedClasses {
+			require.Equal(t,
+				*coreUpdate.
+					StateDiff.
+					ReplacedClasses[rpcUpdate.StateDiff.ReplacedClasses[index].ContractAddress],
+				rpcUpdate.StateDiff.ReplacedClasses[index].ClassHash,
+			)
+		}
+
+		require.Equal(t,
+			len(coreUpdate.StateDiff.DeclaredV1Classes),
+			len(rpcUpdate.StateDiff.DeclaredClasses),
+		)
+		for index := range rpcUpdate.StateDiff.DeclaredClasses {
+			require.Equal(
+				t,
+				*coreUpdate.
+					StateDiff.
+					DeclaredV1Classes[rpcUpdate.StateDiff.DeclaredClasses[index].ClassHash],
+				rpcUpdate.StateDiff.DeclaredClasses[index].CompiledClassHash,
+			)
+		}
+	}
+
+	t.Run("latest", func(t *testing.T) {
+		mockReader.EXPECT().Height().Return(uint64(21656), nil)
+		mockReader.EXPECT().StateUpdateByNumber(uint64(21656)).Return(update21656, nil)
+
+		update, rpcErr := handler.StateUpdate(blockIDLatest(t))
+		require.Nil(t, rpcErr)
+		checkUpdate(t, update21656, update)
+	})
+
+	t.Run("by height", func(t *testing.T) {
+		mockReader.EXPECT().StateUpdateByNumber(uint64(21656)).Return(update21656, nil)
+
+		update, rpcErr := handler.StateUpdate(blockIDNumber(t, 21656))
+		require.Nil(t, rpcErr)
+		checkUpdate(t, update21656, update)
+	})
+
+	t.Run("by hash", func(t *testing.T) {
+		mockReader.EXPECT().StateUpdateByHash(update21656.BlockHash).Return(update21656, nil)
+
+		update, rpcErr := handler.StateUpdate(blockIDHash(t, update21656.BlockHash))
+		require.Nil(t, rpcErr)
+		checkUpdate(t, update21656, update)
+	})
+
+	t.Run("post v0.11.0", func(t *testing.T) {
+		integrationClient := feeder.NewTestClient(t, &utils.Integration)
+		integGw := adaptfeeder.New(integrationClient)
+
+		for name, height := range map[string]uint64{
+			"declared Cairo0 classes": 283746,
+			"declared Cairo1 classes": 283364,
+			"replaced classes":        283428,
+		} {
+			t.Run(name, func(t *testing.T) {
+				gwUpdate, err := integGw.StateUpdate(t.Context(), height)
+				require.NoError(t, err)
+
+				mockReader.EXPECT().StateUpdateByNumber(height).Return(gwUpdate, nil)
+
+				update, rpcErr := handler.StateUpdate(blockIDNumber(t, height))
+				require.Nil(t, rpcErr)
+
+				checkUpdate(t, gwUpdate, update)
+			})
+		}
+	})
+
+	t.Run("pending", func(t *testing.T) {
+		update21656, err := mainnetGw.StateUpdate(t.Context(), 21656)
+		require.NoError(t, err)
+
+		blockToRegisterHash := core.Header{
+			Hash:   felt.NewUnsafeFromString[felt.Felt]("0xFFFF"),
+			Number: 21647,
+		}
+		// to update block hash registry
+		mockReader.EXPECT().BlockHeaderByNumber(blockToRegisterHash.Number).
+			Return(&blockToRegisterHash, nil)
+		mockReader.EXPECT().HeadsHeader().Return(&core.Header{
+			GlobalStateRoot: update21656.NewRoot,
+			Number:          21656,
+		}, nil)
+
+		update, rpcErr := handler.StateUpdate(blockIDPending(t))
+		require.Nil(t, rpcErr)
+		expectedStateDiff := core.EmptyStateDiff()
+		expectedStateDiff.StorageDiffs[*sync.BlockHashStorageContract] = map[felt.Felt]*felt.Felt{
+			felt.FromUint64[felt.Felt](blockToRegisterHash.Number): blockToRegisterHash.Hash,
+		}
+		checkUpdate(t, &core.StateUpdate{
+			OldRoot:   update21656.NewRoot,
+			StateDiff: &expectedStateDiff,
+		}, update)
+	})
+}

--- a/rpc/v8/subscriptions.go
+++ b/rpc/v8/subscriptions.go
@@ -41,6 +41,8 @@ func (e errorTxnHashNotFound) Error() string {
 	return fmt.Sprintf("transaction %v not found", e.txHash)
 }
 
+type SubscriptionID string
+
 // As per the spec, this is the same as BlockID, but without `pending`
 type SubscriptionBlockID BlockID
 
@@ -104,6 +106,11 @@ func unsubscribeFeedSubscription[T any](sub *feed.Subscription[T]) {
 	if sub != nil {
 		sub.Unsubscribe()
 	}
+}
+
+func (h *Handler) unsubscribe(sub *subscription, id string) {
+	sub.cancel()
+	h.subscriptions.Delete(id)
 }
 
 func (h *Handler) subscribe(

--- a/rpc/v8/sync.go
+++ b/rpc/v8/sync.go
@@ -1,0 +1,69 @@
+package rpcv8
+
+import (
+	"encoding/json"
+
+	"github.com/NethermindEth/juno/core/felt"
+	"github.com/NethermindEth/juno/jsonrpc"
+)
+
+// https://github.com/starkware-libs/starknet-specs/blob/v0.8.1/api/starknet_api_openrpc.json#L1228
+type Sync struct {
+	Syncing             *bool      `json:"-"`
+	StartingBlockHash   *felt.Felt `json:"starting_block_hash,omitempty"`
+	StartingBlockNumber *uint64    `json:"starting_block_num,omitempty"`
+	CurrentBlockHash    *felt.Felt `json:"current_block_hash,omitempty"`
+	CurrentBlockNumber  *uint64    `json:"current_block_num,omitempty"`
+	HighestBlockHash    *felt.Felt `json:"highest_block_hash,omitempty"`
+	HighestBlockNumber  *uint64    `json:"highest_block_num,omitempty"`
+}
+
+func (s Sync) MarshalJSON() ([]byte, error) {
+	if s.Syncing != nil && !*s.Syncing {
+		return json.Marshal(false)
+	}
+
+	type alias Sync
+	return json.Marshal(alias(s))
+}
+
+/****************************************************
+		Syncing Handlers
+*****************************************************/
+
+// Syncing returns the syncing status of the node.
+//
+// It follows the specification defined here:
+// https://github.com/starkware-libs/starknet-specs/blob/v0.8.1/api/starknet_api_openrpc.json#L772
+func (h *Handler) Syncing() (*Sync, *jsonrpc.Error) {
+	defaultSyncState := &Sync{Syncing: new(bool)}
+
+	startingBlockNumber, err := h.syncReader.StartingBlockNumber()
+	if err != nil {
+		return defaultSyncState, nil
+	}
+	startingBlockHeader, err := h.bcReader.BlockHeaderByNumber(startingBlockNumber)
+	if err != nil {
+		return defaultSyncState, nil
+	}
+	head, err := h.bcReader.HeadsHeader()
+	if err != nil {
+		return defaultSyncState, nil
+	}
+	highestBlockHeader := h.syncReader.HighestBlockHeader()
+	if highestBlockHeader == nil {
+		return defaultSyncState, nil
+	}
+	if highestBlockHeader.Number <= head.Number {
+		return defaultSyncState, nil
+	}
+
+	return &Sync{
+		StartingBlockHash:   startingBlockHeader.Hash,
+		StartingBlockNumber: &startingBlockHeader.Number,
+		CurrentBlockHash:    head.Hash,
+		CurrentBlockNumber:  &head.Number,
+		HighestBlockHash:    highestBlockHeader.Hash,
+		HighestBlockNumber:  &highestBlockHeader.Number,
+	}, nil
+}

--- a/rpc/v8/sync_test.go
+++ b/rpc/v8/sync_test.go
@@ -56,7 +56,9 @@ func TestSyncing(t *testing.T) {
 		assert.Equal(t, &rpc.Sync{Syncing: &defaultSyncState}, syncing)
 	})
 
-	synchronizer.EXPECT().HighestBlockHeader().Return(&core.Header{Number: 2, Hash: new(felt.Felt).SetUint64(2)}).Times(2)
+	synchronizer.EXPECT().HighestBlockHeader().Return(
+		&core.Header{Number: 2, Hash: new(felt.Felt).SetUint64(2)},
+	).Times(2)
 	t.Run("block height is equal to highest block", func(t *testing.T) {
 		mockReader.EXPECT().BlockHeaderByNumber(startingBlock).Return(&core.Header{}, nil)
 		mockReader.EXPECT().HeadsHeader().Return(&core.Header{Number: 2}, nil)
@@ -67,7 +69,10 @@ func TestSyncing(t *testing.T) {
 	})
 	t.Run("syncing", func(t *testing.T) {
 		mockReader.EXPECT().BlockHeaderByNumber(startingBlock).Return(&core.Header{Hash: &felt.Zero}, nil)
-		mockReader.EXPECT().HeadsHeader().Return(&core.Header{Number: 1, Hash: new(felt.Felt).SetUint64(1)}, nil)
+		mockReader.EXPECT().HeadsHeader().Return(
+			&core.Header{Number: 1, Hash: new(felt.Felt).SetUint64(1)},
+			nil,
+		)
 
 		currentBlockNumber := uint64(1)
 		highestBlockNumber := uint64(2)

--- a/rpc/v8/sync_test.go
+++ b/rpc/v8/sync_test.go
@@ -1,0 +1,86 @@
+package rpcv8_test
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/NethermindEth/juno/core"
+	"github.com/NethermindEth/juno/core/felt"
+	"github.com/NethermindEth/juno/mocks"
+	rpc "github.com/NethermindEth/juno/rpc/v8"
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/mock/gomock"
+)
+
+func TestSyncing(t *testing.T) {
+	mockCtrl := gomock.NewController(t)
+	t.Cleanup(mockCtrl.Finish)
+
+	synchronizer := mocks.NewMockSyncReader(mockCtrl)
+	mockReader := mocks.NewMockReader(mockCtrl)
+	handler := rpc.New(mockReader, synchronizer, nil, nil)
+	defaultSyncState := false
+
+	startingBlock := uint64(0)
+	synchronizer.EXPECT().StartingBlockNumber().Return(startingBlock, errors.New("nope"))
+	t.Run("undefined starting block", func(t *testing.T) {
+		syncing, err := handler.Syncing()
+		assert.Nil(t, err)
+		assert.Equal(t, &rpc.Sync{Syncing: &defaultSyncState}, syncing)
+	})
+
+	synchronizer.EXPECT().StartingBlockNumber().Return(startingBlock, nil).AnyTimes()
+	t.Run("empty blockchain", func(t *testing.T) {
+		mockReader.EXPECT().BlockHeaderByNumber(startingBlock).Return(nil, errors.New("empty blockchain"))
+
+		syncing, err := handler.Syncing()
+		assert.Nil(t, err)
+		assert.Equal(t, &rpc.Sync{Syncing: &defaultSyncState}, syncing)
+	})
+
+	synchronizer.EXPECT().HighestBlockHeader().Return(nil).Times(2)
+	t.Run("undefined highest block", func(t *testing.T) {
+		mockReader.EXPECT().BlockHeaderByNumber(startingBlock).Return(&core.Header{}, nil)
+		mockReader.EXPECT().HeadsHeader().Return(&core.Header{}, nil)
+
+		syncing, err := handler.Syncing()
+		assert.Nil(t, err)
+		assert.Equal(t, &rpc.Sync{Syncing: &defaultSyncState}, syncing)
+	})
+	t.Run("block height is greater than highest block", func(t *testing.T) {
+		mockReader.EXPECT().BlockHeaderByNumber(startingBlock).Return(&core.Header{}, nil)
+		mockReader.EXPECT().HeadsHeader().Return(&core.Header{Number: 1}, nil)
+
+		syncing, err := handler.Syncing()
+		assert.Nil(t, err)
+		assert.Equal(t, &rpc.Sync{Syncing: &defaultSyncState}, syncing)
+	})
+
+	synchronizer.EXPECT().HighestBlockHeader().Return(&core.Header{Number: 2, Hash: new(felt.Felt).SetUint64(2)}).Times(2)
+	t.Run("block height is equal to highest block", func(t *testing.T) {
+		mockReader.EXPECT().BlockHeaderByNumber(startingBlock).Return(&core.Header{}, nil)
+		mockReader.EXPECT().HeadsHeader().Return(&core.Header{Number: 2}, nil)
+
+		syncing, err := handler.Syncing()
+		assert.Nil(t, err)
+		assert.Equal(t, &rpc.Sync{Syncing: &defaultSyncState}, syncing)
+	})
+	t.Run("syncing", func(t *testing.T) {
+		mockReader.EXPECT().BlockHeaderByNumber(startingBlock).Return(&core.Header{Hash: &felt.Zero}, nil)
+		mockReader.EXPECT().HeadsHeader().Return(&core.Header{Number: 1, Hash: new(felt.Felt).SetUint64(1)}, nil)
+
+		currentBlockNumber := uint64(1)
+		highestBlockNumber := uint64(2)
+		expectedSyncing := &rpc.Sync{
+			StartingBlockHash:   &felt.Zero,
+			StartingBlockNumber: &startingBlock,
+			CurrentBlockHash:    new(felt.Felt).SetUint64(1),
+			CurrentBlockNumber:  &currentBlockNumber,
+			HighestBlockHash:    new(felt.Felt).SetUint64(2),
+			HighestBlockNumber:  &highestBlockNumber,
+		}
+		syncing, err := handler.Syncing()
+		assert.Nil(t, err)
+		assert.Equal(t, expectedSyncing, syncing)
+	})
+}

--- a/rpc/v8/trace.go
+++ b/rpc/v8/trace.go
@@ -58,6 +58,13 @@ type FunctionInvocation struct {
 	IsReverted         bool                     `json:"is_reverted"`
 }
 
+// https://github.com/starkware-libs/starknet-specs/blob/v0.8.1/api/starknet_api_openrpc.json#L3135
+type FunctionCall struct {
+	ContractAddress    felt.Felt      `json:"contract_address"`
+	EntryPointSelector felt.Felt      `json:"entry_point_selector"`
+	Calldata           CalldataInputs `json:"calldata"`
+}
+
 type OrderedEvent struct {
 	Order uint64       `json:"order"`
 	Keys  []*felt.Felt `json:"keys"`

--- a/rpc/v8/trace.go
+++ b/rpc/v8/trace.go
@@ -14,7 +14,6 @@ import (
 	"github.com/NethermindEth/juno/db"
 	"github.com/NethermindEth/juno/jsonrpc"
 	"github.com/NethermindEth/juno/rpc/rpccore"
-	rpcv6 "github.com/NethermindEth/juno/rpc/v6"
 	"github.com/NethermindEth/juno/utils"
 	"github.com/NethermindEth/juno/vm"
 )
@@ -44,19 +43,32 @@ func (e ExecuteInvocation) MarshalJSON() ([]byte, error) {
 }
 
 type FunctionInvocation struct {
-	ContractAddress    felt.Felt                    `json:"contract_address"`
-	EntryPointSelector *felt.Felt                   `json:"entry_point_selector"`
-	Calldata           []felt.Felt                  `json:"calldata"`
-	CallerAddress      felt.Felt                    `json:"caller_address"`
-	ClassHash          *felt.Felt                   `json:"class_hash"`
-	EntryPointType     string                       `json:"entry_point_type"` // shouldnt we put it as enum here ?
-	CallType           string                       `json:"call_type"`        // shouldnt we put it as enum here ?
-	Result             []felt.Felt                  `json:"result"`
-	Calls              []FunctionInvocation         `json:"calls"`
-	Events             []rpcv6.OrderedEvent         `json:"events"`
-	Messages           []rpcv6.OrderedL2toL1Message `json:"messages"`
-	ExecutionResources *InnerExecutionResources     `json:"execution_resources"`
-	IsReverted         bool                         `json:"is_reverted"`
+	ContractAddress    felt.Felt                `json:"contract_address"`
+	EntryPointSelector *felt.Felt               `json:"entry_point_selector"`
+	Calldata           []felt.Felt              `json:"calldata"`
+	CallerAddress      felt.Felt                `json:"caller_address"`
+	ClassHash          *felt.Felt               `json:"class_hash"`
+	EntryPointType     string                   `json:"entry_point_type"` // shouldnt we put it as enum here ?
+	CallType           string                   `json:"call_type"`        // shouldnt we put it as enum here ?
+	Result             []felt.Felt              `json:"result"`
+	Calls              []FunctionInvocation     `json:"calls"`
+	Events             []OrderedEvent           `json:"events"`
+	Messages           []OrderedL2toL1Message   `json:"messages"`
+	ExecutionResources *InnerExecutionResources `json:"execution_resources"`
+	IsReverted         bool                     `json:"is_reverted"`
+}
+
+type OrderedEvent struct {
+	Order uint64       `json:"order"`
+	Keys  []*felt.Felt `json:"keys"`
+	Data  []*felt.Felt `json:"data"`
+}
+
+type OrderedL2toL1Message struct {
+	Order   uint64       `json:"order"`
+	From    *felt.Felt   `json:"from_address"`
+	To      *felt.Felt   `json:"to_address"`
+	Payload []*felt.Felt `json:"payload"`
 }
 
 /****************************************************

--- a/rpc/v8/trace.go
+++ b/rpc/v8/trace.go
@@ -26,7 +26,7 @@ type TransactionTrace struct {
 	FeeTransferInvocation *FunctionInvocation `json:"fee_transfer_invocation,omitempty"`
 	ConstructorInvocation *FunctionInvocation `json:"constructor_invocation,omitempty" validate:"required_if=Type DEPLOY_ACCOUNT"`
 	FunctionInvocation    *FunctionInvocation `json:"function_invocation,omitempty" validate:"required_if=Type L1_HANDLER"`
-	StateDiff             *rpcv6.StateDiff    `json:"state_diff,omitempty"`
+	StateDiff             *StateDiff          `json:"state_diff,omitempty"`
 	ExecutionResources    *ExecutionResources `json:"execution_resources"`
 }
 

--- a/rpc/v8/trace.go
+++ b/rpc/v8/trace.go
@@ -48,8 +48,8 @@ type FunctionInvocation struct {
 	Calldata           []felt.Felt              `json:"calldata"`
 	CallerAddress      felt.Felt                `json:"caller_address"`
 	ClassHash          *felt.Felt               `json:"class_hash"`
-	EntryPointType     string                   `json:"entry_point_type"` // shouldnt we put it as enum here ?
-	CallType           string                   `json:"call_type"`        // shouldnt we put it as enum here ?
+	EntryPointType     string                   `json:"entry_point_type"`
+	CallType           string                   `json:"call_type"`
 	Result             []felt.Felt              `json:"result"`
 	Calls              []FunctionInvocation     `json:"calls"`
 	Events             []OrderedEvent           `json:"events"`

--- a/rpc/v8/trace_test.go
+++ b/rpc/v8/trace_test.go
@@ -759,7 +759,7 @@ func TestAdaptVMTransactionTrace(t *testing.T) {
 			},
 			ConstructorInvocation: &vm.FunctionInvocation{},
 			FunctionInvocation:    &vm.ExecuteInvocation{},
-			StateDiff: &vm.StateDiff{ //nolint:dupl
+			StateDiff: &vm.StateDiff{ //nolint:dupl // Similar, but for different cases
 				StorageDiffs: []vm.StorageDiff{
 					{
 						Address: felt.Zero,
@@ -843,7 +843,7 @@ func TestAdaptVMTransactionTrace(t *testing.T) {
 					IsReverted: false,
 				},
 			},
-			StateDiff: &rpc.StateDiff{ //nolint:dupl
+			StateDiff: &rpc.StateDiff{ //nolint:dupl // Similar, but for different cases
 				StorageDiffs: []rpc.StorageDiff{
 					{
 						Address: felt.Zero,

--- a/rpc/v8/trace_test.go
+++ b/rpc/v8/trace_test.go
@@ -844,11 +844,11 @@ func TestAdaptVMTransactionTrace(t *testing.T) {
 					IsReverted: false,
 				},
 			},
-			StateDiff: &rpcv6.StateDiff{ //nolint:dupl
-				StorageDiffs: []rpcv6.StorageDiff{
+			StateDiff: &rpc.StateDiff{ //nolint:dupl
+				StorageDiffs: []rpc.StorageDiff{
 					{
 						Address: felt.Zero,
-						StorageEntries: []rpcv6.Entry{
+						StorageEntries: []rpc.Entry{
 							{
 								Key:   felt.Zero,
 								Value: felt.Zero,
@@ -856,13 +856,13 @@ func TestAdaptVMTransactionTrace(t *testing.T) {
 						},
 					},
 				},
-				Nonces: []rpcv6.Nonce{
+				Nonces: []rpc.Nonce{
 					{
 						ContractAddress: felt.Zero,
 						Nonce:           felt.Zero,
 					},
 				},
-				DeployedContracts: []rpcv6.DeployedContract{
+				DeployedContracts: []rpc.DeployedContract{
 					{
 						Address:   felt.Zero,
 						ClassHash: felt.Zero,
@@ -871,13 +871,13 @@ func TestAdaptVMTransactionTrace(t *testing.T) {
 				DeprecatedDeclaredClasses: []*felt.Felt{
 					&felt.Zero,
 				},
-				DeclaredClasses: []rpcv6.DeclaredClass{
+				DeclaredClasses: []rpc.DeclaredClass{
 					{
 						ClassHash:         felt.Zero,
 						CompiledClassHash: felt.Zero,
 					},
 				},
-				ReplacedClasses: []rpcv6.ReplacedClass{
+				ReplacedClasses: []rpc.ReplacedClass{
 					{
 						ContractAddress: felt.Zero,
 						ClassHash:       felt.Zero,

--- a/rpc/v8/trace_test.go
+++ b/rpc/v8/trace_test.go
@@ -14,7 +14,6 @@ import (
 	"github.com/NethermindEth/juno/db/memory"
 	"github.com/NethermindEth/juno/mocks"
 	"github.com/NethermindEth/juno/rpc/rpccore"
-	rpcv6 "github.com/NethermindEth/juno/rpc/v6"
 	rpc "github.com/NethermindEth/juno/rpc/v8"
 	"github.com/NethermindEth/juno/starknet"
 	adaptfeeder "github.com/NethermindEth/juno/starknetdata/feeder"
@@ -466,8 +465,8 @@ func TestTraceTransaction(t *testing.T) {
 				CallType:       "CALL",
 				Result:         []felt.Felt{*felt.NewUnsafeFromString[felt.Felt]("0x56414c4944")},
 				Calls:          []rpc.FunctionInvocation{},
-				Events:         []rpcv6.OrderedEvent{},
-				Messages:       []rpcv6.OrderedL2toL1Message{},
+				Events:         []rpc.OrderedEvent{},
+				Messages:       []rpc.OrderedL2toL1Message{},
 				ExecutionResources: &rpc.InnerExecutionResources{
 					L1Gas: 0,
 					L2Gas: 0,
@@ -501,7 +500,7 @@ func TestTraceTransaction(t *testing.T) {
 						CallType:       "DELEGATE",
 						Result:         []felt.Felt{*felt.NewUnsafeFromString[felt.Felt]("0x1")},
 						Calls:          []rpc.FunctionInvocation{},
-						Events: []rpcv6.OrderedEvent{
+						Events: []rpc.OrderedEvent{
 							{
 								Order: 0,
 								Keys:  []*felt.Felt{felt.NewUnsafeFromString[felt.Felt]("0x99cd8bde557814842a3121e8ddfd433a539b8c9f14bf31ebf108d12e6196e9")},
@@ -513,15 +512,15 @@ func TestTraceTransaction(t *testing.T) {
 								},
 							},
 						},
-						Messages: []rpcv6.OrderedL2toL1Message{},
+						Messages: []rpc.OrderedL2toL1Message{},
 						ExecutionResources: &rpc.InnerExecutionResources{
 							L1Gas: 0,
 							L2Gas: 0,
 						},
 					},
 				},
-				Events:   []rpcv6.OrderedEvent{},
-				Messages: []rpcv6.OrderedL2toL1Message{},
+				Events:   []rpc.OrderedEvent{},
+				Messages: []rpc.OrderedL2toL1Message{},
 				ExecutionResources: &rpc.InnerExecutionResources{
 					L1Gas: 0,
 					L2Gas: 0,
@@ -806,8 +805,8 @@ func TestAdaptVMTransactionTrace(t *testing.T) {
 			Type: rpc.TxnInvoke,
 			ValidateInvocation: &rpc.FunctionInvocation{
 				Calls:  []rpc.FunctionInvocation{},
-				Events: []rpcv6.OrderedEvent{},
-				Messages: []rpcv6.OrderedL2toL1Message{
+				Events: []rpc.OrderedEvent{},
+				Messages: []rpc.OrderedL2toL1Message{
 					{
 						Order: 0,
 						From:  fromAddr,
@@ -831,16 +830,16 @@ func TestAdaptVMTransactionTrace(t *testing.T) {
 			},
 			FeeTransferInvocation: &rpc.FunctionInvocation{
 				Calls:      []rpc.FunctionInvocation{},
-				Events:     []rpcv6.OrderedEvent{},
-				Messages:   []rpcv6.OrderedL2toL1Message{},
+				Events:     []rpc.OrderedEvent{},
+				Messages:   []rpc.OrderedL2toL1Message{},
 				IsReverted: false,
 			},
 			ExecuteInvocation: &rpc.ExecuteInvocation{
 				RevertReason: "",
 				FunctionInvocation: &rpc.FunctionInvocation{
 					Calls:      []rpc.FunctionInvocation{},
-					Events:     []rpcv6.OrderedEvent{},
-					Messages:   []rpcv6.OrderedL2toL1Message{},
+					Events:     []rpc.OrderedEvent{},
+					Messages:   []rpc.OrderedL2toL1Message{},
 					IsReverted: false,
 				},
 			},
@@ -906,18 +905,18 @@ func TestAdaptVMTransactionTrace(t *testing.T) {
 			Type: rpc.TxnDeployAccount,
 			ValidateInvocation: &rpc.FunctionInvocation{
 				Calls:    []rpc.FunctionInvocation{},
-				Events:   []rpcv6.OrderedEvent{},
-				Messages: []rpcv6.OrderedL2toL1Message{},
+				Events:   []rpc.OrderedEvent{},
+				Messages: []rpc.OrderedL2toL1Message{},
 			},
 			FeeTransferInvocation: &rpc.FunctionInvocation{
 				Calls:    []rpc.FunctionInvocation{},
-				Events:   []rpcv6.OrderedEvent{},
-				Messages: []rpcv6.OrderedL2toL1Message{},
+				Events:   []rpc.OrderedEvent{},
+				Messages: []rpc.OrderedL2toL1Message{},
 			},
 			ConstructorInvocation: &rpc.FunctionInvocation{
 				Calls:    []rpc.FunctionInvocation{},
-				Events:   []rpcv6.OrderedEvent{},
-				Messages: []rpcv6.OrderedL2toL1Message{},
+				Events:   []rpc.OrderedEvent{},
+				Messages: []rpc.OrderedL2toL1Message{},
 			},
 		}
 
@@ -946,8 +945,8 @@ func TestAdaptVMTransactionTrace(t *testing.T) {
 				Type: rpc.TxnL1Handler,
 				FunctionInvocation: &rpc.FunctionInvocation{
 					Calls:    []rpc.FunctionInvocation{},
-					Events:   []rpcv6.OrderedEvent{},
-					Messages: []rpcv6.OrderedL2toL1Message{},
+					Events:   []rpc.OrderedEvent{},
+					Messages: []rpc.OrderedL2toL1Message{},
 				},
 			}
 
@@ -1045,12 +1044,12 @@ func TestAdaptFeederBlockTrace(t *testing.T) {
 					Type: rpc.TxnL1Handler,
 					FunctionInvocation: &rpc.FunctionInvocation{
 						Calls: []rpc.FunctionInvocation{},
-						Events: []rpcv6.OrderedEvent{{
+						Events: []rpc.OrderedEvent{{
 							Order: 1,
 							Keys:  []*felt.Felt{new(felt.Felt).SetUint64(2)},
 							Data:  []*felt.Felt{new(felt.Felt).SetUint64(3)},
 						}},
-						Messages: []rpcv6.OrderedL2toL1Message{},
+						Messages: []rpc.OrderedL2toL1Message{},
 						ExecutionResources: &rpc.InnerExecutionResources{
 							L1Gas: 10,
 							L2Gas: 11,
@@ -1092,14 +1091,14 @@ func TestAdaptFeederBlockTrace(t *testing.T) {
 					Type: rpc.TxnInvoke,
 					FeeTransferInvocation: &rpc.FunctionInvocation{
 						Calls:              []rpc.FunctionInvocation{},
-						Events:             []rpcv6.OrderedEvent{},
-						Messages:           []rpcv6.OrderedL2toL1Message{},
+						Events:             []rpc.OrderedEvent{},
+						Messages:           []rpc.OrderedL2toL1Message{},
 						ExecutionResources: &rpc.InnerExecutionResources{},
 					},
 					ValidateInvocation: &rpc.FunctionInvocation{
 						Calls:              []rpc.FunctionInvocation{},
-						Events:             []rpcv6.OrderedEvent{},
-						Messages:           []rpcv6.OrderedL2toL1Message{},
+						Events:             []rpc.OrderedEvent{},
+						Messages:           []rpc.OrderedL2toL1Message{},
 						ExecutionResources: &rpc.InnerExecutionResources{},
 					},
 					ExecuteInvocation: &rpc.ExecuteInvocation{


### PR DESCRIPTION
Make RPC v8 self-contained, so that it no longer depends on code from v6 pkg.
