### PR TITLE
fix(vm): account for tip when computing max L2 gas limit

### DIFF
--- a/vm/rust/src/entrypoint/execute/process/binary_search_execution.rs
+++ b/vm/rust/src/entrypoint/execute/process/binary_search_execution.rs
@@ -198,12 +198,14 @@ where
                     .max_possible_fee(account_transaction.tip());
             if balance > max_fee_without_l2_gas.0.into() {
                 // Calculate the maximum amount of L2 gas that can be bought with the balance.
-                let max_l2_gas = (balance - max_fee_without_l2_gas.0)
-                    / initial_resource_bounds
-                        .l2_gas
-                        .max_price_per_unit
-                        .0
-                        .max(1u64.into());
+                // max_possible_fee = max_amount * (max_price + tip).
+                let effective_l2_price: u128 = initial_resource_bounds
+                    .l2_gas
+                    .max_price_per_unit
+                    .0
+                    .saturating_add(account_transaction.tip().0.into())
+                    .max(1u64.into());
+                let max_l2_gas = (balance - max_fee_without_l2_gas.0) / effective_l2_price;
                 Ok(u64::try_from(max_l2_gas).unwrap_or(GasAmount::MAX.0).into())
             } else {
                 // Balance is less than committed L1 gas and L1 data gas, transaction will fail.


### PR DESCRIPTION
## Summary

Account for the tip when computing the maximum L2 gas amount covered by the account balance in `calculate_max_l2_gas_covered`.

**Problem**: The remaining balance is divided by `l2_gas.max_price_per_unit` to compute the max affordable L2 gas. However, the blockifier's `max_possible_fee` (used in `verify_can_pay_committed_bounds`) computes `max_amount * (max_price_per_unit + tip)`. When tip > 0, the inflated L2 gas bound exceeds the account balance, causing `starknet_simulateTransactions` to reject transactions that succeeded on-chain.

**Fix**: Divide by `(max_price_per_unit + tip)` to match the blockifier's fee calculation.

**Impact**: Observed on mainnet block 8821583 (tx index 1, tip=1001). The old formula computed `max_l2_gas = 128,174,880,959`. The blockifier then checked `128,174,880,959 * (60,200,000,000 + 1001) > balance` — failing by ~128 trillion FRI. The fix computes a slightly lower `max_l2_gas` that passes the balance check.

Note: Same bug exists in Pathfinder (fix submitted at https://github.com/eqlabs/pathfinder/pull/3346).