### PR TITLE
Reapply "refactor: deprecate HeapPtr use new instead"

### DIFF
--- a/adapters/consensus2p2p/proposal.go
+++ b/adapters/consensus2p2p/proposal.go
@@ -4,7 +4,6 @@ import (
 	"github.com/NethermindEth/juno/adapters/core2p2p"
 	consensus "github.com/NethermindEth/juno/consensus/types"
 	"github.com/NethermindEth/juno/core/felt"
-	"github.com/NethermindEth/juno/utils"
 	"github.com/starknet-io/starknet-p2p-specs/p2p/proto/common"
 	p2pconsensus "github.com/starknet-io/starknet-p2p-specs/p2p/proto/consensus/consensus"
 )
@@ -27,7 +26,7 @@ func toFelt252(val *felt.Felt) *common.Felt252 {
 func AdaptProposalInit(msg *consensus.ProposalInit) p2pconsensus.ProposalInit {
 	var validRound *uint32
 	if msg.ValidRound >= 0 {
-		validRound = utils.HeapPtr(uint32(msg.ValidRound))
+		validRound = new(uint32(msg.ValidRound))
 	}
 
 	return p2pconsensus.ProposalInit{

--- a/adapters/core2p2p/receipt.go
+++ b/adapters/core2p2p/receipt.go
@@ -69,7 +69,7 @@ func receiptCommon(r *core.TransactionReceipt) *receipt.Receipt_Common {
 		revertReason = &r.RevertReason
 	} else if r.Reverted {
 		// in some cases receipt marked as reverted may contain empty string in revert_reason
-		revertReason = utils.HeapPtr("")
+		revertReason = new("")
 	}
 
 	return &receipt.Receipt_Common{

--- a/adapters/vm2core/vm2core_test.go
+++ b/adapters/vm2core/vm2core_test.go
@@ -6,7 +6,6 @@ import (
 	"github.com/NethermindEth/juno/adapters/vm2core"
 	"github.com/NethermindEth/juno/core"
 	"github.com/NethermindEth/juno/core/felt"
-	"github.com/NethermindEth/juno/utils"
 	"github.com/NethermindEth/juno/vm"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/stretchr/testify/require"
@@ -60,10 +59,10 @@ func TestAdaptOrderedMessagesToL1(t *testing.T) {
 		messages = append(messages, vm.OrderedL2toL1Message{Order: uint64(i)})
 	}
 	require.Equal(t, []*core.L2ToL1Message{
-		utils.HeapPtr(vm2core.AdaptOrderedMessageToL1(&messages[4])),
-		utils.HeapPtr(vm2core.AdaptOrderedMessageToL1(&messages[3])),
-		utils.HeapPtr(vm2core.AdaptOrderedMessageToL1(&messages[2])),
-		utils.HeapPtr(vm2core.AdaptOrderedMessageToL1(&messages[1])),
-		utils.HeapPtr(vm2core.AdaptOrderedMessageToL1(&messages[0])),
+		new(vm2core.AdaptOrderedMessageToL1(&messages[4])),
+		new(vm2core.AdaptOrderedMessageToL1(&messages[3])),
+		new(vm2core.AdaptOrderedMessageToL1(&messages[2])),
+		new(vm2core.AdaptOrderedMessageToL1(&messages[1])),
+		new(vm2core.AdaptOrderedMessageToL1(&messages[0])),
 	}, vm2core.AdaptOrderedMessagesToL1(messages))
 }

--- a/builder/state.go
+++ b/builder/state.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/NethermindEth/juno/core"
 	"github.com/NethermindEth/juno/core/felt"
-	"github.com/NethermindEth/juno/utils"
 )
 
 type BuildState struct {
@@ -55,7 +54,7 @@ func clonePreconfirmed(preconfirmed *core.PreConfirmed) *core.PreConfirmed {
 
 func cloneBlock(block *core.Block) *core.Block {
 	return &core.Block{
-		Header:       utils.HeapPtr(*block.Header),
+		Header:       new(*block.Header),
 		Transactions: block.Transactions,
 		Receipts:     block.Receipts,
 	}

--- a/clients/feeder/feeder_test.go
+++ b/clients/feeder/feeder_test.go
@@ -83,8 +83,8 @@ func TestDeclareTransactionUnmarshal(t *testing.T) {
 				),
 			},
 			Nonce:       new(felt.Felt).SetUint64(1),
-			NonceDAMode: utils.HeapPtr(starknet.DAModeL1),
-			FeeDAMode:   utils.HeapPtr(starknet.DAModeL1),
+			NonceDAMode: new(starknet.DAModeL1),
+			FeeDAMode:   new(starknet.DAModeL1),
 			ResourceBounds: &map[starknet.Resource]starknet.ResourceBounds{
 				starknet.ResourceL1Gas: {
 					MaxAmount:       felt.NewUnsafeFromString[felt.Felt]("0x186a0"),
@@ -177,8 +177,8 @@ func TestInvokeTransactionUnmarshal(t *testing.T) {
 				),
 			},
 			Nonce:       felt.NewUnsafeFromString[felt.Felt]("0xe97"),
-			NonceDAMode: utils.HeapPtr(starknet.DAModeL1),
-			FeeDAMode:   utils.HeapPtr(starknet.DAModeL1),
+			NonceDAMode: new(starknet.DAModeL1),
+			FeeDAMode:   new(starknet.DAModeL1),
 			ResourceBounds: &map[starknet.Resource]starknet.ResourceBounds{
 				starknet.ResourceL1Gas: {
 					MaxAmount:       felt.NewUnsafeFromString[felt.Felt]("0x186a0"),
@@ -381,8 +381,8 @@ func TestDeployAccountTransactionUnmarshal(t *testing.T) {
 				),
 			},
 			Nonce:       new(felt.Felt),
-			NonceDAMode: utils.HeapPtr(starknet.DAModeL1),
-			FeeDAMode:   utils.HeapPtr(starknet.DAModeL1),
+			NonceDAMode: new(starknet.DAModeL1),
+			FeeDAMode:   new(starknet.DAModeL1),
 			ResourceBounds: &map[starknet.Resource]starknet.ResourceBounds{
 				starknet.ResourceL1Gas: {
 					MaxAmount:       felt.NewUnsafeFromString[felt.Felt]("0x186a0"),

--- a/consensus/driver/driver_test.go
+++ b/consensus/driver/driver_test.go
@@ -95,22 +95,22 @@ func generateAndRegisterRandomActions(
 		case 0:
 			proposal := getRandProposal(random)
 			expectedBroadcast.proposals = append(expectedBroadcast.proposals, &proposal)
-			actions[i] = utils.HeapPtr(starknet.BroadcastProposal(proposal))
+			actions[i] = new(starknet.BroadcastProposal(proposal))
 		case 1:
 			prevote := getRandPrevote(random)
 			expectedBroadcast.prevotes = append(expectedBroadcast.prevotes, &prevote)
-			actions[i] = utils.HeapPtr(starknet.BroadcastPrevote(prevote))
+			actions[i] = new(starknet.BroadcastPrevote(prevote))
 		case 2:
 			precommit := getRandPrecommit(random)
 			expectedBroadcast.precommits = append(expectedBroadcast.precommits, &precommit)
-			actions[i] = utils.HeapPtr(starknet.BroadcastPrecommit(precommit))
+			actions[i] = new(starknet.BroadcastPrecommit(precommit))
 		}
 	}
 	return actions
 }
 
 func toAction(timeout types.Timeout) starknet.Action {
-	return utils.HeapPtr(actions.ScheduleTimeout(timeout))
+	return new(actions.ScheduleTimeout(timeout))
 }
 
 func increaseBroadcasterWaitGroup[M any](

--- a/consensus/p2p/validator/empty_fixtures_test.go
+++ b/consensus/p2p/validator/empty_fixtures_test.go
@@ -10,7 +10,6 @@ import (
 	"github.com/NethermindEth/juno/core"
 	"github.com/NethermindEth/juno/core/felt"
 	"github.com/NethermindEth/juno/db"
-	"github.com/NethermindEth/juno/utils"
 	"github.com/starknet-io/starknet-p2p-specs/p2p/proto/common"
 	"github.com/starknet-io/starknet-p2p-specs/p2p/proto/consensus/consensus"
 )
@@ -62,7 +61,7 @@ func NewEmptyTestFixture(
 			Init: &consensus.ProposalInit{
 				BlockNumber: uint64(testCase.Height),
 				Round:       uint32(testCase.Round),
-				ValidRound:  utils.HeapPtr(uint32(testCase.ValidRound)),
+				ValidRound:  new(uint32(testCase.ValidRound)),
 				Proposer:    &common.Address{Elements: ToBytes(*proposer)},
 			},
 		},
@@ -119,7 +118,7 @@ func EmptyBuildResult(headBlock *core.Block, proposer, expectedHash *felt.Felt, 
 			},
 			StateUpdate: &core.StateUpdate{
 				OldRoot:   headBlock.GlobalStateRoot,
-				StateDiff: utils.HeapPtr(core.EmptyStateDiff()),
+				StateDiff: new(core.EmptyStateDiff()),
 			},
 			NewClasses:            make(map[felt.Felt]core.ClassDefinition),
 			TransactionStateDiffs: []*core.StateDiff{},

--- a/consensus/p2p/validator/fixtures_test.go
+++ b/consensus/p2p/validator/fixtures_test.go
@@ -129,7 +129,7 @@ func buildProposalInit(
 ) consensus.ProposalPart {
 	var validRoundPtr *uint32
 	if testCase.ValidRound != -1 {
-		validRoundPtr = utils.HeapPtr(uint32(testCase.ValidRound))
+		validRoundPtr = new(uint32(testCase.ValidRound))
 	}
 
 	return consensus.ProposalPart{
@@ -284,7 +284,7 @@ func buildProposal(round, validRound types.Round, block *core.Block) starknetcon
 			Sender: starknetconsensus.Address(*block.SequencerAddress),
 		},
 		ValidRound: validRound,
-		Value:      utils.HeapPtr(starknetconsensus.Value(*block.Hash)),
+		Value:      new(starknetconsensus.Value(*block.Hash)),
 	}
 }
 
@@ -305,7 +305,7 @@ func buildPreState(buildResult *builder.BuildResult, headBlockHeader, revealedBl
 			},
 			StateUpdate: &core.StateUpdate{
 				OldRoot:   headBlockHeader.GlobalStateRoot,
-				StateDiff: utils.HeapPtr(core.EmptyStateDiff()),
+				StateDiff: new(core.EmptyStateDiff()),
 			},
 			NewClasses:            map[felt.Felt]core.ClassDefinition{},
 			TransactionStateDiffs: []*core.StateDiff{},

--- a/consensus/sync/sync_test.go
+++ b/consensus/sync/sync_test.go
@@ -129,7 +129,7 @@ func getTestData(
 			BlockHash: &blockHash,
 			NewRoot:   felt.NewRandom[felt.Felt](),
 			OldRoot:   felt.NewRandom[felt.Felt](),
-			StateDiff: utils.HeapPtr(core.EmptyStateDiff()),
+			StateDiff: new(core.EmptyStateDiff()),
 		},
 		NewClasses: make(map[felt.Felt]core.ClassDefinition),
 		Commitments: &core.BlockCommitments{

--- a/consensus/tendermint/action_asserter_test.go
+++ b/consensus/tendermint/action_asserter_test.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/NethermindEth/juno/consensus/starknet"
 	"github.com/NethermindEth/juno/consensus/types/actions"
-	"github.com/NethermindEth/juno/utils"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -46,7 +45,7 @@ func (a actionAsserter[T]) expectActions(expected ...starknet.Action) actionAsse
 
 func getHash(val *starknet.Value) *starknet.Hash {
 	if val != nil {
-		return utils.HeapPtr(val.Hash())
+		return new(val.Hash())
 	}
 	return nil
 }

--- a/consensus/tendermint/rule_first_proposal_test.go
+++ b/consensus/tendermint/rule_first_proposal_test.go
@@ -4,7 +4,6 @@ import (
 	"testing"
 
 	"github.com/NethermindEth/juno/consensus/types"
-	"github.com/NethermindEth/juno/utils"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -41,14 +40,14 @@ func TestFirstProposal(t *testing.T) {
 			previousRound.action().writeWALProposal(0, expectedValue, -1),
 			previousRound.action().broadcastPrevote(&expectedValue),
 		)
-		previousRound.validator(0).prevote(utils.HeapPtr(expectedValue))
+		previousRound.validator(0).prevote(new(expectedValue))
 		previousRound.validator(1).prevote(nil)
-		previousRound.validator(2).prevote(utils.HeapPtr(expectedValue))
+		previousRound.validator(2).prevote(new(expectedValue))
 		assertState(t, stateMachine, types.Height(0), types.Round(0), types.StepPrecommit)
 
 		// Validator 0 stays silent in the precommit step
 		previousRound.validator(1).precommit(nil)
-		previousRound.validator(2).precommit(utils.HeapPtr(expectedValue))
+		previousRound.validator(2).precommit(new(expectedValue))
 		assertState(t, stateMachine, types.Height(0), types.Round(0), types.StepPrecommit)
 		assert.Equal(t, &expectedValue, stateMachine.state.lockedValue)
 		assert.Equal(t, types.Round(0), stateMachine.state.lockedRound)
@@ -76,14 +75,14 @@ func TestFirstProposal(t *testing.T) {
 		// Validator 0 is a faulty proposer, proposing an invalid value to validator 1
 		previousRound.start()
 		previousRound.validator(0).proposal(expectedValue, -1)
-		previousRound.validator(0).prevote(utils.HeapPtr(expectedValue))
+		previousRound.validator(0).prevote(new(expectedValue))
 		previousRound.validator(1).prevote(nil)
-		previousRound.validator(2).prevote(utils.HeapPtr(expectedValue))
+		previousRound.validator(2).prevote(new(expectedValue))
 		assertState(t, stateMachine, types.Height(0), types.Round(0), types.StepPrecommit)
 
 		// Validator 0 stays silent in the precommit step
 		previousRound.validator(1).precommit(nil)
-		previousRound.validator(2).precommit(utils.HeapPtr(expectedValue))
+		previousRound.validator(2).precommit(new(expectedValue))
 		assertState(t, stateMachine, types.Height(0), types.Round(0), types.StepPrecommit)
 		assert.Equal(t, &expectedValue, stateMachine.state.lockedValue)
 		assert.Equal(t, types.Round(0), stateMachine.state.lockedRound)

--- a/consensus/tendermint/rule_polka_any_test.go
+++ b/consensus/tendermint/rule_polka_any_test.go
@@ -4,7 +4,6 @@ import (
 	"testing"
 
 	"github.com/NethermindEth/juno/consensus/types"
-	"github.com/NethermindEth/juno/utils"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -21,8 +20,8 @@ func TestPolkaAny(t *testing.T) {
 
 		// Receive 2 more prevotes combined with our own prevote, all in mixed value
 		currentRound.validator(1).prevote(nil)
-		currentRound.validator(2).prevote(utils.HeapPtr(value(44))).expectActions(
-			currentRound.action().writeWALPrevote(2, utils.HeapPtr(value(44))),
+		currentRound.validator(2).prevote(new(value(44))).expectActions(
+			currentRound.action().writeWALPrevote(2, new(value(44))),
 			currentRound.action().scheduleTimeout(types.StepPrevote),
 		)
 		assert.True(t, stateMachine.state.timeoutPrevoteScheduled)
@@ -42,7 +41,7 @@ func TestPolkaAny(t *testing.T) {
 		currentRound.validator(0).proposal(value(42), -1)
 
 		// Receive 1 more prevote (not enough for 2f+1 where f=1)
-		currentRound.validator(0).prevote(utils.HeapPtr(value(42)))
+		currentRound.validator(0).prevote(new(value(42)))
 
 		// No action should be taken
 		assertState(t, stateMachine, types.Height(0), types.Round(0), types.StepPrevote)
@@ -56,14 +55,14 @@ func TestPolkaAny(t *testing.T) {
 		currentRound.start()
 
 		// Add enough prevotes, but since we're not in prevote step, nothing should happen
-		currentRound.validator(0).prevote(utils.HeapPtr(value(42))).expectActions(
-			currentRound.action().writeWALPrevote(0, utils.HeapPtr(value(42))),
+		currentRound.validator(0).prevote(new(value(42))).expectActions(
+			currentRound.action().writeWALPrevote(0, new(value(42))),
 		)
-		currentRound.validator(1).prevote(utils.HeapPtr(value(43))).expectActions(
-			currentRound.action().writeWALPrevote(1, utils.HeapPtr(value(43))),
+		currentRound.validator(1).prevote(new(value(43))).expectActions(
+			currentRound.action().writeWALPrevote(1, new(value(43))),
 		)
-		currentRound.validator(2).prevote(utils.HeapPtr(value(44))).expectActions(
-			currentRound.action().writeWALPrevote(2, utils.HeapPtr(value(44))),
+		currentRound.validator(2).prevote(new(value(44))).expectActions(
+			currentRound.action().writeWALPrevote(2, new(value(44))),
 		)
 
 		// Assertions - still in propose step, no timeout should be scheduled
@@ -84,15 +83,15 @@ func TestPolkaAny(t *testing.T) {
 		currentRound.validator(0).prevote(nil).expectActions(
 			currentRound.action().writeWALPrevote(0, nil),
 		)
-		currentRound.validator(1).prevote(utils.HeapPtr(value(43))).expectActions(
-			currentRound.action().writeWALPrevote(1, utils.HeapPtr(value(43))),
+		currentRound.validator(1).prevote(new(value(43))).expectActions(
+			currentRound.action().writeWALPrevote(1, new(value(43))),
 			currentRound.action().scheduleTimeout(types.StepPrevote),
 		)
 		assert.True(t, stateMachine.state.timeoutPrevoteScheduled)
 
 		// Receive 1 more prevote, no timeout should be scheduled
-		currentRound.validator(2).prevote(utils.HeapPtr(value(44))).expectActions(
-			currentRound.action().writeWALPrevote(2, utils.HeapPtr(value(44))),
+		currentRound.validator(2).prevote(new(value(44))).expectActions(
+			currentRound.action().writeWALPrevote(2, new(value(44))),
 		)
 		assert.True(t, stateMachine.state.timeoutPrevoteScheduled)
 

--- a/consensus/tendermint/rule_precommit_any_test.go
+++ b/consensus/tendermint/rule_precommit_any_test.go
@@ -4,7 +4,6 @@ import (
 	"testing"
 
 	"github.com/NethermindEth/juno/consensus/types"
-	"github.com/NethermindEth/juno/utils"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -18,12 +17,12 @@ func TestPrecommitAny(t *testing.T) {
 
 		// We need to get to precommit step, so first go through proposal and prevote
 		currentRound.validator(0).proposal(value(42), -1)
-		currentRound.validator(0).prevote(utils.HeapPtr(value(42)))
+		currentRound.validator(0).prevote(new(value(42)))
 		currentRound.validator(1).prevote(nil)
-		currentRound.validator(2).prevote(utils.HeapPtr(value(42)))
+		currentRound.validator(2).prevote(new(value(42)))
 
 		// Receive 2 more precommits combined with our own precommit, all with mixed values
-		currentRound.validator(0).precommit(utils.HeapPtr(value(42)))
+		currentRound.validator(0).precommit(new(value(42)))
 		currentRound.validator(1).precommit(nil).expectActions(
 			currentRound.action().writeWALPrecommit(1, nil),
 			currentRound.action().scheduleTimeout(types.StepPrecommit),
@@ -41,10 +40,10 @@ func TestPrecommitAny(t *testing.T) {
 		currentRound.start()
 
 		// Receive 3 precommits even though we haven't received a proposal.
-		currentRound.validator(0).precommit(utils.HeapPtr(value(42)))
+		currentRound.validator(0).precommit(new(value(42)))
 		currentRound.validator(1).precommit(nil)
-		currentRound.validator(2).precommit(utils.HeapPtr(value(43))).expectActions(
-			currentRound.action().writeWALPrecommit(2, utils.HeapPtr(value(43))),
+		currentRound.validator(2).precommit(new(value(43))).expectActions(
+			currentRound.action().writeWALPrecommit(2, new(value(43))),
 			currentRound.action().scheduleTimeout(types.StepPrecommit),
 		)
 
@@ -61,12 +60,12 @@ func TestPrecommitAny(t *testing.T) {
 
 		// Set up to reach precommit step
 		currentRound.validator(0).proposal(value(42), -1)
-		currentRound.validator(0).prevote(utils.HeapPtr(value(42)))
-		currentRound.validator(1).prevote(utils.HeapPtr(value(42)))
+		currentRound.validator(0).prevote(new(value(42)))
+		currentRound.validator(1).prevote(new(value(42)))
 
 		// Receive 1 more precommit (not enough for 2f+1 where f=1)
-		currentRound.validator(1).precommit(utils.HeapPtr(value(42))).expectActions(
-			currentRound.action().writeWALPrecommit(1, utils.HeapPtr(value(42))),
+		currentRound.validator(1).precommit(new(value(42))).expectActions(
+			currentRound.action().writeWALPrecommit(1, new(value(42))),
 		)
 
 		// No timeout should be scheduled
@@ -85,21 +84,21 @@ func TestPrecommitAny(t *testing.T) {
 		// Validator 0 is a faulty proposer
 		currentRound.validator(0).proposal(value(42), -1).expectActions(
 			currentRound.action().writeWALProposal(0, value(42), -1),
-			currentRound.action().broadcastPrevote(utils.HeapPtr(value(42))),
+			currentRound.action().broadcastPrevote(new(value(42))),
 		)
-		currentRound.validator(0).prevote(utils.HeapPtr(value(42)))
-		currentRound.validator(1).prevote(utils.HeapPtr(value(42))).expectActions(
-			currentRound.action().writeWALPrevote(1, utils.HeapPtr(value(42))),
+		currentRound.validator(0).prevote(new(value(42)))
+		currentRound.validator(1).prevote(new(value(42))).expectActions(
+			currentRound.action().writeWALPrevote(1, new(value(42))),
 			currentRound.action().scheduleTimeout(types.StepPrevote),
-			currentRound.action().broadcastPrecommit(utils.HeapPtr(value(42))),
+			currentRound.action().broadcastPrecommit(new(value(42))),
 		)
 		assert.False(t, stateMachine.state.timeoutPrecommitScheduled)
 		assertState(t, stateMachine, types.Height(0), types.Round(0), types.StepPrecommit)
 
 		// Receive 2 precommits, combined with our own precommit and schedule timeout
 		currentRound.validator(0).precommit(nil)
-		currentRound.validator(1).precommit(utils.HeapPtr(value(42))).expectActions(
-			currentRound.action().writeWALPrecommit(1, utils.HeapPtr(value(42))),
+		currentRound.validator(1).precommit(new(value(42))).expectActions(
+			currentRound.action().writeWALPrecommit(1, new(value(42))),
 			currentRound.action().scheduleTimeout(types.StepPrecommit),
 		)
 		assert.True(t, stateMachine.state.timeoutPrecommitScheduled)

--- a/consensus/tendermint/start_test.go
+++ b/consensus/tendermint/start_test.go
@@ -4,7 +4,6 @@ import (
 	"testing"
 
 	"github.com/NethermindEth/juno/consensus/types"
-	"github.com/NethermindEth/juno/utils"
 )
 
 func TestStartRound(t *testing.T) {
@@ -17,7 +16,7 @@ func TestStartRound(t *testing.T) {
 		currentRound.start().expectActions(
 			currentRound.action().writeWALStart(),
 			currentRound.action().broadcastProposal(val, -1),
-			currentRound.action().broadcastPrevote(utils.HeapPtr(val)),
+			currentRound.action().broadcastPrevote(new(val)),
 		)
 
 		assertState(t, stateMachine, types.Height(0), types.Round(0), types.StepPrevote)

--- a/consensus/tendermint/tendermint.go
+++ b/consensus/tendermint/tendermint.go
@@ -120,7 +120,7 @@ func (s *stateMachine[V, H, A]) startRound(r types.Round) actions.Action[V, H, A
 		if s.state.validValue != nil {
 			proposalValue = s.state.validValue
 		} else {
-			proposalValue = utils.HeapPtr(s.application.Value())
+			proposalValue = new(s.application.Value())
 		}
 		actions := s.sendProposal(proposalValue)
 		return actions
@@ -130,7 +130,7 @@ func (s *stateMachine[V, H, A]) startRound(r types.Round) actions.Action[V, H, A
 }
 
 func (t *stateMachine[V, H, A]) scheduleTimeout(s types.Step) actions.Action[V, H, A] {
-	return utils.HeapPtr(
+	return new(
 		actions.ScheduleTimeout{
 			Step:   s,
 			Height: t.state.height,
@@ -148,6 +148,6 @@ func (s *stateMachine[V, H, A]) findProposal(r types.Round) *CachedProposal[V, H
 	return &CachedProposal[V, H, A]{
 		Proposal: *proposal,
 		Valid:    s.application.Valid(*proposal.Value),
-		ID:       utils.HeapPtr((*proposal.Value).Hash()),
+		ID:       new((*proposal.Value).Hash()),
 	}
 }

--- a/consensus/tendermint/timeout_test.go
+++ b/consensus/tendermint/timeout_test.go
@@ -4,7 +4,6 @@ import (
 	"testing"
 
 	"github.com/NethermindEth/juno/consensus/types"
-	"github.com/NethermindEth/juno/utils"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -32,7 +31,7 @@ func TestTimeout(t *testing.T) {
 
 		currentRound.start()
 		currentRound.validator(0).proposal(value(42), -1)
-		currentRound.validator(1).prevote(utils.HeapPtr(value(42)))
+		currentRound.validator(1).prevote(new(value(42)))
 		currentRound.validator(2).prevote(nil).expectActions(
 			currentRound.action().writeWALPrevote(2, nil),
 			currentRound.action().scheduleTimeout(types.StepPrevote),
@@ -54,7 +53,7 @@ func TestTimeout(t *testing.T) {
 		nextRound := newTestRound(t, stateMachine, 0, 1)
 
 		currentRound.start()
-		currentRound.validator(0).precommit(utils.HeapPtr(value(10)))
+		currentRound.validator(0).precommit(new(value(10)))
 		currentRound.validator(1).precommit(nil)
 		currentRound.validator(2).precommit(nil).expectActions(
 			currentRound.action().writeWALPrecommit(2, nil),

--- a/consensus/tendermint/wal_test.go
+++ b/consensus/tendermint/wal_test.go
@@ -23,7 +23,7 @@ func getPrevote(idx int, value *starknet.Value) starknet.Prevote {
 			Round:  types.Round(0),
 			Sender: *getVal(idx),
 		},
-		ID: utils.HeapPtr(value.Hash()),
+		ID: new(value.Hash()),
 	}
 }
 
@@ -34,7 +34,7 @@ func getPrecommit(idx int, value *starknet.Value) starknet.Precommit {
 			Round:  types.Round(0),
 			Sender: *getVal(idx),
 		},
-		ID: utils.HeapPtr(value.Hash()),
+		ID: new(value.Hash()),
 	}
 }
 

--- a/consensus/votecounter/round_data.go
+++ b/consensus/votecounter/round_data.go
@@ -2,7 +2,6 @@ package votecounter
 
 import (
 	"github.com/NethermindEth/juno/consensus/types"
-	"github.com/NethermindEth/juno/utils"
 )
 
 type roundMap[V types.Hashable[H], H types.Hash, A types.Addr] = map[types.Round]*roundData[V, H, A]
@@ -42,7 +41,7 @@ func (r *roundData[V, H, A]) addVote(vote *types.Vote[H, A], votingPower types.V
 	var perVote *ballotSet[A]
 	if vote.ID != nil {
 		if perVote = r.perIDVotes[*vote.ID]; perVote == nil {
-			perVote = utils.HeapPtr(newBallotSet[A]())
+			perVote = new(newBallotSet[A]())
 			r.perIDVotes[*vote.ID] = perVote
 		}
 	} else {

--- a/consensus/votecounter/round_data_test.go
+++ b/consensus/votecounter/round_data_test.go
@@ -9,7 +9,6 @@ import (
 	"github.com/NethermindEth/juno/consensus/starknet"
 	"github.com/NethermindEth/juno/consensus/types"
 	"github.com/NethermindEth/juno/core/felt"
-	"github.com/NethermindEth/juno/utils"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -69,7 +68,7 @@ func newVoteTestCase(addrIndex voter, voteType VoteType, idIndex *uint64) *voteT
 	var id *starknet.Hash
 	if idIndex != nil {
 		value := felt.FromUint64[starknet.Value](*idIndex)
-		id = utils.HeapPtr(value.Hash())
+		id = new(value.Hash())
 	}
 
 	return &voteTestCase{

--- a/consensus/votecounter/vote_counter.go
+++ b/consensus/votecounter/vote_counter.go
@@ -2,7 +2,6 @@ package votecounter
 
 import (
 	"github.com/NethermindEth/juno/consensus/types"
-	"github.com/NethermindEth/juno/utils"
 )
 
 type Validators[A types.Addr] interface {
@@ -83,7 +82,7 @@ func getOrCreateRoundData[V types.Hashable[H], H types.Hash, A types.Addr](
 ) *roundData[V, H, A] {
 	entry, ok := roundMap[round]
 	if !ok {
-		entry = utils.HeapPtr(newRoundData[V, H, A]())
+		entry = new(newRoundData[V, H, A]())
 		roundMap[round] = entry
 	}
 	return entry

--- a/migration/blocktransactions/blocktransactions_test.go
+++ b/migration/blocktransactions/blocktransactions_test.go
@@ -96,7 +96,7 @@ func runTestBlockTransactionsMigration(
 
 		require.NoError(
 			t,
-			core.ChainHeightBucket.Put(database, struct{}{}, utils.HeapPtr(chainHeight)),
+			core.ChainHeightBucket.Put(database, struct{}{}, new(chainHeight)),
 		)
 
 		conciter.ForEachIdx(counts, func(blockNumber int, count *int) {

--- a/rpc/v10/adapt_trace.go
+++ b/rpc/v10/adapt_trace.go
@@ -17,12 +17,12 @@ import (
 func AdaptVMTransactionTrace(trace *vm.TransactionTrace) TransactionTrace {
 	var validateInvocation *FunctionInvocation
 	if trace.ValidateInvocation != nil && trace.Type != vm.TxnL1Handler {
-		validateInvocation = utils.HeapPtr(AdaptVMFunctionInvocation(trace.ValidateInvocation))
+		validateInvocation = new(AdaptVMFunctionInvocation(trace.ValidateInvocation))
 	}
 
 	var feeTransferInvocation *FunctionInvocation
 	if trace.FeeTransferInvocation != nil && trace.Type != vm.TxnL1Handler {
-		feeTransferInvocation = utils.HeapPtr(
+		feeTransferInvocation = new(
 			AdaptVMFunctionInvocation(trace.FeeTransferInvocation),
 		)
 	}
@@ -34,28 +34,28 @@ func AdaptVMTransactionTrace(trace *vm.TransactionTrace) TransactionTrace {
 	switch trace.Type {
 	case vm.TxnDeployAccount, vm.TxnDeploy:
 		if trace.ConstructorInvocation != nil {
-			constructorInvocation = utils.HeapPtr(
+			constructorInvocation = new(
 				AdaptVMFunctionInvocation(trace.ConstructorInvocation),
 			)
 		}
 	case vm.TxnInvoke:
 		if trace.ExecuteInvocation != nil {
-			executeInvocation = utils.HeapPtr(AdaptVMExecuteInvocation(trace.ExecuteInvocation))
+			executeInvocation = new(AdaptVMExecuteInvocation(trace.ExecuteInvocation))
 		}
 	case vm.TxnL1Handler:
 		if trace.FunctionInvocation != nil {
-			functionInvocation = utils.HeapPtr(AdaptVMExecuteInvocation(trace.FunctionInvocation))
+			functionInvocation = new(AdaptVMExecuteInvocation(trace.FunctionInvocation))
 		}
 	}
 
 	var resources *ExecutionResources
 	if trace.ExecutionResources != nil {
-		resources = utils.HeapPtr(AdaptVMExecutionResources(trace.ExecutionResources))
+		resources = new(AdaptVMExecutionResources(trace.ExecutionResources))
 	}
 
 	var stateDiff *StateDiff
 	if trace.StateDiff != nil {
-		stateDiff = utils.HeapPtr(AdaptVMStateDiff(trace.StateDiff))
+		stateDiff = new(AdaptVMStateDiff(trace.StateDiff))
 	}
 
 	traceType := TransactionType(trace.Type)
@@ -80,7 +80,7 @@ func AdaptVMTransactionTrace(trace *vm.TransactionTrace) TransactionTrace {
 func AdaptVMExecuteInvocation(vmFnInvocation *vm.ExecuteInvocation) ExecuteInvocation {
 	var functionInvocation *FunctionInvocation
 	if vmFnInvocation.FunctionInvocation != nil {
-		functionInvocation = utils.HeapPtr(AdaptVMFunctionInvocation(vmFnInvocation.FunctionInvocation))
+		functionInvocation = new(AdaptVMFunctionInvocation(vmFnInvocation.FunctionInvocation))
 	}
 
 	return ExecuteInvocation{
@@ -325,20 +325,20 @@ func AdaptFeederBlockTrace(
 		}
 
 		if feederTrace.FeeTransferInvocation != nil && trace.Type != TxnL1Handler {
-			trace.FeeTransferInvocation = utils.HeapPtr(
+			trace.FeeTransferInvocation = new(
 				AdaptFeederFunctionInvocation(feederTrace.FeeTransferInvocation),
 			)
 		}
 
 		if feederTrace.ValidateInvocation != nil && trace.Type != TxnL1Handler {
-			trace.ValidateInvocation = utils.HeapPtr(
+			trace.ValidateInvocation = new(
 				AdaptFeederFunctionInvocation(feederTrace.ValidateInvocation),
 			)
 		}
 
 		var fnInvocation *FunctionInvocation
 		if fct := feederTrace.FunctionInvocation; fct != nil {
-			fnInvocation = utils.HeapPtr(AdaptFeederFunctionInvocation(fct))
+			fnInvocation = new(AdaptFeederFunctionInvocation(fct))
 		}
 
 		switch trace.Type {
@@ -415,8 +415,9 @@ func AdaptFeederFunctionInvocation(snFnInvocation *starknet.FunctionInvocation) 
 		Calls:              adaptedCalls,
 		Events:             adaptedEvents,
 		Messages:           adaptedMessages,
-		ExecutionResources: utils.HeapPtr(
-			adaptFeederExecutionResources(&snFnInvocation.ExecutionResources)),
+		ExecutionResources: new(
+			adaptFeederExecutionResources(&snFnInvocation.ExecutionResources),
+		),
 		IsReverted: snFnInvocation.Failed,
 	}
 }

--- a/rpc/v10/adapt_transaction.go
+++ b/rpc/v10/adapt_transaction.go
@@ -306,7 +306,7 @@ func adaptInvokeTransaction(t *core.InvokeTransaction) *Transaction {
 		Hash:               t.Hash(),
 		MaxFee:             t.MaxFee,
 		Version:            t.Version.AsFelt(),
-		Signature:          utils.HeapPtr(t.Signature()),
+		Signature:          new(t.Signature()),
 		Nonce:              t.Nonce,
 		CallData:           &t.CallData,
 		ContractAddress:    t.ContractAddress,
@@ -315,12 +315,12 @@ func adaptInvokeTransaction(t *core.InvokeTransaction) *Transaction {
 	}
 
 	if tx.Version.Uint64() == 3 {
-		tx.ResourceBounds = utils.HeapPtr(adaptResourceBounds(t.ResourceBounds))
+		tx.ResourceBounds = new(adaptResourceBounds(t.ResourceBounds))
 		tx.Tip = felt.NewFromUint64[felt.Felt](t.Tip)
 		tx.PaymasterData = &t.PaymasterData
 		tx.AccountDeploymentData = &t.AccountDeploymentData
-		tx.NonceDAMode = utils.HeapPtr(DataAvailabilityMode(t.NonceDAMode))
-		tx.FeeDAMode = utils.HeapPtr(DataAvailabilityMode(t.FeeDAMode))
+		tx.NonceDAMode = new(DataAvailabilityMode(t.NonceDAMode))
+		tx.FeeDAMode = new(DataAvailabilityMode(t.FeeDAMode))
 
 		if t.ProofFacts != nil {
 			tx.ProofFacts = &t.ProofFacts
@@ -335,7 +335,7 @@ func adaptDeclareTransaction(t *core.DeclareTransaction) *Transaction {
 		Type:              TxnDeclare,
 		MaxFee:            t.MaxFee,
 		Version:           t.Version.AsFelt(),
-		Signature:         utils.HeapPtr(t.Signature()),
+		Signature:         new(t.Signature()),
 		Nonce:             t.Nonce,
 		ClassHash:         t.ClassHash,
 		SenderAddress:     t.SenderAddress,
@@ -343,12 +343,12 @@ func adaptDeclareTransaction(t *core.DeclareTransaction) *Transaction {
 	}
 
 	if tx.Version.Uint64() == 3 {
-		tx.ResourceBounds = utils.HeapPtr(adaptResourceBounds(t.ResourceBounds))
+		tx.ResourceBounds = new(adaptResourceBounds(t.ResourceBounds))
 		tx.Tip = felt.NewFromUint64[felt.Felt](t.Tip)
 		tx.PaymasterData = &t.PaymasterData
 		tx.AccountDeploymentData = &t.AccountDeploymentData
-		tx.NonceDAMode = utils.HeapPtr(DataAvailabilityMode(t.NonceDAMode))
-		tx.FeeDAMode = utils.HeapPtr(DataAvailabilityMode(t.FeeDAMode))
+		tx.NonceDAMode = new(DataAvailabilityMode(t.NonceDAMode))
+		tx.FeeDAMode = new(DataAvailabilityMode(t.FeeDAMode))
 	}
 
 	return tx
@@ -359,7 +359,7 @@ func adaptDeployAccountTransaction(t *core.DeployAccountTransaction) *Transactio
 		Hash:                t.Hash(),
 		MaxFee:              t.MaxFee,
 		Version:             t.Version.AsFelt(),
-		Signature:           utils.HeapPtr(t.Signature()),
+		Signature:           new(t.Signature()),
 		Nonce:               t.Nonce,
 		Type:                TxnDeployAccount,
 		ContractAddressSalt: t.ContractAddressSalt,
@@ -368,11 +368,11 @@ func adaptDeployAccountTransaction(t *core.DeployAccountTransaction) *Transactio
 	}
 
 	if tx.Version.Uint64() == 3 {
-		tx.ResourceBounds = utils.HeapPtr(adaptResourceBounds(t.ResourceBounds))
+		tx.ResourceBounds = new(adaptResourceBounds(t.ResourceBounds))
 		tx.Tip = felt.NewFromUint64[felt.Felt](t.Tip)
 		tx.PaymasterData = &t.PaymasterData
-		tx.NonceDAMode = utils.HeapPtr(DataAvailabilityMode(t.NonceDAMode))
-		tx.FeeDAMode = utils.HeapPtr(DataAvailabilityMode(t.FeeDAMode))
+		tx.NonceDAMode = new(DataAvailabilityMode(t.NonceDAMode))
+		tx.FeeDAMode = new(DataAvailabilityMode(t.FeeDAMode))
 	}
 
 	return tx

--- a/rpc/v10/block_test.go
+++ b/rpc/v10/block_test.go
@@ -505,7 +505,7 @@ func TestBlockTransactionCount(t *testing.T) {
 	mockCtrl := gomock.NewController(t)
 	t.Cleanup(mockCtrl.Finish)
 	mockSyncReader := mocks.NewMockSyncReader(mockCtrl)
-	n := utils.HeapPtr(utils.Sepolia)
+	n := new(utils.Sepolia)
 	mockReader := mocks.NewMockReader(mockCtrl)
 	log := utils.NewNopZapLogger()
 	handler := rpc.New(mockReader, mockSyncReader, nil, log)
@@ -998,7 +998,7 @@ func TestRpcBlockAdaptation(t *testing.T) {
 	mockCtrl := gomock.NewController(t)
 	t.Cleanup(mockCtrl.Finish)
 
-	n := utils.HeapPtr(utils.Sepolia)
+	n := new(utils.Sepolia)
 	mockReader := mocks.NewMockReader(mockCtrl)
 	handler := rpc.New(mockReader, nil, nil, nil)
 
@@ -1032,7 +1032,7 @@ func TestRpcBlockAdaptation(t *testing.T) {
 }
 
 func TestBlockWithTxHashesV013(t *testing.T) {
-	network := utils.HeapPtr(utils.SepoliaIntegration)
+	network := new(utils.SepoliaIntegration)
 	blockNumber := uint64(16350)
 	client := feeder.NewTestClient(t, network)
 	block, commitments, stateUpdate := rpc.GetTestBlockWithCommitments(t, client, blockNumber)
@@ -1065,7 +1065,7 @@ func TestBlockWithTxHashesV013(t *testing.T) {
 			NewRoot:         block.GlobalStateRoot,
 			Number:          &block.Number,
 			ParentHash:      block.ParentHash,
-			L1DAMode:        utils.HeapPtr(rpc.Blob),
+			L1DAMode:        new(rpc.Blob),
 			L1GasPrice: &rpc.ResourcePrice{
 				InFri: felt.NewUnsafeFromString[felt.Felt]("0x17882b6aa74"),
 				InWei: felt.NewUnsafeFromString[felt.Felt]("0x3b9aca10"),
@@ -1122,8 +1122,8 @@ func TestBlockWithTxHashesV013(t *testing.T) {
 				Tip:                   felt.NewFromUint64[felt.Felt](tx.Tip),
 				PaymasterData:         &tx.PaymasterData,
 				AccountDeploymentData: &tx.AccountDeploymentData,
-				NonceDAMode:           utils.HeapPtr(rpc.DataAvailabilityMode(tx.NonceDAMode)),
-				FeeDAMode:             utils.HeapPtr(rpc.DataAvailabilityMode(tx.FeeDAMode)),
+				NonceDAMode:           new(rpc.DataAvailabilityMode(tx.NonceDAMode)),
+				FeeDAMode:             new(rpc.DataAvailabilityMode(tx.FeeDAMode)),
 			},
 		},
 	}, got)

--- a/rpc/v10/simulation.go
+++ b/rpc/v10/simulation.go
@@ -374,7 +374,7 @@ func createSimulatedTransactions(
 	simulatedTransactions := make([]SimulatedTransaction, len(overallFees))
 	for i, overallFee := range overallFees {
 		// Adapt transaction trace to rpc v10 trace
-		trace := utils.HeapPtr(AdaptVMTransactionTrace(&traces[i]))
+		trace := new(AdaptVMTransactionTrace(&traces[i]))
 
 		// Add root level execution resources
 		trace.ExecutionResources = &ExecutionResources{

--- a/rpc/v10/simulation_pkg_test.go
+++ b/rpc/v10/simulation_pkg_test.go
@@ -78,7 +78,7 @@ func TestCreateSimulatedTransactions(t *testing.T) {
 				L1DataGasConsumed: felt.NewFromUint64[felt.Felt](50),
 				L1DataGasPrice:    felt.NewFromUint64[felt.Felt](5),
 				OverallFee:        felt.NewFromUint64[felt.Felt](10),
-				Unit:              utils.HeapPtr(WEI),
+				Unit:              new(WEI),
 			},
 		},
 		{
@@ -99,7 +99,7 @@ func TestCreateSimulatedTransactions(t *testing.T) {
 				L1DataGasConsumed: felt.NewFromUint64[felt.Felt](70),
 				L1DataGasPrice:    felt.NewFromUint64[felt.Felt](6),
 				OverallFee:        felt.NewFromUint64[felt.Felt](20),
-				Unit:              utils.HeapPtr(FRI),
+				Unit:              new(FRI),
 			},
 		},
 	}

--- a/rpc/v10/subscriptions_test.go
+++ b/rpc/v10/subscriptions_test.go
@@ -432,7 +432,7 @@ func TestSubscribeEvents(t *testing.T) {
 
 	basicSubscriptionWithPreConfirmed := testCase{
 		description:    "Events from new blocks - status PRE_CONFIRMED",
-		finalityStatus: utils.HeapPtr(TxnFinalityStatusWithoutL1(TxnPreConfirmed)),
+		finalityStatus: new(TxnFinalityStatusWithoutL1(TxnPreConfirmed)),
 		blockID:        nil,
 		keys:           nil,
 		fromAddrs:      nil,
@@ -510,7 +510,7 @@ func TestSubscribeEvents(t *testing.T) {
 
 	eventsFromHistoricalBlocks := testCase{
 		description: "Events from historical blocks - default status, events from 2 block",
-		blockID:     utils.HeapPtr(SubscriptionBlockID(BlockIDFromNumber(b1.Number))),
+		blockID:     new(SubscriptionBlockID(BlockIDFromNumber(b1.Number))),
 		keys:        nil,
 		fromAddrs:   nil,
 		setupMocks: func() {
@@ -538,7 +538,7 @@ func TestSubscribeEvents(t *testing.T) {
 
 	eventsWithContinuationToken := testCase{
 		description: "Events with continuation token - default status",
-		blockID:     utils.HeapPtr(SubscriptionBlockID(BlockIDFromNumber(b1.Number))),
+		blockID:     new(SubscriptionBlockID(BlockIDFromNumber(b1.Number))),
 		keys:        nil,
 		fromAddrs:   nil,
 		setupMocks: func() {
@@ -595,7 +595,7 @@ func TestSubscribeEvents(t *testing.T) {
 	eventsWithFromAddressAndPreConfirmed := testCase{
 		description:    "Events with from_address filter, finality PRE_CONFIRMED",
 		blockID:        nil,
-		finalityStatus: utils.HeapPtr(TxnFinalityStatusWithoutL1(TxnPreConfirmed)),
+		finalityStatus: new(TxnFinalityStatusWithoutL1(TxnPreConfirmed)),
 		fromAddrs:      targetAddrs,
 		keys:           nil,
 		setupMocks: func() {
@@ -638,7 +638,7 @@ func TestSubscribeEvents(t *testing.T) {
 	eventsWithAllFilterAndPreConfirmed := testCase{
 		description:    "Events with from_address and key, finality PRE_CONFIRMED",
 		blockID:        nil,
-		finalityStatus: utils.HeapPtr(TxnFinalityStatusWithoutL1(TxnPreConfirmed)),
+		finalityStatus: new(TxnFinalityStatusWithoutL1(TxnPreConfirmed)),
 		fromAddrs:      targetAddrs,
 		keys:           keys,
 		setupMocks: func() {
@@ -679,7 +679,7 @@ func TestSubscribeEvents(t *testing.T) {
 
 	deduplication := testCase{
 		description:    "deduplicate events",
-		finalityStatus: utils.HeapPtr(TxnFinalityStatusWithoutL1(TxnPreConfirmed)),
+		finalityStatus: new(TxnFinalityStatusWithoutL1(TxnPreConfirmed)),
 		setupMocks: func() {
 			setupMockEventFiltererWithMultiple(
 				mockChain,
@@ -741,7 +741,7 @@ func TestSubscribeEvents(t *testing.T) {
 
 	deduplicationWithPreLatestOnStart := testCase{
 		description:    "deduplicate events with prelatest on start",
-		finalityStatus: utils.HeapPtr(TxnFinalityStatusWithoutL1(TxnPreConfirmed)),
+		finalityStatus: new(TxnFinalityStatusWithoutL1(TxnPreConfirmed)),
 		setupMocks: func() {
 			setupMockEventFiltererWithMultiple(
 				mockChain,
@@ -1890,7 +1890,7 @@ func TestSubscribeNewTransactions(t *testing.T) {
 			{
 				description: "on new pre_confirmed full of candidates",
 				notify: func() {
-					syncer.preConfirmed.Send(utils.HeapPtr(CreateTestPreConfirmed(t, newHead2, 0)))
+					syncer.preConfirmed.Send(new(CreateTestPreConfirmed(t, newHead2, 0)))
 				},
 				expect: [][]*SubscriptionNewTransaction{
 					toTransactionsWithFinalityStatus(

--- a/rpc/v10/transaction_test.go
+++ b/rpc/v10/transaction_test.go
@@ -1453,11 +1453,11 @@ func TestAddTransaction(t *testing.T) {
 				Times(1)
 
 			handler := rpcv10.New(nil, nil, nil, utils.NewNopZapLogger())
-			_, rpcErr := handler.AddTransaction(t.Context(), utils.HeapPtr(test.txn))
+			_, rpcErr := handler.AddTransaction(t.Context(), new(test.txn))
 			require.Equal(t, rpcErr.Code, rpccore.ErrInternal.Code)
 
 			handler = handler.WithGateway(mockGateway)
-			got, rpcErr := handler.AddTransaction(t.Context(), utils.HeapPtr(test.txn))
+			got, rpcErr := handler.AddTransaction(t.Context(), new(test.txn))
 			require.Nil(t, rpcErr)
 			require.Equal(t, rpcv10.AddTxResponse{
 				TransactionHash: felt.FromUint64[felt.TransactionHash](0x1),
@@ -1538,7 +1538,7 @@ func TestAddTransaction(t *testing.T) {
 				handler := rpcv10.New(nil, nil, nil, utils.NewNopZapLogger()).WithGateway(mockGateway)
 				addTxRes, rpcErr := handler.AddTransaction(
 					t.Context(),
-					utils.HeapPtr(tests["invoke v0"].txn),
+					new(tests["invoke v0"].txn),
 				)
 
 				require.Equal(t, tc.expectedError, rpcErr)

--- a/rpc/v8/adapters.go
+++ b/rpc/v8/adapters.go
@@ -16,12 +16,12 @@ import (
 func AdaptVMTransactionTrace(trace *vm.TransactionTrace) TransactionTrace {
 	var validateInvocation *FunctionInvocation
 	if trace.ValidateInvocation != nil && trace.Type != vm.TxnL1Handler {
-		validateInvocation = utils.HeapPtr(adaptVMFunctionInvocation(trace.ValidateInvocation))
+		validateInvocation = new(adaptVMFunctionInvocation(trace.ValidateInvocation))
 	}
 
 	var feeTransferInvocation *FunctionInvocation
 	if trace.FeeTransferInvocation != nil && trace.Type != vm.TxnL1Handler {
-		feeTransferInvocation = utils.HeapPtr(adaptVMFunctionInvocation(trace.FeeTransferInvocation))
+		feeTransferInvocation = new(adaptVMFunctionInvocation(trace.FeeTransferInvocation))
 	}
 
 	var constructorInvocation *FunctionInvocation
@@ -31,16 +31,16 @@ func AdaptVMTransactionTrace(trace *vm.TransactionTrace) TransactionTrace {
 	switch trace.Type {
 	case vm.TxnDeployAccount, vm.TxnDeploy:
 		if trace.ConstructorInvocation != nil {
-			constructorInvocation = utils.HeapPtr(adaptVMFunctionInvocation(trace.ConstructorInvocation))
+			constructorInvocation = new(adaptVMFunctionInvocation(trace.ConstructorInvocation))
 		}
 	case vm.TxnInvoke:
 		if trace.ExecuteInvocation != nil {
-			executeInvocation = utils.HeapPtr(adaptVMExecuteInvocation(trace.ExecuteInvocation))
+			executeInvocation = new(adaptVMExecuteInvocation(trace.ExecuteInvocation))
 		}
 	case vm.TxnL1Handler:
 		if trace.FunctionInvocation != nil {
 			if trace.FunctionInvocation.FunctionInvocation != nil {
-				functionInvocation = utils.HeapPtr(adaptVMFunctionInvocation(trace.FunctionInvocation.FunctionInvocation))
+				functionInvocation = new(adaptVMFunctionInvocation(trace.FunctionInvocation.FunctionInvocation))
 			} else {
 				defaultResult := DefaultL1HandlerFunctionInvocation()
 				functionInvocation = &defaultResult
@@ -50,12 +50,12 @@ func AdaptVMTransactionTrace(trace *vm.TransactionTrace) TransactionTrace {
 
 	var resources *ExecutionResources
 	if trace.ExecutionResources != nil {
-		resources = utils.HeapPtr(adaptVMExecutionResources(trace.ExecutionResources))
+		resources = new(adaptVMExecutionResources(trace.ExecutionResources))
 	}
 
 	var stateDiff *StateDiff
 	if trace.StateDiff != nil {
-		stateDiff = utils.HeapPtr(AdaptVMStateDiff(trace.StateDiff))
+		stateDiff = new(AdaptVMStateDiff(trace.StateDiff))
 	}
 
 	traceType := TransactionType(trace.Type)
@@ -80,7 +80,7 @@ func AdaptVMTransactionTrace(trace *vm.TransactionTrace) TransactionTrace {
 func adaptVMExecuteInvocation(vmFnInvocation *vm.ExecuteInvocation) ExecuteInvocation {
 	var functionInvocation *FunctionInvocation
 	if vmFnInvocation.FunctionInvocation != nil {
-		functionInvocation = utils.HeapPtr(adaptVMFunctionInvocation(vmFnInvocation.FunctionInvocation))
+		functionInvocation = new(adaptVMFunctionInvocation(vmFnInvocation.FunctionInvocation))
 	}
 
 	return ExecuteInvocation{
@@ -268,7 +268,7 @@ func AdaptFeederBlockTrace(block *BlockWithTxs, blockTrace *starknet.BlockTrace)
 
 		var fnInvocation *FunctionInvocation
 		if fct := feederTrace.FunctionInvocation; fct != nil {
-			fnInvocation = utils.HeapPtr(adaptFeederFunctionInvocation(fct))
+			fnInvocation = new(adaptFeederFunctionInvocation(fct))
 		}
 
 		switch trace.Type {
@@ -340,7 +340,7 @@ func adaptFeederFunctionInvocation(snFnInvocation *starknet.FunctionInvocation) 
 		Calls:              adaptedCalls,
 		Events:             adaptedEvents,
 		Messages:           adaptedMessages,
-		ExecutionResources: utils.HeapPtr(adaptFeederExecutionResources(&snFnInvocation.ExecutionResources)),
+		ExecutionResources: new(adaptFeederExecutionResources(&snFnInvocation.ExecutionResources)),
 		IsReverted:         snFnInvocation.Failed,
 	}
 }

--- a/rpc/v8/block_test.go
+++ b/rpc/v8/block_test.go
@@ -155,7 +155,7 @@ func TestBlockTransactionCount(t *testing.T) {
 	mockCtrl := gomock.NewController(t)
 	t.Cleanup(mockCtrl.Finish)
 	mockSyncReader := mocks.NewMockSyncReader(mockCtrl)
-	n := utils.HeapPtr(utils.Sepolia)
+	n := new(utils.Sepolia)
 	mockReader := mocks.NewMockReader(mockCtrl)
 	handler := rpc.New(mockReader, mockSyncReader, nil, nil)
 
@@ -650,7 +650,7 @@ func TestBlockWithTxs_TxnsFetchError(t *testing.T) {
 }
 
 func TestBlockWithTxHashesV013(t *testing.T) {
-	n := utils.HeapPtr(utils.SepoliaIntegration)
+	n := new(utils.SepoliaIntegration)
 	mockCtrl := gomock.NewController(t)
 	t.Cleanup(mockCtrl.Finish)
 	mockReader := mocks.NewMockReader(mockCtrl)
@@ -679,7 +679,7 @@ func TestBlockWithTxHashesV013(t *testing.T) {
 			NewRoot:         coreBlock.GlobalStateRoot,
 			Number:          &coreBlock.Number,
 			ParentHash:      coreBlock.ParentHash,
-			L1DAMode:        utils.HeapPtr(rpc.Blob),
+			L1DAMode:        new(rpc.Blob),
 			L1GasPrice: &rpc.ResourcePrice{
 				InFri: felt.NewUnsafeFromString[felt.Felt]("0x17882b6aa74"),
 				InWei: felt.NewUnsafeFromString[felt.Felt]("0x3b9aca10"),
@@ -725,8 +725,8 @@ func TestBlockWithTxHashesV013(t *testing.T) {
 				Tip:                   new(felt.Felt).SetUint64(tx.Tip),
 				PaymasterData:         &tx.PaymasterData,
 				AccountDeploymentData: &tx.AccountDeploymentData,
-				NonceDAMode:           utils.HeapPtr(rpc.DataAvailabilityMode(tx.NonceDAMode)),
-				FeeDAMode:             utils.HeapPtr(rpc.DataAvailabilityMode(tx.FeeDAMode)),
+				NonceDAMode:           new(rpc.DataAvailabilityMode(tx.NonceDAMode)),
+				FeeDAMode:             new(rpc.DataAvailabilityMode(tx.FeeDAMode)),
 			},
 		},
 	}, got)
@@ -736,7 +736,7 @@ func TestBlockWithReceipts(t *testing.T) {
 	mockCtrl := gomock.NewController(t)
 	t.Cleanup(mockCtrl.Finish)
 
-	n := utils.HeapPtr(utils.Mainnet)
+	n := new(utils.Mainnet)
 	mockReader := mocks.NewMockReader(mockCtrl)
 	mockSyncReader := mocks.NewMockSyncReader(mockCtrl)
 	handler := rpc.New(mockReader, mockSyncReader, nil, nil)
@@ -846,7 +846,7 @@ func TestRpcBlockAdaptation(t *testing.T) {
 	mockCtrl := gomock.NewController(t)
 	t.Cleanup(mockCtrl.Finish)
 
-	n := utils.HeapPtr(utils.Sepolia)
+	n := new(utils.Sepolia)
 	mockReader := mocks.NewMockReader(mockCtrl)
 	handler := rpc.New(mockReader, nil, nil, nil)
 

--- a/rpc/v8/events_test.go
+++ b/rpc/v8/events_test.go
@@ -46,8 +46,8 @@ func TestEvents(t *testing.T) {
 	)
 	args := rpc.EventsArg{
 		EventFilter: rpc.EventFilter{
-			FromBlock: utils.HeapPtr(rpc.BlockIDFromNumber(0)),
-			ToBlock:   utils.HeapPtr(blockIDLatest(t)),
+			FromBlock: new(rpc.BlockIDFromNumber(0)),
+			ToBlock:   new(blockIDLatest(t)),
 			Address:   from,
 			Keys:      [][]felt.Felt{},
 		},
@@ -59,14 +59,14 @@ func TestEvents(t *testing.T) {
 
 	t.Run("filter non-existent", func(t *testing.T) {
 		t.Run("block number - bound to latest", func(t *testing.T) {
-			args.ToBlock = utils.HeapPtr(rpc.BlockIDFromNumber(55))
+			args.ToBlock = new(rpc.BlockIDFromNumber(55))
 			events, err := handler.Events(args)
 			require.Nil(t, err)
 			require.Len(t, events.Events, 4)
 		})
 
 		t.Run("block hash", func(t *testing.T) {
-			args.ToBlock = utils.HeapPtr(rpc.BlockIDFromHash(felt.NewFromUint64[felt.Felt](55)))
+			args.ToBlock = new(rpc.BlockIDFromHash(felt.NewFromUint64[felt.Felt](55)))
 			_, err := handler.Events(args)
 			require.Equal(t, rpccore.ErrBlockNotFound, err)
 		})
@@ -74,13 +74,13 @@ func TestEvents(t *testing.T) {
 
 	t.Run("filter with no from_block", func(t *testing.T) {
 		args.FromBlock = nil
-		args.ToBlock = utils.HeapPtr(blockIDLatest(t))
+		args.ToBlock = new(blockIDLatest(t))
 		_, err := handler.Events(args)
 		require.Nil(t, err)
 	})
 
 	t.Run("filter with no to_block", func(t *testing.T) {
-		args.FromBlock = utils.HeapPtr(rpc.BlockIDFromNumber(0))
+		args.FromBlock = new(rpc.BlockIDFromNumber(0))
 		args.ToBlock = nil
 		_, err := handler.Events(args)
 		require.Nil(t, err)
@@ -89,8 +89,8 @@ func TestEvents(t *testing.T) {
 	t.Run("filter with from_block > to_block", func(t *testing.T) {
 		fArgs := rpc.EventsArg{
 			EventFilter: rpc.EventFilter{
-				FromBlock: utils.HeapPtr(rpc.BlockIDFromNumber(1)),
-				ToBlock:   utils.HeapPtr(rpc.BlockIDFromNumber(0)),
+				FromBlock: new(rpc.BlockIDFromNumber(1)),
+				ToBlock:   new(rpc.BlockIDFromNumber(0)),
 			},
 			ResultPageRequest: rpc.ResultPageRequest{
 				ChunkSize:         100,
@@ -104,7 +104,7 @@ func TestEvents(t *testing.T) {
 	})
 
 	t.Run("filter with no address", func(t *testing.T) {
-		args.ToBlock = utils.HeapPtr(blockIDLatest(t))
+		args.ToBlock = new(blockIDLatest(t))
 		args.Address = nil
 		_, err := handler.Events(args)
 		require.Nil(t, err)
@@ -113,7 +113,7 @@ func TestEvents(t *testing.T) {
 	t.Run("filter with no keys", func(t *testing.T) {
 		var allEvents []rpc.EmittedEvent
 		t.Run("get canonical events without pagination", func(t *testing.T) {
-			args.ToBlock = utils.HeapPtr(blockIDLatest(t))
+			args.ToBlock = new(blockIDLatest(t))
 			args.Address = from
 			events, err := handler.Events(args)
 			require.Nil(t, err)
@@ -222,8 +222,8 @@ func TestEvents(t *testing.T) {
 	t.Run("pending block always empty", func(t *testing.T) {
 		args = rpc.EventsArg{
 			EventFilter: rpc.EventFilter{
-				FromBlock: utils.HeapPtr(blockIDPending(t)),
-				ToBlock:   utils.HeapPtr(blockIDPending(t)),
+				FromBlock: new(blockIDPending(t)),
+				ToBlock:   new(blockIDPending(t)),
 			},
 			ResultPageRequest: rpc.ResultPageRequest{
 				ChunkSize:         100,

--- a/rpc/v8/pending_wrapper_test.go
+++ b/rpc/v8/pending_wrapper_test.go
@@ -19,7 +19,7 @@ func TestPendingWrapper_Pending(t *testing.T) {
 	mockCtrl := gomock.NewController(t)
 	t.Cleanup(mockCtrl.Finish)
 	mockSyncReader := mocks.NewMockSyncReader(mockCtrl)
-	n := utils.HeapPtr(utils.Sepolia)
+	n := new(utils.Sepolia)
 	mockReader := mocks.NewMockReader(mockCtrl)
 	log := utils.NewNopZapLogger()
 	handler := rpc.New(mockReader, mockSyncReader, nil, log)

--- a/rpc/v8/simulation.go
+++ b/rpc/v8/simulation.go
@@ -247,7 +247,7 @@ func createSimulatedTransactions(
 	simulatedTransactions := make([]SimulatedTransaction, len(overallFees))
 	for i, overallFee := range overallFees {
 		// Adapt transaction trace to rpc v8 trace
-		trace := utils.HeapPtr(AdaptVMTransactionTrace(&traces[i]))
+		trace := new(AdaptVMTransactionTrace(&traces[i]))
 
 		// Add root level execution resources
 		trace.ExecutionResources = &ExecutionResources{

--- a/rpc/v8/simulation_pkg_test.go
+++ b/rpc/v8/simulation_pkg_test.go
@@ -75,7 +75,7 @@ func TestCreateSimulatedTransactions(t *testing.T) {
 				L1DataGasConsumed: new(felt.Felt).SetUint64(50),
 				L1DataGasPrice:    new(felt.Felt).SetUint64(5),
 				OverallFee:        new(felt.Felt).SetUint64(10),
-				Unit:              utils.HeapPtr(WEI),
+				Unit:              new(WEI),
 			},
 		},
 		{
@@ -96,7 +96,7 @@ func TestCreateSimulatedTransactions(t *testing.T) {
 				L1DataGasConsumed: new(felt.Felt).SetUint64(70),
 				L1DataGasPrice:    new(felt.Felt).SetUint64(6),
 				OverallFee:        new(felt.Felt).SetUint64(20),
-				Unit:              utils.HeapPtr(FRI),
+				Unit:              new(FRI),
 			},
 		},
 	}

--- a/rpc/v8/subscriptions_test.go
+++ b/rpc/v8/subscriptions_test.go
@@ -1026,7 +1026,7 @@ func subMsg(method string) string {
 func testHeadBlock(t *testing.T) *core.Block {
 	t.Helper()
 
-	n := utils.HeapPtr(utils.Sepolia)
+	n := new(utils.Sepolia)
 	client := feeder.NewTestClient(t, n)
 	gw := adaptfeeder.New(client)
 

--- a/rpc/v8/trace.go
+++ b/rpc/v8/trace.go
@@ -249,7 +249,7 @@ func (h *Handler) traceBlockTransactionWithVM(block *core.Block) (
 	result := make([]TracedBlockTransaction, len(executionResult.Traces))
 	// Adapt every vm transaction trace to rpc v8 trace and add root level execution resources
 	for index := range executionResult.Traces {
-		trace := utils.HeapPtr(AdaptVMTransactionTrace(&executionResult.Traces[index]))
+		trace := new(AdaptVMTransactionTrace(&executionResult.Traces[index]))
 
 		trace.ExecutionResources = &ExecutionResources{
 			InnerExecutionResources: InnerExecutionResources{

--- a/rpc/v8/transaction.go
+++ b/rpc/v8/transaction.go
@@ -448,7 +448,7 @@ func adaptToFeederDAMode(mode *DataAvailabilityMode) *starknet.DataAvailabilityM
 	if mode == nil {
 		return nil
 	}
-	return utils.HeapPtr(starknet.DataAvailabilityMode(*mode))
+	return new(starknet.DataAvailabilityMode(*mode))
 }
 
 func adaptRPCTxToFeederTx(rpcTx *Transaction) *starknet.Transaction {
@@ -1007,7 +1007,7 @@ func adaptInvokeTransaction(t *core.InvokeTransaction) *Transaction {
 		Hash:               t.Hash(),
 		MaxFee:             t.MaxFee,
 		Version:            t.Version.AsFelt(),
-		Signature:          utils.HeapPtr(t.Signature()),
+		Signature:          new(t.Signature()),
 		Nonce:              t.Nonce,
 		CallData:           &t.CallData,
 		ContractAddress:    t.ContractAddress,
@@ -1016,12 +1016,12 @@ func adaptInvokeTransaction(t *core.InvokeTransaction) *Transaction {
 	}
 
 	if tx.Version.Uint64() == 3 {
-		tx.ResourceBounds = utils.HeapPtr(adaptResourceBounds(t.ResourceBounds))
+		tx.ResourceBounds = new(adaptResourceBounds(t.ResourceBounds))
 		tx.Tip = new(felt.Felt).SetUint64(t.Tip)
 		tx.PaymasterData = &t.PaymasterData
 		tx.AccountDeploymentData = &t.AccountDeploymentData
-		tx.NonceDAMode = utils.HeapPtr(DataAvailabilityMode(t.NonceDAMode))
-		tx.FeeDAMode = utils.HeapPtr(DataAvailabilityMode(t.FeeDAMode))
+		tx.NonceDAMode = new(DataAvailabilityMode(t.NonceDAMode))
+		tx.FeeDAMode = new(DataAvailabilityMode(t.FeeDAMode))
 	}
 	return tx
 }
@@ -1033,7 +1033,7 @@ func adaptDeclareTransaction(t *core.DeclareTransaction) *Transaction {
 		Type:              TxnDeclare,
 		MaxFee:            t.MaxFee,
 		Version:           t.Version.AsFelt(),
-		Signature:         utils.HeapPtr(t.Signature()),
+		Signature:         new(t.Signature()),
 		Nonce:             t.Nonce,
 		ClassHash:         t.ClassHash,
 		SenderAddress:     t.SenderAddress,
@@ -1041,12 +1041,12 @@ func adaptDeclareTransaction(t *core.DeclareTransaction) *Transaction {
 	}
 
 	if tx.Version.Uint64() == 3 {
-		tx.ResourceBounds = utils.HeapPtr(adaptResourceBounds(t.ResourceBounds))
+		tx.ResourceBounds = new(adaptResourceBounds(t.ResourceBounds))
 		tx.Tip = new(felt.Felt).SetUint64(t.Tip)
 		tx.PaymasterData = &t.PaymasterData
 		tx.AccountDeploymentData = &t.AccountDeploymentData
-		tx.NonceDAMode = utils.HeapPtr(DataAvailabilityMode(t.NonceDAMode))
-		tx.FeeDAMode = utils.HeapPtr(DataAvailabilityMode(t.FeeDAMode))
+		tx.NonceDAMode = new(DataAvailabilityMode(t.NonceDAMode))
+		tx.FeeDAMode = new(DataAvailabilityMode(t.FeeDAMode))
 	}
 
 	return tx
@@ -1057,7 +1057,7 @@ func adaptDeployAccountTransaction(t *core.DeployAccountTransaction) *Transactio
 		Hash:                t.Hash(),
 		MaxFee:              t.MaxFee,
 		Version:             t.Version.AsFelt(),
-		Signature:           utils.HeapPtr(t.Signature()),
+		Signature:           new(t.Signature()),
 		Nonce:               t.Nonce,
 		Type:                TxnDeployAccount,
 		ContractAddressSalt: t.ContractAddressSalt,
@@ -1066,11 +1066,11 @@ func adaptDeployAccountTransaction(t *core.DeployAccountTransaction) *Transactio
 	}
 
 	if tx.Version.Uint64() == 3 {
-		tx.ResourceBounds = utils.HeapPtr(adaptResourceBounds(t.ResourceBounds))
+		tx.ResourceBounds = new(adaptResourceBounds(t.ResourceBounds))
 		tx.Tip = new(felt.Felt).SetUint64(t.Tip)
 		tx.PaymasterData = &t.PaymasterData
-		tx.NonceDAMode = utils.HeapPtr(DataAvailabilityMode(t.NonceDAMode))
-		tx.FeeDAMode = utils.HeapPtr(DataAvailabilityMode(t.FeeDAMode))
+		tx.NonceDAMode = new(DataAvailabilityMode(t.NonceDAMode))
+		tx.FeeDAMode = new(DataAvailabilityMode(t.FeeDAMode))
 	}
 
 	return tx

--- a/rpc/v8/transaction_test.go
+++ b/rpc/v8/transaction_test.go
@@ -1244,11 +1244,11 @@ func TestAddTransaction(t *testing.T) {
 				Times(1)
 
 			handler := rpc.New(nil, nil, nil, utils.NewNopZapLogger())
-			_, rpcErr := handler.AddTransaction(t.Context(), utils.HeapPtr(test.txn))
+			_, rpcErr := handler.AddTransaction(t.Context(), new(test.txn))
 			require.Equal(t, rpcErr.Code, rpccore.ErrInternal.Code)
 
 			handler = handler.WithGateway(mockGateway)
-			got, rpcErr := handler.AddTransaction(t.Context(), utils.HeapPtr(test.txn))
+			got, rpcErr := handler.AddTransaction(t.Context(), new(test.txn))
 			require.Nil(t, rpcErr)
 			require.Equal(t, rpc.AddTxResponse{
 				TransactionHash: felt.NewUnsafeFromString[felt.Felt]("0x1"),
@@ -1290,7 +1290,7 @@ func TestAddTransaction(t *testing.T) {
 				handler := rpc.New(nil, nil, nil, utils.NewNopZapLogger()).WithGateway(mockGateway)
 				addTxRes, rpcErr := handler.AddTransaction(
 					t.Context(),
-					utils.HeapPtr(tests["invoke v0"].txn),
+					new(tests["invoke v0"].txn),
 				)
 
 				require.Equal(t, tc.expectedError, rpcErr)

--- a/rpc/v9/adapters.go
+++ b/rpc/v9/adapters.go
@@ -16,12 +16,12 @@ import (
 func AdaptVMTransactionTrace(trace *vm.TransactionTrace) TransactionTrace {
 	var validateInvocation *FunctionInvocation
 	if trace.ValidateInvocation != nil && trace.Type != vm.TxnL1Handler {
-		validateInvocation = utils.HeapPtr(AdaptVMFunctionInvocation(trace.ValidateInvocation))
+		validateInvocation = new(AdaptVMFunctionInvocation(trace.ValidateInvocation))
 	}
 
 	var feeTransferInvocation *FunctionInvocation
 	if trace.FeeTransferInvocation != nil && trace.Type != vm.TxnL1Handler {
-		feeTransferInvocation = utils.HeapPtr(AdaptVMFunctionInvocation(trace.FeeTransferInvocation))
+		feeTransferInvocation = new(AdaptVMFunctionInvocation(trace.FeeTransferInvocation))
 	}
 
 	var constructorInvocation *FunctionInvocation
@@ -31,26 +31,26 @@ func AdaptVMTransactionTrace(trace *vm.TransactionTrace) TransactionTrace {
 	switch trace.Type {
 	case vm.TxnDeployAccount, vm.TxnDeploy:
 		if trace.ConstructorInvocation != nil {
-			constructorInvocation = utils.HeapPtr(AdaptVMFunctionInvocation(trace.ConstructorInvocation))
+			constructorInvocation = new(AdaptVMFunctionInvocation(trace.ConstructorInvocation))
 		}
 	case vm.TxnInvoke:
 		if trace.ExecuteInvocation != nil {
-			executeInvocation = utils.HeapPtr(AdaptVMExecuteInvocation(trace.ExecuteInvocation))
+			executeInvocation = new(AdaptVMExecuteInvocation(trace.ExecuteInvocation))
 		}
 	case vm.TxnL1Handler:
 		if trace.FunctionInvocation != nil {
-			functionInvocation = utils.HeapPtr(AdaptVMExecuteInvocation(trace.FunctionInvocation))
+			functionInvocation = new(AdaptVMExecuteInvocation(trace.FunctionInvocation))
 		}
 	}
 
 	var resources *ExecutionResources
 	if trace.ExecutionResources != nil {
-		resources = utils.HeapPtr(AdaptVMExecutionResources(trace.ExecutionResources))
+		resources = new(AdaptVMExecutionResources(trace.ExecutionResources))
 	}
 
 	var stateDiff *StateDiff
 	if trace.StateDiff != nil {
-		stateDiff = utils.HeapPtr(AdaptVMStateDiff(trace.StateDiff))
+		stateDiff = new(AdaptVMStateDiff(trace.StateDiff))
 	}
 
 	traceType := TransactionType(trace.Type)
@@ -75,7 +75,7 @@ func AdaptVMTransactionTrace(trace *vm.TransactionTrace) TransactionTrace {
 func AdaptVMExecuteInvocation(vmFnInvocation *vm.ExecuteInvocation) ExecuteInvocation {
 	var functionInvocation *FunctionInvocation
 	if vmFnInvocation.FunctionInvocation != nil {
-		functionInvocation = utils.HeapPtr(AdaptVMFunctionInvocation(vmFnInvocation.FunctionInvocation))
+		functionInvocation = new(AdaptVMFunctionInvocation(vmFnInvocation.FunctionInvocation))
 	}
 
 	return ExecuteInvocation{
@@ -266,7 +266,7 @@ func AdaptFeederFunctionInvocation(snFnInvocation *starknet.FunctionInvocation) 
 		Calls:              adaptedCalls,
 		Events:             adaptedEvents,
 		Messages:           adaptedMessages,
-		ExecutionResources: utils.HeapPtr(adaptFeederExecutionResources(&snFnInvocation.ExecutionResources)),
+		ExecutionResources: new(adaptFeederExecutionResources(&snFnInvocation.ExecutionResources)),
 		IsReverted:         snFnInvocation.Failed,
 	}
 }

--- a/rpc/v9/block_test.go
+++ b/rpc/v9/block_test.go
@@ -161,7 +161,7 @@ func TestBlockTransactionCount(t *testing.T) {
 	mockCtrl := gomock.NewController(t)
 	t.Cleanup(mockCtrl.Finish)
 	mockSyncReader := mocks.NewMockSyncReader(mockCtrl)
-	n := utils.HeapPtr(utils.Sepolia)
+	n := new(utils.Sepolia)
 	mockReader := mocks.NewMockReader(mockCtrl)
 	log := utils.NewNopZapLogger()
 	handler := rpc.New(mockReader, mockSyncReader, nil, log)
@@ -708,7 +708,7 @@ func TestBlockWithTxs_TxnsFetchError(t *testing.T) {
 }
 
 func TestBlockWithTxHashesV013(t *testing.T) {
-	n := utils.HeapPtr(utils.SepoliaIntegration)
+	n := new(utils.SepoliaIntegration)
 	mockCtrl := gomock.NewController(t)
 	t.Cleanup(mockCtrl.Finish)
 	mockReader := mocks.NewMockReader(mockCtrl)
@@ -737,7 +737,7 @@ func TestBlockWithTxHashesV013(t *testing.T) {
 			NewRoot:         coreBlock.GlobalStateRoot,
 			Number:          &coreBlock.Number,
 			ParentHash:      coreBlock.ParentHash,
-			L1DAMode:        utils.HeapPtr(rpc.Blob),
+			L1DAMode:        new(rpc.Blob),
 			L1GasPrice: &rpc.ResourcePrice{
 				InFri: felt.NewUnsafeFromString[felt.Felt]("0x17882b6aa74"),
 				InWei: felt.NewUnsafeFromString[felt.Felt]("0x3b9aca10"),
@@ -783,8 +783,8 @@ func TestBlockWithTxHashesV013(t *testing.T) {
 				Tip:                   felt.NewFromUint64[felt.Felt](tx.Tip),
 				PaymasterData:         &tx.PaymasterData,
 				AccountDeploymentData: &tx.AccountDeploymentData,
-				NonceDAMode:           utils.HeapPtr(rpc.DataAvailabilityMode(tx.NonceDAMode)),
-				FeeDAMode:             utils.HeapPtr(rpc.DataAvailabilityMode(tx.FeeDAMode)),
+				NonceDAMode:           new(rpc.DataAvailabilityMode(tx.NonceDAMode)),
+				FeeDAMode:             new(rpc.DataAvailabilityMode(tx.FeeDAMode)),
 			},
 		},
 	}, got)
@@ -794,7 +794,7 @@ func TestBlockWithReceipts(t *testing.T) {
 	mockCtrl := gomock.NewController(t)
 	t.Cleanup(mockCtrl.Finish)
 
-	n := utils.HeapPtr(utils.Mainnet)
+	n := new(utils.Mainnet)
 	mockReader := mocks.NewMockReader(mockCtrl)
 	mockSyncReader := mocks.NewMockSyncReader(mockCtrl)
 	handler := rpc.New(mockReader, mockSyncReader, nil, nil)
@@ -933,7 +933,7 @@ func TestRpcBlockAdaptation(t *testing.T) {
 	mockCtrl := gomock.NewController(t)
 	t.Cleanup(mockCtrl.Finish)
 
-	n := utils.HeapPtr(utils.Sepolia)
+	n := new(utils.Sepolia)
 	mockReader := mocks.NewMockReader(mockCtrl)
 	handler := rpc.New(mockReader, nil, nil, nil)
 

--- a/rpc/v9/simulation.go
+++ b/rpc/v9/simulation.go
@@ -251,7 +251,7 @@ func createSimulatedTransactions(
 	simulatedTransactions := make([]SimulatedTransaction, len(overallFees))
 	for i, overallFee := range overallFees {
 		// Adapt transaction trace to rpc v9 trace
-		trace := utils.HeapPtr(AdaptVMTransactionTrace(&traces[i]))
+		trace := new(AdaptVMTransactionTrace(&traces[i]))
 
 		// Add root level execution resources
 		trace.ExecutionResources = &ExecutionResources{

--- a/rpc/v9/simulation_pkg_test.go
+++ b/rpc/v9/simulation_pkg_test.go
@@ -75,7 +75,7 @@ func TestCreateSimulatedTransactions(t *testing.T) {
 				L1DataGasConsumed: felt.NewFromUint64[felt.Felt](50),
 				L1DataGasPrice:    felt.NewFromUint64[felt.Felt](5),
 				OverallFee:        felt.NewFromUint64[felt.Felt](10),
-				Unit:              utils.HeapPtr(WEI),
+				Unit:              new(WEI),
 			},
 		},
 		{
@@ -96,7 +96,7 @@ func TestCreateSimulatedTransactions(t *testing.T) {
 				L1DataGasConsumed: felt.NewFromUint64[felt.Felt](70),
 				L1DataGasPrice:    felt.NewFromUint64[felt.Felt](6),
 				OverallFee:        felt.NewFromUint64[felt.Felt](20),
-				Unit:              utils.HeapPtr(FRI),
+				Unit:              new(FRI),
 			},
 		},
 	}

--- a/rpc/v9/subscriptions_test.go
+++ b/rpc/v9/subscriptions_test.go
@@ -417,7 +417,7 @@ func TestSubscribeEvents(t *testing.T) {
 
 	basicSubscriptionWithPreConfirmed := testCase{
 		description:    "Events from new blocks - status PRE_CONFIRMED",
-		finalityStatus: utils.HeapPtr(TxnFinalityStatusWithoutL1(TxnPreConfirmed)),
+		finalityStatus: new(TxnFinalityStatusWithoutL1(TxnPreConfirmed)),
 		blockID:        nil,
 		keys:           nil,
 		fromAddr:       nil,
@@ -495,7 +495,7 @@ func TestSubscribeEvents(t *testing.T) {
 
 	eventsFromHistoricalBlocks := testCase{
 		description: "Events from historical blocks - default status, events from 2 block",
-		blockID:     utils.HeapPtr(SubscriptionBlockID(BlockIDFromNumber(b1.Number))),
+		blockID:     new(SubscriptionBlockID(BlockIDFromNumber(b1.Number))),
 		keys:        nil,
 		fromAddr:    nil,
 		setupMocks: func() {
@@ -523,7 +523,7 @@ func TestSubscribeEvents(t *testing.T) {
 
 	eventsWithContinuationToken := testCase{
 		description: "Events with continuation token - default status",
-		blockID:     utils.HeapPtr(SubscriptionBlockID(BlockIDFromNumber(b1.Number))),
+		blockID:     new(SubscriptionBlockID(BlockIDFromNumber(b1.Number))),
 		keys:        nil,
 		fromAddr:    nil,
 		setupMocks: func() {
@@ -576,7 +576,7 @@ func TestSubscribeEvents(t *testing.T) {
 	eventsWithFromAddressAndPreConfirmed := testCase{ //nolint:dupl // params and return values are different
 		description:    "Events with from_address filter, finality PRE_CONFIRMED",
 		blockID:        nil,
-		finalityStatus: utils.HeapPtr(TxnFinalityStatusWithoutL1(TxnPreConfirmed)),
+		finalityStatus: new(TxnFinalityStatusWithoutL1(TxnPreConfirmed)),
 		fromAddr:       targetAddr,
 		keys:           nil,
 		setupMocks: func() {
@@ -618,7 +618,7 @@ func TestSubscribeEvents(t *testing.T) {
 	eventsWithAllFilterAndPreConfirmed := testCase{ //nolint:dupl // params and return values are different
 		description:    "Events with from_address and key, finality PRE_CONFIRMED",
 		blockID:        nil,
-		finalityStatus: utils.HeapPtr(TxnFinalityStatusWithoutL1(TxnPreConfirmed)),
+		finalityStatus: new(TxnFinalityStatusWithoutL1(TxnPreConfirmed)),
 		fromAddr:       targetAddr,
 		keys:           keys,
 		setupMocks: func() {
@@ -659,7 +659,7 @@ func TestSubscribeEvents(t *testing.T) {
 
 	deduplication := testCase{
 		description:    "deduplicate events",
-		finalityStatus: utils.HeapPtr(TxnFinalityStatusWithoutL1(TxnPreConfirmed)),
+		finalityStatus: new(TxnFinalityStatusWithoutL1(TxnPreConfirmed)),
 		setupMocks: func() {
 			setupMockEventFiltererWithMultiple(
 				mockChain,
@@ -721,7 +721,7 @@ func TestSubscribeEvents(t *testing.T) {
 
 	deduplicationWithPreLatestOnStart := testCase{
 		description:    "deduplicate events with prelatest on start",
-		finalityStatus: utils.HeapPtr(TxnFinalityStatusWithoutL1(TxnPreConfirmed)),
+		finalityStatus: new(TxnFinalityStatusWithoutL1(TxnPreConfirmed)),
 		setupMocks: func() {
 			setupMockEventFiltererWithMultiple(
 				mockChain,
@@ -1703,7 +1703,7 @@ func TestSubscribeNewTransactions(t *testing.T) {
 			{
 				description: "on new pre_confirmed full of candidates",
 				notify: func() {
-					syncer.preConfirmed.Send(utils.HeapPtr(createTestPreConfirmed(t, newHead2, 0)))
+					syncer.preConfirmed.Send(new(createTestPreConfirmed(t, newHead2, 0)))
 				},
 				expect: [][]*SubscriptionNewTransaction{
 					toTransactionsWithFinalityStatus(senderTransactions, TxnStatusWithoutL1(TxnStatusCandidate)),
@@ -2488,7 +2488,7 @@ func subMsg(method string) string {
 func testHeadBlock(t *testing.T) *core.Block {
 	t.Helper()
 
-	n := utils.HeapPtr(utils.Sepolia)
+	n := new(utils.Sepolia)
 	client := feeder.NewTestClient(t, n)
 	gw := adaptfeeder.New(client)
 

--- a/rpc/v9/transaction.go
+++ b/rpc/v9/transaction.go
@@ -1104,7 +1104,7 @@ func adaptInvokeTransaction(t *core.InvokeTransaction) *Transaction {
 		Hash:               t.Hash(),
 		MaxFee:             t.MaxFee,
 		Version:            t.Version.AsFelt(),
-		Signature:          utils.HeapPtr(t.Signature()),
+		Signature:          new(t.Signature()),
 		Nonce:              t.Nonce,
 		CallData:           &t.CallData,
 		ContractAddress:    t.ContractAddress,
@@ -1113,12 +1113,12 @@ func adaptInvokeTransaction(t *core.InvokeTransaction) *Transaction {
 	}
 
 	if tx.Version.Uint64() == 3 {
-		tx.ResourceBounds = utils.HeapPtr(adaptResourceBounds(t.ResourceBounds))
+		tx.ResourceBounds = new(adaptResourceBounds(t.ResourceBounds))
 		tx.Tip = felt.NewFromUint64[felt.Felt](t.Tip)
 		tx.PaymasterData = &t.PaymasterData
 		tx.AccountDeploymentData = &t.AccountDeploymentData
-		tx.NonceDAMode = utils.HeapPtr(DataAvailabilityMode(t.NonceDAMode))
-		tx.FeeDAMode = utils.HeapPtr(DataAvailabilityMode(t.FeeDAMode))
+		tx.NonceDAMode = new(DataAvailabilityMode(t.NonceDAMode))
+		tx.FeeDAMode = new(DataAvailabilityMode(t.FeeDAMode))
 	}
 	return tx
 }
@@ -1130,7 +1130,7 @@ func adaptDeclareTransaction(t *core.DeclareTransaction) *Transaction {
 		Type:              TxnDeclare,
 		MaxFee:            t.MaxFee,
 		Version:           t.Version.AsFelt(),
-		Signature:         utils.HeapPtr(t.Signature()),
+		Signature:         new(t.Signature()),
 		Nonce:             t.Nonce,
 		ClassHash:         t.ClassHash,
 		SenderAddress:     t.SenderAddress,
@@ -1138,12 +1138,12 @@ func adaptDeclareTransaction(t *core.DeclareTransaction) *Transaction {
 	}
 
 	if tx.Version.Uint64() == 3 {
-		tx.ResourceBounds = utils.HeapPtr(adaptResourceBounds(t.ResourceBounds))
+		tx.ResourceBounds = new(adaptResourceBounds(t.ResourceBounds))
 		tx.Tip = felt.NewFromUint64[felt.Felt](t.Tip)
 		tx.PaymasterData = &t.PaymasterData
 		tx.AccountDeploymentData = &t.AccountDeploymentData
-		tx.NonceDAMode = utils.HeapPtr(DataAvailabilityMode(t.NonceDAMode))
-		tx.FeeDAMode = utils.HeapPtr(DataAvailabilityMode(t.FeeDAMode))
+		tx.NonceDAMode = new(DataAvailabilityMode(t.NonceDAMode))
+		tx.FeeDAMode = new(DataAvailabilityMode(t.FeeDAMode))
 	}
 
 	return tx
@@ -1154,7 +1154,7 @@ func adaptDeployAccountTransaction(t *core.DeployAccountTransaction) *Transactio
 		Hash:                t.Hash(),
 		MaxFee:              t.MaxFee,
 		Version:             t.Version.AsFelt(),
-		Signature:           utils.HeapPtr(t.Signature()),
+		Signature:           new(t.Signature()),
 		Nonce:               t.Nonce,
 		Type:                TxnDeployAccount,
 		ContractAddressSalt: t.ContractAddressSalt,
@@ -1163,11 +1163,11 @@ func adaptDeployAccountTransaction(t *core.DeployAccountTransaction) *Transactio
 	}
 
 	if tx.Version.Uint64() == 3 {
-		tx.ResourceBounds = utils.HeapPtr(adaptResourceBounds(t.ResourceBounds))
+		tx.ResourceBounds = new(adaptResourceBounds(t.ResourceBounds))
 		tx.Tip = felt.NewFromUint64[felt.Felt](t.Tip)
 		tx.PaymasterData = &t.PaymasterData
-		tx.NonceDAMode = utils.HeapPtr(DataAvailabilityMode(t.NonceDAMode))
-		tx.FeeDAMode = utils.HeapPtr(DataAvailabilityMode(t.FeeDAMode))
+		tx.NonceDAMode = new(DataAvailabilityMode(t.NonceDAMode))
+		tx.FeeDAMode = new(DataAvailabilityMode(t.FeeDAMode))
 	}
 
 	return tx

--- a/rpc/v9/transaction_test.go
+++ b/rpc/v9/transaction_test.go
@@ -1472,11 +1472,11 @@ func TestAddTransaction(t *testing.T) {
 				Times(1)
 
 			handler := rpc.New(nil, nil, nil, utils.NewNopZapLogger())
-			_, rpcErr := handler.AddTransaction(t.Context(), utils.HeapPtr(test.txn))
+			_, rpcErr := handler.AddTransaction(t.Context(), new(test.txn))
 			require.Equal(t, rpcErr.Code, rpccore.ErrInternal.Code)
 
 			handler = handler.WithGateway(mockGateway)
-			got, rpcErr := handler.AddTransaction(t.Context(), utils.HeapPtr(test.txn))
+			got, rpcErr := handler.AddTransaction(t.Context(), new(test.txn))
 			require.Nil(t, rpcErr)
 			require.Equal(t, rpc.AddTxResponse{
 				TransactionHash: felt.NewFromUint64[felt.Felt](0x1),
@@ -1546,7 +1546,7 @@ func TestAddTransaction(t *testing.T) {
 				handler := rpc.New(nil, nil, nil, utils.NewNopZapLogger()).WithGateway(mockGateway)
 				addTxRes, rpcErr := handler.AddTransaction(
 					t.Context(),
-					utils.HeapPtr(tests["invoke v0"].txn),
+					new(tests["invoke v0"].txn),
 				)
 
 				require.Equal(t, tc.expectedError, rpcErr)

--- a/utils/broadcast/broadcast_test.go
+++ b/utils/broadcast/broadcast_test.go
@@ -7,7 +7,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/NethermindEth/juno/utils"
 	"github.com/NethermindEth/juno/utils/broadcast"
 	"github.com/stretchr/testify/require"
 )
@@ -202,9 +201,9 @@ func TestLaggedDetection(t *testing.T) {
 	// wait for subscriber to take first value to chan and
 	// second value to memory to avoid race and consistency of test
 	time.Sleep(5 * time.Millisecond)
-	require.NoError(t, bc.Send(utils.HeapPtr(3)))
-	require.NoError(t, bc.Send(utils.HeapPtr(4)))
-	require.NoError(t, bc.Send(utils.HeapPtr(5))) // Lag
+	require.NoError(t, bc.Send(new(3)))
+	require.NoError(t, bc.Send(new(4)))
+	require.NoError(t, bc.Send(new(5))) // Lag
 
 	// move cursor to missing seq 3
 	for i := range 2 {
@@ -239,9 +238,9 @@ func TestLagResyncAfterError(t *testing.T) {
 
 	// Sleep to allow forwarder goroutine to put 1 to chan and 2 to memory
 	time.Sleep(5 * time.Millisecond)
-	require.NoError(t, bc.Send(utils.HeapPtr(3)))
-	require.NoError(t, bc.Send(utils.HeapPtr(4)))
-	require.NoError(t, bc.Send(utils.HeapPtr(5))) // Lag
+	require.NoError(t, bc.Send(new(3)))
+	require.NoError(t, bc.Send(new(4)))
+	require.NoError(t, bc.Send(new(5))) // Lag
 
 	for i := range 2 {
 		ev := <-sub.Recv()

--- a/utils/ptr.go
+++ b/utils/ptr.go
@@ -1,7 +1,6 @@
 package utils
 
-// This function allocates a value into the heap and returns
-// a pointer to it
+// Deprecated: Use new(val) instead.
 func HeapPtr[T any](v T) *T {
 	return &v
 }

--- a/vm/transaction.go
+++ b/vm/transaction.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/NethermindEth/juno/core"
 	"github.com/NethermindEth/juno/core/felt"
-	"github.com/NethermindEth/juno/utils"
 )
 
 // marshalTxn returns a json structure that includes the transaction serde will
@@ -124,7 +123,7 @@ func adaptTransaction(txn core.Transaction) *Transaction {
 		tx = &Transaction{
 			MaxFee:            t.MaxFee,
 			Version:           t.Version.AsFelt(),
-			Signature:         utils.HeapPtr(t.Signature()),
+			Signature:         new(t.Signature()),
 			Nonce:             t.Nonce,
 			ClassHash:         t.ClassHash,
 			SenderAddress:     t.SenderAddress,
@@ -132,18 +131,18 @@ func adaptTransaction(txn core.Transaction) *Transaction {
 		}
 
 		if tx.Version.Uint64() == 3 {
-			tx.ResourceBounds = utils.HeapPtr(adaptResourceBounds(t.ResourceBounds))
+			tx.ResourceBounds = new(adaptResourceBounds(t.ResourceBounds))
 			tx.Tip = new(felt.Felt).SetUint64(t.Tip)
 			tx.PaymasterData = nilToZero(t.PaymasterData)
 			tx.AccountDeploymentData = nilToZero(t.AccountDeploymentData)
-			tx.NonceDAMode = utils.HeapPtr(DataAvailabilityMode(t.NonceDAMode))
-			tx.FeeDAMode = utils.HeapPtr(DataAvailabilityMode(t.FeeDAMode))
+			tx.NonceDAMode = new(DataAvailabilityMode(t.NonceDAMode))
+			tx.FeeDAMode = new(DataAvailabilityMode(t.FeeDAMode))
 		}
 	case *core.InvokeTransaction:
 		tx = &Transaction{
 			MaxFee:             t.MaxFee,
 			Version:            t.Version.AsFelt(),
-			Signature:          utils.HeapPtr(t.Signature()),
+			Signature:          new(t.Signature()),
 			Nonce:              t.Nonce,
 			CallData:           &t.CallData,
 			ContractAddress:    t.ContractAddress,
@@ -152,12 +151,12 @@ func adaptTransaction(txn core.Transaction) *Transaction {
 		}
 
 		if t.Version.Is(3) {
-			tx.ResourceBounds = utils.HeapPtr(adaptResourceBounds(t.ResourceBounds))
+			tx.ResourceBounds = new(adaptResourceBounds(t.ResourceBounds))
 			tx.Tip = new(felt.Felt).SetUint64(t.Tip)
 			tx.PaymasterData = nilToZero(t.PaymasterData)
 			tx.AccountDeploymentData = nilToZero(t.AccountDeploymentData)
-			tx.NonceDAMode = utils.HeapPtr(DataAvailabilityMode(t.NonceDAMode))
-			tx.FeeDAMode = utils.HeapPtr(DataAvailabilityMode(t.FeeDAMode))
+			tx.NonceDAMode = new(DataAvailabilityMode(t.NonceDAMode))
+			tx.FeeDAMode = new(DataAvailabilityMode(t.FeeDAMode))
 			if t.ProofFacts != nil {
 				tx.ProofFacts = &t.ProofFacts
 			}
@@ -183,7 +182,7 @@ func adaptTransaction(txn core.Transaction) *Transaction {
 		tx = &Transaction{
 			MaxFee:              t.MaxFee,
 			Version:             t.Version.AsFelt(),
-			Signature:           utils.HeapPtr(t.Signature()),
+			Signature:           new(t.Signature()),
 			Nonce:               t.Nonce,
 			ContractAddressSalt: t.ContractAddressSalt,
 			ConstructorCallData: &t.ConstructorCallData,
@@ -191,11 +190,11 @@ func adaptTransaction(txn core.Transaction) *Transaction {
 		}
 
 		if tx.Version.Uint64() == 3 {
-			tx.ResourceBounds = utils.HeapPtr(adaptResourceBounds(t.ResourceBounds))
+			tx.ResourceBounds = new(adaptResourceBounds(t.ResourceBounds))
 			tx.Tip = new(felt.Felt).SetUint64(t.Tip)
 			tx.PaymasterData = nilToZero(t.PaymasterData)
-			tx.NonceDAMode = utils.HeapPtr(DataAvailabilityMode(t.NonceDAMode))
-			tx.FeeDAMode = utils.HeapPtr(DataAvailabilityMode(t.FeeDAMode))
+			tx.NonceDAMode = new(DataAvailabilityMode(t.NonceDAMode))
+			tx.FeeDAMode = new(DataAvailabilityMode(t.FeeDAMode))
 		}
 	default:
 		panic(fmt.Sprintf("unknown txn type in core2sn.AdaptTransaction: %T", t))


### PR DESCRIPTION
This reverts commit 3318620ef50b9c92dacf41073088a6b6c7238541 which was itself a revert from 03171e0e9e30fc1e497fe76d701335d36458d0b0

Meaning, we are re-applying 03171e0e9e30fc1e497fe76d701335d36458d0b0 because I accidentaly pushed to main. I've removed those permissions now