### PR TITLE
refactor(core): new `pending` pkg

### DIFF
--- a/adapters/sn2core/sn2core.go
+++ b/adapters/sn2core/sn2core.go
@@ -522,7 +522,9 @@ func AdaptPreConfirmedBlock(
 	isInvalidPayloadSizes := len(response.Transactions) != len(response.TransactionStateDiffs) ||
 		len(response.Transactions) != len(response.Receipts)
 	if isInvalidPayloadSizes {
-		return pending.PreConfirmed{}, errors.New("invalid sizes of transactions, state diffs and receipts")
+		return pending.PreConfirmed{}, errors.New(
+			"invalid sizes of transactions, state diffs and receipts",
+		)
 	}
 
 	preConfirmedTxCount := 0

--- a/adapters/sn2core/sn2core.go
+++ b/adapters/sn2core/sn2core.go
@@ -8,6 +8,7 @@ import (
 	"github.com/NethermindEth/juno/core"
 	"github.com/NethermindEth/juno/core/crypto"
 	"github.com/NethermindEth/juno/core/felt"
+	"github.com/NethermindEth/juno/core/pending"
 	"github.com/NethermindEth/juno/starknet"
 	"github.com/NethermindEth/juno/utils"
 	"github.com/ethereum/go-ethereum/common"
@@ -509,19 +510,19 @@ func IsCandidateTx(response *starknet.PreConfirmedBlock, id int) bool {
 func AdaptPreConfirmedBlock(
 	response *starknet.PreConfirmedBlock,
 	number uint64,
-) (core.PreConfirmed, error) {
+) (pending.PreConfirmed, error) {
 	if response == nil {
-		return core.PreConfirmed{}, errors.New("nil preconfirmed block")
+		return pending.PreConfirmed{}, errors.New("nil preconfirmed block")
 	}
 
 	if response.Status != "PRE_CONFIRMED" {
-		return core.PreConfirmed{}, errors.New("invalid status for pre_confirmed block")
+		return pending.PreConfirmed{}, errors.New("invalid status for pre_confirmed block")
 	}
 
 	isInvalidPayloadSizes := len(response.Transactions) != len(response.TransactionStateDiffs) ||
 		len(response.Transactions) != len(response.Receipts)
 	if isInvalidPayloadSizes {
-		return core.PreConfirmed{}, errors.New("invalid sizes of transactions, state diffs and receipts")
+		return pending.PreConfirmed{}, errors.New("invalid sizes of transactions, state diffs and receipts")
 	}
 
 	preConfirmedTxCount := 0
@@ -545,12 +546,12 @@ func AdaptPreConfirmedBlock(
 		if !IsCandidateTx(response, i) {
 			txns[preIdx], err = AdaptTransaction(&response.Transactions[i])
 			if err != nil {
-				return core.PreConfirmed{}, err
+				return pending.PreConfirmed{}, err
 			}
 			var stateDiff core.StateDiff
 			stateDiff, err = AdaptStateDiff(response.TransactionStateDiffs[i])
 			if err != nil {
-				return core.PreConfirmed{}, err
+				return pending.PreConfirmed{}, err
 			}
 			txStateDiffs[preIdx] = &stateDiff
 			receipts[preIdx] = AdaptTransactionReceipt(response.Receipts[i])
@@ -559,7 +560,7 @@ func AdaptPreConfirmedBlock(
 		} else {
 			candidateTxs[candIdx], err = AdaptTransaction(&response.Transactions[i])
 			if err != nil {
-				return core.PreConfirmed{}, err
+				return pending.PreConfirmed{}, err
 			}
 			candIdx++
 		}
@@ -606,7 +607,7 @@ func AdaptPreConfirmedBlock(
 		Transactions: txns,
 		Receipts:     receipts,
 	}
-	return core.NewPreConfirmed(adaptedBlock, &stateUpdate, txStateDiffs, candidateTxs), nil
+	return pending.NewPreConfirmed(adaptedBlock, &stateUpdate, txStateDiffs, candidateTxs), nil
 }
 
 func safeFeltToUint64(f *felt.Felt) uint64 {

--- a/adapters/sn2core/sn2core_test.go
+++ b/adapters/sn2core/sn2core_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/NethermindEth/juno/clients/feeder"
 	"github.com/NethermindEth/juno/core"
 	"github.com/NethermindEth/juno/core/felt"
+	"github.com/NethermindEth/juno/core/pending"
 	"github.com/NethermindEth/juno/starknet"
 	"github.com/NethermindEth/juno/utils"
 	"github.com/stretchr/testify/assert"
@@ -717,7 +718,7 @@ func getPreconfirmedReceipts(
 
 func assertPreConfirmedBlockBasics(
 	t *testing.T,
-	preConfirmed *core.PreConfirmed,
+	preConfirmed *pending.PreConfirmed,
 	blockNum uint64,
 	response *starknet.PreConfirmedBlock,
 	expectedTxCount int,

--- a/blockchain/blockchain.go
+++ b/blockchain/blockchain.go
@@ -6,6 +6,7 @@ import (
 	"github.com/NethermindEth/juno/blockchain/statebackend"
 	"github.com/NethermindEth/juno/core"
 	"github.com/NethermindEth/juno/core/felt"
+	"github.com/NethermindEth/juno/core/pending"
 	"github.com/NethermindEth/juno/db"
 	"github.com/NethermindEth/juno/feed"
 	"github.com/NethermindEth/juno/utils"
@@ -59,7 +60,7 @@ type Reader interface {
 	EventFilter(
 		addresses []felt.Address,
 		keys [][]felt.Felt,
-		preConfirmedFn func() (*core.PreConfirmed, error),
+		preConfirmedFn func() (*pending.PreConfirmed, error),
 	) (EventFilterer, error)
 
 	Network() *utils.Network
@@ -370,7 +371,7 @@ func (b *Blockchain) StateAtBlockHash(
 func (b *Blockchain) EventFilter(
 	addresses []felt.Address,
 	keys [][]felt.Felt,
-	preConfirmedFn func() (*core.PreConfirmed, error),
+	preConfirmedFn func() (*pending.PreConfirmed, error),
 ) (EventFilterer, error) {
 	b.listener.OnRead("EventFilter")
 	latest, err := core.GetChainHeight(b.database)

--- a/blockchain/blockchain_test.go
+++ b/blockchain/blockchain_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/NethermindEth/juno/clients/feeder"
 	"github.com/NethermindEth/juno/core"
 	"github.com/NethermindEth/juno/core/felt"
+	"github.com/NethermindEth/juno/core/pending"
 	"github.com/NethermindEth/juno/db"
 	"github.com/NethermindEth/juno/db/memory"
 	adaptfeeder "github.com/NethermindEth/juno/starknetdata/feeder"
@@ -450,8 +451,8 @@ func TestState(t *testing.T) {
 
 func TestEvents(t *testing.T) {
 	var pendingB *core.Block
-	preConfirmedFunc := func() (*core.PreConfirmed, error) { //nolint:unparam // used in tests
-		preConfirmed := core.NewPreConfirmed(pendingB, nil, nil, nil)
+	preConfirmedFunc := func() (*pending.PreConfirmed, error) { //nolint:unparam // used in tests
+		preConfirmed := pending.NewPreConfirmed(pendingB, nil, nil, nil)
 		return &preConfirmed, nil
 	}
 

--- a/blockchain/event_filter.go
+++ b/blockchain/event_filter.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/NethermindEth/juno/core"
 	"github.com/NethermindEth/juno/core/felt"
+	"github.com/NethermindEth/juno/core/pending"
 	"github.com/NethermindEth/juno/db"
 )
 
@@ -30,7 +31,7 @@ type EventFilter struct {
 	toBlock        uint64
 	matcher        EventMatcher
 	maxScanned     uint // maximum number of scanned blocks in single call.
-	preConfirmedFn func() (*core.PreConfirmed, error)
+	preConfirmedFn func() (*pending.PreConfirmed, error)
 	cachedFilters  *AggregatedBloomFilterCache
 	runningFilter  *core.RunningEventFilter
 }
@@ -47,7 +48,7 @@ func newEventFilter(
 	contractAddresses []felt.Address,
 	keys [][]felt.Felt,
 	fromBlock, toBlock uint64,
-	preConfirmedFn func() (*core.PreConfirmed, error),
+	preConfirmedFn func() (*pending.PreConfirmed, error),
 	cachedFilters *AggregatedBloomFilterCache,
 	runningFilter *core.RunningEventFilter,
 ) *EventFilter {
@@ -289,7 +290,7 @@ func (e *EventFilter) pendingEvents(
 ) ([]FilteredEvent, ContinuationToken, error) {
 	preConfirmed, err := e.preConfirmedFn()
 	if err != nil {
-		if errors.Is(err, core.ErrPreConfirmedNotFound) {
+		if errors.Is(err, pending.ErrPreConfirmedNotFound) {
 			return matchedEvents, ContinuationToken{}, nil
 		}
 		return nil, ContinuationToken{}, err
@@ -356,7 +357,7 @@ func (e *EventFilter) processPreLatestBlock(
 // processPreConfirmedBlock processes pre-confirmed block events
 func (e *EventFilter) processPreConfirmedBlock(
 	matchedEvents []FilteredEvent,
-	preConfirmed *core.PreConfirmed,
+	preConfirmed *pending.PreConfirmed,
 	skippedEvents,
 	chunkSize uint64,
 ) ([]FilteredEvent, ContinuationToken, error) {

--- a/builder/builder.go
+++ b/builder/builder.go
@@ -7,6 +7,7 @@ import (
 	"github.com/NethermindEth/juno/blockchain"
 	"github.com/NethermindEth/juno/core"
 	"github.com/NethermindEth/juno/core/felt"
+	"github.com/NethermindEth/juno/core/pending"
 	"github.com/NethermindEth/juno/mempool"
 	"github.com/NethermindEth/juno/utils"
 	"github.com/consensys/gnark-crypto/ecc/stark-curve/ecdsa"
@@ -52,7 +53,7 @@ func (b *Builder) Network() *utils.Network {
 	return b.blockchain.Network()
 }
 
-func (b *Builder) Finalise(preconfirmed *core.PreConfirmed, signer utils.BlockSignFunc, privateKey *ecdsa.PrivateKey) error {
+func (b *Builder) Finalise(preconfirmed *pending.PreConfirmed, signer utils.BlockSignFunc, privateKey *ecdsa.PrivateKey) error {
 	return b.blockchain.Finalise(preconfirmed.Block, preconfirmed.StateUpdate, preconfirmed.NewClasses, signer)
 }
 
@@ -101,7 +102,7 @@ func (b *Builder) InitPreconfirmedBlock(params *BuildParams) (*BuildState, error
 		OldRoot:   header.GlobalStateRoot,
 		StateDiff: &emptyStateDiff,
 	}
-	preconfirmed := core.PreConfirmed{
+	preconfirmed := pending.PreConfirmed{
 		Block:                 &preconfirmedBlock,
 		StateUpdate:           &su,
 		NewClasses:            newClasses,
@@ -132,7 +133,7 @@ func (b *Builder) PendingState(
 	buildState *BuildState,
 ) (core.StateReader, func() error, error) {
 	if buildState.PreConfirmed == nil {
-		return nil, nil, core.ErrPreConfirmedNotFound
+		return nil, nil, pending.ErrPreConfirmedNotFound
 	}
 
 	headState, headCloser, err := b.blockchain.HeadState()
@@ -141,7 +142,7 @@ func (b *Builder) PendingState(
 	}
 
 	// TODO: remove the state closer once we refactor the state
-	return core.NewPendingState(
+	return pending.NewPendingState(
 			buildState.PreConfirmed.StateUpdate.StateDiff,
 			buildState.PreConfirmed.NewClasses,
 			headState,

--- a/builder/builder.go
+++ b/builder/builder.go
@@ -142,7 +142,7 @@ func (b *Builder) PendingState(
 	}
 
 	// TODO: remove the state closer once we refactor the state
-	return pending.NewPendingState(
+	return pending.NewState(
 			buildState.PreConfirmed.StateUpdate.StateDiff,
 			buildState.PreConfirmed.NewClasses,
 			headState,

--- a/builder/builder.go
+++ b/builder/builder.go
@@ -53,8 +53,17 @@ func (b *Builder) Network() *utils.Network {
 	return b.blockchain.Network()
 }
 
-func (b *Builder) Finalise(preconfirmed *pending.PreConfirmed, signer utils.BlockSignFunc, privateKey *ecdsa.PrivateKey) error {
-	return b.blockchain.Finalise(preconfirmed.Block, preconfirmed.StateUpdate, preconfirmed.NewClasses, signer)
+func (b *Builder) Finalise(
+	preconfirmed *pending.PreConfirmed,
+	signer utils.BlockSignFunc,
+	privateKey *ecdsa.PrivateKey,
+) error {
+	return b.blockchain.Finalise(
+		preconfirmed.Block,
+		preconfirmed.StateUpdate,
+		preconfirmed.NewClasses,
+		signer,
+	)
 }
 
 func (b *Builder) InitPreconfirmedBlock(params *BuildParams) (*BuildState, error) {

--- a/builder/executor.go
+++ b/builder/executor.go
@@ -59,7 +59,7 @@ func (e *executor) RunTxns(state *BuildState, txns []mempool.BroadcastedTransact
 	}()
 
 	// Create a state writer for the transaction execution
-	stateWriter := pending.NewPendingStateWriter(
+	stateWriter := pending.NewStateWriter(
 		state.PreConfirmed.StateUpdate.StateDiff,
 		state.PreConfirmed.NewClasses,
 		headState,
@@ -134,7 +134,7 @@ func (e *executor) RunTxns(state *BuildState, txns []mempool.BroadcastedTransact
 // processClassDeclaration handles class declaration storage for declare transactions
 func (e *executor) processClassDeclaration(
 	txn *mempool.BroadcastedTransaction,
-	state *pending.PendingStateWriter,
+	state *pending.StateWriter,
 ) error {
 	if t, ok := (txn.Transaction).(*core.DeclareTransaction); ok {
 		if err := state.SetContractClass(t.ClassHash, txn.DeclaredClass); err != nil {

--- a/builder/executor.go
+++ b/builder/executor.go
@@ -5,6 +5,7 @@ import (
 	"github.com/NethermindEth/juno/blockchain"
 	"github.com/NethermindEth/juno/core"
 	"github.com/NethermindEth/juno/core/felt"
+	"github.com/NethermindEth/juno/core/pending"
 	"github.com/NethermindEth/juno/mempool"
 	"github.com/NethermindEth/juno/utils"
 	"github.com/NethermindEth/juno/vm"
@@ -58,7 +59,7 @@ func (e *executor) RunTxns(state *BuildState, txns []mempool.BroadcastedTransact
 	}()
 
 	// Create a state writer for the transaction execution
-	stateWriter := core.NewPendingStateWriter(
+	stateWriter := pending.NewPendingStateWriter(
 		state.PreConfirmed.StateUpdate.StateDiff,
 		state.PreConfirmed.NewClasses,
 		headState,
@@ -133,7 +134,7 @@ func (e *executor) RunTxns(state *BuildState, txns []mempool.BroadcastedTransact
 // processClassDeclaration handles class declaration storage for declare transactions
 func (e *executor) processClassDeclaration(
 	txn *mempool.BroadcastedTransaction,
-	state *core.PendingStateWriter,
+	state *pending.PendingStateWriter,
 ) error {
 	if t, ok := (txn.Transaction).(*core.DeclareTransaction); ok {
 		if err := state.SetContractClass(t.ClassHash, txn.DeclaredClass); err != nil {
@@ -153,7 +154,7 @@ func (e *executor) processClassDeclaration(
 
 // updatePreconfirmedBlock updates the preconfirmed block with transaction results
 func updatePreconfirmedBlock(
-	preconfirmed *core.PreConfirmed,
+	preconfirmed *pending.PreConfirmed,
 	receipts []*core.TransactionReceipt,
 	transactions []core.Transaction,
 	stateDiffs []*core.StateDiff,

--- a/builder/result.go
+++ b/builder/result.go
@@ -4,12 +4,12 @@ import (
 	"github.com/Masterminds/semver/v3"
 	"github.com/NethermindEth/juno/blockchain"
 	"github.com/NethermindEth/juno/consensus/types"
-	"github.com/NethermindEth/juno/core"
 	"github.com/NethermindEth/juno/core/felt"
+	"github.com/NethermindEth/juno/core/pending"
 )
 
 type BuildResult struct {
-	PreConfirmed   *core.PreConfirmed
+	PreConfirmed   *pending.PreConfirmed
 	SimulateResult *blockchain.SimulateResult
 	L2GasConsumed  uint64
 }

--- a/builder/state.go
+++ b/builder/state.go
@@ -6,11 +6,12 @@ import (
 
 	"github.com/NethermindEth/juno/core"
 	"github.com/NethermindEth/juno/core/felt"
+	"github.com/NethermindEth/juno/core/pending"
 	"github.com/NethermindEth/juno/utils"
 )
 
 type BuildState struct {
-	PreConfirmed      *core.PreConfirmed
+	PreConfirmed      *pending.PreConfirmed
 	L2GasConsumed     uint64
 	RevealedBlockHash *felt.Felt
 }
@@ -24,7 +25,7 @@ func (b *BuildState) PreConfirmedBlock() *core.Block {
 
 func (b *BuildState) ClearPending() error {
 	b.L2GasConsumed = 0
-	b.PreConfirmed = &core.PreConfirmed{}
+	b.PreConfirmed = &pending.PreConfirmed{}
 	b.RevealedBlockHash = nil
 
 	return nil
@@ -43,8 +44,8 @@ func (b *BuildState) Clone() BuildState {
 	}
 }
 
-func clonePreconfirmed(preconfirmed *core.PreConfirmed) *core.PreConfirmed {
-	return &core.PreConfirmed{
+func clonePreconfirmed(preconfirmed *pending.PreConfirmed) *pending.PreConfirmed {
+	return &pending.PreConfirmed{
 		Block:                 cloneBlock(preconfirmed.Block),
 		StateUpdate:           cloneStateUpdate(preconfirmed.StateUpdate),
 		NewClasses:            maps.Clone(preconfirmed.NewClasses),

--- a/consensus/datasource/consensus_data_source.go
+++ b/consensus/datasource/consensus_data_source.go
@@ -76,7 +76,10 @@ func (c *consensusDataSource[V, H]) BlockPreLatest(ctx context.Context) (pending
 	return pending.PreLatest{}, errors.New("not implemented") // TODO: Revise this
 }
 
-func (c *consensusDataSource[V, H]) PreConfirmedBlockByNumber(ctx context.Context, blockNumber uint64) (pending.PreConfirmed, error) {
+func (c *consensusDataSource[V, H]) PreConfirmedBlockByNumber(
+	ctx context.Context,
+	blockNumber uint64,
+) (pending.PreConfirmed, error) {
 	preconfirmed := c.proposer.Preconfirmed()
 	if preconfirmed.Block.Number != blockNumber {
 		return pending.PreConfirmed{}, fmt.Errorf("block %d is not preconfirmed", blockNumber)

--- a/consensus/datasource/consensus_data_source.go
+++ b/consensus/datasource/consensus_data_source.go
@@ -11,6 +11,7 @@ import (
 	"github.com/NethermindEth/juno/consensus/proposer"
 	"github.com/NethermindEth/juno/consensus/types"
 	"github.com/NethermindEth/juno/core"
+	"github.com/NethermindEth/juno/core/pending"
 	"github.com/NethermindEth/juno/sync"
 )
 
@@ -71,14 +72,14 @@ func (c *consensusDataSource[V, H]) BlockHeaderLatest(ctx context.Context) (*cor
 	return committedBlock.Block.Header, nil
 }
 
-func (c *consensusDataSource[V, H]) BlockPreLatest(ctx context.Context) (core.PreLatest, error) {
-	return core.PreLatest{}, errors.New("not implemented") // TODO: Revise this
+func (c *consensusDataSource[V, H]) BlockPreLatest(ctx context.Context) (pending.PreLatest, error) {
+	return pending.PreLatest{}, errors.New("not implemented") // TODO: Revise this
 }
 
-func (c *consensusDataSource[V, H]) PreConfirmedBlockByNumber(ctx context.Context, blockNumber uint64) (core.PreConfirmed, error) {
+func (c *consensusDataSource[V, H]) PreConfirmedBlockByNumber(ctx context.Context, blockNumber uint64) (pending.PreConfirmed, error) {
 	preconfirmed := c.proposer.Preconfirmed()
 	if preconfirmed.Block.Number != blockNumber {
-		return core.PreConfirmed{}, fmt.Errorf("block %d is not preconfirmed", blockNumber)
+		return pending.PreConfirmed{}, fmt.Errorf("block %d is not preconfirmed", blockNumber)
 	}
 	return *preconfirmed, nil
 }

--- a/consensus/p2p/validator/empty_fixtures_test.go
+++ b/consensus/p2p/validator/empty_fixtures_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/NethermindEth/juno/consensus/starknet"
 	"github.com/NethermindEth/juno/core"
 	"github.com/NethermindEth/juno/core/felt"
+	"github.com/NethermindEth/juno/core/pending"
 	"github.com/NethermindEth/juno/db"
 	"github.com/NethermindEth/juno/utils"
 	"github.com/starknet-io/starknet-p2p-specs/p2p/proto/common"
@@ -88,7 +89,7 @@ func NewEmptyTestFixture(
 
 func EmptyBuildResult(headBlock *core.Block, proposer, expectedHash *felt.Felt, timestamp uint64) builder.BuildResult {
 	return builder.BuildResult{
-		PreConfirmed: &core.PreConfirmed{
+		PreConfirmed: &pending.PreConfirmed{
 			Block: &core.Block{
 				Header: &core.Header{
 					Hash:             expectedHash,

--- a/consensus/p2p/validator/fixtures_test.go
+++ b/consensus/p2p/validator/fixtures_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/NethermindEth/juno/consensus/types"
 	"github.com/NethermindEth/juno/core"
 	"github.com/NethermindEth/juno/core/felt"
+	"github.com/NethermindEth/juno/core/pending"
 	"github.com/NethermindEth/juno/db"
 	"github.com/NethermindEth/juno/starknet"
 	adaptfeeder "github.com/NethermindEth/juno/starknetdata/feeder"
@@ -258,7 +259,7 @@ func buildBuildResult(
 	totalGasConsumed int,
 ) builder.BuildResult {
 	return builder.BuildResult{
-		PreConfirmed: &core.PreConfirmed{
+		PreConfirmed: &pending.PreConfirmed{
 			Block:       block,
 			StateUpdate: stateUpdate,
 			NewClasses:  calculateNewClasses(t, gw, stateUpdate),
@@ -297,7 +298,7 @@ func buildPreState(buildResult *builder.BuildResult, headBlockHeader, revealedBl
 	strippedBlockHeader.EventsBloom = nil
 	strippedBlockHeader.Signatures = nil
 	return builder.BuildState{
-		PreConfirmed: &core.PreConfirmed{
+		PreConfirmed: &pending.PreConfirmed{
 			Block: &core.Block{
 				Header:       &strippedBlockHeader,
 				Transactions: []core.Transaction{},

--- a/consensus/proposal/proposal_store_test.go
+++ b/consensus/proposal/proposal_store_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/NethermindEth/juno/consensus/starknet"
 	"github.com/NethermindEth/juno/core"
 	"github.com/NethermindEth/juno/core/felt"
+	"github.com/NethermindEth/juno/core/pending"
 	"github.com/sourcegraph/conc"
 	"github.com/stretchr/testify/require"
 )
@@ -22,7 +23,7 @@ const (
 func createTestBuildResult() *builder.BuildResult {
 	blockNumber := rand.Uint64()
 	return &builder.BuildResult{
-		PreConfirmed: &core.PreConfirmed{
+		PreConfirmed: &pending.PreConfirmed{
 			Block: &core.Block{
 				Header: &core.Header{
 					Number: blockNumber,

--- a/consensus/proposer/proposer.go
+++ b/consensus/proposer/proposer.go
@@ -13,6 +13,7 @@ import (
 	"github.com/NethermindEth/juno/consensus/types"
 	"github.com/NethermindEth/juno/core"
 	"github.com/NethermindEth/juno/core/felt"
+	"github.com/NethermindEth/juno/core/pending"
 	"github.com/NethermindEth/juno/mempool"
 	"github.com/NethermindEth/juno/service"
 	"github.com/NethermindEth/juno/utils"
@@ -40,7 +41,7 @@ type Proposer[V types.Hashable[H], H types.Hash] interface {
 	mempool.Pool
 	OnCommit(context.Context, types.Height, V)
 	Submit(context.Context, []mempool.BroadcastedTransaction)
-	Preconfirmed() *core.PreConfirmed
+	Preconfirmed() *pending.PreConfirmed
 }
 
 type proposer[V types.Hashable[H], H types.Hash] struct {
@@ -164,7 +165,7 @@ func (p *proposer[V, H]) Push(ctx context.Context, transaction *mempool.Broadcas
 // Return the preconfirmed block currently guarded by the atomic pointer. The implementation
 // assumes that the referenced value by the atomic pointer is immutable, which means the caller
 // shouldn't modify any fields of the returned preconfirmed block.
-func (p *proposer[V, H]) Preconfirmed() *core.PreConfirmed {
+func (p *proposer[V, H]) Preconfirmed() *pending.PreConfirmed {
 	return p.buildState.Load().PreConfirmed
 }
 

--- a/consensus/sync/sync.go
+++ b/consensus/sync/sync.go
@@ -11,6 +11,7 @@ import (
 	"github.com/NethermindEth/juno/consensus/votecounter"
 	"github.com/NethermindEth/juno/core"
 	"github.com/NethermindEth/juno/core/felt"
+	"github.com/NethermindEth/juno/core/pending"
 	"github.com/NethermindEth/juno/p2p/sync"
 )
 
@@ -63,7 +64,7 @@ func (s *MessageExtractor[V, H, A]) Extract(
 		committedBlock.Block.L1DAMode,
 	)
 	buildResult := builder.BuildResult{
-		PreConfirmed: &core.PreConfirmed{
+		PreConfirmed: &pending.PreConfirmed{
 			Block:       committedBlock.Block,
 			StateUpdate: committedBlock.StateUpdate,
 			NewClasses:  committedBlock.NewClasses,

--- a/core/pending/pending.go
+++ b/core/pending/pending.go
@@ -215,7 +215,7 @@ func (p *PreConfirmed) PendingStateBeforeIndex(
 		stateDiff.Merge(txStateDiff)
 	}
 
-	return NewPendingState(&stateDiff, newClasses, baseState, p.Block.Number), nil
+	return NewState(&stateDiff, newClasses, baseState, p.Block.Number), nil
 }
 
 func (p *PreConfirmed) PendingState(baseState core.StateReader) core.StateReader {
@@ -231,5 +231,5 @@ func (p *PreConfirmed) PendingState(baseState core.StateReader) core.StateReader
 
 	stateDiff.Merge(p.StateUpdate.StateDiff)
 
-	return NewPendingState(&stateDiff, newClasses, baseState, p.Block.Number)
+	return NewState(&stateDiff, newClasses, baseState, p.Block.Number)
 }

--- a/core/pending/pending.go
+++ b/core/pending/pending.go
@@ -1,8 +1,9 @@
-package core
+package pending
 
 import (
 	"errors"
 
+	"github.com/NethermindEth/juno/core"
 	"github.com/NethermindEth/juno/core/felt"
 )
 
@@ -19,16 +20,16 @@ var (
 // placeholder returned by rpc/v6/v8's Pending() and MakeEmptyPendingForParent to satisfy
 // the "pending" block ID in the v6/v8 RPC spec. Remove this type when rpc/v6/v8 are deprecated.
 type Pending struct {
-	Block       *Block
-	StateUpdate *StateUpdate
-	NewClasses  map[felt.Felt]ClassDefinition
+	Block       *core.Block
+	StateUpdate *core.StateUpdate
+	NewClasses  map[felt.Felt]core.ClassDefinition
 }
 
 // Deprecated: NewPending constructs the deprecated Pending type.
 func NewPending(
-	block *Block,
-	stateUpdate *StateUpdate,
-	newClasses map[felt.Felt]ClassDefinition,
+	block *core.Block,
+	stateUpdate *core.StateUpdate,
+	newClasses map[felt.Felt]core.ClassDefinition,
 ) Pending {
 	return Pending{
 		Block:       block,
@@ -37,40 +38,40 @@ func NewPending(
 	}
 }
 
-func (p *Pending) GetBlock() *Block {
+func (p *Pending) GetBlock() *core.Block {
 	return p.Block
 }
 
-func (p *Pending) GetHeader() *Header {
+func (p *Pending) GetHeader() *core.Header {
 	return p.Block.Header
 }
 
-func (p *Pending) GetTransactions() []Transaction {
+func (p *Pending) GetTransactions() []core.Transaction {
 	return p.Block.Transactions
 }
 
-func (p *Pending) GetStateUpdate() *StateUpdate {
+func (p *Pending) GetStateUpdate() *core.StateUpdate {
 	return p.StateUpdate
 }
 
 type PreLatest Pending
 
 type PreConfirmed struct {
-	Block       *Block
-	StateUpdate *StateUpdate
+	Block       *core.Block
+	StateUpdate *core.StateUpdate
 	// Node does not fetch unknown classes. but we keep it for sequencer
-	NewClasses            map[felt.Felt]ClassDefinition
-	TransactionStateDiffs []*StateDiff
-	CandidateTxs          []Transaction
+	NewClasses            map[felt.Felt]core.ClassDefinition
+	TransactionStateDiffs []*core.StateDiff
+	CandidateTxs          []core.Transaction
 	// Optional field, exists if pre_confirmed is N+2 when latest is N
 	PreLatest *PreLatest
 }
 
 func NewPreConfirmed(
-	block *Block,
-	stateUpdate *StateUpdate,
-	transactionStateDiffs []*StateDiff,
-	candidateTxs []Transaction,
+	block *core.Block,
+	stateUpdate *core.StateUpdate,
+	transactionStateDiffs []*core.StateDiff,
+	candidateTxs []core.Transaction,
 ) PreConfirmed {
 	return PreConfirmed{
 		Block:                 block,
@@ -80,7 +81,7 @@ func NewPreConfirmed(
 	}
 }
 
-func (p *PreConfirmed) WithNewClasses(newClasses map[felt.Felt]ClassDefinition) *PreConfirmed {
+func (p *PreConfirmed) WithNewClasses(newClasses map[felt.Felt]core.ClassDefinition) *PreConfirmed {
 	p.NewClasses = newClasses
 	return p
 }
@@ -95,31 +96,31 @@ func (p *PreConfirmed) Copy() *PreConfirmed {
 	return &cp
 }
 
-func (p *PreConfirmed) GetBlock() *Block {
+func (p *PreConfirmed) GetBlock() *core.Block {
 	return p.Block
 }
 
-func (p *PreConfirmed) GetHeader() *Header {
+func (p *PreConfirmed) GetHeader() *core.Header {
 	return p.Block.Header
 }
 
-func (p *PreConfirmed) GetTransactions() []Transaction {
+func (p *PreConfirmed) GetTransactions() []core.Transaction {
 	return p.Block.Transactions
 }
 
-func (p *PreConfirmed) GetStateUpdate() *StateUpdate {
+func (p *PreConfirmed) GetStateUpdate() *core.StateUpdate {
 	return p.StateUpdate
 }
 
-func (p *PreConfirmed) GetNewClasses() map[felt.Felt]ClassDefinition {
+func (p *PreConfirmed) GetNewClasses() map[felt.Felt]core.ClassDefinition {
 	return p.NewClasses
 }
 
-func (p *PreConfirmed) GetCandidateTransaction() []Transaction {
+func (p *PreConfirmed) GetCandidateTransaction() []core.Transaction {
 	return p.CandidateTxs
 }
 
-func (p *PreConfirmed) GetTransactionStateDiffs() []*StateDiff {
+func (p *PreConfirmed) GetTransactionStateDiffs() []*core.StateDiff {
 	return p.TransactionStateDiffs
 }
 
@@ -127,7 +128,7 @@ func (p *PreConfirmed) GetPreLatest() *PreLatest {
 	return p.PreLatest
 }
 
-func (p *PreConfirmed) Validate(parent *Header) bool {
+func (p *PreConfirmed) Validate(parent *core.Header) bool {
 	if parent == nil {
 		return p.Block.Number == 0
 	}
@@ -146,7 +147,7 @@ func (p *PreConfirmed) Validate(parent *Header) bool {
 		p.PreLatest.Block.ParentHash.Equal(parent.Hash)
 }
 
-func (p *PreConfirmed) TransactionByHash(hash *felt.Felt) (Transaction, error) {
+func (p *PreConfirmed) TransactionByHash(hash *felt.Felt) (core.Transaction, error) {
 	if preLatest := p.PreLatest; preLatest != nil {
 		for _, tx := range preLatest.Block.Transactions {
 			if tx.Hash().Equal(hash) {
@@ -172,7 +173,7 @@ func (p *PreConfirmed) TransactionByHash(hash *felt.Felt) (Transaction, error) {
 
 func (p *PreConfirmed) ReceiptByHash(
 	hash *felt.Felt,
-) (*TransactionReceipt, *felt.Felt, uint64, error) {
+) (*core.TransactionReceipt, *felt.Felt, uint64, error) {
 	if preLatest := p.PreLatest; preLatest != nil {
 		for _, receipt := range preLatest.Block.Receipts {
 			if receipt.TransactionHash.Equal(hash) {
@@ -191,15 +192,15 @@ func (p *PreConfirmed) ReceiptByHash(
 }
 
 func (p *PreConfirmed) PendingStateBeforeIndex(
-	baseState StateReader,
+	baseState core.StateReader,
 	index uint,
-) (StateReader, error) {
+) (core.StateReader, error) {
 	if index > uint(len(p.Block.Transactions)) {
 		return nil, ErrTransactionIndexOutOfBounds
 	}
 
-	stateDiff := EmptyStateDiff()
-	newClasses := make(map[felt.Felt]ClassDefinition)
+	stateDiff := core.EmptyStateDiff()
+	newClasses := make(map[felt.Felt]core.ClassDefinition)
 
 	// Add pre_latest state diff if available
 	preLatest := p.PreLatest
@@ -217,9 +218,9 @@ func (p *PreConfirmed) PendingStateBeforeIndex(
 	return NewPendingState(&stateDiff, newClasses, baseState, p.Block.Number), nil
 }
 
-func (p *PreConfirmed) PendingState(baseState StateReader) StateReader {
-	stateDiff := EmptyStateDiff()
-	newClasses := make(map[felt.Felt]ClassDefinition)
+func (p *PreConfirmed) PendingState(baseState core.StateReader) core.StateReader {
+	stateDiff := core.EmptyStateDiff()
+	newClasses := make(map[felt.Felt]core.ClassDefinition)
 
 	// Add pre_latest state diff if available
 	preLatest := p.PreLatest

--- a/core/pending/pending_state.go
+++ b/core/pending/pending_state.go
@@ -1,9 +1,10 @@
-package core
+package pending
 
 import (
 	"errors"
 	"fmt"
 
+	"github.com/NethermindEth/juno/core"
 	"github.com/NethermindEth/juno/core/felt"
 	"github.com/NethermindEth/juno/db"
 )
@@ -11,9 +12,9 @@ import (
 var ErrHistoricalTrieNotSupported = errors.New("cannot support historical trie")
 
 type PendingState struct {
-	stateDiff  *StateDiff
-	newClasses map[felt.Felt]ClassDefinition
-	head       StateReader
+	stateDiff  *core.StateDiff
+	newClasses map[felt.Felt]core.ClassDefinition
+	head       core.StateReader
 
 	// The block number of the pending block that this
 	// pending state represents
@@ -21,9 +22,9 @@ type PendingState struct {
 }
 
 func NewPendingState(
-	stateDiff *StateDiff,
-	newClasses map[felt.Felt]ClassDefinition,
-	head StateReader,
+	stateDiff *core.StateDiff,
+	newClasses map[felt.Felt]core.ClassDefinition,
+	head core.StateReader,
 	blockNumber uint64,
 ) *PendingState {
 	return &PendingState{
@@ -34,7 +35,7 @@ func NewPendingState(
 	}
 }
 
-func (p *PendingState) StateDiff() *StateDiff {
+func (p *PendingState) StateDiff() *core.StateDiff {
 	return p.stateDiff
 }
 
@@ -86,9 +87,9 @@ func (p *PendingState) ContractStorageLastUpdatedBlock(
 	return p.head.ContractStorageLastUpdatedBlock(addr, key)
 }
 
-func (p *PendingState) Class(classHash *felt.Felt) (*DeclaredClassDefinition, error) {
+func (p *PendingState) Class(classHash *felt.Felt) (*core.DeclaredClassDefinition, error) {
 	if class, found := p.newClasses[*classHash]; found {
-		return &DeclaredClassDefinition{
+		return &core.DeclaredClassDefinition{
 			At:    0,
 			Class: class,
 		}, nil
@@ -116,15 +117,15 @@ func (p *PendingState) CompiledClassHashV2(
 	return p.head.CompiledClassHashV2(classHash)
 }
 
-func (p *PendingState) ClassTrie() (Trie, error) {
+func (p *PendingState) ClassTrie() (core.Trie, error) {
 	return nil, ErrHistoricalTrieNotSupported
 }
 
-func (p *PendingState) ContractTrie() (Trie, error) {
+func (p *PendingState) ContractTrie() (core.Trie, error) {
 	return nil, ErrHistoricalTrieNotSupported
 }
 
-func (p *PendingState) ContractStorageTrie(addr *felt.Felt) (Trie, error) {
+func (p *PendingState) ContractStorageTrie(addr *felt.Felt) (core.Trie, error) {
 	return nil, ErrHistoricalTrieNotSupported
 }
 
@@ -133,9 +134,9 @@ type PendingStateWriter struct {
 }
 
 func NewPendingStateWriter(
-	stateDiff *StateDiff,
-	newClasses map[felt.Felt]ClassDefinition,
-	head StateReader,
+	stateDiff *core.StateDiff,
+	newClasses map[felt.Felt]core.ClassDefinition,
+	head core.StateReader,
 ) PendingStateWriter {
 	return PendingStateWriter{
 		PendingState: &PendingState{
@@ -177,7 +178,7 @@ func (p *PendingStateWriter) SetClassHash(contractAddress, classHash *felt.Felt)
 
 // SetContractClass writes a new CairoV0 class to the PendingState
 // Assumption: SetCompiledClassHash should be called for CairoV1 contracts
-func (p *PendingStateWriter) SetContractClass(classHash *felt.Felt, class ClassDefinition) error {
+func (p *PendingStateWriter) SetContractClass(classHash *felt.Felt, class core.ClassDefinition) error {
 	// Only declare the class if it has not already been declared, and return
 	// and unexepcted errors (ie any error that isn't db.ErrKeyNotFound)
 	_, err := p.Class(classHash)
@@ -188,7 +189,7 @@ func (p *PendingStateWriter) SetContractClass(classHash *felt.Felt, class ClassD
 	}
 
 	p.newClasses[*classHash] = class
-	if _, ok := class.(*DeprecatedCairoClass); ok {
+	if _, ok := class.(*core.DeprecatedCairoClass); ok {
 		p.stateDiff.DeclaredV0Classes = append(p.stateDiff.DeclaredV0Classes, classHash.Clone())
 	}
 	return nil
@@ -203,10 +204,10 @@ func (p *PendingStateWriter) SetCompiledClassHash(classHash, compiledClassHash *
 
 // StateDiffAndClasses returns the pending state's internal data. The returned objects will continue to be
 // read and modified by the pending state.
-func (p *PendingStateWriter) StateDiffAndClasses() (StateDiff, map[felt.Felt]ClassDefinition) {
+func (p *PendingStateWriter) StateDiffAndClasses() (core.StateDiff, map[felt.Felt]core.ClassDefinition) {
 	return *p.stateDiff, p.newClasses
 }
 
-func (p *PendingStateWriter) SetStateDiff(stateDiff *StateDiff) {
+func (p *PendingStateWriter) SetStateDiff(stateDiff *core.StateDiff) {
 	p.stateDiff = stateDiff
 }

--- a/core/pending/pending_state_test.go
+++ b/core/pending/pending_state_test.go
@@ -1,10 +1,11 @@
-package core_test
+package pending_test
 
 import (
 	"testing"
 
 	"github.com/NethermindEth/juno/core"
 	"github.com/NethermindEth/juno/core/felt"
+	"github.com/NethermindEth/juno/core/pending"
 	"github.com/NethermindEth/juno/mocks"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -54,7 +55,7 @@ func TestPendingState(t *testing.T) {
 
 	const pendingBlockNumber = uint64(5)
 
-	state := core.NewPendingState(
+	state := pending.NewPendingState(
 		stateDiff, newClasses, mockState, pendingBlockNumber,
 	)
 

--- a/core/pending/pending_test.go
+++ b/core/pending/pending_test.go
@@ -1,17 +1,18 @@
-package core_test
+package pending_test
 
 import (
 	"testing"
 
 	"github.com/NethermindEth/juno/core"
 	"github.com/NethermindEth/juno/core/felt"
+	"github.com/NethermindEth/juno/core/pending"
 	"github.com/stretchr/testify/require"
 )
 
 func TestPreConfirmedValidate(t *testing.T) {
 	t.Run("without pre-latest", func(t *testing.T) {
 		// Genesis case with nil parent
-		preConfirmed0 := &core.PreConfirmed{
+		preConfirmed0 := &pending.PreConfirmed{
 			Block: &core.Block{
 				Header: &core.Header{
 					Number: 0,
@@ -33,7 +34,7 @@ func TestPreConfirmedValidate(t *testing.T) {
 		require.False(t, preConfirmed0.Validate(head0.Header))
 
 		// PreConfirmed for head
-		preConfirmed1 := &core.PreConfirmed{
+		preConfirmed1 := &pending.PreConfirmed{
 			Block: &core.Block{
 				Header: &core.Header{
 					Number: 1,
@@ -53,7 +54,7 @@ func TestPreConfirmedValidate(t *testing.T) {
 			},
 		}
 
-		preLatest1 := core.PreLatest{
+		preLatest1 := pending.PreLatest{
 			Block: &core.Block{
 				Header: &core.Header{
 					ParentHash: &felt.One,
@@ -62,7 +63,7 @@ func TestPreConfirmedValidate(t *testing.T) {
 			},
 		}
 		// Genesis case with nil parent
-		preConfirmed2 := &core.PreConfirmed{
+		preConfirmed2 := &pending.PreConfirmed{
 			Block: &core.Block{
 				Header: &core.Header{
 					Number: 2,
@@ -100,7 +101,7 @@ func TestPreConfirmedTransactionByHash(t *testing.T) {
 		TransactionHash: &candidateTxHash,
 	}
 
-	preLatest := &core.PreLatest{
+	preLatest := &pending.PreLatest{
 		Block: &core.Block{
 			Header: &core.Header{
 				Number:     1,
@@ -110,7 +111,7 @@ func TestPreConfirmedTransactionByHash(t *testing.T) {
 		},
 	}
 
-	preConfirmed := &core.PreConfirmed{
+	preConfirmed := &pending.PreConfirmed{
 		Block: &core.Block{
 			Header: &core.Header{
 				Number: 2,
@@ -142,7 +143,7 @@ func TestPreConfirmedTransactionByHash(t *testing.T) {
 	t.Run("transaction not found", func(t *testing.T) {
 		_, err := preConfirmed.TransactionByHash(&nonExistingTxHash)
 		require.Error(t, err)
-		require.Equal(t, core.ErrTransactionNotFound, err)
+		require.Equal(t, pending.ErrTransactionNotFound, err)
 	})
 }
 
@@ -160,7 +161,7 @@ func TestPreConfirmedReceiptByHash(t *testing.T) {
 
 	preLatestParentHash := felt.FromUint64[felt.Felt](100)
 	preLatestBlockNumber := uint64(1)
-	preLatest := &core.PreLatest{
+	preLatest := &pending.PreLatest{
 		Block: &core.Block{
 			Header: &core.Header{
 				Number:     preLatestBlockNumber,
@@ -171,7 +172,7 @@ func TestPreConfirmedReceiptByHash(t *testing.T) {
 	}
 
 	preConfirmedBlockNumber := uint64(2)
-	preConfirmed := &core.PreConfirmed{
+	preConfirmed := &pending.PreConfirmed{
 		Block: &core.Block{
 			Header: &core.Header{
 				Number: preConfirmedBlockNumber,
@@ -206,7 +207,7 @@ func TestPreConfirmedReceiptByHash(t *testing.T) {
 	t.Run("receipt not found", func(t *testing.T) {
 		_, _, _, err := preConfirmed.ReceiptByHash(&nonExistingReceiptHash)
 		require.Error(t, err)
-		require.Equal(t, core.ErrTransactionReceiptNotFound, err)
+		require.Equal(t, pending.ErrTransactionReceiptNotFound, err)
 	})
 }
 
@@ -283,14 +284,14 @@ func TestPreConfirmed_PendingState(t *testing.T) {
 		storageKey: felt.NewFromUint64[felt.Felt](0xFFFFFFFFFFFFFFFF),
 	}
 
-	preConfirmed := core.PreConfirmed{
+	preConfirmed := pending.PreConfirmed{
 		StateUpdate: &core.StateUpdate{
 			StateDiff: &stateDiff,
 		},
 	}
 	preConfirmed.Block = &emptyBlock
 
-	preLatest := &core.PreLatest{
+	preLatest := &pending.PreLatest{
 		StateUpdate: &core.StateUpdate{
 			StateDiff: &preLatestStateDiff,
 		},
@@ -346,7 +347,7 @@ func TestPending_PendingStateBeforeIndex(t *testing.T) {
 		preConfirmedStorageKey: felt.NewFromUint64[felt.Felt](0xFFFFFFFFFFFFFFFF),
 	}
 
-	preLatest := &core.PreLatest{
+	preLatest := &pending.PreLatest{
 		StateUpdate: &core.StateUpdate{
 			StateDiff: &preLatestStateDiff,
 		},
@@ -361,7 +362,7 @@ func TestPending_PendingStateBeforeIndex(t *testing.T) {
 		numTxs,
 	)
 
-	assertPendingStateAtIndex := func(t *testing.T, preConfirmed *core.PreConfirmed, idx int) {
+	assertPendingStateAtIndex := func(t *testing.T, preConfirmed *pending.PreConfirmed, idx int) {
 		state, err := preConfirmed.PendingStateBeforeIndex(nil, uint(idx+1))
 		require.NoError(t, err)
 		require.NotNil(t, state)
@@ -382,7 +383,7 @@ func TestPending_PendingStateBeforeIndex(t *testing.T) {
 		require.Equal(t, expectedNonce, retrievedNonce)
 	}
 
-	preConfirmed := core.PreConfirmed{
+	preConfirmed := pending.PreConfirmed{
 		Block: &core.Block{
 			Header: &core.Header{
 				Number: 0,
@@ -400,7 +401,7 @@ func TestPending_PendingStateBeforeIndex(t *testing.T) {
 			nil,
 			uint(len(preConfirmed.Block.Transactions)+1),
 		)
-		require.ErrorIs(t, err, core.ErrTransactionIndexOutOfBounds)
+		require.ErrorIs(t, err, pending.ErrTransactionIndexOutOfBounds)
 	})
 
 	t.Run("without pre-latest", func(t *testing.T) {

--- a/core/pending/state.go
+++ b/core/pending/state.go
@@ -11,23 +11,23 @@ import (
 
 var ErrHistoricalTrieNotSupported = errors.New("cannot support historical trie")
 
-type PendingState struct {
+type State struct {
 	stateDiff  *core.StateDiff
 	newClasses map[felt.Felt]core.ClassDefinition
 	head       core.StateReader
 
 	// The block number of the pending block that this
-	// pending state represents
+	// state represents
 	blockNumber uint64
 }
 
-func NewPendingState(
+func NewState(
 	stateDiff *core.StateDiff,
 	newClasses map[felt.Felt]core.ClassDefinition,
 	head core.StateReader,
 	blockNumber uint64,
-) *PendingState {
-	return &PendingState{
+) *State {
+	return &State{
 		stateDiff:   stateDiff,
 		newClasses:  newClasses,
 		head:        head,
@@ -35,11 +35,11 @@ func NewPendingState(
 	}
 }
 
-func (p *PendingState) StateDiff() *core.StateDiff {
+func (p *State) StateDiff() *core.StateDiff {
 	return p.stateDiff
 }
 
-func (p *PendingState) ContractClassHash(addr *felt.Felt) (felt.Felt, error) {
+func (p *State) ContractClassHash(addr *felt.Felt) (felt.Felt, error) {
 	if classHash, ok := p.stateDiff.ReplacedClasses[*addr]; ok {
 		return *classHash, nil
 	} else if classHash, ok = p.stateDiff.DeployedContracts[*addr]; ok {
@@ -48,7 +48,7 @@ func (p *PendingState) ContractClassHash(addr *felt.Felt) (felt.Felt, error) {
 	return p.head.ContractClassHash(addr)
 }
 
-func (p *PendingState) ContractNonce(addr *felt.Felt) (felt.Felt, error) {
+func (p *State) ContractNonce(addr *felt.Felt) (felt.Felt, error) {
 	if nonce, found := p.stateDiff.Nonces[*addr]; found {
 		return *nonce, nil
 	} else if _, found = p.stateDiff.DeployedContracts[*addr]; found {
@@ -57,7 +57,7 @@ func (p *PendingState) ContractNonce(addr *felt.Felt) (felt.Felt, error) {
 	return p.head.ContractNonce(addr)
 }
 
-func (p *PendingState) ContractStorage(addr, key *felt.Felt) (felt.Felt, error) {
+func (p *State) ContractStorage(addr, key *felt.Felt) (felt.Felt, error) {
 	if diffs, found := p.stateDiff.StorageDiffs[*addr]; found {
 		if value, found := diffs[*key]; found {
 			return *value, nil
@@ -71,7 +71,7 @@ func (p *PendingState) ContractStorage(addr, key *felt.Felt) (felt.Felt, error) 
 
 // ContractStorageLastUpdatedBlock returns the most recent block number at which a given storage
 // slot key of a given contract was last updated.
-func (p *PendingState) ContractStorageLastUpdatedBlock(
+func (p *State) ContractStorageLastUpdatedBlock(
 	addr *felt.Address,
 	key *felt.Felt,
 ) (uint64, error) {
@@ -87,7 +87,7 @@ func (p *PendingState) ContractStorageLastUpdatedBlock(
 	return p.head.ContractStorageLastUpdatedBlock(addr, key)
 }
 
-func (p *PendingState) Class(classHash *felt.Felt) (*core.DeclaredClassDefinition, error) {
+func (p *State) Class(classHash *felt.Felt) (*core.DeclaredClassDefinition, error) {
 	if class, found := p.newClasses[*classHash]; found {
 		return &core.DeclaredClassDefinition{
 			At:    0,
@@ -98,7 +98,7 @@ func (p *PendingState) Class(classHash *felt.Felt) (*core.DeclaredClassDefinitio
 	return p.head.Class(classHash)
 }
 
-func (p *PendingState) CompiledClassHash(
+func (p *State) CompiledClassHash(
 	classHash *felt.SierraClassHash,
 ) (felt.CasmClassHash, error) {
 	classHashFelt := felt.Felt(*classHash)
@@ -108,7 +108,7 @@ func (p *PendingState) CompiledClassHash(
 	return p.head.CompiledClassHash(classHash)
 }
 
-func (p *PendingState) CompiledClassHashV2(
+func (p *State) CompiledClassHashV2(
 	classHash *felt.SierraClassHash,
 ) (felt.CasmClassHash, error) {
 	if casmHash, found := p.stateDiff.MigratedClasses[*classHash]; found {
@@ -117,29 +117,29 @@ func (p *PendingState) CompiledClassHashV2(
 	return p.head.CompiledClassHashV2(classHash)
 }
 
-func (p *PendingState) ClassTrie() (core.Trie, error) {
+func (p *State) ClassTrie() (core.Trie, error) {
 	return nil, ErrHistoricalTrieNotSupported
 }
 
-func (p *PendingState) ContractTrie() (core.Trie, error) {
+func (p *State) ContractTrie() (core.Trie, error) {
 	return nil, ErrHistoricalTrieNotSupported
 }
 
-func (p *PendingState) ContractStorageTrie(addr *felt.Felt) (core.Trie, error) {
+func (p *State) ContractStorageTrie(addr *felt.Felt) (core.Trie, error) {
 	return nil, ErrHistoricalTrieNotSupported
 }
 
-type PendingStateWriter struct {
-	*PendingState
+type StateWriter struct {
+	*State
 }
 
-func NewPendingStateWriter(
+func NewStateWriter(
 	stateDiff *core.StateDiff,
 	newClasses map[felt.Felt]core.ClassDefinition,
 	head core.StateReader,
-) PendingStateWriter {
-	return PendingStateWriter{
-		PendingState: &PendingState{
+) StateWriter {
+	return StateWriter{
+		State: &State{
 			stateDiff:  stateDiff,
 			newClasses: newClasses,
 			head:       head,
@@ -147,7 +147,7 @@ func NewPendingStateWriter(
 	}
 }
 
-func (p *PendingStateWriter) SetStorage(contractAddress, key, value *felt.Felt) error {
+func (p *StateWriter) SetStorage(contractAddress, key, value *felt.Felt) error {
 	if _, found := p.stateDiff.StorageDiffs[*contractAddress]; !found {
 		p.stateDiff.StorageDiffs[*contractAddress] = make(map[felt.Felt]*felt.Felt)
 	}
@@ -155,7 +155,7 @@ func (p *PendingStateWriter) SetStorage(contractAddress, key, value *felt.Felt) 
 	return nil
 }
 
-func (p *PendingStateWriter) IncrementNonce(contractAddress *felt.Felt) error {
+func (p *StateWriter) IncrementNonce(contractAddress *felt.Felt) error {
 	currentNonce, err := p.ContractNonce(contractAddress)
 	if err != nil {
 		return fmt.Errorf("get contract nonce: %v", err)
@@ -164,7 +164,7 @@ func (p *PendingStateWriter) IncrementNonce(contractAddress *felt.Felt) error {
 	return nil
 }
 
-func (p *PendingStateWriter) SetClassHash(contractAddress, classHash *felt.Felt) error {
+func (p *StateWriter) SetClassHash(contractAddress, classHash *felt.Felt) error {
 	if _, err := p.head.ContractClassHash(contractAddress); err != nil {
 		if errors.Is(err, db.ErrKeyNotFound) {
 			p.stateDiff.DeployedContracts[*contractAddress] = classHash.Clone()
@@ -178,7 +178,7 @@ func (p *PendingStateWriter) SetClassHash(contractAddress, classHash *felt.Felt)
 
 // SetContractClass writes a new CairoV0 class to the PendingState
 // Assumption: SetCompiledClassHash should be called for CairoV1 contracts
-func (p *PendingStateWriter) SetContractClass(classHash *felt.Felt, class core.ClassDefinition) error {
+func (p *StateWriter) SetContractClass(classHash *felt.Felt, class core.ClassDefinition) error {
 	// Only declare the class if it has not already been declared, and return
 	// and unexepcted errors (ie any error that isn't db.ErrKeyNotFound)
 	_, err := p.Class(classHash)
@@ -197,17 +197,17 @@ func (p *PendingStateWriter) SetContractClass(classHash *felt.Felt, class core.C
 
 // SetCompiledClassHash writes CairoV1 classes to the pending state
 // Assumption: SetContractClass was called for classHash and succeeded
-func (p *PendingStateWriter) SetCompiledClassHash(classHash, compiledClassHash *felt.Felt) error {
+func (p *StateWriter) SetCompiledClassHash(classHash, compiledClassHash *felt.Felt) error {
 	p.stateDiff.DeclaredV1Classes[*classHash] = compiledClassHash.Clone()
 	return nil
 }
 
 // StateDiffAndClasses returns the pending state's internal data. The returned objects will continue to be
 // read and modified by the pending state.
-func (p *PendingStateWriter) StateDiffAndClasses() (core.StateDiff, map[felt.Felt]core.ClassDefinition) {
+func (p *StateWriter) StateDiffAndClasses() (core.StateDiff, map[felt.Felt]core.ClassDefinition) {
 	return *p.stateDiff, p.newClasses
 }
 
-func (p *PendingStateWriter) SetStateDiff(stateDiff *core.StateDiff) {
+func (p *StateWriter) SetStateDiff(stateDiff *core.StateDiff) {
 	p.stateDiff = stateDiff
 }

--- a/core/pending/state_test.go
+++ b/core/pending/state_test.go
@@ -55,7 +55,7 @@ func TestPendingState(t *testing.T) {
 
 	const pendingBlockNumber = uint64(5)
 
-	state := pending.NewPendingState(
+	state := pending.NewState(
 		stateDiff, newClasses, mockState, pendingBlockNumber,
 	)
 

--- a/genesis/genesis.go
+++ b/genesis/genesis.go
@@ -104,7 +104,7 @@ func GenesisStateDiff(
 ) (core.StateDiff, map[felt.Felt]core.ClassDefinition, error) {
 	initialStateDiff := core.EmptyStateDiff()
 	memDB := memory.New()
-	genesisState := pending.NewPendingStateWriter(
+	genesisState := pending.NewStateWriter(
 		&initialStateDiff,
 		make(map[felt.Felt]core.ClassDefinition, len(config.Classes)),
 		deprecatedstate.New(memDB.NewIndexedBatch()),
@@ -133,7 +133,7 @@ func GenesisStateDiff(
 func declareClasses(
 	ctx context.Context,
 	config *GenesisConfig,
-	genesisState *pending.PendingStateWriter,
+	genesisState *pending.StateWriter,
 	compiler compiler.Compiler,
 ) error {
 	newClasses, err := loadClasses(ctx, config.Classes, compiler)
@@ -151,7 +151,7 @@ func declareClasses(
 }
 
 func setClass(
-	genesisState *pending.PendingStateWriter,
+	genesisState *pending.StateWriter,
 	classHash *felt.Felt,
 	class core.ClassDefinition,
 ) error {
@@ -173,7 +173,7 @@ func deployContracts(
 	v vm.VM,
 	maxSteps uint64,
 	maxGas uint64,
-	genesisState *pending.PendingStateWriter,
+	genesisState *pending.StateWriter,
 ) error {
 	constructorSelector, err := new(felt.Felt).SetString(constructorSelector)
 	if err != nil {
@@ -205,7 +205,7 @@ func deployContract(
 	v vm.VM,
 	maxSteps uint64,
 	maxGas uint64,
-	genesisState *pending.PendingStateWriter,
+	genesisState *pending.StateWriter,
 	address felt.Felt,
 	contractData GenesisContractData,
 	constructorSelector *felt.Felt,
@@ -251,7 +251,7 @@ func executeFunctionCalls(
 	v vm.VM,
 	maxSteps uint64,
 	maxGas uint64,
-	genesisState *pending.PendingStateWriter,
+	genesisState *pending.StateWriter,
 ) error {
 	blockInfo := vm.BlockInfo{Header: &genesisHeader}
 
@@ -294,7 +294,7 @@ func executeFunctionCalls(
 func executeTransactions(
 	config *GenesisConfig,
 	v vm.VM,
-	genesisState *pending.PendingStateWriter,
+	genesisState *pending.StateWriter,
 ) error {
 	if len(config.Txns) == 0 {
 		return nil

--- a/genesis/genesis.go
+++ b/genesis/genesis.go
@@ -11,6 +11,7 @@ import (
 	"github.com/NethermindEth/juno/core"
 	"github.com/NethermindEth/juno/core/deprecatedstate"
 	"github.com/NethermindEth/juno/core/felt"
+	"github.com/NethermindEth/juno/core/pending"
 	"github.com/NethermindEth/juno/db/memory"
 	rpc "github.com/NethermindEth/juno/rpc/v8"
 	"github.com/NethermindEth/juno/starknet"
@@ -103,7 +104,7 @@ func GenesisStateDiff(
 ) (core.StateDiff, map[felt.Felt]core.ClassDefinition, error) {
 	initialStateDiff := core.EmptyStateDiff()
 	memDB := memory.New()
-	genesisState := core.NewPendingStateWriter(
+	genesisState := pending.NewPendingStateWriter(
 		&initialStateDiff,
 		make(map[felt.Felt]core.ClassDefinition, len(config.Classes)),
 		deprecatedstate.New(memDB.NewIndexedBatch()),
@@ -132,7 +133,7 @@ func GenesisStateDiff(
 func declareClasses(
 	ctx context.Context,
 	config *GenesisConfig,
-	genesisState *core.PendingStateWriter,
+	genesisState *pending.PendingStateWriter,
 	compiler compiler.Compiler,
 ) error {
 	newClasses, err := loadClasses(ctx, config.Classes, compiler)
@@ -150,7 +151,7 @@ func declareClasses(
 }
 
 func setClass(
-	genesisState *core.PendingStateWriter,
+	genesisState *pending.PendingStateWriter,
 	classHash *felt.Felt,
 	class core.ClassDefinition,
 ) error {
@@ -172,7 +173,7 @@ func deployContracts(
 	v vm.VM,
 	maxSteps uint64,
 	maxGas uint64,
-	genesisState *core.PendingStateWriter,
+	genesisState *pending.PendingStateWriter,
 ) error {
 	constructorSelector, err := new(felt.Felt).SetString(constructorSelector)
 	if err != nil {
@@ -204,7 +205,7 @@ func deployContract(
 	v vm.VM,
 	maxSteps uint64,
 	maxGas uint64,
-	genesisState *core.PendingStateWriter,
+	genesisState *pending.PendingStateWriter,
 	address felt.Felt,
 	contractData GenesisContractData,
 	constructorSelector *felt.Felt,
@@ -250,7 +251,7 @@ func executeFunctionCalls(
 	v vm.VM,
 	maxSteps uint64,
 	maxGas uint64,
-	genesisState *core.PendingStateWriter,
+	genesisState *pending.PendingStateWriter,
 ) error {
 	blockInfo := vm.BlockInfo{Header: &genesisHeader}
 
@@ -293,7 +294,7 @@ func executeFunctionCalls(
 func executeTransactions(
 	config *GenesisConfig,
 	v vm.VM,
-	genesisState *core.PendingStateWriter,
+	genesisState *pending.PendingStateWriter,
 ) error {
 	if len(config.Txns) == 0 {
 		return nil

--- a/mocks/mock_blockchain.go
+++ b/mocks/mock_blockchain.go
@@ -15,6 +15,7 @@ import (
 	blockchain "github.com/NethermindEth/juno/blockchain"
 	core "github.com/NethermindEth/juno/core"
 	felt "github.com/NethermindEth/juno/core/felt"
+	pending "github.com/NethermindEth/juno/core/pending"
 	utils "github.com/NethermindEth/juno/utils"
 	common "github.com/ethereum/go-ethereum/common"
 	gomock "go.uber.org/mock/gomock"
@@ -151,7 +152,7 @@ func (mr *MockReaderMockRecorder) BlockNumberByHash(hash any) *gomock.Call {
 }
 
 // EventFilter mocks base method.
-func (m *MockReader) EventFilter(addresses []felt.Address, keys [][]felt.Felt, preConfirmedFn func() (*core.PreConfirmed, error)) (blockchain.EventFilterer, error) {
+func (m *MockReader) EventFilter(addresses []felt.Address, keys [][]felt.Felt, preConfirmedFn func() (*pending.PreConfirmed, error)) (blockchain.EventFilterer, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "EventFilter", addresses, keys, preConfirmedFn)
 	ret0, _ := ret[0].(blockchain.EventFilterer)

--- a/mocks/mock_starknetdata.go
+++ b/mocks/mock_starknetdata.go
@@ -15,6 +15,7 @@ import (
 
 	core "github.com/NethermindEth/juno/core"
 	felt "github.com/NethermindEth/juno/core/felt"
+	pending "github.com/NethermindEth/juno/core/pending"
 	gomock "go.uber.org/mock/gomock"
 )
 
@@ -118,10 +119,10 @@ func (mr *MockStarknetDataMockRecorder) Class(ctx, classHash any) *gomock.Call {
 }
 
 // PreConfirmedBlockByNumber mocks base method.
-func (m *MockStarknetData) PreConfirmedBlockByNumber(ctx context.Context, blockNumber uint64) (core.PreConfirmed, error) {
+func (m *MockStarknetData) PreConfirmedBlockByNumber(ctx context.Context, blockNumber uint64) (pending.PreConfirmed, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "PreConfirmedBlockByNumber", ctx, blockNumber)
-	ret0, _ := ret[0].(core.PreConfirmed)
+	ret0, _ := ret[0].(pending.PreConfirmed)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }

--- a/mocks/mock_synchronizer.go
+++ b/mocks/mock_synchronizer.go
@@ -13,6 +13,7 @@ import (
 	reflect "reflect"
 
 	core "github.com/NethermindEth/juno/core"
+	pending "github.com/NethermindEth/juno/core/pending"
 	sync "github.com/NethermindEth/juno/sync"
 	gomock "go.uber.org/mock/gomock"
 )
@@ -56,10 +57,10 @@ func (mr *MockSyncReaderMockRecorder) HighestBlockHeader() *gomock.Call {
 }
 
 // PreConfirmed mocks base method.
-func (m *MockSyncReader) PreConfirmed() (*core.PreConfirmed, error) {
+func (m *MockSyncReader) PreConfirmed() (*pending.PreConfirmed, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "PreConfirmed")
-	ret0, _ := ret[0].(*core.PreConfirmed)
+	ret0, _ := ret[0].(*pending.PreConfirmed)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -68,36 +69,6 @@ func (m *MockSyncReader) PreConfirmed() (*core.PreConfirmed, error) {
 func (mr *MockSyncReaderMockRecorder) PreConfirmed() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PreConfirmed", reflect.TypeOf((*MockSyncReader)(nil).PreConfirmed))
-}
-
-// PreConfirmedBlock mocks base method.
-func (m *MockSyncReader) PreConfirmedBlock() *core.Block {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "PreConfirmedBlock")
-	ret0, _ := ret[0].(*core.Block)
-	return ret0
-}
-
-// PreConfirmedBlock indicates an expected call of PreConfirmedBlock.
-func (mr *MockSyncReaderMockRecorder) PreConfirmedBlock() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PreConfirmedBlock", reflect.TypeOf((*MockSyncReader)(nil).PreConfirmedBlock))
-}
-
-// PendingState mocks base method.
-func (m *MockSyncReader) PendingState() (core.StateReader, func() error, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "PendingState")
-	ret0, _ := ret[0].(core.StateReader)
-	ret1, _ := ret[1].(func() error)
-	ret2, _ := ret[2].(error)
-	return ret0, ret1, ret2
-}
-
-// PendingState indicates an expected call of PendingState.
-func (mr *MockSyncReaderMockRecorder) PendingState() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PendingState", reflect.TypeOf((*MockSyncReader)(nil).PendingState))
 }
 
 // StartingBlockNumber mocks base method.

--- a/rpc/handlers_test.go
+++ b/rpc/handlers_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/NethermindEth/juno/blockchain"
 	"github.com/NethermindEth/juno/core"
+	"github.com/NethermindEth/juno/core/pending"
 	"github.com/NethermindEth/juno/feed"
 	"github.com/NethermindEth/juno/jsonrpc"
 	"github.com/NethermindEth/juno/mocks"
@@ -39,8 +40,8 @@ func TestRun(t *testing.T) {
 	l1Sub := feed.New[*core.L1Head]()
 	newHeadsSub := feed.New[*core.Block]()
 	reorgSub := feed.New[*sync.ReorgBlockRange]()
-	preConfirmedSub := feed.New[*core.PreConfirmed]()
-	preLatestSub := feed.New[*core.PreLatest]()
+	preConfirmedSub := feed.New[*pending.PreConfirmed]()
+	preLatestSub := feed.New[*pending.PreLatest]()
 
 	mockBcReader := mocks.NewMockReader(mockCtrl)
 	mockSyncReader := mocks.NewMockSyncReader(mockCtrl)

--- a/rpc/v10/block_test.go
+++ b/rpc/v10/block_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/NethermindEth/juno/clients/feeder"
 	"github.com/NethermindEth/juno/core"
 	"github.com/NethermindEth/juno/core/felt"
+	"github.com/NethermindEth/juno/core/pending"
 	"github.com/NethermindEth/juno/db"
 	"github.com/NethermindEth/juno/db/memory"
 	"github.com/NethermindEth/juno/mocks"
@@ -595,7 +596,7 @@ func TestBlockTransactionCount(t *testing.T) {
 	t.Run("blockID - pre_confirmed", func(t *testing.T) {
 		latestBlock.Hash = nil
 		latestBlock.GlobalStateRoot = nil
-		preConfirmed := core.NewPreConfirmed(latestBlock, nil, nil, nil)
+		preConfirmed := pending.NewPreConfirmed(latestBlock, nil, nil, nil)
 		mockSyncReader.EXPECT().PreConfirmed().Return(
 			&preConfirmed,
 			nil,

--- a/rpc/v10/class_test.go
+++ b/rpc/v10/class_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/NethermindEth/juno/clients/feeder"
 	"github.com/NethermindEth/juno/core"
 	"github.com/NethermindEth/juno/core/felt"
+	"github.com/NethermindEth/juno/core/pending"
 	"github.com/NethermindEth/juno/db"
 	"github.com/NethermindEth/juno/mocks"
 	"github.com/NethermindEth/juno/rpc/rpccore"
@@ -238,7 +239,7 @@ func TestClassHashAt(t *testing.T) {
 		stateDiff := core.EmptyStateDiff()
 		stateDiff.DeployedContracts[targetAddress] = expectedClassHash
 
-		preConfirmed := core.PreConfirmed{
+		preConfirmed := pending.PreConfirmed{
 			Block: &core.Block{
 				Header: &core.Header{
 					Number: 2,

--- a/rpc/v10/events_test.go
+++ b/rpc/v10/events_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/NethermindEth/juno/clients/feeder"
 	"github.com/NethermindEth/juno/core"
 	"github.com/NethermindEth/juno/core/felt"
+	"github.com/NethermindEth/juno/core/pending"
 	"github.com/NethermindEth/juno/db"
 	"github.com/NethermindEth/juno/db/memory"
 	"github.com/NethermindEth/juno/jsonrpc"
@@ -24,7 +25,7 @@ import (
 // createEventPreConfirmedFromBlock creates a pre_confirmed block from the given block and
 // returns the pre_confirmed data and emitted events
 func createEventPreConfirmedFromBlock(block *core.Block) (
-	core.PreConfirmed, []rpc.EmittedEvent,
+	pending.PreConfirmed, []rpc.EmittedEvent,
 ) {
 	newHeader := &core.Header{
 		Number:           block.Header.Number,
@@ -38,7 +39,7 @@ func createEventPreConfirmedFromBlock(block *core.Block) (
 		Receipts:     block.Receipts,
 	}
 
-	preConfirmed := core.NewPreConfirmed(preConfirmedBlock, nil, nil, nil)
+	preConfirmed := pending.NewPreConfirmed(preConfirmedBlock, nil, nil, nil)
 
 	// Extract events from the block and convert to emitted events
 	var events []rpc.EmittedEvent
@@ -64,7 +65,7 @@ func createEventPreConfirmedFromBlock(block *core.Block) (
 
 // createEventPreLatestFromBlock creates a pre_latest block from the given block and
 // returns the pre_latest data and emitted events
-func createEventPreLatestFromBlock(block *core.Block) (core.PreLatest, []rpc.EmittedEvent) {
+func createEventPreLatestFromBlock(block *core.Block) (pending.PreLatest, []rpc.EmittedEvent) {
 	newHeader := &core.Header{
 		ParentHash: block.Header.ParentHash,
 		Number:     block.Header.Number,
@@ -76,7 +77,7 @@ func createEventPreLatestFromBlock(block *core.Block) (core.PreLatest, []rpc.Emi
 		Receipts:     block.Receipts,
 	}
 
-	preLatest := core.PreLatest{Block: preLatestBlock}
+	preLatest := pending.PreLatest{Block: preLatestBlock}
 
 	// Extract events from the block and convert to emitted events
 	var events []rpc.EmittedEvent
@@ -244,7 +245,7 @@ func TestEvents(t *testing.T) {
 	type eventTest struct {
 		description    string
 		args           rpc.EventArgs
-		preConfirmed   *core.PreConfirmed
+		preConfirmed   *pending.PreConfirmed
 		expectedEvents []rpc.EmittedEvent
 		expectError    *jsonrpc.Error
 	}
@@ -727,7 +728,7 @@ func TestEvents_ChainProgressesWhilePaginating(t *testing.T) {
 
 	// pre_confirmed becomes pre_latest, continue pagination from block 6
 	preLatest2, _ := createEventPreLatestFromBlock(block6)
-	preConfirmed2 := core.PreConfirmed{
+	preConfirmed2 := pending.PreConfirmed{
 		Block: &core.Block{
 			Header: &core.Header{
 				Number: 7,

--- a/rpc/v10/handlers.go
+++ b/rpc/v10/handlers.go
@@ -12,6 +12,7 @@ import (
 	"github.com/NethermindEth/juno/blockchain"
 	"github.com/NethermindEth/juno/clients/feeder"
 	"github.com/NethermindEth/juno/core"
+	"github.com/NethermindEth/juno/core/pending"
 	"github.com/NethermindEth/juno/feed"
 	"github.com/NethermindEth/juno/jsonrpc"
 	"github.com/NethermindEth/juno/l1/contract"
@@ -37,9 +38,9 @@ type Handler struct {
 
 	newHeads                *feed.Feed[*core.Block]
 	reorgs                  *feed.Feed[*sync.ReorgBlockRange]
-	preConfirmedFeed        *feed.Feed[*core.PreConfirmed]
+	preConfirmedFeed        *feed.Feed[*pending.PreConfirmed]
 	l1Heads                 *feed.Feed[*core.L1Head]
-	preLatestFeed           *feed.Feed[*core.PreLatest]
+	preLatestFeed           *feed.Feed[*pending.PreLatest]
 	receivedTransactionFeed *feed.Feed[core.Transaction]
 
 	idgen         func() string
@@ -90,9 +91,9 @@ func New(
 		},
 		newHeads:         feed.New[*core.Block](),
 		reorgs:           feed.New[*sync.ReorgBlockRange](),
-		preConfirmedFeed: feed.New[*core.PreConfirmed](),
+		preConfirmedFeed: feed.New[*pending.PreConfirmed](),
 		l1Heads:          feed.New[*core.L1Head](),
-		preLatestFeed:    feed.New[*core.PreLatest](),
+		preLatestFeed:    feed.New[*pending.PreLatest](),
 
 		blockTraceCache: lru.NewCache[
 			rpccore.TraceCacheKey,

--- a/rpc/v10/helpers.go
+++ b/rpc/v10/helpers.go
@@ -6,6 +6,7 @@ import (
 	"github.com/NethermindEth/juno/blockchain"
 	"github.com/NethermindEth/juno/core"
 	"github.com/NethermindEth/juno/core/felt"
+	"github.com/NethermindEth/juno/core/pending"
 	"github.com/NethermindEth/juno/db"
 	"github.com/NethermindEth/juno/jsonrpc"
 	"github.com/NethermindEth/juno/rpc/rpccore"
@@ -35,7 +36,7 @@ func (h *Handler) blockByID(blockID *BlockID) (*core.Block, *jsonrpc.Error) {
 
 	switch {
 	case blockID.IsPreConfirmed():
-		var preConfirmed *core.PreConfirmed
+		var preConfirmed *pending.PreConfirmed
 		preConfirmed, err = h.syncReader.PreConfirmed()
 		if err == nil {
 			block = preConfirmed.GetBlock()
@@ -96,7 +97,7 @@ func (h *Handler) blockHeaderByID(blockID *BlockID) (*core.Header, *jsonrpc.Erro
 	var err error
 	switch {
 	case blockID.IsPreConfirmed():
-		var preConfirmed *core.PreConfirmed
+		var preConfirmed *pending.PreConfirmed
 		preConfirmed, err = h.syncReader.PreConfirmed()
 		if err == nil {
 			header = preConfirmed.GetBlock().Header
@@ -157,7 +158,7 @@ func (h *Handler) stateByBlockID(
 	var err error
 	switch {
 	case blockID.IsPreConfirmed():
-		var preConfirmed *core.PreConfirmed
+		var preConfirmed *pending.PreConfirmed
 		preConfirmed, err = h.syncReader.PreConfirmed()
 		if err == nil {
 			reader, closer, err = sync.PendingState(preConfirmed, h.bcReader)

--- a/rpc/v10/l1_test.go
+++ b/rpc/v10/l1_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/NethermindEth/juno/clients/feeder"
 	"github.com/NethermindEth/juno/core"
 	"github.com/NethermindEth/juno/core/felt"
+	"github.com/NethermindEth/juno/core/pending"
 	"github.com/NethermindEth/juno/mocks"
 	rpc "github.com/NethermindEth/juno/rpc/v10"
 	adaptfeeder "github.com/NethermindEth/juno/starknetdata/feeder"
@@ -103,7 +104,7 @@ func TestGetMessageStatus(t *testing.T) {
 			block, err := gw.BlockByNumber(t.Context(), test.blockNum)
 			require.NoError(t, err)
 
-			preConfirmed := &core.PreConfirmed{
+			preConfirmed := &pending.PreConfirmed{
 				Block: &core.Block{
 					Header: &core.Header{
 						Number:           block.Number + 1,

--- a/rpc/v10/nonce_test.go
+++ b/rpc/v10/nonce_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/NethermindEth/juno/core"
 	"github.com/NethermindEth/juno/core/felt"
+	"github.com/NethermindEth/juno/core/pending"
 	"github.com/NethermindEth/juno/db"
 	"github.com/NethermindEth/juno/mocks"
 	"github.com/NethermindEth/juno/rpc/rpccore"
@@ -102,7 +103,7 @@ func TestNonce(t *testing.T) {
 		stateDiff := core.EmptyStateDiff()
 		stateDiff.Nonces[targetAddress] = expectedNonce
 
-		preConfirmed := core.PreConfirmed{
+		preConfirmed := pending.PreConfirmed{
 			Block: &core.Block{
 				Header: &core.Header{
 					Number: 2,

--- a/rpc/v10/state_update_test.go
+++ b/rpc/v10/state_update_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/NethermindEth/juno/clients/feeder"
 	"github.com/NethermindEth/juno/core"
 	"github.com/NethermindEth/juno/core/felt"
+	"github.com/NethermindEth/juno/core/pending"
 	"github.com/NethermindEth/juno/db"
 	"github.com/NethermindEth/juno/db/memory"
 	"github.com/NethermindEth/juno/mocks"
@@ -132,7 +133,7 @@ func TestStateUpdate(t *testing.T) {
 	t.Run("pre_confirmed", func(t *testing.T) {
 		update3077642.BlockHash = nil
 		update3077642.NewRoot = nil
-		preConfirmed := core.NewPreConfirmed(nil, update3077642, nil, nil)
+		preConfirmed := pending.NewPreConfirmed(nil, update3077642, nil, nil)
 		mockSyncReader.EXPECT().PreConfirmed().Return(
 			&preConfirmed,
 			nil,
@@ -175,7 +176,7 @@ func TestStateUpdate(t *testing.T) {
 		})
 
 		t.Run("empty filter returns full state diff", func(t *testing.T) {
-			preConfirmed := core.NewPreConfirmed(nil, update3077642, nil, nil)
+			preConfirmed := pending.NewPreConfirmed(nil, update3077642, nil, nil)
 			mockSyncReader.EXPECT().PreConfirmed().Return(&preConfirmed, nil)
 			id := rpcv10.BlockIDPreConfirmed()
 			emptyFilter := rpcv10.AddressList{}

--- a/rpc/v10/storage_test.go
+++ b/rpc/v10/storage_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/NethermindEth/juno/core"
 	"github.com/NethermindEth/juno/core/crypto"
 	"github.com/NethermindEth/juno/core/felt"
+	"github.com/NethermindEth/juno/core/pending"
 	"github.com/NethermindEth/juno/core/trie"
 	"github.com/NethermindEth/juno/db"
 	"github.com/NethermindEth/juno/db/memory"
@@ -234,7 +235,7 @@ func TestStorageAt(t *testing.T) {
 			preConfirmedStateDiff.
 				DeployedContracts[targetAddressFelt] = felt.NewFromUint64[felt.Felt](123456789)
 
-			preConfirmed := core.PreConfirmed{
+			preConfirmed := pending.PreConfirmed{
 				Block: &core.Block{
 					Header: &core.Header{
 						Number: 2,
@@ -353,7 +354,7 @@ func TestStorageAt(t *testing.T) {
 			preConfirmedBlockNumber := uint64(3)
 			lastUpdateBlockNum := uint64(1)
 
-			preConfirmed := core.PreConfirmed{
+			preConfirmed := pending.PreConfirmed{
 				Block: &core.Block{
 					Header: &core.Header{
 						Number: preConfirmedBlockNumber,

--- a/rpc/v10/subscription_events.go
+++ b/rpc/v10/subscription_events.go
@@ -6,6 +6,7 @@ import (
 	"github.com/NethermindEth/juno/blockchain"
 	"github.com/NethermindEth/juno/core"
 	"github.com/NethermindEth/juno/core/felt"
+	"github.com/NethermindEth/juno/core/pending"
 	"github.com/NethermindEth/juno/jsonrpc"
 	"github.com/NethermindEth/juno/rpc/rpccore"
 	"github.com/NethermindEth/juno/sync"
@@ -148,7 +149,7 @@ func (s *eventSubscriberState) onPreLatest(
 	ctx context.Context,
 	id string,
 	_ *subscription,
-	preLatest *core.PreLatest,
+	preLatest *pending.PreLatest,
 ) error {
 	return s.processBlock(ctx, id, preLatest.Block, TxnPreConfirmed)
 }
@@ -157,7 +158,7 @@ func (s *eventSubscriberState) onPreConfirmed(
 	ctx context.Context,
 	id string,
 	_ *subscription,
-	preConfirmed *core.PreConfirmed,
+	preConfirmed *pending.PreConfirmed,
 ) error {
 	return s.processBlock(ctx, id, preConfirmed.GetBlock(), TxnPreConfirmed)
 }

--- a/rpc/v10/subscription_receipts.go
+++ b/rpc/v10/subscription_receipts.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/NethermindEth/juno/core"
 	"github.com/NethermindEth/juno/core/felt"
+	"github.com/NethermindEth/juno/core/pending"
 	"github.com/NethermindEth/juno/jsonrpc"
 	"github.com/NethermindEth/juno/rpc/rpccore"
 	"github.com/NethermindEth/juno/sync"
@@ -114,7 +115,7 @@ func (s *receiptsSubscriberState) onPreLatest(
 	_ context.Context,
 	id string,
 	_ *subscription,
-	preLatest *core.PreLatest,
+	preLatest *pending.PreLatest,
 ) error {
 	return s.processBlock(
 		id,
@@ -127,7 +128,7 @@ func (s *receiptsSubscriberState) onPreConfirmed(
 	_ context.Context,
 	id string,
 	_ *subscription,
-	preConfirmed *core.PreConfirmed,
+	preConfirmed *pending.PreConfirmed,
 ) error {
 	return s.processBlock(
 		id,

--- a/rpc/v10/subscription_status.go
+++ b/rpc/v10/subscription_status.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/NethermindEth/juno/core"
 	"github.com/NethermindEth/juno/core/felt"
+	"github.com/NethermindEth/juno/core/pending"
 	"github.com/NethermindEth/juno/jsonrpc"
 	"github.com/NethermindEth/juno/rpc/rpccore"
 	"github.com/NethermindEth/juno/sync"
@@ -106,7 +107,7 @@ func (s *txStatusSubscriberState) onPreLatest(
 	ctx context.Context,
 	id string,
 	sub *subscription,
-	_ *core.PreLatest,
+	_ *pending.PreLatest,
 ) error {
 	return s.checkTxStatusIfPending(ctx, id, sub)
 }
@@ -115,7 +116,7 @@ func (s *txStatusSubscriberState) onPreConfirmed(
 	ctx context.Context,
 	id string,
 	sub *subscription,
-	_ *core.PreConfirmed,
+	_ *pending.PreConfirmed,
 ) error {
 	return s.checkTxStatusIfPending(ctx, id, sub)
 }

--- a/rpc/v10/subscription_transactions.go
+++ b/rpc/v10/subscription_transactions.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/NethermindEth/juno/core"
 	"github.com/NethermindEth/juno/core/felt"
+	"github.com/NethermindEth/juno/core/pending"
 	"github.com/NethermindEth/juno/jsonrpc"
 	"github.com/NethermindEth/juno/rpc/rpccore"
 	"github.com/NethermindEth/juno/sync"
@@ -136,7 +137,7 @@ func (s *transactionsSubscriberState) onPreLatest(
 	_ context.Context,
 	id string,
 	_ *subscription,
-	preLatest *core.PreLatest,
+	preLatest *pending.PreLatest,
 ) error {
 	return s.processBlock(
 		id,
@@ -149,7 +150,7 @@ func (s *transactionsSubscriberState) onPreConfirmed(
 	_ context.Context,
 	id string,
 	_ *subscription,
-	preConfirmed *core.PreConfirmed,
+	preConfirmed *pending.PreConfirmed,
 ) error {
 	if slices.Contains(s.finalityStatus, TxnStatusWithoutL1(TxnStatusPreConfirmed)) {
 		if err := s.processBlock(
@@ -192,7 +193,7 @@ func (s *transactionsSubscriberState) processBlock(
 
 func (s *transactionsSubscriberState) processCandidateTransactions(
 	id string,
-	preConfirmed *core.PreConfirmed,
+	preConfirmed *pending.PreConfirmed,
 ) error {
 	blockNumber := preConfirmed.GetBlock().Number
 	for _, txn := range preConfirmed.GetCandidateTransaction() {

--- a/rpc/v10/subscriptions.go
+++ b/rpc/v10/subscriptions.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/NethermindEth/juno/core"
 	"github.com/NethermindEth/juno/core/felt"
+	"github.com/NethermindEth/juno/core/pending"
 	"github.com/NethermindEth/juno/feed"
 	"github.com/NethermindEth/juno/jsonrpc"
 	"github.com/NethermindEth/juno/rpc/rpccore"
@@ -26,9 +27,9 @@ type subscriber struct {
 	onStart               on[any]
 	onReorg               on[*sync.ReorgBlockRange]
 	onNewHead             on[*core.Block]
-	onPreConfirmed        on[*core.PreConfirmed]
+	onPreConfirmed        on[*pending.PreConfirmed]
 	onL1Head              on[*core.L1Head]
-	onPreLatest           on[*core.PreLatest]
+	onPreLatest           on[*pending.PreLatest]
 	onReceivedTransaction on[core.Transaction]
 }
 

--- a/rpc/v10/subscriptions_test.go
+++ b/rpc/v10/subscriptions_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/NethermindEth/juno/clients/feeder"
 	"github.com/NethermindEth/juno/core"
 	"github.com/NethermindEth/juno/core/felt"
+	"github.com/NethermindEth/juno/core/pending"
 	"github.com/NethermindEth/juno/db"
 	"github.com/NethermindEth/juno/feed"
 	"github.com/NethermindEth/juno/jsonrpc"
@@ -50,16 +51,16 @@ func (fc *fakeConn) Equal(other jsonrpc.Conn) bool {
 type fakeSyncer struct {
 	newHeads     *feed.Feed[*core.Block]
 	reorgs       *feed.Feed[*sync.ReorgBlockRange]
-	preConfirmed *feed.Feed[*core.PreConfirmed]
-	preLatest    *feed.Feed[*core.PreLatest]
+	preConfirmed *feed.Feed[*pending.PreConfirmed]
+	preLatest    *feed.Feed[*pending.PreLatest]
 }
 
 func newFakeSyncer() *fakeSyncer {
 	return &fakeSyncer{
 		newHeads:     feed.New[*core.Block](),
 		reorgs:       feed.New[*sync.ReorgBlockRange](),
-		preConfirmed: feed.New[*core.PreConfirmed](),
-		preLatest:    feed.New[*core.PreLatest](),
+		preConfirmed: feed.New[*pending.PreConfirmed](),
+		preLatest:    feed.New[*pending.PreLatest](),
 	}
 }
 
@@ -87,7 +88,7 @@ func (fs *fakeSyncer) HighestBlockHeader() *core.Header {
 	return nil
 }
 
-func (fs *fakeSyncer) PreConfirmed() (*core.PreConfirmed, error) {
+func (fs *fakeSyncer) PreConfirmed() (*pending.PreConfirmed, error) {
 	return nil, db.ErrKeyNotFound
 }
 
@@ -1029,7 +1030,7 @@ func TestSubscribeTxnStatus(t *testing.T) {
 		mockChain.EXPECT().BlockNumberAndIndexByTxHash(
 			&txHash,
 		).Return(uint64(0), uint64(0), db.ErrKeyNotFound)
-		preConfirmed := &core.PreConfirmed{
+		preConfirmed := &pending.PreConfirmed{
 			Block: &core.Block{
 				Header: &core.Header{
 					Number:           block.Number,
@@ -1059,7 +1060,7 @@ func TestSubscribeTxnStatus(t *testing.T) {
 		rpcTx := AdaptCoreTransaction(block.Transactions[0])
 		rpcTx.Hash = (*felt.Felt)(&txHash)
 
-		preConfirmed = &core.PreConfirmed{
+		preConfirmed = &pending.PreConfirmed{
 			Block: &core.Block{
 				Header: &core.Header{
 					Number:           block.Number,
@@ -1087,7 +1088,7 @@ func TestSubscribeTxnStatus(t *testing.T) {
 			"",
 		)
 
-		preConfirmed = &core.PreConfirmed{
+		preConfirmed = &pending.PreConfirmed{
 			Block: &core.Block{
 				Header: &core.Header{
 					Number:           block.Number + 1,
@@ -1166,7 +1167,7 @@ func TestSubscribeTxnStatus(t *testing.T) {
 		targetTxn := block.Transactions[0]
 		targetReceipt := block.Receipts[0]
 
-		preConfirmedData1 := &core.PreConfirmed{
+		preConfirmedData1 := &pending.PreConfirmed{
 			Block: &core.Block{
 				Header: &core.Header{
 					Number:           block.Number,
@@ -1178,7 +1179,7 @@ func TestSubscribeTxnStatus(t *testing.T) {
 			},
 		}
 		// PreLatest Status - should check transaction status
-		preLatest := &core.PreLatest{
+		preLatest := &pending.PreLatest{
 			Block: &core.Block{
 				Header: &core.Header{
 					Number:           block.Number,
@@ -1190,7 +1191,7 @@ func TestSubscribeTxnStatus(t *testing.T) {
 			},
 		}
 
-		preConfirmedData2 := &core.PreConfirmed{
+		preConfirmedData2 := &pending.PreConfirmed{
 			Block: &core.Block{
 				Header: &core.Header{
 					Number: preLatest.Block.Number + 1,
@@ -1234,7 +1235,7 @@ func TestSubscribeTxnStatus(t *testing.T) {
 		targetTxn := block.Transactions[0]
 		targetReceipt := block.Receipts[0]
 
-		preConfirmedData1 := &core.PreConfirmed{
+		preConfirmedData1 := &pending.PreConfirmed{
 			Block: &core.Block{
 				Header: &core.Header{
 					Number:           block.Number,
@@ -3034,7 +3035,7 @@ func assertNextReorg(t *testing.T, conn net.Conn, id SubscriptionID, reorg *Reor
 	assertNextMessage(t, conn, id, "starknet_subscriptionReorg", reorg)
 }
 
-func createTestPreLatest(t *testing.T, b *core.Block, txCount int) core.PreLatest {
+func createTestPreLatest(t *testing.T, b *core.Block, txCount int) pending.PreLatest {
 	t.Helper()
 
 	preLatest := core.Block{
@@ -3047,16 +3048,16 @@ func createTestPreLatest(t *testing.T, b *core.Block, txCount int) core.PreLates
 
 	preLatest.Transactions = b.Transactions[:txCount]
 	preLatest.Receipts = b.Receipts[:txCount]
-	return core.PreLatest{
+	return pending.PreLatest{
 		Block: &preLatest,
 	}
 }
 
-func CreateTestPreConfirmed(t *testing.T, b *core.Block, preConfirmedCount int) core.PreConfirmed {
+func CreateTestPreConfirmed(t *testing.T, b *core.Block, preConfirmedCount int) pending.PreConfirmed {
 	t.Helper()
 
 	actualTxCount := len(b.Transactions)
-	var preConfirmed core.PreConfirmed
+	var preConfirmed pending.PreConfirmed
 	if candidateCount := actualTxCount - preConfirmedCount; candidateCount > 0 {
 		preConfirmed.CandidateTxs = make([]core.Transaction, candidateCount)
 		candidateIndex := actualTxCount - candidateCount

--- a/rpc/v10/subscriptions_test.go
+++ b/rpc/v10/subscriptions_test.go
@@ -3053,7 +3053,11 @@ func createTestPreLatest(t *testing.T, b *core.Block, txCount int) pending.PreLa
 	}
 }
 
-func CreateTestPreConfirmed(t *testing.T, b *core.Block, preConfirmedCount int) pending.PreConfirmed {
+func CreateTestPreConfirmed(
+	t *testing.T,
+	b *core.Block,
+	preConfirmedCount int,
+) pending.PreConfirmed {
 	t.Helper()
 
 	actualTxCount := len(b.Transactions)

--- a/rpc/v10/trace.go
+++ b/rpc/v10/trace.go
@@ -11,6 +11,7 @@ import (
 	"github.com/NethermindEth/juno/blockchain"
 	"github.com/NethermindEth/juno/core"
 	"github.com/NethermindEth/juno/core/felt"
+	"github.com/NethermindEth/juno/core/pending"
 	"github.com/NethermindEth/juno/db"
 	"github.com/NethermindEth/juno/jsonrpc"
 	"github.com/NethermindEth/juno/rpc/rpccore"
@@ -316,7 +317,7 @@ func (h *Handler) findAndTraceInPreConfirmed(
 
 // findAndTraceInPendingBlock finds and traces a transaction in the pre_confirmed block.
 func (h *Handler) findAndTraceInPreConfirmedBlock(
-	preConfirmed *core.PreConfirmed, hash *felt.Felt,
+	preConfirmed *pending.PreConfirmed, hash *felt.Felt,
 ) (TransactionTrace, http.Header, *jsonrpc.Error) {
 	block := preConfirmed.GetBlock()
 	txIndex, rpcErr := findTransactionInBlock(block, hash)
@@ -329,7 +330,7 @@ func (h *Handler) findAndTraceInPreConfirmedBlock(
 
 // findAndTraceInPrelatestBlock finds and traces a transaction in the prelatest block.
 func (h *Handler) findAndTraceInPrelatestBlock(
-	preConfirmed *core.PreConfirmed, hash *felt.Felt,
+	preConfirmed *pending.PreConfirmed, hash *felt.Felt,
 ) (TransactionTrace, http.Header, *jsonrpc.Error) {
 	preLatest := preConfirmed.GetPreLatest()
 	if preLatest == nil {
@@ -346,7 +347,7 @@ func (h *Handler) findAndTraceInPrelatestBlock(
 
 // traceInPrelatestBlock traces a transaction in the prelatest block.
 func (h *Handler) traceInPrelatestBlock(
-	preLatest *core.PreLatest, txIndex uint,
+	preLatest *pending.PreLatest, txIndex uint,
 ) (TransactionTrace, http.Header, *jsonrpc.Error) {
 	state, closer, err := h.bcReader.StateAtBlockHash(preLatest.Block.ParentHash)
 	if err != nil {
@@ -354,7 +355,7 @@ func (h *Handler) traceInPrelatestBlock(
 	}
 	defer h.callAndLogErr(closer, "Failed to close state in tracePreLatestTransaction")
 
-	preLatestState := core.NewPendingState(
+	preLatestState := pending.NewPendingState(
 		preLatest.StateUpdate.StateDiff,
 		preLatest.NewClasses,
 		state,
@@ -383,7 +384,7 @@ func (h *Handler) traceInPrelatestBlock(
 
 // traceInPreConfirmedBlock traces a transaction in a preconfirmed block.
 func (h *Handler) traceInPreConfirmedBlock(
-	preConfirmed *core.PreConfirmed, txIndex uint,
+	preConfirmed *pending.PreConfirmed, txIndex uint,
 ) (TransactionTrace, http.Header, *jsonrpc.Error) {
 	state, stateCloser, err := sync.PendingStateBeforeIndex(preConfirmed, h.bcReader, txIndex)
 	if err != nil {

--- a/rpc/v10/trace.go
+++ b/rpc/v10/trace.go
@@ -355,7 +355,7 @@ func (h *Handler) traceInPrelatestBlock(
 	}
 	defer h.callAndLogErr(closer, "Failed to close state in tracePreLatestTransaction")
 
-	preLatestState := pending.NewPendingState(
+	preLatestState := pending.NewState(
 		preLatest.StateUpdate.StateDiff,
 		preLatest.NewClasses,
 		state,

--- a/rpc/v10/trace_test.go
+++ b/rpc/v10/trace_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/NethermindEth/juno/clients/feeder"
 	"github.com/NethermindEth/juno/core"
 	"github.com/NethermindEth/juno/core/felt"
+	"github.com/NethermindEth/juno/core/pending"
 	"github.com/NethermindEth/juno/db"
 	"github.com/NethermindEth/juno/db/memory"
 	"github.com/NethermindEth/juno/mocks"
@@ -330,7 +331,7 @@ func TestTraceTransaction(t *testing.T) {
 			hash := felt.NewUnsafeFromString[felt.Felt]("0xBBBB")
 			// Receipt() returns error related to db
 			mockReader.EXPECT().Receipt(hash).Return(nil, nil, uint64(0), db.ErrKeyNotFound)
-			preConfirmed := core.NewPreConfirmed(&core.Block{}, nil, nil, nil)
+			preConfirmed := pending.NewPreConfirmed(&core.Block{}, nil, nil, nil)
 			mockSyncReader.EXPECT().PreConfirmed().Return(
 				&preConfirmed,
 				nil,
@@ -456,7 +457,7 @@ func TestTraceTransaction(t *testing.T) {
 
 		mockReader.EXPECT().Receipt(hash).Return(nil, nil, uint64(0), db.ErrKeyNotFound)
 		preConfirmedStateDiff := core.EmptyStateDiff()
-		preConfirmed := core.PreConfirmed{
+		preConfirmed := pending.PreConfirmed{
 			Block: block,
 			StateUpdate: &core.StateUpdate{
 				StateDiff: &preConfirmedStateDiff,
@@ -540,7 +541,7 @@ func TestTraceTransaction(t *testing.T) {
 			Class: &core.SierraClass{},
 		}
 		preLatestStateDiff := core.EmptyStateDiff()
-		preLatest := core.PreLatest{
+		preLatest := pending.PreLatest{
 			Block: block,
 			StateUpdate: &core.StateUpdate{
 				StateDiff: &preLatestStateDiff,
@@ -548,7 +549,7 @@ func TestTraceTransaction(t *testing.T) {
 			NewClasses: map[felt.Felt]core.ClassDefinition{*tx.ClassHash: declaredClass.Class},
 		}
 
-		preConfirmed := core.PreConfirmed{
+		preConfirmed := pending.PreConfirmed{
 			Block: &core.Block{
 				Header: &core.Header{
 					Number: preLatest.Block.Number + 1,

--- a/rpc/v10/transaction_test.go
+++ b/rpc/v10/transaction_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/NethermindEth/juno/clients/gateway"
 	"github.com/NethermindEth/juno/core"
 	"github.com/NethermindEth/juno/core/felt"
+	"github.com/NethermindEth/juno/core/pending"
 	"github.com/NethermindEth/juno/db"
 	"github.com/NethermindEth/juno/feed"
 	"github.com/NethermindEth/juno/jsonrpc"
@@ -79,7 +80,7 @@ func TestTransactionByHashNotFoundInPreConfirmedBlock(t *testing.T) {
 		Version:         new(core.TransactionVersion).SetUint64(1),
 	}
 
-	preConfirmed := core.PreConfirmed{
+	preConfirmed := pending.PreConfirmed{
 		Block: &core.Block{
 			Transactions: []core.Transaction{preConfirmedTx},
 		},
@@ -565,7 +566,7 @@ func TestTransactionByHash(t *testing.T) {
 				}
 				return tx, nil
 			}).Times(1)
-			mockSyncReader.EXPECT().PreConfirmed().Return(&core.PreConfirmed{
+			mockSyncReader.EXPECT().PreConfirmed().Return(&pending.PreConfirmed{
 				Block: &core.Block{
 					Header: &core.Header{
 						Number:           1,
@@ -629,7 +630,7 @@ func TestTransactionByHash_PreConfirmedBlock(t *testing.T) {
 		require.NoError(t, gwErr)
 		searchTxn := testBlock.Transactions[0]
 
-		preLatest := core.PreLatest{
+		preLatest := pending.PreLatest{
 			Block: testBlock,
 		}
 		adaptedPreConfirmed.WithPreLatest(&preLatest)
@@ -780,7 +781,7 @@ func TestTransactionByBlockIdAndIndex(t *testing.T) {
 	t.Run("blockID - pre_confirmed", func(t *testing.T) {
 		latestBlock.Hash = nil
 		latestBlock.GlobalStateRoot = nil
-		preConfirmed := core.NewPreConfirmed(latestBlock, nil, nil, nil)
+		preConfirmed := pending.NewPreConfirmed(latestBlock, nil, nil, nil)
 		mockSyncReader.EXPECT().PreConfirmed().Return(
 			&preConfirmed,
 			nil,
@@ -874,12 +875,12 @@ func TestTransactionReceiptByHash(t *testing.T) {
 		description    string
 		network        *utils.Network
 		expected       *rpcv10.TransactionReceipt
-		preConfirmedFn func(t *testing.T, block *core.Block) *core.PreConfirmed
+		preConfirmedFn func(t *testing.T, block *core.Block) *pending.PreConfirmed
 		l1Head         core.L1Head
 	}
 
-	emptyPreConfirmedFunc := func(t *testing.T, block *core.Block) *core.PreConfirmed {
-		return &core.PreConfirmed{
+	emptyPreConfirmedFunc := func(t *testing.T, block *core.Block) *pending.PreConfirmed {
+		return &pending.PreConfirmed{
 			Block: &core.Block{
 				Header: &core.Header{
 					Number: block.Number + 1,
@@ -888,8 +889,8 @@ func TestTransactionReceiptByHash(t *testing.T) {
 		}
 	}
 
-	preConfirmedFunc := func(t *testing.T, block *core.Block) *core.PreConfirmed {
-		return &core.PreConfirmed{
+	preConfirmedFunc := func(t *testing.T, block *core.Block) *pending.PreConfirmed {
+		return &pending.PreConfirmed{
 			Block: &core.Block{
 				Header: &core.Header{
 					Number:           block.Number,
@@ -902,8 +903,8 @@ func TestTransactionReceiptByHash(t *testing.T) {
 		}
 	}
 
-	withPreLatestPreConfirmedFunc := func(t *testing.T, block *core.Block) *core.PreConfirmed {
-		preLatest := core.PreLatest{
+	withPreLatestPreConfirmedFunc := func(t *testing.T, block *core.Block) *pending.PreConfirmed {
+		preLatest := pending.PreLatest{
 			Block: &core.Block{
 				Header: &core.Header{
 					Number:           block.Number,
@@ -915,7 +916,7 @@ func TestTransactionReceiptByHash(t *testing.T) {
 				Receipts:     block.Receipts,
 			},
 		}
-		preConfirmed := &core.PreConfirmed{
+		preConfirmed := &pending.PreConfirmed{
 			Block: &core.Block{
 				Header: &core.Header{
 					Number: preLatest.Block.Number + 1,
@@ -1620,7 +1621,7 @@ func TestTransactionStatus(t *testing.T) {
 			mockSyncReader *mocks.MockSyncReader,
 		)
 	}
-	preConfirmedPlaceHolder := core.PreConfirmed{
+	preConfirmedPlaceHolder := pending.PreConfirmed{
 		Block: &core.Block{
 			Header: &core.Header{
 				Number: block.Number + 1,
@@ -1691,7 +1692,7 @@ func TestTransactionStatus(t *testing.T) {
 			},
 			setupMocks: func(mockReader *mocks.MockReader, mockSyncReader *mocks.MockSyncReader) {
 				mockSyncReader.EXPECT().PreConfirmed().Return(
-					&core.PreConfirmed{
+					&pending.PreConfirmed{
 						Block: &core.Block{
 							Header: &core.Header{
 								Number: block.Number,
@@ -1716,7 +1717,7 @@ func TestTransactionStatus(t *testing.T) {
 					(*felt.TransactionHash)(targetTxnHash),
 				).Return(uint64(0), uint64(0), db.ErrKeyNotFound)
 				mockSyncReader.EXPECT().PreConfirmed().Return(
-					&core.PreConfirmed{
+					&pending.PreConfirmed{
 						Block: &core.Block{
 							Header: &core.Header{
 								Number: block.Number,
@@ -1736,7 +1737,7 @@ func TestTransactionStatus(t *testing.T) {
 				Execution: rpcv10.TxnSuccess,
 			},
 			setupMocks: func(mockReader *mocks.MockReader, mockSyncReader *mocks.MockSyncReader) {
-				preLatest := core.PreLatest{
+				preLatest := pending.PreLatest{
 					Block: &core.Block{
 						Header: &core.Header{
 							ParentHash: block.ParentHash,
@@ -1848,7 +1849,7 @@ func TestSubmittedTransactionsCache(t *testing.T) {
 		Return(rawGatewayResponse, nil).
 		Times(2)
 
-	preConfirmedPlaceHolder := core.PreConfirmed{
+	preConfirmedPlaceHolder := pending.PreConfirmed{
 		Block: &core.Block{
 			Header: &core.Header{
 				Number: 1,

--- a/rpc/v8/events.go
+++ b/rpc/v8/events.go
@@ -2,8 +2,8 @@ package rpcv8
 
 import (
 	"github.com/NethermindEth/juno/blockchain"
-	"github.com/NethermindEth/juno/core"
 	"github.com/NethermindEth/juno/core/felt"
+	pendingpkg "github.com/NethermindEth/juno/core/pending"
 	"github.com/NethermindEth/juno/jsonrpc"
 	"github.com/NethermindEth/juno/rpc/rpccore"
 )
@@ -74,12 +74,12 @@ func (h *Handler) Events(args EventsArg) (*EventsChunk, *jsonrpc.Error) {
 		addresses = []felt.Address{felt.Address(*args.EventFilter.Address)}
 	}
 	// rpc/v8 builds its pending block via MakeEmptyPendingForParent, which returns the deprecated
-	// *core.Pending type and carries no events. EventFilter requires *core.PreConfirmed, so a
+	// *pending.Pending type and carries no events. EventFilter requires *pending.PreConfirmed, so a
 	// no-op is passed here — the result is identical since there are no pending events to emit.
 	filter, err := h.bcReader.EventFilter(
 		addresses,
 		args.EventFilter.Keys,
-		func() (*core.PreConfirmed, error) { return nil, core.ErrPreConfirmedNotFound },
+		func() (*pendingpkg.PreConfirmed, error) { return nil, pendingpkg.ErrPreConfirmedNotFound },
 	)
 	if err != nil {
 		return nil, rpccore.ErrInternal

--- a/rpc/v8/handlers.go
+++ b/rpc/v8/handlers.go
@@ -12,6 +12,7 @@ import (
 	"github.com/NethermindEth/juno/blockchain"
 	"github.com/NethermindEth/juno/clients/feeder"
 	"github.com/NethermindEth/juno/core"
+	pendingpkg "github.com/NethermindEth/juno/core/pending"
 	"github.com/NethermindEth/juno/feed"
 	"github.com/NethermindEth/juno/jsonrpc"
 	"github.com/NethermindEth/juno/l1/contract"
@@ -38,7 +39,7 @@ type Handler struct {
 
 	newHeads                *feed.Feed[*core.Block]
 	reorgs                  *feed.Feed[*sync.ReorgBlockRange]
-	preConfirmedFeed        *feed.Feed[*core.PreConfirmed]
+	preConfirmedFeed        *feed.Feed[*pendingpkg.PreConfirmed]
 	l1Heads                 *feed.Feed[*core.L1Head]
 	receivedTransactionFeed *feed.Feed[core.Transaction]
 
@@ -85,7 +86,7 @@ func New(
 		},
 		newHeads:         feed.New[*core.Block](),
 		reorgs:           feed.New[*sync.ReorgBlockRange](),
-		preConfirmedFeed: feed.New[*core.PreConfirmed](),
+		preConfirmedFeed: feed.New[*pendingpkg.PreConfirmed](),
 		l1Heads:          feed.New[*core.L1Head](),
 
 		blockTraceCache: lru.NewCache[rpccore.TraceCacheKey, []TracedBlockTransaction](rpccore.TraceCacheSize),

--- a/rpc/v8/helpers.go
+++ b/rpc/v8/helpers.go
@@ -38,6 +38,7 @@ func (h *Handler) blockByID(blockID *BlockID) (*core.Block, *jsonrpc.Error) {
 
 	switch blockID.Type() {
 	case pending:
+		//nolint:staticcheck // Pending is supported by RPCv8
 		var pending *pendingpkg.Pending
 		pending, err = h.Pending()
 		if err == nil {
@@ -92,6 +93,7 @@ func (h *Handler) blockHeaderByID(blockID *BlockID) (*core.Header, *jsonrpc.Erro
 	var err error
 	switch blockID.Type() {
 	case pending:
+		//nolint:staticcheck // Pending is supported by RPCv8
 		var pendingBlock *pendingpkg.Pending
 		pendingBlock, err = h.Pending()
 		if err == nil {

--- a/rpc/v8/helpers.go
+++ b/rpc/v8/helpers.go
@@ -9,6 +9,7 @@ import (
 	"github.com/NethermindEth/juno/blockchain"
 	"github.com/NethermindEth/juno/core"
 	"github.com/NethermindEth/juno/core/felt"
+	pendingpkg "github.com/NethermindEth/juno/core/pending"
 	"github.com/NethermindEth/juno/db"
 	"github.com/NethermindEth/juno/jsonrpc"
 	"github.com/NethermindEth/juno/rpc/rpccore"
@@ -37,7 +38,7 @@ func (h *Handler) blockByID(blockID *BlockID) (*core.Block, *jsonrpc.Error) {
 
 	switch blockID.Type() {
 	case pending:
-		var pending *core.Pending
+		var pending *pendingpkg.Pending
 		pending, err = h.Pending()
 		if err == nil {
 			block = pending.GetBlock()
@@ -91,7 +92,7 @@ func (h *Handler) blockHeaderByID(blockID *BlockID) (*core.Header, *jsonrpc.Erro
 	var err error
 	switch blockID.Type() {
 	case pending:
-		var pendingBlock *core.Pending
+		var pendingBlock *pendingpkg.Pending
 		pendingBlock, err = h.Pending()
 		if err == nil {
 			header = pendingBlock.GetHeader()

--- a/rpc/v8/pending_wrapper.go
+++ b/rpc/v8/pending_wrapper.go
@@ -6,6 +6,7 @@ import (
 	"github.com/NethermindEth/juno/sync"
 )
 
+//nolint:staticcheck // Pending is supported by RPCv8
 func (h *Handler) Pending() (*pendingpkg.Pending, error) {
 	latestHeader, err := h.bcReader.HeadsHeader()
 	if err != nil {

--- a/rpc/v8/pending_wrapper.go
+++ b/rpc/v8/pending_wrapper.go
@@ -2,10 +2,11 @@ package rpcv8
 
 import (
 	"github.com/NethermindEth/juno/core"
+	pendingpkg "github.com/NethermindEth/juno/core/pending"
 	"github.com/NethermindEth/juno/sync"
 )
 
-func (h *Handler) Pending() (*core.Pending, error) {
+func (h *Handler) Pending() (*pendingpkg.Pending, error) {
 	latestHeader, err := h.bcReader.HeadsHeader()
 	if err != nil {
 		return nil, err

--- a/rpc/v8/state_update.go
+++ b/rpc/v8/state_update.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/NethermindEth/juno/core"
 	"github.com/NethermindEth/juno/core/felt"
+	pendingpkg "github.com/NethermindEth/juno/core/pending"
 	"github.com/NethermindEth/juno/db"
 	"github.com/NethermindEth/juno/jsonrpc"
 	"github.com/NethermindEth/juno/rpc/rpccore"
@@ -76,7 +77,7 @@ func (h *Handler) StateUpdate(id BlockID) (*StateUpdate, *jsonrpc.Error) {
 		}
 	} else if id.IsPending() {
 		//nolint:staticcheck // Necessary for v8
-		var pending *core.Pending
+		var pending *pendingpkg.Pending
 		pending, err = h.Pending()
 		if err == nil {
 			update = pending.GetStateUpdate()

--- a/rpc/v8/subscriptions.go
+++ b/rpc/v8/subscriptions.go
@@ -10,6 +10,7 @@ import (
 	"github.com/NethermindEth/juno/blockchain"
 	"github.com/NethermindEth/juno/core"
 	"github.com/NethermindEth/juno/core/felt"
+	pendingpkg "github.com/NethermindEth/juno/core/pending"
 	"github.com/NethermindEth/juno/feed"
 	"github.com/NethermindEth/juno/jsonrpc"
 	"github.com/NethermindEth/juno/rpc/rpccore"
@@ -345,13 +346,13 @@ func (h *Handler) processEvents(
 		addresses = []felt.Address{*fromAddr}
 	}
 	// rpc/v8 builds its pending block via MakeEmptyPendingForParent, which returns the deprecated
-	// *core.Pending type and carries no events. EventFilter requires *core.PreConfirmed, so a
+	// *pending.Pending type and carries no events. EventFilter requires *pending.PreConfirmed, so a
 	// no-op is passed here — the result is identical since there are no pending events to emit.
 	filter, err := h.bcReader.EventFilter(
 		addresses,
 		keys,
-		func() (*core.PreConfirmed, error) {
-			return nil, core.ErrPreConfirmedNotFound
+		func() (*pendingpkg.PreConfirmed, error) {
+			return nil, pendingpkg.ErrPreConfirmedNotFound
 		},
 	)
 	if err != nil {

--- a/rpc/v8/subscriptions_test.go
+++ b/rpc/v8/subscriptions_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/NethermindEth/juno/clients/feeder"
 	"github.com/NethermindEth/juno/core"
 	"github.com/NethermindEth/juno/core/felt"
+	pendingpkg "github.com/NethermindEth/juno/core/pending"
 	"github.com/NethermindEth/juno/db"
 	"github.com/NethermindEth/juno/db/memory"
 	"github.com/NethermindEth/juno/feed"
@@ -249,14 +250,14 @@ func TestSubscribeEvents(t *testing.T) {
 		assertNextEvents(t, clientConn, id, b1Emitted)
 
 		// Sending PreConfirmed does nothing — the handler was removed
-		// because it only handled the deprecated core.Pending variant.
+		// because it only handled the deprecated pending.Pending variant.
 		pending1 := createTestPendingBlock(t, b2, 3)
-		preConfirmed1 := core.NewPreConfirmed(pending1, nil, nil, nil)
+		preConfirmed1 := pendingpkg.NewPreConfirmed(pending1, nil, nil, nil)
 		handler.preConfirmedFeed.Send(&preConfirmed1)
 		assertNoMessage(t, clientConn)
 
 		pending2 := createTestPendingBlock(t, b2, 6)
-		preConfirmed2 := core.NewPreConfirmed(pending2, nil, nil, nil)
+		preConfirmed2 := pendingpkg.NewPreConfirmed(pending2, nil, nil, nil)
 		handler.preConfirmedFeed.Send(&preConfirmed2)
 		assertNoMessage(t, clientConn)
 
@@ -388,8 +389,8 @@ func TestSubscribeTxnStatus(t *testing.T) {
 		).Return(*block.Receipts[0], block.Hash, nil)
 		mockChain.EXPECT().L1Head().Return(core.L1Head{}, db.ErrKeyNotFound)
 		for i := range 3 {
-			handler.preConfirmedFeed.Send(&core.PreConfirmed{Block: &core.Block{Header: &core.Header{}}})
-			handler.preConfirmedFeed.Send(&core.PreConfirmed{Block: &core.Block{Header: &core.Header{}}})
+			handler.preConfirmedFeed.Send(&pendingpkg.PreConfirmed{Block: &core.Block{Header: &core.Header{}}})
+			handler.preConfirmedFeed.Send(&pendingpkg.PreConfirmed{Block: &core.Block{Header: &core.Header{}}})
 			handler.newHeads.Send(&core.Block{Header: &core.Header{Number: block.Number + 1 + uint64(i)}})
 		}
 		assertNextTxnStatus(t, conn, id, txHash, TxnStatusAcceptedOnL2, TxnSuccess, "")
@@ -413,16 +414,16 @@ func TestSubscribeTxnStatus(t *testing.T) {
 type fakeSyncer struct {
 	newHeads     *feed.Feed[*core.Block]
 	reorgs       *feed.Feed[*sync.ReorgBlockRange]
-	preConfirmed *feed.Feed[*core.PreConfirmed]
-	preLatest    *feed.Feed[*core.PreLatest]
+	preConfirmed *feed.Feed[*pendingpkg.PreConfirmed]
+	preLatest    *feed.Feed[*pendingpkg.PreLatest]
 }
 
 func newFakeSyncer() *fakeSyncer {
 	return &fakeSyncer{
 		newHeads:     feed.New[*core.Block](),
 		reorgs:       feed.New[*sync.ReorgBlockRange](),
-		preConfirmed: feed.New[*core.PreConfirmed](),
-		preLatest:    feed.New[*core.PreLatest](),
+		preConfirmed: feed.New[*pendingpkg.PreConfirmed](),
+		preLatest:    feed.New[*pendingpkg.PreLatest](),
 	}
 }
 
@@ -450,8 +451,8 @@ func (fs *fakeSyncer) HighestBlockHeader() *core.Header {
 	return nil
 }
 
-func (fs *fakeSyncer) PreConfirmed() (*core.PreConfirmed, error) {
-	return nil, core.ErrPreConfirmedNotFound
+func (fs *fakeSyncer) PreConfirmed() (*pendingpkg.PreConfirmed, error) {
+	return nil, pendingpkg.ErrPreConfirmedNotFound
 }
 
 func TestSubscribeNewHeads(t *testing.T) {
@@ -767,7 +768,7 @@ func TestSubscribePendingTxs(t *testing.T) {
 		hash4 := new(felt.Felt).SetUint64(4)
 		hash5 := new(felt.Felt).SetUint64(5)
 
-		syncer.preConfirmed.Send(&core.PreConfirmed{
+		syncer.preConfirmed.Send(&pendingpkg.PreConfirmed{
 			Block: &core.Block{
 				Header: &core.Header{
 					ParentHash: parentHash,
@@ -812,7 +813,7 @@ func TestSubscribePendingTxs(t *testing.T) {
 		hash7 := new(felt.Felt).SetUint64(7)
 		addr7 := new(felt.Felt).SetUint64(77)
 
-		syncer.preConfirmed.Send(&core.PreConfirmed{
+		syncer.preConfirmed.Send(&pendingpkg.PreConfirmed{
 			Block: &core.Block{
 				Header: &core.Header{
 					ParentHash: parentHash,
@@ -842,7 +843,7 @@ func TestSubscribePendingTxs(t *testing.T) {
 		require.Equal(t, subResp(id), got)
 
 		parentHash := new(felt.Felt).SetUint64(1)
-		syncer.preConfirmed.Send(&core.PreConfirmed{
+		syncer.preConfirmed.Send(&pendingpkg.PreConfirmed{
 			Block: &core.Block{
 				Header: &core.Header{
 					ParentHash: parentHash,

--- a/rpc/v8/subscriptions_test.go
+++ b/rpc/v8/subscriptions_test.go
@@ -389,8 +389,12 @@ func TestSubscribeTxnStatus(t *testing.T) {
 		).Return(*block.Receipts[0], block.Hash, nil)
 		mockChain.EXPECT().L1Head().Return(core.L1Head{}, db.ErrKeyNotFound)
 		for i := range 3 {
-			handler.preConfirmedFeed.Send(&pendingpkg.PreConfirmed{Block: &core.Block{Header: &core.Header{}}})
-			handler.preConfirmedFeed.Send(&pendingpkg.PreConfirmed{Block: &core.Block{Header: &core.Header{}}})
+			handler.preConfirmedFeed.Send(
+				&pendingpkg.PreConfirmed{Block: &core.Block{Header: &core.Header{}}},
+			)
+			handler.preConfirmedFeed.Send(
+				&pendingpkg.PreConfirmed{Block: &core.Block{Header: &core.Header{}}},
+			)
 			handler.newHeads.Send(&core.Block{Header: &core.Header{Number: block.Number + 1 + uint64(i)}})
 		}
 		assertNextTxnStatus(t, conn, id, txHash, TxnStatusAcceptedOnL2, TxnSuccess, "")

--- a/rpc/v9/block_test.go
+++ b/rpc/v9/block_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/NethermindEth/juno/clients/feeder"
 	"github.com/NethermindEth/juno/core"
 	"github.com/NethermindEth/juno/core/felt"
+	"github.com/NethermindEth/juno/core/pending"
 	"github.com/NethermindEth/juno/db"
 	"github.com/NethermindEth/juno/db/memory"
 	"github.com/NethermindEth/juno/mocks"
@@ -251,7 +252,7 @@ func TestBlockTransactionCount(t *testing.T) {
 	t.Run("blockID - pre_confirmed", func(t *testing.T) {
 		latestBlock.Hash = nil
 		latestBlock.GlobalStateRoot = nil
-		preConfirmed := core.NewPreConfirmed(latestBlock, nil, nil, nil)
+		preConfirmed := pending.NewPreConfirmed(latestBlock, nil, nil, nil)
 		mockSyncReader.EXPECT().PreConfirmed().Return(
 			&preConfirmed,
 			nil,
@@ -410,7 +411,7 @@ func TestBlockWithTxHashes(t *testing.T) {
 	t.Run("blockID - pre_confirmed", func(t *testing.T) {
 		latestBlock.Hash = nil
 		latestBlock.GlobalStateRoot = nil
-		preConfirmed := core.NewPreConfirmed(latestBlock, nil, nil, nil)
+		preConfirmed := pending.NewPreConfirmed(latestBlock, nil, nil, nil)
 		mockSyncReader.EXPECT().PreConfirmed().Return(
 			&preConfirmed,
 			nil,
@@ -528,7 +529,7 @@ func TestBlockWithTxs(t *testing.T) {
 		latestBlockTxMap[*tx.Hash()] = tx
 	}
 
-	preConfirmed := &core.PreConfirmed{
+	preConfirmed := &pending.PreConfirmed{
 		Block: &core.Block{
 			Header: &core.Header{
 				Number: latestBlockNumber + 1,
@@ -652,7 +653,7 @@ func TestBlockWithTxs(t *testing.T) {
 	t.Run("blockID - pre_confirmed", func(t *testing.T) {
 		latestBlock.Hash = nil
 		latestBlock.GlobalStateRoot = nil
-		preConfirmed := core.NewPreConfirmed(latestBlock, nil, nil, nil)
+		preConfirmed := pending.NewPreConfirmed(latestBlock, nil, nil, nil)
 		mockSyncReader.EXPECT().PreConfirmed().Return(
 			&preConfirmed,
 			nil,
@@ -834,7 +835,7 @@ func TestBlockWithReceipts(t *testing.T) {
 		block0.Hash = nil
 		block0.ParentHash = nil
 		block0.GlobalStateRoot = nil
-		preConfirmed := core.NewPreConfirmed(block0, nil, nil, nil)
+		preConfirmed := pending.NewPreConfirmed(block0, nil, nil, nil)
 		mockSyncReader.EXPECT().PreConfirmed().Return(
 			&preConfirmed,
 			nil,

--- a/rpc/v9/class_test.go
+++ b/rpc/v9/class_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/NethermindEth/juno/clients/feeder"
 	"github.com/NethermindEth/juno/core"
 	"github.com/NethermindEth/juno/core/felt"
+	"github.com/NethermindEth/juno/core/pending"
 	"github.com/NethermindEth/juno/db"
 	"github.com/NethermindEth/juno/mocks"
 	rpccore "github.com/NethermindEth/juno/rpc/rpccore"
@@ -238,7 +239,7 @@ func TestClassHashAt(t *testing.T) {
 		stateDiff := core.EmptyStateDiff()
 		stateDiff.DeployedContracts[targetAddress] = expectedClassHash
 
-		preConfirmed := core.PreConfirmed{
+		preConfirmed := pending.PreConfirmed{
 			Block: &core.Block{
 				Header: &core.Header{
 					Number: 2,

--- a/rpc/v9/events_test.go
+++ b/rpc/v9/events_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/NethermindEth/juno/clients/feeder"
 	"github.com/NethermindEth/juno/core"
 	"github.com/NethermindEth/juno/core/felt"
+	"github.com/NethermindEth/juno/core/pending"
 	"github.com/NethermindEth/juno/db"
 	"github.com/NethermindEth/juno/db/memory"
 	"github.com/NethermindEth/juno/jsonrpc"
@@ -23,7 +24,7 @@ import (
 // createEventPreConfirmedFromBlock creates a pre_confirmed block from the given block and
 // returns the pre_confirmed data and emitted events
 func createEventPreConfirmedFromBlock(block *core.Block) (
-	core.PreConfirmed, []rpc.EmittedEvent,
+	pending.PreConfirmed, []rpc.EmittedEvent,
 ) {
 	newHeader := &core.Header{
 		Number:           block.Header.Number,
@@ -37,7 +38,7 @@ func createEventPreConfirmedFromBlock(block *core.Block) (
 		Receipts:     block.Receipts,
 	}
 
-	preConfirmed := core.NewPreConfirmed(preConfirmedBlock, nil, nil, nil)
+	preConfirmed := pending.NewPreConfirmed(preConfirmedBlock, nil, nil, nil)
 
 	// Extract events from the block and convert to emitted events
 	var events []rpc.EmittedEvent
@@ -61,7 +62,7 @@ func createEventPreConfirmedFromBlock(block *core.Block) (
 
 // createEventPreLatestFromBlock creates a pre_latest block from the given block and
 // returns the pre_latest data and emitted events
-func createEventPreLatestFromBlock(block *core.Block) (core.PreLatest, []rpc.EmittedEvent) {
+func createEventPreLatestFromBlock(block *core.Block) (pending.PreLatest, []rpc.EmittedEvent) {
 	newHeader := &core.Header{
 		ParentHash: block.Header.ParentHash,
 		Number:     block.Header.Number,
@@ -73,7 +74,7 @@ func createEventPreLatestFromBlock(block *core.Block) (core.PreLatest, []rpc.Emi
 		Receipts:     block.Receipts,
 	}
 
-	preLatest := core.PreLatest{Block: preLatestBlock}
+	preLatest := pending.PreLatest{Block: preLatestBlock}
 
 	// Extract events from the block and convert to emitted events
 	var events []rpc.EmittedEvent
@@ -237,7 +238,7 @@ func TestEvents(t *testing.T) {
 	type eventTest struct {
 		description    string
 		args           rpc.EventArgs
-		preConfirmed   *core.PreConfirmed
+		preConfirmed   *pending.PreConfirmed
 		expectedEvents []rpc.EmittedEvent
 		expectError    *jsonrpc.Error
 	}
@@ -692,7 +693,7 @@ func TestEvents_ChainProgressesWhilePaginating(t *testing.T) {
 
 	// pre_confirmed becomes pre_latest, continue pagination from block 6
 	preLatest2, _ := createEventPreLatestFromBlock(block6)
-	preConfirmed2 := core.PreConfirmed{
+	preConfirmed2 := pending.PreConfirmed{
 		Block: &core.Block{
 			Header: &core.Header{
 				Number: 7,

--- a/rpc/v9/handlers.go
+++ b/rpc/v9/handlers.go
@@ -12,6 +12,7 @@ import (
 	"github.com/NethermindEth/juno/blockchain"
 	"github.com/NethermindEth/juno/clients/feeder"
 	"github.com/NethermindEth/juno/core"
+	"github.com/NethermindEth/juno/core/pending"
 	"github.com/NethermindEth/juno/feed"
 	"github.com/NethermindEth/juno/jsonrpc"
 	"github.com/NethermindEth/juno/l1/contract"
@@ -38,9 +39,9 @@ type Handler struct {
 
 	newHeads                *feed.Feed[*core.Block]
 	reorgs                  *feed.Feed[*sync.ReorgBlockRange]
-	preConfirmedFeed        *feed.Feed[*core.PreConfirmed]
+	preConfirmedFeed        *feed.Feed[*pending.PreConfirmed]
 	l1Heads                 *feed.Feed[*core.L1Head]
-	preLatestFeed           *feed.Feed[*core.PreLatest]
+	preLatestFeed           *feed.Feed[*pending.PreLatest]
 	receivedTransactionFeed *feed.Feed[core.Transaction]
 
 	idgen         func() string
@@ -89,9 +90,9 @@ func New(
 		},
 		newHeads:         feed.New[*core.Block](),
 		reorgs:           feed.New[*sync.ReorgBlockRange](),
-		preConfirmedFeed: feed.New[*core.PreConfirmed](),
+		preConfirmedFeed: feed.New[*pending.PreConfirmed](),
 		l1Heads:          feed.New[*core.L1Head](),
-		preLatestFeed:    feed.New[*core.PreLatest](),
+		preLatestFeed:    feed.New[*pending.PreLatest](),
 
 		blockTraceCache: lru.NewCache[
 			rpccore.TraceCacheKey,

--- a/rpc/v9/helpers.go
+++ b/rpc/v9/helpers.go
@@ -9,6 +9,7 @@ import (
 	"github.com/NethermindEth/juno/blockchain"
 	"github.com/NethermindEth/juno/core"
 	"github.com/NethermindEth/juno/core/felt"
+	"github.com/NethermindEth/juno/core/pending"
 	"github.com/NethermindEth/juno/db"
 	"github.com/NethermindEth/juno/jsonrpc"
 	"github.com/NethermindEth/juno/rpc/rpccore"
@@ -38,7 +39,7 @@ func (h *Handler) blockByID(blockID *BlockID) (*core.Block, *jsonrpc.Error) {
 
 	switch blockID.Type() {
 	case preConfirmed:
-		var preConfirmed *core.PreConfirmed
+		var preConfirmed *pending.PreConfirmed
 		preConfirmed, err = h.syncReader.PreConfirmed()
 		if err == nil {
 			block = preConfirmed.GetBlock()
@@ -99,7 +100,7 @@ func (h *Handler) blockHeaderByID(blockID *BlockID) (*core.Header, *jsonrpc.Erro
 	var err error
 	switch blockID.Type() {
 	case preConfirmed:
-		var preConfirmed *core.PreConfirmed
+		var preConfirmed *pending.PreConfirmed
 		preConfirmed, err = h.syncReader.PreConfirmed()
 		if err == nil {
 			header = preConfirmed.GetBlock().Header
@@ -184,7 +185,7 @@ func (h *Handler) stateByBlockID(
 	var err error
 	switch blockID.Type() {
 	case preConfirmed:
-		var preConfirmed *core.PreConfirmed
+		var preConfirmed *pending.PreConfirmed
 		preConfirmed, err = h.syncReader.PreConfirmed()
 		if err == nil {
 			reader, closer, err = sync.PendingState(preConfirmed, h.bcReader)

--- a/rpc/v9/l1_test.go
+++ b/rpc/v9/l1_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/NethermindEth/juno/clients/feeder"
 	"github.com/NethermindEth/juno/core"
 	"github.com/NethermindEth/juno/core/felt"
+	"github.com/NethermindEth/juno/core/pending"
 	"github.com/NethermindEth/juno/mocks"
 	rpc "github.com/NethermindEth/juno/rpc/v9"
 	adaptfeeder "github.com/NethermindEth/juno/starknetdata/feeder"
@@ -80,7 +81,7 @@ func TestGetMessageStatus(t *testing.T) {
 			block, err := gw.BlockByNumber(t.Context(), test.blockNum)
 			require.NoError(t, err)
 
-			preConfirmed := &core.PreConfirmed{
+			preConfirmed := &pending.PreConfirmed{
 				Block: &core.Block{
 					Header: &core.Header{
 						Number:           block.Number + 1,

--- a/rpc/v9/nonce_test.go
+++ b/rpc/v9/nonce_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/NethermindEth/juno/core"
 	"github.com/NethermindEth/juno/core/felt"
+	"github.com/NethermindEth/juno/core/pending"
 	"github.com/NethermindEth/juno/db"
 	"github.com/NethermindEth/juno/mocks"
 	"github.com/NethermindEth/juno/rpc/rpccore"
@@ -102,7 +103,7 @@ func TestNonce(t *testing.T) {
 		stateDiff := core.EmptyStateDiff()
 		stateDiff.Nonces[targetAddress] = expectedNonce
 
-		preConfirmed := core.PreConfirmed{
+		preConfirmed := pending.PreConfirmed{
 			Block: &core.Block{
 				Header: &core.Header{
 					Number: 2,

--- a/rpc/v9/state_update_test.go
+++ b/rpc/v9/state_update_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/NethermindEth/juno/clients/feeder"
 	"github.com/NethermindEth/juno/core"
 	"github.com/NethermindEth/juno/core/felt"
+	"github.com/NethermindEth/juno/core/pending"
 	"github.com/NethermindEth/juno/db"
 	"github.com/NethermindEth/juno/db/memory"
 	"github.com/NethermindEth/juno/mocks"
@@ -164,7 +165,7 @@ func TestStateUpdate(t *testing.T) {
 	t.Run("pre_confirmed", func(t *testing.T) {
 		update21656.BlockHash = nil
 		update21656.NewRoot = nil
-		preConfirmed := core.NewPreConfirmed(nil, update21656, nil, nil)
+		preConfirmed := pending.NewPreConfirmed(nil, update21656, nil, nil)
 		mockSyncReader.EXPECT().PreConfirmed().Return(
 			&preConfirmed,
 			nil,

--- a/rpc/v9/storage_test.go
+++ b/rpc/v9/storage_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/NethermindEth/juno/core"
 	"github.com/NethermindEth/juno/core/crypto"
 	"github.com/NethermindEth/juno/core/felt"
+	"github.com/NethermindEth/juno/core/pending"
 	"github.com/NethermindEth/juno/core/trie"
 	"github.com/NethermindEth/juno/db"
 	"github.com/NethermindEth/juno/db/memory"
@@ -178,7 +179,7 @@ func TestStorageAt(t *testing.T) {
 		preConfirmedStateDiff.
 			DeployedContracts[targetAddress] = felt.NewFromUint64[felt.Felt](123456789)
 
-		preConfirmed := core.PreConfirmed{
+		preConfirmed := pending.PreConfirmed{
 			Block: &core.Block{
 				Header: &core.Header{
 					Number: 2,

--- a/rpc/v9/subscription_events.go
+++ b/rpc/v9/subscription_events.go
@@ -6,6 +6,7 @@ import (
 	"github.com/NethermindEth/juno/blockchain"
 	"github.com/NethermindEth/juno/core"
 	"github.com/NethermindEth/juno/core/felt"
+	"github.com/NethermindEth/juno/core/pending"
 	"github.com/NethermindEth/juno/jsonrpc"
 	"github.com/NethermindEth/juno/rpc/rpccore"
 	"github.com/NethermindEth/juno/sync"
@@ -152,7 +153,7 @@ func (s *eventSubscriberState) onPreLatest(
 	ctx context.Context,
 	id string,
 	_ *subscription,
-	preLatest *core.PreLatest,
+	preLatest *pending.PreLatest,
 ) error {
 	return s.processBlock(ctx, id, preLatest.Block, TxnPreConfirmed)
 }
@@ -161,7 +162,7 @@ func (s *eventSubscriberState) onPreConfirmed(
 	ctx context.Context,
 	id string,
 	_ *subscription,
-	preConfirmed *core.PreConfirmed,
+	preConfirmed *pending.PreConfirmed,
 ) error {
 	return s.processBlock(ctx, id, preConfirmed.GetBlock(), TxnPreConfirmed)
 }

--- a/rpc/v9/subscription_receipts.go
+++ b/rpc/v9/subscription_receipts.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/NethermindEth/juno/core"
 	"github.com/NethermindEth/juno/core/felt"
+	"github.com/NethermindEth/juno/core/pending"
 	"github.com/NethermindEth/juno/jsonrpc"
 	"github.com/NethermindEth/juno/rpc/rpccore"
 	"github.com/NethermindEth/juno/sync"
@@ -118,7 +119,7 @@ func (s *receiptsSubscriberState) onPreLatest(
 	_ context.Context,
 	id string,
 	_ *subscription,
-	preLatest *core.PreLatest,
+	preLatest *pending.PreLatest,
 ) error {
 	return s.processBlock(
 		id,
@@ -131,7 +132,7 @@ func (s *receiptsSubscriberState) onPreConfirmed(
 	_ context.Context,
 	id string,
 	_ *subscription,
-	preConfirmed *core.PreConfirmed,
+	preConfirmed *pending.PreConfirmed,
 ) error {
 	return s.processBlock(
 		id,

--- a/rpc/v9/subscription_status.go
+++ b/rpc/v9/subscription_status.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/NethermindEth/juno/core"
 	"github.com/NethermindEth/juno/core/felt"
+	"github.com/NethermindEth/juno/core/pending"
 	"github.com/NethermindEth/juno/jsonrpc"
 	"github.com/NethermindEth/juno/rpc/rpccore"
 	"github.com/NethermindEth/juno/sync"
@@ -111,7 +112,7 @@ func (s *txStatusSubscriberState) onPreLatest(
 	ctx context.Context,
 	id string,
 	sub *subscription,
-	_ *core.PreLatest,
+	_ *pending.PreLatest,
 ) error {
 	return s.checkTxStatusIfPending(ctx, id, sub)
 }
@@ -120,7 +121,7 @@ func (s *txStatusSubscriberState) onPreConfirmed(
 	ctx context.Context,
 	id string,
 	sub *subscription,
-	_ *core.PreConfirmed,
+	_ *pending.PreConfirmed,
 ) error {
 	return s.checkTxStatusIfPending(ctx, id, sub)
 }

--- a/rpc/v9/subscription_transactions.go
+++ b/rpc/v9/subscription_transactions.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/NethermindEth/juno/core"
 	"github.com/NethermindEth/juno/core/felt"
+	"github.com/NethermindEth/juno/core/pending"
 	"github.com/NethermindEth/juno/jsonrpc"
 	"github.com/NethermindEth/juno/rpc/rpccore"
 	"github.com/NethermindEth/juno/sync"
@@ -131,7 +132,7 @@ func (s *transactionsSubscriberState) onPreLatest(
 	_ context.Context,
 	id string,
 	_ *subscription,
-	preLatest *core.PreLatest,
+	preLatest *pending.PreLatest,
 ) error {
 	return s.processBlock(
 		id,
@@ -144,7 +145,7 @@ func (s *transactionsSubscriberState) onPreConfirmed(
 	_ context.Context,
 	id string,
 	_ *subscription,
-	preConfirmed *core.PreConfirmed,
+	preConfirmed *pending.PreConfirmed,
 ) error {
 	if slices.Contains(s.finalityStatus, TxnStatusWithoutL1(TxnStatusPreConfirmed)) {
 		if err := s.processBlock(
@@ -187,7 +188,7 @@ func (s *transactionsSubscriberState) processBlock(
 
 func (s *transactionsSubscriberState) processCandidateTransactions(
 	id string,
-	preConfirmed *core.PreConfirmed,
+	preConfirmed *pending.PreConfirmed,
 ) error {
 	blockNumber := preConfirmed.GetBlock().Number
 	for _, txn := range preConfirmed.GetCandidateTransaction() {

--- a/rpc/v9/subscriptions.go
+++ b/rpc/v9/subscriptions.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/NethermindEth/juno/core"
 	"github.com/NethermindEth/juno/core/felt"
+	"github.com/NethermindEth/juno/core/pending"
 	"github.com/NethermindEth/juno/feed"
 	"github.com/NethermindEth/juno/jsonrpc"
 	"github.com/NethermindEth/juno/rpc/rpccore"
@@ -79,9 +80,9 @@ type subscriber struct {
 	onStart               on[any]
 	onReorg               on[*sync.ReorgBlockRange]
 	onNewHead             on[*core.Block]
-	onPreConfirmed        on[*core.PreConfirmed]
+	onPreConfirmed        on[*pending.PreConfirmed]
 	onL1Head              on[*core.L1Head]
-	onPreLatest           on[*core.PreLatest]
+	onPreLatest           on[*pending.PreLatest]
 	onReceivedTransaction on[core.Transaction]
 }
 

--- a/rpc/v9/subscriptions_test.go
+++ b/rpc/v9/subscriptions_test.go
@@ -2646,7 +2646,11 @@ func createTestPreLatest(t *testing.T, b *core.Block, txCount int) pending.PreLa
 	}
 }
 
-func createTestPreConfirmed(t *testing.T, b *core.Block, preConfirmedCount int) pending.PreConfirmed {
+func createTestPreConfirmed(
+	t *testing.T,
+	b *core.Block,
+	preConfirmedCount int,
+) pending.PreConfirmed {
 	t.Helper()
 
 	actualTxCount := len(b.Transactions)

--- a/rpc/v9/subscriptions_test.go
+++ b/rpc/v9/subscriptions_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/NethermindEth/juno/clients/feeder"
 	"github.com/NethermindEth/juno/core"
 	"github.com/NethermindEth/juno/core/felt"
+	"github.com/NethermindEth/juno/core/pending"
 	"github.com/NethermindEth/juno/db"
 	"github.com/NethermindEth/juno/db/memory"
 	"github.com/NethermindEth/juno/feed"
@@ -50,16 +51,16 @@ func (fc *fakeConn) Equal(other jsonrpc.Conn) bool {
 type fakeSyncer struct {
 	newHeads     *feed.Feed[*core.Block]
 	reorgs       *feed.Feed[*sync.ReorgBlockRange]
-	preConfirmed *feed.Feed[*core.PreConfirmed]
-	preLatest    *feed.Feed[*core.PreLatest]
+	preConfirmed *feed.Feed[*pending.PreConfirmed]
+	preLatest    *feed.Feed[*pending.PreLatest]
 }
 
 func newFakeSyncer() *fakeSyncer {
 	return &fakeSyncer{
 		newHeads:     feed.New[*core.Block](),
 		reorgs:       feed.New[*sync.ReorgBlockRange](),
-		preConfirmed: feed.New[*core.PreConfirmed](),
-		preLatest:    feed.New[*core.PreLatest](),
+		preConfirmed: feed.New[*pending.PreConfirmed](),
+		preLatest:    feed.New[*pending.PreLatest](),
 	}
 }
 
@@ -87,7 +88,7 @@ func (fs *fakeSyncer) HighestBlockHeader() *core.Header {
 	return nil
 }
 
-func (fs *fakeSyncer) PreConfirmed() (*core.PreConfirmed, error) {
+func (fs *fakeSyncer) PreConfirmed() (*pending.PreConfirmed, error) {
 	return nil, db.ErrKeyNotFound
 }
 
@@ -928,7 +929,7 @@ func TestSubscribeTxnStatus(t *testing.T) {
 		mockChain.EXPECT().BlockNumberAndIndexByTxHash((*felt.TransactionHash)(txHash)).Return(
 			uint64(0), uint64(0), db.ErrKeyNotFound,
 		)
-		preConfirmed := &core.PreConfirmed{
+		preConfirmed := &pending.PreConfirmed{
 			Block: &core.Block{
 				Header: &core.Header{
 					Number:           block.Number,
@@ -950,7 +951,7 @@ func TestSubscribeTxnStatus(t *testing.T) {
 		rpcTx := AdaptTransaction(block.Transactions[0])
 		rpcTx.Hash = txHash
 
-		preConfirmed = &core.PreConfirmed{
+		preConfirmed = &pending.PreConfirmed{
 			Block: &core.Block{
 				Header: &core.Header{
 					Number:           block.Number,
@@ -970,7 +971,7 @@ func TestSubscribeTxnStatus(t *testing.T) {
 		handler.preConfirmedFeed.Send(preConfirmed)
 		assertNextTxnStatus(t, conn, id, txHash, TxnStatusPreConfirmed, TxnSuccess, "")
 
-		preConfirmed = &core.PreConfirmed{
+		preConfirmed = &pending.PreConfirmed{
 			Block: &core.Block{
 				Header: &core.Header{
 					Number:           block.Number + 1,
@@ -1032,7 +1033,7 @@ func TestSubscribeTxnStatus(t *testing.T) {
 		targetTxn := block.Transactions[0]
 		targetReceipt := block.Receipts[0]
 
-		preConfirmedData1 := &core.PreConfirmed{
+		preConfirmedData1 := &pending.PreConfirmed{
 			Block: &core.Block{
 				Header: &core.Header{
 					Number:           block.Number,
@@ -1044,7 +1045,7 @@ func TestSubscribeTxnStatus(t *testing.T) {
 			},
 		}
 		// PreLatest Status - should check transaction status
-		preLatest := &core.PreLatest{
+		preLatest := &pending.PreLatest{
 			Block: &core.Block{
 				Header: &core.Header{
 					Number:           block.Number,
@@ -1056,7 +1057,7 @@ func TestSubscribeTxnStatus(t *testing.T) {
 			},
 		}
 
-		preConfirmedData2 := &core.PreConfirmed{
+		preConfirmedData2 := &pending.PreConfirmed{
 			Block: &core.Block{
 				Header: &core.Header{
 					Number: preLatest.Block.Number + 1,
@@ -2627,7 +2628,7 @@ func assertNextTransactions(t *testing.T, conn net.Conn, id SubscriptionID, tran
 	}
 }
 
-func createTestPreLatest(t *testing.T, b *core.Block, txCount int) core.PreLatest {
+func createTestPreLatest(t *testing.T, b *core.Block, txCount int) pending.PreLatest {
 	t.Helper()
 
 	preLatest := core.Block{
@@ -2640,16 +2641,16 @@ func createTestPreLatest(t *testing.T, b *core.Block, txCount int) core.PreLates
 
 	preLatest.Transactions = b.Transactions[:txCount]
 	preLatest.Receipts = b.Receipts[:txCount]
-	return core.PreLatest{
+	return pending.PreLatest{
 		Block: &preLatest,
 	}
 }
 
-func createTestPreConfirmed(t *testing.T, b *core.Block, preConfirmedCount int) core.PreConfirmed {
+func createTestPreConfirmed(t *testing.T, b *core.Block, preConfirmedCount int) pending.PreConfirmed {
 	t.Helper()
 
 	actualTxCount := len(b.Transactions)
-	var preConfirmed core.PreConfirmed
+	var preConfirmed pending.PreConfirmed
 	if candidateCount := actualTxCount - preConfirmedCount; candidateCount > 0 {
 		preConfirmed.CandidateTxs = make([]core.Transaction, candidateCount)
 		candidateIndex := actualTxCount - candidateCount

--- a/rpc/v9/trace.go
+++ b/rpc/v9/trace.go
@@ -388,7 +388,7 @@ func (h *Handler) traceInPrelatestBlock(
 	}
 	defer h.callAndLogErr(closer, "Failed to close state in tracePreLatestTransaction")
 
-	preLatestState := pending.NewPendingState(
+	preLatestState := pending.NewState(
 		preLatest.StateUpdate.StateDiff,
 		preLatest.NewClasses,
 		state,

--- a/rpc/v9/trace.go
+++ b/rpc/v9/trace.go
@@ -11,6 +11,7 @@ import (
 	"github.com/NethermindEth/juno/blockchain"
 	"github.com/NethermindEth/juno/core"
 	"github.com/NethermindEth/juno/core/felt"
+	"github.com/NethermindEth/juno/core/pending"
 	"github.com/NethermindEth/juno/db"
 	"github.com/NethermindEth/juno/jsonrpc"
 	"github.com/NethermindEth/juno/rpc/rpccore"
@@ -349,7 +350,7 @@ func (h *Handler) findAndTraceInPreConfirmed(
 
 // findAndTraceInPendingBlock finds and traces a transaction in the pre_confirmed block.
 func (h *Handler) findAndTraceInPreConfirmedBlock(
-	preConfirmed *core.PreConfirmed, hash *felt.Felt,
+	preConfirmed *pending.PreConfirmed, hash *felt.Felt,
 ) (TransactionTrace, http.Header, *jsonrpc.Error) {
 	block := preConfirmed.GetBlock()
 	txIndex, rpcErr := findTransactionInBlock(block, hash)
@@ -362,7 +363,7 @@ func (h *Handler) findAndTraceInPreConfirmedBlock(
 
 // findAndTraceInPrelatestBlock finds and traces a transaction in the prelatest block.
 func (h *Handler) findAndTraceInPrelatestBlock(
-	preConfirmed *core.PreConfirmed, hash *felt.Felt,
+	preConfirmed *pending.PreConfirmed, hash *felt.Felt,
 ) (TransactionTrace, http.Header, *jsonrpc.Error) {
 	preLatest := preConfirmed.GetPreLatest()
 	if preLatest == nil {
@@ -379,7 +380,7 @@ func (h *Handler) findAndTraceInPrelatestBlock(
 
 // traceInPrelatestBlock traces a transaction in the prelatest block.
 func (h *Handler) traceInPrelatestBlock(
-	preLatest *core.PreLatest, txIndex uint,
+	preLatest *pending.PreLatest, txIndex uint,
 ) (TransactionTrace, http.Header, *jsonrpc.Error) {
 	state, closer, err := h.bcReader.StateAtBlockHash(preLatest.Block.ParentHash)
 	if err != nil {
@@ -387,7 +388,7 @@ func (h *Handler) traceInPrelatestBlock(
 	}
 	defer h.callAndLogErr(closer, "Failed to close state in tracePreLatestTransaction")
 
-	preLatestState := core.NewPendingState(
+	preLatestState := pending.NewPendingState(
 		preLatest.StateUpdate.StateDiff,
 		preLatest.NewClasses,
 		state,
@@ -415,7 +416,7 @@ func (h *Handler) traceInPrelatestBlock(
 
 // traceInPreConfirmedBlock traces a transaction in a preconfirmed block.
 func (h *Handler) traceInPreConfirmedBlock(
-	preConfirmed *core.PreConfirmed, txIndex uint,
+	preConfirmed *pending.PreConfirmed, txIndex uint,
 ) (TransactionTrace, http.Header, *jsonrpc.Error) {
 	state, stateCloser, err := sync.PendingStateBeforeIndex(preConfirmed, h.bcReader, txIndex)
 	if err != nil {

--- a/rpc/v9/trace_test.go
+++ b/rpc/v9/trace_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/NethermindEth/juno/clients/feeder"
 	"github.com/NethermindEth/juno/core"
 	"github.com/NethermindEth/juno/core/felt"
+	"github.com/NethermindEth/juno/core/pending"
 	"github.com/NethermindEth/juno/db"
 	"github.com/NethermindEth/juno/db/memory"
 	"github.com/NethermindEth/juno/mocks"
@@ -331,7 +332,7 @@ func TestTraceTransaction(t *testing.T) {
 			hash := felt.NewUnsafeFromString[felt.Felt]("0xBBBB")
 			// Receipt() returns error related to db
 			mockReader.EXPECT().Receipt(hash).Return(nil, nil, uint64(0), db.ErrKeyNotFound)
-			preConfirmed := core.NewPreConfirmed(&core.Block{}, nil, nil, nil)
+			preConfirmed := pending.NewPreConfirmed(&core.Block{}, nil, nil, nil)
 			mockSyncReader.EXPECT().PreConfirmed().Return(
 				&preConfirmed,
 				nil,
@@ -451,7 +452,7 @@ func TestTraceTransaction(t *testing.T) {
 
 		mockReader.EXPECT().Receipt(hash).Return(nil, nil, uint64(0), db.ErrKeyNotFound)
 		preConfirmedStateDiff := core.EmptyStateDiff()
-		preConfirmed := core.PreConfirmed{
+		preConfirmed := pending.PreConfirmed{
 			Block: block,
 			StateUpdate: &core.StateUpdate{
 				StateDiff: &preConfirmedStateDiff,
@@ -536,7 +537,7 @@ func TestTraceTransaction(t *testing.T) {
 			Class: &core.SierraClass{},
 		}
 		preLatestStateDiff := core.EmptyStateDiff()
-		preLatest := core.PreLatest{
+		preLatest := pending.PreLatest{
 			Block: block,
 			StateUpdate: &core.StateUpdate{
 				StateDiff: &preLatestStateDiff,
@@ -544,7 +545,7 @@ func TestTraceTransaction(t *testing.T) {
 			NewClasses: map[felt.Felt]core.ClassDefinition{*tx.ClassHash: declaredClass.Class},
 		}
 
-		preConfirmed := core.PreConfirmed{
+		preConfirmed := pending.PreConfirmed{
 			Block: &core.Block{
 				Header: &core.Header{
 					Number: preLatest.Block.Number + 1,

--- a/rpc/v9/transaction_test.go
+++ b/rpc/v9/transaction_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/NethermindEth/juno/clients/gateway"
 	"github.com/NethermindEth/juno/core"
 	"github.com/NethermindEth/juno/core/felt"
+	"github.com/NethermindEth/juno/core/pending"
 	"github.com/NethermindEth/juno/db"
 	"github.com/NethermindEth/juno/feed"
 	"github.com/NethermindEth/juno/jsonrpc"
@@ -61,7 +62,7 @@ func TestTransactionByHashNotFoundInPreConfirmedBlock(t *testing.T) {
 		Version:         new(core.TransactionVersion).SetUint64(1),
 	}
 
-	preConfirmed := core.PreConfirmed{
+	preConfirmed := pending.PreConfirmed{
 		Block: &core.Block{
 			Transactions: []core.Transaction{preConfirmedTx},
 		},
@@ -432,7 +433,7 @@ func TestTransactionByHash(t *testing.T) {
 			mockReader.EXPECT().TransactionByHash(gomock.Any()).DoAndReturn(func(hash *felt.Felt) (core.Transaction, error) {
 				return gw.Transaction(t.Context(), hash)
 			}).Times(1)
-			mockSyncReader.EXPECT().PreConfirmed().Return(&core.PreConfirmed{
+			mockSyncReader.EXPECT().PreConfirmed().Return(&pending.PreConfirmed{
 				Block: &core.Block{
 					Header: &core.Header{
 						Number:           1,
@@ -497,7 +498,7 @@ func TestTransactionByHash_PreConfirmedBlock(t *testing.T) {
 		require.NoError(t, gwErr)
 		searchTxn := testBlock.Transactions[0]
 
-		preLatest := core.PreLatest{
+		preLatest := pending.PreLatest{
 			Block: testBlock,
 		}
 		adaptedPreConfirmed.WithPreLatest(&preLatest)
@@ -642,7 +643,7 @@ func TestTransactionByBlockIdAndIndex(t *testing.T) {
 	t.Run("blockID - pre_confirmed", func(t *testing.T) {
 		latestBlock.Hash = nil
 		latestBlock.GlobalStateRoot = nil
-		preConfirmed := core.NewPreConfirmed(latestBlock, nil, nil, nil)
+		preConfirmed := pending.NewPreConfirmed(latestBlock, nil, nil, nil)
 		mockSyncReader.EXPECT().PreConfirmed().Return(
 			&preConfirmed,
 			nil,
@@ -768,7 +769,7 @@ func TestTransactionReceiptByHash(t *testing.T) {
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
 			txHash := block0.Transactions[test.index].Hash()
-			mockSyncReader.EXPECT().PreConfirmed().Return(&core.PreConfirmed{
+			mockSyncReader.EXPECT().PreConfirmed().Return(&pending.PreConfirmed{
 				Block: &core.Block{
 					Header: &core.Header{
 						Number: block0.Number + 1,
@@ -820,7 +821,7 @@ func TestTransactionReceiptByHash(t *testing.T) {
 
 			txHash := block0.Transactions[i].Hash()
 
-			preConfirmed := &core.PreConfirmed{
+			preConfirmed := &pending.PreConfirmed{
 				Block: &core.Block{
 					Header: &core.Header{
 						Number:           block0.Number,
@@ -869,10 +870,10 @@ func TestTransactionReceiptByHash(t *testing.T) {
 
 			txHash := block0.Transactions[i].Hash()
 
-			preLatest := core.PreLatest{
+			preLatest := pending.PreLatest{
 				Block: block0,
 			}
-			preConfirmed := &core.PreConfirmed{
+			preConfirmed := &pending.PreConfirmed{
 				Block: &core.Block{
 					Header: &core.Header{
 						Number: preLatest.Block.Number + 1,
@@ -920,7 +921,7 @@ func TestTransactionReceiptByHash(t *testing.T) {
 
 		txHash := block0.Transactions[i].Hash()
 		mockSyncReader.EXPECT().PreConfirmed().Return(
-			&core.PreConfirmed{
+			&pending.PreConfirmed{
 				Block: &core.Block{
 					Header: &core.Header{
 						Number: block0.Number + 1,
@@ -975,7 +976,7 @@ func TestTransactionReceiptByHash(t *testing.T) {
 		revertedTxnHash := blockWithRevertedTxn.Transactions[revertedTxnIdx].Hash()
 
 		mockSyncReader.EXPECT().PreConfirmed().Return(
-			&core.PreConfirmed{
+			&pending.PreConfirmed{
 				Block: &core.Block{
 					Header: &core.Header{
 						Number: blockWithRevertedTxn.Number + 1,
@@ -1054,7 +1055,7 @@ func TestTransactionReceiptByHash(t *testing.T) {
 		index := 0
 		txnHash := block.Transactions[index].Hash()
 		mockSyncReader.EXPECT().PreConfirmed().Return(
-			&core.PreConfirmed{
+			&pending.PreConfirmed{
 				Block: &core.Block{
 					Header: &core.Header{
 						Number: block.Number + 1,
@@ -1120,7 +1121,7 @@ func TestTransactionReceiptByHash(t *testing.T) {
 		index := 0
 		txnHash := block.Transactions[index].Hash()
 		mockSyncReader.EXPECT().PreConfirmed().Return(
-			&core.PreConfirmed{
+			&pending.PreConfirmed{
 				Block: &core.Block{
 					Header: &core.Header{
 						Number: block.Number + 1,
@@ -1652,7 +1653,7 @@ func TestTransactionStatus(t *testing.T) {
 				t.Run("not verified", func(t *testing.T) {
 					mockReader := mocks.NewMockReader(mockCtrl)
 					mockSyncReader := mocks.NewMockSyncReader(mockCtrl)
-					mockSyncReader.EXPECT().PreConfirmed().Return(&core.PreConfirmed{
+					mockSyncReader.EXPECT().PreConfirmed().Return(&pending.PreConfirmed{
 						Block: &core.Block{
 							Header: &core.Header{
 								Number: block.Number + 1,
@@ -1683,7 +1684,7 @@ func TestTransactionStatus(t *testing.T) {
 				t.Run("verified", func(t *testing.T) {
 					mockReader := mocks.NewMockReader(mockCtrl)
 					mockSyncReader := mocks.NewMockSyncReader(mockCtrl)
-					mockSyncReader.EXPECT().PreConfirmed().Return(&core.PreConfirmed{
+					mockSyncReader.EXPECT().PreConfirmed().Return(&pending.PreConfirmed{
 						Block: &core.Block{
 							Header: &core.Header{
 								Number: block.Number + 1,
@@ -1808,7 +1809,7 @@ func TestTransactionStatus(t *testing.T) {
 				require.NoError(t, gwErr)
 				preLatestTx := testBlock.Transactions[0]
 
-				preLatest := core.PreLatest{
+				preLatest := pending.PreLatest{
 					Block: testBlock,
 				}
 				preConfirmed.WithPreLatest(&preLatest)

--- a/sequencer/sequencer.go
+++ b/sequencer/sequencer.go
@@ -9,6 +9,7 @@ import (
 	"github.com/NethermindEth/juno/builder"
 	"github.com/NethermindEth/juno/core"
 	"github.com/NethermindEth/juno/core/felt"
+	"github.com/NethermindEth/juno/core/pending"
 	"github.com/NethermindEth/juno/feed"
 	"github.com/NethermindEth/juno/mempool"
 	"github.com/NethermindEth/juno/plugin"
@@ -36,9 +37,9 @@ type Sequencer struct {
 	mempool          *mempool.SequencerMempool
 
 	subNewHeads     *feed.Feed[*core.Block]
-	subPreConfirmed *feed.Feed[*core.PreConfirmed]
+	subPreConfirmed *feed.Feed[*pending.PreConfirmed]
 	subReorgFeed    *feed.Feed[*sync.ReorgBlockRange]
-	subPreLatest    *feed.Feed[*core.PreLatest]
+	subPreLatest    *feed.Feed[*pending.PreLatest]
 	plugin          plugin.JunoPlugin
 
 	mu syncLock.RWMutex
@@ -61,9 +62,9 @@ func New(
 		log:              log,
 		blockTime:        blockTime,
 		subNewHeads:      feed.New[*core.Block](),
-		subPreConfirmed:  feed.New[*core.PreConfirmed](),
+		subPreConfirmed:  feed.New[*pending.PreConfirmed](),
 		subReorgFeed:     feed.New[*sync.ReorgBlockRange](),
-		subPreLatest:     feed.New[*core.PreLatest](),
+		subPreLatest:     feed.New[*pending.PreLatest](),
 	}
 }
 
@@ -162,7 +163,7 @@ func (s *Sequencer) listenPool(ctx context.Context) error {
 		}
 
 		// push the preconfirmed block to the feed
-		preconfirmed := core.NewPreConfirmed(s.buildState.PreConfirmedBlock(), nil, nil, nil)
+		preconfirmed := pending.NewPreConfirmed(s.buildState.PreConfirmedBlock(), nil, nil, nil)
 		s.subPreConfirmed.Send(&preconfirmed)
 		select {
 		case <-ctx.Done():
@@ -203,7 +204,7 @@ func (s *Sequencer) depletePool(ctx context.Context) error {
 	}
 }
 
-func (s *Sequencer) PreConfirmed() (*core.PreConfirmed, error) {
+func (s *Sequencer) PreConfirmed() (*pending.PreConfirmed, error) {
 	return s.buildState.PreConfirmed, nil
 }
 

--- a/starknetdata/feeder/feeder.go
+++ b/starknetdata/feeder/feeder.go
@@ -10,6 +10,7 @@ import (
 	"github.com/NethermindEth/juno/clients/feeder"
 	"github.com/NethermindEth/juno/core"
 	"github.com/NethermindEth/juno/core/felt"
+	"github.com/NethermindEth/juno/core/pending"
 	"github.com/NethermindEth/juno/starknet"
 	"github.com/NethermindEth/juno/starknetdata"
 )
@@ -188,16 +189,16 @@ func (f *Feeder) StateUpdateWithBlock(ctx context.Context, blockNumber uint64) (
 }
 
 // PreConfirmedWithBlockByNumber gets both pending state update and pending block from the feeder,
-// then adapts them to the core.PreConfirmed and list of transaction hashes types respectively
-func (f *Feeder) PreConfirmedBlockByNumber(ctx context.Context, blockNumber uint64) (core.PreConfirmed, error) {
+// then adapts them to the pending.PreConfirmed and list of transaction hashes types respectively
+func (f *Feeder) PreConfirmedBlockByNumber(ctx context.Context, blockNumber uint64) (pending.PreConfirmed, error) {
 	response, err := f.client.PreConfirmedBlock(ctx, strconv.FormatUint(blockNumber, 10))
 	if err != nil {
-		return core.PreConfirmed{}, err
+		return pending.PreConfirmed{}, err
 	}
 
 	adaptedPreConfirmed, err := sn2core.AdaptPreConfirmedBlock(response, blockNumber)
 	if err != nil {
-		return core.PreConfirmed{}, err
+		return pending.PreConfirmed{}, err
 	}
 
 	return adaptedPreConfirmed, nil

--- a/starknetdata/feeder/feeder.go
+++ b/starknetdata/feeder/feeder.go
@@ -178,19 +178,27 @@ func (f *Feeder) stateUpdateWithBlock(ctx context.Context, blockID string) (*cor
 
 // StateUpdatePendingWithBlock gets both pending state update and pending block from the feeder,
 // then adapts them to the core.StateUpdate and core.Block types respectively
-func (f *Feeder) StateUpdatePendingWithBlock(ctx context.Context) (*core.StateUpdate, *core.Block, error) {
+func (f *Feeder) StateUpdatePendingWithBlock(
+	ctx context.Context,
+) (*core.StateUpdate, *core.Block, error) {
 	return f.stateUpdateWithBlock(ctx, pendingID)
 }
 
 // StateUpdateWithBlock gets both state update and block for a given block number from the feeder,
 // then adapts them to the core.StateUpdate and core.Block types respectively
-func (f *Feeder) StateUpdateWithBlock(ctx context.Context, blockNumber uint64) (*core.StateUpdate, *core.Block, error) {
+func (f *Feeder) StateUpdateWithBlock(
+	ctx context.Context,
+	blockNumber uint64,
+) (*core.StateUpdate, *core.Block, error) {
 	return f.stateUpdateWithBlock(ctx, strconv.FormatUint(blockNumber, 10))
 }
 
 // PreConfirmedWithBlockByNumber gets both pending state update and pending block from the feeder,
 // then adapts them to the pending.PreConfirmed and list of transaction hashes types respectively
-func (f *Feeder) PreConfirmedBlockByNumber(ctx context.Context, blockNumber uint64) (pending.PreConfirmed, error) {
+func (f *Feeder) PreConfirmedBlockByNumber(
+	ctx context.Context,
+	blockNumber uint64,
+) (pending.PreConfirmed, error) {
 	response, err := f.client.PreConfirmedBlock(ctx, strconv.FormatUint(blockNumber, 10))
 	if err != nil {
 		return pending.PreConfirmed{}, err

--- a/starknetdata/starknetdata.go
+++ b/starknetdata/starknetdata.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/NethermindEth/juno/core"
 	"github.com/NethermindEth/juno/core/felt"
+	"github.com/NethermindEth/juno/core/pending"
 )
 
 // StarknetData defines the function which are required to retrieve Starknet's state
@@ -22,5 +23,5 @@ type StarknetData interface {
 	StateUpdatePending(ctx context.Context) (*core.StateUpdate, error)
 	StateUpdateWithBlock(ctx context.Context, blockNumber uint64) (*core.StateUpdate, *core.Block, error)
 	StateUpdatePendingWithBlock(ctx context.Context) (*core.StateUpdate, *core.Block, error)
-	PreConfirmedBlockByNumber(ctx context.Context, blockNumber uint64) (core.PreConfirmed, error)
+	PreConfirmedBlockByNumber(ctx context.Context, blockNumber uint64) (pending.PreConfirmed, error)
 }

--- a/sync/data_source.go
+++ b/sync/data_source.go
@@ -139,7 +139,10 @@ func (f *feederGatewayDataSource) fetchUnknownClasses(
 	return newClasses, closer()
 }
 
-func (f *feederGatewayDataSource) PreConfirmedBlockByNumber(ctx context.Context, blockNumber uint64) (pending.PreConfirmed, error) {
+func (f *feederGatewayDataSource) PreConfirmedBlockByNumber(
+	ctx context.Context,
+	blockNumber uint64,
+) (pending.PreConfirmed, error) {
 	preConfirmed, err := f.starknetData.PreConfirmedBlockByNumber(ctx, blockNumber)
 	if err != nil {
 		return pending.PreConfirmed{}, err

--- a/sync/data_source.go
+++ b/sync/data_source.go
@@ -7,6 +7,7 @@ import (
 	"github.com/NethermindEth/juno/blockchain"
 	"github.com/NethermindEth/juno/core"
 	"github.com/NethermindEth/juno/core/felt"
+	"github.com/NethermindEth/juno/core/pending"
 	"github.com/NethermindEth/juno/db"
 	"github.com/NethermindEth/juno/starknetdata"
 	"github.com/NethermindEth/juno/utils"
@@ -22,8 +23,8 @@ type CommittedBlock struct {
 type DataSource interface {
 	BlockByNumber(ctx context.Context, blockNumber uint64) (CommittedBlock, error)
 	BlockHeaderLatest(ctx context.Context) (*core.Header, error)
-	BlockPreLatest(ctx context.Context) (core.PreLatest, error)
-	PreConfirmedBlockByNumber(ctx context.Context, blockNumber uint64) (core.PreConfirmed, error)
+	BlockPreLatest(ctx context.Context) (pending.PreLatest, error)
+	PreConfirmedBlockByNumber(ctx context.Context, blockNumber uint64) (pending.PreConfirmed, error)
 }
 
 type feederGatewayDataSource struct {
@@ -65,18 +66,18 @@ func (f *feederGatewayDataSource) BlockHeaderLatest(ctx context.Context) (*core.
 	return &header, nil
 }
 
-func (f *feederGatewayDataSource) BlockPreLatest(ctx context.Context) (core.PreLatest, error) {
+func (f *feederGatewayDataSource) BlockPreLatest(ctx context.Context) (pending.PreLatest, error) {
 	pendingStateUpdate, pendingBlock, err := f.starknetData.StateUpdatePendingWithBlock(ctx)
 	if err != nil {
-		return core.PreLatest{}, err
+		return pending.PreLatest{}, err
 	}
 
 	newClasses, err := f.fetchUnknownClasses(ctx, pendingStateUpdate)
 	if err != nil {
-		return core.PreLatest{}, err
+		return pending.PreLatest{}, err
 	}
 
-	return core.PreLatest{
+	return pending.PreLatest{
 		Block:       pendingBlock,
 		StateUpdate: pendingStateUpdate,
 		NewClasses:  newClasses,
@@ -138,10 +139,10 @@ func (f *feederGatewayDataSource) fetchUnknownClasses(
 	return newClasses, closer()
 }
 
-func (f *feederGatewayDataSource) PreConfirmedBlockByNumber(ctx context.Context, blockNumber uint64) (core.PreConfirmed, error) {
+func (f *feederGatewayDataSource) PreConfirmedBlockByNumber(ctx context.Context, blockNumber uint64) (pending.PreConfirmed, error) {
 	preConfirmed, err := f.starknetData.PreConfirmedBlockByNumber(ctx, blockNumber)
 	if err != nil {
-		return core.PreConfirmed{}, err
+		return pending.PreConfirmed{}, err
 	}
 
 	return preConfirmed, nil

--- a/sync/helpers.go
+++ b/sync/helpers.go
@@ -6,6 +6,7 @@ import (
 	"github.com/NethermindEth/juno/blockchain"
 	"github.com/NethermindEth/juno/core"
 	"github.com/NethermindEth/juno/core/felt"
+	"github.com/NethermindEth/juno/core/pending"
 )
 
 const BlockHashLag uint64 = 10
@@ -40,12 +41,12 @@ func makeStateDiffForEmptyBlock(bc blockchain.Reader, blockNumber uint64) (*core
 	return stateDiff, nil
 }
 
-// Deprecated: MakeEmptyPendingForParent constructs an empty core.Pending placeholder used by
+// Deprecated: MakeEmptyPendingForParent constructs an empty pending.Pending placeholder used by
 // rpc/v8 to serve "pending" block ID requests. Remove when rpc/v8 is deprecated.
 func MakeEmptyPendingForParent(
 	bcReader blockchain.Reader,
 	latestHeader *core.Header,
-) (core.Pending, error) {
+) (pending.Pending, error) {
 	receipts := make([]*core.TransactionReceipt, 0)
 	pendingBlock := &core.Block{
 		Header: &core.Header{
@@ -67,10 +68,10 @@ func MakeEmptyPendingForParent(
 
 	stateDiff, err := makeStateDiffForEmptyBlock(bcReader, latestHeader.Number+1)
 	if err != nil {
-		return core.Pending{}, err
+		return pending.Pending{}, err
 	}
 
-	pending := core.Pending{
+	pending := pending.Pending{
 		Block: pendingBlock,
 		StateUpdate: &core.StateUpdate{
 			OldRoot:   latestHeader.GlobalStateRoot,
@@ -84,7 +85,7 @@ func MakeEmptyPendingForParent(
 func MakeEmptyPreConfirmedForParent(
 	bcReader blockchain.Reader,
 	latestHeader *core.Header,
-) (core.PreConfirmed, error) {
+) (pending.PreConfirmed, error) {
 	receipts := make([]*core.TransactionReceipt, 0)
 	preConfirmedBlock := &core.Block{
 		// pre_confirmed block does not have parent hash
@@ -106,10 +107,10 @@ func MakeEmptyPreConfirmedForParent(
 
 	stateDiff, err := makeStateDiffForEmptyBlock(bcReader, latestHeader.Number+1)
 	if err != nil {
-		return core.PreConfirmed{}, err
+		return pending.PreConfirmed{}, err
 	}
 
-	preConfirmed := core.PreConfirmed{
+	preConfirmed := pending.PreConfirmed{
 		Block: preConfirmedBlock,
 		StateUpdate: &core.StateUpdate{
 			StateDiff: stateDiff,
@@ -124,7 +125,7 @@ func MakeEmptyPreConfirmedForParent(
 
 // ResolvePreConfirmedBaseState resolves the base state for pre-confirmed blocks
 func ResolvePreConfirmedBaseState(
-	preConfirmed *core.PreConfirmed,
+	preConfirmed *pending.PreConfirmed,
 	stateReader blockchain.Reader,
 ) (core.StateReader, blockchain.StateCloser, error) {
 	preLatest := preConfirmed.PreLatest
@@ -146,7 +147,7 @@ func ResolvePreConfirmedBaseState(
 // PendingState is a convenience function that combines
 // base state resolution with pending state creation
 func PendingState(
-	preConfirmed *core.PreConfirmed,
+	preConfirmed *pending.PreConfirmed,
 	stateReader blockchain.Reader,
 ) (core.StateReader, blockchain.StateCloser, error) {
 	baseState, baseStateCloser, err := ResolvePreConfirmedBaseState(preConfirmed, stateReader)
@@ -160,7 +161,7 @@ func PendingState(
 // PendingStateBeforeIndex is a convenience function that combines
 // base state resolution with pending state before index creation
 func PendingStateBeforeIndex(
-	preConfirmed *core.PreConfirmed,
+	preConfirmed *pending.PreConfirmed,
 	stateReader blockchain.Reader,
 	index uint,
 ) (core.StateReader, blockchain.StateCloser, error) {

--- a/sync/helpers_test.go
+++ b/sync/helpers_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/NethermindEth/juno/core"
 	"github.com/NethermindEth/juno/core/felt"
+	"github.com/NethermindEth/juno/core/pending"
 	"github.com/NethermindEth/juno/mocks"
 	"github.com/NethermindEth/juno/sync"
 	"github.com/stretchr/testify/require"
@@ -19,7 +20,7 @@ func TestResolvePreConfirmedBaseState(t *testing.T) {
 	mockStateReader := mocks.NewMockStateReader(mockCtrl)
 	t.Run("PreConfirmedBlock without pre-latest", func(t *testing.T) {
 		// Create a pre-confirmed block without pre-latest
-		preConfirmed := &core.PreConfirmed{
+		preConfirmed := &pending.PreConfirmed{
 			Block: &core.Block{
 				Header: &core.Header{
 					Number: 5,
@@ -43,14 +44,14 @@ func TestResolvePreConfirmedBaseState(t *testing.T) {
 
 	t.Run("PreConfirmedBlock with pre-latest", func(t *testing.T) {
 		// Create a pre-confirmed block with pre-latest
-		preLatest := &core.PreLatest{
+		preLatest := &pending.PreLatest{
 			Block: &core.Block{
 				Header: &core.Header{
 					ParentHash: &[]felt.Felt{felt.FromUint64[felt.Felt](0x456)}[0],
 				},
 			},
 		}
-		preConfirmed := &core.PreConfirmed{
+		preConfirmed := &pending.PreConfirmed{
 			PreLatest: preLatest,
 		}
 
@@ -69,7 +70,7 @@ func TestResolvePreConfirmedBaseState(t *testing.T) {
 
 	t.Run("PreConfirmedBlock genesis block", func(t *testing.T) {
 		// Create a pre-confirmed block for genesis (number 0)
-		preConfirmed := &core.PreConfirmed{
+		preConfirmed := &pending.PreConfirmed{
 			Block: &core.Block{
 				Header: &core.Header{
 					Number: 0,

--- a/sync/pending_polling.go
+++ b/sync/pending_polling.go
@@ -53,7 +53,10 @@ func shouldPreservePreConfirmed(
 // pre_confirmed at the given blockNumber by atomically swapping the stored pointer.
 // Returns true if the store was updated, false if no matching pre_confirmed is stored
 // or the attachment was already equal.
-func (s *Synchronizer) UpdatePreLatestAttachment(blockNumber uint64, preLatest *pending.PreLatest) bool {
+func (s *Synchronizer) UpdatePreLatestAttachment(
+	blockNumber uint64,
+	preLatest *pending.PreLatest,
+) bool {
 	pc := s.preConfirmed.Load()
 
 	if pc == nil || pc.Block == nil || pc.Block.Number != blockNumber {

--- a/sync/pending_polling.go
+++ b/sync/pending_polling.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/NethermindEth/juno/core"
 	"github.com/NethermindEth/juno/core/felt"
+	"github.com/NethermindEth/juno/core/pending"
 	"github.com/NethermindEth/juno/db"
 	"github.com/ethereum/go-ethereum/common/lru"
 	"go.uber.org/zap"
@@ -29,8 +30,8 @@ func (s *Synchronizer) isGreaterThanTip(blockNumber uint64) bool {
 // Returns true if existing preConfirmed is valid for head and incoming is not richer than existing.
 // Otherwise returns false.
 func shouldPreservePreConfirmed(
-	existingPending *core.PreConfirmed,
-	incomingPending *core.PreConfirmed,
+	existingPending *pending.PreConfirmed,
+	incomingPending *pending.PreConfirmed,
 	head *core.Header,
 ) bool {
 	if existingPending == nil {
@@ -52,7 +53,7 @@ func shouldPreservePreConfirmed(
 // pre_confirmed at the given blockNumber by atomically swapping the stored pointer.
 // Returns true if the store was updated, false if no matching pre_confirmed is stored
 // or the attachment was already equal.
-func (s *Synchronizer) UpdatePreLatestAttachment(blockNumber uint64, preLatest *core.PreLatest) bool {
+func (s *Synchronizer) UpdatePreLatestAttachment(blockNumber uint64, preLatest *pending.PreLatest) bool {
 	pc := s.preConfirmed.Load()
 
 	if pc == nil || pc.Block == nil || pc.Block.Number != blockNumber {
@@ -75,7 +76,7 @@ func (s *Synchronizer) UpdatePreLatestAttachment(blockNumber uint64, preLatest *
 // StorePreConfirmed stores a pre_confirmed block given that it is for the next height.
 // If an equal-number block with >= txCount already exists, we do not overwrite it,
 // but we allow updating the PreLatest attachment in-place via a CAS swap.
-func (s *Synchronizer) StorePreConfirmed(p *core.PreConfirmed) (bool, error) {
+func (s *Synchronizer) StorePreConfirmed(p *pending.PreConfirmed) (bool, error) {
 	if err := core.CheckBlockVersion(p.GetBlock().ProtocolVersion); err != nil {
 		return false, err
 	}
@@ -106,7 +107,7 @@ func (s *Synchronizer) StorePreConfirmed(p *core.PreConfirmed) (bool, error) {
 // Pass preLatest to attach it to the baseline; pass nil to clear any attachment.
 func (s *Synchronizer) storeEmptyPreConfirmed(
 	latestHeader *core.Header,
-	preLatest *core.PreLatest,
+	preLatest *pending.PreLatest,
 ) error {
 	preConfirmed, err := MakeEmptyPreConfirmedForParent(s.blockchain, latestHeader)
 	if err != nil {
@@ -126,8 +127,8 @@ func (s *Synchronizer) storeEmptyPreConfirmed(
 func (s *Synchronizer) handleTickerPreLatest(
 	ctx context.Context,
 	currentHead *core.Block,
-	seenByParent *lru.BasicLRU[felt.Felt, *core.PreLatest],
-	out chan<- *core.PreLatest,
+	seenByParent *lru.BasicLRU[felt.Felt, *pending.PreLatest],
+	out chan<- *pending.PreLatest,
 ) bool {
 	preLatest, err := s.dataSource.BlockPreLatest(ctx)
 	if err != nil {
@@ -153,7 +154,7 @@ func (s *Synchronizer) handleTickerPreLatest(
 // pollPreLatest fetches at most one pre-latest per head while at tip and forwards it to out.
 // It avoids duplicate deliveries. If a fetched pre-latest corresponds to a future head,
 // it is cached keyed by ParentHash and emitted immediately when that head arrives.
-func (s *Synchronizer) pollPreLatest(ctx context.Context, out chan<- *core.PreLatest) {
+func (s *Synchronizer) pollPreLatest(ctx context.Context, out chan<- *pending.PreLatest) {
 	if s.preLatestPollInterval == 0 {
 		s.log.Info("Pre-latest block polling is disabled")
 		return
@@ -164,7 +165,7 @@ func (s *Synchronizer) pollPreLatest(ctx context.Context, out chan<- *core.PreLa
 
 	// Cache of pre-latest blocks keyed by the hash of their parent.
 	// When we receive the head with this parent hash, we emit the cached pre-latest.
-	seenByParent := lru.NewBasicLRU[felt.Felt, *core.PreLatest](preLatestCacheSize)
+	seenByParent := lru.NewBasicLRU[felt.Felt, *pending.PreLatest](preLatestCacheSize)
 
 	ticker := time.NewTicker(s.preLatestPollInterval)
 	defer ticker.Stop()
@@ -228,7 +229,7 @@ func (s *Synchronizer) pollPreLatest(ctx context.Context, out chan<- *core.PreLa
 func (s *Synchronizer) pollPreConfirmed(
 	ctx context.Context,
 	blockNumberToPoll *atomic.Uint64,
-	out chan<- *core.PreConfirmed,
+	out chan<- *pending.PreConfirmed,
 ) {
 	if s.preConfirmedPollInterval == 0 {
 		s.log.Info("Pre-confirmed block polling is disabled")
@@ -273,8 +274,8 @@ func (s *Synchronizer) pollPreConfirmed(
 func (s *Synchronizer) handleHeadInPreConfirmedPhase(
 	head *core.Block,
 	targetPreConfirmedNum *atomic.Uint64,
-	stagedPreLatest *core.PreLatest,
-) *core.PreLatest {
+	stagedPreLatest *pending.PreLatest,
+) *pending.PreLatest {
 	next := head.Number + 1
 	targetNum := targetPreConfirmedNum.Load()
 	if next < targetNum {
@@ -297,10 +298,10 @@ func (s *Synchronizer) handleHeadInPreConfirmedPhase(
 // If it raises the target, it stages the attachment and stores a baseline with it.
 // Returns updated staged pre-latest.
 func (s *Synchronizer) handlePreLatest(
-	pl *core.PreLatest,
+	pl *pending.PreLatest,
 	targetPreConfirmedNum *atomic.Uint64,
-	stagedPreLatest *core.PreLatest,
-) *core.PreLatest {
+	stagedPreLatest *pending.PreLatest,
+) *pending.PreLatest {
 	next := pl.Block.Number + 1
 	if next <= targetPreConfirmedNum.Load() {
 		return stagedPreLatest
@@ -318,8 +319,8 @@ func (s *Synchronizer) handlePreLatest(
 // handlePreConfirmed finalises when the polled pre_confirmed equals the target.
 // It attaches the staged pre_latest, stores it, and feeds if changed.
 func (s *Synchronizer) handlePreConfirmed(
-	pc *core.PreConfirmed,
-	stagedPreLatest *core.PreLatest,
+	pc *pending.PreConfirmed,
+	stagedPreLatest *pending.PreLatest,
 ) {
 	pc.WithPreLatest(stagedPreLatest)
 	changed, err := s.StorePreConfirmed(pc)
@@ -343,14 +344,14 @@ func (s *Synchronizer) pollPendingData(ctx context.Context) {
 	headsSub := s.newHeads.SubscribeKeepLast()
 	defer headsSub.Unsubscribe()
 
-	preLatestCh := make(chan *core.PreLatest, 1)
-	preConfirmedCh := make(chan *core.PreConfirmed, 1)
+	preLatestCh := make(chan *pending.PreLatest, 1)
+	preConfirmedCh := make(chan *pending.PreConfirmed, 1)
 	var preConfirmedBlockNumberToPoll atomic.Uint64
 
 	go s.pollPreLatest(ctx, preLatestCh)
 	go s.pollPreConfirmed(ctx, &preConfirmedBlockNumberToPoll, preConfirmedCh)
 
-	var stagedPreLatest *core.PreLatest
+	var stagedPreLatest *pending.PreLatest
 
 	for {
 		select {

--- a/sync/pending_polling_test.go
+++ b/sync/pending_polling_test.go
@@ -45,7 +45,10 @@ func (m *MockDataSource) BlockPreLatest(ctx context.Context) (pending.PreLatest,
 }
 
 // Override PreConfirmedBlockByNumber to simulate errors and variable tx count
-func (m *MockDataSource) PreConfirmedBlockByNumber(ctx context.Context, number uint64) (pending.PreConfirmed, error) {
+func (m *MockDataSource) PreConfirmedBlockByNumber(
+	ctx context.Context,
+	number uint64,
+) (pending.PreConfirmed, error) {
 	m.numCallsPreConfirmed += 1
 	if m.numCallsPreConfirmed <= m.preConfirmedErrorThreshold {
 		return pending.PreConfirmed{}, errors.New("some error")

--- a/sync/pending_polling_test.go
+++ b/sync/pending_polling_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/NethermindEth/juno/clients/feeder"
 	"github.com/NethermindEth/juno/core"
 	"github.com/NethermindEth/juno/core/felt"
+	"github.com/NethermindEth/juno/core/pending"
 	"github.com/NethermindEth/juno/db/memory"
 	adaptfeeder "github.com/NethermindEth/juno/starknetdata/feeder"
 	"github.com/NethermindEth/juno/utils"
@@ -27,14 +28,14 @@ type MockDataSource struct {
 	preConfirmedErrorThreshold uint
 	numCallsPreConfirmed       uint
 	numCallsPending            uint
-	PendingFunc                func(ctx context.Context) (core.PreLatest, error)
+	PendingFunc                func(ctx context.Context) (pending.PreLatest, error)
 }
 
 // Override BlockPreLatest to simulate errors and/or injected responses
-func (m *MockDataSource) BlockPreLatest(ctx context.Context) (core.PreLatest, error) {
+func (m *MockDataSource) BlockPreLatest(ctx context.Context) (pending.PreLatest, error) {
 	m.numCallsPending += 1
 	if m.numCallsPending <= m.pendingErrorThreshold {
-		return core.PreLatest{}, errors.New("some error")
+		return pending.PreLatest{}, errors.New("some error")
 	}
 	// fallback to embedded real method if no override set
 	if m.PendingFunc != nil {
@@ -44,10 +45,10 @@ func (m *MockDataSource) BlockPreLatest(ctx context.Context) (core.PreLatest, er
 }
 
 // Override PreConfirmedBlockByNumber to simulate errors and variable tx count
-func (m *MockDataSource) PreConfirmedBlockByNumber(ctx context.Context, number uint64) (core.PreConfirmed, error) {
+func (m *MockDataSource) PreConfirmedBlockByNumber(ctx context.Context, number uint64) (pending.PreConfirmed, error) {
 	m.numCallsPreConfirmed += 1
 	if m.numCallsPreConfirmed <= m.preConfirmedErrorThreshold {
-		return core.PreConfirmed{}, errors.New("some error")
+		return pending.PreConfirmed{}, errors.New("some error")
 	}
 	preConfirmed := makeTestPreConfirmed(number)
 	preConfirmed.Block.TransactionCount = number%10 + uint64(m.numCallsPreConfirmed)/2
@@ -68,7 +69,7 @@ func TestPollPreLatest(t *testing.T) {
 
 		mockDS := &MockDataSource{
 			DataSource: dataSource,
-			PendingFunc: func(context.Context) (core.PreLatest, error) {
+			PendingFunc: func(context.Context) (pending.PreLatest, error) {
 				return makeEmptyPreLatestForParent(head.Header), nil
 			},
 		}
@@ -76,7 +77,7 @@ func TestPollPreLatest(t *testing.T) {
 		s := New(bc, mockDS, log, 50*time.Millisecond, 100*time.Millisecond, false, testDB)
 		s.highestBlockHeader.Store(head.Header)
 
-		preLatestCh := make(chan *core.PreLatest, 1)
+		preLatestCh := make(chan *pending.PreLatest, 1)
 		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 		defer cancel()
 
@@ -110,7 +111,7 @@ func TestPollPreLatest(t *testing.T) {
 
 		mockDS := &MockDataSource{
 			DataSource: dataSource,
-			PendingFunc: func(context.Context) (core.PreLatest, error) {
+			PendingFunc: func(context.Context) (pending.PreLatest, error) {
 				// Always return pending for 'latest' (future relative to headMinusOne)
 				return makeEmptyPreLatestForParent(latest.Header), nil
 			},
@@ -118,7 +119,7 @@ func TestPollPreLatest(t *testing.T) {
 		s := New(bc, mockDS, log, 50*time.Millisecond, 100*time.Millisecond, false, testDB)
 		s.highestBlockHeader.Store(latestMinusOne.Header)
 
-		preLatestCh := make(chan *core.PreLatest, 1)
+		preLatestCh := make(chan *pending.PreLatest, 1)
 		ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
 		defer cancel()
 
@@ -158,7 +159,7 @@ func TestPollPreLatest(t *testing.T) {
 		mockDS := &MockDataSource{
 			DataSource:            dataSource,
 			pendingErrorThreshold: 2,
-			PendingFunc: func(context.Context) (core.PreLatest, error) {
+			PendingFunc: func(context.Context) (pending.PreLatest, error) {
 				return makeEmptyPreLatestForParent(head.Header), nil
 			},
 			preConfirmedErrorThreshold: 0,
@@ -167,7 +168,7 @@ func TestPollPreLatest(t *testing.T) {
 		s := New(bc, mockDS, log, 50*time.Millisecond, 100*time.Millisecond, false, testDB)
 		s.highestBlockHeader.Store(head.Header)
 
-		preLatestCh := make(chan *core.PreLatest, 2)
+		preLatestCh := make(chan *pending.PreLatest, 2)
 		ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
 		defer cancel()
 
@@ -197,7 +198,7 @@ func TestPollPreLatest(t *testing.T) {
 		mockDS := &MockDataSource{
 			DataSource:            dataSource,
 			pendingErrorThreshold: ^uint(0), // always error
-			PendingFunc: func(context.Context) (core.PreLatest, error) {
+			PendingFunc: func(context.Context) (pending.PreLatest, error) {
 				return makeEmptyPreLatestForParent(head.Header), nil
 			},
 		}
@@ -205,7 +206,7 @@ func TestPollPreLatest(t *testing.T) {
 		s := New(bc, mockDS, log, 50*time.Millisecond, 100*time.Millisecond, false, testDB)
 		s.highestBlockHeader.Store(head.Header)
 
-		preLatestCh := make(chan *core.PreLatest, 2)
+		preLatestCh := make(chan *pending.PreLatest, 2)
 		ctx, cancel := context.WithCancel(context.Background())
 
 		var wg stdsync.WaitGroup
@@ -256,7 +257,7 @@ func TestPollPreConfirmedLoop(t *testing.T) {
 		s := New(bc, mockDS, log, 0, 30*time.Millisecond, false, testDB)
 
 		var preConfirmedBlockNumberToPoll atomic.Uint64
-		out := make(chan *core.PreConfirmed, 1)
+		out := make(chan *pending.PreConfirmed, 1)
 		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 		defer cancel()
 
@@ -309,7 +310,7 @@ func TestPollPreConfirmedLoop(t *testing.T) {
 		var preConfirmedBlockNumberToPoll atomic.Uint64
 		preConfirmedBlockNumberToPoll.Store(1)
 
-		out := make(chan *core.PreConfirmed, 1)
+		out := make(chan *pending.PreConfirmed, 1)
 		ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
 		defer cancel()
 
@@ -344,7 +345,7 @@ func TestPollPendingData(t *testing.T) {
 	))
 
 	// Mock data source to delay pre_latest (pending) while allowing pre_confirmed to arrive
-	pendingFunc := func(context.Context) (core.PreLatest, error) {
+	pendingFunc := func(context.Context) (pending.PreLatest, error) {
 		head, err := bc.HeadsHeader()
 		require.NoError(t, err)
 		return makeEmptyPreLatestForParent(head), nil
@@ -411,7 +412,7 @@ func TestPollPendingDataPreConfirmedPolling(t *testing.T) {
 	dataSource := NewFeederGatewayDataSource(bc, gw)
 
 	// Returns pending block with protocol version 0.14.0
-	pendingFunc := func(context.Context) (core.PreLatest, error) {
+	pendingFunc := func(context.Context) (pending.PreLatest, error) {
 		head, err := bc.HeadsHeader()
 		require.NoError(t, err)
 		return makeEmptyPreLatestForParent(head), nil
@@ -474,7 +475,7 @@ func TestStorePreConfirmed(t *testing.T) {
 	s := New(bc, NewFeederGatewayDataSource(bc, nil), log, 0, 0, false, testDB)
 
 	t.Run("stores pre_confirmed when there is none (first entry)", func(t *testing.T) {
-		preConfirmed := core.PreConfirmed{
+		preConfirmed := pending.PreConfirmed{
 			Block: &core.Block{
 				Header: &core.Header{Number: 0},
 			},
@@ -507,7 +508,7 @@ func TestStorePreConfirmed(t *testing.T) {
 	})
 
 	t.Run("returns error if ProtocolVersion unsupported", func(t *testing.T) {
-		pc := &core.PreConfirmed{
+		pc := &pending.PreConfirmed{
 			Block: &core.Block{
 				Header: &core.Header{
 					Number:          1,
@@ -524,13 +525,13 @@ func TestStorePreConfirmed(t *testing.T) {
 	t.Run("overwrites if existing pending is invalid", func(t *testing.T) {
 		head, err := bc.HeadsHeader()
 		require.NoError(t, err)
-		invalidPreConfirmed := core.PreConfirmed{
+		invalidPreConfirmed := pending.PreConfirmed{
 			Block:       &core.Block{Header: &core.Header{Number: 0}},
 			StateUpdate: &core.StateUpdate{},
 		}
 		// Insert invalid pending (simulate old data)
 		s.preConfirmed.Store(&invalidPreConfirmed)
-		pc := &core.PreConfirmed{
+		pc := &pending.PreConfirmed{
 			Block:       &core.Block{Header: &core.Header{Number: head.Number + 1}},
 			StateUpdate: &core.StateUpdate{},
 		}
@@ -544,7 +545,7 @@ func TestStorePreConfirmed(t *testing.T) {
 		require.NoError(t, err)
 
 		// Store "better" with higher tx count
-		better := &core.PreConfirmed{
+		better := &pending.PreConfirmed{
 			Block: &core.Block{
 				Header: &core.Header{
 					Number:           head.Number + 1,
@@ -561,7 +562,7 @@ func TestStorePreConfirmed(t *testing.T) {
 		// should keep existing but update attachment
 		pl := makeEmptyPreLatestForParent(head)
 
-		worse := &core.PreConfirmed{
+		worse := &pending.PreConfirmed{
 			Block: &core.Block{
 				Header: &core.Header{
 					Number:           head.Number + 1,
@@ -587,7 +588,7 @@ func TestStorePreConfirmed(t *testing.T) {
 		head, err := bc.HeadsHeader()
 		require.NoError(t, err)
 
-		worse := core.PreConfirmed{
+		worse := pending.PreConfirmed{
 			Block: &core.Block{
 				Header: &core.Header{
 					Number:           head.Number + 1,
@@ -602,7 +603,7 @@ func TestStorePreConfirmed(t *testing.T) {
 		ptr := s.preConfirmed.Load()
 		require.Equal(t, worse, *ptr)
 
-		better := core.PreConfirmed{
+		better := pending.PreConfirmed{
 			Block: &core.Block{
 				Header: &core.Header{
 					Number:           head.Number + 1,
@@ -623,7 +624,7 @@ func TestStorePreConfirmed(t *testing.T) {
 		head, err := bc.HeadsHeader()
 		require.NoError(t, err)
 
-		old := core.PreConfirmed{
+		old := pending.PreConfirmed{
 			Block: &core.Block{
 				Header: &core.Header{
 					Number:           head.Number + 1,
@@ -640,7 +641,7 @@ func TestStorePreConfirmed(t *testing.T) {
 
 		// Attach prelatest to make validate pass for pre_confirmed number == head + 2.
 		// Similar as storing head + 1
-		preLatest := &core.PreLatest{
+		preLatest := &pending.PreLatest{
 			Block: &core.Block{
 				Header: &core.Header{
 					ParentHash: head.Hash,
@@ -648,7 +649,7 @@ func TestStorePreConfirmed(t *testing.T) {
 				},
 			},
 		}
-		newer := core.PreConfirmed{
+		newer := pending.PreConfirmed{
 			Block: &core.Block{
 				Header: &core.Header{
 					Number:           head.Number + 2,
@@ -675,7 +676,7 @@ func TestStorePreConfirmed(t *testing.T) {
 		require.NoError(t, err)
 		// Attach prelatest to make validate pass for pre_confirmed number == head + 2.
 		// Similar as storing head + 1
-		preLatest := &core.PreLatest{
+		preLatest := &pending.PreLatest{
 			Block: &core.Block{
 				Header: &core.Header{
 					ParentHash: head.Hash,
@@ -683,7 +684,7 @@ func TestStorePreConfirmed(t *testing.T) {
 				},
 			},
 		}
-		newer := core.PreConfirmed{
+		newer := pending.PreConfirmed{
 			Block: &core.Block{
 				Header: &core.Header{
 					Number:           head.Number + 2,
@@ -699,7 +700,7 @@ func TestStorePreConfirmed(t *testing.T) {
 		ptr := s.preConfirmed.Load()
 		require.Equal(t, newer, *ptr)
 		// Valid older pre_confirmed
-		old := core.PreConfirmed{
+		old := pending.PreConfirmed{
 			Block: &core.Block{
 				Header: &core.Header{
 					Number:           head.Number + 1,
@@ -716,7 +717,7 @@ func TestStorePreConfirmed(t *testing.T) {
 	})
 }
 
-func makeTestPreConfirmed(num uint64) core.PreConfirmed {
+func makeTestPreConfirmed(num uint64) pending.PreConfirmed {
 	receipts := make([]*core.TransactionReceipt, 0)
 	preConfirmedBlock := &core.Block{
 		// pre_confirmed block does not have parent hash
@@ -742,7 +743,7 @@ func makeTestPreConfirmed(num uint64) core.PreConfirmed {
 		Receipts:     receipts,
 	}
 	stateDiff := core.EmptyStateDiff()
-	preConfirmed := core.PreConfirmed{
+	preConfirmed := pending.PreConfirmed{
 		Block: preConfirmedBlock,
 		StateUpdate: &core.StateUpdate{
 			StateDiff: &stateDiff,
@@ -754,7 +755,7 @@ func makeTestPreConfirmed(num uint64) core.PreConfirmed {
 	return preConfirmed
 }
 
-func makeEmptyPreLatestForParent(parent *core.Header) core.PreLatest {
+func makeEmptyPreLatestForParent(parent *core.Header) pending.PreLatest {
 	receipts := make([]*core.TransactionReceipt, 0)
 	pendingBlock := &core.Block{
 		Header: &core.Header{
@@ -774,7 +775,7 @@ func makeEmptyPreLatestForParent(parent *core.Header) core.PreLatest {
 		Receipts:     receipts,
 	}
 	stateDiff := core.EmptyStateDiff()
-	pending := core.PreLatest{
+	pending := pending.PreLatest{
 		Block: pendingBlock,
 		StateUpdate: &core.StateUpdate{
 			OldRoot:   parent.GlobalStateRoot,

--- a/sync/reorg_test.go
+++ b/sync/reorg_test.go
@@ -64,7 +64,10 @@ func (t *testBlockDataSource) BlockPreLatest(ctx context.Context) (pending.PreLa
 	return pending.PreLatest{}, errors.New("not implemented")
 }
 
-func (t *testBlockDataSource) PreConfirmedBlockByNumber(ctx context.Context, blockNumber uint64) (pending.PreConfirmed, error) {
+func (t *testBlockDataSource) PreConfirmedBlockByNumber(
+	ctx context.Context,
+	blockNumber uint64,
+) (pending.PreConfirmed, error) {
 	return pending.PreConfirmed{}, errors.New("not implemented")
 }
 

--- a/sync/reorg_test.go
+++ b/sync/reorg_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/NethermindEth/juno/builder"
 	"github.com/NethermindEth/juno/core"
 	"github.com/NethermindEth/juno/core/felt"
+	"github.com/NethermindEth/juno/core/pending"
 	"github.com/NethermindEth/juno/db/memory"
 	"github.com/NethermindEth/juno/genesis"
 	"github.com/NethermindEth/juno/starknet/compiler"
@@ -59,12 +60,12 @@ func (t *testBlockDataSource) BlockHeaderLatest(ctx context.Context) (*core.Head
 	return getBlock(blocks, uint64(len(blocks)-1)).Block.Header, nil
 }
 
-func (t *testBlockDataSource) BlockPreLatest(ctx context.Context) (core.PreLatest, error) {
-	return core.PreLatest{}, errors.New("not implemented")
+func (t *testBlockDataSource) BlockPreLatest(ctx context.Context) (pending.PreLatest, error) {
+	return pending.PreLatest{}, errors.New("not implemented")
 }
 
-func (t *testBlockDataSource) PreConfirmedBlockByNumber(ctx context.Context, blockNumber uint64) (core.PreConfirmed, error) {
-	return core.PreConfirmed{}, errors.New("not implemented")
+func (t *testBlockDataSource) PreConfirmedBlockByNumber(ctx context.Context, blockNumber uint64) (pending.PreConfirmed, error) {
+	return pending.PreConfirmed{}, errors.New("not implemented")
 }
 
 func (t *testBlockDataSource) setBlocks(blocks []sync.CommittedBlock) {

--- a/sync/sync.go
+++ b/sync/sync.go
@@ -11,6 +11,7 @@ import (
 	"github.com/NethermindEth/juno/blockchain"
 	"github.com/NethermindEth/juno/core"
 	"github.com/NethermindEth/juno/core/felt"
+	"github.com/NethermindEth/juno/core/pending"
 	"github.com/NethermindEth/juno/db"
 	"github.com/NethermindEth/juno/feed"
 	junoplugin "github.com/NethermindEth/juno/plugin"
@@ -45,11 +46,11 @@ type PendingTxSubscription struct {
 }
 
 type PreConfirmedDataSubscription struct {
-	*feed.Subscription[*core.PreConfirmed]
+	*feed.Subscription[*pending.PreConfirmed]
 }
 
 type PreLatestDataSubscription struct {
-	*feed.Subscription[*core.PreLatest]
+	*feed.Subscription[*pending.PreLatest]
 }
 
 // ReorgBlockRange represents data about reorganised blocks, starting and ending block number and hash
@@ -74,7 +75,7 @@ type Reader interface {
 	SubscribeReorg() ReorgSubscription
 	SubscribePreConfirmed() PreConfirmedDataSubscription
 	SubscribePreLatest() PreLatestDataSubscription
-	PreConfirmed() (*core.PreConfirmed, error)
+	PreConfirmed() (*pending.PreConfirmed, error)
 }
 
 // This is temporary and will be removed once the p2p synchronizer implements this interface.
@@ -97,14 +98,14 @@ func (n *NoopSynchronizer) SubscribeReorg() ReorgSubscription {
 }
 
 func (n *NoopSynchronizer) SubscribePreConfirmed() PreConfirmedDataSubscription {
-	return PreConfirmedDataSubscription{feed.New[*core.PreConfirmed]().Subscribe()}
+	return PreConfirmedDataSubscription{feed.New[*pending.PreConfirmed]().Subscribe()}
 }
 
 func (n *NoopSynchronizer) SubscribePreLatest() PreLatestDataSubscription {
-	return PreLatestDataSubscription{feed.New[*core.PreLatest]().Subscribe()}
+	return PreLatestDataSubscription{feed.New[*pending.PreLatest]().Subscribe()}
 }
 
-func (n *NoopSynchronizer) PreConfirmed() (*core.PreConfirmed, error) {
+func (n *NoopSynchronizer) PreConfirmed() (*pending.PreConfirmed, error) {
 	return nil, errors.New("PreConfirmed() is not implemented")
 }
 
@@ -118,13 +119,13 @@ type Synchronizer struct {
 	highestBlockHeader   atomic.Pointer[core.Header]
 	newHeads             *feed.Feed[*core.Block]
 	reorgFeed            *feed.Feed[*ReorgBlockRange]
-	preConfirmedDataFeed *feed.Feed[*core.PreConfirmed]
-	preLatestDataFeed    *feed.Feed[*core.PreLatest]
+	preConfirmedDataFeed *feed.Feed[*pending.PreConfirmed]
+	preLatestDataFeed    *feed.Feed[*pending.PreLatest]
 
 	log      utils.StructuredLogger
 	listener EventListener
 
-	preConfirmed             atomic.Pointer[core.PreConfirmed]
+	preConfirmed             atomic.Pointer[pending.PreConfirmed]
 	preLatestPollInterval    time.Duration
 	preConfirmedPollInterval time.Duration
 
@@ -150,8 +151,8 @@ func New(
 		log:                      log,
 		newHeads:                 feed.New[*core.Block](),
 		reorgFeed:                feed.New[*ReorgBlockRange](),
-		preConfirmedDataFeed:     feed.New[*core.PreConfirmed](),
-		preLatestDataFeed:        feed.New[*core.PreLatest](),
+		preConfirmedDataFeed:     feed.New[*pending.PreConfirmed](),
+		preLatestDataFeed:        feed.New[*pending.PreLatest](),
 		preLatestPollInterval:    preLatestPollInterval,
 		preConfirmedPollInterval: preConfirmedPollInterval,
 		listener:                 &SelectiveListener{},
@@ -594,7 +595,7 @@ func (s *Synchronizer) pollLatest(ctx context.Context) {
 	}
 }
 
-func (s *Synchronizer) PreConfirmed() (*core.PreConfirmed, error) {
+func (s *Synchronizer) PreConfirmed() (*pending.PreConfirmed, error) {
 	head, err := s.blockchain.HeadsHeader()
 	if err != nil {
 		if !errors.Is(err, db.ErrKeyNotFound) {


### PR DESCRIPTION
This PR moves the pending code in the core pkg into a new core/pending pkg.

Changes made:

- copy/pasted of the pending code from `core` to `core/pending`;
- renamed `PendingState` and `PendingStateWriter` to `State` and `StateWriter` since now the pkg prefix gives the context (e.g: `pending.NewState` instead of `pending.NewPendingState`;