### PR TITLE
refactor: new `blockchain/networks` pkg

### DIFF
--- a/adapters/consensus2p2p/consensus_p2p_adapters_test.go
+++ b/adapters/consensus2p2p/consensus_p2p_adapters_test.go
@@ -8,8 +8,8 @@ import (
 	"github.com/NethermindEth/juno/adapters/consensus2p2p/testutils"
 	"github.com/NethermindEth/juno/adapters/p2p2consensus"
 	transactiontestutils "github.com/NethermindEth/juno/adapters/testutils"
+	"github.com/NethermindEth/juno/blockchain/networks"
 	"github.com/NethermindEth/juno/starknet/compiler"
-	"github.com/NethermindEth/juno/utils"
 	"github.com/stretchr/testify/require"
 )
 
@@ -44,7 +44,7 @@ func TestAdaptProposalCommitment(t *testing.T) {
 func TestAdaptProposalTransaction(t *testing.T) {
 	consensusTransactions, p2pTransactions := transactiontestutils.GetTestTransactions(
 		t,
-		&utils.Mainnet,
+		&networks.Mainnet,
 		testutils.TransactionBuilder.GetTestDeclareTransaction,
 		testutils.TransactionBuilder.GetTestDeployAccountTransaction,
 		testutils.TransactionBuilder.GetTestInvokeTransaction,
@@ -58,7 +58,7 @@ func TestAdaptProposalTransaction(t *testing.T) {
 			require.Equal(t, p2pTransactions[i], convertedP2PTransaction)
 
 			convertedConsensusTransaction, err := p2p2consensus.AdaptTransaction(
-				t.Context(), compiler.NewUnsafe(), convertedP2PTransaction, &utils.Mainnet,
+				t.Context(), compiler.NewUnsafe(), convertedP2PTransaction, &networks.Mainnet,
 			)
 			require.NoError(t, err)
 
@@ -74,7 +74,7 @@ func TestAdaptProposalTransaction(t *testing.T) {
 		require.Equal(t, p2pTransactions, convertedP2PTransactions.Transactions)
 
 		convertedConsensusTransactions, err := p2p2consensus.AdaptProposalTransaction(
-			t.Context(), compiler.NewUnsafe(), &convertedP2PTransactions, &utils.Mainnet,
+			t.Context(), compiler.NewUnsafe(), &convertedP2PTransactions, &networks.Mainnet,
 		)
 		require.NoError(t, err)
 		for i := range consensusTransactions {

--- a/adapters/mempool2p2p/mempool_p2p_adapters_test.go
+++ b/adapters/mempool2p2p/mempool_p2p_adapters_test.go
@@ -8,15 +8,15 @@ import (
 	"github.com/NethermindEth/juno/adapters/mempool2p2p/testutils"
 	"github.com/NethermindEth/juno/adapters/p2p2mempool"
 	transactiontestutils "github.com/NethermindEth/juno/adapters/testutils"
+	"github.com/NethermindEth/juno/blockchain/networks"
 	"github.com/NethermindEth/juno/starknet/compiler"
-	"github.com/NethermindEth/juno/utils"
 	"github.com/stretchr/testify/require"
 )
 
 func TestAdaptTransaction(t *testing.T) {
 	mempoolTransactions, p2pTransactions := transactiontestutils.GetTestTransactions(
 		t,
-		&utils.Sepolia,
+		&networks.Sepolia,
 		testutils.TransactionBuilder.GetTestDeclareTransaction,
 		testutils.TransactionBuilder.GetTestDeployAccountTransaction,
 		testutils.TransactionBuilder.GetTestInvokeTransaction,
@@ -29,7 +29,7 @@ func TestAdaptTransaction(t *testing.T) {
 			require.Equal(t, p2pTransactions[i], convertedP2PTransaction)
 
 			convertedmempoolTransaction, err := p2p2mempool.AdaptTransaction(
-				t.Context(), compiler.NewUnsafe(), convertedP2PTransaction, &utils.Sepolia,
+				t.Context(), compiler.NewUnsafe(), convertedP2PTransaction, &networks.Sepolia,
 			)
 			require.NoError(t, err)
 

--- a/adapters/p2p2consensus/p2p_consensus_adapters_test.go
+++ b/adapters/p2p2consensus/p2p_consensus_adapters_test.go
@@ -8,8 +8,8 @@ import (
 	"github.com/NethermindEth/juno/adapters/consensus2p2p/testutils"
 	"github.com/NethermindEth/juno/adapters/p2p2consensus"
 	transactiontestutils "github.com/NethermindEth/juno/adapters/testutils"
+	"github.com/NethermindEth/juno/blockchain/networks"
 	"github.com/NethermindEth/juno/starknet/compiler"
-	"github.com/NethermindEth/juno/utils"
 	"github.com/starknet-io/starknet-p2p-specs/p2p/proto/consensus/consensus"
 	"github.com/stretchr/testify/require"
 )
@@ -45,7 +45,7 @@ func TestAdaptProposalCommitment(t *testing.T) {
 func TestAdaptProposalTransaction(t *testing.T) {
 	consensusTransactions, p2pTransactions := transactiontestutils.GetTestTransactions(
 		t,
-		&utils.Mainnet,
+		&networks.Mainnet,
 		testutils.TransactionBuilder.GetTestDeclareTransaction,
 		testutils.TransactionBuilder.GetTestDeployAccountTransaction,
 		testutils.TransactionBuilder.GetTestInvokeTransaction,
@@ -55,7 +55,7 @@ func TestAdaptProposalTransaction(t *testing.T) {
 	for i := range consensusTransactions {
 		t.Run(fmt.Sprintf("%T", consensusTransactions[i].Transaction), func(t *testing.T) {
 			convertedConsensusTransaction, err := p2p2consensus.AdaptTransaction(
-				t.Context(), compiler.NewUnsafe(), p2pTransactions[i], &utils.Mainnet,
+				t.Context(), compiler.NewUnsafe(), p2pTransactions[i], &networks.Mainnet,
 			)
 			require.NoError(t, err)
 
@@ -74,7 +74,7 @@ func TestAdaptProposalTransaction(t *testing.T) {
 			Transactions: p2pTransactions,
 		}
 		convertedConsensusTransactions, err := p2p2consensus.AdaptProposalTransaction(
-			t.Context(), compiler.NewUnsafe(), &transactionBatch, &utils.Mainnet,
+			t.Context(), compiler.NewUnsafe(), &transactionBatch, &networks.Mainnet,
 		)
 		require.NoError(t, err)
 

--- a/adapters/p2p2consensus/proposal.go
+++ b/adapters/p2p2consensus/proposal.go
@@ -5,11 +5,11 @@ import (
 
 	"github.com/Masterminds/semver/v3"
 	"github.com/NethermindEth/juno/adapters/p2p2core"
+	"github.com/NethermindEth/juno/blockchain/networks"
 	consensus "github.com/NethermindEth/juno/consensus/types"
 	"github.com/NethermindEth/juno/core"
 	"github.com/NethermindEth/juno/core/felt"
 	"github.com/NethermindEth/juno/starknet/compiler"
-	"github.com/NethermindEth/juno/utils"
 	p2pconsensus "github.com/starknet-io/starknet-p2p-specs/p2p/proto/consensus/consensus"
 )
 
@@ -62,7 +62,7 @@ func AdaptProposalTransaction(
 	ctx context.Context,
 	compiler compiler.Compiler,
 	msg *p2pconsensus.TransactionBatch,
-	network *utils.Network,
+	network *networks.Network,
 ) ([]consensus.Transaction, error) {
 	var err error
 	txns := make([]consensus.Transaction, len(msg.Transactions))

--- a/adapters/p2p2consensus/transaction.go
+++ b/adapters/p2p2consensus/transaction.go
@@ -5,11 +5,11 @@ import (
 	"fmt"
 
 	"github.com/NethermindEth/juno/adapters/p2p2core"
+	"github.com/NethermindEth/juno/blockchain/networks"
 	consensus "github.com/NethermindEth/juno/consensus/types"
 	"github.com/NethermindEth/juno/core"
 	"github.com/NethermindEth/juno/core/felt"
 	"github.com/NethermindEth/juno/starknet/compiler"
-	"github.com/NethermindEth/juno/utils"
 	p2pconsensus "github.com/starknet-io/starknet-p2p-specs/p2p/proto/consensus/consensus"
 )
 
@@ -17,7 +17,7 @@ func AdaptTransaction(
 	ctx context.Context,
 	compiler compiler.Compiler,
 	t *p2pconsensus.ConsensusTransaction,
-	network *utils.Network,
+	network *networks.Network,
 ) (consensus.Transaction, error) {
 	if err := validateConsensusTransaction(t); err != nil {
 		return consensus.Transaction{}, err

--- a/adapters/p2p2core/transaction.go
+++ b/adapters/p2p2core/transaction.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/NethermindEth/juno/blockchain/networks"
 	"github.com/NethermindEth/juno/core"
 	"github.com/NethermindEth/juno/core/felt"
 	"github.com/NethermindEth/juno/starknet/compiler"
@@ -358,7 +359,7 @@ func AdaptL1Handler(tx *transaction.L1HandlerV0, txnHash *common.Hash) *core.L1H
 
 func AdaptTransaction(
 	t *synctransaction.TransactionInBlock,
-	network *utils.Network,
+	network *networks.Network,
 ) (core.Transaction, error) {
 	// can Txn be nil?
 

--- a/adapters/p2p2core/transaction_test.go
+++ b/adapters/p2p2core/transaction_test.go
@@ -7,9 +7,9 @@ import (
 	"github.com/NethermindEth/juno/adapters/core2p2p"
 	"github.com/NethermindEth/juno/adapters/p2p2core"
 	transactiontestutils "github.com/NethermindEth/juno/adapters/testutils"
+	"github.com/NethermindEth/juno/blockchain/networks"
 	"github.com/NethermindEth/juno/core"
 	"github.com/NethermindEth/juno/core/felt"
-	"github.com/NethermindEth/juno/utils"
 	"github.com/starknet-io/starknet-p2p-specs/p2p/proto/common"
 	synctransaction "github.com/starknet-io/starknet-p2p-specs/p2p/proto/sync/transaction"
 	"github.com/stretchr/testify/require"
@@ -146,7 +146,7 @@ var SyncTransactionBuilder = transactiontestutils.SyncTransactionBuilder[
 func TestAdaptTransactionInBlock(t *testing.T) {
 	consensusTransactions, p2pTransactions := transactiontestutils.GetTestTransactions(
 		t,
-		&utils.Mainnet,
+		&networks.Mainnet,
 		SyncTransactionBuilder.GetTestDeclareV0Transaction,
 		SyncTransactionBuilder.GetTestDeclareV1Transaction,
 		SyncTransactionBuilder.GetTestDeclareV2Transaction,
@@ -163,7 +163,7 @@ func TestAdaptTransactionInBlock(t *testing.T) {
 		t.Run(fmt.Sprintf("%T", consensusTransactions[i].Hash()), func(t *testing.T) {
 			convertedConsensusTransaction, err := p2p2core.AdaptTransaction(
 				p2pTransactions[i],
-				&utils.Mainnet,
+				&networks.Mainnet,
 			)
 			require.NoError(t, err)
 			require.Equal(t, consensusTransactions[i], convertedConsensusTransaction)

--- a/adapters/p2p2mempool/p2p_mempool_adapters_test.go
+++ b/adapters/p2p2mempool/p2p_mempool_adapters_test.go
@@ -8,15 +8,15 @@ import (
 	"github.com/NethermindEth/juno/adapters/mempool2p2p/testutils"
 	"github.com/NethermindEth/juno/adapters/p2p2mempool"
 	transactiontestutils "github.com/NethermindEth/juno/adapters/testutils"
+	"github.com/NethermindEth/juno/blockchain/networks"
 	"github.com/NethermindEth/juno/starknet/compiler"
-	"github.com/NethermindEth/juno/utils"
 	"github.com/stretchr/testify/require"
 )
 
 func TestAdaptProposalTransaction(t *testing.T) {
 	mempoolTransactions, p2pTransactions := transactiontestutils.GetTestTransactions(
 		t,
-		&utils.Sepolia,
+		&networks.Sepolia,
 		testutils.TransactionBuilder.GetTestDeclareTransaction,
 		testutils.TransactionBuilder.GetTestDeployAccountTransaction,
 		testutils.TransactionBuilder.GetTestInvokeTransaction,
@@ -25,7 +25,7 @@ func TestAdaptProposalTransaction(t *testing.T) {
 	for i := range mempoolTransactions {
 		t.Run(fmt.Sprintf("%T", mempoolTransactions[i].Transaction), func(t *testing.T) {
 			convertedmempoolTransaction, err := p2p2mempool.AdaptTransaction(
-				t.Context(), compiler.NewUnsafe(), p2pTransactions[i], &utils.Sepolia,
+				t.Context(), compiler.NewUnsafe(), p2pTransactions[i], &networks.Sepolia,
 			)
 			require.NoError(t, err)
 

--- a/adapters/p2p2mempool/transaction.go
+++ b/adapters/p2p2mempool/transaction.go
@@ -6,10 +6,10 @@ import (
 	"fmt"
 
 	"github.com/NethermindEth/juno/adapters/p2p2core"
+	"github.com/NethermindEth/juno/blockchain/networks"
 	"github.com/NethermindEth/juno/core"
 	"github.com/NethermindEth/juno/mempool"
 	"github.com/NethermindEth/juno/starknet/compiler"
-	"github.com/NethermindEth/juno/utils"
 	mempooltransaction "github.com/starknet-io/starknet-p2p-specs/p2p/proto/mempool/transaction"
 )
 
@@ -31,7 +31,7 @@ func AdaptTransaction(
 	ctx context.Context,
 	compiler compiler.Compiler,
 	t *mempooltransaction.MempoolTransaction,
-	network *utils.Network,
+	network *networks.Network,
 ) (mempool.BroadcastedTransaction, error) {
 	if err := validateMempoolTransaction(t); err != nil {
 		return mempool.BroadcastedTransaction{}, err

--- a/adapters/sn2core/sn2core_test.go
+++ b/adapters/sn2core/sn2core_test.go
@@ -5,12 +5,12 @@ import (
 	"testing"
 
 	"github.com/NethermindEth/juno/adapters/sn2core"
+	"github.com/NethermindEth/juno/blockchain/networks"
 	"github.com/NethermindEth/juno/clients/feeder"
 	"github.com/NethermindEth/juno/core"
 	"github.com/NethermindEth/juno/core/felt"
 	"github.com/NethermindEth/juno/core/pending"
 	"github.com/NethermindEth/juno/starknet"
-	"github.com/NethermindEth/juno/utils"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -19,7 +19,7 @@ func TestAdaptBlock(t *testing.T) {
 	tests := []struct {
 		number          uint64
 		protocolVersion string
-		network         utils.Network
+		network         networks.Network
 		sig             *starknet.Signature
 		l1GasPriceWEI   *felt.Felt
 		l1GasPriceSTRK  *felt.Felt
@@ -30,19 +30,19 @@ func TestAdaptBlock(t *testing.T) {
 	}{
 		{
 			number:        147,
-			network:       utils.Mainnet,
+			network:       networks.Mainnet,
 			l1GasPriceWEI: &felt.Zero,
 		},
 		{
 			number:          11817,
 			protocolVersion: "0.10.1",
-			network:         utils.Mainnet,
+			network:         networks.Mainnet,
 			l1GasPriceWEI:   felt.NewUnsafeFromString[felt.Felt]("0x27ad16775"),
 		},
 		{
 			number:          304740,
 			protocolVersion: "0.12.1",
-			network:         utils.Integration,
+			network:         networks.Integration,
 			sig: &starknet.Signature{
 				Signature: []*felt.Felt{felt.NewUnsafeFromString[felt.Felt]("0x44"), felt.NewUnsafeFromString[felt.Felt]("0x37")},
 			},
@@ -50,7 +50,7 @@ func TestAdaptBlock(t *testing.T) {
 		},
 		{
 			number:          319132,
-			network:         utils.Integration,
+			network:         networks.Integration,
 			protocolVersion: "0.13.0",
 			sig: &starknet.Signature{
 				Signature: []*felt.Felt{
@@ -63,7 +63,7 @@ func TestAdaptBlock(t *testing.T) {
 		},
 		{
 			number:          330363,
-			network:         utils.Integration,
+			network:         networks.Integration,
 			protocolVersion: "0.13.1",
 			sig: &starknet.Signature{
 				Signature: []*felt.Felt{
@@ -78,7 +78,7 @@ func TestAdaptBlock(t *testing.T) {
 		},
 		{
 			number:          64164,
-			network:         utils.SepoliaIntegration,
+			network:         networks.SepoliaIntegration,
 			protocolVersion: "0.13.4",
 			sig: &starknet.Signature{
 				Signature: []*felt.Felt{
@@ -160,7 +160,7 @@ func TestAdaptBlock(t *testing.T) {
 func TestStateUpdate(t *testing.T) {
 	numbers := []uint64{0, 1, 2, 21656}
 
-	client := feeder.NewTestClient(t, &utils.Mainnet)
+	client := feeder.NewTestClient(t, &networks.Mainnet)
 	ctx := t.Context()
 
 	for _, number := range numbers {
@@ -209,7 +209,7 @@ func TestStateUpdate(t *testing.T) {
 	}
 
 	t.Run("v0.11.0 state update", func(t *testing.T) {
-		integClient := feeder.NewTestClient(t, &utils.Integration)
+		integClient := feeder.NewTestClient(t, &networks.Integration)
 
 		t.Run("declared Cairo0 classes", func(t *testing.T) {
 			feederUpdate, err := integClient.StateUpdate(ctx, "283746")
@@ -251,7 +251,7 @@ func TestClassV0(t *testing.T) {
 		"0x28d1671fb74ecb54d848d463cefccffaef6df3ae40db52130e19fe8299a7b43",
 	}
 
-	client := feeder.NewTestClient(t, &utils.Sepolia)
+	client := feeder.NewTestClient(t, &networks.Sepolia)
 	ctx := t.Context()
 
 	for _, hashString := range classHashes {
@@ -291,8 +291,8 @@ func TestClassV0(t *testing.T) {
 }
 
 func TestTransaction(t *testing.T) {
-	clientGoerli := feeder.NewTestClient(t, &utils.Goerli)
-	clientMainnet := feeder.NewTestClient(t, &utils.Mainnet)
+	clientGoerli := feeder.NewTestClient(t, &networks.Goerli)
+	clientMainnet := feeder.NewTestClient(t, &networks.Mainnet)
 	ctx := t.Context()
 
 	t.Run("invoke transaction", func(t *testing.T) {
@@ -403,7 +403,7 @@ func TestTransaction(t *testing.T) {
 }
 
 func TestTransactionV3(t *testing.T) {
-	client := feeder.NewTestClient(t, &utils.Integration)
+	client := feeder.NewTestClient(t, &networks.Integration)
 	ctx := t.Context()
 
 	tests := map[string]core.Transaction{
@@ -539,19 +539,19 @@ func TestClassV1(t *testing.T) {
 	tests := []struct {
 		name                  string
 		classHash             string
-		network               *utils.Network
+		network               *networks.Network
 		expectedSierraVersion string
 	}{
 		{
 			name:                  "cairo one class adapt sierra version 0.1.0",
 			classHash:             "0x1cd2edfb485241c4403254d550de0a097fa76743cd30696f714a491a454bad5",
-			network:               &utils.Integration,
+			network:               &networks.Integration,
 			expectedSierraVersion: "0.1.0",
 		},
 		{
 			name:                  "cairo one class adapt sierra version 1.6.0",
 			classHash:             "0x03cc90db763e736ca9b6c581ea4008408842b1a125947ab087438676a7e40b7b",
-			network:               &utils.Sepolia,
+			network:               &networks.Sepolia,
 			expectedSierraVersion: "1.6.0",
 		},
 	}
@@ -637,7 +637,7 @@ func TestAdaptCompiledClass(t *testing.T) {
 }
 
 func TestAdaptPreConfirmed(t *testing.T) {
-	n := &utils.SepoliaIntegration
+	n := &networks.SepoliaIntegration
 	client := feeder.NewTestClient(t, n)
 	emptyPreConfirmedBlock := uint64(1201960)
 	blockWithCandidates := uint64(1204672)

--- a/adapters/testutils/core_test_utils.go
+++ b/adapters/testutils/core_test_utils.go
@@ -6,9 +6,9 @@ import (
 	"math/rand/v2"
 	"testing"
 
+	"github.com/NethermindEth/juno/blockchain/networks"
 	"github.com/NethermindEth/juno/core"
 	"github.com/NethermindEth/juno/core/felt"
-	"github.com/NethermindEth/juno/utils"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/stretchr/testify/require"
 )
@@ -158,7 +158,7 @@ func GetCoreTransactions(t *testing.T, count int) []core.Transaction {
 				transactionBuilder.GetTestInvokeTransactionV3,
 				transactionBuilder.GetTestL1HandlerTransaction,
 			)
-			transaction, _ := generator(t, &utils.Mainnet)
+			transaction, _ := generator(t, &networks.Mainnet)
 			return transaction
 		},
 	)

--- a/adapters/testutils/synctransaction_test_utils.go
+++ b/adapters/testutils/synctransaction_test_utils.go
@@ -5,9 +5,9 @@ import (
 	"math/rand/v2"
 	"testing"
 
+	"github.com/NethermindEth/juno/blockchain/networks"
 	"github.com/NethermindEth/juno/core"
 	"github.com/NethermindEth/juno/core/felt"
-	"github.com/NethermindEth/juno/utils"
 	"github.com/starknet-io/starknet-p2p-specs/p2p/proto/common"
 	synctransaction "github.com/starknet-io/starknet-p2p-specs/p2p/proto/sync/transaction"
 	"github.com/starknet-io/starknet-p2p-specs/p2p/proto/transaction"
@@ -30,7 +30,7 @@ type SyncTransactionBuilder[C, P any] struct {
 
 func (b *SyncTransactionBuilder[C, P]) GetTestDeclareV0Transaction(
 	t *testing.T,
-	network *utils.Network,
+	network *networks.Network,
 ) (C, P) {
 	t.Helper()
 	classHash, classHashBytes := getRandomFelt(t)
@@ -76,7 +76,7 @@ func (b *SyncTransactionBuilder[C, P]) GetTestDeclareV0Transaction(
 
 func (b *SyncTransactionBuilder[C, P]) GetTestDeclareV1Transaction(
 	t *testing.T,
-	network *utils.Network,
+	network *networks.Network,
 ) (C, P) {
 	t.Helper()
 
@@ -125,7 +125,7 @@ func (b *SyncTransactionBuilder[C, P]) GetTestDeclareV1Transaction(
 
 func (b *SyncTransactionBuilder[C, P]) GetTestDeclareV2Transaction(
 	t *testing.T,
-	network *utils.Network,
+	network *networks.Network,
 ) (C, P) {
 	t.Helper()
 	classHash, classHashBytes := getRandomFelt(t)
@@ -176,7 +176,7 @@ func (b *SyncTransactionBuilder[C, P]) GetTestDeclareV2Transaction(
 
 func (b *SyncTransactionBuilder[C, P]) GetTestDeclareV3Transaction(
 	t *testing.T,
-	network *utils.Network,
+	network *networks.Network,
 ) (C, P) {
 	t.Helper()
 	classHash, classHashBytes := getRandomFelt(t)
@@ -237,7 +237,7 @@ func (b *SyncTransactionBuilder[C, P]) GetTestDeclareV3Transaction(
 
 func (b *SyncTransactionBuilder[C, P]) GetTestDeployTransactionV0(
 	t *testing.T,
-	network *utils.Network,
+	network *networks.Network,
 ) (C, P) {
 	t.Helper()
 	// DeployTransaction is a special case because we don't verify the transaction hash
@@ -276,7 +276,7 @@ func (b *SyncTransactionBuilder[C, P]) GetTestDeployTransactionV0(
 
 func (b *SyncTransactionBuilder[C, P]) GetTestDeployAccountTransactionV1(
 	t *testing.T,
-	network *utils.Network,
+	network *networks.Network,
 ) (C, P) {
 	t.Helper()
 	contractAddressSalt, contractAddressSaltBytes := getRandomFelt(t)
@@ -335,7 +335,7 @@ func (b *SyncTransactionBuilder[C, P]) GetTestDeployAccountTransactionV1(
 
 func (b *SyncTransactionBuilder[C, P]) GetTestDeployAccountTransactionV3(
 	t *testing.T,
-	network *utils.Network,
+	network *networks.Network,
 ) (C, P) {
 	t.Helper()
 	contractAddressSalt, contractAddressSaltBytes := getRandomFelt(t)
@@ -402,7 +402,7 @@ func (b *SyncTransactionBuilder[C, P]) GetTestDeployAccountTransactionV3(
 
 func (b *SyncTransactionBuilder[C, P]) GetTestInvokeTransactionV0(
 	t *testing.T,
-	network *utils.Network,
+	network *networks.Network,
 ) (C, P) {
 	t.Helper()
 	constructorCallData, constructorCallDataBytes := getRandomFeltSlice(t)
@@ -454,7 +454,7 @@ func (b *SyncTransactionBuilder[C, P]) GetTestInvokeTransactionV0(
 
 func (b *SyncTransactionBuilder[C, P]) GetTestInvokeTransactionV1(
 	t *testing.T,
-	network *utils.Network,
+	network *networks.Network,
 ) (C, P) {
 	t.Helper()
 	constructorCallData, constructorCallDataBytes := getRandomFeltSlice(t)
@@ -506,7 +506,7 @@ func (b *SyncTransactionBuilder[C, P]) GetTestInvokeTransactionV1(
 
 func (b *SyncTransactionBuilder[C, P]) GetTestInvokeTransactionV3(
 	t *testing.T,
-	network *utils.Network,
+	network *networks.Network,
 ) (C, P) {
 	t.Helper()
 	constructorCallData, constructorCallDataBytes := getRandomFeltSlice(t)
@@ -567,7 +567,7 @@ func (b *SyncTransactionBuilder[C, P]) GetTestInvokeTransactionV3(
 
 func (b *SyncTransactionBuilder[C, P]) GetTestL1HandlerTransaction(
 	t *testing.T,
-	network *utils.Network,
+	network *networks.Network,
 ) (C, P) {
 	t.Helper()
 	contractAddress, contractAddressBytes := getRandomFelt(t)

--- a/adapters/testutils/transaction_test_utils.go
+++ b/adapters/testutils/transaction_test_utils.go
@@ -6,11 +6,11 @@ import (
 	"testing"
 
 	"github.com/NethermindEth/juno/adapters/core2p2p"
+	"github.com/NethermindEth/juno/blockchain/networks"
 	"github.com/NethermindEth/juno/clients/feeder"
 	"github.com/NethermindEth/juno/core"
 	"github.com/NethermindEth/juno/core/felt"
 	adaptfeeder "github.com/NethermindEth/juno/starknetdata/feeder"
-	"github.com/NethermindEth/juno/utils"
 	"github.com/starknet-io/starknet-p2p-specs/p2p/proto/common"
 	"github.com/starknet-io/starknet-p2p-specs/p2p/proto/transaction"
 	"github.com/stretchr/testify/require"
@@ -30,9 +30,9 @@ type TransactionBuilder[C, P any] struct {
 	ToP2PL1Handler toP2PType[P, *transaction.L1HandlerV0]
 }
 
-type factory[C, P any] func(t *testing.T, network *utils.Network) (C, P)
+type factory[C, P any] func(t *testing.T, network *networks.Network) (C, P)
 
-func GetTestTransactions[C, P any](t *testing.T, network *utils.Network, factories ...factory[C, P]) ([]C, []P) {
+func GetTestTransactions[C, P any](t *testing.T, network *networks.Network, factories ...factory[C, P]) ([]C, []P) {
 	t.Helper()
 	consensusTransactions := make([]C, len(factories))
 	p2pTransactions := make([]P, len(factories))
@@ -123,7 +123,7 @@ func getSampleClass(t *testing.T) (felt.Felt, *core.SierraClass) {
 	_, err := classHash.SetString("0x3cc90db763e736ca9b6c581ea4008408842b1a125947ab087438676a7e40b7b")
 	require.NoError(t, err)
 
-	client := feeder.NewTestClient(t, &utils.Sepolia)
+	client := feeder.NewTestClient(t, &networks.Sepolia)
 	gw := adaptfeeder.New(client)
 
 	class, err := gw.Class(t.Context(), &classHash)
@@ -138,7 +138,7 @@ func getSampleClass(t *testing.T) (felt.Felt, *core.SierraClass) {
 func getTransactionHash(
 	t *testing.T,
 	tx core.Transaction,
-	network *utils.Network,
+	network *networks.Network,
 ) (felt.Felt, *common.Hash) {
 	t.Helper()
 	hash, err := core.TransactionHash(tx, network)
@@ -147,7 +147,7 @@ func getTransactionHash(
 	return hash, adaptedHash
 }
 
-func (b *TransactionBuilder[C, P]) GetTestDeclareTransaction(t *testing.T, network *utils.Network) (C, P) {
+func (b *TransactionBuilder[C, P]) GetTestDeclareTransaction(t *testing.T, network *networks.Network) (C, P) {
 	t.Helper()
 	classHash, sierraClass := getSampleClass(t)
 	senderAddress, senderAddressBytes := getRandomFelt(t)
@@ -200,7 +200,7 @@ func (b *TransactionBuilder[C, P]) GetTestDeclareTransaction(t *testing.T, netwo
 		b.ToP2PDeclareV3(&p2pTransaction, p2pHash)
 }
 
-func (b *TransactionBuilder[C, P]) GetTestDeployAccountTransaction(t *testing.T, network *utils.Network) (C, P) {
+func (b *TransactionBuilder[C, P]) GetTestDeployAccountTransaction(t *testing.T, network *networks.Network) (C, P) {
 	t.Helper()
 	contractAddressSalt, contractAddressSaltBytes := getRandomFelt(t)
 	classHash, classHashBytes := getRandomFelt(t)
@@ -252,7 +252,7 @@ func (b *TransactionBuilder[C, P]) GetTestDeployAccountTransaction(t *testing.T,
 	return b.ToCore(&consensusDeployAccountTransaction, nil, nil), b.ToP2PDeploy(&p2pTransaction, p2pHash)
 }
 
-func (b *TransactionBuilder[C, P]) GetTestInvokeTransaction(t *testing.T, network *utils.Network) (C, P) {
+func (b *TransactionBuilder[C, P]) GetTestInvokeTransaction(t *testing.T, network *networks.Network) (C, P) {
 	t.Helper()
 	constructorCallData, constructorCallDataBytes := getRandomFeltSlice(t)
 	transactionSignature, transactionSignatureBytes := getRandomFeltSlice(t)
@@ -301,7 +301,7 @@ func (b *TransactionBuilder[C, P]) GetTestInvokeTransaction(t *testing.T, networ
 	return b.ToCore(&consensusInvokeTransaction, nil, nil), b.ToP2PInvoke(&p2pTransaction, p2pHash)
 }
 
-func (b *TransactionBuilder[C, P]) GetTestL1HandlerTransaction(t *testing.T, network *utils.Network) (C, P) {
+func (b *TransactionBuilder[C, P]) GetTestL1HandlerTransaction(t *testing.T, network *networks.Network) (C, P) {
 	t.Helper()
 	contractAddress, contractAddressBytes := getRandomFelt(t)
 	entryPointSelector, entryPointSelectorBytes := getRandomFelt(t)

--- a/adapters/testutils/transaction_test_utils.go
+++ b/adapters/testutils/transaction_test_utils.go
@@ -32,7 +32,11 @@ type TransactionBuilder[C, P any] struct {
 
 type factory[C, P any] func(t *testing.T, network *networks.Network) (C, P)
 
-func GetTestTransactions[C, P any](t *testing.T, network *networks.Network, factories ...factory[C, P]) ([]C, []P) {
+func GetTestTransactions[C, P any](
+	t *testing.T,
+	network *networks.Network,
+	factories ...factory[C, P],
+) ([]C, []P) {
 	t.Helper()
 	consensusTransactions := make([]C, len(factories))
 	p2pTransactions := make([]P, len(factories))
@@ -147,7 +151,10 @@ func getTransactionHash(
 	return hash, adaptedHash
 }
 
-func (b *TransactionBuilder[C, P]) GetTestDeclareTransaction(t *testing.T, network *networks.Network) (C, P) {
+func (b *TransactionBuilder[C, P]) GetTestDeclareTransaction(
+	t *testing.T,
+	network *networks.Network,
+) (C, P) {
 	t.Helper()
 	classHash, sierraClass := getSampleClass(t)
 	senderAddress, senderAddressBytes := getRandomFelt(t)
@@ -200,7 +207,10 @@ func (b *TransactionBuilder[C, P]) GetTestDeclareTransaction(t *testing.T, netwo
 		b.ToP2PDeclareV3(&p2pTransaction, p2pHash)
 }
 
-func (b *TransactionBuilder[C, P]) GetTestDeployAccountTransaction(t *testing.T, network *networks.Network) (C, P) {
+func (b *TransactionBuilder[C, P]) GetTestDeployAccountTransaction(
+	t *testing.T,
+	network *networks.Network,
+) (C, P) {
 	t.Helper()
 	contractAddressSalt, contractAddressSaltBytes := getRandomFelt(t)
 	classHash, classHashBytes := getRandomFelt(t)
@@ -252,7 +262,10 @@ func (b *TransactionBuilder[C, P]) GetTestDeployAccountTransaction(t *testing.T,
 	return b.ToCore(&consensusDeployAccountTransaction, nil, nil), b.ToP2PDeploy(&p2pTransaction, p2pHash)
 }
 
-func (b *TransactionBuilder[C, P]) GetTestInvokeTransaction(t *testing.T, network *networks.Network) (C, P) {
+func (b *TransactionBuilder[C, P]) GetTestInvokeTransaction(
+	t *testing.T,
+	network *networks.Network,
+) (C, P) {
 	t.Helper()
 	constructorCallData, constructorCallDataBytes := getRandomFeltSlice(t)
 	transactionSignature, transactionSignatureBytes := getRandomFeltSlice(t)
@@ -301,7 +314,10 @@ func (b *TransactionBuilder[C, P]) GetTestInvokeTransaction(t *testing.T, networ
 	return b.ToCore(&consensusInvokeTransaction, nil, nil), b.ToP2PInvoke(&p2pTransaction, p2pHash)
 }
 
-func (b *TransactionBuilder[C, P]) GetTestL1HandlerTransaction(t *testing.T, network *networks.Network) (C, P) {
+func (b *TransactionBuilder[C, P]) GetTestL1HandlerTransaction(
+	t *testing.T,
+	network *networks.Network,
+) (C, P) {
 	t.Helper()
 	contractAddress, contractAddressBytes := getRandomFelt(t)
 	entryPointSelector, entryPointSelectorBytes := getRandomFelt(t)

--- a/blockchain/blockchain.go
+++ b/blockchain/blockchain.go
@@ -3,13 +3,13 @@ package blockchain
 import (
 	"errors"
 
+	"github.com/NethermindEth/juno/blockchain/networks"
 	"github.com/NethermindEth/juno/blockchain/statebackend"
 	"github.com/NethermindEth/juno/core"
 	"github.com/NethermindEth/juno/core/felt"
 	"github.com/NethermindEth/juno/core/pending"
 	"github.com/NethermindEth/juno/db"
 	"github.com/NethermindEth/juno/feed"
-	"github.com/NethermindEth/juno/utils"
 	"github.com/ethereum/go-ethereum/common"
 )
 
@@ -63,7 +63,7 @@ type Reader interface {
 		preConfirmedFn func() (*pending.PreConfirmed, error),
 	) (EventFilterer, error)
 
-	Network() *utils.Network
+	Network() *networks.Network
 }
 
 // Re-export statebackend types for API compatibility.
@@ -78,7 +78,7 @@ var _ Reader = (*Blockchain)(nil)
 
 // Blockchain is responsible for keeping track of all things related to the Starknet blockchain
 type Blockchain struct {
-	network       *utils.Network
+	network       *networks.Network
 	database      db.KeyValueStore
 	listener      EventListener
 	l1HeadFeed    *feed.Feed[*core.L1Head]
@@ -108,7 +108,7 @@ func WithNewState(enabled bool) Option {
 	return func(o *options) { o.stateVersion = enabled }
 }
 
-func New(database db.KeyValueStore, network *utils.Network, opts ...Option) *Blockchain {
+func New(database db.KeyValueStore, network *networks.Network, opts ...Option) *Blockchain {
 	o := options{
 		listener:     &SelectiveListener{},
 		stateVersion: false,
@@ -141,7 +141,7 @@ func New(database db.KeyValueStore, network *utils.Network, opts ...Option) *Blo
 	}
 }
 
-func (b *Blockchain) Network() *utils.Network {
+func (b *Blockchain) Network() *networks.Network {
 	return b.network
 }
 

--- a/blockchain/blockchain_test.go
+++ b/blockchain/blockchain_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/NethermindEth/juno/blockchain"
+	"github.com/NethermindEth/juno/blockchain/networks"
 	"github.com/NethermindEth/juno/clients/feeder"
 	"github.com/NethermindEth/juno/core"
 	"github.com/NethermindEth/juno/core/felt"
@@ -12,7 +13,6 @@ import (
 	"github.com/NethermindEth/juno/db"
 	"github.com/NethermindEth/juno/db/memory"
 	adaptfeeder "github.com/NethermindEth/juno/starknetdata/feeder"
-	"github.com/NethermindEth/juno/utils"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -21,11 +21,11 @@ import (
 var emptyCommitments = core.BlockCommitments{}
 
 func TestNew(t *testing.T) {
-	client := feeder.NewTestClient(t, &utils.Mainnet)
+	client := feeder.NewTestClient(t, &networks.Mainnet)
 	gw := adaptfeeder.New(client)
 	t.Run("empty blockchain's head is nil", func(t *testing.T) {
-		chain := blockchain.New(memory.New(), &utils.Mainnet)
-		assert.Equal(t, &utils.Mainnet, chain.Network())
+		chain := blockchain.New(memory.New(), &networks.Mainnet)
+		assert.Equal(t, &networks.Mainnet, chain.Network())
 		b, err := chain.Head()
 		assert.Nil(t, b)
 		assert.EqualError(t, err, db.ErrKeyNotFound.Error())
@@ -38,10 +38,10 @@ func TestNew(t *testing.T) {
 		require.NoError(t, err)
 
 		testDB := memory.New()
-		chain := blockchain.New(testDB, &utils.Mainnet)
+		chain := blockchain.New(testDB, &networks.Mainnet)
 		assert.NoError(t, chain.Store(block0, &emptyCommitments, stateUpdate0, nil))
 
-		chain = blockchain.New(testDB, &utils.Mainnet)
+		chain = blockchain.New(testDB, &networks.Mainnet)
 		b, err := chain.Head()
 		require.NoError(t, err)
 		assert.Equal(t, block0, b)
@@ -49,10 +49,10 @@ func TestNew(t *testing.T) {
 }
 
 func TestHeight(t *testing.T) {
-	client := feeder.NewTestClient(t, &utils.Mainnet)
+	client := feeder.NewTestClient(t, &networks.Mainnet)
 	gw := adaptfeeder.New(client)
 	t.Run("return nil if blockchain is empty", func(t *testing.T) {
-		chain := blockchain.New(memory.New(), &utils.Sepolia)
+		chain := blockchain.New(memory.New(), &networks.Sepolia)
 		_, err := chain.Height()
 		assert.Error(t, err)
 	})
@@ -64,10 +64,10 @@ func TestHeight(t *testing.T) {
 		require.NoError(t, err)
 
 		testDB := memory.New()
-		chain := blockchain.New(testDB, &utils.Mainnet)
+		chain := blockchain.New(testDB, &networks.Mainnet)
 		assert.NoError(t, chain.Store(block0, &emptyCommitments, stateUpdate0, nil))
 
-		chain = blockchain.New(testDB, &utils.Mainnet)
+		chain = blockchain.New(testDB, &networks.Mainnet)
 		height, err := chain.Height()
 		require.NoError(t, err)
 		assert.Equal(t, block0.Number, height)
@@ -75,9 +75,9 @@ func TestHeight(t *testing.T) {
 }
 
 func TestBlockByNumberAndHash(t *testing.T) {
-	chain := blockchain.New(memory.New(), &utils.Sepolia)
+	chain := blockchain.New(memory.New(), &networks.Sepolia)
 	t.Run("same block is returned for both core.GetBlockByNumber and GetBlockByHash", func(t *testing.T) {
-		client := feeder.NewTestClient(t, &utils.Mainnet)
+		client := feeder.NewTestClient(t, &networks.Mainnet)
 		gw := adaptfeeder.New(client)
 
 		block, err := gw.BlockByNumber(t.Context(), 0)
@@ -109,9 +109,9 @@ func TestBlockByNumberAndHash(t *testing.T) {
 func TestSanityCheckNewHeight(t *testing.T) {
 	h1 := felt.NewRandom[felt.Felt]()
 
-	chain := blockchain.New(memory.New(), &utils.Mainnet)
+	chain := blockchain.New(memory.New(), &networks.Mainnet)
 
-	client := feeder.NewTestClient(t, &utils.Mainnet)
+	client := feeder.NewTestClient(t, &networks.Mainnet)
 
 	gw := adaptfeeder.New(client)
 
@@ -144,7 +144,7 @@ func TestSanityCheckNewHeight(t *testing.T) {
 }
 
 func TestStore(t *testing.T) {
-	client := feeder.NewTestClient(t, &utils.Mainnet)
+	client := feeder.NewTestClient(t, &networks.Mainnet)
 	gw := adaptfeeder.New(client)
 
 	block0, err := gw.BlockByNumber(t.Context(), 0)
@@ -154,7 +154,7 @@ func TestStore(t *testing.T) {
 	require.NoError(t, err)
 
 	t.Run("add block to empty blockchain", func(t *testing.T) {
-		chain := blockchain.New(memory.New(), &utils.Mainnet)
+		chain := blockchain.New(memory.New(), &networks.Mainnet)
 		require.NoError(t, chain.Store(block0, &emptyCommitments, stateUpdate0, nil))
 
 		headBlock, err := chain.Head()
@@ -181,7 +181,7 @@ func TestStore(t *testing.T) {
 		stateUpdate1, err := gw.StateUpdate(t.Context(), 1)
 		require.NoError(t, err)
 
-		chain := blockchain.New(memory.New(), &utils.Mainnet)
+		chain := blockchain.New(memory.New(), &networks.Mainnet)
 		require.NoError(t, chain.Store(block0, &emptyCommitments, stateUpdate0, nil))
 		require.NoError(t, chain.Store(block1, &emptyCommitments, stateUpdate1, nil))
 
@@ -204,9 +204,9 @@ func TestStore(t *testing.T) {
 }
 
 func TestStoreL1HandlerTxnHash(t *testing.T) {
-	client := feeder.NewTestClient(t, &utils.Sepolia)
+	client := feeder.NewTestClient(t, &networks.Sepolia)
 	gw := adaptfeeder.New(client)
-	chain := blockchain.New(memory.New(), &utils.Sepolia)
+	chain := blockchain.New(memory.New(), &networks.Sepolia)
 	var stateUpdate *core.StateUpdate
 	for i := range uint64(7) {
 		block, err := gw.BlockByNumber(t.Context(), i)
@@ -225,8 +225,8 @@ func TestStoreL1HandlerTxnHash(t *testing.T) {
 }
 
 func TestBlockCommitments(t *testing.T) {
-	chain := blockchain.New(memory.New(), &utils.Mainnet)
-	client := feeder.NewTestClient(t, &utils.Mainnet)
+	chain := blockchain.New(memory.New(), &networks.Mainnet)
+	client := feeder.NewTestClient(t, &networks.Mainnet)
 	gw := adaptfeeder.New(client)
 
 	b, err := gw.BlockByNumber(t.Context(), 0)
@@ -250,9 +250,9 @@ func TestBlockCommitments(t *testing.T) {
 }
 
 func TestTransactionAndReceipt(t *testing.T) {
-	chain := blockchain.New(memory.New(), &utils.Mainnet)
+	chain := blockchain.New(memory.New(), &networks.Mainnet)
 
-	client := feeder.NewTestClient(t, &utils.Mainnet)
+	client := feeder.NewTestClient(t, &networks.Mainnet)
 	gw := adaptfeeder.New(client)
 
 	for i := range uint64(3) {
@@ -388,9 +388,9 @@ func TestTransactionAndReceipt(t *testing.T) {
 
 func TestState(t *testing.T) {
 	testDB := memory.New()
-	chain := blockchain.New(testDB, &utils.Mainnet)
+	chain := blockchain.New(testDB, &networks.Mainnet)
 
-	client := feeder.NewTestClient(t, &utils.Mainnet)
+	client := feeder.NewTestClient(t, &networks.Mainnet)
 	gw := adaptfeeder.New(client)
 
 	t.Run("head with no blocks", func(t *testing.T) {
@@ -457,9 +457,9 @@ func TestEvents(t *testing.T) {
 	}
 
 	testDB := memory.New()
-	chain := blockchain.New(testDB, &utils.Goerli2)
+	chain := blockchain.New(testDB, &networks.Goerli2)
 
-	client := feeder.NewTestClient(t, &utils.Goerli2)
+	client := feeder.NewTestClient(t, &networks.Goerli2)
 	gw := adaptfeeder.New(client)
 
 	const (
@@ -665,9 +665,9 @@ func TestEvents(t *testing.T) {
 
 func TestRevert(t *testing.T) {
 	testDB := memory.New()
-	chain := blockchain.New(testDB, &utils.Mainnet)
+	chain := blockchain.New(testDB, &networks.Mainnet)
 
-	client := feeder.NewTestClient(t, &utils.Mainnet)
+	client := feeder.NewTestClient(t, &networks.Mainnet)
 	gw := adaptfeeder.New(client)
 
 	for i := range uint64(3) {
@@ -739,7 +739,7 @@ func TestRevert(t *testing.T) {
 // MigratedClasses and then reverting, the classes trie and CASM hash metadata
 // are correctly reverted to V1.
 func TestRevertHeadMigratedCasmClasses(t *testing.T) {
-	client := feeder.NewTestClient(t, &utils.Integration)
+	client := feeder.NewTestClient(t, &networks.Integration)
 	gw := adaptfeeder.New(client)
 
 	sierraClassHashFelt := felt.UnsafeFromString[felt.Felt](
@@ -760,7 +760,7 @@ func TestRevertHeadMigratedCasmClasses(t *testing.T) {
 	}
 
 	testDB := memory.New()
-	chain := blockchain.New(testDB, &utils.Integration)
+	chain := blockchain.New(testDB, &networks.Integration)
 
 	receipts0 := make([]*core.TransactionReceipt, 0)
 	//nolint:dupl // Similar to block0 in `TestRevertHeadDeclaredV2CasmClasses`
@@ -852,7 +852,7 @@ func TestRevertHeadMigratedCasmClasses(t *testing.T) {
 // DeclaredV1Classes under protocol >= 0.14.1 (V2 CASM hash path) and then
 // reverting, the class metadata is correctly deleted.
 func TestRevertHeadDeclaredV2CasmClasses(t *testing.T) {
-	network := &utils.Integration
+	network := &networks.Integration
 	client := feeder.NewTestClient(t, network)
 	gw := adaptfeeder.New(client)
 
@@ -968,7 +968,7 @@ func TestL1Update(t *testing.T) {
 
 	for _, head := range heads {
 		t.Run(fmt.Sprintf("update L1 head to block %d", head.BlockNumber), func(t *testing.T) {
-			chain := blockchain.New(memory.New(), &utils.Mainnet)
+			chain := blockchain.New(memory.New(), &networks.Mainnet)
 			require.NoError(t, chain.SetL1Head(head))
 			got, err := chain.L1Head()
 			require.NoError(t, err)
@@ -983,7 +983,7 @@ func TestSubscribeL1Head(t *testing.T) {
 		StateRoot:   new(felt.Felt).SetUint64(2),
 	}
 
-	chain := blockchain.New(memory.New(), &utils.Mainnet)
+	chain := blockchain.New(memory.New(), &networks.Mainnet)
 	sub := chain.SubscribeL1Head()
 	t.Cleanup(sub.Unsubscribe)
 
@@ -995,7 +995,7 @@ func TestSubscribeL1Head(t *testing.T) {
 }
 
 func TestStateCommitmentEmptyChain(t *testing.T) {
-	chain := blockchain.New(memory.New(), &utils.Mainnet)
+	chain := blockchain.New(memory.New(), &networks.Mainnet)
 	commitment, err := chain.StateCommitment()
 	require.NoError(t, err)
 	assert.Equal(t, felt.Felt{}, commitment)

--- a/blockchain/networks/network.go
+++ b/blockchain/networks/network.go
@@ -1,4 +1,4 @@
-package utils
+package networks
 
 import (
 	"encoding"

--- a/blockchain/networks/network_test.go
+++ b/blockchain/networks/network_test.go
@@ -1,4 +1,4 @@
-package utils_test
+package networks_test
 
 import (
 	"encoding/json"
@@ -7,17 +7,17 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/NethermindEth/juno/blockchain/networks"
 	"github.com/NethermindEth/juno/core/felt"
-	"github.com/NethermindEth/juno/utils"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
-var networkStrings = map[utils.Network]string{
-	utils.Mainnet:            "mainnet",
-	utils.Sepolia:            "sepolia",
-	utils.SepoliaIntegration: "sepolia-integration",
+var networkStrings = map[networks.Network]string{
+	networks.Mainnet:            "mainnet",
+	networks.Sepolia:            "sepolia",
+	networks.SepoliaIntegration: "sepolia-integration",
 }
 
 func TestNetwork(t *testing.T) {
@@ -28,16 +28,16 @@ func TestNetwork(t *testing.T) {
 	})
 	t.Run("feeder and gateway url", func(t *testing.T) {
 		testCases := []struct {
-			network    utils.Network
+			network    networks.Network
 			feederURL  string
 			gatewayURL string
 		}{
-			{utils.Mainnet, "https://feeder.alpha-mainnet.starknet.io/feeder_gateway/", "https://alpha-mainnet.starknet.io/gateway/"},
-			{utils.Goerli, "https://alpha4.starknet.io/feeder_gateway/", "https://alpha4.starknet.io/gateway/"},
-			{utils.Goerli2, "https://alpha4-2.starknet.io/feeder_gateway/", "https://alpha4-2.starknet.io/gateway/"},
-			{utils.Integration, "https://external.integration.starknet.io/feeder_gateway/", "https://external.integration.starknet.io/gateway/"},
-			{utils.Sepolia, "https://feeder.alpha-sepolia.starknet.io/feeder_gateway/", "https://alpha-sepolia.starknet.io/gateway/"},
-			{utils.SepoliaIntegration, "https://feeder.integration-sepolia.starknet.io/feeder_gateway/", "https://integration-sepolia.starknet.io/gateway/"},
+			{networks.Mainnet, "https://feeder.alpha-mainnet.starknet.io/feeder_gateway/", "https://alpha-mainnet.starknet.io/gateway/"},
+			{networks.Goerli, "https://alpha4.starknet.io/feeder_gateway/", "https://alpha4.starknet.io/gateway/"},
+			{networks.Goerli2, "https://alpha4-2.starknet.io/feeder_gateway/", "https://alpha4-2.starknet.io/gateway/"},
+			{networks.Integration, "https://external.integration.starknet.io/feeder_gateway/", "https://external.integration.starknet.io/gateway/"},
+			{networks.Sepolia, "https://feeder.alpha-sepolia.starknet.io/feeder_gateway/", "https://alpha-sepolia.starknet.io/gateway/"},
+			{networks.SepoliaIntegration, "https://feeder.integration-sepolia.starknet.io/feeder_gateway/", "https://integration-sepolia.starknet.io/gateway/"},
 		}
 
 		for _, tc := range testCases {
@@ -51,15 +51,15 @@ func TestNetwork(t *testing.T) {
 	t.Run("chainId", func(t *testing.T) {
 		for n := range networkStrings {
 			switch n {
-			case utils.Goerli, utils.Integration:
+			case networks.Goerli, networks.Integration:
 				assert.Equal(t, new(felt.Felt).SetBytes([]byte("SN_GOERLI")), n.L2ChainIDFelt())
-			case utils.Mainnet:
+			case networks.Mainnet:
 				assert.Equal(t, new(felt.Felt).SetBytes([]byte("SN_MAIN")), n.L2ChainIDFelt())
-			case utils.Goerli2:
+			case networks.Goerli2:
 				assert.Equal(t, new(felt.Felt).SetBytes([]byte("SN_GOERLI2")), n.L2ChainIDFelt())
-			case utils.Sepolia:
+			case networks.Sepolia:
 				assert.Equal(t, new(felt.Felt).SetBytes([]byte("SN_SEPOLIA")), n.L2ChainIDFelt())
-			case utils.SepoliaIntegration:
+			case networks.SepoliaIntegration:
 				assert.Equal(t, new(felt.Felt).SetBytes([]byte("SN_INTEGRATION_SEPOLIA")), n.L2ChainIDFelt())
 			default:
 				assert.Fail(t, "unexpected network")
@@ -70,11 +70,11 @@ func TestNetwork(t *testing.T) {
 		for n := range networkStrings {
 			got := n.L1ChainID
 			switch n {
-			case utils.Mainnet:
+			case networks.Mainnet:
 				assert.Equal(t, big.NewInt(1), got)
-			case utils.Goerli, utils.Goerli2, utils.Integration:
+			case networks.Goerli, networks.Goerli2, networks.Integration:
 				assert.Equal(t, big.NewInt(5), got)
-			case utils.Sepolia, utils.SepoliaIntegration:
+			case networks.Sepolia, networks.SepoliaIntegration:
 				assert.Equal(t, big.NewInt(11155111), got)
 			default:
 				assert.Fail(t, "unexpected network")
@@ -84,42 +84,42 @@ func TestNetwork(t *testing.T) {
 }
 
 func TestNetworkSet(t *testing.T) {
-	for network, str := range networkStrings {
+	for net, str := range networkStrings {
 		t.Run("network "+str, func(t *testing.T) {
-			n := new(utils.Network)
+			n := new(networks.Network)
 			require.NoError(t, n.Set(str))
-			assert.Equal(t, network, *n)
+			assert.Equal(t, net, *n)
 		})
 		uppercase := strings.ToUpper(str)
 		t.Run("network "+uppercase, func(t *testing.T) {
-			n := new(utils.Network)
+			n := new(networks.Network)
 			require.NoError(t, n.Set(uppercase))
-			assert.Equal(t, network, *n)
+			assert.Equal(t, net, *n)
 		})
 	}
 	t.Run("unknown network", func(t *testing.T) {
-		n := utils.Network{}
+		n := networks.Network{}
 		require.Error(t, n.Set("blah"))
 	})
 }
 
 func TestNetworkUnmarshalText(t *testing.T) {
-	for network, str := range networkStrings {
+	for net, str := range networkStrings {
 		t.Run("network "+str, func(t *testing.T) {
-			n := new(utils.Network)
+			n := new(networks.Network)
 			require.NoError(t, n.UnmarshalText([]byte(str)))
-			assert.Equal(t, network, *n)
+			assert.Equal(t, net, *n)
 		})
 		uppercase := strings.ToUpper(str)
 		t.Run("network "+uppercase, func(t *testing.T) {
-			n := new(utils.Network)
+			n := new(networks.Network)
 			require.NoError(t, n.UnmarshalText([]byte(uppercase)))
-			assert.Equal(t, network, *n)
+			assert.Equal(t, net, *n)
 		})
 	}
 
 	t.Run("unknown network", func(t *testing.T) {
-		l := new(utils.Network)
+		l := new(networks.Network)
 		require.Error(t, l.UnmarshalText([]byte("blah")))
 	})
 }
@@ -137,17 +137,17 @@ func TestNetworkMarshalJSON(t *testing.T) {
 }
 
 func TestNetworkType(t *testing.T) {
-	assert.Equal(t, "Network", new(utils.Network).Type())
+	assert.Equal(t, "Network", new(networks.Network).Type())
 }
 
 func TestCoreContractAddress(t *testing.T) {
-	addresses := map[utils.Network]common.Address{
-		utils.Mainnet:            common.HexToAddress("0xc662c410C0ECf747543f5bA90660f6ABeBD9C8c4"),
-		utils.Goerli:             common.HexToAddress("0xde29d060D45901Fb19ED6C6e959EB22d8626708e"),
-		utils.Goerli2:            common.HexToAddress("0xa4eD3aD27c294565cB0DCc993BDdCC75432D498c"),
-		utils.Integration:        common.HexToAddress("0xd5c325D183C592C94998000C5e0EED9e6655c020"),
-		utils.Sepolia:            common.HexToAddress("0xE2Bb56ee936fd6433DC0F6e7e3b8365C906AA057"),
-		utils.SepoliaIntegration: common.HexToAddress("0x4737c0c1B4D5b1A687B42610DdabEE781152359c"),
+	addresses := map[networks.Network]common.Address{
+		networks.Mainnet:            common.HexToAddress("0xc662c410C0ECf747543f5bA90660f6ABeBD9C8c4"),
+		networks.Goerli:             common.HexToAddress("0xde29d060D45901Fb19ED6C6e959EB22d8626708e"),
+		networks.Goerli2:            common.HexToAddress("0xa4eD3aD27c294565cB0DCc993BDdCC75432D498c"),
+		networks.Integration:        common.HexToAddress("0xd5c325D183C592C94998000C5e0EED9e6655c020"),
+		networks.Sepolia:            common.HexToAddress("0xE2Bb56ee936fd6433DC0F6e7e3b8365C906AA057"),
+		networks.SepoliaIntegration: common.HexToAddress("0x4737c0c1B4D5b1A687B42610DdabEE781152359c"),
 	}
 
 	for n := range networkStrings {

--- a/blockchain/statebackend/block_ops.go
+++ b/blockchain/statebackend/block_ops.go
@@ -4,10 +4,10 @@ import (
 	"errors"
 	"fmt"
 
+	"github.com/NethermindEth/juno/blockchain/networks"
 	"github.com/NethermindEth/juno/core"
 	"github.com/NethermindEth/juno/core/felt"
 	"github.com/NethermindEth/juno/db"
-	"github.com/NethermindEth/juno/utils"
 )
 
 var ErrParentDoesNotMatchHead = errors.New("block's parent hash does not match head block hash")
@@ -51,7 +51,7 @@ func verifyBlockSuccession(reader db.KeyValueReader, block *core.Block) error {
 func updateBlockHash(
 	block *core.Block,
 	stateUpdate *core.StateUpdate,
-	network *utils.Network,
+	network *networks.Network,
 ) (*core.BlockCommitments, error) {
 	blockHash, commitments, err := core.BlockHash(
 		block,

--- a/blockchain/statebackend/types.go
+++ b/blockchain/statebackend/types.go
@@ -1,10 +1,10 @@
 package statebackend
 
 import (
+	"github.com/NethermindEth/juno/blockchain/networks"
 	"github.com/NethermindEth/juno/core"
 	"github.com/NethermindEth/juno/core/felt"
 	"github.com/NethermindEth/juno/db"
-	"github.com/NethermindEth/juno/utils"
 )
 
 // StateBackend is the interface for state operations in blockchain.
@@ -49,13 +49,13 @@ type SimulateResult struct {
 type baseState struct {
 	database      db.KeyValueStore
 	runningFilter *core.RunningEventFilter
-	network       *utils.Network
+	network       *networks.Network
 }
 
 func New(
 	database db.KeyValueStore,
 	runningFilter *core.RunningEventFilter,
-	network *utils.Network,
+	network *networks.Network,
 	stateVersion bool,
 ) StateBackend {
 	base := baseState{

--- a/builder/builder.go
+++ b/builder/builder.go
@@ -5,11 +5,11 @@ import (
 
 	"github.com/Masterminds/semver/v3"
 	"github.com/NethermindEth/juno/blockchain"
+	"github.com/NethermindEth/juno/blockchain/networks"
 	"github.com/NethermindEth/juno/core"
 	"github.com/NethermindEth/juno/core/felt"
 	"github.com/NethermindEth/juno/core/pending"
 	"github.com/NethermindEth/juno/mempool"
-	"github.com/NethermindEth/juno/utils"
 	"github.com/consensys/gnark-crypto/ecc/stark-curve/ecdsa"
 )
 
@@ -49,7 +49,7 @@ func New(
 	}
 }
 
-func (b *Builder) Network() *utils.Network {
+func (b *Builder) Network() *networks.Network {
 	return b.blockchain.Network()
 }
 

--- a/clients/feeder/feeder_test.go
+++ b/clients/feeder/feeder_test.go
@@ -7,10 +7,10 @@ import (
 	"testing"
 	"time"
 
+	"github.com/NethermindEth/juno/blockchain/networks"
 	"github.com/NethermindEth/juno/clients/feeder"
 	"github.com/NethermindEth/juno/core/felt"
 	"github.com/NethermindEth/juno/starknet"
-	"github.com/NethermindEth/juno/utils"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -21,7 +21,7 @@ const (
 
 func TestDeclareTransactionUnmarshal(t *testing.T) {
 	t.Run("pre-v0.3", func(t *testing.T) {
-		client := feeder.NewTestClient(t, &utils.Mainnet)
+		client := feeder.NewTestClient(t, &networks.Mainnet)
 		txnHash := felt.NewUnsafeFromString[felt.Felt](
 			"0x93f542728e403f1edcea4a41f1509a39be35ebcad7d4b5aa77623e5e6480d",
 		)
@@ -62,7 +62,7 @@ func TestDeclareTransactionUnmarshal(t *testing.T) {
 	})
 
 	t.Run("v0.3", func(t *testing.T) {
-		client := feeder.NewTestClient(t, &utils.Integration)
+		client := feeder.NewTestClient(t, &networks.Integration)
 		txnHash := felt.NewUnsafeFromString[felt.Felt](
 			"0x41d1f5206ef58a443e7d3d1ca073171ec25fa75313394318fc83a074a6631c3",
 		)
@@ -118,7 +118,7 @@ func TestDeclareTransactionUnmarshal(t *testing.T) {
 
 func TestInvokeTransactionUnmarshal(t *testing.T) {
 	t.Run("pre-v0.3", func(t *testing.T) {
-		client := feeder.NewTestClient(t, &utils.Mainnet)
+		client := feeder.NewTestClient(t, &networks.Mainnet)
 
 		txnHash := felt.NewUnsafeFromString[felt.Felt](
 			"0x631333277e88053336d8c302630b4420dc3ff24018a1c464da37d5e36ea19df",
@@ -156,7 +156,7 @@ func TestInvokeTransactionUnmarshal(t *testing.T) {
 	})
 
 	t.Run("v0.3", func(t *testing.T) {
-		client := feeder.NewTestClient(t, &utils.Integration)
+		client := feeder.NewTestClient(t, &networks.Integration)
 		txnHash := felt.NewUnsafeFromString[felt.Felt](
 			"0x49728601e0bb2f48ce506b0cbd9c0e2a9e50d95858aa41463f46386dca489fd",
 		)
@@ -239,7 +239,7 @@ func TestInvokeTransactionUnmarshal(t *testing.T) {
 
 //nolint:dupl
 func TestDeployTransactionUnmarshal(t *testing.T) {
-	client := feeder.NewTestClient(t, &utils.Mainnet)
+	client := feeder.NewTestClient(t, &networks.Mainnet)
 
 	txnHash := felt.NewUnsafeFromString[felt.Felt](
 		"0x6d3e06989ee2245139cd677f59b4da7f360a27b2b614a4eb088fdf5862d23ee",
@@ -291,7 +291,7 @@ func TestDeployTransactionUnmarshal(t *testing.T) {
 
 func TestDeployAccountTransactionUnmarshal(t *testing.T) {
 	t.Run("pre-v0.3", func(t *testing.T) {
-		client := feeder.NewTestClient(t, &utils.Mainnet)
+		client := feeder.NewTestClient(t, &networks.Mainnet)
 
 		txnHash := felt.NewUnsafeFromString[felt.Felt](
 			"0x32b272b6d0d584305a460197aa849b5c7a9a85903b66e9d3e1afa2427ef093e",
@@ -357,7 +357,7 @@ func TestDeployAccountTransactionUnmarshal(t *testing.T) {
 	})
 
 	t.Run("v0.3", func(t *testing.T) {
-		client := feeder.NewTestClient(t, &utils.Integration)
+		client := feeder.NewTestClient(t, &networks.Integration)
 		txnHash := felt.NewUnsafeFromString[felt.Felt](
 			"0x29fd7881f14380842414cdfdd8d6c0b1f2174f8916edcfeb1ede1eb26ac3ef0",
 		)
@@ -415,7 +415,7 @@ func TestDeployAccountTransactionUnmarshal(t *testing.T) {
 
 //nolint:dupl
 func TestL1HandlerTransactionUnmarshal(t *testing.T) {
-	client := feeder.NewTestClient(t, &utils.Mainnet)
+	client := feeder.NewTestClient(t, &networks.Mainnet)
 
 	txnHash := felt.NewUnsafeFromString[felt.Felt](
 		"0x218adbb5aea7985d67fe49b45d44a991380b63db41622f9f4adc36274d02190",
@@ -458,7 +458,7 @@ func TestL1HandlerTransactionUnmarshal(t *testing.T) {
 }
 
 func TestBlockWithoutSequencerAddressUnmarshal(t *testing.T) {
-	client := feeder.NewTestClient(t, &utils.Mainnet)
+	client := feeder.NewTestClient(t, &networks.Mainnet)
 
 	block, err := client.Block(t.Context(), strconv.Itoa(11817))
 	require.NoError(t, err)
@@ -488,7 +488,7 @@ func TestBlockWithoutSequencerAddressUnmarshal(t *testing.T) {
 }
 
 func TestBlockWithSequencerAddressUnmarshal(t *testing.T) {
-	client := feeder.NewTestClient(t, &utils.Mainnet)
+	client := feeder.NewTestClient(t, &networks.Mainnet)
 
 	block, err := client.Block(t.Context(), strconv.Itoa(19199))
 	require.NoError(t, err)
@@ -523,7 +523,7 @@ func TestBlockWithSequencerAddressUnmarshal(t *testing.T) {
 }
 
 func TestBlockHeaderV013Unmarshal(t *testing.T) {
-	client := feeder.NewTestClient(t, &utils.Integration)
+	client := feeder.NewTestClient(t, &networks.Integration)
 	block, err := client.Block(t.Context(), "319132")
 	require.NoError(t, err)
 
@@ -562,7 +562,7 @@ func TestBlockHeaderV013Unmarshal(t *testing.T) {
 }
 
 func TestBlockHeaderV0131Unmarshal(t *testing.T) {
-	client := feeder.NewTestClient(t, &utils.Integration)
+	client := feeder.NewTestClient(t, &networks.Integration)
 	block, err := client.Block(t.Context(), "330363")
 	require.NoError(t, err)
 
@@ -614,7 +614,7 @@ func TestBlockHeaderV0131Unmarshal(t *testing.T) {
 }
 
 func TestBlockHeaderv0132Unmarshal(t *testing.T) {
-	client := feeder.NewTestClient(t, &utils.SepoliaIntegration)
+	client := feeder.NewTestClient(t, &networks.SepoliaIntegration)
 	block, err := client.Block(t.Context(), "35748")
 	require.NoError(t, err)
 
@@ -654,7 +654,7 @@ func TestBlockHeaderv0132Unmarshal(t *testing.T) {
 }
 
 func TestClassV0Unmarshal(t *testing.T) {
-	client := feeder.NewTestClient(t, &utils.Mainnet)
+	client := feeder.NewTestClient(t, &networks.Mainnet)
 
 	hash := felt.NewUnsafeFromString[felt.Felt](
 		"0x01efa8f84fd4dff9e2902ec88717cf0dafc8c188f80c3450615944a469428f7f",
@@ -678,7 +678,7 @@ func TestClassV0Unmarshal(t *testing.T) {
 }
 
 func TestClassV1Unmarshal(t *testing.T) {
-	client := feeder.NewTestClient(t, &utils.Integration)
+	client := feeder.NewTestClient(t, &networks.Integration)
 
 	hash := felt.NewUnsafeFromString[felt.Felt](
 		"0x4e70b19333ae94bd958625f7b61ce9eec631653597e68645e13780061b2136c",
@@ -720,7 +720,7 @@ func TestBuildQueryString_WithErrorUrl(t *testing.T) {
 }
 
 func TestStateUpdate(t *testing.T) {
-	client := feeder.NewTestClient(t, &utils.Mainnet)
+	client := feeder.NewTestClient(t, &networks.Mainnet)
 
 	t.Run("Test normal case", func(t *testing.T) {
 		stateUpdate, err := client.StateUpdate(t.Context(), "0")
@@ -767,7 +767,7 @@ func TestStateUpdate(t *testing.T) {
 	})
 
 	t.Run("v0.11.0 state update", func(t *testing.T) {
-		client := feeder.NewTestClient(t, &utils.Integration)
+		client := feeder.NewTestClient(t, &networks.Integration)
 
 		t.Run("declared Cairo0 classes", func(t *testing.T) {
 			update, err := client.StateUpdate(t.Context(), "283746")
@@ -790,7 +790,7 @@ func TestStateUpdate(t *testing.T) {
 }
 
 func TestTransaction(t *testing.T) {
-	client := feeder.NewTestClient(t, &utils.Mainnet)
+	client := feeder.NewTestClient(t, &networks.Mainnet)
 
 	t.Run("Test normal case", func(t *testing.T) {
 		transactionHash := felt.NewUnsafeFromString[felt.Felt](
@@ -809,7 +809,7 @@ func TestTransaction(t *testing.T) {
 }
 
 func TestBlock(t *testing.T) {
-	client := feeder.NewTestClient(t, &utils.Mainnet)
+	client := feeder.NewTestClient(t, &networks.Mainnet)
 
 	t.Run("Test normal case", func(t *testing.T) {
 		actualBlock, err := client.Block(t.Context(), strconv.Itoa(11817))
@@ -829,7 +829,7 @@ func TestBlock(t *testing.T) {
 }
 
 func TestClassDefinition(t *testing.T) {
-	client := feeder.NewTestClient(t, &utils.Mainnet)
+	client := feeder.NewTestClient(t, &networks.Mainnet)
 
 	t.Run("Test normal case", func(t *testing.T) {
 		classHash := felt.NewUnsafeFromString[felt.Felt](
@@ -908,7 +908,7 @@ func TestBackoffFailure(t *testing.T) {
 }
 
 func TestCompiledClassDefinition(t *testing.T) {
-	client := feeder.NewTestClient(t, &utils.Integration)
+	client := feeder.NewTestClient(t, &networks.Integration)
 
 	classHash := felt.NewUnsafeFromString[felt.Felt](
 		"0x1cd2edfb485241c4403254d550de0a097fa76743cd30696f714a491a454bad5",
@@ -933,7 +933,7 @@ func TestCompiledClassDefinition(t *testing.T) {
 }
 
 func TestTransactionStatusRevertError(t *testing.T) {
-	client := feeder.NewTestClient(t, &utils.Integration)
+	client := feeder.NewTestClient(t, &networks.Integration)
 
 	txnHash := felt.NewUnsafeFromString[felt.Felt](
 		"0x19abec18bbacec23c2eee160c70190a48e4b41dd5ff98ad8f247f9393559998",
@@ -944,7 +944,7 @@ func TestTransactionStatusRevertError(t *testing.T) {
 }
 
 func TestTransactionStatusTransactionFailureReason(t *testing.T) {
-	client := feeder.NewTestClient(t, &utils.SepoliaIntegration)
+	client := feeder.NewTestClient(t, &networks.SepoliaIntegration)
 
 	txnHash := felt.NewUnsafeFromString[felt.Felt]("0x1111")
 	expectedMessage := "some error"
@@ -956,7 +956,7 @@ func TestTransactionStatusTransactionFailureReason(t *testing.T) {
 }
 
 func TestPublicKey(t *testing.T) {
-	client := feeder.NewTestClient(t, &utils.Integration)
+	client := feeder.NewTestClient(t, &networks.Integration)
 
 	actualPublicKey, err := client.PublicKey(t.Context())
 	assert.NoError(t, err)
@@ -968,7 +968,7 @@ func TestPublicKey(t *testing.T) {
 }
 
 func TestSignature(t *testing.T) {
-	client := feeder.NewTestClient(t, &utils.Integration)
+	client := feeder.NewTestClient(t, &networks.Integration)
 
 	t.Run("Test normal case", func(t *testing.T) {
 		actualSignature, err := client.Signature(t.Context(), strconv.Itoa(214584))
@@ -1008,7 +1008,7 @@ func TestSignature(t *testing.T) {
 }
 
 func TestStateUpdateWithBlock(t *testing.T) {
-	client := feeder.NewTestClient(t, &utils.Integration)
+	client := feeder.NewTestClient(t, &networks.Integration)
 
 	t.Run("Test normal case", func(t *testing.T) {
 		actualStateUpdate, err := client.StateUpdateWithBlock(t.Context(), strconv.Itoa(0))
@@ -1054,7 +1054,7 @@ func TestStateUpdateWithBlock(t *testing.T) {
 }
 
 func TestBlockTrace(t *testing.T) {
-	client := feeder.NewTestClient(t, &utils.Integration)
+	client := feeder.NewTestClient(t, &networks.Integration)
 
 	t.Run("old block", func(t *testing.T) {
 		trace, err := client.BlockTrace(
@@ -1078,7 +1078,7 @@ func TestBlockTrace(t *testing.T) {
 func TestEventListener(t *testing.T) {
 	isCalled := false
 	client := feeder.
-		NewTestClient(t, &utils.Integration).
+		NewTestClient(t, &networks.Integration).
 		WithListener(&feeder.SelectiveListener{
 			OnResponseCb: func(urlPath string, status int, _ time.Duration) {
 				isCalled = true
@@ -1175,7 +1175,7 @@ func TestClientRetryBehavior(t *testing.T) {
 }
 
 func TestPreConfirmedBlock(t *testing.T) {
-	client := feeder.NewTestClient(t, &utils.SepoliaIntegration)
+	client := feeder.NewTestClient(t, &networks.SepoliaIntegration)
 
 	snPreConfirmedBlock, err := client.PreConfirmedBlock(t.Context(), strconv.Itoa(1204672))
 	assert.NoError(t, err)

--- a/clients/feeder/test_feeder.go
+++ b/clients/feeder/test_feeder.go
@@ -10,7 +10,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/NethermindEth/juno/utils"
+	"github.com/NethermindEth/juno/blockchain/networks"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -18,7 +18,7 @@ import (
 const transactionHashArg = "transactionHash"
 
 // NewTestClient returns a client and a function to close a test server.
-func NewTestClient(t testing.TB, network *utils.Network) *Client {
+func NewTestClient(t testing.TB, network *networks.Network) *Client {
 	srv := newTestServer(t, network)
 	t.Cleanup(srv.Close)
 	ua := "Juno/v0.0.1-test Starknet Implementation"
@@ -43,7 +43,7 @@ func NewTestClient(t testing.TB, network *utils.Network) *Client {
 	return c
 }
 
-func newTestServer(t testing.TB, network *utils.Network) *httptest.Server {
+func newTestServer(t testing.TB, network *networks.Network) *httptest.Server {
 	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		queryMap, err := url.ParseQuery(r.URL.RawQuery)
 		if err != nil {

--- a/clients/feeder/test_feeder_test.go
+++ b/clients/feeder/test_feeder_test.go
@@ -5,13 +5,13 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/NethermindEth/juno/utils"
+	"github.com/NethermindEth/juno/blockchain/networks"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
 func TestNewTestServerRejectsPathTraversal(t *testing.T) {
-	srv := newTestServer(t, &utils.Mainnet)
+	srv := newTestServer(t, &networks.Mainnet)
 	t.Cleanup(srv.Close)
 	ctx := t.Context()
 

--- a/clients/feeder/timeouts_test.go
+++ b/clients/feeder/timeouts_test.go
@@ -8,7 +8,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/NethermindEth/juno/utils"
+	"github.com/NethermindEth/juno/blockchain/networks"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -175,13 +175,13 @@ func setupTimeoutTest(t *testing.T, ctx context.Context, method, path string, cl
 func TestHTTPTimeoutsSettings(t *testing.T) {
 	timeouts, fixed, err := ParseTimeouts(DefaultTimeouts)
 	require.NoError(t, err)
-	client := NewTestClient(t, &utils.Mainnet).WithMaxRetries(4).WithTimeouts(timeouts, fixed)
+	client := NewTestClient(t, &networks.Mainnet).WithMaxRetries(4).WithTimeouts(timeouts, fixed)
 	ctx := t.Context()
 
 	t.Run("GET current timeouts", func(t *testing.T) {
 		timeouts, fixed, err := ParseTimeouts(DefaultTimeouts)
 		require.NoError(t, err)
-		client := NewTestClient(t, &utils.Mainnet).WithMaxRetries(4).WithTimeouts(timeouts, fixed)
+		client := NewTestClient(t, &networks.Mainnet).WithMaxRetries(4).WithTimeouts(timeouts, fixed)
 		ctx := t.Context()
 		rr := setupTimeoutTest(t, ctx, http.MethodGet, "/feeder/timeouts", client)
 		assert.Equal(t, http.StatusOK, rr.Code)
@@ -192,7 +192,7 @@ func TestHTTPTimeoutsSettings(t *testing.T) {
 	t.Run("GET current timeouts single value", func(t *testing.T) {
 		timeouts, fixed, err := ParseTimeouts("5s")
 		require.NoError(t, err)
-		client := NewTestClient(t, &utils.Mainnet).WithMaxRetries(4).WithTimeouts(timeouts, fixed)
+		client := NewTestClient(t, &networks.Mainnet).WithMaxRetries(4).WithTimeouts(timeouts, fixed)
 		ctx := t.Context()
 		rr := setupTimeoutTest(t, ctx, http.MethodGet, "/feeder/timeouts", client)
 		assert.Equal(t, http.StatusOK, rr.Code)

--- a/cmd/juno/dbcmd.go
+++ b/cmd/juno/dbcmd.go
@@ -7,6 +7,7 @@ import (
 	"os"
 
 	"github.com/NethermindEth/juno/blockchain"
+	"github.com/NethermindEth/juno/blockchain/networks"
 	"github.com/NethermindEth/juno/core"
 	"github.com/NethermindEth/juno/core/felt"
 	"github.com/NethermindEth/juno/db"
@@ -303,13 +304,13 @@ func dbSize(cmd *cobra.Command, args []string) error {
 }
 
 func getNetwork(head *core.Block, stateDiff *core.StateDiff) string {
-	networks := []*utils.Network{
-		&utils.Mainnet,
-		&utils.Sepolia,
-		&utils.Goerli,
-		&utils.Goerli2,
-		&utils.Integration,
-		&utils.SepoliaIntegration,
+	networks := []*networks.Network{
+		&networks.Mainnet,
+		&networks.Sepolia,
+		&networks.Goerli,
+		&networks.Goerli2,
+		&networks.Integration,
+		&networks.SepoliaIntegration,
 	}
 
 	for _, network := range networks {

--- a/cmd/juno/dbcmd_test.go
+++ b/cmd/juno/dbcmd_test.go
@@ -5,12 +5,12 @@ import (
 	"testing"
 
 	"github.com/NethermindEth/juno/blockchain"
+	"github.com/NethermindEth/juno/blockchain/networks"
 	"github.com/NethermindEth/juno/clients/feeder"
 	juno "github.com/NethermindEth/juno/cmd/juno"
 	"github.com/NethermindEth/juno/core"
 	"github.com/NethermindEth/juno/db/pebblev2"
 	adaptfeeder "github.com/NethermindEth/juno/starknetdata/feeder"
-	"github.com/NethermindEth/juno/utils"
 	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -30,7 +30,7 @@ func TestDBCmd(t *testing.T) {
 	})
 
 	t.Run("revert db by 1 block", func(t *testing.T) {
-		network := utils.Mainnet
+		network := networks.Mainnet
 
 		const (
 			syncToBlock   = uint64(2)
@@ -65,13 +65,13 @@ func TestDBCmd(t *testing.T) {
 func executeCmdInDB(t *testing.T, cmd *cobra.Command) {
 	cmd.Flags().String("db-path", "", "")
 
-	dbPath := prepareDB(t, &utils.Mainnet, 0)
+	dbPath := prepareDB(t, &networks.Mainnet, 0)
 
 	require.NoError(t, cmd.Flags().Set("db-path", dbPath))
 	require.NoError(t, cmd.Execute())
 }
 
-func prepareDB(t *testing.T, network *utils.Network, syncToBlock uint64) string {
+func prepareDB(t *testing.T, network *networks.Network, syncToBlock uint64) string {
 	client := feeder.NewTestClient(t, network)
 	gw := adaptfeeder.New(client)
 

--- a/cmd/juno/juno.go
+++ b/cmd/juno/juno.go
@@ -13,6 +13,7 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/NethermindEth/juno/blockchain/networks"
 	_ "github.com/NethermindEth/juno/encoder/registry"
 	_ "github.com/NethermindEth/juno/jemalloc"
 	"github.com/NethermindEth/juno/node"
@@ -366,14 +367,14 @@ func NewCmd(config *node.Config, run func(*cobra.Command, []string) error) *cobr
 				return fmt.Errorf("invalid %s:%v, must be uint array of length 2 (e.g. `0,100`)", cnUnverifiableRangeF, unverifRange)
 			}
 
-			config.Network = utils.Network{
+			config.Network = networks.Network{
 				Name:                v.GetString(cnNameF),
 				FeederURL:           v.GetString(cnFeederURLF),
 				GatewayURL:          v.GetString(cnGatewayURLF),
 				L1ChainID:           l1ChainID,
 				L2ChainID:           v.GetString(cnL2ChainIDF),
 				CoreContractAddress: common.HexToAddress(v.GetString(cnCoreContractAddressF)),
-				BlockHashMetaInfo: &utils.BlockHashMetaInfo{
+				BlockHashMetaInfo: &networks.BlockHashMetaInfo{
 					First07Block:      0,
 					UnverifiableRange: []uint64{uint64(unverifRange[0]), uint64(unverifRange[1])},
 				},
@@ -394,7 +395,7 @@ func NewCmd(config *node.Config, run func(*cobra.Command, []string) error) *cobr
 
 	// For testing purposes, these variables cannot be declared outside the function because Cobra
 	// may mutate their values.
-	defaultNetwork := utils.Mainnet
+	defaultNetwork := networks.Mainnet
 	defaultMaxVMs := 3 * runtime.GOMAXPROCS(0)
 	defaultCNUnverifiableRange := []int{} // Uint64Slice is not supported in Flags()
 

--- a/cmd/juno/juno_test.go
+++ b/cmd/juno/juno_test.go
@@ -10,9 +10,9 @@ import (
 	"testing"
 	"time"
 
+	"github.com/NethermindEth/juno/blockchain/networks"
 	juno "github.com/NethermindEth/juno/cmd/juno"
 	"github.com/NethermindEth/juno/node"
-	"github.com/NethermindEth/juno/utils"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
@@ -36,15 +36,15 @@ func TestConfigPrecedence(t *testing.T) {
 	defaultWSPort := uint16(6061)
 	defaultDBPath := filepath.Join(pwd, "juno")
 	defaultCoreContractAddress := common.HexToAddress("0xc662c410C0ECf747543f5bA90660f6ABeBD9C8c4")
-	defaultNetwork := utils.Mainnet
-	defaultCustomNetwork := utils.Network{
+	defaultNetwork := networks.Mainnet
+	defaultCustomNetwork := networks.Network{
 		Name:                "custom",
 		FeederURL:           "awesome_feeder_url",
 		GatewayURL:          "awesome_gateway_url",
 		L2ChainID:           "SN_AWESOME",
 		L1ChainID:           new(big.Int).SetUint64(1),
 		CoreContractAddress: defaultCoreContractAddress,
-		BlockHashMetaInfo: &utils.BlockHashMetaInfo{
+		BlockHashMetaInfo: &networks.BlockHashMetaInfo{
 			First07Block:      0,
 			UnverifiableRange: []uint64{0, 10},
 		},
@@ -238,7 +238,7 @@ pprof: true
 				MetricsHost:                        defaultHost,
 				MetricsPort:                        defaultMetricsPort,
 				DatabasePath:                       "/home/.juno",
-				Network:                            utils.Sepolia,
+				Network:                            networks.Sepolia,
 				Pprof:                              true,
 				PprofHost:                          defaultHost,
 				PprofPort:                          defaultPprofPort,
@@ -337,7 +337,7 @@ http-port: 4576
 				MetricsHost:                        defaultHost,
 				MetricsPort:                        defaultMetricsPort,
 				DatabasePath:                       "/home/.juno",
-				Network:                            utils.SepoliaIntegration,
+				Network:                            networks.SepoliaIntegration,
 				Pprof:                              true,
 				PprofHost:                          defaultHost,
 				PprofPort:                          defaultPprofPort,
@@ -386,7 +386,7 @@ http-port: 4576
 				MetricsHost:                        defaultHost,
 				MetricsPort:                        defaultMetricsPort,
 				DatabasePath:                       "/home/.juno",
-				Network:                            utils.Sepolia,
+				Network:                            networks.Sepolia,
 				Pprof:                              defaultPprof,
 				PprofHost:                          defaultHost,
 				PprofPort:                          defaultPprofPort,
@@ -461,7 +461,7 @@ db-cache-size: 1024
 				GRPCHost:                           "127.0.0.1",
 				GRPCPort:                           4577,
 				DatabasePath:                       "/home/flag/.juno",
-				Network:                            utils.Mainnet,
+				Network:                            networks.Mainnet,
 				Pprof:                              true,
 				PprofHost:                          "0.0.0.0",
 				PprofPort:                          6064,
@@ -513,7 +513,7 @@ network: sepolia
 				MetricsHost:                        defaultHost,
 				MetricsPort:                        defaultMetricsPort,
 				DatabasePath:                       "/home/flag/.juno",
-				Network:                            utils.Sepolia,
+				Network:                            networks.Sepolia,
 				Pprof:                              defaultPprof,
 				PprofHost:                          defaultHost,
 				PprofPort:                          defaultPprofPort,
@@ -561,7 +561,7 @@ network: sepolia
 				MetricsHost:                        defaultHost,
 				MetricsPort:                        defaultMetricsPort,
 				DatabasePath:                       "/home/flag/.juno",
-				Network:                            utils.SepoliaIntegration,
+				Network:                            networks.SepoliaIntegration,
 				Pprof:                              true,
 				PprofHost:                          defaultHost,
 				PprofPort:                          defaultPprofPort,

--- a/consensus/consensus_test.go
+++ b/consensus/consensus_test.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/NethermindEth/juno/blockchain"
+	"github.com/NethermindEth/juno/blockchain/networks"
 	"github.com/NethermindEth/juno/consensus"
 	"github.com/NethermindEth/juno/consensus/driver"
 	"github.com/NethermindEth/juno/consensus/starknet"
@@ -38,7 +39,7 @@ const (
 )
 
 var (
-	network  = utils.Mainnet
+	network  = networks.Mainnet
 	logLevel = zap.DebugLevel
 )
 
@@ -65,7 +66,7 @@ func getBlockchain(
 ) *blockchain.Blockchain {
 	t.Helper()
 	testDB := memory.New()
-	network := &utils.Mainnet
+	network := &networks.Mainnet
 	bc := blockchain.New(testDB, network)
 	require.NoError(t, bc.StoreGenesis(&genesisDiff, genesisClasses))
 	return bc
@@ -84,7 +85,7 @@ func loadGenesis(
 		"../genesis/classes/universaldeployer.json", "../genesis/classes/udacnt.json",
 	}
 
-	feeTokens := utils.DefaultFeeTokenAddresses
+	feeTokens := networks.DefaultFeeTokenAddresses
 	chainInfo := vm.ChainInfo{
 		ChainID:           network.L2ChainID,
 		FeeTokenAddresses: feeTokens,
@@ -122,7 +123,7 @@ func initNode(
 	consensusDB := memory.New()
 	bc := getBlockchain(t, genesisDiff, genesisClasses)
 
-	feeTokens := utils.DefaultFeeTokenAddresses
+	feeTokens := networks.DefaultFeeTokenAddresses
 	chainInfo := vm.ChainInfo{
 		ChainID:           network.L2ChainID,
 		FeeTokenAddresses: feeTokens,

--- a/consensus/p2p/buffered/buffered_test.go
+++ b/consensus/p2p/buffered/buffered_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/NethermindEth/juno/blockchain/networks"
 	"github.com/NethermindEth/juno/consensus/p2p/buffered"
 	"github.com/NethermindEth/juno/consensus/p2p/config"
 	"github.com/NethermindEth/juno/p2p/pubsub/testutils"
@@ -33,7 +34,7 @@ const (
 	maxWait      = 30 * time.Second
 )
 
-var network = &utils.Mainnet
+var network = &networks.Mainnet
 
 type TestMessage = consensus.ConsensusStreamId
 

--- a/consensus/p2p/p2p.go
+++ b/consensus/p2p/p2p.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 
+	"github.com/NethermindEth/juno/blockchain/networks"
 	"github.com/NethermindEth/juno/builder"
 	"github.com/NethermindEth/juno/consensus/p2p/config"
 	"github.com/NethermindEth/juno/consensus/p2p/proposer"
@@ -42,7 +43,7 @@ type P2P[V types.Hashable[H], H types.Hash, A types.Addr] interface {
 type p2p[V types.Hashable[H], H types.Hash, A types.Addr] struct {
 	host             host.Host
 	log              utils.Logger
-	network          *utils.Network
+	network          *networks.Network
 	commitNotifier   chan types.Height
 	broadcasters     Broadcasters[V, H, A]
 	listeners        Listeners[V, H, A]

--- a/consensus/p2p/validator/fixtures_test.go
+++ b/consensus/p2p/validator/fixtures_test.go
@@ -50,7 +50,12 @@ func SetChainHeight(t *testing.T, database db.KeyValueStore, chainHeight types.H
 	}))
 }
 
-func LoadBlockDependencies(t *testing.T, database db.KeyValueStore, height types.Height, network *networks.Network) (headBlock, revealedBlock *core.Block) {
+func LoadBlockDependencies(
+	t *testing.T,
+	database db.KeyValueStore,
+	height types.Height,
+	network *networks.Network,
+) (headBlock, revealedBlock *core.Block) {
 	var err error
 	t.Helper()
 

--- a/consensus/p2p/validator/fixtures_test.go
+++ b/consensus/p2p/validator/fixtures_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/NethermindEth/juno/adapters/consensus2p2p"
 	"github.com/NethermindEth/juno/adapters/core2p2p"
 	"github.com/NethermindEth/juno/blockchain"
+	"github.com/NethermindEth/juno/blockchain/networks"
 	"github.com/NethermindEth/juno/builder"
 	"github.com/NethermindEth/juno/clients/feeder"
 	starknetconsensus "github.com/NethermindEth/juno/consensus/starknet"
@@ -18,7 +19,6 @@ import (
 	"github.com/NethermindEth/juno/db"
 	"github.com/NethermindEth/juno/starknet"
 	adaptfeeder "github.com/NethermindEth/juno/starknetdata/feeder"
-	"github.com/NethermindEth/juno/utils"
 	"github.com/starknet-io/starknet-p2p-specs/p2p/proto/common"
 	"github.com/starknet-io/starknet-p2p-specs/p2p/proto/consensus/consensus"
 	"github.com/stretchr/testify/require"
@@ -28,7 +28,7 @@ type TestCase struct {
 	Height       types.Height
 	Round        types.Round
 	ValidRound   types.Round
-	Network      *utils.Network
+	Network      *networks.Network
 	TxBatchCount int
 }
 
@@ -50,7 +50,7 @@ func SetChainHeight(t *testing.T, database db.KeyValueStore, chainHeight types.H
 	}))
 }
 
-func LoadBlockDependencies(t *testing.T, database db.KeyValueStore, height types.Height, network *utils.Network) (headBlock, revealedBlock *core.Block) {
+func LoadBlockDependencies(t *testing.T, database db.KeyValueStore, height types.Height, network *networks.Network) (headBlock, revealedBlock *core.Block) {
 	var err error
 	t.Helper()
 

--- a/consensus/p2p/validator/mock_executor_test.go
+++ b/consensus/p2p/validator/mock_executor_test.go
@@ -4,11 +4,11 @@ import (
 	"testing"
 
 	"github.com/NethermindEth/juno/blockchain"
+	"github.com/NethermindEth/juno/blockchain/networks"
 	"github.com/NethermindEth/juno/builder"
 	"github.com/NethermindEth/juno/consensus/starknet"
 	"github.com/NethermindEth/juno/consensus/types"
 	"github.com/NethermindEth/juno/mempool"
-	"github.com/NethermindEth/juno/utils"
 	"github.com/stretchr/testify/require"
 )
 
@@ -23,7 +23,7 @@ type mockExecutor struct {
 	states map[types.Height]map[starknet.Address]*mockExecutorState
 }
 
-func NewMockExecutor(t *testing.T, network *utils.Network) *mockExecutor {
+func NewMockExecutor(t *testing.T, network *networks.Network) *mockExecutor {
 	return &mockExecutor{
 		t:      t,
 		states: make(map[types.Height]map[starknet.Address]*mockExecutorState),

--- a/consensus/p2p/validator/proposal_stream_demux_test.go
+++ b/consensus/p2p/validator/proposal_stream_demux_test.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/NethermindEth/juno/blockchain"
+	"github.com/NethermindEth/juno/blockchain/networks"
 	"github.com/NethermindEth/juno/builder"
 	"github.com/NethermindEth/juno/consensus/p2p/config"
 	"github.com/NethermindEth/juno/consensus/proposal"
@@ -38,7 +39,7 @@ const (
 	firstHalfSize = 2
 )
 
-var network = &utils.Mainnet
+var network = &networks.Mainnet
 
 func TestProposalStreamDemux(t *testing.T) {
 	logger, err := utils.NewZapLogger(utils.NewLogLevel(logLevel), utils.WithColour(true))
@@ -178,7 +179,7 @@ func createProposal(t *testing.T, executor *mockExecutor, database db.KeyValueSt
 		Height:     height,
 		Round:      types.Round(rand.Uint32()),
 		ValidRound: types.Round(rand.Uint32()),
-		Network:    &utils.SepoliaIntegration,
+		Network:    &networks.SepoliaIntegration,
 	}
 	fixture := NewEmptyTestFixture(t, executor, database, testCase)
 	builder := newProposalBuilder(t)

--- a/consensus/p2p/validator/proposal_stream_test.go
+++ b/consensus/p2p/validator/proposal_stream_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/NethermindEth/juno/blockchain/networks"
 	"github.com/NethermindEth/juno/builder"
 	"github.com/NethermindEth/juno/consensus/proposal"
 	"github.com/NethermindEth/juno/consensus/starknet"
@@ -162,7 +163,7 @@ func TestProposalStream_ProcessMessage(t *testing.T) {
 		Height:       1164618,
 		Round:        1339,
 		ValidRound:   1338,
-		Network:      &utils.SepoliaIntegration,
+		Network:      &networks.SepoliaIntegration,
 		TxBatchCount: 2,
 	}
 

--- a/consensus/p2p/validator/state_machine_test.go
+++ b/consensus/p2p/validator/state_machine_test.go
@@ -4,10 +4,10 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/NethermindEth/juno/blockchain/networks"
 	"github.com/NethermindEth/juno/builder"
 	"github.com/NethermindEth/juno/consensus/p2p/validator"
 	"github.com/NethermindEth/juno/db/memory"
-	"github.com/NethermindEth/juno/utils"
 	"github.com/starknet-io/starknet-p2p-specs/p2p/proto/consensus/consensus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -23,7 +23,7 @@ func TestProposalStateMachine_EmptyProposalStream(t *testing.T) {
 		Height:     1164618,
 		Round:      2,
 		ValidRound: 1,
-		Network:    &utils.SepoliaIntegration,
+		Network:    &networks.SepoliaIntegration,
 	}
 
 	database := memory.New()
@@ -62,7 +62,7 @@ func TestProposalStateMachine_NonEmptyProposalStream(t *testing.T) {
 			Height:       1164618,
 			Round:        2,
 			ValidRound:   -1,
-			Network:      &utils.SepoliaIntegration,
+			Network:      &networks.SepoliaIntegration,
 			TxBatchCount: 3,
 		},
 	}

--- a/consensus/p2p/validator/transition.go
+++ b/consensus/p2p/validator/transition.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 
+	"github.com/NethermindEth/juno/blockchain/networks"
 	"github.com/NethermindEth/juno/builder"
 	"github.com/NethermindEth/juno/consensus/starknet"
 	"github.com/NethermindEth/juno/consensus/types"
@@ -12,13 +13,12 @@ import (
 	"github.com/NethermindEth/juno/core/felt"
 	"github.com/NethermindEth/juno/mempool"
 	"github.com/NethermindEth/juno/starknet/compiler"
-	"github.com/NethermindEth/juno/utils"
 )
 
 var errHashMismatch = errors.New("hash mismatch")
 
 type Transition interface {
-	Network() *utils.Network
+	Network() *networks.Network
 	Compiler() compiler.Compiler
 	OnProposalInit(
 		context.Context,
@@ -66,7 +66,7 @@ func NewTransition(
 	}
 }
 
-func (t *transition) Network() *utils.Network {
+func (t *transition) Network() *networks.Network {
 	return t.builder.Network()
 }
 

--- a/consensus/p2p/validator/transition_test.go
+++ b/consensus/p2p/validator/transition_test.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/NethermindEth/juno/blockchain"
+	"github.com/NethermindEth/juno/blockchain/networks"
 	"github.com/NethermindEth/juno/builder"
 	"github.com/NethermindEth/juno/consensus/types"
 	"github.com/NethermindEth/juno/core"
@@ -29,7 +30,7 @@ import (
 func getBuilder(t *testing.T, seqAddr *felt.Felt) (*builder.Builder, *core.Header) {
 	t.Helper()
 	testDB := memory.New()
-	network := &utils.Mainnet
+	network := &networks.Mainnet
 	bc := blockchain.New(testDB, network)
 	log := utils.NewNopZapLogger()
 
@@ -44,7 +45,7 @@ func getBuilder(t *testing.T, seqAddr *felt.Felt) (*builder.Builder, *core.Heade
 		"../../../genesis/classes/universaldeployer.json", "../../../genesis/classes/udacnt.json",
 	}
 
-	feeTokens := utils.DefaultFeeTokenAddresses
+	feeTokens := networks.DefaultFeeTokenAddresses
 	chainInfo := vm.ChainInfo{
 		ChainID:           network.L2ChainID,
 		FeeTokenAddresses: feeTokens,

--- a/consensus/p2p/vote/vote_broadcasters_listeners_test.go
+++ b/consensus/p2p/vote/vote_broadcasters_listeners_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/NethermindEth/juno/blockchain/networks"
 	"github.com/NethermindEth/juno/consensus/p2p/config"
 	"github.com/NethermindEth/juno/consensus/p2p/vote"
 	"github.com/NethermindEth/juno/consensus/starknet"
@@ -31,7 +32,7 @@ const (
 	maxWait      = 5 * time.Second
 )
 
-var network = &utils.Mainnet
+var network = &networks.Mainnet
 
 func TestVoteBroadcastersAndListeners(t *testing.T) {
 	logger, err := utils.NewZapLogger(utils.NewLogLevel(logLevel), utils.WithColour(true))

--- a/consensus/proposer/proposer_test.go
+++ b/consensus/proposer/proposer_test.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/NethermindEth/juno/blockchain"
+	"github.com/NethermindEth/juno/blockchain/networks"
 	"github.com/NethermindEth/juno/builder"
 	"github.com/NethermindEth/juno/consensus/proposal"
 	"github.com/NethermindEth/juno/consensus/proposer"
@@ -213,7 +214,7 @@ func runConcurrentReads(t *testing.T, p proposer.Proposer[starknet.Value, starkn
 func getBlockchain(t *testing.T) *blockchain.Blockchain {
 	t.Helper()
 	testDB := memory.New()
-	network := &utils.Mainnet
+	network := &networks.Mainnet
 	bc := blockchain.New(testDB, network)
 	return bc
 }
@@ -228,7 +229,7 @@ func getBuilder(t *testing.T, log utils.Logger, bc *blockchain.Blockchain) *buil
 		"../../genesis/classes/universaldeployer.json", "../../genesis/classes/udacnt.json",
 	}
 
-	feeTokens := utils.DefaultFeeTokenAddresses
+	feeTokens := networks.DefaultFeeTokenAddresses
 	chainInfo := vm.ChainInfo{
 		ChainID:           bc.Network().L2ChainID,
 		FeeTokenAddresses: feeTokens,

--- a/core/accessors_test.go
+++ b/core/accessors_test.go
@@ -4,13 +4,13 @@ import (
 	"math"
 	"testing"
 
+	"github.com/NethermindEth/juno/blockchain/networks"
 	"github.com/NethermindEth/juno/clients/feeder"
 	"github.com/NethermindEth/juno/core"
 	"github.com/NethermindEth/juno/core/felt"
 	"github.com/NethermindEth/juno/db"
 	"github.com/NethermindEth/juno/db/memory"
 	adaptfeeder "github.com/NethermindEth/juno/starknetdata/feeder"
-	"github.com/NethermindEth/juno/utils"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -20,7 +20,7 @@ const nonexistentBlockNumber = math.MaxUint64
 func setupForTxsAndReceiptsTests(t *testing.T) (db.KeyValueStore, *core.Block) {
 	t.Helper()
 	memDB := memory.New()
-	client := feeder.NewTestClient(t, &utils.Sepolia)
+	client := feeder.NewTestClient(t, &networks.Sepolia)
 	gw := adaptfeeder.New(client)
 
 	block, err := gw.BlockByNumber(t.Context(), 4072139)
@@ -56,7 +56,7 @@ func clearEmptyProofFacts(txs []core.Transaction) {
 func TestWriteTransactionsAndReceipts(t *testing.T) {
 	t.Parallel()
 	memDB := memory.New()
-	client := feeder.NewTestClient(t, &utils.Sepolia)
+	client := feeder.NewTestClient(t, &networks.Sepolia)
 	gw := adaptfeeder.New(client)
 
 	block, err := gw.BlockByNumber(t.Context(), 4072139)

--- a/core/block.go
+++ b/core/block.go
@@ -98,7 +98,11 @@ type BlockCommitments struct {
 
 // VerifyBlockHash verifies the block hash. Due to bugs in Starknet alpha, not all blocks have
 // verifiable hashes.
-func VerifyBlockHash(b *Block, network *networks.Network, stateDiff *StateDiff) (*BlockCommitments, error) {
+func VerifyBlockHash(
+	b *Block,
+	network *networks.Network,
+	stateDiff *StateDiff,
+) (*BlockCommitments, error) {
 	if len(b.Transactions) != len(b.Receipts) {
 		return nil, fmt.Errorf("len of transactions: %v do not match len of receipts: %v",
 			len(b.Transactions), len(b.Receipts))

--- a/core/block.go
+++ b/core/block.go
@@ -6,9 +6,9 @@ import (
 	"fmt"
 	"slices"
 
+	"github.com/NethermindEth/juno/blockchain/networks"
 	"github.com/NethermindEth/juno/core/crypto"
 	"github.com/NethermindEth/juno/core/felt"
-	"github.com/NethermindEth/juno/utils"
 	"github.com/bits-and-blooms/bloom/v3"
 	"github.com/sourcegraph/conc"
 )
@@ -98,7 +98,7 @@ type BlockCommitments struct {
 
 // VerifyBlockHash verifies the block hash. Due to bugs in Starknet alpha, not all blocks have
 // verifiable hashes.
-func VerifyBlockHash(b *Block, network *utils.Network, stateDiff *StateDiff) (*BlockCommitments, error) {
+func VerifyBlockHash(b *Block, network *networks.Network, stateDiff *StateDiff) (*BlockCommitments, error) {
 	if len(b.Transactions) != len(b.Receipts) {
 		return nil, fmt.Errorf("len of transactions: %v do not match len of receipts: %v",
 			len(b.Transactions), len(b.Receipts))
@@ -155,7 +155,7 @@ func VerifyBlockHash(b *Block, network *utils.Network, stateDiff *StateDiff) (*B
 func BlockHash(
 	b *Block,
 	stateDiff *StateDiff,
-	network *utils.Network,
+	network *networks.Network,
 	overrideSeqAddr *felt.Felt,
 ) (felt.Felt, *BlockCommitments, error) {
 	metaInfo := network.BlockHashMetaInfo

--- a/core/block_test.go
+++ b/core/block_test.go
@@ -4,11 +4,11 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/NethermindEth/juno/blockchain/networks"
 	"github.com/NethermindEth/juno/clients/feeder"
 	"github.com/NethermindEth/juno/core"
 	"github.com/NethermindEth/juno/core/felt"
 	adaptfeeder "github.com/NethermindEth/juno/starknetdata/feeder"
-	"github.com/NethermindEth/juno/utils"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -17,155 +17,155 @@ func TestBlockHash(t *testing.T) {
 	t.Parallel()
 	tests := []struct {
 		number uint64
-		chain  utils.Network
+		chain  networks.Network
 		name   string
 	}{
 		{
 			// block 231579: goerli
 			// "https://alpha4.starknet.io/feeder_gateway/get_block?blockHash=0x40ffdbd9abbc4fc64652c50db94a29bce65c183316f304a95df624de708e746",
 			number: 231579,
-			chain:  utils.Goerli,
+			chain:  networks.Goerli,
 			name:   "goerli network (post 0.7.0 with sequencer address)",
 		},
 		{
 			// block 156000: goerli
 			// "https://alpha4.starknet.io/feeder_gateway/get_block?blockNumber=156000",
 			number: 156000,
-			chain:  utils.Goerli,
+			chain:  networks.Goerli,
 			name:   "goerli network (post 0.7.0 without sequencer address)",
 		},
 		{
 			// block 1: goerli
 			// "https://alpha4.starknet.io/feeder_gateway/get_block?blockNumber=1",
 			number: 1,
-			chain:  utils.Goerli,
+			chain:  networks.Goerli,
 			name:   "goerli network (pre 0.7.0 without sequencer address)",
 		},
 		{
 			// block 16789: mainnet
 			// "https://alpha-mainnet.starknet.io/feeder_gateway/get_block?blockNumber=16789"
 			number: 16789,
-			chain:  utils.Mainnet,
+			chain:  networks.Mainnet,
 			name:   "mainnet (post 0.7.0 with sequencer address)",
 		},
 		{
 			// block 1: integration
 			// "https://external.integration.starknet.io/feeder_gateway/get_block?blockNumber=1"
 			number: 1,
-			chain:  utils.Integration,
+			chain:  networks.Integration,
 			name:   "integration network (pre 0.7.0 without sequencer address)",
 		},
 		{
 			// block 119802: goerli
 			// https://alpha4.starknet.io/feeder_gateway/get_block?blockNumber=119802
 			number: 119802,
-			chain:  utils.Goerli,
+			chain:  networks.Goerli,
 			name:   "goerli network (post 0.7.0 without sequencer address)",
 		},
 		{
 			// block 10: goerli2
 			// https://alpha4-2.starknet.io/feeder_gateway/get_block?blockNumber=10
 			number: 10,
-			chain:  utils.Goerli2,
+			chain:  networks.Goerli2,
 			name:   "goerli2 network (post 0.7.0 with sequencer address)",
 		},
 		{
 			// https://alpha4-2.starknet.io/feeder_gateway/get_block?blockNumber=49
 			number: 49,
-			chain:  utils.Goerli2,
+			chain:  networks.Goerli2,
 			name:   "Block with multiple failed transaction hash",
 		},
 		{
 			// block 0: main
 			// https://alpha-mainnet.starknet.io/feeder_gateway/get_block?blockNumber=0
 			number: 0,
-			chain:  utils.Mainnet,
+			chain:  networks.Mainnet,
 			name:   "mainnet (pre 0.7.0 without sequencer address)",
 		},
 		{
 			// block 833: main
 			// https://alpha-mainnet.starknet.io/feeder_gateway/get_block?blockNumber=833
 			number: 833,
-			chain:  utils.Mainnet,
+			chain:  networks.Mainnet,
 			name:   "mainnet 833 (post 0.7.0 without sequencer address)",
 		},
 
 		// "https://alpha-mainnet.starknet.io/feeder_gateway/get_block?blockNumber=16259"
 		{
 			number: 16259,
-			chain:  utils.Mainnet,
+			chain:  networks.Mainnet,
 			name:   "Block 16259 with Deploy transaction version 0",
 		},
 		// https://alpha4.starknet.io/feeder_gateway/get_block?blockNumber=485004"
 		{
 			number: 485004,
-			chain:  utils.Goerli,
+			chain:  networks.Goerli,
 			name:   "Block 485004 with Deploy transaction version 1",
 		},
 		// "https://alpha-mainnet.starknet.io/feeder_gateway/get_block?blockNumber=8"
 		{
 			number: 8,
-			chain:  utils.Mainnet,
+			chain:  networks.Mainnet,
 			name:   "Block 8 with Invoke transaction version 0",
 		},
 		// "https://alpha-mainnet.starknet.io/feeder_gateway/get_block?blockNumber=16730"
 		{
 			number: 16730,
-			chain:  utils.Mainnet,
+			chain:  networks.Mainnet,
 			name:   "Block 16730 with Invoke transaction version 1",
 		},
 		// "https://alpha-mainnet.starknet.io/feeder_gateway/get_block?blockNumber=2889"
 		{
 			number: 2889,
-			chain:  utils.Mainnet,
+			chain:  networks.Mainnet,
 			name:   "Block 2889 with Declare transaction version 0",
 		},
 		// "https://alpha-mainnet.starknet.io/feeder_gateway/get_block?blockNumber=2889"
 		{
 			number: 16697,
-			chain:  utils.Mainnet,
+			chain:  networks.Mainnet,
 			name:   "Block 16697 with Declare transaction version 1",
 		},
 		// "https://alpha-mainnet.starknet.io/feeder_gateway/get_block?blockNumber=1059"
 		{
 			number: 1059,
-			chain:  utils.Mainnet,
+			chain:  networks.Mainnet,
 			name:   "Block 1059 with L1Handler transaction version 0",
 		},
 		// "https://alpha-mainnet.starknet.io/feeder_gateway/get_block?blockNumber=7320"
 		{
 			number: 7320,
-			chain:  utils.Mainnet,
+			chain:  networks.Mainnet,
 			name:   "Block 7320 with Deploy account transaction version 1",
 		},
 		// "https://alpha-mainnet.starknet.io/feeder_gateway/get_block?blockNumber=192"
 		{
 			number: 192,
-			chain:  utils.Mainnet,
+			chain:  networks.Mainnet,
 			name:   "Block 192 with Failing l1 handler transaction version 1",
 		},
 		// "https://external.integration.starknet.io/feeder_gateway/get_block?blockNumber=283364"
 		{
 			number: 283364,
-			chain:  utils.Integration,
+			chain:  networks.Integration,
 			name:   "Block 283364 with Declare v2",
 		},
 		// "https://external.integration.starknet.io/feeder_gateway/get_block?blockNumber=286310"
 		{
 			number: 286310,
-			chain:  utils.Integration,
+			chain:  networks.Integration,
 			name:   "Block 286310 with version 0.11.1",
 		},
 		// "https://alpha4-2.starknet.io/feeder_gateway/get_block?blockNumber=110238"
 		{
 			number: 110238,
-			chain:  utils.Goerli2,
+			chain:  networks.Goerli2,
 			name:   "Block 110238 with version 0.11.1",
 		},
 		// https://external.integration.starknet.io/feeder_gateway/get_block?blockNumber=330363
 		{
 			number: 330363,
-			chain:  utils.Integration,
+			chain:  networks.Integration,
 			name:   "Block 330363 with version 0.13.1",
 		},
 	}
@@ -187,7 +187,7 @@ func TestBlockHash(t *testing.T) {
 
 	h1 := felt.NewRandom[felt.Felt]()
 
-	client := feeder.NewTestClient(t, &utils.Mainnet)
+	client := feeder.NewTestClient(t, &networks.Mainnet)
 	mainnetGW := adaptfeeder.New(client)
 	t.Run("error if block hash has not being calculated properly", func(t *testing.T) {
 		mainnetBlock1, err := mainnetGW.BlockByNumber(t.Context(), 1)
@@ -196,18 +196,18 @@ func TestBlockHash(t *testing.T) {
 		mainnetBlock1.Hash = h1
 
 		expectedErr := "can not verify hash in block header"
-		commitments, err := core.VerifyBlockHash(mainnetBlock1, &utils.Mainnet, nil)
+		commitments, err := core.VerifyBlockHash(mainnetBlock1, &networks.Mainnet, nil)
 		assert.EqualError(t, err, expectedErr)
 		assert.Nil(t, commitments)
 	})
 
 	t.Run("no error if block is unverifiable", func(t *testing.T) {
-		client := feeder.NewTestClient(t, &utils.Goerli)
+		client := feeder.NewTestClient(t, &networks.Goerli)
 		goerliGW := adaptfeeder.New(client)
 		block119802, err := goerliGW.BlockByNumber(t.Context(), 119802)
 		require.NoError(t, err)
 
-		commitments, err := core.VerifyBlockHash(block119802, &utils.Goerli, nil)
+		commitments, err := core.VerifyBlockHash(block119802, &networks.Goerli, nil)
 		assert.NoError(t, err)
 		assert.NotNil(t, commitments)
 	})
@@ -221,7 +221,7 @@ func TestBlockHash(t *testing.T) {
 		expectedErr := fmt.Sprintf("len of transactions: %v do not match len of receipts: %v",
 			len(mainnetBlock1.Transactions), len(mainnetBlock1.Receipts))
 
-		commitments, err := core.VerifyBlockHash(mainnetBlock1, &utils.Mainnet, nil)
+		commitments, err := core.VerifyBlockHash(mainnetBlock1, &networks.Mainnet, nil)
 		assert.EqualError(t, err, expectedErr)
 		assert.Nil(t, commitments)
 	})
@@ -235,7 +235,7 @@ func TestBlockHash(t *testing.T) {
 			"transaction hash (%v) at index: %v does not match receipt's hash (%v)",
 			mainnetBlock1.Transactions[1].Hash().String(), 1,
 			mainnetBlock1.Receipts[1].TransactionHash)
-		commitments, err := core.VerifyBlockHash(mainnetBlock1, &utils.Mainnet, nil)
+		commitments, err := core.VerifyBlockHash(mainnetBlock1, &networks.Mainnet, nil)
 		assert.EqualError(t, err, expectedErr)
 		assert.Nil(t, commitments)
 	})
@@ -244,7 +244,7 @@ func TestBlockHash(t *testing.T) {
 //nolint:dupl
 func Test0132BlockHash(t *testing.T) {
 	t.Parallel()
-	client := feeder.NewTestClient(t, &utils.SepoliaIntegration)
+	client := feeder.NewTestClient(t, &networks.SepoliaIntegration)
 	gw := adaptfeeder.New(client)
 
 	for _, test := range []struct {
@@ -260,7 +260,7 @@ func Test0132BlockHash(t *testing.T) {
 			su, err := gw.StateUpdate(t.Context(), test.blockNum)
 			require.NoError(t, err)
 
-			c, err := core.VerifyBlockHash(b, &utils.SepoliaIntegration, su.StateDiff)
+			c, err := core.VerifyBlockHash(b, &networks.SepoliaIntegration, su.StateDiff)
 			require.NoError(t, err)
 			assert.NotNil(t, c)
 		})
@@ -269,7 +269,7 @@ func Test0132BlockHash(t *testing.T) {
 
 func Test0134BlockHash(t *testing.T) {
 	t.Parallel()
-	client := feeder.NewTestClient(t, &utils.SepoliaIntegration)
+	client := feeder.NewTestClient(t, &networks.SepoliaIntegration)
 	gw := adaptfeeder.New(client)
 
 	for _, test := range []struct {
@@ -285,7 +285,7 @@ func Test0134BlockHash(t *testing.T) {
 			su, err := gw.StateUpdate(t.Context(), test.blockNum)
 			require.NoError(t, err)
 
-			c, err := core.VerifyBlockHash(b, &utils.SepoliaIntegration, su.StateDiff)
+			c, err := core.VerifyBlockHash(b, &networks.SepoliaIntegration, su.StateDiff)
 			require.NoError(t, err)
 			assert.NotNil(t, c)
 		})

--- a/core/class_test.go
+++ b/core/class_test.go
@@ -5,19 +5,19 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/NethermindEth/juno/blockchain/networks"
 	"github.com/NethermindEth/juno/clients/feeder"
 	"github.com/NethermindEth/juno/core"
 	"github.com/NethermindEth/juno/core/felt"
 	"github.com/NethermindEth/juno/db"
 	"github.com/NethermindEth/juno/encoder"
 	adaptfeeder "github.com/NethermindEth/juno/starknetdata/feeder"
-	"github.com/NethermindEth/juno/utils"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
 func TestClassV0Hash(t *testing.T) {
-	client := feeder.NewTestClient(t, &utils.Sepolia)
+	client := feeder.NewTestClient(t, &networks.Sepolia)
 
 	gw := adaptfeeder.New(client)
 	tests := []struct {
@@ -51,7 +51,7 @@ func TestClassV0Hash(t *testing.T) {
 }
 
 func TestClassV1Hash(t *testing.T) {
-	client := feeder.NewTestClient(t, &utils.Integration)
+	client := feeder.NewTestClient(t, &networks.Integration)
 	gw := adaptfeeder.New(client)
 	tests := []struct {
 		classHash       string
@@ -82,7 +82,7 @@ func TestClassV1Hash(t *testing.T) {
 
 func TestCompiledClassHash(t *testing.T) {
 	tests := []struct {
-		network                   utils.Network
+		network                   networks.Network
 		classHash                 string
 		expectedCompiledClassHash string
 		hashVersion               core.CasmHashVersion
@@ -92,27 +92,27 @@ func TestCompiledClassHash(t *testing.T) {
 			classHash:                 "0x6d8ede036bb4720e6f348643221d8672bf4f0895622c32c11e57460b3b7dffc",
 			expectedCompiledClassHash: "0x18f95714044fd5408d3bf812bcd249ddec098ab3cd201b7916170cfbfa59e05",
 			hashVersion:               core.HashVersionV1,
-			network:                   utils.Integration,
+			network:                   networks.Integration,
 		},
 		{
 			// https://external.integration.starknet.io/feeder_gateway/get_class_by_hash?classHash=0x6b3da05b352f93912df0593a703f1884c4c607523bb33feaff4940635ef050d
 			classHash:                 "0x6b3da05b352f93912df0593a703f1884c4c607523bb33feaff4940635ef050d",
 			expectedCompiledClassHash: "0x603dd72504d8b0bc54df4f1102fdcf87fc3b2b94750a9083a5876913eec08e4",
 			hashVersion:               core.HashVersionV1,
-			network:                   utils.Integration,
+			network:                   networks.Integration,
 		},
 		{
 			// https://external.integration.starknet.io/feeder_gateway/get_class_by_hash?classHash=0x1fb5f6adb94dd3c0bfda71f7f73957691619ab9fe8f6b9b675da13877086f89
 			classHash:                 "0x1fb5f6adb94dd3c0bfda71f7f73957691619ab9fe8f6b9b675da13877086f89",
 			expectedCompiledClassHash: "0x260f0d9862f0dd76ac1f9c93e6ce0c2536f7c0275c87061e73abce321bfd4ad",
 			hashVersion:               core.HashVersionV1,
-			network:                   utils.Integration,
+			network:                   networks.Integration,
 		},
 		{
 			classHash:                 "0x941a2dc3ab607819fdc929bea95831a2e0c1aab2f2f34b3a23c55cebc8a040",
 			expectedCompiledClassHash: "0x6c1f99f23865abe822bd9690f8d6cd181d43b1ff5535842aa973363aa7c7bb3",
 			hashVersion:               core.HashVersionV2,
-			network:                   utils.SepoliaIntegration,
+			network:                   networks.SepoliaIntegration,
 		},
 	}
 
@@ -206,7 +206,7 @@ func TestVerifyClassHash(t *testing.T) {
 		wantErr   error
 	}
 
-	client := feeder.NewTestClient(t, &utils.Integration)
+	client := feeder.NewTestClient(t, &networks.Integration)
 	gw := adaptfeeder.New(client)
 
 	sierraClassHash := felt.NewUnsafeFromString[felt.Felt](

--- a/core/deprecatedstate/state_test.go
+++ b/core/deprecatedstate/state_test.go
@@ -6,6 +6,7 @@ import (
 	"maps"
 	"testing"
 
+	"github.com/NethermindEth/juno/blockchain/networks"
 	"github.com/NethermindEth/juno/clients/feeder"
 	"github.com/NethermindEth/juno/core"
 	"github.com/NethermindEth/juno/core/deprecatedstate"
@@ -13,7 +14,6 @@ import (
 	"github.com/NethermindEth/juno/db"
 	"github.com/NethermindEth/juno/db/memory"
 	adaptfeeder "github.com/NethermindEth/juno/starknetdata/feeder"
-	"github.com/NethermindEth/juno/utils"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -27,7 +27,7 @@ var (
 )
 
 func TestUpdate(t *testing.T) {
-	client := feeder.NewTestClient(t, &utils.Mainnet)
+	client := feeder.NewTestClient(t, &networks.Mainnet)
 	gw := adaptfeeder.New(client)
 
 	testDB := memory.New()
@@ -164,7 +164,7 @@ func TestUpdate(t *testing.T) {
 }
 
 func TestContractClassHash(t *testing.T) {
-	client := feeder.NewTestClient(t, &utils.Mainnet)
+	client := feeder.NewTestClient(t, &networks.Mainnet)
 	gw := adaptfeeder.New(client)
 
 	testDB := memory.New()
@@ -271,7 +271,7 @@ func TestNonce(t *testing.T) {
 func TestStateHistoricalReads(t *testing.T) {
 	testDB := memory.New()
 	txn := testDB.NewIndexedBatch()
-	client := feeder.NewTestClient(t, &utils.Mainnet)
+	client := feeder.NewTestClient(t, &networks.Mainnet)
 	gw := adaptfeeder.New(client)
 
 	state := deprecatedstate.New(txn)
@@ -414,7 +414,7 @@ func TestHistory(t *testing.T) {
 }
 
 func TestContractIsDeployedAt(t *testing.T) {
-	client := feeder.NewTestClient(t, &utils.Mainnet)
+	client := feeder.NewTestClient(t, &networks.Mainnet)
 	gw := adaptfeeder.New(client)
 
 	testDB := memory.New()
@@ -468,7 +468,7 @@ func TestContractIsDeployedAt(t *testing.T) {
 func TestClass(t *testing.T) {
 	testDB := memory.New()
 	txn := testDB.NewIndexedBatch()
-	client := feeder.NewTestClient(t, &utils.Integration)
+	client := feeder.NewTestClient(t, &networks.Integration)
 	gw := adaptfeeder.New(client)
 
 	deprecatedCairoHash := felt.NewUnsafeFromString[felt.Felt](
@@ -505,7 +505,7 @@ func TestRevert(t *testing.T) {
 	testDB := memory.New()
 	txn := testDB.NewIndexedBatch()
 
-	client := feeder.NewTestClient(t, &utils.Mainnet)
+	client := feeder.NewTestClient(t, &networks.Mainnet)
 	gw := adaptfeeder.New(client)
 
 	state := deprecatedstate.New(txn)
@@ -696,7 +696,7 @@ func TestRevertGenesisStateDiff(t *testing.T) {
 }
 
 func TestRevertSystemContracts(t *testing.T) {
-	client := feeder.NewTestClient(t, &utils.Mainnet)
+	client := feeder.NewTestClient(t, &networks.Mainnet)
 	gw := adaptfeeder.New(client)
 
 	testDB := memory.New()

--- a/core/running_event_filter_test.go
+++ b/core/running_event_filter_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/NethermindEth/juno/blockchain"
+	"github.com/NethermindEth/juno/blockchain/networks"
 	"github.com/NethermindEth/juno/clients/feeder"
 	"github.com/NethermindEth/juno/core"
 	"github.com/NethermindEth/juno/core/felt"
@@ -11,7 +12,6 @@ import (
 	"github.com/NethermindEth/juno/db/memory"
 	"github.com/NethermindEth/juno/encoder"
 	adaptfeeder "github.com/NethermindEth/juno/starknetdata/feeder"
-	"github.com/NethermindEth/juno/utils"
 	"github.com/bits-and-blooms/bitset"
 	"github.com/bits-and-blooms/bloom/v3"
 	"github.com/stretchr/testify/require"
@@ -65,7 +65,7 @@ func TestRunningEventFilter_LazyInitialization_EmptyDB(t *testing.T) {
 
 func TestRunningEventFilter_LazyInitialization_Preload(t *testing.T) {
 	testDB := memory.New()
-	n := &utils.Sepolia
+	n := &networks.Sepolia
 	chain := blockchain.New(testDB, n)
 	client := feeder.NewTestClient(t, n)
 	gw := adaptfeeder.New(client)

--- a/core/state/state_reader_test.go
+++ b/core/state/state_reader_test.go
@@ -4,11 +4,11 @@ import (
 	"maps"
 	"testing"
 
+	"github.com/NethermindEth/juno/blockchain/networks"
 	"github.com/NethermindEth/juno/clients/feeder"
 	"github.com/NethermindEth/juno/core"
 	"github.com/NethermindEth/juno/core/felt"
 	adaptfeeder "github.com/NethermindEth/juno/starknetdata/feeder"
-	"github.com/NethermindEth/juno/utils"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -123,7 +123,7 @@ func TestNonce(t *testing.T) {
 func TestClass(t *testing.T) {
 	stateDB := setupState(t, nil, 0)
 
-	client := feeder.NewTestClient(t, &utils.Integration)
+	client := feeder.NewTestClient(t, &networks.Integration)
 	gw := adaptfeeder.New(client)
 
 	deprecatedCairoHash := felt.NewUnsafeFromString[felt.Felt](

--- a/core/state/state_test.go
+++ b/core/state/state_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"testing"
 
+	"github.com/NethermindEth/juno/blockchain/networks"
 	"github.com/NethermindEth/juno/clients/feeder"
 	"github.com/NethermindEth/juno/core"
 	"github.com/NethermindEth/juno/core/felt"
@@ -13,7 +14,6 @@ import (
 	"github.com/NethermindEth/juno/db/memory"
 	_ "github.com/NethermindEth/juno/encoder/registry"
 	adaptfeeder "github.com/NethermindEth/juno/starknetdata/feeder"
-	"github.com/NethermindEth/juno/utils"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -698,7 +698,7 @@ func TestRevert(t *testing.T) {
 }
 
 func BenchmarkStateUpdate(b *testing.B) {
-	client := feeder.NewTestClient(b, &utils.Mainnet)
+	client := feeder.NewTestClient(b, &networks.Mainnet)
 	gw := adaptfeeder.New(client)
 
 	su0, err := gw.StateUpdate(b.Context(), block0)
@@ -729,7 +729,7 @@ func BenchmarkStateUpdate(b *testing.B) {
 
 // Get the first 3 state updates from the mainnet.
 func getStateUpdates(t *testing.T) []*core.StateUpdate {
-	client := feeder.NewTestClient(t, &utils.Mainnet)
+	client := feeder.NewTestClient(t, &networks.Mainnet)
 	gw := adaptfeeder.New(client)
 
 	ctx, cancel := context.WithCancel(t.Context())

--- a/core/state_update_test.go
+++ b/core/state_update_test.go
@@ -4,17 +4,17 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/NethermindEth/juno/blockchain/networks"
 	"github.com/NethermindEth/juno/clients/feeder"
 	"github.com/NethermindEth/juno/core"
 	"github.com/NethermindEth/juno/core/felt"
 	adaptfeeder "github.com/NethermindEth/juno/starknetdata/feeder"
-	"github.com/NethermindEth/juno/utils"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
 func TestStateDiffCommitment(t *testing.T) {
-	client := feeder.NewTestClient(t, &utils.Integration)
+	client := feeder.NewTestClient(t, &networks.Integration)
 	gw := adaptfeeder.New(client)
 
 	for _, test := range []struct {
@@ -48,7 +48,7 @@ func TestStateDiffCommitment(t *testing.T) {
 }
 
 func TestStateDiffHash(t *testing.T) {
-	client := feeder.NewTestClient(t, &utils.SepoliaIntegration)
+	client := feeder.NewTestClient(t, &networks.SepoliaIntegration)
 	gw := adaptfeeder.New(client)
 
 	for _, test := range []struct {
@@ -85,7 +85,7 @@ func TestStateDiffHash(t *testing.T) {
 }
 
 func BenchmarkStateDiffHash(b *testing.B) {
-	client := feeder.NewTestClient(b, &utils.SepoliaIntegration)
+	client := feeder.NewTestClient(b, &networks.SepoliaIntegration)
 	gw := adaptfeeder.New(client)
 	su, err := gw.StateUpdate(b.Context(), 38748)
 	require.NoError(b, err)
@@ -97,7 +97,7 @@ func BenchmarkStateDiffHash(b *testing.B) {
 }
 
 func TestStateDiffLength(t *testing.T) {
-	client := feeder.NewTestClient(t, &utils.Sepolia)
+	client := feeder.NewTestClient(t, &networks.Sepolia)
 	gw := adaptfeeder.New(client)
 
 	for _, test := range []struct {

--- a/core/transaction.go
+++ b/core/transaction.go
@@ -8,10 +8,10 @@ import (
 	"slices"
 
 	"github.com/Masterminds/semver/v3"
+	"github.com/NethermindEth/juno/blockchain/networks"
 	"github.com/NethermindEth/juno/core/crypto"
 	"github.com/NethermindEth/juno/core/felt"
 	"github.com/NethermindEth/juno/core/trie"
-	"github.com/NethermindEth/juno/utils"
 	"github.com/bits-and-blooms/bloom/v3"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/fxamacker/cbor/v2"
@@ -414,7 +414,7 @@ func (l *L1HandlerTransaction) MessageHash() []byte {
 	return digest.Sum(nil)
 }
 
-func TransactionHash(transaction Transaction, n *utils.Network) (felt.Felt, error) {
+func TransactionHash(transaction Transaction, n *networks.Network) (felt.Felt, error) {
 	switch t := transaction.(type) {
 	case *DeclareTransaction:
 		return declareTransactionHash(t, n)
@@ -449,7 +449,7 @@ func errInvalidTransactionVersion(t Transaction, version *TransactionVersion) er
 	return fmt.Errorf("invalid Transaction (type: %T) version: %s", t, version)
 }
 
-func invokeTransactionHash(i *InvokeTransaction, n *utils.Network) (felt.Felt, error) {
+func invokeTransactionHash(i *InvokeTransaction, n *networks.Network) (felt.Felt, error) {
 	switch {
 	case i.Version.Is(0):
 		calldataHash := crypto.PedersenArray(i.CallData...)
@@ -534,7 +534,7 @@ func dataAvailabilityMode(feeDAMode, nonceDAMode DataAvailabilityMode) uint64 {
 	return uint64(feeDAMode) + uint64(nonceDAMode)<<dataAvailabilityModeBits
 }
 
-func declareTransactionHash(d *DeclareTransaction, n *utils.Network) (felt.Felt, error) {
+func declareTransactionHash(d *DeclareTransaction, n *networks.Network) (felt.Felt, error) {
 	switch {
 	case d.Version.Is(0):
 		// Due to inconsistencies in version 0 hash calculation we don't verify the hash
@@ -605,7 +605,7 @@ func declareTransactionHash(d *DeclareTransaction, n *utils.Network) (felt.Felt,
 	}
 }
 
-func l1HandlerTransactionHash(l *L1HandlerTransaction, n *utils.Network) (felt.Felt, error) {
+func l1HandlerTransactionHash(l *L1HandlerTransaction, n *networks.Network) (felt.Felt, error) {
 	switch {
 	case l.Version.Is(0):
 		// There are some l1 handler transaction which do not return a nonce and for some random
@@ -631,7 +631,7 @@ func l1HandlerTransactionHash(l *L1HandlerTransaction, n *utils.Network) (felt.F
 
 func deployAccountTransactionHash(
 	d *DeployAccountTransaction,
-	n *utils.Network,
+	n *networks.Network,
 ) (felt.Felt, error) {
 	// There is no version 0 for deploy account
 	switch {
@@ -675,7 +675,7 @@ func deployAccountTransactionHash(
 	}
 }
 
-func VerifyTransactions(txs []Transaction, n *utils.Network, protocolVersion string) error {
+func VerifyTransactions(txs []Transaction, n *networks.Network, protocolVersion string) error {
 	blockVersion, err := ParseBlockVersion(protocolVersion)
 	if err != nil {
 		return err

--- a/core/transaction_test.go
+++ b/core/transaction_test.go
@@ -7,12 +7,12 @@ import (
 	"testing"
 
 	"github.com/Masterminds/semver/v3"
+	"github.com/NethermindEth/juno/blockchain/networks"
 	"github.com/NethermindEth/juno/clients/feeder"
 	"github.com/NethermindEth/juno/core"
 	"github.com/NethermindEth/juno/core/felt"
 	"github.com/NethermindEth/juno/encoder"
 	adaptfeeder "github.com/NethermindEth/juno/starknetdata/feeder"
-	"github.com/NethermindEth/juno/utils"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -149,7 +149,7 @@ func checkTransactionSymmetry(t *testing.T, input core.Transaction) {
 }
 
 func TestVerifyTransactionHash(t *testing.T) {
-	client := feeder.NewTestClient(t, &utils.Mainnet)
+	client := feeder.NewTestClient(t, &networks.Mainnet)
 	gw := adaptfeeder.New(client)
 
 	txnHash0 := felt.NewUnsafeFromString[felt.Felt]("0x1b4d9f09276629d496af1af8ff00173c11ff146affacb1b5c858d7aa89001ae")
@@ -205,7 +205,7 @@ func TestVerifyTransactionHash(t *testing.T) {
 
 		for _, test := range tests {
 			t.Run(test.name, func(t *testing.T) {
-				tErr := core.VerifyTransactions([]core.Transaction{test.txn}, &utils.Mainnet, "99.99.99")
+				tErr := core.VerifyTransactions([]core.Transaction{test.txn}, &networks.Mainnet, "99.99.99")
 				require.Equal(t, test.wantErr, tErr)
 			})
 		}
@@ -213,12 +213,12 @@ func TestVerifyTransactionHash(t *testing.T) {
 
 	t.Run("does not contain bad transaction(s)", func(t *testing.T) {
 		txns := []core.Transaction{txn0, txn1, txn2, txn3, txn4}
-		assert.NoError(t, core.VerifyTransactions(txns, &utils.Mainnet, "99.99.99"))
+		assert.NoError(t, core.VerifyTransactions(txns, &networks.Mainnet, "99.99.99"))
 	})
 }
 
 func TestTransactionV3Hash(t *testing.T) {
-	network := utils.Sepolia
+	network := networks.Sepolia
 	gw := adaptfeeder.New(feeder.NewTestClient(t, &network))
 	ctx := t.Context()
 
@@ -334,7 +334,7 @@ func TestMessageHash(t *testing.T) {
 }
 
 func TestDeclareV0TransactionHash(t *testing.T) {
-	network := utils.Goerli
+	network := networks.Goerli
 	gw := adaptfeeder.New(feeder.NewTestClient(t, &network))
 	ctx := t.Context()
 

--- a/docs/generate-config.js
+++ b/docs/generate-config.js
@@ -134,7 +134,7 @@ function parseValue(value) {
   }
 
   // Network type
-  if (value === "utils.Mainnet") {
+  if (value === "networks.Mainnet") {
     return "mainnet";
   }
 

--- a/genesis/genesis.go
+++ b/genesis/genesis.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/NethermindEth/juno/adapters/sn2core"
 	"github.com/NethermindEth/juno/adapters/vm2core"
+	"github.com/NethermindEth/juno/blockchain/networks"
 	"github.com/NethermindEth/juno/core"
 	"github.com/NethermindEth/juno/core/deprecatedstate"
 	"github.com/NethermindEth/juno/core/felt"
@@ -16,7 +17,6 @@ import (
 	rpc "github.com/NethermindEth/juno/rpc/v8"
 	"github.com/NethermindEth/juno/starknet"
 	"github.com/NethermindEth/juno/starknet/compiler"
-	"github.com/NethermindEth/juno/utils"
 	"github.com/NethermindEth/juno/vm"
 )
 
@@ -97,7 +97,7 @@ func GenesisStateDiff(
 	ctx context.Context,
 	config *GenesisConfig,
 	v vm.VM,
-	network *utils.Network,
+	network *networks.Network,
 	maxSteps uint64,
 	maxGas uint64,
 	compiler compiler.Compiler,

--- a/genesis/genesis_test.go
+++ b/genesis/genesis_test.go
@@ -3,6 +3,7 @@ package genesis_test
 import (
 	"testing"
 
+	"github.com/NethermindEth/juno/blockchain/networks"
 	"github.com/NethermindEth/juno/core/felt"
 	"github.com/NethermindEth/juno/genesis"
 	"github.com/NethermindEth/juno/starknet/compiler"
@@ -12,11 +13,11 @@ import (
 )
 
 func TestGenesisStateDiff(t *testing.T) {
-	network := &utils.Mainnet
+	network := &networks.Mainnet
 	log := utils.NewNopZapLogger()
 
 	t.Run("empty genesis config", func(t *testing.T) {
-		feeTokens := utils.DefaultFeeTokenAddresses
+		feeTokens := networks.DefaultFeeTokenAddresses
 		chainInfo := vm.ChainInfo{
 			ChainID:           network.L2ChainID,
 			FeeTokenAddresses: feeTokens,
@@ -41,7 +42,7 @@ func TestGenesisStateDiff(t *testing.T) {
 		require.NoError(t, err)
 		genesisConfig.Classes = []string{"./classes/strk.json", "./classes/account.json", "./classes/universaldeployer.json", "./classes/udacnt.json"}
 
-		feeTokens := utils.DefaultFeeTokenAddresses
+		feeTokens := networks.DefaultFeeTokenAddresses
 		chainInfo := vm.ChainInfo{
 			ChainID:           network.L2ChainID,
 			FeeTokenAddresses: feeTokens,

--- a/l1/l1.go
+++ b/l1/l1.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/NethermindEth/juno/blockchain"
+	"github.com/NethermindEth/juno/blockchain/networks"
 	"github.com/NethermindEth/juno/core"
 	"github.com/NethermindEth/juno/core/felt"
 	"github.com/NethermindEth/juno/l1/contract"
@@ -33,7 +34,7 @@ type Client struct {
 	l1                    Subscriber
 	l2Chain               *blockchain.Blockchain
 	log                   utils.StructuredLogger
-	network               *utils.Network
+	network               *networks.Network
 	resubscribeDelay      time.Duration
 	pollFinalisedInterval time.Duration
 	nonFinalisedLogs      map[uint64]*contract.StarknetLogStateUpdate

--- a/l1/l1_pkg_test.go
+++ b/l1/l1_pkg_test.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/NethermindEth/juno/blockchain"
+	"github.com/NethermindEth/juno/blockchain/networks"
 	"github.com/NethermindEth/juno/core"
 	"github.com/NethermindEth/juno/core/felt"
 	"github.com/NethermindEth/juno/db/memory"
@@ -335,7 +336,7 @@ func TestClient(t *testing.T) {
 
 			ctrl := gomock.NewController(t)
 			nopLog := utils.NewNopZapLogger()
-			network := utils.Mainnet
+			network := networks.Mainnet
 			chain := blockchain.New(memory.New(), &network)
 
 			client := NewClient(nil, chain, nopLog).WithResubscribeDelay(0).WithPollFinalisedInterval(time.Nanosecond)
@@ -396,7 +397,7 @@ func TestUnreliableSubscription(t *testing.T) {
 
 	ctrl := gomock.NewController(t)
 	nopLog := utils.NewNopZapLogger()
-	network := utils.Mainnet
+	network := networks.Mainnet
 	chain := blockchain.New(memory.New(), &network)
 	client := NewClient(nil, chain, nopLog).WithResubscribeDelay(0).WithPollFinalisedInterval(time.Nanosecond)
 

--- a/l1/l1_test.go
+++ b/l1/l1_test.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/NethermindEth/juno/blockchain"
+	"github.com/NethermindEth/juno/blockchain/networks"
 	"github.com/NethermindEth/juno/core"
 	"github.com/NethermindEth/juno/core/felt"
 	"github.com/NethermindEth/juno/db/memory"
@@ -51,7 +52,7 @@ func TestFailToCreateSubscription(t *testing.T) {
 
 	err := errors.New("test error")
 
-	network := utils.Mainnet
+	network := networks.Mainnet
 	ctrl := gomock.NewController(t)
 	nopLog := utils.NewNopZapLogger()
 	chain := blockchain.New(memory.New(), &network)
@@ -82,7 +83,7 @@ func TestFailToCreateSubscription(t *testing.T) {
 func TestMismatchedChainID(t *testing.T) {
 	t.Parallel()
 
-	network := utils.Mainnet
+	network := networks.Mainnet
 	ctrl := gomock.NewController(t)
 	nopLog := utils.NewNopZapLogger()
 	chain := blockchain.New(memory.New(), &network)
@@ -109,7 +110,7 @@ func TestEventListener(t *testing.T) {
 
 	ctrl := gomock.NewController(t)
 	nopLog := utils.NewNopZapLogger()
-	network := utils.Mainnet
+	network := networks.Mainnet
 	chain := blockchain.New(memory.New(), &network)
 
 	subscriber := mocks.NewMockSubscriber(ctrl)

--- a/mempool/mempool_test.go
+++ b/mempool/mempool_test.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/NethermindEth/juno/blockchain"
+	"github.com/NethermindEth/juno/blockchain/networks"
 	"github.com/NethermindEth/juno/clients/feeder"
 	"github.com/NethermindEth/juno/core"
 	"github.com/NethermindEth/juno/core/felt"
@@ -186,7 +187,7 @@ func TestRestoreMempool(t *testing.T) {
 }
 
 func TestWait(t *testing.T) {
-	client := feeder.NewTestClient(t, &utils.Sepolia)
+	client := feeder.NewTestClient(t, &networks.Sepolia)
 	gw := adaptfeeder.New(client)
 	log := utils.NewNopZapLogger()
 	testDB, dbCloser, err := setupDatabase("testwait", true)
@@ -194,7 +195,7 @@ func TestWait(t *testing.T) {
 	defer dbCloser()
 	mockCtrl := gomock.NewController(t)
 	t.Cleanup(mockCtrl.Finish)
-	bc := blockchain.New(testDB, &utils.Sepolia)
+	bc := blockchain.New(testDB, &networks.Sepolia)
 	block0, err := gw.BlockByNumber(t.Context(), 0)
 	require.NoError(t, err)
 	stateUpdate0, err := gw.StateUpdate(t.Context(), 0)

--- a/mempool/p2p/p2p.go
+++ b/mempool/p2p/p2p.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 
+	"github.com/NethermindEth/juno/blockchain/networks"
 	"github.com/NethermindEth/juno/consensus/p2p/buffered"
 	"github.com/NethermindEth/juno/consensus/p2p/config"
 	"github.com/NethermindEth/juno/mempool"
@@ -26,7 +27,7 @@ const (
 type P2P struct {
 	host             host.Host
 	log              utils.Logger
-	network          *utils.Network
+	network          *networks.Network
 	pool             mempool.Pool
 	broadcaster      transactionBroadcaster
 	listener         buffered.TopicSubscription
@@ -35,7 +36,7 @@ type P2P struct {
 }
 
 func New(
-	network *utils.Network,
+	network *networks.Network,
 	host host.Host,
 	log utils.Logger,
 	pool mempool.Pool,

--- a/mempool/p2p/p2p_broadcasters_listeners_test.go
+++ b/mempool/p2p/p2p_broadcasters_listeners_test.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/NethermindEth/juno/adapters/mempool2p2p/testutils"
+	"github.com/NethermindEth/juno/blockchain/networks"
 	"github.com/NethermindEth/juno/consensus/p2p/config"
 	"github.com/NethermindEth/juno/mempool"
 	"github.com/NethermindEth/juno/mempool/p2p"
@@ -68,7 +69,7 @@ func TestMempoolBroadcastersAndListeners(t *testing.T) {
 		pool := mockMempool(received)
 
 		p2p := p2p.New(
-			&utils.Mainnet,
+			&networks.Mainnet,
 			node.Host,
 			logger,
 			&pool,
@@ -124,7 +125,7 @@ func TestMempoolBroadcastersAndListeners(t *testing.T) {
 func getRandomTransactions(t *testing.T) []mempool.BroadcastedTransaction {
 	transactions := make([]mempool.BroadcastedTransaction, txCount)
 	for i := range txCount {
-		transactions[i], _ = testutils.TransactionBuilder.GetTestInvokeTransaction(t, &utils.Mainnet)
+		transactions[i], _ = testutils.TransactionBuilder.GetTestInvokeTransaction(t, &networks.Mainnet)
 	}
 	return transactions
 }

--- a/mempool/p2p/transaction_listener.go
+++ b/mempool/p2p/transaction_listener.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/NethermindEth/juno/adapters/p2p2mempool"
+	"github.com/NethermindEth/juno/blockchain/networks"
 	"github.com/NethermindEth/juno/consensus/p2p/buffered"
 	"github.com/NethermindEth/juno/mempool"
 	"github.com/NethermindEth/juno/starknet/compiler"
@@ -15,7 +16,7 @@ import (
 )
 
 func NewTransactionListener(
-	network *utils.Network,
+	network *networks.Network,
 	log utils.Logger,
 	pool mempool.Pool,
 	bufferSize int,

--- a/migration/blocktransactions/blocktransactions.go
+++ b/migration/blocktransactions/blocktransactions.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"time"
 
+	"github.com/NethermindEth/juno/blockchain/networks"
 	"github.com/NethermindEth/juno/core"
 	"github.com/NethermindEth/juno/db"
 	"github.com/NethermindEth/juno/db/typed/key"
@@ -118,7 +119,7 @@ func (Migrator) Before([]byte) error {
 func (Migrator) Migrate(
 	ctx context.Context,
 	database db.KeyValueStore,
-	network *utils.Network,
+	network *networks.Network,
 	logger utils.StructuredLogger,
 ) ([]byte, error) {
 	chainHeight, err := core.GetChainHeight(database)

--- a/migration/blocktransactions/blocktransactions_test.go
+++ b/migration/blocktransactions/blocktransactions_test.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/NethermindEth/juno/adapters/testutils"
+	"github.com/NethermindEth/juno/blockchain/networks"
 	"github.com/NethermindEth/juno/core"
 	"github.com/NethermindEth/juno/db"
 	"github.com/NethermindEth/juno/db/pebblev2"
@@ -35,7 +36,7 @@ func TestBlockTransactionsMigration(t *testing.T) {
 		state, err := blocktransactions.Migrator{}.Migrate(
 			t.Context(),
 			database,
-			&utils.Sepolia,
+			&networks.Sepolia,
 			utils.NewNopZapLogger(),
 		)
 		require.NoError(t, err)
@@ -171,7 +172,7 @@ func runTestBlockTransactionsMigration(
 				state, err := blocktransactions.Migrator{}.Migrate(
 					ctx,
 					database,
-					&utils.Sepolia,
+					&networks.Sepolia,
 					logger,
 				)
 

--- a/migration/deprecated/bucket_migrator.go
+++ b/migration/deprecated/bucket_migrator.go
@@ -8,6 +8,7 @@ import (
 	"os/signal"
 	"syscall"
 
+	"github.com/NethermindEth/juno/blockchain/networks"
 	"github.com/NethermindEth/juno/db"
 	"github.com/NethermindEth/juno/utils"
 )
@@ -15,7 +16,7 @@ import (
 var _ Migration = (*BucketMigrator)(nil)
 
 type (
-	BucketMigratorDoFunc    func(t db.KeyValueWriter, b1, b2 []byte, n *utils.Network) error
+	BucketMigratorDoFunc    func(t db.KeyValueWriter, b1, b2 []byte, n *networks.Network) error
 	BucketMigratorKeyFilter func([]byte) (bool, error)
 )
 
@@ -45,7 +46,7 @@ func NewBucketMigrator(target db.Bucket, do BucketMigratorDoFunc) *BucketMigrato
 }
 
 func NewBucketMover(source, destination db.Bucket) *BucketMigrator {
-	return NewBucketMigrator(source, func(txn db.KeyValueWriter, key, value []byte, n *utils.Network) error {
+	return NewBucketMigrator(source, func(txn db.KeyValueWriter, key, value []byte, n *networks.Network) error {
 		err := txn.Delete(key)
 		if err != nil {
 			return err
@@ -79,7 +80,7 @@ func (m *BucketMigrator) Before(_ []byte) error {
 func (m *BucketMigrator) Migrate(
 	ctx context.Context,
 	database db.KeyValueStore,
-	network *utils.Network,
+	network *networks.Network,
 	log utils.StructuredLogger,
 ) ([]byte, error) {
 	remainingInBatch := m.batchSize

--- a/migration/deprecated/bucket_migrator.go
+++ b/migration/deprecated/bucket_migrator.go
@@ -46,7 +46,12 @@ func NewBucketMigrator(target db.Bucket, do BucketMigratorDoFunc) *BucketMigrato
 }
 
 func NewBucketMover(source, destination db.Bucket) *BucketMigrator {
-	return NewBucketMigrator(source, func(txn db.KeyValueWriter, key, value []byte, n *networks.Network) error {
+	return NewBucketMigrator(source, func(
+		txn db.KeyValueWriter,
+		key []byte,
+		value []byte,
+		_ *networks.Network,
+	) error {
 		err := txn.Delete(key)
 		if err != nil {
 			return err

--- a/migration/deprecated/bucket_migrator_test.go
+++ b/migration/deprecated/bucket_migrator_test.go
@@ -5,10 +5,10 @@ import (
 	"errors"
 	"testing"
 
+	"github.com/NethermindEth/juno/blockchain/networks"
 	"github.com/NethermindEth/juno/db"
 	"github.com/NethermindEth/juno/db/memory"
 	"github.com/NethermindEth/juno/migration/deprecated"
-	"github.com/NethermindEth/juno/utils"
 	"github.com/stretchr/testify/require"
 )
 
@@ -38,10 +38,10 @@ func TestBucketMover(t *testing.T) {
 		intermediateState []byte
 		err               error
 	)
-	_, err = mover.Migrate(t.Context(), testDB, &utils.Mainnet, nil)
+	_, err = mover.Migrate(t.Context(), testDB, &networks.Mainnet, nil)
 	require.ErrorIs(t, err, deprecated.ErrCallWithNewTransaction)
 
-	intermediateState, err = mover.Migrate(t.Context(), testDB, &utils.Mainnet, nil)
+	intermediateState, err = mover.Migrate(t.Context(), testDB, &networks.Mainnet, nil)
 	require.NoError(t, err)
 
 	err = testDB.View(func(txn db.Snapshot) error {

--- a/migration/deprecated/casmhashmetadata/migrator.go
+++ b/migration/deprecated/casmhashmetadata/migrator.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/Masterminds/semver/v3"
+	"github.com/NethermindEth/juno/blockchain/networks"
 	"github.com/NethermindEth/juno/core"
 	"github.com/NethermindEth/juno/db"
 	"github.com/NethermindEth/juno/db/typed"
@@ -55,7 +56,7 @@ func (m *Migrator) Before(intermediateState []byte) error {
 func (m *Migrator) Migrate(
 	ctx context.Context,
 	database db.KeyValueStore,
-	network *utils.Network,
+	network *networks.Network,
 	log utils.StructuredLogger,
 ) ([]byte, error) {
 	chainHeight, err := core.GetChainHeight(database)

--- a/migration/deprecated/l1handlermapping/migrator.go
+++ b/migration/deprecated/l1handlermapping/migrator.go
@@ -7,6 +7,7 @@ import (
 	"runtime"
 	"time"
 
+	"github.com/NethermindEth/juno/blockchain/networks"
 	"github.com/NethermindEth/juno/core"
 	"github.com/NethermindEth/juno/db"
 	deprecatedprogresslogger "github.com/NethermindEth/juno/migration/deprecated/progresslogger"
@@ -43,7 +44,7 @@ func (m *Migrator) Before(intermediateState []byte) error {
 func (m *Migrator) Migrate(
 	ctx context.Context,
 	database db.KeyValueStore,
-	_ *utils.Network,
+	_ *networks.Network,
 	log utils.StructuredLogger,
 ) ([]byte, error) {
 	chainHeight, err := core.GetChainHeight(database)

--- a/migration/deprecated/l1handlermapping/migrator_test.go
+++ b/migration/deprecated/l1handlermapping/migrator_test.go
@@ -21,7 +21,12 @@ func TestRecalculateL1HandlerMsgHashesToTxnHashes(t *testing.T) {
 		testdb := memory.New()
 		m := l1handlermapping.Migrator{}
 		require.NoError(t, m.Before(nil))
-		intermediateState, err := m.Migrate(t.Context(), testdb, &networks.Sepolia, utils.NewNopZapLogger())
+		intermediateState, err := m.Migrate(
+			t.Context(),
+			testdb,
+			&networks.Sepolia,
+			utils.NewNopZapLogger(),
+		)
 		require.NoError(t, err)
 		require.Nil(t, intermediateState)
 	})
@@ -93,7 +98,12 @@ func TestRecalculateL1HandlerMsgHashesToTxnHashes(t *testing.T) {
 		// Run migration
 		m := l1handlermapping.Migrator{}
 		require.NoError(t, m.Before(nil))
-		intermediateState, err := m.Migrate(t.Context(), testdb, &networks.Sepolia, utils.NewNopZapLogger())
+		intermediateState, err := m.Migrate(
+			t.Context(),
+			testdb,
+			&networks.Sepolia,
+			utils.NewNopZapLogger(),
+		)
 		require.NoError(t, err)
 		require.Nil(t, intermediateState)
 

--- a/migration/deprecated/l1handlermapping/migrator_test.go
+++ b/migration/deprecated/l1handlermapping/migrator_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/NethermindEth/juno/adapters/testutils"
+	"github.com/NethermindEth/juno/blockchain/networks"
 	"github.com/NethermindEth/juno/core"
 	"github.com/NethermindEth/juno/core/felt"
 	"github.com/NethermindEth/juno/db"
@@ -20,7 +21,7 @@ func TestRecalculateL1HandlerMsgHashesToTxnHashes(t *testing.T) {
 		testdb := memory.New()
 		m := l1handlermapping.Migrator{}
 		require.NoError(t, m.Before(nil))
-		intermediateState, err := m.Migrate(t.Context(), testdb, &utils.Sepolia, utils.NewNopZapLogger())
+		intermediateState, err := m.Migrate(t.Context(), testdb, &networks.Sepolia, utils.NewNopZapLogger())
 		require.NoError(t, err)
 		require.Nil(t, intermediateState)
 	})
@@ -54,7 +55,7 @@ func TestRecalculateL1HandlerMsgHashesToTxnHashes(t *testing.T) {
 			numTxs := minTxsPerBlock + rand.Intn(maxTxsPerBlock-minTxsPerBlock+1)
 
 			// Generate transactions with weighted sampling
-			txs, receipts := generateWeightedTestTxs(t, &utils.Sepolia, numTxs, weights)
+			txs, receipts := generateWeightedTestTxs(t, &networks.Sepolia, numTxs, weights)
 
 			// Write transactions using per-tx layout (migration reads from per-tx layout)
 			require.NoError(
@@ -92,7 +93,7 @@ func TestRecalculateL1HandlerMsgHashesToTxnHashes(t *testing.T) {
 		// Run migration
 		m := l1handlermapping.Migrator{}
 		require.NoError(t, m.Before(nil))
-		intermediateState, err := m.Migrate(t.Context(), testdb, &utils.Sepolia, utils.NewNopZapLogger())
+		intermediateState, err := m.Migrate(t.Context(), testdb, &networks.Sepolia, utils.NewNopZapLogger())
 		require.NoError(t, err)
 		require.Nil(t, intermediateState)
 
@@ -116,7 +117,7 @@ type txWeights struct {
 // generateWeightedTestTxs generates n random transactions with receipts based on weights
 func generateWeightedTestTxs(
 	t *testing.T,
-	network *utils.Network,
+	network *networks.Network,
 	n int,
 	weights txWeights,
 ) ([]core.Transaction, []*core.TransactionReceipt) {

--- a/migration/deprecated/migration.go
+++ b/migration/deprecated/migration.go
@@ -50,10 +50,17 @@ type HTTPConfig struct {
 
 type Migration interface {
 	Before(intermediateState []byte) error
-	// Migration should return intermediate state whenever it requests new txn or detects cancelled ctx.
-	Migrate(context.Context, db.KeyValueStore, *networks.Network, utils.StructuredLogger) ([]byte, error)
+	// Migration should return intermediate state whenever it requests new txn or
+	// detects cancelled ctx.
+	Migrate(
+		context.Context,
+		db.KeyValueStore,
+		*networks.Network,
+		utils.StructuredLogger,
+	) ([]byte, error)
 }
 
+//nolint:staticcheck // [db.IndexedBatch] is necessary for deprecated migrations
 type MigrationFunc func(db.IndexedBatch, *networks.Network) error
 
 // Migrate returns f(txn).
@@ -238,6 +245,8 @@ func updateSchemaMetadata(txn db.KeyValueWriter, schema schemaMetadata) error {
 }
 
 // migration0000 makes sure the targetDB is empty
+//
+//nolint:staticcheck // [db.IndexedBatch] is necessary for deprecated migrations
 func migration0000(txn db.IndexedBatch, _ *networks.Network) error {
 	it, err := txn.NewIterator(nil, false)
 	if err != nil {
@@ -257,6 +266,8 @@ func migration0000(txn db.IndexedBatch, _ *networks.Network) error {
 // After: the key to the root of the contract storage trie is stored at 3+<contractAddress>.
 //
 // This enables us to remove the db.ContractRootKey prefix.
+//
+//nolint:staticcheck // [db.IndexedBatch] is necessary for deprecated migrations
 func relocateContractStorageRootKeys(txn db.IndexedBatch, _ *networks.Network) error {
 	it, err := txn.NewIterator(nil, false)
 	if err != nil {
@@ -311,6 +322,8 @@ func relocateContractStorageRootKeys(txn db.IndexedBatch, _ *networks.Network) e
 }
 
 // recalculateBloomFilters updates bloom filters in block headers to match what the most recent implementation expects
+//
+//nolint:staticcheck // [db.IndexedBatch] is necessary for deprecated migrations
 func recalculateBloomFilters(txn db.IndexedBatch, _ *networks.Network) error {
 	for blockNumber := uint64(0); ; blockNumber++ {
 		block, err := txlayout.TransactionLayoutPerTx.BlockByNumber(txn, blockNumber)
@@ -327,6 +340,7 @@ func recalculateBloomFilters(txn db.IndexedBatch, _ *networks.Network) error {
 	}
 }
 
+//nolint:staticcheck // [db.IndexedBatch] is necessary for deprecated migrations
 func removePendingBlock(txn db.IndexedBatch, _ *networks.Network) error {
 	return txn.Delete(db.Unused.Key())
 }
@@ -538,6 +552,8 @@ func processBlocks(txn db.IndexedBatch, processBlock func(uint64, *sync.Mutex) e
 }
 
 // calculateBlockCommitments calculates the txn and event commitments for each block and stores them separately
+//
+//nolint:staticcheck // [db.IndexedBatch] is necessary for deprecated migrations
 func calculateBlockCommitments(txn db.IndexedBatch, network *networks.Network) error {
 	processBlockFunc := func(blockNumber uint64, txnLock *sync.Mutex) error {
 		txnLock.Lock()
@@ -559,6 +575,7 @@ func calculateBlockCommitments(txn db.IndexedBatch, network *networks.Network) e
 	return processBlocks(txn, processBlockFunc)
 }
 
+//nolint:staticcheck // [db.IndexedBatch] is necessary for deprecated migrations
 func calculateL1MsgHashes2(txn db.IndexedBatch, n *networks.Network) error {
 	processBlockFunc := func(blockNumber uint64, txnLock *sync.Mutex) error {
 		txnLock.Lock()
@@ -590,7 +607,11 @@ func bitset2BitArray(bs *bitset.BitSet) *trie.BitArray {
 	return new(trie.BitArray).SetFelt(uint8(bs.Len()), f)
 }
 
-func migrateTrieRootKeysFromBitsetToTrieKeys(txn db.KeyValueWriter, key, value []byte, _ *networks.Network) error {
+func migrateTrieRootKeysFromBitsetToTrieKeys(
+	txn db.KeyValueWriter,
+	key, value []byte,
+	_ *networks.Network,
+) error {
 	var bs bitset.BitSet
 	var tempBuf bytes.Buffer
 	if err := bs.UnmarshalBinary(value); err != nil {
@@ -771,7 +792,11 @@ func (o *oldCairo1Class) Hash() (*felt.Felt, error) {
 	return nil, nil
 }
 
-func migrateCairo1CompiledClass2(txn db.KeyValueWriter, key, value []byte, _ *networks.Network) error {
+func migrateCairo1CompiledClass2(
+	txn db.KeyValueWriter,
+	key, value []byte,
+	_ *networks.Network,
+) error {
 	var class declaredClass
 	err := encoder.Unmarshal(value, &class)
 	if err != nil {
@@ -819,6 +844,7 @@ func migrateCairo1CompiledClass2(txn db.KeyValueWriter, key, value []byte, _ *ne
 	return txn.Put(key, value)
 }
 
+//nolint:staticcheck // [db.IndexedBatch] is necessary for deprecated migrations
 func reconstructAggregatedBloomFilters(txn db.IndexedBatch, network *networks.Network) error {
 	chainHeight, err := core.GetChainHeight(txn)
 	if err != nil {
@@ -894,6 +920,7 @@ func reconstructAggregatedBloomFilters(txn db.IndexedBatch, network *networks.Ne
 	return core.WriteRunningEventFilter(txn, runningFilter)
 }
 
+//nolint:staticcheck // [db.IndexedBatch] is necessary for deprecated migrations
 func calculateCasmClassHashesV2(txn db.IndexedBatch, network *networks.Network) error {
 	deprecatedCasmClassHashesV2Bucket := typed.NewBucket(
 		db.ClassCasmHashMetadata,

--- a/migration/deprecated/migration.go
+++ b/migration/deprecated/migration.go
@@ -17,6 +17,7 @@ import (
 	"sync"
 
 	"github.com/NethermindEth/juno/adapters/sn2core"
+	"github.com/NethermindEth/juno/blockchain/networks"
 	"github.com/NethermindEth/juno/core"
 	"github.com/NethermindEth/juno/core/felt"
 	"github.com/NethermindEth/juno/core/trie"
@@ -50,14 +51,14 @@ type HTTPConfig struct {
 type Migration interface {
 	Before(intermediateState []byte) error
 	// Migration should return intermediate state whenever it requests new txn or detects cancelled ctx.
-	Migrate(context.Context, db.KeyValueStore, *utils.Network, utils.StructuredLogger) ([]byte, error)
+	Migrate(context.Context, db.KeyValueStore, *networks.Network, utils.StructuredLogger) ([]byte, error)
 }
 
-type MigrationFunc func(db.IndexedBatch, *utils.Network) error
+type MigrationFunc func(db.IndexedBatch, *networks.Network) error
 
 // Migrate returns f(txn).
 func (f MigrationFunc) Migrate(
-	_ context.Context, database db.KeyValueStore, network *utils.Network, _ utils.StructuredLogger,
+	_ context.Context, database db.KeyValueStore, network *networks.Network, _ utils.StructuredLogger,
 ) ([]byte, error) {
 	txn := database.NewIndexedBatch()
 	if err := f(txn, network); err != nil {
@@ -102,7 +103,7 @@ var ErrCallWithNewTransaction = errors.New("call with new transaction")
 func MigrateIfNeeded(
 	ctx context.Context,
 	targetDB db.KeyValueStore,
-	network *utils.Network,
+	network *networks.Network,
 	log utils.StructuredLogger,
 ) error {
 	return migrateIfNeeded(ctx, targetDB, network, log, defaultMigrations)
@@ -111,7 +112,7 @@ func MigrateIfNeeded(
 func migrateIfNeeded(
 	ctx context.Context,
 	targetDB db.KeyValueStore,
-	network *utils.Network,
+	network *networks.Network,
 	log utils.StructuredLogger,
 	migrations []Migration,
 ) error {
@@ -237,7 +238,7 @@ func updateSchemaMetadata(txn db.KeyValueWriter, schema schemaMetadata) error {
 }
 
 // migration0000 makes sure the targetDB is empty
-func migration0000(txn db.IndexedBatch, _ *utils.Network) error {
+func migration0000(txn db.IndexedBatch, _ *networks.Network) error {
 	it, err := txn.NewIterator(nil, false)
 	if err != nil {
 		return err
@@ -256,7 +257,7 @@ func migration0000(txn db.IndexedBatch, _ *utils.Network) error {
 // After: the key to the root of the contract storage trie is stored at 3+<contractAddress>.
 //
 // This enables us to remove the db.ContractRootKey prefix.
-func relocateContractStorageRootKeys(txn db.IndexedBatch, _ *utils.Network) error {
+func relocateContractStorageRootKeys(txn db.IndexedBatch, _ *networks.Network) error {
 	it, err := txn.NewIterator(nil, false)
 	if err != nil {
 		return err
@@ -310,7 +311,7 @@ func relocateContractStorageRootKeys(txn db.IndexedBatch, _ *utils.Network) erro
 }
 
 // recalculateBloomFilters updates bloom filters in block headers to match what the most recent implementation expects
-func recalculateBloomFilters(txn db.IndexedBatch, _ *utils.Network) error {
+func recalculateBloomFilters(txn db.IndexedBatch, _ *networks.Network) error {
 	for blockNumber := uint64(0); ; blockNumber++ {
 		block, err := txlayout.TransactionLayoutPerTx.BlockByNumber(txn, blockNumber)
 		if err != nil {
@@ -326,7 +327,7 @@ func recalculateBloomFilters(txn db.IndexedBatch, _ *utils.Network) error {
 	}
 }
 
-func removePendingBlock(txn db.IndexedBatch, _ *utils.Network) error {
+func removePendingBlock(txn db.IndexedBatch, _ *networks.Network) error {
 	return txn.Delete(db.Unused.Key())
 }
 
@@ -429,7 +430,7 @@ func (n *node) _UnmarshalBinary(data []byte) error {
 }
 
 func (m *changeTrieNodeEncoding) Migrate(
-	_ context.Context, database db.KeyValueStore, _ *utils.Network, _ utils.StructuredLogger,
+	_ context.Context, database db.KeyValueStore, _ *networks.Network, _ utils.StructuredLogger,
 ) ([]byte, error) {
 	// If we made n a trie.Node, the encoder would fall back to the custom encoding methods.
 	// We instead define a custom struct to force the encoder to use the default encoding.
@@ -537,7 +538,7 @@ func processBlocks(txn db.IndexedBatch, processBlock func(uint64, *sync.Mutex) e
 }
 
 // calculateBlockCommitments calculates the txn and event commitments for each block and stores them separately
-func calculateBlockCommitments(txn db.IndexedBatch, network *utils.Network) error {
+func calculateBlockCommitments(txn db.IndexedBatch, network *networks.Network) error {
 	processBlockFunc := func(blockNumber uint64, txnLock *sync.Mutex) error {
 		txnLock.Lock()
 		block, err := txlayout.TransactionLayoutPerTx.BlockByNumber(txn, blockNumber)
@@ -558,7 +559,7 @@ func calculateBlockCommitments(txn db.IndexedBatch, network *utils.Network) erro
 	return processBlocks(txn, processBlockFunc)
 }
 
-func calculateL1MsgHashes2(txn db.IndexedBatch, n *utils.Network) error {
+func calculateL1MsgHashes2(txn db.IndexedBatch, n *networks.Network) error {
 	processBlockFunc := func(blockNumber uint64, txnLock *sync.Mutex) error {
 		txnLock.Lock()
 		txns, err := txlayout.TransactionLayoutPerTx.TransactionsByBlockNumber(txn, blockNumber)
@@ -589,7 +590,7 @@ func bitset2BitArray(bs *bitset.BitSet) *trie.BitArray {
 	return new(trie.BitArray).SetFelt(uint8(bs.Len()), f)
 }
 
-func migrateTrieRootKeysFromBitsetToTrieKeys(txn db.KeyValueWriter, key, value []byte, _ *utils.Network) error {
+func migrateTrieRootKeysFromBitsetToTrieKeys(txn db.KeyValueWriter, key, value []byte, _ *networks.Network) error {
 	var bs bitset.BitSet
 	var tempBuf bytes.Buffer
 	if err := bs.UnmarshalBinary(value); err != nil {
@@ -623,7 +624,7 @@ func nodesFilter(target db.Bucket) BucketMigratorKeyFilter {
 }
 
 func migrateTrieNodesFromBitsetToTrieKey(target db.Bucket) BucketMigratorDoFunc {
-	return func(txn db.KeyValueWriter, key, value []byte, _ *utils.Network) error {
+	return func(txn db.KeyValueWriter, key, value []byte, _ *networks.Network) error {
 		var n node
 		var tempBuf bytes.Buffer
 		if err := n._UnmarshalBinary(value); err != nil {
@@ -690,7 +691,7 @@ type oldStateUpdate struct {
 	StateDiff *oldStateDiff
 }
 
-func changeStateDiffStruct2(txn db.KeyValueWriter, key, value []byte, _ *utils.Network) error {
+func changeStateDiffStruct2(txn db.KeyValueWriter, key, value []byte, _ *networks.Network) error {
 	old := new(oldStateUpdate)
 	if err := encoder.Unmarshal(value, old); err != nil {
 		return fmt.Errorf("unmarshal: %v", err)
@@ -770,7 +771,7 @@ func (o *oldCairo1Class) Hash() (*felt.Felt, error) {
 	return nil, nil
 }
 
-func migrateCairo1CompiledClass2(txn db.KeyValueWriter, key, value []byte, _ *utils.Network) error {
+func migrateCairo1CompiledClass2(txn db.KeyValueWriter, key, value []byte, _ *networks.Network) error {
 	var class declaredClass
 	err := encoder.Unmarshal(value, &class)
 	if err != nil {
@@ -818,7 +819,7 @@ func migrateCairo1CompiledClass2(txn db.KeyValueWriter, key, value []byte, _ *ut
 	return txn.Put(key, value)
 }
 
-func reconstructAggregatedBloomFilters(txn db.IndexedBatch, network *utils.Network) error {
+func reconstructAggregatedBloomFilters(txn db.IndexedBatch, network *networks.Network) error {
 	chainHeight, err := core.GetChainHeight(txn)
 	if err != nil {
 		if errors.Is(err, db.ErrKeyNotFound) {
@@ -893,7 +894,7 @@ func reconstructAggregatedBloomFilters(txn db.IndexedBatch, network *utils.Netwo
 	return core.WriteRunningEventFilter(txn, runningFilter)
 }
 
-func calculateCasmClassHashesV2(txn db.IndexedBatch, network *utils.Network) error {
+func calculateCasmClassHashesV2(txn db.IndexedBatch, network *networks.Network) error {
 	deprecatedCasmClassHashesV2Bucket := typed.NewBucket(
 		db.ClassCasmHashMetadata,
 		key.SierraClassHash,

--- a/migration/deprecated/migration_pkg_test.go
+++ b/migration/deprecated/migration_pkg_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	"github.com/NethermindEth/juno/blockchain"
+	"github.com/NethermindEth/juno/blockchain/networks"
 	"github.com/NethermindEth/juno/clients/feeder"
 	"github.com/NethermindEth/juno/core"
 	"github.com/NethermindEth/juno/core/felt"
@@ -30,7 +31,7 @@ func TestMigration0000(t *testing.T) {
 
 	t.Run("empty DB", func(t *testing.T) {
 		txn := testDB.NewIndexedBatch()
-		require.NoError(t, migration0000(txn, &utils.Mainnet))
+		require.NoError(t, migration0000(txn, &networks.Mainnet))
 	})
 
 	t.Run("non-empty DB", func(t *testing.T) {
@@ -39,7 +40,7 @@ func TestMigration0000(t *testing.T) {
 		require.NoError(t, txn.Write())
 
 		txn = testDB.NewIndexedBatch()
-		require.EqualError(t, migration0000(txn, &utils.Mainnet), "initial DB should be empty")
+		require.EqualError(t, migration0000(txn, &networks.Mainnet), "initial DB should be empty")
 	})
 }
 
@@ -57,7 +58,7 @@ func TestRelocateContractStorageRootKeys(t *testing.T) {
 		require.NoError(t, err)
 	}
 
-	require.NoError(t, relocateContractStorageRootKeys(txn, &utils.Mainnet))
+	require.NoError(t, relocateContractStorageRootKeys(txn, &networks.Mainnet))
 
 	// Each root-key entry should have been moved to its new location
 	// and the old entry should not exist.
@@ -88,8 +89,8 @@ func TestRelocateContractStorageRootKeys(t *testing.T) {
 
 func TestRecalculateBloomFilters(t *testing.T) {
 	testDB := memory.New()
-	chain := blockchain.New(testDB, &utils.Mainnet)
-	client := feeder.NewTestClient(t, &utils.Mainnet)
+	chain := blockchain.New(testDB, &networks.Mainnet)
+	client := feeder.NewTestClient(t, &networks.Mainnet)
 	gw := adaptfeeder.New(client)
 
 	for i := range uint64(3) {
@@ -103,7 +104,7 @@ func TestRecalculateBloomFilters(t *testing.T) {
 	}
 
 	require.NoError(t, testDB.Update(func(txn db.IndexedBatch) error {
-		return recalculateBloomFilters(txn, &utils.Mainnet)
+		return recalculateBloomFilters(txn, &networks.Mainnet)
 	}))
 
 	for i := range uint64(3) {
@@ -172,7 +173,7 @@ func TestChangeTrieNodeEncoding(t *testing.T) {
 
 	m := new(changeTrieNodeEncoding)
 	require.NoError(t, m.Before(nil))
-	_, err := m.Migrate(t.Context(), testdb, &utils.Mainnet, nil)
+	_, err := m.Migrate(t.Context(), testdb, &networks.Mainnet, nil)
 	require.NoError(t, err)
 
 	require.NoError(t, testdb.Update(func(txn db.IndexedBatch) error {
@@ -192,9 +193,9 @@ func TestCalculateBlockCommitments(t *testing.T) {
 	testdb := memory.New()
 	state := NewTestState(
 		testdb,
-		&utils.Mainnet,
+		&networks.Mainnet,
 	)
-	client := feeder.NewTestClient(t, &utils.Mainnet)
+	client := feeder.NewTestClient(t, &networks.Mainnet)
 	gw := adaptfeeder.New(client)
 
 	for i := range uint64(3) {
@@ -206,7 +207,7 @@ func TestCalculateBlockCommitments(t *testing.T) {
 	}
 
 	require.NoError(t, testdb.Update(func(txn db.IndexedBatch) error {
-		return calculateBlockCommitments(txn, &utils.Mainnet)
+		return calculateBlockCommitments(txn, &networks.Mainnet)
 	}))
 	for i := range uint64(3) {
 		b, err := core.GetBlockCommitmentByBlockNum(testdb, i)
@@ -219,9 +220,9 @@ func TestL1HandlerTxns(t *testing.T) {
 	testdb := memory.New()
 	state := NewTestState(
 		testdb,
-		&utils.Sepolia,
+		&networks.Sepolia,
 	)
-	client := feeder.NewTestClient(t, &utils.Sepolia)
+	client := feeder.NewTestClient(t, &networks.Sepolia)
 	gw := adaptfeeder.New(client)
 
 	for i := range uint64(7) { // First l1 handler txn is in block 6
@@ -245,7 +246,7 @@ func TestL1HandlerTxns(t *testing.T) {
 
 	// Recalculate and store the L1 message hashes
 	require.NoError(t, testdb.Update(func(txn db.IndexedBatch) error {
-		return calculateL1MsgHashes2(txn, &utils.Sepolia)
+		return calculateL1MsgHashes2(txn, &networks.Sepolia)
 	}))
 
 	msgHash = common.HexToHash("0x42e76df4e3d5255262929c27132bd0d295a8d3db2cfe63d2fcd061c7a7a7ab34")
@@ -265,7 +266,7 @@ func TestMigrateTrieRootKeysFromBitsetToTrieKeys(t *testing.T) {
 	err = memTxn.Put(key, bsBytes)
 	require.NoError(t, err)
 
-	require.NoError(t, migrateTrieRootKeysFromBitsetToTrieKeys(memTxn, key, bsBytes, &utils.Mainnet))
+	require.NoError(t, migrateTrieRootKeysFromBitsetToTrieKeys(memTxn, key, bsBytes, &networks.Mainnet))
 
 	var trieKey trie.BitArray
 	err = memTxn.Get(key, trieKey.UnmarshalBinary)
@@ -332,7 +333,7 @@ func TestMigrateCairo1CompiledClass(t *testing.T) {
 		err = txn.Put(key, classBytes)
 		require.NoError(t, err)
 
-		require.NoError(t, migrateCairo1CompiledClass2(txn, key, classBytes, &utils.Mainnet))
+		require.NoError(t, migrateCairo1CompiledClass2(txn, key, classBytes, &networks.Mainnet))
 
 		var actualDeclared core.DeclaredClassDefinition
 		err = txn.Get(key, func(data []byte) error {
@@ -383,7 +384,7 @@ func TestMigrateTrieNodesFromBitsetToBitArray(t *testing.T) {
 	err = memTxn.Put(nodeKey, nodeBytes.Bytes())
 	require.NoError(t, err)
 
-	require.NoError(t, migrator(memTxn, nodeKey, nodeBytes.Bytes(), &utils.Mainnet))
+	require.NoError(t, migrator(memTxn, nodeKey, nodeBytes.Bytes(), &networks.Mainnet))
 
 	err = memTxn.Get(db.ClassesTrie.Key(bsBytes), func([]byte) error { return nil })
 	require.ErrorIs(t, err, db.ErrKeyNotFound)
@@ -484,12 +485,12 @@ func TestSchemaMetadata(t *testing.T) {
 }
 
 type testMigration struct {
-	exec   func(context.Context, db.KeyValueStore, *utils.Network) ([]byte, error)
+	exec   func(context.Context, db.KeyValueStore, *networks.Network) ([]byte, error)
 	before func([]byte) error
 }
 
 func (f testMigration) Migrate(
-	ctx context.Context, database db.KeyValueStore, network *utils.Network, _ utils.StructuredLogger,
+	ctx context.Context, database db.KeyValueStore, network *networks.Network, _ utils.StructuredLogger,
 ) ([]byte, error) {
 	return f.exec(ctx, database, network)
 }
@@ -501,7 +502,7 @@ func TestMigrateIfNeeded(t *testing.T) {
 		testDB := memory.New()
 		migrations := []Migration{
 			testMigration{
-				exec: func(context.Context, db.KeyValueStore, *utils.Network) ([]byte, error) {
+				exec: func(context.Context, db.KeyValueStore, *networks.Network) ([]byte, error) {
 					return nil, errors.New("foo")
 				},
 				before: func([]byte) error {
@@ -513,7 +514,7 @@ func TestMigrateIfNeeded(t *testing.T) {
 			migrateIfNeeded(
 				t.Context(),
 				testDB,
-				&utils.Mainnet,
+				&networks.Mainnet,
 				utils.NewNopZapLogger(),
 				migrations,
 			),
@@ -526,7 +527,7 @@ func TestMigrateIfNeeded(t *testing.T) {
 		var counter int
 		migrations := []Migration{
 			testMigration{
-				exec: func(context.Context, db.KeyValueStore, *utils.Network) ([]byte, error) {
+				exec: func(context.Context, db.KeyValueStore, *networks.Network) ([]byte, error) {
 					if counter == 0 {
 						counter++
 						return nil, ErrCallWithNewTransaction
@@ -543,7 +544,7 @@ func TestMigrateIfNeeded(t *testing.T) {
 			migrateIfNeeded(
 				t.Context(),
 				testDB,
-				&utils.Mainnet,
+				&networks.Mainnet,
 				utils.NewNopZapLogger(),
 				migrations,
 			),
@@ -554,7 +555,7 @@ func TestMigrateIfNeeded(t *testing.T) {
 		testDB := memory.New()
 		migrations := []Migration{
 			testMigration{
-				exec: func(context.Context, db.KeyValueStore, *utils.Network) ([]byte, error) {
+				exec: func(context.Context, db.KeyValueStore, *networks.Network) ([]byte, error) {
 					return nil, errors.New("foo")
 				},
 				before: func([]byte) error {
@@ -567,7 +568,7 @@ func TestMigrateIfNeeded(t *testing.T) {
 			migrateIfNeeded(
 				t.Context(),
 				testDB,
-				&utils.Mainnet,
+				&networks.Mainnet,
 				utils.NewNopZapLogger(),
 				migrations,
 			),
@@ -579,7 +580,7 @@ func TestMigrateIfNeeded(t *testing.T) {
 		testDB := memory.New()
 		migrations := []Migration{
 			testMigration{
-				exec: func(context.Context, db.KeyValueStore, *utils.Network) ([]byte, error) {
+				exec: func(context.Context, db.KeyValueStore, *networks.Network) ([]byte, error) {
 					return nil, nil
 				},
 				before: func([]byte) error {
@@ -592,7 +593,7 @@ func TestMigrateIfNeeded(t *testing.T) {
 			migrateIfNeeded(
 				t.Context(),
 				testDB,
-				&utils.Mainnet,
+				&networks.Mainnet,
 				utils.NewNopZapLogger(),
 				migrations,
 			),
@@ -603,7 +604,7 @@ func TestMigrateIfNeeded(t *testing.T) {
 			migrateIfNeeded(
 				t.Context(),
 				testDB,
-				&utils.Mainnet,
+				&networks.Mainnet,
 				utils.NewNopZapLogger(),
 				[]Migration{},
 			),
@@ -616,7 +617,7 @@ func TestChangeStateDiffStructEmptyDB(t *testing.T) {
 	testdb := memory.New()
 	migrator := NewBucketMigrator(db.StateUpdatesByBlockNumber, changeStateDiffStruct2)
 	require.NoError(t, migrator.Before(nil))
-	intermediateState, err := migrator.Migrate(t.Context(), testdb, &utils.Mainnet, nil)
+	intermediateState, err := migrator.Migrate(t.Context(), testdb, &networks.Mainnet, nil)
 	require.NoError(t, err)
 	require.Nil(t, intermediateState)
 
@@ -689,7 +690,7 @@ func TestChangeStateDiffStruct(t *testing.T) {
 	// Migrate.
 	migrator := NewBucketMigrator(db.StateUpdatesByBlockNumber, changeStateDiffStruct2)
 	require.NoError(t, migrator.Before(nil))
-	intermediateState, err := migrator.Migrate(t.Context(), testdb, &utils.Mainnet, nil)
+	intermediateState, err := migrator.Migrate(t.Context(), testdb, &networks.Mainnet, nil)
 	require.NoError(t, err)
 	require.Nil(t, intermediateState)
 

--- a/migration/deprecated/migration_pkg_test.go
+++ b/migration/deprecated/migration_pkg_test.go
@@ -266,7 +266,15 @@ func TestMigrateTrieRootKeysFromBitsetToTrieKeys(t *testing.T) {
 	err = memTxn.Put(key, bsBytes)
 	require.NoError(t, err)
 
-	require.NoError(t, migrateTrieRootKeysFromBitsetToTrieKeys(memTxn, key, bsBytes, &networks.Mainnet))
+	require.NoError(
+		t,
+		migrateTrieRootKeysFromBitsetToTrieKeys(
+			memTxn,
+			key,
+			bsBytes,
+			&networks.Mainnet,
+		),
+	)
 
 	var trieKey trie.BitArray
 	err = memTxn.Get(key, trieKey.UnmarshalBinary)
@@ -490,7 +498,10 @@ type testMigration struct {
 }
 
 func (f testMigration) Migrate(
-	ctx context.Context, database db.KeyValueStore, network *networks.Network, _ utils.StructuredLogger,
+	ctx context.Context,
+	database db.KeyValueStore,
+	network *networks.Network,
+	_ utils.StructuredLogger,
 ) ([]byte, error) {
 	return f.exec(ctx, database, network)
 }

--- a/migration/deprecated/migration_test.go
+++ b/migration/deprecated/migration_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"testing"
 
+	"github.com/NethermindEth/juno/blockchain/networks"
 	"github.com/NethermindEth/juno/db/memory"
 	"github.com/NethermindEth/juno/migration/deprecated"
 	"github.com/NethermindEth/juno/utils"
@@ -21,7 +22,7 @@ func TestMigrateIfNeeded(t *testing.T) {
 			deprecated.MigrateIfNeeded(
 				ctx,
 				testDB,
-				&utils.Mainnet,
+				&networks.Mainnet,
 				utils.NewNopZapLogger(),
 			),
 			ctx.Err())
@@ -38,7 +39,7 @@ func TestMigrateIfNeeded(t *testing.T) {
 			deprecated.MigrateIfNeeded(
 				t.Context(),
 				testDB,
-				&utils.Mainnet,
+				&networks.Mainnet,
 				utils.NewNopZapLogger(),
 			),
 		)
@@ -55,7 +56,7 @@ func TestMigrateIfNeeded(t *testing.T) {
 			deprecated.MigrateIfNeeded(
 				t.Context(),
 				testDB,
-				&utils.Mainnet,
+				&networks.Mainnet,
 				utils.NewNopZapLogger(),
 			),
 		)

--- a/migration/deprecated/state_test.go
+++ b/migration/deprecated/state_test.go
@@ -4,12 +4,12 @@ import (
 	"errors"
 	"fmt"
 
+	"github.com/NethermindEth/juno/blockchain/networks"
 	"github.com/NethermindEth/juno/core"
 	"github.com/NethermindEth/juno/core/deprecatedstate"
 	"github.com/NethermindEth/juno/core/felt"
 	"github.com/NethermindEth/juno/db"
 	"github.com/NethermindEth/juno/migration/blocktransactions/txlayout"
-	"github.com/NethermindEth/juno/utils"
 )
 
 // testStateBackend is a copy of the [statebackend.deprecatedStateBackend] type
@@ -21,13 +21,13 @@ import (
 // [testStateBackend] was created specifically to solve this problem.
 type testStateBackend struct {
 	database db.KeyValueStore
-	network  *utils.Network
+	network  *networks.Network
 }
 
 // NewTestState creates a new test state that stores the data using the old layout.
 func NewTestState(
 	database db.KeyValueStore,
-	network *utils.Network,
+	network *networks.Network,
 ) *testStateBackend {
 	return &testStateBackend{
 		database: database,

--- a/migration/registry_test.go
+++ b/migration/registry_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"testing"
 
+	"github.com/NethermindEth/juno/blockchain/networks"
 	"github.com/NethermindEth/juno/db"
 	"github.com/NethermindEth/juno/migration"
 	"github.com/NethermindEth/juno/utils"
@@ -29,7 +30,7 @@ func (m *mockMigration) Before(intermediateState []byte) error {
 func (m *mockMigration) Migrate(
 	ctx context.Context,
 	database db.KeyValueStore,
-	network *utils.Network,
+	network *networks.Network,
 	log utils.StructuredLogger,
 ) ([]byte, error) {
 	m.migrateCalled = true

--- a/migration/runner.go
+++ b/migration/runner.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 
+	"github.com/NethermindEth/juno/blockchain/networks"
 	"github.com/NethermindEth/juno/db"
 	"github.com/NethermindEth/juno/utils"
 	"go.uber.org/zap"
@@ -44,7 +45,7 @@ type Migration interface {
 	Migrate(
 		ctx context.Context,
 		database db.KeyValueStore,
-		network *utils.Network,
+		network *networks.Network,
 		log utils.StructuredLogger,
 	) ([]byte, error)
 }
@@ -54,7 +55,7 @@ type MigrationRunner struct {
 	targetVersion SchemaVersion
 	metadata      SchemaMetadata
 	database      db.KeyValueStore
-	network       *utils.Network
+	network       *networks.Network
 	log           utils.StructuredLogger
 }
 
@@ -68,7 +69,7 @@ type MigrationRunner struct {
 func NewRunner(
 	registry *Registry,
 	database db.KeyValueStore,
-	network *utils.Network,
+	network *networks.Network,
 	log utils.StructuredLogger,
 ) (*MigrationRunner, error) {
 	metadata, err := GetSchemaMetadata(database)

--- a/migration/runner_test.go
+++ b/migration/runner_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/NethermindEth/juno/blockchain/networks"
 	"github.com/NethermindEth/juno/db"
 	"github.com/NethermindEth/juno/db/memory"
 	"github.com/NethermindEth/juno/migration"
@@ -32,7 +33,7 @@ func (m *cancellableMockMigration) Before(intermediateState []byte) error {
 func (m *cancellableMockMigration) Migrate(
 	ctx context.Context,
 	database db.KeyValueStore,
-	network *utils.Network,
+	network *networks.Network,
 	log utils.StructuredLogger,
 ) ([]byte, error) {
 	m.migrateCalled = true
@@ -74,7 +75,7 @@ func createRunner(
 	runner, err := migration.NewRunner(
 		registry,
 		testDB,
-		&utils.Mainnet,
+		&networks.Mainnet,
 		utils.NewNopZapLogger(),
 	)
 	require.NoError(t, err)
@@ -123,7 +124,7 @@ func TestNewRunner(t *testing.T) {
 		runner, err := migration.NewRunner(
 			registry,
 			testDB,
-			&utils.Mainnet,
+			&networks.Mainnet,
 			utils.NewNopZapLogger(),
 		)
 		require.Error(t, err)
@@ -149,7 +150,7 @@ func TestNewRunner(t *testing.T) {
 		runner, err := migration.NewRunner(
 			registry,
 			testDB,
-			&utils.Mainnet,
+			&networks.Mainnet,
 			utils.NewNopZapLogger(),
 		)
 		require.Error(t, err)

--- a/mocks/mock_blockchain.go
+++ b/mocks/mock_blockchain.go
@@ -13,10 +13,10 @@ import (
 	reflect "reflect"
 
 	blockchain "github.com/NethermindEth/juno/blockchain"
+	"github.com/NethermindEth/juno/blockchain/networks"
 	core "github.com/NethermindEth/juno/core"
 	felt "github.com/NethermindEth/juno/core/felt"
 	pending "github.com/NethermindEth/juno/core/pending"
-	utils "github.com/NethermindEth/juno/utils"
 	common "github.com/ethereum/go-ethereum/common"
 	gomock "go.uber.org/mock/gomock"
 )
@@ -258,10 +258,10 @@ func (mr *MockReaderMockRecorder) L1Head() *gomock.Call {
 }
 
 // Network mocks base method.
-func (m *MockReader) Network() *utils.Network {
+func (m *MockReader) Network() *networks.Network {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Network")
-	ret0, _ := ret[0].(*utils.Network)
+	ret0, _ := ret[0].(*networks.Network)
 	return ret0
 }
 

--- a/node/node.go
+++ b/node/node.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/Masterminds/semver/v3"
 	"github.com/NethermindEth/juno/blockchain"
+	"github.com/NethermindEth/juno/blockchain/networks"
 	"github.com/NethermindEth/juno/builder"
 	"github.com/NethermindEth/juno/clients/feeder"
 	"github.com/NethermindEth/juno/clients/gateway"
@@ -59,30 +60,30 @@ const (
 
 // Config is the top-level juno configuration.
 type Config struct {
-	LogLevel                 string        `mapstructure:"log-level"`
-	LogJSON                  bool          `mapstructure:"log-json"`
-	HTTP                     bool          `mapstructure:"http"`
-	HTTPHost                 string        `mapstructure:"http-host"`
-	HTTPPort                 uint16        `mapstructure:"http-port"`
-	RPCCorsEnable            bool          `mapstructure:"rpc-cors-enable"`
-	Websocket                bool          `mapstructure:"ws"`
-	WebsocketHost            string        `mapstructure:"ws-host"`
-	WebsocketPort            uint16        `mapstructure:"ws-port"`
-	GRPC                     bool          `mapstructure:"grpc"`
-	GRPCHost                 string        `mapstructure:"grpc-host"`
-	GRPCPort                 uint16        `mapstructure:"grpc-port"`
-	DatabasePath             string        `mapstructure:"db-path"`
-	Network                  utils.Network `mapstructure:"network"`
-	EthNode                  string        `mapstructure:"eth-node"`
-	DisableL1Verification    bool          `mapstructure:"disable-l1-verification"`
-	Pprof                    bool          `mapstructure:"pprof"`
-	PprofHost                string        `mapstructure:"pprof-host"`
-	PprofPort                uint16        `mapstructure:"pprof-port"`
-	Colour                   bool          `mapstructure:"colour"`
-	PreLatestPollInterval    time.Duration `mapstructure:"prelatest-poll-interval"`
-	PreConfirmedPollInterval time.Duration `mapstructure:"preconfirmed-poll-interval"`
-	RemoteDB                 string        `mapstructure:"remote-db"`
-	VersionedConstantsFile   string        `mapstructure:"versioned-constants-file"`
+	LogLevel                 string           `mapstructure:"log-level"`
+	LogJSON                  bool             `mapstructure:"log-json"`
+	HTTP                     bool             `mapstructure:"http"`
+	HTTPHost                 string           `mapstructure:"http-host"`
+	HTTPPort                 uint16           `mapstructure:"http-port"`
+	RPCCorsEnable            bool             `mapstructure:"rpc-cors-enable"`
+	Websocket                bool             `mapstructure:"ws"`
+	WebsocketHost            string           `mapstructure:"ws-host"`
+	WebsocketPort            uint16           `mapstructure:"ws-port"`
+	GRPC                     bool             `mapstructure:"grpc"`
+	GRPCHost                 string           `mapstructure:"grpc-host"`
+	GRPCPort                 uint16           `mapstructure:"grpc-port"`
+	DatabasePath             string           `mapstructure:"db-path"`
+	Network                  networks.Network `mapstructure:"network"`
+	EthNode                  string           `mapstructure:"eth-node"`
+	DisableL1Verification    bool             `mapstructure:"disable-l1-verification"`
+	Pprof                    bool             `mapstructure:"pprof"`
+	PprofHost                string           `mapstructure:"pprof-host"`
+	PprofPort                uint16           `mapstructure:"pprof-port"`
+	Colour                   bool             `mapstructure:"colour"`
+	PreLatestPollInterval    time.Duration    `mapstructure:"prelatest-poll-interval"`
+	PreConfirmedPollInterval time.Duration    `mapstructure:"preconfirmed-poll-interval"`
+	RemoteDB                 string           `mapstructure:"remote-db"`
+	VersionedConstantsFile   string           `mapstructure:"versioned-constants-file"`
 
 	Sequencer      bool   `mapstructure:"seq-enable"`
 	SeqBlockTime   uint   `mapstructure:"seq-block-time"`
@@ -251,14 +252,14 @@ func New(cfg *Config, version string, logLevel *utils.LogLevel) (*Node, error) {
 	if cfg.Sequencer {
 		// Sequencer mode only supports known networks and
 		// uses default fee tokens (custom networks not supported yet)
-		if !slices.Contains(utils.KnownNetworkNames, cfg.Network.Name) {
+		if !slices.Contains(networks.KnownNetworkNames, cfg.Network.Name) {
 			return nil, fmt.Errorf("custom networks are not supported in sequencer mode yet")
 		}
 		pKey, kErr := ecdsa.GenerateKey(rand.Reader) // Todo: currently private key changes with every sequencer run
 		if kErr != nil {
 			return nil, kErr
 		}
-		feeTokens := utils.DefaultFeeTokenAddresses
+		feeTokens := networks.DefaultFeeTokenAddresses
 		chainInfo := vm.ChainInfo{
 			ChainID:           cfg.Network.L2ChainID,
 			FeeTokenAddresses: feeTokens,
@@ -292,8 +293,8 @@ func New(cfg *Config, version string, logLevel *utils.LogLevel) (*Node, error) {
 			WithAPIKey(cfg.GatewayAPIKey)
 
 		// Handle fee tokens for custom networks
-		feeTokens := utils.DefaultFeeTokenAddresses
-		if !slices.Contains(utils.KnownNetworkNames, cfg.Network.Name) {
+		feeTokens := networks.DefaultFeeTokenAddresses
+		if !slices.Contains(networks.KnownNetworkNames, cfg.Network.Name) {
 			// For custom networks, fetch fee tokens from the gateway
 			feeTokens, err = client.FeeTokenAddresses(context.Background())
 			if err != nil {
@@ -325,8 +326,8 @@ func New(cfg *Config, version string, logLevel *utils.LogLevel) (*Node, error) {
 			WithAPIKey(cfg.GatewayAPIKey)
 
 		if cfg.P2P {
-			if cfg.Network == utils.Mainnet {
-				return nil, fmt.Errorf("P2P cannot be used on %v network", utils.Mainnet)
+			if cfg.Network == networks.Mainnet {
+				return nil, fmt.Errorf("P2P cannot be used on %v network", networks.Mainnet)
 			}
 			log.Warn("P2P features enabled. Please note P2P is in experimental stage")
 
@@ -599,11 +600,11 @@ func (n *Node) Run(ctx context.Context) {
 
 	if n.cfg.Sequencer {
 		// Custom networks are not supported in sequencer mode yet
-		if !slices.Contains(utils.KnownNetworkNames, n.cfg.Network.Name) {
+		if !slices.Contains(networks.KnownNetworkNames, n.cfg.Network.Name) {
 			n.log.Error("Custom networks are not supported in sequencer mode yet")
 			return
 		}
-		feeTokens := utils.DefaultFeeTokenAddresses
+		feeTokens := networks.DefaultFeeTokenAddresses
 		chainInfo := vm.ChainInfo{
 			ChainID:           n.cfg.Network.L2ChainID,
 			FeeTokenAddresses: feeTokens,

--- a/node/node_test.go
+++ b/node/node_test.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/NethermindEth/juno/blockchain"
+	"github.com/NethermindEth/juno/blockchain/networks"
 	"github.com/NethermindEth/juno/clients/feeder"
 	"github.com/NethermindEth/juno/db/pebblev2"
 	"github.com/NethermindEth/juno/node"
@@ -27,7 +28,7 @@ func TestNewNode(t *testing.T) {
 		GRPCPort:                           0,
 		DatabasePath:                       t.TempDir(),
 		DBCompression:                      "zstd",
-		Network:                            utils.Sepolia, // P2P will only work with Sepolia (for the time being)
+		Network:                            networks.Sepolia, // P2P will only work with Sepolia (for the time being)
 		EthNode:                            "",
 		DisableL1Verification:              true,
 		Pprof:                              true,
@@ -53,9 +54,9 @@ func TestNewNode(t *testing.T) {
 }
 
 func TestNetworkVerificationOnNonEmptyDB(t *testing.T) {
-	network := utils.Sepolia
+	network := networks.Sepolia
 	tests := map[string]struct {
-		network   utils.Network
+		network   networks.Network
 		errString string
 	}{
 		"same network": {
@@ -63,7 +64,7 @@ func TestNetworkVerificationOnNonEmptyDB(t *testing.T) {
 			errString: "",
 		},
 		"different network": {
-			network:   utils.Mainnet,
+			network:   networks.Mainnet,
 			errString: "unable to verify latest block hash; are the database and --network option compatible?",
 		},
 	}

--- a/node/node_test.go
+++ b/node/node_test.go
@@ -19,16 +19,17 @@ import (
 // Create a new node with all services enabled.
 func TestNewNode(t *testing.T) {
 	config := &node.Config{
-		LogLevel:                           "info",
-		HTTP:                               true,
-		HTTPPort:                           0,
-		Websocket:                          true,
-		WebsocketPort:                      0,
-		GRPC:                               true,
-		GRPCPort:                           0,
-		DatabasePath:                       t.TempDir(),
-		DBCompression:                      "zstd",
-		Network:                            networks.Sepolia, // P2P will only work with Sepolia (for the time being)
+		LogLevel:      "info",
+		HTTP:          true,
+		HTTPPort:      0,
+		Websocket:     true,
+		WebsocketPort: 0,
+		GRPC:          true,
+		GRPCPort:      0,
+		DatabasePath:  t.TempDir(),
+		DBCompression: "zstd",
+		// P2P will only work with Sepolia (for the time being)
+		Network:                            networks.Sepolia,
 		EthNode:                            "",
 		DisableL1Verification:              true,
 		Pprof:                              true,

--- a/p2p/dht/dht.go
+++ b/p2p/dht/dht.go
@@ -5,8 +5,8 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/NethermindEth/juno/blockchain/networks"
 	"github.com/NethermindEth/juno/p2p/starknetp2p"
-	"github.com/NethermindEth/juno/utils"
 	dht "github.com/libp2p/go-libp2p-kad-dht"
 	"github.com/libp2p/go-libp2p/core/host"
 	"github.com/libp2p/go-libp2p/core/peer"
@@ -15,7 +15,7 @@ import (
 func New(
 	ctx context.Context,
 	host host.Host,
-	network *utils.Network,
+	network *networks.Network,
 	starknetProtocol starknetp2p.Protocol,
 	bootstrapPeersFn func() []peer.AddrInfo,
 ) (*dht.IpfsDHT, error) {

--- a/p2p/p2p.go
+++ b/p2p/p2p.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/Masterminds/semver/v3"
 	"github.com/NethermindEth/juno/blockchain"
+	"github.com/NethermindEth/juno/blockchain/networks"
 	"github.com/NethermindEth/juno/db"
 	"github.com/NethermindEth/juno/p2p/dht"
 	"github.com/NethermindEth/juno/p2p/server"
@@ -41,7 +42,7 @@ const (
 type Service struct {
 	host host.Host
 
-	network *utils.Network
+	network *networks.Network
 	server  *server.Server
 	log     utils.StructuredLogger
 
@@ -61,7 +62,7 @@ func New(
 	privKeyStr string,
 	feederNode bool,
 	bc *blockchain.Blockchain,
-	snNetwork *utils.Network,
+	snNetwork *networks.Network,
 	log utils.StructuredLogger,
 	database db.KeyValueStore,
 	compiler compiler.Compiler,
@@ -131,7 +132,7 @@ func NewWithHost(
 	peers string,
 	feederNode bool,
 	bc *blockchain.Blockchain,
-	snNetwork *utils.Network,
+	snNetwork *networks.Network,
 	log utils.StructuredLogger,
 	database db.KeyValueStore,
 	compiler compiler.Compiler,

--- a/p2p/p2p_test.go
+++ b/p2p/p2p_test.go
@@ -3,6 +3,7 @@ package p2p_test
 import (
 	"testing"
 
+	"github.com/NethermindEth/juno/blockchain/networks"
 	"github.com/NethermindEth/juno/db"
 	"github.com/NethermindEth/juno/db/memory"
 	"github.com/NethermindEth/juno/p2p"
@@ -21,7 +22,7 @@ func TestInvalidKey(t *testing.T) {
 		"something",
 		false,
 		nil,
-		&utils.Integration,
+		&networks.Integration,
 		utils.NewNopZapLogger(),
 		nil,
 		nil,
@@ -57,7 +58,7 @@ func TestLoadAndPersistPeers(t *testing.T) {
 		"5f6cdc3aebcc74af494df054876100368ef6126e3a33fa65b90c765b381ffc37a0a63bbeeefab0740f24a6a38dabb513b9233254ad0020c721c23e69bc820089",
 		false,
 		nil,
-		&utils.Integration,
+		&networks.Integration,
 		utils.NewNopZapLogger(),
 		testDB,
 		nil,

--- a/p2p/pubsub/pubsub.go
+++ b/p2p/pubsub/pubsub.go
@@ -4,9 +4,9 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/NethermindEth/juno/blockchain/networks"
 	"github.com/NethermindEth/juno/p2p/dht"
 	"github.com/NethermindEth/juno/p2p/starknetp2p"
-	"github.com/NethermindEth/juno/utils"
 	"github.com/libp2p/go-libp2p"
 	pubsub "github.com/libp2p/go-libp2p-pubsub"
 	"github.com/libp2p/go-libp2p/core/crypto"
@@ -38,7 +38,7 @@ func GetHost(hostPrivateKey crypto.PrivKey, hostAddress string) (host.Host, erro
 func Run(
 	ctx context.Context,
 	host host.Host,
-	network *utils.Network,
+	network *networks.Network,
 	starknetProtocol starknetp2p.Protocol,
 	bootstrapPeersFn func() []peer.AddrInfo,
 	pubSubQueueSize int,

--- a/p2p/pubsub/testutils/pubsub.go
+++ b/p2p/pubsub/testutils/pubsub.go
@@ -6,10 +6,10 @@ import (
 	"sync"
 	"testing"
 
+	"github.com/NethermindEth/juno/blockchain/networks"
 	"github.com/NethermindEth/juno/consensus/p2p/config"
 	"github.com/NethermindEth/juno/p2p/pubsub"
 	"github.com/NethermindEth/juno/p2p/starknetp2p"
-	"github.com/NethermindEth/juno/utils"
 	libp2p "github.com/libp2p/go-libp2p-pubsub"
 	"github.com/libp2p/go-libp2p/core/crypto"
 	"github.com/libp2p/go-libp2p/core/host"
@@ -81,7 +81,7 @@ func BuildNetworks(
 
 func (n Nodes) JoinTopic(
 	t *testing.T,
-	network *utils.Network,
+	network *networks.Network,
 	protocolID starknetp2p.Protocol,
 	topicName string,
 ) []*libp2p.Topic {

--- a/p2p/starknetp2p/starknetp2p.go
+++ b/p2p/starknetp2p/starknetp2p.go
@@ -3,7 +3,7 @@ package starknetp2p
 import (
 	"fmt"
 
-	"github.com/NethermindEth/juno/utils"
+	"github.com/NethermindEth/juno/blockchain/networks"
 	dht "github.com/libp2p/go-libp2p-kad-dht"
 	"github.com/libp2p/go-libp2p/core/protocol"
 )
@@ -28,7 +28,7 @@ const (
 	syncProtocolVersion = "0.1.0-rc.0"
 )
 
-func Sync(network *utils.Network, subProtocol SyncSubProtocol) protocol.ID {
+func Sync(network *networks.Network, subProtocol SyncSubProtocol) protocol.ID {
 	return protocol.ID(
 		fmt.Sprintf(
 			"/%s/%s/%s/%s/%s",
@@ -41,7 +41,7 @@ func Sync(network *utils.Network, subProtocol SyncSubProtocol) protocol.ID {
 	)
 }
 
-func DHT(network *utils.Network, starknetProtocol Protocol) []dht.Option {
+func DHT(network *networks.Network, starknetProtocol Protocol) []dht.Option {
 	return []dht.Option{
 		dht.ProtocolPrefix("/" + protocolPrefix),
 		dht.ProtocolExtension("/" + protocol.ID(network.L2ChainID)),

--- a/p2p/starknetp2p/starknetp2p_test.go
+++ b/p2p/starknetp2p/starknetp2p_test.go
@@ -4,24 +4,24 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/NethermindEth/juno/blockchain/networks"
 	"github.com/NethermindEth/juno/p2p/starknetp2p"
-	"github.com/NethermindEth/juno/utils"
 	"github.com/libp2p/go-libp2p"
 	dht "github.com/libp2p/go-libp2p-kad-dht"
 	"github.com/libp2p/go-libp2p/core/protocol"
 	"github.com/stretchr/testify/require"
 )
 
-var networks = []struct {
-	network *utils.Network
+var networkArr = []struct {
+	network *networks.Network
 	name    string
 }{
-	{&utils.Mainnet, "SN_MAIN"},
-	{&utils.Goerli, "SN_GOERLI"},
-	{&utils.Goerli2, "SN_GOERLI2"},
-	{&utils.Integration, "SN_GOERLI"},
-	{&utils.Sepolia, "SN_SEPOLIA"},
-	{&utils.SepoliaIntegration, "SN_INTEGRATION_SEPOLIA"},
+	{&networks.Mainnet, "SN_MAIN"},
+	{&networks.Goerli, "SN_GOERLI"},
+	{&networks.Goerli2, "SN_GOERLI2"},
+	{&networks.Integration, "SN_GOERLI"},
+	{&networks.Sepolia, "SN_SEPOLIA"},
+	{&networks.SepoliaIntegration, "SN_INTEGRATION_SEPOLIA"},
 }
 
 func TestSync(t *testing.T) {
@@ -36,7 +36,7 @@ func TestSync(t *testing.T) {
 		{starknetp2p.EventsSyncSubProtocol, "events"},
 	}
 
-	for _, network := range networks {
+	for _, network := range networkArr {
 		for _, protocol := range subProtocols {
 			testName := fmt.Sprintf("Sub-protocol %s in network %s", protocol.name, network.name)
 			t.Run(testName, func(t *testing.T) {
@@ -60,7 +60,7 @@ func TestDHT(t *testing.T) {
 		{starknetp2p.SyncProtocolID, "sync"},
 	}
 
-	for _, network := range networks {
+	for _, network := range networkArr {
 		for _, p := range protocols {
 			testName := fmt.Sprintf("Protocol %s in network %s", p.name, network.name)
 			t.Run(testName, func(t *testing.T) {

--- a/p2p/sync/client.go
+++ b/p2p/sync/client.go
@@ -7,6 +7,7 @@ import (
 	"iter"
 	"time"
 
+	"github.com/NethermindEth/juno/blockchain/networks"
 	"github.com/NethermindEth/juno/db"
 	"github.com/NethermindEth/juno/p2p/starknetp2p"
 	"github.com/NethermindEth/juno/utils"
@@ -31,12 +32,12 @@ type NewStreamFunc func(ctx context.Context, pids ...protocol.ID) (network.Strea
 
 type Client struct {
 	newStream NewStreamFunc
-	network   *utils.Network
+	network   *networks.Network
 	log       utils.StructuredLogger
 }
 
 func NewClient(
-	newStream NewStreamFunc, snNetwork *utils.Network, log utils.StructuredLogger,
+	newStream NewStreamFunc, snNetwork *networks.Network, log utils.StructuredLogger,
 ) *Client {
 	return &Client{
 		newStream: newStream,

--- a/p2p/sync/sync.go
+++ b/p2p/sync/sync.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/NethermindEth/juno/adapters/p2p2core"
 	"github.com/NethermindEth/juno/blockchain"
+	"github.com/NethermindEth/juno/blockchain/networks"
 	"github.com/NethermindEth/juno/core"
 	"github.com/NethermindEth/juno/core/felt"
 	"github.com/NethermindEth/juno/db"
@@ -123,7 +124,7 @@ func (s *Service) logError(msg string, err error) {
 }
 
 type BlockFetcher struct {
-	network    *utils.Network
+	network    *networks.Network
 	client     *Client // todo: merge all the functionality of Client with p2p SyncService
 	blockchain *blockchain.Blockchain
 	compiler   compiler.Compiler
@@ -135,7 +136,7 @@ func NewBlockFetcher(
 	bc *blockchain.Blockchain,
 	compiler compiler.Compiler,
 	h host.Host,
-	n *utils.Network,
+	n *networks.Network,
 	log utils.StructuredLogger,
 ) BlockFetcher {
 	return BlockFetcher{

--- a/plugin/plugin_test.go
+++ b/plugin/plugin_test.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/NethermindEth/juno/blockchain"
+	"github.com/NethermindEth/juno/blockchain/networks"
 	"github.com/NethermindEth/juno/clients/feeder"
 	"github.com/NethermindEth/juno/core/felt"
 	"github.com/NethermindEth/juno/db/memory"
@@ -25,10 +26,10 @@ func TestPlugin(t *testing.T) {
 
 	plugin := mocks.NewMockJunoPlugin(mockCtrl)
 
-	mainClient := feeder.NewTestClient(t, &utils.Mainnet)
+	mainClient := feeder.NewTestClient(t, &networks.Mainnet)
 	mainGw := adaptfeeder.New(mainClient)
 
-	integClient := feeder.NewTestClient(t, &utils.Integration)
+	integClient := feeder.NewTestClient(t, &networks.Integration)
 	integGw := adaptfeeder.New(integClient)
 
 	testDB := memory.New()
@@ -39,7 +40,7 @@ func TestPlugin(t *testing.T) {
 		require.NoError(t, err)
 		plugin.EXPECT().NewBlock(block, su, gomock.Any())
 	}
-	bc := blockchain.New(testDB, &utils.Integration)
+	bc := blockchain.New(testDB, &networks.Integration)
 	dataSource := sync.NewFeederGatewayDataSource(bc, integGw)
 	synchronizer := sync.New(bc, dataSource, utils.NewNopZapLogger(), 0, 0, false, nil).WithPlugin(plugin)
 
@@ -48,7 +49,7 @@ func TestPlugin(t *testing.T) {
 	cancel()
 
 	t.Run("resync to mainnet with the same db", func(t *testing.T) {
-		bc := blockchain.New(testDB, &utils.Mainnet)
+		bc := blockchain.New(testDB, &networks.Mainnet)
 
 		// Ensure current head is Integration head
 		head, err := bc.HeadsHeader()

--- a/rpc/handlers.go
+++ b/rpc/handlers.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/NethermindEth/juno/blockchain"
+	"github.com/NethermindEth/juno/blockchain/networks"
 	"github.com/NethermindEth/juno/clients/feeder"
 	"github.com/NethermindEth/juno/core"
 	"github.com/NethermindEth/juno/feed"
@@ -28,7 +29,7 @@ type Handler struct {
 }
 
 func New(bcReader blockchain.Reader, syncReader sync.Reader, virtualMachine vm.VM, version string,
-	logger utils.Logger, network *utils.Network,
+	logger utils.Logger, network *networks.Network,
 ) *Handler {
 	handlerv8 := rpcv8.New(bcReader, syncReader, virtualMachine, logger)
 	handlerv9 := rpcv9.New(bcReader, syncReader, virtualMachine, logger)

--- a/rpc/v10/block_test.go
+++ b/rpc/v10/block_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/NethermindEth/juno/blockchain"
+	"github.com/NethermindEth/juno/blockchain/networks"
 	"github.com/NethermindEth/juno/clients/feeder"
 	"github.com/NethermindEth/juno/core"
 	"github.com/NethermindEth/juno/core/felt"
@@ -470,7 +471,7 @@ func TestBlockHashAndNumber(t *testing.T) {
 	mockCtrl := gomock.NewController(t)
 	t.Cleanup(mockCtrl.Finish)
 
-	n := &utils.Mainnet
+	n := &networks.Mainnet
 	mockReader := mocks.NewMockReader(mockCtrl)
 	handler := rpc.New(mockReader, nil, nil, nil)
 
@@ -506,7 +507,7 @@ func TestBlockTransactionCount(t *testing.T) {
 	mockCtrl := gomock.NewController(t)
 	t.Cleanup(mockCtrl.Finish)
 	mockSyncReader := mocks.NewMockSyncReader(mockCtrl)
-	n := new(utils.Sepolia)
+	n := new(networks.Sepolia)
 	mockReader := mocks.NewMockReader(mockCtrl)
 	log := utils.NewNopZapLogger()
 	handler := rpc.New(mockReader, mockSyncReader, nil, log)
@@ -624,7 +625,7 @@ func TestBlockWithTxHashes_ErrorCases(t *testing.T) {
 			t.Cleanup(mockCtrl.Finish)
 
 			log := utils.NewNopZapLogger()
-			n := &utils.Mainnet
+			n := &networks.Mainnet
 			chain := blockchain.New(memory.New(), n)
 			mockSyncReader := mocks.NewMockSyncReader(mockCtrl)
 			handler := rpc.New(chain, mockSyncReader, nil, log)
@@ -662,7 +663,7 @@ func TestBlockWithTxHashes_ErrorCases(t *testing.T) {
 }
 
 func TestBlockWithTxHashes(t *testing.T) {
-	network := &utils.Sepolia
+	network := &networks.Sepolia
 	client := feeder.NewTestClient(t, network)
 
 	block, commitments, stateUpdate := rpc.GetTestBlockWithCommitments(t, client, 56377)
@@ -753,7 +754,7 @@ func TestBlockWithTxs_ErrorCases(t *testing.T) {
 	for description, id := range errTests {
 		t.Run(description, func(t *testing.T) {
 			log := utils.NewNopZapLogger()
-			n := &utils.Mainnet
+			n := &networks.Mainnet
 			chain := blockchain.New(memory.New(), n)
 			mockSyncReader := mocks.NewMockSyncReader(mockCtrl)
 
@@ -793,14 +794,14 @@ func TestBlockWithTxs_ErrorCases(t *testing.T) {
 }
 
 func TestBlockWithTxs(t *testing.T) {
-	network := &utils.Mainnet
+	network := &networks.Mainnet
 	client := feeder.NewTestClient(t, network)
 
 	block, commitments, stateUpdate := rpc.GetTestBlockWithCommitments(t, client, 16697)
 
 	testCases := createBlockTestCases(block, commitments, stateUpdate)
 
-	clientSepolia := feeder.NewTestClient(t, &utils.Sepolia)
+	clientSepolia := feeder.NewTestClient(t, &networks.Sepolia)
 	blockWithProofFacts, commitmentsPF, stateUpdatePF := rpc.GetTestBlockWithCommitments(
 		t,
 		clientSepolia,
@@ -900,7 +901,7 @@ func TestBlockWithReceipts_ErrorCases(t *testing.T) {
 			t.Cleanup(mockCtrl.Finish)
 
 			log := utils.NewNopZapLogger()
-			n := &utils.Mainnet
+			n := &networks.Mainnet
 			chain := blockchain.New(memory.New(), n)
 			mockSyncReader := mocks.NewMockSyncReader(mockCtrl)
 			handler := rpc.New(chain, mockSyncReader, nil, log)
@@ -939,14 +940,14 @@ func TestBlockWithReceipts_ErrorCases(t *testing.T) {
 }
 
 func TestBlockWithReceipts(t *testing.T) {
-	network := &utils.Mainnet
+	network := &networks.Mainnet
 	client := feeder.NewTestClient(t, network)
 
 	block, commitments, stateUpdate := rpc.GetTestBlockWithCommitments(t, client, 16697)
 
 	testCases := createBlockTestCases(block, commitments, stateUpdate)
 
-	clientSepolia := feeder.NewTestClient(t, &utils.Sepolia)
+	clientSepolia := feeder.NewTestClient(t, &networks.Sepolia)
 	blockWithProofFacts, commitmentsPF, stateUpdatePF := rpc.GetTestBlockWithCommitments(
 		t,
 		clientSepolia,
@@ -999,7 +1000,7 @@ func TestRpcBlockAdaptation(t *testing.T) {
 	mockCtrl := gomock.NewController(t)
 	t.Cleanup(mockCtrl.Finish)
 
-	n := new(utils.Sepolia)
+	n := new(networks.Sepolia)
 	mockReader := mocks.NewMockReader(mockCtrl)
 	handler := rpc.New(mockReader, nil, nil, nil)
 
@@ -1033,7 +1034,7 @@ func TestRpcBlockAdaptation(t *testing.T) {
 }
 
 func TestBlockWithTxHashesV013(t *testing.T) {
-	network := new(utils.SepoliaIntegration)
+	network := new(networks.SepoliaIntegration)
 	blockNumber := uint64(16350)
 	client := feeder.NewTestClient(t, network)
 	block, commitments, stateUpdate := rpc.GetTestBlockWithCommitments(t, client, blockNumber)
@@ -1148,7 +1149,7 @@ func TestBlockWithTxsWithResponseFlags(t *testing.T) {
 	mockCtrl := gomock.NewController(t)
 	t.Cleanup(mockCtrl.Finish)
 
-	network := &utils.Sepolia
+	network := &networks.Sepolia
 	client := feeder.NewTestClient(t, network)
 	gw := adaptfeeder.New(client)
 
@@ -1249,7 +1250,7 @@ func TestBlockWithReceiptsWithResponseFlags(t *testing.T) {
 	mockCtrl := gomock.NewController(t)
 	t.Cleanup(mockCtrl.Finish)
 
-	network := &utils.Sepolia
+	network := &networks.Sepolia
 	client := feeder.NewTestClient(t, network)
 	gw := adaptfeeder.New(client)
 

--- a/rpc/v10/chain_test.go
+++ b/rpc/v10/chain_test.go
@@ -3,17 +3,17 @@ package rpcv10_test
 import (
 	"testing"
 
+	"github.com/NethermindEth/juno/blockchain/networks"
 	"github.com/NethermindEth/juno/mocks"
 	rpc "github.com/NethermindEth/juno/rpc/v10"
-	"github.com/NethermindEth/juno/utils"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
 )
 
 func TestChainId(t *testing.T) {
-	for _, n := range []utils.Network{
-		utils.Mainnet, utils.Sepolia, utils.SepoliaIntegration,
+	for _, n := range []networks.Network{
+		networks.Mainnet, networks.Sepolia, networks.SepoliaIntegration,
 	} {
 		t.Run(n.String(), func(t *testing.T) {
 			mockCtrl := gomock.NewController(t)

--- a/rpc/v10/class_test.go
+++ b/rpc/v10/class_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"testing"
 
+	"github.com/NethermindEth/juno/blockchain/networks"
 	"github.com/NethermindEth/juno/clients/feeder"
 	"github.com/NethermindEth/juno/core"
 	"github.com/NethermindEth/juno/core/felt"
@@ -21,7 +22,7 @@ import (
 )
 
 func TestClass(t *testing.T) {
-	n := &utils.Integration
+	n := &networks.Integration
 	integrationClient := feeder.NewTestClient(t, n)
 	integGw := adaptfeeder.New(integrationClient)
 
@@ -101,7 +102,7 @@ func TestClass(t *testing.T) {
 }
 
 func TestClassAt(t *testing.T) {
-	n := &utils.Integration
+	n := &networks.Integration
 	integrationClient := feeder.NewTestClient(t, n)
 	integGw := adaptfeeder.New(integrationClient)
 

--- a/rpc/v10/compiled_casm_test.go
+++ b/rpc/v10/compiled_casm_test.go
@@ -5,6 +5,7 @@ import (
 	"math/big"
 	"testing"
 
+	"github.com/NethermindEth/juno/blockchain/networks"
 	clientFeeder "github.com/NethermindEth/juno/clients/feeder"
 	"github.com/NethermindEth/juno/core"
 	"github.com/NethermindEth/juno/core/felt"
@@ -14,7 +15,6 @@ import (
 	"github.com/NethermindEth/juno/rpc/rpccore"
 	rpc "github.com/NethermindEth/juno/rpc/v10"
 	"github.com/NethermindEth/juno/starknetdata/feeder"
-	"github.com/NethermindEth/juno/utils"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
@@ -49,7 +49,7 @@ func TestCompiledCasm(t *testing.T) {
 			"0x5f18f9cdc05da87f04e8e7685bd346fc029f977167d5b1b2b59f69a7dacbfc8",
 		)
 
-		cl := clientFeeder.NewTestClient(t, &utils.Sepolia)
+		cl := clientFeeder.NewTestClient(t, &networks.Sepolia)
 		fd := feeder.New(cl)
 
 		class, err := fd.Class(t.Context(), classHash)

--- a/rpc/v10/estimate_fee_test.go
+++ b/rpc/v10/estimate_fee_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"testing"
 
+	"github.com/NethermindEth/juno/blockchain/networks"
 	"github.com/NethermindEth/juno/core"
 	"github.com/NethermindEth/juno/core/felt"
 	"github.com/NethermindEth/juno/jsonrpc"
@@ -21,7 +22,7 @@ func TestEstimateFee(t *testing.T) {
 	mockCtrl := gomock.NewController(t)
 	defer mockCtrl.Finish()
 
-	n := &utils.Mainnet
+	n := &networks.Mainnet
 
 	mockReader := mocks.NewMockReader(mockCtrl)
 	mockReader.EXPECT().Network().Return(n).AnyTimes()

--- a/rpc/v10/events_test.go
+++ b/rpc/v10/events_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/NethermindEth/juno/blockchain"
+	"github.com/NethermindEth/juno/blockchain/networks"
 	"github.com/NethermindEth/juno/clients/feeder"
 	"github.com/NethermindEth/juno/core"
 	"github.com/NethermindEth/juno/core/felt"
@@ -172,7 +173,7 @@ func fetchAndStoreBlock(
 // setupTestChain sets up a test chain with the given number of blocks
 func setupTestChain(
 	t *testing.T,
-	network *utils.Network,
+	network *networks.Network,
 	numBlocks uint64,
 ) (*blockchain.Blockchain, *adaptfeeder.Feeder) {
 	t.Helper()
@@ -190,7 +191,7 @@ func setupTestChain(
 }
 
 func TestEvents(t *testing.T) {
-	network := utils.Sepolia
+	network := networks.Sepolia
 	numCanonicalBlocks := uint64(5)
 	chain, gw := setupTestChain(t, &network, numCanonicalBlocks)
 
@@ -592,7 +593,7 @@ func TestEvents(t *testing.T) {
 }
 
 func TestEvents_FilterWithLimit(t *testing.T) {
-	n := &utils.Sepolia
+	n := &networks.Sepolia
 	chain, _ := setupTestChain(t, n, uint64(6))
 
 	mockCtrl := gomock.NewController(t)
@@ -636,7 +637,7 @@ func TestEvents_FilterWithLimit(t *testing.T) {
 }
 
 func TestEvents_ChainProgressesWhilePaginating(t *testing.T) {
-	network := utils.Sepolia
+	network := networks.Sepolia
 	numCanonicalBlocks := uint64(5)
 	chain, gw := setupTestChain(t, &network, numCanonicalBlocks)
 

--- a/rpc/v10/handlers_test.go
+++ b/rpc/v10/handlers_test.go
@@ -3,12 +3,12 @@ package rpcv10_test
 import (
 	"testing"
 
+	"github.com/NethermindEth/juno/blockchain/networks"
 	"github.com/NethermindEth/juno/core"
 	"github.com/NethermindEth/juno/core/felt"
 	"github.com/NethermindEth/juno/mocks"
 	"github.com/NethermindEth/juno/node"
 	rpcv10 "github.com/NethermindEth/juno/rpc/v10"
-	"github.com/NethermindEth/juno/utils"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
@@ -28,7 +28,7 @@ func TestThrottledVMError(t *testing.T) {
 	t.Cleanup(mockCtrl.Finish)
 	mockSyncReader := mocks.NewMockSyncReader(mockCtrl)
 	mockReader := mocks.NewMockReader(mockCtrl)
-	mockReader.EXPECT().Network().Return(&utils.Mainnet).AnyTimes()
+	mockReader.EXPECT().Network().Return(&networks.Mainnet).AnyTimes()
 	mockVM := mocks.NewMockVM(mockCtrl)
 
 	throttledVM := node.NewThrottledVM(mockVM, 0, 0)

--- a/rpc/v10/l1_test.go
+++ b/rpc/v10/l1_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"testing"
 
+	"github.com/NethermindEth/juno/blockchain/networks"
 	"github.com/NethermindEth/juno/clients/feeder"
 	"github.com/NethermindEth/juno/core"
 	"github.com/NethermindEth/juno/core/felt"
@@ -12,7 +13,6 @@ import (
 	"github.com/NethermindEth/juno/mocks"
 	rpc "github.com/NethermindEth/juno/rpc/v10"
 	adaptfeeder "github.com/NethermindEth/juno/starknetdata/feeder"
-	"github.com/NethermindEth/juno/utils"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/stretchr/testify/require"
@@ -47,7 +47,7 @@ func TestGetMessageStatus(t *testing.T) {
 	require.NoError(t, json.Unmarshal(rawL1ReceiptSepolia, &l1TxnReceiptSepolia))
 
 	tests := map[string]struct {
-		network        utils.Network
+		network        networks.Network
 		l1TxnHash      common.Hash
 		msgs           []rpc.MsgStatus
 		msgHashes      []common.Hash
@@ -56,7 +56,7 @@ func TestGetMessageStatus(t *testing.T) {
 		l1HeadBlockNum uint64
 	}{
 		"mainnet 0.13.2.1": {
-			network: utils.Mainnet,
+			network: networks.Mainnet,
 			l1TxnHash: common.HexToHash(
 				"0x5780c6fe46f958a7ebf9308e6db16d819ff9e06b1e88f9e718c50cde10898f38",
 			),
@@ -76,7 +76,7 @@ func TestGetMessageStatus(t *testing.T) {
 			l1HeadBlockNum: 763498,
 		},
 		"sepolia 0.13.4": {
-			network: utils.Sepolia,
+			network: networks.Sepolia,
 			l1TxnHash: common.HexToHash(
 				"0xeafadb9958437ef43ce7ed19f8ac0c8071c18f4a55fd778cecc23d8b6f86026f",
 			),

--- a/rpc/v10/simulation.go
+++ b/rpc/v10/simulation.go
@@ -9,6 +9,7 @@ import (
 	"slices"
 	"strconv"
 
+	"github.com/NethermindEth/juno/blockchain/networks"
 	"github.com/NethermindEth/juno/core"
 	"github.com/NethermindEth/juno/core/felt"
 	"github.com/NethermindEth/juno/jsonrpc"
@@ -273,7 +274,7 @@ func checkTxHasResourceBounds(tx *BroadcastedTransaction) bool {
 func (h *Handler) prepareTransactions(
 	ctx context.Context,
 	transactions []BroadcastedTransaction,
-	network *utils.Network,
+	network *networks.Network,
 ) ([]core.Transaction, []core.ClassDefinition, []*felt.Felt, *jsonrpc.Error) {
 	txns := make([]core.Transaction, len(transactions))
 	var classes []core.ClassDefinition

--- a/rpc/v10/simulation_test.go
+++ b/rpc/v10/simulation_test.go
@@ -7,6 +7,7 @@ import (
 	"strconv"
 	"testing"
 
+	"github.com/NethermindEth/juno/blockchain/networks"
 	"github.com/NethermindEth/juno/core"
 	"github.com/NethermindEth/juno/core/felt"
 	"github.com/NethermindEth/juno/jsonrpc"
@@ -21,7 +22,7 @@ import (
 
 func TestSimulateTransactions(t *testing.T) {
 	t.Parallel()
-	n := &utils.Mainnet
+	n := &networks.Mainnet
 	headsHeader := &core.Header{
 		SequencerAddress: n.BlockHashMetaInfo.FallBackSequencerAddress,
 		L1GasPriceETH:    &felt.Zero,
@@ -185,7 +186,7 @@ func TestSimulateTransactions(t *testing.T) {
 
 func TestSimulateTransactionsShouldErrorWithoutSenderAddressOrResourceBounds(t *testing.T) {
 	t.Parallel()
-	n := &utils.Mainnet
+	n := &networks.Mainnet
 	headsHeader := &core.Header{
 		SequencerAddress: n.BlockHashMetaInfo.FallBackSequencerAddress,
 		L1GasPriceETH:    &felt.Zero,
@@ -399,7 +400,7 @@ func initialReadsTestCases() []initialReadsTestCase {
 
 func TestSimulateTransactionsWithReturnInitialReads(t *testing.T) {
 	t.Parallel()
-	n := &utils.Mainnet
+	n := &networks.Mainnet
 	headsHeader := &core.Header{
 		SequencerAddress: n.BlockHashMetaInfo.FallBackSequencerAddress,
 		L1GasPriceETH:    &felt.Zero,

--- a/rpc/v10/state_update_test.go
+++ b/rpc/v10/state_update_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/NethermindEth/juno/blockchain"
+	"github.com/NethermindEth/juno/blockchain/networks"
 	"github.com/NethermindEth/juno/clients/feeder"
 	"github.com/NethermindEth/juno/core"
 	"github.com/NethermindEth/juno/core/felt"
@@ -32,7 +33,7 @@ func TestStateUpdate_ErrorCases(t *testing.T) {
 	t.Cleanup(mockCtrl.Finish)
 	var mockSyncReader *mocks.MockSyncReader
 
-	n := &utils.Mainnet
+	n := &networks.Mainnet
 	for description, id := range errTests {
 		t.Run(description, func(t *testing.T) {
 			chain := blockchain.New(memory.New(), n)
@@ -54,7 +55,7 @@ func TestStateUpdate(t *testing.T) {
 	mockCtrl := gomock.NewController(t)
 	t.Cleanup(mockCtrl.Finish)
 
-	n := &utils.SepoliaIntegration
+	n := &networks.SepoliaIntegration
 
 	log := utils.NewNopZapLogger()
 	mockReader := mocks.NewMockReader(mockCtrl)
@@ -93,7 +94,7 @@ func TestStateUpdate(t *testing.T) {
 	})
 
 	t.Run("post v0.11.0", func(t *testing.T) {
-		integrationClient := feeder.NewTestClient(t, &utils.Integration)
+		integrationClient := feeder.NewTestClient(t, &networks.Integration)
 		integGw := adaptfeeder.New(integrationClient)
 
 		for name, height := range map[string]uint64{

--- a/rpc/v10/storage_test.go
+++ b/rpc/v10/storage_test.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/NethermindEth/juno/blockchain"
+	"github.com/NethermindEth/juno/blockchain/networks"
 	"github.com/NethermindEth/juno/clients/feeder"
 	"github.com/NethermindEth/juno/core"
 	"github.com/NethermindEth/juno/core/crypto"
@@ -1284,12 +1285,12 @@ func TestStorageProof_StorageRoots(t *testing.T) {
 	mockCtrl := gomock.NewController(t)
 	t.Cleanup(mockCtrl.Finish)
 
-	client := feeder.NewTestClient(t, &utils.Mainnet)
+	client := feeder.NewTestClient(t, &networks.Mainnet)
 	gw := adaptfeeder.New(client)
 
 	log := utils.NewNopZapLogger()
 	testDB := memory.New()
-	bc := blockchain.New(testDB, &utils.Mainnet)
+	bc := blockchain.New(testDB, &networks.Mainnet)
 	dataSource := sync.NewFeederGatewayDataSource(bc, gw)
 	synchronizer := sync.New(bc, dataSource, log, time.Duration(0), time.Duration(0), false, testDB)
 	ctx, cancel := context.WithTimeout(t.Context(), time.Second)

--- a/rpc/v10/subscriptions_test.go
+++ b/rpc/v10/subscriptions_test.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/NethermindEth/juno/adapters/sn2core"
 	"github.com/NethermindEth/juno/blockchain"
+	"github.com/NethermindEth/juno/blockchain/networks"
 	"github.com/NethermindEth/juno/clients/feeder"
 	"github.com/NethermindEth/juno/core"
 	"github.com/NethermindEth/juno/core/felt"
@@ -210,7 +211,7 @@ func TestSubscribeEventsInvalidInputs(t *testing.T) {
 func TestSubscribeEvents(t *testing.T) {
 	log := utils.NewNopZapLogger()
 
-	n := &utils.Sepolia
+	n := &networks.Sepolia
 	client := feeder.NewTestClient(t, n)
 	gw := adaptfeeder.New(client)
 
@@ -926,7 +927,7 @@ func TestSubscribeTxnStatus(t *testing.T) {
 		mockChain := mocks.NewMockReader(mockCtrl)
 		mockSyncer := mocks.NewMockSyncReader(mockCtrl)
 		handler := New(mockChain, mockSyncer, nil, log)
-		handler.WithFeeder(feeder.NewTestClient(t, &utils.SepoliaIntegration))
+		handler.WithFeeder(feeder.NewTestClient(t, &networks.SepoliaIntegration))
 		mockSyncer.EXPECT().PreConfirmed().Return(nil, db.ErrKeyNotFound).AnyTimes()
 		mockChain.EXPECT().HeadsHeader().Return(nil, db.ErrKeyNotFound).AnyTimes()
 		t.Run("reverted", func(t *testing.T) {
@@ -972,7 +973,7 @@ func TestSubscribeTxnStatus(t *testing.T) {
 		mockCtrl := gomock.NewController(t)
 		t.Cleanup(mockCtrl.Finish)
 
-		client := feeder.NewTestClient(t, &utils.SepoliaIntegration)
+		client := feeder.NewTestClient(t, &networks.SepoliaIntegration)
 		mockGateway := mocks.NewMockGateway(mockCtrl)
 		adapterFeeder := adaptfeeder.New(client)
 		mockChain := mocks.NewMockReader(mockCtrl)
@@ -1157,7 +1158,7 @@ func TestSubscribeTxnStatus(t *testing.T) {
 		mockCtrl := gomock.NewController(t)
 		t.Cleanup(mockCtrl.Finish)
 
-		client := feeder.NewTestClient(t, &utils.SepoliaIntegration)
+		client := feeder.NewTestClient(t, &networks.SepoliaIntegration)
 		adapterFeeder := adaptfeeder.New(client)
 		mockSyncer := mocks.NewMockSyncReader(mockCtrl)
 		handler := New(nil, mockSyncer, nil, log)
@@ -1225,7 +1226,7 @@ func TestSubscribeTxnStatus(t *testing.T) {
 		mockCtrl := gomock.NewController(t)
 		t.Cleanup(mockCtrl.Finish)
 
-		client := feeder.NewTestClient(t, &utils.SepoliaIntegration)
+		client := feeder.NewTestClient(t, &networks.SepoliaIntegration)
 		adapterFeeder := adaptfeeder.New(client)
 		mockSyncer := mocks.NewMockSyncReader(mockCtrl)
 		handler := New(nil, mockSyncer, nil, log)
@@ -1326,7 +1327,7 @@ func TestSubscribeNewHeadsErrorCases(t *testing.T) {
 
 func TestSubscribeNewHeads(t *testing.T) {
 	log := utils.NewNopZapLogger()
-	client := feeder.NewTestClient(t, &utils.Sepolia)
+	client := feeder.NewTestClient(t, &networks.Sepolia)
 	blockNumber1 := uint64(56377)
 	blockNumber2 := uint64(56378)
 	blockNumber3 := uint64(56379)
@@ -1372,7 +1373,7 @@ func TestSubscribeNewHeads(t *testing.T) {
 
 func TestSubscribeNewHeadsHistorical(t *testing.T) {
 	log := utils.NewNopZapLogger()
-	client := feeder.NewTestClient(t, &utils.Sepolia)
+	client := feeder.NewTestClient(t, &networks.Sepolia)
 	blockNumber1 := uint64(56377)
 	blockNumber2 := uint64(56378)
 	blockNumber3 := uint64(56379)
@@ -1420,7 +1421,7 @@ func TestSubscribeNewHeadsHistorical(t *testing.T) {
 
 func TestSubscribeNewHeadsReturnsReorgNotification(t *testing.T) {
 	log := utils.NewNopZapLogger()
-	client := feeder.NewTestClient(t, &utils.Sepolia)
+	client := feeder.NewTestClient(t, &networks.Sepolia)
 	blockNumber1 := uint64(56377)
 	block1, commitments1, stateUpdate1 := GetTestBlockWithCommitments(t, client, blockNumber1)
 
@@ -1471,7 +1472,7 @@ func TestSubscribeNewHeadsReturnsReorgNotification(t *testing.T) {
 
 func TestMultipleSubscribeNewHeadsAndUnsubscribe(t *testing.T) {
 	log := utils.NewNopZapLogger()
-	client := feeder.NewTestClient(t, &utils.Sepolia)
+	client := feeder.NewTestClient(t, &networks.Sepolia)
 	blockNumber1 := uint64(56377)
 	blockNumber2 := uint64(56378)
 
@@ -1542,7 +1543,7 @@ func TestSubscribeNewTransactions(t *testing.T) {
 	defer handlerWg.Wait()
 	defer handlerCancel()
 
-	n := &utils.Sepolia
+	n := &networks.Sepolia
 	client := feeder.NewTestClient(t, n)
 	gw := adaptfeeder.New(client)
 
@@ -2323,7 +2324,7 @@ func TestSubscribeTransactionReceipts(t *testing.T) {
 	defer handlerWg.Wait()
 	defer handlerCancel()
 
-	n := &utils.Sepolia
+	n := &networks.Sepolia
 	client := feeder.NewTestClient(t, n)
 	gw := adaptfeeder.New(client)
 

--- a/rpc/v10/trace.go
+++ b/rpc/v10/trace.go
@@ -9,6 +9,7 @@ import (
 	"strconv"
 
 	"github.com/NethermindEth/juno/blockchain"
+	"github.com/NethermindEth/juno/blockchain/networks"
 	"github.com/NethermindEth/juno/core"
 	"github.com/NethermindEth/juno/core/felt"
 	"github.com/NethermindEth/juno/core/pending"
@@ -579,7 +580,7 @@ func (h *Handler) buildBlockInfo(header *core.Header) (vm.BlockInfo, *jsonrpc.Er
 
 // shouldFetchTracesFromFeederGateway determines if
 // traces for a block should be fetched from the feeder gateway.
-func shouldFetchTracesFromFeederGateway(block *core.Block, network *utils.Network) (bool, error) {
+func shouldFetchTracesFromFeederGateway(block *core.Block, network *networks.Network) (bool, error) {
 	blockVer, err := core.ParseBlockVersion(block.ProtocolVersion)
 	if err != nil {
 		return false, err
@@ -593,7 +594,7 @@ func shouldFetchTracesFromFeederGateway(block *core.Block, network *utils.Networ
 	fetchFromFeederGW = fetchFromFeederGW ||
 		(block.Number >= 1943705 &&
 			block.Number <= 1952704 &&
-			*network == utils.Mainnet)
+			*network == networks.Mainnet)
 
 	return fetchFromFeederGW, nil
 }

--- a/rpc/v10/trace.go
+++ b/rpc/v10/trace.go
@@ -580,7 +580,10 @@ func (h *Handler) buildBlockInfo(header *core.Header) (vm.BlockInfo, *jsonrpc.Er
 
 // shouldFetchTracesFromFeederGateway determines if
 // traces for a block should be fetched from the feeder gateway.
-func shouldFetchTracesFromFeederGateway(block *core.Block, network *networks.Network) (bool, error) {
+func shouldFetchTracesFromFeederGateway(
+	block *core.Block,
+	network *networks.Network,
+) (bool, error) {
 	blockVer, err := core.ParseBlockVersion(block.ProtocolVersion)
 	if err != nil {
 		return false, err

--- a/rpc/v10/trace_test.go
+++ b/rpc/v10/trace_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	"github.com/NethermindEth/juno/blockchain"
+	"github.com/NethermindEth/juno/blockchain/networks"
 	"github.com/NethermindEth/juno/clients/feeder"
 	"github.com/NethermindEth/juno/core"
 	"github.com/NethermindEth/juno/core/felt"
@@ -100,7 +101,7 @@ func TestTraceFallback(t *testing.T) {
 			},
 		}
 
-		AssertTracedBlockTransactions(t, &utils.Integration, tests)
+		AssertTracedBlockTransactions(t, &networks.Integration, tests)
 	})
 
 	t.Run("Sepolia", func(t *testing.T) {
@@ -124,13 +125,13 @@ func TestTraceFallback(t *testing.T) {
 			},
 		}
 
-		AssertTracedBlockTransactions(t, &utils.Sepolia, tests)
+		AssertTracedBlockTransactions(t, &networks.Sepolia, tests)
 	})
 }
 
 func AssertTracedBlockTransactions(
 	t *testing.T,
-	n *utils.Network,
+	n *networks.Network,
 	tests map[string]expectedBlockTrace,
 ) {
 	t.Helper()
@@ -169,7 +170,7 @@ func AssertTracedBlockTransactions(
 			tracesResp, httpHeader, err := handler.TraceBlockTransactions(t.Context(), &blockID, nil)
 			require.Nil(t, err)
 			traces := tracesResp.Traces
-			if n == &utils.Sepolia && description == "newer block" {
+			if n == &networks.Sepolia && description == "newer block" {
 				// For the newer block test, we test 3 of the block traces (INVOKE, DEPLOY_ACCOUNT, DECLARE)
 				traces = []rpcv10.TracedBlockTransaction{traces[0], traces[7], traces[11]}
 			}
@@ -185,7 +186,7 @@ func TestTraceBlockTransactionsReturnsError(t *testing.T) {
 		mockCtrl := gomock.NewController(t)
 		mockReader := mocks.NewMockReader(mockCtrl)
 
-		network := utils.Sepolia
+		network := networks.Sepolia
 		client := feeder.NewTestClient(t, &network)
 		gateway := adaptfeeder.New(client)
 
@@ -322,7 +323,7 @@ func TestTraceTransaction(t *testing.T) {
 
 	mockReader := mocks.NewMockReader(mockCtrl)
 	mockSyncReader := mocks.NewMockSyncReader(mockCtrl)
-	mockReader.EXPECT().Network().Return(&utils.Mainnet).AnyTimes()
+	mockReader.EXPECT().Network().Return(&networks.Mainnet).AnyTimes()
 	mockVM := mocks.NewMockVM(mockCtrl)
 	handler := rpcv10.New(mockReader, mockSyncReader, mockVM, utils.NewNopZapLogger())
 
@@ -607,7 +608,7 @@ func TestTraceTransaction(t *testing.T) {
 	})
 
 	t.Run("reverted INVOKE tx from feeder", func(t *testing.T) {
-		n := &utils.Sepolia
+		n := &networks.Sepolia
 
 		handler := rpcv10.New(mockReader, mockSyncReader, mockVM, utils.NewNopZapLogger())
 
@@ -656,7 +657,7 @@ func TestTraceBlockTransactions(t *testing.T) {
 	for description, blockID := range errTests {
 		t.Run(description, func(t *testing.T) {
 			log := utils.NewNopZapLogger()
-			n := &utils.Mainnet
+			n := &networks.Mainnet
 			chain := blockchain.New(memory.New(), n)
 			handler := rpcv10.New(chain, nil, nil, log)
 
@@ -679,7 +680,7 @@ func TestTraceBlockTransactions(t *testing.T) {
 
 	mockCtrl := gomock.NewController(t)
 	t.Cleanup(mockCtrl.Finish)
-	n := &utils.Mainnet
+	n := &networks.Mainnet
 
 	mockReader := mocks.NewMockReader(mockCtrl)
 	mockSyncReader := mocks.NewMockSyncReader(mockCtrl)
@@ -1364,7 +1365,7 @@ func TestCall(t *testing.T) {
 
 func TestTraceBlockTransactionsWithReturnInitialReads(t *testing.T) {
 	t.Parallel()
-	n := &utils.Mainnet
+	n := &networks.Mainnet
 	headsHeader := &core.Header{
 		SequencerAddress: n.BlockHashMetaInfo.FallBackSequencerAddress,
 		L1GasPriceETH:    &felt.Zero,

--- a/rpc/v10/transaction.go
+++ b/rpc/v10/transaction.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 
 	"github.com/NethermindEth/juno/adapters/sn2core"
+	"github.com/NethermindEth/juno/blockchain/networks"
 	"github.com/NethermindEth/juno/core"
 	"github.com/NethermindEth/juno/core/felt"
 	"github.com/NethermindEth/juno/db"
@@ -44,7 +45,7 @@ func AdaptBroadcastedTransaction(
 	ctx context.Context,
 	compiler compiler.Compiler,
 	broadcastedTxn *BroadcastedTransaction,
-	network *utils.Network,
+	network *networks.Network,
 ) (core.Transaction, core.ClassDefinition, *felt.Felt, error) {
 	feederTxn := AdaptRPCTxToFeederTx(&broadcastedTxn.Transaction)
 

--- a/rpc/v10/transaction_test.go
+++ b/rpc/v10/transaction_test.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/NethermindEth/juno/adapters/sn2core"
+	"github.com/NethermindEth/juno/blockchain/networks"
 	"github.com/NethermindEth/juno/clients/feeder"
 	"github.com/NethermindEth/juno/clients/gateway"
 	"github.com/NethermindEth/juno/core"
@@ -37,7 +38,7 @@ var validate = rpcv10.Validator()
 // This allows us to use testdata blocks without fetching from a real gateway.
 func loadBlockFromFeederTestdata(
 	t *testing.T,
-	network *utils.Network,
+	network *networks.Network,
 	blockNumber uint64,
 ) *core.Block {
 	t.Helper()
@@ -99,14 +100,14 @@ func TestTransactionByHashNotFoundInPreConfirmedBlock(t *testing.T) {
 func TestTransactionByHash(t *testing.T) {
 	tests := map[string]struct {
 		hash           string
-		network        *utils.Network
+		network        *networks.Network
 		expected       string
 		responseFlags  rpcv10.ResponseFlags
 		withProofFacts bool
 	}{
 		"DECLARE v1": {
 			hash:    "0x1b4d9f09276629d496af1af8ff00173c11ff146affacb1b5c858d7aa89001ae",
-			network: &utils.Mainnet,
+			network: &networks.Mainnet,
 			expected: `{
 			"type": "DECLARE",
 			"transaction_hash": "0x1b4d9f09276629d496af1af8ff00173c11ff146affacb1b5c858d7aa89001ae",
@@ -124,7 +125,7 @@ func TestTransactionByHash(t *testing.T) {
 
 		"DECLARE v0": {
 			hash:    "0x222f8902d1eeea76fa2642a90e2411bfd71cffb299b3a299029e1937fab3fe4",
-			network: &utils.Mainnet,
+			network: &networks.Mainnet,
 			expected: `{
 				"transaction_hash": "0x222f8902d1eeea76fa2642a90e2411bfd71cffb299b3a299029e1937fab3fe4",
 				"type": "DECLARE",
@@ -138,7 +139,7 @@ func TestTransactionByHash(t *testing.T) {
 
 		"L1 Handler v0 with nonce": {
 			hash:    "0x537eacfd3c49166eec905daff61ff7feef9c133a049ea2135cb94eec840a4a8",
-			network: &utils.Mainnet,
+			network: &networks.Mainnet,
 			expected: `{
        "type": "L1_HANDLER",
        "transaction_hash": "0x537eacfd3c49166eec905daff61ff7feef9c133a049ea2135cb94eec840a4a8",
@@ -157,7 +158,7 @@ func TestTransactionByHash(t *testing.T) {
 		},
 		"L1 Handler v0 without nonce": {
 			hash:    "0x5d50b7020f7cf8033fd7d913e489f47edf74fbf3c8ada85be512c7baa6a2eab",
-			network: &utils.Mainnet,
+			network: &networks.Mainnet,
 			expected: `{
 				"type": "L1_HANDLER",
 				"transaction_hash":  "0x5d50b7020f7cf8033fd7d913e489f47edf74fbf3c8ada85be512c7baa6a2eab",
@@ -176,7 +177,7 @@ func TestTransactionByHash(t *testing.T) {
 
 		"Invoke v1": {
 			hash:    "0x2897e3cec3e24e4d341df26b8cf1ab84ea1c01a051021836b36c6639145b497",
-			network: &utils.Mainnet,
+			network: &networks.Mainnet,
 			expected: `{
        "type": "INVOKE",
        "transaction_hash": "0x2897e3cec3e24e4d341df26b8cf1ab84ea1c01a051021836b36c6639145b497",
@@ -212,7 +213,7 @@ func TestTransactionByHash(t *testing.T) {
 
 		"DEPLOY v0": {
 			hash:    "0x6486c6303dba2f364c684a2e9609211c5b8e417e767f37b527cda51e776e6f0",
-			network: &utils.Mainnet,
+			network: &networks.Mainnet,
 			expected: `{
        "type": "DEPLOY",
        "transaction_hash": "0x6486c6303dba2f364c684a2e9609211c5b8e417e767f37b527cda51e776e6f0",
@@ -231,7 +232,7 @@ func TestTransactionByHash(t *testing.T) {
 
 		"DEPLOY ACCOUNT v1": {
 			hash:    "0xd61fc89f4d1dc4dc90a014957d655d38abffd47ecea8e3fa762e3160f155f2",
-			network: &utils.Mainnet,
+			network: &networks.Mainnet,
 			expected: `{
        "type": "DEPLOY_ACCOUNT",
        "transaction_hash": "0xd61fc89f4d1dc4dc90a014957d655d38abffd47ecea8e3fa762e3160f155f2",
@@ -252,7 +253,7 @@ func TestTransactionByHash(t *testing.T) {
 
 		"INVOKE v0": {
 			hash:    "0xf1d99fb97509e0dfc425ddc2a8c5398b74231658ca58b6f8da92f39cb739e",
-			network: &utils.Mainnet,
+			network: &networks.Mainnet,
 			expected: `{
        "type": "INVOKE",
        "transaction_hash": "0xf1d99fb97509e0dfc425ddc2a8c5398b74231658ca58b6f8da92f39cb739e",
@@ -271,7 +272,7 @@ func TestTransactionByHash(t *testing.T) {
 		},
 		"DECLARE v3": {
 			hash:    "0x41d1f5206ef58a443e7d3d1ca073171ec25fa75313394318fc83a074a6631c3",
-			network: &utils.Integration,
+			network: &networks.Integration,
 			expected: `{
 		"transaction_hash": "0x41d1f5206ef58a443e7d3d1ca073171ec25fa75313394318fc83a074a6631c3",
 		"type": "DECLARE",
@@ -304,7 +305,7 @@ func TestTransactionByHash(t *testing.T) {
 		},
 		"INVOKE v3": {
 			hash:    "0x49728601e0bb2f48ce506b0cbd9c0e2a9e50d95858aa41463f46386dca489fd",
-			network: &utils.Integration,
+			network: &networks.Integration,
 			expected: `{
 				"type": "INVOKE",
 				"transaction_hash": "0x49728601e0bb2f48ce506b0cbd9c0e2a9e50d95858aa41463f46386dca489fd",
@@ -352,7 +353,7 @@ func TestTransactionByHash(t *testing.T) {
 		},
 		"DEPLOY ACCOUNT v3": {
 			hash:    "0x29fd7881f14380842414cdfdd8d6c0b1f2174f8916edcfeb1ede1eb26ac3ef0",
-			network: &utils.Integration,
+			network: &networks.Integration,
 			expected: `{
 				"transaction_hash": "0x29fd7881f14380842414cdfdd8d6c0b1f2174f8916edcfeb1ede1eb26ac3ef0",
 				"version": "0x3",
@@ -386,7 +387,7 @@ func TestTransactionByHash(t *testing.T) {
 		},
 		"INVOKE v3 without l1_data_gas": {
 			hash:    "0x2db07ed11b1f6c678de9fc19ef0dfb8e71631e1cff236a34e68f51528a21282",
-			network: &utils.Integration,
+			network: &networks.Integration,
 			expected: `{
 				"transaction_hash": "0x2db07ed11b1f6c678de9fc19ef0dfb8e71631e1cff236a34e68f51528a21282",
 				"version": "0x3",
@@ -442,7 +443,7 @@ func TestTransactionByHash(t *testing.T) {
 		},
 		"INVOKE v3 with response flags": {
 			hash:           "0x49728601e0bb2f48ce506b0cbd9c0e2a9e50d95858aa41463f46386dca489fd",
-			network:        &utils.Integration,
+			network:        &networks.Integration,
 			withProofFacts: true,
 			expected: `{
 				"type": "INVOKE",
@@ -493,7 +494,7 @@ func TestTransactionByHash(t *testing.T) {
 		},
 		"INVOKE v3 with response flags and no proof facts": {
 			hash:    "0x49728601e0bb2f48ce506b0cbd9c0e2a9e50d95858aa41463f46386dca489fd",
-			network: &utils.Integration,
+			network: &networks.Integration,
 			expected: `{
 				"type": "INVOKE",
 				"transaction_hash": "0x49728601e0bb2f48ce506b0cbd9c0e2a9e50d95858aa41463f46386dca489fd",
@@ -589,7 +590,7 @@ func TestTransactionByHash(t *testing.T) {
 }
 
 func TestTransactionByHash_PreConfirmedBlock(t *testing.T) {
-	gw := feeder.NewTestClient(t, &utils.SepoliaIntegration)
+	gw := feeder.NewTestClient(t, &networks.SepoliaIntegration)
 	adapterFeeder := adaptfeeder.New(gw)
 	mockCtrl := gomock.NewController(t)
 	t.Cleanup(mockCtrl.Finish)
@@ -645,7 +646,7 @@ func TestTransactionByHash_PreConfirmedBlock(t *testing.T) {
 func TestTransactionByBlockIdAndIndex(t *testing.T) {
 	mockCtrl := gomock.NewController(t)
 	t.Cleanup(mockCtrl.Finish)
-	n := &utils.Mainnet
+	n := &networks.Mainnet
 	mockReader := mocks.NewMockReader(mockCtrl)
 	mockSyncReader := mocks.NewMockSyncReader(mockCtrl)
 	client := feeder.NewTestClient(t, n)
@@ -815,7 +816,7 @@ func TestTransactionByBlockIdAndIndex(t *testing.T) {
 	})
 
 	t.Run("response flags", func(t *testing.T) {
-		network := &utils.Sepolia
+		network := &networks.Sepolia
 		client := feeder.NewTestClient(t, network)
 		gw := adaptfeeder.New(client)
 		txnHash := felt.NewUnsafeFromString[felt.Felt](
@@ -873,7 +874,7 @@ func TestTransactionByBlockIdAndIndex(t *testing.T) {
 func TestTransactionReceiptByHash(t *testing.T) {
 	type testCase struct {
 		description    string
-		network        *utils.Network
+		network        *networks.Network
 		expected       *rpcv10.TransactionReceipt
 		preConfirmedFn func(t *testing.T, block *core.Block) *pending.PreConfirmed
 		l1Head         core.L1Head
@@ -931,7 +932,7 @@ func TestTransactionReceiptByHash(t *testing.T) {
 	testCases := []testCase{
 		{
 			description: "receipt accepted on l2",
-			network:     &utils.Mainnet,
+			network:     &networks.Mainnet,
 			expected: readTestData[*rpcv10.TransactionReceipt](
 				t,
 				"transactions/receipt_accepted_on_l2.json",
@@ -941,7 +942,7 @@ func TestTransactionReceiptByHash(t *testing.T) {
 		},
 		{
 			description: "receipt accepted on l1",
-			network:     &utils.Mainnet,
+			network:     &networks.Mainnet,
 			expected: readTestData[*rpcv10.TransactionReceipt](
 				t,
 				"transactions/receipt_accepted_on_l1.json",
@@ -951,7 +952,7 @@ func TestTransactionReceiptByHash(t *testing.T) {
 		},
 		{
 			description: "receipt pre confirmed",
-			network:     &utils.Mainnet,
+			network:     &networks.Mainnet,
 			expected: readTestData[*rpcv10.TransactionReceipt](
 				t,
 				"transactions/receipt_pre_confirmed.json",
@@ -961,7 +962,7 @@ func TestTransactionReceiptByHash(t *testing.T) {
 		},
 		{
 			description: "receipt pre latest",
-			network:     &utils.Mainnet,
+			network:     &networks.Mainnet,
 			expected: readTestData[*rpcv10.TransactionReceipt](
 				t,
 				"transactions/receipt_pre_latest.json",
@@ -971,7 +972,7 @@ func TestTransactionReceiptByHash(t *testing.T) {
 		},
 		{
 			description: "receipt reverted",
-			network:     &utils.Integration,
+			network:     &networks.Integration,
 			expected: readTestData[*rpcv10.TransactionReceipt](
 				t,
 				"transactions/receipt_reverted.json",
@@ -981,7 +982,7 @@ func TestTransactionReceiptByHash(t *testing.T) {
 		},
 		{
 			description: "receipt invoke v3",
-			network:     &utils.Integration,
+			network:     &networks.Integration,
 			expected: readTestData[*rpcv10.TransactionReceipt](
 				t,
 				"transactions/receipt_invoke_v3.json",
@@ -991,7 +992,7 @@ func TestTransactionReceiptByHash(t *testing.T) {
 		},
 		{
 			description: "receipt non empty da",
-			network:     &utils.SepoliaIntegration,
+			network:     &networks.SepoliaIntegration,
 			expected: readTestData[*rpcv10.TransactionReceipt](
 				t,
 				"transactions/receipt_non_empty_da.json",
@@ -1001,7 +1002,7 @@ func TestTransactionReceiptByHash(t *testing.T) {
 		},
 		{
 			description: "receipt deploy",
-			network:     &utils.Mainnet,
+			network:     &networks.Mainnet,
 			expected: readTestData[*rpcv10.TransactionReceipt](
 				t,
 				"transactions/receipt_deploy.json",
@@ -1125,7 +1126,7 @@ func TestAddTransactionUnmarshal(t *testing.T) {
 }
 
 func TestAddTransaction(t *testing.T) {
-	n := &utils.Integration
+	n := &networks.Integration
 	gw := adaptfeeder.New(feeder.NewTestClient(t, n))
 	txWithoutClass := func(hash string) rpcv10.BroadcastedTransaction {
 		tx, err := gw.Transaction(t.Context(), felt.NewUnsafeFromString[felt.Felt](hash))
@@ -1553,7 +1554,7 @@ func TestAddTransaction(t *testing.T) {
 		t.Cleanup(mockCtrl.Finish)
 
 		mockReader := mocks.NewMockReader(mockCtrl)
-		n := &utils.Sepolia
+		n := &networks.Sepolia
 		mockReader.EXPECT().Network().Return(n).AnyTimes()
 
 		receivedTxFeed := feed.New[core.Transaction]()
@@ -1603,7 +1604,7 @@ func TestAddTransaction(t *testing.T) {
 }
 
 func TestTransactionStatus(t *testing.T) {
-	mainnetClient := feeder.NewTestClient(t, &utils.Mainnet)
+	mainnetClient := feeder.NewTestClient(t, &networks.Mainnet)
 	gw := adaptfeeder.New(mainnetClient)
 
 	block, err := gw.BlockLatest(t.Context())
@@ -1612,7 +1613,7 @@ func TestTransactionStatus(t *testing.T) {
 	targetTxnHash := tx.Hash()
 	type testCase struct {
 		description    string
-		network        *utils.Network
+		network        *networks.Network
 		txHash         *felt.Felt
 		expectedStatus rpcv10.TransactionStatus
 		expectedErr    *jsonrpc.Error
@@ -1658,7 +1659,7 @@ func TestTransactionStatus(t *testing.T) {
 	testCases := []testCase{
 		{
 			description: "status ACCEPTED_ON_L2",
-			network:     &utils.Mainnet,
+			network:     &networks.Mainnet,
 			txHash:      targetTxnHash,
 			expectedStatus: rpcv10.TransactionStatus{
 				Finality:  rpcv10.TxnStatusAcceptedOnL2,
@@ -1671,7 +1672,7 @@ func TestTransactionStatus(t *testing.T) {
 		},
 		{
 			description: "status ACCEPTED_ON_L1",
-			network:     &utils.Mainnet,
+			network:     &networks.Mainnet,
 			txHash:      targetTxnHash,
 			expectedStatus: rpcv10.TransactionStatus{
 				Finality:  rpcv10.TxnStatusAcceptedOnL1,
@@ -1684,7 +1685,7 @@ func TestTransactionStatus(t *testing.T) {
 		},
 		{
 			description: "status PRE_CONFIRMED",
-			network:     &utils.Mainnet,
+			network:     &networks.Mainnet,
 			txHash:      targetTxnHash,
 			expectedStatus: rpcv10.TransactionStatus{
 				Finality:  rpcv10.TxnStatusPreConfirmed,
@@ -1706,7 +1707,7 @@ func TestTransactionStatus(t *testing.T) {
 		},
 		{
 			description: "status CANDIDATE",
-			network:     &utils.Mainnet,
+			network:     &networks.Mainnet,
 			txHash:      targetTxnHash,
 			expectedStatus: rpcv10.TransactionStatus{
 				Finality:  rpcv10.TxnStatusCandidate,
@@ -1730,7 +1731,7 @@ func TestTransactionStatus(t *testing.T) {
 		},
 		{
 			description: "status PRE_CONFIRMED from pre-latest",
-			network:     &utils.Mainnet,
+			network:     &networks.Mainnet,
 			txHash:      targetTxnHash,
 			expectedStatus: rpcv10.TransactionStatus{
 				Finality:  rpcv10.TxnStatusPreConfirmed,
@@ -1756,7 +1757,7 @@ func TestTransactionStatus(t *testing.T) {
 		},
 		{
 			description: "not found localy - ACCEPTED_ON_L1 from feeder",
-			network:     &utils.Mainnet,
+			network:     &networks.Mainnet,
 			txHash: felt.NewUnsafeFromString[felt.Felt](
 				"0xf1d99fb97509e0dfc425ddc2a8c5398b74231658ca58b6f8da92f39cb739e",
 			),
@@ -1768,7 +1769,7 @@ func TestTransactionStatus(t *testing.T) {
 		},
 		{
 			description: "not found localy - ACCEPTED_ON_L2 from feeder",
-			network:     &utils.Mainnet,
+			network:     &networks.Mainnet,
 			txHash: felt.NewUnsafeFromString[felt.Felt](
 				"0x6c40890743aa220b10e5ee68cef694c5c23cc2defd0dbdf5546e687f9982ab1",
 			),
@@ -1780,7 +1781,7 @@ func TestTransactionStatus(t *testing.T) {
 		},
 		{
 			description: "transaction not found",
-			network:     &utils.Mainnet,
+			network:     &networks.Mainnet,
 			txHash:      felt.NewUnsafeFromString[felt.Felt]("0xFF00FF00"),
 			expectedErr: rpccore.ErrTxnHashNotFound,
 			setupMocks:  mockNotFound,
@@ -1789,7 +1790,7 @@ func TestTransactionStatus(t *testing.T) {
 			// RPCv10 does not have REJECTED status.
 			// For historical queries return not found error instead.
 			description: "REJECTED historical txn found in feeder",
-			network:     &utils.SepoliaIntegration,
+			network:     &networks.SepoliaIntegration,
 			txHash:      felt.NewUnsafeFromString[felt.Felt]("0x1111"),
 			expectedErr: rpccore.ErrTxnHashNotFound,
 			setupMocks:  mockNotFound,
@@ -1819,7 +1820,7 @@ func TestSubmittedTransactionsCache(t *testing.T) {
 	t.Cleanup(mockCtrl.Finish)
 
 	log := utils.NewNopZapLogger()
-	network := utils.Integration
+	network := networks.Integration
 
 	client := feeder.NewTestClient(t, &network)
 
@@ -1919,7 +1920,7 @@ func TestSubmittedTransactionsCache(t *testing.T) {
 }
 
 func TestAdaptBroadcastedTransactionValidation(t *testing.T) {
-	network := &utils.Sepolia
+	network := &networks.Sepolia
 
 	t.Run("RejectProofForNonInvoke", func(t *testing.T) {
 		broadcastedTxn := &rpcv10.BroadcastedTransaction{

--- a/rpc/v8/block_test.go
+++ b/rpc/v8/block_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/NethermindEth/juno/blockchain"
+	"github.com/NethermindEth/juno/blockchain/networks"
 	"github.com/NethermindEth/juno/clients/feeder"
 	"github.com/NethermindEth/juno/core"
 	"github.com/NethermindEth/juno/core/felt"
@@ -119,7 +120,7 @@ func TestBlockHashAndNumber(t *testing.T) {
 	mockCtrl := gomock.NewController(t)
 	t.Cleanup(mockCtrl.Finish)
 
-	n := &utils.Mainnet
+	n := &networks.Mainnet
 	mockReader := mocks.NewMockReader(mockCtrl)
 	handler := rpc.New(mockReader, nil, nil, nil)
 
@@ -155,7 +156,7 @@ func TestBlockTransactionCount(t *testing.T) {
 	mockCtrl := gomock.NewController(t)
 	t.Cleanup(mockCtrl.Finish)
 	mockSyncReader := mocks.NewMockSyncReader(mockCtrl)
-	n := new(utils.Sepolia)
+	n := new(networks.Sepolia)
 	mockReader := mocks.NewMockReader(mockCtrl)
 	handler := rpc.New(mockReader, mockSyncReader, nil, nil)
 
@@ -261,7 +262,7 @@ func TestBlockWithTxHashes(t *testing.T) {
 	for description, id := range errTests {
 		t.Run(description, func(t *testing.T) {
 			log := utils.NewNopZapLogger()
-			n := &utils.Mainnet
+			n := &networks.Mainnet
 			chain := blockchain.New(memory.New(), n)
 
 			handler := rpc.New(chain, mockSyncReader, nil, log)
@@ -272,7 +273,7 @@ func TestBlockWithTxHashes(t *testing.T) {
 		})
 	}
 
-	n := &utils.Sepolia
+	n := &networks.Sepolia
 	handler := rpc.New(mockReader, mockSyncReader, nil, nil)
 
 	client := feeder.NewTestClient(t, n)
@@ -452,7 +453,7 @@ func TestBlockWithTxs(t *testing.T) {
 	for description, id := range errTests {
 		t.Run(description, func(t *testing.T) {
 			log := utils.NewNopZapLogger()
-			n := &utils.Mainnet
+			n := &networks.Mainnet
 			chain := blockchain.New(memory.New(), n)
 
 			handler := rpc.New(chain, mockSyncReader, nil, log)
@@ -463,7 +464,7 @@ func TestBlockWithTxs(t *testing.T) {
 		})
 	}
 
-	n := &utils.Mainnet
+	n := &networks.Mainnet
 	handler := rpc.New(mockReader, mockSyncReader, nil, nil)
 
 	client := feeder.NewTestClient(t, n)
@@ -650,7 +651,7 @@ func TestBlockWithTxs_TxnsFetchError(t *testing.T) {
 }
 
 func TestBlockWithTxHashesV013(t *testing.T) {
-	n := new(utils.SepoliaIntegration)
+	n := new(networks.SepoliaIntegration)
 	mockCtrl := gomock.NewController(t)
 	t.Cleanup(mockCtrl.Finish)
 	mockReader := mocks.NewMockReader(mockCtrl)
@@ -736,7 +737,7 @@ func TestBlockWithReceipts(t *testing.T) {
 	mockCtrl := gomock.NewController(t)
 	t.Cleanup(mockCtrl.Finish)
 
-	n := new(utils.Mainnet)
+	n := new(networks.Mainnet)
 	mockReader := mocks.NewMockReader(mockCtrl)
 	mockSyncReader := mocks.NewMockSyncReader(mockCtrl)
 	handler := rpc.New(mockReader, mockSyncReader, nil, nil)
@@ -846,7 +847,7 @@ func TestRpcBlockAdaptation(t *testing.T) {
 	mockCtrl := gomock.NewController(t)
 	t.Cleanup(mockCtrl.Finish)
 
-	n := new(utils.Sepolia)
+	n := new(networks.Sepolia)
 	mockReader := mocks.NewMockReader(mockCtrl)
 	handler := rpc.New(mockReader, nil, nil, nil)
 

--- a/rpc/v8/chain_test.go
+++ b/rpc/v8/chain_test.go
@@ -3,17 +3,17 @@ package rpcv8_test
 import (
 	"testing"
 
+	"github.com/NethermindEth/juno/blockchain/networks"
 	"github.com/NethermindEth/juno/mocks"
 	rpc "github.com/NethermindEth/juno/rpc/v8"
-	"github.com/NethermindEth/juno/utils"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
 )
 
 func TestChainId(t *testing.T) {
-	for _, n := range []utils.Network{
-		utils.Mainnet, utils.Sepolia, utils.SepoliaIntegration,
+	for _, n := range []networks.Network{
+		networks.Mainnet, networks.Sepolia, networks.SepoliaIntegration,
 	} {
 		t.Run(n.String(), func(t *testing.T) {
 			mockCtrl := gomock.NewController(t)

--- a/rpc/v8/class_test.go
+++ b/rpc/v8/class_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"testing"
 
+	"github.com/NethermindEth/juno/blockchain/networks"
 	"github.com/NethermindEth/juno/clients/feeder"
 	"github.com/NethermindEth/juno/core"
 	"github.com/NethermindEth/juno/core/felt"
@@ -20,7 +21,7 @@ import (
 )
 
 func TestClass(t *testing.T) {
-	n := &utils.Integration
+	n := &networks.Integration
 	integrationClient := feeder.NewTestClient(t, n)
 	integGw := adaptfeeder.New(integrationClient)
 
@@ -102,7 +103,7 @@ func TestClass(t *testing.T) {
 }
 
 func TestClassAt(t *testing.T) {
-	n := &utils.Integration
+	n := &networks.Integration
 	integrationClient := feeder.NewTestClient(t, n)
 	integGw := adaptfeeder.New(integrationClient)
 

--- a/rpc/v8/compiled_casm_test.go
+++ b/rpc/v8/compiled_casm_test.go
@@ -5,6 +5,7 @@ import (
 	"math/big"
 	"testing"
 
+	"github.com/NethermindEth/juno/blockchain/networks"
 	clientFeeder "github.com/NethermindEth/juno/clients/feeder"
 	"github.com/NethermindEth/juno/core"
 	"github.com/NethermindEth/juno/core/felt"
@@ -14,7 +15,6 @@ import (
 	"github.com/NethermindEth/juno/rpc/rpccore"
 	rpc "github.com/NethermindEth/juno/rpc/v8"
 	"github.com/NethermindEth/juno/starknetdata/feeder"
-	"github.com/NethermindEth/juno/utils"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
@@ -47,7 +47,7 @@ func TestCompiledCasm(t *testing.T) {
 	t.Run("deprecatedCairo", func(t *testing.T) {
 		classHash := felt.NewUnsafeFromString[felt.Felt]("0x5f18f9cdc05da87f04e8e7685bd346fc029f977167d5b1b2b59f69a7dacbfc8")
 
-		cl := clientFeeder.NewTestClient(t, &utils.Sepolia)
+		cl := clientFeeder.NewTestClient(t, &networks.Sepolia)
 		fd := feeder.New(cl)
 
 		class, err := fd.Class(t.Context(), classHash)

--- a/rpc/v8/estimate_fee_test.go
+++ b/rpc/v8/estimate_fee_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"testing"
 
+	"github.com/NethermindEth/juno/blockchain/networks"
 	"github.com/NethermindEth/juno/core"
 	"github.com/NethermindEth/juno/core/felt"
 	"github.com/NethermindEth/juno/jsonrpc"
@@ -21,7 +22,7 @@ func TestEstimateFee(t *testing.T) {
 	mockCtrl := gomock.NewController(t)
 	defer mockCtrl.Finish()
 
-	n := &utils.Mainnet
+	n := &networks.Mainnet
 
 	mockReader := mocks.NewMockReader(mockCtrl)
 	mockReader.EXPECT().Network().Return(n).AnyTimes()

--- a/rpc/v8/events_test.go
+++ b/rpc/v8/events_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/NethermindEth/juno/blockchain"
+	"github.com/NethermindEth/juno/blockchain/networks"
 	"github.com/NethermindEth/juno/clients/feeder"
 	"github.com/NethermindEth/juno/core"
 	"github.com/NethermindEth/juno/core/felt"
@@ -19,7 +20,7 @@ import (
 
 func TestEvents(t *testing.T) {
 	testDB := memory.New()
-	n := &utils.Sepolia
+	n := &networks.Sepolia
 	chain := blockchain.New(testDB, n)
 
 	mockCtrl := gomock.NewController(t)

--- a/rpc/v8/handlers_test.go
+++ b/rpc/v8/handlers_test.go
@@ -3,12 +3,12 @@ package rpcv8_test
 import (
 	"testing"
 
+	"github.com/NethermindEth/juno/blockchain/networks"
 	"github.com/NethermindEth/juno/core"
 	"github.com/NethermindEth/juno/core/felt"
 	"github.com/NethermindEth/juno/mocks"
 	"github.com/NethermindEth/juno/node"
 	rpcv8 "github.com/NethermindEth/juno/rpc/v8"
-	"github.com/NethermindEth/juno/utils"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
@@ -28,7 +28,7 @@ func TestThrottledVMError(t *testing.T) {
 	t.Cleanup(mockCtrl.Finish)
 	mockSyncReader := mocks.NewMockSyncReader(mockCtrl)
 	mockReader := mocks.NewMockReader(mockCtrl)
-	mockReader.EXPECT().Network().Return(&utils.Mainnet).AnyTimes()
+	mockReader.EXPECT().Network().Return(&networks.Mainnet).AnyTimes()
 	mockVM := mocks.NewMockVM(mockCtrl)
 
 	throttledVM := node.NewThrottledVM(mockVM, 0, 0)

--- a/rpc/v8/l1_test.go
+++ b/rpc/v8/l1_test.go
@@ -4,13 +4,13 @@ import (
 	"encoding/json"
 	"testing"
 
+	"github.com/NethermindEth/juno/blockchain/networks"
 	"github.com/NethermindEth/juno/clients/feeder"
 	"github.com/NethermindEth/juno/core"
 	"github.com/NethermindEth/juno/core/felt"
 	"github.com/NethermindEth/juno/mocks"
 	rpc "github.com/NethermindEth/juno/rpc/v8"
 	adaptfeeder "github.com/NethermindEth/juno/starknetdata/feeder"
-	"github.com/NethermindEth/juno/utils"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/stretchr/testify/require"
@@ -34,7 +34,7 @@ func TestGetMessageStatus(t *testing.T) {
 	require.NoError(t, json.Unmarshal([]byte(l1ReceiptSepolia), &l1TxnReceiptSepolia))
 
 	tests := map[string]struct {
-		network        utils.Network
+		network        networks.Network
 		l1TxnHash      common.Hash
 		msgs           []rpc.MsgStatus
 		msgHashes      []common.Hash
@@ -43,7 +43,7 @@ func TestGetMessageStatus(t *testing.T) {
 		l1HeadBlockNum uint
 	}{
 		"mainnet 0.13.2.1": {
-			network:   utils.Mainnet,
+			network:   networks.Mainnet,
 			l1TxnHash: common.HexToHash("0x5780c6fe46f958a7ebf9308e6db16d819ff9e06b1e88f9e718c50cde10898f38"),
 			msgs: []rpc.MsgStatus{{
 				L1HandlerHash:  felt.NewUnsafeFromString[felt.Felt]("0xc470e30f97f64255a62215633e35a7c6ae10332a9011776dde1143ab0202c3"),
@@ -56,7 +56,7 @@ func TestGetMessageStatus(t *testing.T) {
 			l1HeadBlockNum: 763498,
 		},
 		"sepolia 0.13.4": {
-			network:   utils.Sepolia,
+			network:   networks.Sepolia,
 			l1TxnHash: common.HexToHash("0xeafadb9958437ef43ce7ed19f8ac0c8071c18f4a55fd778cecc23d8b6f86026f"),
 			msgs: []rpc.MsgStatus{{
 				L1HandlerHash:  felt.NewUnsafeFromString[felt.Felt]("0x304c78cccf0569159d4b2aff2117f060509b7c6d590ae740d2031d1eb507b10"),

--- a/rpc/v8/pending_wrapper_test.go
+++ b/rpc/v8/pending_wrapper_test.go
@@ -3,6 +3,7 @@ package rpcv8_test
 import (
 	"testing"
 
+	"github.com/NethermindEth/juno/blockchain/networks"
 	"github.com/NethermindEth/juno/clients/feeder"
 	"github.com/NethermindEth/juno/core"
 	"github.com/NethermindEth/juno/core/felt"
@@ -19,7 +20,7 @@ func TestPendingWrapper_Pending(t *testing.T) {
 	mockCtrl := gomock.NewController(t)
 	t.Cleanup(mockCtrl.Finish)
 	mockSyncReader := mocks.NewMockSyncReader(mockCtrl)
-	n := new(utils.Sepolia)
+	n := new(networks.Sepolia)
 	mockReader := mocks.NewMockReader(mockCtrl)
 	log := utils.NewNopZapLogger()
 	handler := rpc.New(mockReader, mockSyncReader, nil, log)

--- a/rpc/v8/simulation.go
+++ b/rpc/v8/simulation.go
@@ -9,6 +9,7 @@ import (
 	"slices"
 	"strconv"
 
+	"github.com/NethermindEth/juno/blockchain/networks"
 	"github.com/NethermindEth/juno/core"
 	"github.com/NethermindEth/juno/core/felt"
 	"github.com/NethermindEth/juno/jsonrpc"
@@ -149,7 +150,7 @@ func checkTxHasResourceBounds(tx *BroadcastedTransaction) bool {
 }
 
 func (h *Handler) prepareTransactions(
-	ctx context.Context, transactions []BroadcastedTransaction, network *utils.Network,
+	ctx context.Context, transactions []BroadcastedTransaction, network *networks.Network,
 ) (
 	[]core.Transaction, []core.ClassDefinition, []*felt.Felt, *jsonrpc.Error,
 ) {

--- a/rpc/v8/simulation_test.go
+++ b/rpc/v8/simulation_test.go
@@ -6,6 +6,7 @@ import (
 	"strconv"
 	"testing"
 
+	"github.com/NethermindEth/juno/blockchain/networks"
 	"github.com/NethermindEth/juno/core"
 	"github.com/NethermindEth/juno/core/felt"
 	"github.com/NethermindEth/juno/jsonrpc"
@@ -20,7 +21,7 @@ import (
 
 func TestSimulateTransactions(t *testing.T) {
 	t.Parallel()
-	n := &utils.Mainnet
+	n := &networks.Mainnet
 	headsHeader := &core.Header{
 		SequencerAddress: n.BlockHashMetaInfo.FallBackSequencerAddress,
 		L1GasPriceETH:    &felt.Zero,
@@ -188,7 +189,7 @@ func TestSimulateTransactions(t *testing.T) {
 
 func TestSimulateTransactionsShouldErrorWithoutSenderAddressOrResourceBounds(t *testing.T) {
 	t.Parallel()
-	n := &utils.Mainnet
+	n := &networks.Mainnet
 	headsHeader := &core.Header{
 		SequencerAddress: n.BlockHashMetaInfo.FallBackSequencerAddress,
 		L1GasPriceETH:    &felt.Zero,

--- a/rpc/v8/state_update_test.go
+++ b/rpc/v8/state_update_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/NethermindEth/juno/blockchain"
+	"github.com/NethermindEth/juno/blockchain/networks"
 	"github.com/NethermindEth/juno/clients/feeder"
 	"github.com/NethermindEth/juno/core"
 	"github.com/NethermindEth/juno/core/felt"
@@ -13,7 +14,6 @@ import (
 	rpc "github.com/NethermindEth/juno/rpc/v8"
 	adaptfeeder "github.com/NethermindEth/juno/starknetdata/feeder"
 	"github.com/NethermindEth/juno/sync"
-	"github.com/NethermindEth/juno/utils"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
@@ -30,7 +30,7 @@ func TestStateUpdate(t *testing.T) {
 	t.Cleanup(mockCtrl.Finish)
 	var mockSyncReader *mocks.MockSyncReader
 
-	n := &utils.Mainnet
+	n := &networks.Mainnet
 	for description, id := range errTests {
 		t.Run(description, func(t *testing.T) {
 			chain := blockchain.New(memory.New(), n)
@@ -148,7 +148,7 @@ func TestStateUpdate(t *testing.T) {
 	})
 
 	t.Run("post v0.11.0", func(t *testing.T) {
-		integrationClient := feeder.NewTestClient(t, &utils.Integration)
+		integrationClient := feeder.NewTestClient(t, &networks.Integration)
 		integGw := adaptfeeder.New(integrationClient)
 
 		for name, height := range map[string]uint64{

--- a/rpc/v8/storage_test.go
+++ b/rpc/v8/storage_test.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/NethermindEth/juno/blockchain"
+	"github.com/NethermindEth/juno/blockchain/networks"
 	"github.com/NethermindEth/juno/clients/feeder"
 	"github.com/NethermindEth/juno/core"
 	"github.com/NethermindEth/juno/core/crypto"
@@ -740,12 +741,12 @@ func TestStorageProof_StorageRoots(t *testing.T) {
 	mockCtrl := gomock.NewController(t)
 	t.Cleanup(mockCtrl.Finish)
 
-	client := feeder.NewTestClient(t, &utils.Mainnet)
+	client := feeder.NewTestClient(t, &networks.Mainnet)
 	gw := adaptfeeder.New(client)
 
 	log := utils.NewNopZapLogger()
 	testDB := memory.New()
-	bc := blockchain.New(testDB, &utils.Mainnet)
+	bc := blockchain.New(testDB, &networks.Mainnet)
 	dataSource := sync.NewFeederGatewayDataSource(bc, gw)
 	synchronizer := sync.New(bc, dataSource, log, time.Duration(0), time.Duration(0), false, testDB)
 	ctx, cancel := context.WithTimeout(t.Context(), time.Second)

--- a/rpc/v8/subscriptions_test.go
+++ b/rpc/v8/subscriptions_test.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/NethermindEth/juno/blockchain"
+	"github.com/NethermindEth/juno/blockchain/networks"
 	"github.com/NethermindEth/juno/clients/feeder"
 	"github.com/NethermindEth/juno/core"
 	"github.com/NethermindEth/juno/core/felt"
@@ -119,7 +120,7 @@ func TestSubscribeEvents(t *testing.T) {
 		})
 	})
 
-	n := &utils.Sepolia
+	n := &networks.Sepolia
 	client := feeder.NewTestClient(t, n)
 	gw := adaptfeeder.New(client)
 
@@ -309,7 +310,7 @@ func TestSubscribeTxnStatus(t *testing.T) {
 		mockChain := mocks.NewMockReader(mockCtrl)
 		mockSyncer := mocks.NewMockSyncReader(mockCtrl)
 		handler := New(mockChain, mockSyncer, nil, log)
-		handler.WithFeeder(feeder.NewTestClient(t, &utils.SepoliaIntegration))
+		handler.WithFeeder(feeder.NewTestClient(t, &networks.SepoliaIntegration))
 		mockSyncer.EXPECT().PreConfirmed().Return(nil, db.ErrKeyNotFound).AnyTimes()
 		mockChain.EXPECT().HeadsHeader().Return(nil, db.ErrKeyNotFound).AnyTimes()
 		t.Run("reverted", func(t *testing.T) {
@@ -358,7 +359,7 @@ func TestSubscribeTxnStatus(t *testing.T) {
 		mockCtrl := gomock.NewController(t)
 		t.Cleanup(mockCtrl.Finish)
 
-		client := feeder.NewTestClient(t, &utils.SepoliaIntegration)
+		client := feeder.NewTestClient(t, &networks.SepoliaIntegration)
 		gw := adaptfeeder.New(client)
 		mockChain := mocks.NewMockReader(mockCtrl)
 		mockSyncer := mocks.NewMockSyncReader(mockCtrl)
@@ -538,7 +539,7 @@ func TestSubscribeNewHeads(t *testing.T) {
 }
 
 func TestSubscribeNewHeadsHistorical(t *testing.T) {
-	client := feeder.NewTestClient(t, &utils.Mainnet)
+	client := feeder.NewTestClient(t, &networks.Mainnet)
 	gw := adaptfeeder.New(client)
 
 	block0, err := gw.BlockByNumber(t.Context(), 0)
@@ -548,10 +549,10 @@ func TestSubscribeNewHeadsHistorical(t *testing.T) {
 	require.NoError(t, err)
 
 	testDB := memory.New()
-	chain := blockchain.New(testDB, &utils.Mainnet)
+	chain := blockchain.New(testDB, &networks.Mainnet)
 	assert.NoError(t, chain.Store(block0, &emptyCommitments, stateUpdate0, nil))
 
-	chain = blockchain.New(testDB, &utils.Mainnet)
+	chain = blockchain.New(testDB, &networks.Mainnet)
 	syncer := newFakeSyncer()
 
 	ctx, cancel := context.WithCancel(t.Context())
@@ -1031,7 +1032,7 @@ func subMsg(method string) string {
 func testHeadBlock(t *testing.T) *core.Block {
 	t.Helper()
 
-	n := new(utils.Sepolia)
+	n := new(networks.Sepolia)
 	client := feeder.NewTestClient(t, n)
 	gw := adaptfeeder.New(client)
 

--- a/rpc/v8/trace.go
+++ b/rpc/v8/trace.go
@@ -9,6 +9,7 @@ import (
 	"strconv"
 
 	"github.com/NethermindEth/juno/blockchain"
+	"github.com/NethermindEth/juno/blockchain/networks"
 	"github.com/NethermindEth/juno/core"
 	"github.com/NethermindEth/juno/core/felt"
 	"github.com/NethermindEth/juno/db"
@@ -166,7 +167,7 @@ func (h *Handler) traceBlockTransactions(
 		fetchFromFeederGW = fetchFromFeederGW ||
 			(block.Number >= 1943705 &&
 				block.Number <= 1952704 &&
-				*h.bcReader.Network() == utils.Mainnet)
+				*h.bcReader.Network() == networks.Mainnet)
 
 		if fetchFromFeederGW {
 			traces, err := h.fetchTracesFromFeederGateway(ctx, block)

--- a/rpc/v8/trace_test.go
+++ b/rpc/v8/trace_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/NethermindEth/juno/blockchain"
+	"github.com/NethermindEth/juno/blockchain/networks"
 	"github.com/NethermindEth/juno/clients/feeder"
 	"github.com/NethermindEth/juno/core"
 	"github.com/NethermindEth/juno/core/felt"
@@ -46,7 +47,7 @@ func TestTraceFallback(t *testing.T) {
 			},
 		}
 
-		AssertTracedBlockTransactions(t, &utils.Integration, tests)
+		AssertTracedBlockTransactions(t, &networks.Integration, tests)
 	})
 
 	t.Run("Sepolia", func(t *testing.T) {
@@ -64,11 +65,11 @@ func TestTraceFallback(t *testing.T) {
 			},
 		}
 
-		AssertTracedBlockTransactions(t, &utils.Sepolia, tests)
+		AssertTracedBlockTransactions(t, &networks.Sepolia, tests)
 	})
 }
 
-func AssertTracedBlockTransactions(t *testing.T, n *utils.Network, tests map[string]expectedBlockTrace) {
+func AssertTracedBlockTransactions(t *testing.T, n *networks.Network, tests map[string]expectedBlockTrace) {
 	t.Helper()
 
 	mockCtrl := gomock.NewController(t)
@@ -119,7 +120,7 @@ func AssertTracedBlockTransactions(t *testing.T, n *utils.Network, tests map[str
 			handler = handler.WithFeeder(client)
 			blockID := blockIDNumber(t, test.blockNumber)
 			traces, httpHeader, err := handler.TraceBlockTransactions(t.Context(), &blockID)
-			if n == &utils.Sepolia && description == "newer block" {
+			if n == &networks.Sepolia && description == "newer block" {
 				// For the newer block test, we test 3 of the block traces (INVOKE, DEPLOY_ACCOUNT, DECLARE)
 				traces = []rpc.TracedBlockTransaction{traces[0], traces[7], traces[11]}
 			}
@@ -138,7 +139,7 @@ func TestTraceBlockTransactionsReturnsError(t *testing.T) {
 		mockCtrl := gomock.NewController(t)
 		mockReader := mocks.NewMockReader(mockCtrl)
 
-		client := feeder.NewTestClient(t, &utils.Sepolia)
+		client := feeder.NewTestClient(t, &networks.Sepolia)
 		gateway := adaptfeeder.New(client)
 
 		blockNumber := uint64(40000)
@@ -275,7 +276,7 @@ func TestTraceTransaction(t *testing.T) {
 
 	mockReader := mocks.NewMockReader(mockCtrl)
 	mockSyncReader := mocks.NewMockSyncReader(mockCtrl)
-	mockReader.EXPECT().Network().Return(&utils.Mainnet).AnyTimes()
+	mockReader.EXPECT().Network().Return(&networks.Mainnet).AnyTimes()
 	mockVM := mocks.NewMockVM(mockCtrl)
 	handler := rpc.New(mockReader, mockSyncReader, mockVM, utils.NewNopZapLogger())
 
@@ -409,7 +410,7 @@ func TestTraceTransaction(t *testing.T) {
 	})
 
 	t.Run("reverted INVOKE tx from feeder", func(t *testing.T) {
-		n := &utils.Sepolia
+		n := &networks.Sepolia
 
 		handler := rpc.New(mockReader, mockSyncReader, mockVM, utils.NewNopZapLogger())
 
@@ -557,7 +558,7 @@ func TestTraceBlockTransactions(t *testing.T) {
 	for description, blockID := range errTests {
 		t.Run(description, func(t *testing.T) {
 			log := utils.NewNopZapLogger()
-			n := &utils.Mainnet
+			n := &networks.Mainnet
 			chain := blockchain.New(memory.New(), n)
 			handler := rpc.New(chain, nil, nil, log)
 
@@ -570,7 +571,7 @@ func TestTraceBlockTransactions(t *testing.T) {
 
 	mockCtrl := gomock.NewController(t)
 	t.Cleanup(mockCtrl.Finish)
-	n := &utils.Mainnet
+	n := &networks.Mainnet
 
 	mockReader := mocks.NewMockReader(mockCtrl)
 	mockSyncReader := mocks.NewMockSyncReader(mockCtrl)

--- a/rpc/v8/trace_test.go
+++ b/rpc/v8/trace_test.go
@@ -69,7 +69,11 @@ func TestTraceFallback(t *testing.T) {
 	})
 }
 
-func AssertTracedBlockTransactions(t *testing.T, n *networks.Network, tests map[string]expectedBlockTrace) {
+func AssertTracedBlockTransactions(
+	t *testing.T,
+	n *networks.Network,
+	tests map[string]expectedBlockTrace,
+) {
 	t.Helper()
 
 	mockCtrl := gomock.NewController(t)

--- a/rpc/v8/transaction.go
+++ b/rpc/v8/transaction.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	"github.com/NethermindEth/juno/adapters/sn2core"
+	"github.com/NethermindEth/juno/blockchain/networks"
 	"github.com/NethermindEth/juno/clients/gateway"
 	"github.com/NethermindEth/juno/core"
 	"github.com/NethermindEth/juno/core/felt"
@@ -338,7 +339,7 @@ func AdaptBroadcastedTransaction(
 	ctx context.Context,
 	compiler compiler.Compiler,
 	broadcastedTxn *BroadcastedTransaction,
-	network *utils.Network,
+	network *networks.Network,
 ) (core.Transaction, core.ClassDefinition, *felt.Felt, error) {
 	feederTxn := adaptRPCTxToFeederTx(&broadcastedTxn.Transaction)
 

--- a/rpc/v8/transaction_test.go
+++ b/rpc/v8/transaction_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/NethermindEth/juno/blockchain/networks"
 	"github.com/NethermindEth/juno/clients/feeder"
 	"github.com/NethermindEth/juno/clients/gateway"
 	"github.com/NethermindEth/juno/core"
@@ -64,12 +65,12 @@ func TestTransactionByHashNotFoundInPendingBlock(t *testing.T) {
 func TestTransactionByHash(t *testing.T) {
 	tests := map[string]struct {
 		hash     string
-		network  *utils.Network
+		network  *networks.Network
 		expected string
 	}{
 		"DECLARE v1": {
 			hash:    "0x1b4d9f09276629d496af1af8ff00173c11ff146affacb1b5c858d7aa89001ae",
-			network: &utils.Mainnet,
+			network: &networks.Mainnet,
 			expected: `{
 			"type": "DECLARE",
 			"transaction_hash": "0x1b4d9f09276629d496af1af8ff00173c11ff146affacb1b5c858d7aa89001ae",
@@ -87,7 +88,7 @@ func TestTransactionByHash(t *testing.T) {
 
 		"DECLARE v0": {
 			hash:    "0x222f8902d1eeea76fa2642a90e2411bfd71cffb299b3a299029e1937fab3fe4",
-			network: &utils.Mainnet,
+			network: &networks.Mainnet,
 			expected: `{
 				"transaction_hash": "0x222f8902d1eeea76fa2642a90e2411bfd71cffb299b3a299029e1937fab3fe4",
 				"type": "DECLARE",
@@ -101,7 +102,7 @@ func TestTransactionByHash(t *testing.T) {
 
 		"L1 Handler v0 with nonce": {
 			hash:    "0x537eacfd3c49166eec905daff61ff7feef9c133a049ea2135cb94eec840a4a8",
-			network: &utils.Mainnet,
+			network: &networks.Mainnet,
 			expected: `{
        "type": "L1_HANDLER",
        "transaction_hash": "0x537eacfd3c49166eec905daff61ff7feef9c133a049ea2135cb94eec840a4a8",
@@ -120,7 +121,7 @@ func TestTransactionByHash(t *testing.T) {
 		},
 		"L1 Handler v0 without nonce": {
 			hash:    "0x5d50b7020f7cf8033fd7d913e489f47edf74fbf3c8ada85be512c7baa6a2eab",
-			network: &utils.Mainnet,
+			network: &networks.Mainnet,
 			expected: `{
 				"type": "L1_HANDLER",
 				"transaction_hash":  "0x5d50b7020f7cf8033fd7d913e489f47edf74fbf3c8ada85be512c7baa6a2eab",
@@ -139,7 +140,7 @@ func TestTransactionByHash(t *testing.T) {
 
 		"Invoke v1": {
 			hash:    "0x2897e3cec3e24e4d341df26b8cf1ab84ea1c01a051021836b36c6639145b497",
-			network: &utils.Mainnet,
+			network: &networks.Mainnet,
 			expected: `{
        "type": "INVOKE",
        "transaction_hash": "0x2897e3cec3e24e4d341df26b8cf1ab84ea1c01a051021836b36c6639145b497",
@@ -175,7 +176,7 @@ func TestTransactionByHash(t *testing.T) {
 
 		"DEPLOY v0": {
 			hash:    "0x6486c6303dba2f364c684a2e9609211c5b8e417e767f37b527cda51e776e6f0",
-			network: &utils.Mainnet,
+			network: &networks.Mainnet,
 			expected: `{
        "type": "DEPLOY",
        "transaction_hash": "0x6486c6303dba2f364c684a2e9609211c5b8e417e767f37b527cda51e776e6f0",
@@ -194,7 +195,7 @@ func TestTransactionByHash(t *testing.T) {
 
 		"DEPLOY ACCOUNT v1": {
 			hash:    "0xd61fc89f4d1dc4dc90a014957d655d38abffd47ecea8e3fa762e3160f155f2",
-			network: &utils.Mainnet,
+			network: &networks.Mainnet,
 			expected: `{
        "type": "DEPLOY_ACCOUNT",
        "transaction_hash": "0xd61fc89f4d1dc4dc90a014957d655d38abffd47ecea8e3fa762e3160f155f2",
@@ -215,7 +216,7 @@ func TestTransactionByHash(t *testing.T) {
 
 		"INVOKE v0": {
 			hash:    "0xf1d99fb97509e0dfc425ddc2a8c5398b74231658ca58b6f8da92f39cb739e",
-			network: &utils.Mainnet,
+			network: &networks.Mainnet,
 			expected: `{
        "type": "INVOKE",
        "transaction_hash": "0xf1d99fb97509e0dfc425ddc2a8c5398b74231658ca58b6f8da92f39cb739e",
@@ -234,7 +235,7 @@ func TestTransactionByHash(t *testing.T) {
 		},
 		"DECLARE v3": {
 			hash:    "0x41d1f5206ef58a443e7d3d1ca073171ec25fa75313394318fc83a074a6631c3",
-			network: &utils.Integration,
+			network: &networks.Integration,
 			expected: `{
 		"transaction_hash": "0x41d1f5206ef58a443e7d3d1ca073171ec25fa75313394318fc83a074a6631c3",
 		"type": "DECLARE",
@@ -267,7 +268,7 @@ func TestTransactionByHash(t *testing.T) {
 		},
 		"INVOKE v3": {
 			hash:    "0x49728601e0bb2f48ce506b0cbd9c0e2a9e50d95858aa41463f46386dca489fd",
-			network: &utils.Integration,
+			network: &networks.Integration,
 			expected: `{
 				"type": "INVOKE",
 				"transaction_hash": "0x49728601e0bb2f48ce506b0cbd9c0e2a9e50d95858aa41463f46386dca489fd",
@@ -315,7 +316,7 @@ func TestTransactionByHash(t *testing.T) {
 		},
 		"DEPLOY ACCOUNT v3": {
 			hash:    "0x29fd7881f14380842414cdfdd8d6c0b1f2174f8916edcfeb1ede1eb26ac3ef0",
-			network: &utils.Integration,
+			network: &networks.Integration,
 			expected: `{
 				"transaction_hash": "0x29fd7881f14380842414cdfdd8d6c0b1f2174f8916edcfeb1ede1eb26ac3ef0",
 				"version": "0x3",
@@ -350,7 +351,7 @@ func TestTransactionByHash(t *testing.T) {
 		// https://alpha-sepolia.starknet.io/feeder_gateway/get_transaction?transactionHash=0x2db07ed11b1f6c678de9fc19ef0dfb8e71631e1cff236a34e68f51528a21282
 		"INVOKE v3 without l1_data_gas": {
 			hash:    "0x2db07ed11b1f6c678de9fc19ef0dfb8e71631e1cff236a34e68f51528a21282",
-			network: &utils.Integration,
+			network: &networks.Integration,
 			expected: `{
 				"transaction_hash": "0x2db07ed11b1f6c678de9fc19ef0dfb8e71631e1cff236a34e68f51528a21282",
 				"version": "0x3",
@@ -439,7 +440,7 @@ func TestTransactionByHash(t *testing.T) {
 func TestTransactionByBlockIdAndIndex(t *testing.T) {
 	mockCtrl := gomock.NewController(t)
 	t.Cleanup(mockCtrl.Finish)
-	n := &utils.Mainnet
+	n := &networks.Mainnet
 	mockReader := mocks.NewMockReader(mockCtrl)
 	mockSyncReader := mocks.NewMockSyncReader(mockCtrl)
 	client := feeder.NewTestClient(t, n)
@@ -581,7 +582,7 @@ func TestTransactionReceiptByHash(t *testing.T) {
 	mockCtrl := gomock.NewController(t)
 	t.Cleanup(mockCtrl.Finish)
 
-	n := &utils.Mainnet
+	n := &networks.Mainnet
 	mockReader := mocks.NewMockReader(mockCtrl)
 	mockSyncReader := mocks.NewMockSyncReader(mockCtrl)
 	handler := rpc.New(mockReader, mockSyncReader, nil, nil)
@@ -770,7 +771,7 @@ func TestTransactionReceiptByHash(t *testing.T) {
 			}
 		}`
 
-		integClient := feeder.NewTestClient(t, &utils.Integration)
+		integClient := feeder.NewTestClient(t, &networks.Integration)
 		integGw := adaptfeeder.New(integClient)
 
 		blockWithRevertedTxn, err := integGw.BlockByNumber(t.Context(), 304740)
@@ -840,7 +841,7 @@ func TestTransactionReceiptByHash(t *testing.T) {
 			"type": "INVOKE"
 		}`
 
-		integClient := feeder.NewTestClient(t, &utils.Integration)
+		integClient := feeder.NewTestClient(t, &networks.Integration)
 		integGw := adaptfeeder.New(integClient)
 
 		block, err := integGw.BlockByNumber(t.Context(), 319132)
@@ -897,7 +898,7 @@ func TestTransactionReceiptByHash(t *testing.T) {
 			}
 		}`
 
-		netClient := feeder.NewTestClient(t, &utils.SepoliaIntegration)
+		netClient := feeder.NewTestClient(t, &networks.SepoliaIntegration)
 		netGW := adaptfeeder.New(netClient)
 
 		block, err := netGW.BlockByNumber(t.Context(), 35748)
@@ -965,7 +966,7 @@ func TestAddTransactionUnmarshal(t *testing.T) {
 }
 
 func TestAddTransaction(t *testing.T) {
-	n := &utils.Integration
+	n := &networks.Integration
 	gw := adaptfeeder.New(feeder.NewTestClient(t, n))
 	txWithoutClass := func(hash string) rpc.BroadcastedTransaction {
 		tx, err := gw.Transaction(t.Context(), felt.NewUnsafeFromString[felt.Felt](hash))
@@ -1303,7 +1304,7 @@ func TestAddTransaction(t *testing.T) {
 			t.Cleanup(mockCtrl.Finish)
 
 			mockReader := mocks.NewMockReader(mockCtrl)
-			n := &utils.Sepolia
+			n := &networks.Sepolia
 			mockReader.EXPECT().Network().Return(n).AnyTimes()
 
 			receivedTxFeed := feed.New[core.Transaction]()
@@ -1356,19 +1357,19 @@ func TestTransactionStatus(t *testing.T) {
 	t.Cleanup(mockCtrl.Finish)
 
 	tests := []struct {
-		network           *utils.Network
+		network           *networks.Network
 		verifiedTxHash    *felt.Felt
 		nonVerifiedTxHash *felt.Felt
 		notFoundTxHash    *felt.Felt
 	}{
 		{
-			network:           &utils.Mainnet,
+			network:           &networks.Mainnet,
 			verifiedTxHash:    felt.NewUnsafeFromString[felt.Felt]("0xf1d99fb97509e0dfc425ddc2a8c5398b74231658ca58b6f8da92f39cb739e"),
 			nonVerifiedTxHash: felt.NewUnsafeFromString[felt.Felt]("0x6c40890743aa220b10e5ee68cef694c5c23cc2defd0dbdf5546e687f9982ab1"),
 			notFoundTxHash:    felt.NewUnsafeFromString[felt.Felt]("0x8c96a2b3d73294667e489bf8904c6aa7c334e38e24ad5a721c7e04439ff9"),
 		},
 		{
-			network:           &utils.Integration,
+			network:           &networks.Integration,
 			verifiedTxHash:    felt.NewUnsafeFromString[felt.Felt]("0x5e91283c1c04c3f88e4a98070df71227fb44dea04ce349c7eb379f85a10d1c3"),
 			nonVerifiedTxHash: felt.NewUnsafeFromString[felt.Felt]("0x45d9c2c8e01bacae6dec3438874576a4a1ce65f1d4247f4e9748f0e7216838"),
 			notFoundTxHash:    felt.NewUnsafeFromString[felt.Felt]("0xd7747f3d0ce84b3a19b05b987a782beac22c54e66773303e94ea78cc3c15"),
@@ -1523,7 +1524,7 @@ func TestTransactionStatus(t *testing.T) {
 	t.Run("Rejected transaction found in feeder", func(t *testing.T) {
 		mockReader := mocks.NewMockReader(mockCtrl)
 		mockSyncReader := mocks.NewMockSyncReader(mockCtrl)
-		client := feeder.NewTestClient(t, &utils.SepoliaIntegration)
+		client := feeder.NewTestClient(t, &networks.SepoliaIntegration)
 		txHash, err := new(felt.Felt).SetString("0x1111")
 		require.NoError(t, err)
 
@@ -1847,7 +1848,7 @@ func TestAdaptBroadcastedTransaction(t *testing.T) {
 	require.NoError(t, json.Unmarshal([]byte(txnNonZeroL2GasData), &txnNonZeroL2Gas))
 
 	tx, _, _, err := rpc.AdaptBroadcastedTransaction(
-		t.Context(), nil, &txnNonZeroL2Gas, &utils.Sepolia,
+		t.Context(), nil, &txnNonZeroL2Gas, &networks.Sepolia,
 	)
 	require.NoError(t, err)
 	resultTxn, ok := (tx).(*core.DeployAccountTransaction)
@@ -1942,7 +1943,7 @@ func TestSubmittedTransactionsCache(t *testing.T) {
 
 	ctx := t.Context()
 	log := utils.NewNopZapLogger()
-	network := utils.Integration
+	network := networks.Integration
 
 	client := feeder.NewTestClient(t, &network)
 

--- a/rpc/v9/block_test.go
+++ b/rpc/v9/block_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/NethermindEth/juno/blockchain"
+	"github.com/NethermindEth/juno/blockchain/networks"
 	"github.com/NethermindEth/juno/clients/feeder"
 	"github.com/NethermindEth/juno/core"
 	"github.com/NethermindEth/juno/core/felt"
@@ -126,7 +127,7 @@ func TestBlockHashAndNumber(t *testing.T) {
 	mockCtrl := gomock.NewController(t)
 	t.Cleanup(mockCtrl.Finish)
 
-	n := &utils.Mainnet
+	n := &networks.Mainnet
 	mockReader := mocks.NewMockReader(mockCtrl)
 	handler := rpc.New(mockReader, nil, nil, nil)
 
@@ -162,7 +163,7 @@ func TestBlockTransactionCount(t *testing.T) {
 	mockCtrl := gomock.NewController(t)
 	t.Cleanup(mockCtrl.Finish)
 	mockSyncReader := mocks.NewMockSyncReader(mockCtrl)
-	n := new(utils.Sepolia)
+	n := new(networks.Sepolia)
 	mockReader := mocks.NewMockReader(mockCtrl)
 	log := utils.NewNopZapLogger()
 	handler := rpc.New(mockReader, mockSyncReader, nil, log)
@@ -281,7 +282,7 @@ func TestBlockWithTxHashes(t *testing.T) {
 	for description, id := range errTests { //nolint:dupl
 		t.Run(description, func(t *testing.T) {
 			log := utils.NewNopZapLogger()
-			n := &utils.Mainnet
+			n := &networks.Mainnet
 			chain := blockchain.New(memory.New(), n)
 
 			if description == "pre_confirmed" {
@@ -298,7 +299,7 @@ func TestBlockWithTxHashes(t *testing.T) {
 	}
 
 	mockSyncReader = mocks.NewMockSyncReader(mockCtrl)
-	n := &utils.Sepolia
+	n := &networks.Sepolia
 	handler := rpc.New(mockReader, mockSyncReader, nil, nil)
 
 	client := feeder.NewTestClient(t, n)
@@ -479,7 +480,7 @@ func TestBlockWithTxs(t *testing.T) {
 	for description, id := range errTests { //nolint:dupl
 		t.Run(description, func(t *testing.T) {
 			log := utils.NewNopZapLogger()
-			n := &utils.Mainnet
+			n := &networks.Mainnet
 			chain := blockchain.New(memory.New(), n)
 
 			if description == "pre_confirmed" {
@@ -498,7 +499,7 @@ func TestBlockWithTxs(t *testing.T) {
 	mockSyncReader = mocks.NewMockSyncReader(mockCtrl)
 	handler := rpc.New(mockReader, mockSyncReader, nil, nil)
 
-	n := &utils.Mainnet
+	n := &networks.Mainnet
 	client := feeder.NewTestClient(t, n)
 	gw := adaptfeeder.New(client)
 
@@ -709,7 +710,7 @@ func TestBlockWithTxs_TxnsFetchError(t *testing.T) {
 }
 
 func TestBlockWithTxHashesV013(t *testing.T) {
-	n := new(utils.SepoliaIntegration)
+	n := new(networks.SepoliaIntegration)
 	mockCtrl := gomock.NewController(t)
 	t.Cleanup(mockCtrl.Finish)
 	mockReader := mocks.NewMockReader(mockCtrl)
@@ -795,7 +796,7 @@ func TestBlockWithReceipts(t *testing.T) {
 	mockCtrl := gomock.NewController(t)
 	t.Cleanup(mockCtrl.Finish)
 
-	n := new(utils.Mainnet)
+	n := new(networks.Mainnet)
 	mockReader := mocks.NewMockReader(mockCtrl)
 	mockSyncReader := mocks.NewMockSyncReader(mockCtrl)
 	handler := rpc.New(mockReader, mockSyncReader, nil, nil)
@@ -934,7 +935,7 @@ func TestRpcBlockAdaptation(t *testing.T) {
 	mockCtrl := gomock.NewController(t)
 	t.Cleanup(mockCtrl.Finish)
 
-	n := new(utils.Sepolia)
+	n := new(networks.Sepolia)
 	mockReader := mocks.NewMockReader(mockCtrl)
 	handler := rpc.New(mockReader, nil, nil, nil)
 

--- a/rpc/v9/chain_test.go
+++ b/rpc/v9/chain_test.go
@@ -3,17 +3,17 @@ package rpcv9_test
 import (
 	"testing"
 
+	"github.com/NethermindEth/juno/blockchain/networks"
 	"github.com/NethermindEth/juno/mocks"
 	rpc "github.com/NethermindEth/juno/rpc/v9"
-	"github.com/NethermindEth/juno/utils"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
 )
 
 func TestChainId(t *testing.T) {
-	for _, n := range []utils.Network{
-		utils.Mainnet, utils.Sepolia, utils.SepoliaIntegration,
+	for _, n := range []networks.Network{
+		networks.Mainnet, networks.Sepolia, networks.SepoliaIntegration,
 	} {
 		t.Run(n.String(), func(t *testing.T) {
 			mockCtrl := gomock.NewController(t)

--- a/rpc/v9/class_test.go
+++ b/rpc/v9/class_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"testing"
 
+	"github.com/NethermindEth/juno/blockchain/networks"
 	"github.com/NethermindEth/juno/clients/feeder"
 	"github.com/NethermindEth/juno/core"
 	"github.com/NethermindEth/juno/core/felt"
@@ -21,7 +22,7 @@ import (
 )
 
 func TestClass(t *testing.T) {
-	n := &utils.Integration
+	n := &networks.Integration
 	integrationClient := feeder.NewTestClient(t, n)
 	integGw := adaptfeeder.New(integrationClient)
 
@@ -101,7 +102,7 @@ func TestClass(t *testing.T) {
 }
 
 func TestClassAt(t *testing.T) {
-	n := &utils.Integration
+	n := &networks.Integration
 	integrationClient := feeder.NewTestClient(t, n)
 	integGw := adaptfeeder.New(integrationClient)
 

--- a/rpc/v9/compiled_casm_test.go
+++ b/rpc/v9/compiled_casm_test.go
@@ -5,6 +5,7 @@ import (
 	"math/big"
 	"testing"
 
+	"github.com/NethermindEth/juno/blockchain/networks"
 	clientFeeder "github.com/NethermindEth/juno/clients/feeder"
 	"github.com/NethermindEth/juno/core"
 	"github.com/NethermindEth/juno/core/felt"
@@ -14,7 +15,6 @@ import (
 	"github.com/NethermindEth/juno/rpc/rpccore"
 	rpc "github.com/NethermindEth/juno/rpc/v9"
 	"github.com/NethermindEth/juno/starknetdata/feeder"
-	"github.com/NethermindEth/juno/utils"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
@@ -47,7 +47,7 @@ func TestCompiledCasm(t *testing.T) {
 	t.Run("deprecated cairo", func(t *testing.T) {
 		classHash := felt.NewUnsafeFromString[felt.Felt]("0x5f18f9cdc05da87f04e8e7685bd346fc029f977167d5b1b2b59f69a7dacbfc8")
 
-		cl := clientFeeder.NewTestClient(t, &utils.Sepolia)
+		cl := clientFeeder.NewTestClient(t, &networks.Sepolia)
 		fd := feeder.New(cl)
 
 		class, err := fd.Class(t.Context(), classHash)

--- a/rpc/v9/estimate_fee_test.go
+++ b/rpc/v9/estimate_fee_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"testing"
 
+	"github.com/NethermindEth/juno/blockchain/networks"
 	"github.com/NethermindEth/juno/core"
 	"github.com/NethermindEth/juno/core/felt"
 	"github.com/NethermindEth/juno/jsonrpc"
@@ -21,7 +22,7 @@ func TestEstimateFee(t *testing.T) {
 	mockCtrl := gomock.NewController(t)
 	defer mockCtrl.Finish()
 
-	n := &utils.Mainnet
+	n := &networks.Mainnet
 
 	mockReader := mocks.NewMockReader(mockCtrl)
 	mockReader.EXPECT().Network().Return(n).AnyTimes()

--- a/rpc/v9/events_test.go
+++ b/rpc/v9/events_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/NethermindEth/juno/blockchain"
+	"github.com/NethermindEth/juno/blockchain/networks"
 	"github.com/NethermindEth/juno/clients/feeder"
 	"github.com/NethermindEth/juno/core"
 	"github.com/NethermindEth/juno/core/felt"
@@ -165,7 +166,7 @@ func fetchAndStoreBlock(
 // setupTestChain sets up a test chain with the given number of blocks
 func setupTestChain(
 	t *testing.T,
-	network *utils.Network,
+	network *networks.Network,
 	numBlocks uint64,
 ) (*blockchain.Blockchain, *adaptfeeder.Feeder) {
 	t.Helper()
@@ -183,7 +184,7 @@ func setupTestChain(
 }
 
 func TestEvents(t *testing.T) {
-	network := utils.Sepolia
+	network := networks.Sepolia
 	numCanonicalBlocks := uint64(5)
 	chain, gw := setupTestChain(t, &network, numCanonicalBlocks)
 
@@ -559,7 +560,7 @@ func TestEvents(t *testing.T) {
 }
 
 func TestEvents_FilterWithLimit(t *testing.T) {
-	n := &utils.Sepolia
+	n := &networks.Sepolia
 	chain, _ := setupTestChain(t, n, uint64(6))
 
 	mockCtrl := gomock.NewController(t)
@@ -601,7 +602,7 @@ func TestEvents_FilterWithLimit(t *testing.T) {
 }
 
 func TestEvents_ChainProgressesWhilePaginating(t *testing.T) {
-	network := utils.Sepolia
+	network := networks.Sepolia
 	numCanonicalBlocks := uint64(5)
 	chain, gw := setupTestChain(t, &network, numCanonicalBlocks)
 

--- a/rpc/v9/handlers_test.go
+++ b/rpc/v9/handlers_test.go
@@ -3,12 +3,12 @@ package rpcv9_test
 import (
 	"testing"
 
+	"github.com/NethermindEth/juno/blockchain/networks"
 	"github.com/NethermindEth/juno/core"
 	"github.com/NethermindEth/juno/core/felt"
 	"github.com/NethermindEth/juno/mocks"
 	"github.com/NethermindEth/juno/node"
 	rpcv9 "github.com/NethermindEth/juno/rpc/v9"
-	"github.com/NethermindEth/juno/utils"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
@@ -28,7 +28,7 @@ func TestThrottledVMError(t *testing.T) {
 	t.Cleanup(mockCtrl.Finish)
 	mockSyncReader := mocks.NewMockSyncReader(mockCtrl)
 	mockReader := mocks.NewMockReader(mockCtrl)
-	mockReader.EXPECT().Network().Return(&utils.Mainnet).AnyTimes()
+	mockReader.EXPECT().Network().Return(&networks.Mainnet).AnyTimes()
 	mockVM := mocks.NewMockVM(mockCtrl)
 
 	throttledVM := node.NewThrottledVM(mockVM, 0, 0)

--- a/rpc/v9/l1_test.go
+++ b/rpc/v9/l1_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"testing"
 
+	"github.com/NethermindEth/juno/blockchain/networks"
 	"github.com/NethermindEth/juno/clients/feeder"
 	"github.com/NethermindEth/juno/core"
 	"github.com/NethermindEth/juno/core/felt"
@@ -11,7 +12,6 @@ import (
 	"github.com/NethermindEth/juno/mocks"
 	rpc "github.com/NethermindEth/juno/rpc/v9"
 	adaptfeeder "github.com/NethermindEth/juno/starknetdata/feeder"
-	"github.com/NethermindEth/juno/utils"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/stretchr/testify/require"
@@ -36,7 +36,7 @@ func TestGetMessageStatus(t *testing.T) {
 	require.NoError(t, json.Unmarshal([]byte(l1ReceiptSepolia), &l1TxnReceiptSepolia))
 
 	tests := map[string]struct {
-		network        utils.Network
+		network        networks.Network
 		l1TxnHash      common.Hash
 		msgs           []rpc.MsgStatus
 		msgHashes      []common.Hash
@@ -45,7 +45,7 @@ func TestGetMessageStatus(t *testing.T) {
 		l1HeadBlockNum uint64
 	}{
 		"mainnet 0.13.2.1": {
-			network:   utils.Mainnet,
+			network:   networks.Mainnet,
 			l1TxnHash: common.HexToHash("0x5780c6fe46f958a7ebf9308e6db16d819ff9e06b1e88f9e718c50cde10898f38"),
 			msgs: []rpc.MsgStatus{{
 				L1HandlerHash:   felt.NewUnsafeFromString[felt.Felt]("0xc470e30f97f64255a62215633e35a7c6ae10332a9011776dde1143ab0202c3"),
@@ -59,7 +59,7 @@ func TestGetMessageStatus(t *testing.T) {
 			l1HeadBlockNum: 763498,
 		},
 		"sepolia 0.13.4": {
-			network:   utils.Sepolia,
+			network:   networks.Sepolia,
 			l1TxnHash: common.HexToHash("0xeafadb9958437ef43ce7ed19f8ac0c8071c18f4a55fd778cecc23d8b6f86026f"),
 			msgs: []rpc.MsgStatus{{
 				L1HandlerHash:   felt.NewUnsafeFromString[felt.Felt]("0x304c78cccf0569159d4b2aff2117f060509b7c6d590ae740d2031d1eb507b10"),

--- a/rpc/v9/simulation.go
+++ b/rpc/v9/simulation.go
@@ -9,6 +9,7 @@ import (
 	"slices"
 	"strconv"
 
+	"github.com/NethermindEth/juno/blockchain/networks"
 	"github.com/NethermindEth/juno/core"
 	"github.com/NethermindEth/juno/core/felt"
 	"github.com/NethermindEth/juno/jsonrpc"
@@ -161,7 +162,7 @@ func checkTxHasResourceBounds(tx *BroadcastedTransaction) bool {
 }
 
 func (h *Handler) prepareTransactions(
-	ctx context.Context, transactions []BroadcastedTransaction, network *utils.Network,
+	ctx context.Context, transactions []BroadcastedTransaction, network *networks.Network,
 ) (
 	[]core.Transaction, []core.ClassDefinition, []*felt.Felt, *jsonrpc.Error,
 ) {

--- a/rpc/v9/simulation_test.go
+++ b/rpc/v9/simulation_test.go
@@ -6,6 +6,7 @@ import (
 	"strconv"
 	"testing"
 
+	"github.com/NethermindEth/juno/blockchain/networks"
 	"github.com/NethermindEth/juno/core"
 	"github.com/NethermindEth/juno/core/felt"
 	"github.com/NethermindEth/juno/jsonrpc"
@@ -20,7 +21,7 @@ import (
 
 func TestSimulateTransactions(t *testing.T) {
 	t.Parallel()
-	n := &utils.Mainnet
+	n := &networks.Mainnet
 	headsHeader := &core.Header{
 		SequencerAddress: n.BlockHashMetaInfo.FallBackSequencerAddress,
 		L1GasPriceETH:    &felt.Zero,
@@ -184,7 +185,7 @@ func TestSimulateTransactions(t *testing.T) {
 
 func TestSimulateTransactionsShouldErrorWithoutSenderAddressOrResourceBounds(t *testing.T) {
 	t.Parallel()
-	n := &utils.Mainnet
+	n := &networks.Mainnet
 	headsHeader := &core.Header{
 		SequencerAddress: n.BlockHashMetaInfo.FallBackSequencerAddress,
 		L1GasPriceETH:    &felt.Zero,

--- a/rpc/v9/state_update_test.go
+++ b/rpc/v9/state_update_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/NethermindEth/juno/blockchain"
+	"github.com/NethermindEth/juno/blockchain/networks"
 	"github.com/NethermindEth/juno/clients/feeder"
 	"github.com/NethermindEth/juno/core"
 	"github.com/NethermindEth/juno/core/felt"
@@ -32,7 +33,7 @@ func TestStateUpdate(t *testing.T) {
 	t.Cleanup(mockCtrl.Finish)
 	var mockSyncReader *mocks.MockSyncReader
 
-	n := &utils.Mainnet
+	n := &networks.Mainnet
 	for description, id := range errTests {
 		t.Run(description, func(t *testing.T) {
 			chain := blockchain.New(memory.New(), n)
@@ -124,7 +125,7 @@ func TestStateUpdate(t *testing.T) {
 	})
 
 	t.Run("post v0.11.0", func(t *testing.T) {
-		integrationClient := feeder.NewTestClient(t, &utils.Integration)
+		integrationClient := feeder.NewTestClient(t, &networks.Integration)
 		integGw := adaptfeeder.New(integrationClient)
 
 		for name, height := range map[string]uint64{

--- a/rpc/v9/storage_test.go
+++ b/rpc/v9/storage_test.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/NethermindEth/juno/blockchain"
+	"github.com/NethermindEth/juno/blockchain/networks"
 	"github.com/NethermindEth/juno/clients/feeder"
 	"github.com/NethermindEth/juno/core"
 	"github.com/NethermindEth/juno/core/crypto"
@@ -773,12 +774,12 @@ func TestStorageProof_StorageRoots(t *testing.T) {
 	mockCtrl := gomock.NewController(t)
 	t.Cleanup(mockCtrl.Finish)
 
-	client := feeder.NewTestClient(t, &utils.Mainnet)
+	client := feeder.NewTestClient(t, &networks.Mainnet)
 	gw := adaptfeeder.New(client)
 
 	log := utils.NewNopZapLogger()
 	testDB := memory.New()
-	bc := blockchain.New(testDB, &utils.Mainnet)
+	bc := blockchain.New(testDB, &networks.Mainnet)
 	dataSource := sync.NewFeederGatewayDataSource(bc, gw)
 	synchronizer := sync.New(bc, dataSource, log, time.Duration(0), time.Duration(0), false, testDB)
 	ctx, cancel := context.WithTimeout(t.Context(), time.Second)

--- a/rpc/v9/subscriptions_test.go
+++ b/rpc/v9/subscriptions_test.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/NethermindEth/juno/blockchain"
+	"github.com/NethermindEth/juno/blockchain/networks"
 	"github.com/NethermindEth/juno/clients/feeder"
 	"github.com/NethermindEth/juno/core"
 	"github.com/NethermindEth/juno/core/felt"
@@ -210,7 +211,7 @@ func TestSubscribeEventsInvalidInputs(t *testing.T) {
 func TestSubscribeEvents(t *testing.T) {
 	log := utils.NewNopZapLogger()
 
-	n := &utils.Sepolia
+	n := &networks.Sepolia
 	client := feeder.NewTestClient(t, n)
 	gw := adaptfeeder.New(client)
 
@@ -852,7 +853,7 @@ func TestSubscribeTxnStatus(t *testing.T) {
 		mockChain := mocks.NewMockReader(mockCtrl)
 		mockSyncer := mocks.NewMockSyncReader(mockCtrl)
 		handler := New(mockChain, mockSyncer, nil, log)
-		handler.WithFeeder(feeder.NewTestClient(t, &utils.SepoliaIntegration))
+		handler.WithFeeder(feeder.NewTestClient(t, &networks.SepoliaIntegration))
 		mockSyncer.EXPECT().PreConfirmed().Return(nil, db.ErrKeyNotFound).AnyTimes()
 		mockChain.EXPECT().HeadsHeader().Return(nil, db.ErrKeyNotFound).AnyTimes()
 		t.Run("reverted", func(t *testing.T) {
@@ -881,7 +882,7 @@ func TestSubscribeTxnStatus(t *testing.T) {
 		mockCtrl := gomock.NewController(t)
 		t.Cleanup(mockCtrl.Finish)
 
-		client := feeder.NewTestClient(t, &utils.SepoliaIntegration)
+		client := feeder.NewTestClient(t, &networks.SepoliaIntegration)
 		mockGateway := mocks.NewMockGateway(mockCtrl)
 		adapterFeeder := adaptfeeder.New(client)
 		mockChain := mocks.NewMockReader(mockCtrl)
@@ -1023,7 +1024,7 @@ func TestSubscribeTxnStatus(t *testing.T) {
 		mockCtrl := gomock.NewController(t)
 		t.Cleanup(mockCtrl.Finish)
 
-		client := feeder.NewTestClient(t, &utils.SepoliaIntegration)
+		client := feeder.NewTestClient(t, &networks.SepoliaIntegration)
 		adapterFeeder := adaptfeeder.New(client)
 		mockSyncer := mocks.NewMockSyncReader(mockCtrl)
 		handler := New(nil, mockSyncer, nil, log)
@@ -1159,7 +1160,7 @@ func TestSubscribeNewHeads(t *testing.T) {
 }
 
 func TestSubscribeNewHeadsHistorical(t *testing.T) {
-	client := feeder.NewTestClient(t, &utils.Mainnet)
+	client := feeder.NewTestClient(t, &networks.Mainnet)
 	gw := adaptfeeder.New(client)
 
 	block0, err := gw.BlockByNumber(t.Context(), 0)
@@ -1169,10 +1170,10 @@ func TestSubscribeNewHeadsHistorical(t *testing.T) {
 	require.NoError(t, err)
 
 	testDB := memory.New()
-	chain := blockchain.New(testDB, &utils.Mainnet)
+	chain := blockchain.New(testDB, &networks.Mainnet)
 	assert.NoError(t, chain.Store(block0, &emptyCommitments, stateUpdate0, nil))
 
-	chain = blockchain.New(testDB, &utils.Mainnet)
+	chain = blockchain.New(testDB, &networks.Mainnet)
 	syncer := newFakeSyncer()
 
 	ctx, cancel := context.WithCancel(t.Context())
@@ -1381,7 +1382,7 @@ func TestSubscribeNewTransactions(t *testing.T) {
 	mockChain.EXPECT().SubscribeL1Head().Return(blockchain.L1HeadSubscription{Subscription: l1Feed.Subscribe()})
 	handler, _ := setupRPC(t, ctx, mockChain, syncer)
 
-	n := &utils.Sepolia
+	n := &networks.Sepolia
 	client := feeder.NewTestClient(t, n)
 	gw := adaptfeeder.New(client)
 
@@ -1929,7 +1930,7 @@ func TestSubscribeTransactionReceipts(t *testing.T) {
 	mockChain.EXPECT().SubscribeL1Head().Return(blockchain.L1HeadSubscription{Subscription: l1Feed.Subscribe()})
 	handler, _ := setupRPC(t, ctx, mockChain, syncer)
 
-	n := &utils.Sepolia
+	n := &networks.Sepolia
 	client := feeder.NewTestClient(t, n)
 	gw := adaptfeeder.New(client)
 
@@ -2489,7 +2490,7 @@ func subMsg(method string) string {
 func testHeadBlock(t *testing.T) *core.Block {
 	t.Helper()
 
-	n := new(utils.Sepolia)
+	n := new(networks.Sepolia)
 	client := feeder.NewTestClient(t, n)
 	gw := adaptfeeder.New(client)
 

--- a/rpc/v9/trace.go
+++ b/rpc/v9/trace.go
@@ -9,6 +9,7 @@ import (
 	"strconv"
 
 	"github.com/NethermindEth/juno/blockchain"
+	"github.com/NethermindEth/juno/blockchain/networks"
 	"github.com/NethermindEth/juno/core"
 	"github.com/NethermindEth/juno/core/felt"
 	"github.com/NethermindEth/juno/core/pending"
@@ -569,7 +570,7 @@ func (h *Handler) buildBlockInfo(header *core.Header) (vm.BlockInfo, *jsonrpc.Er
 
 // shouldFetchTracesFromFeederGateway determines if
 // traces for a block should be fetched from the feeder gateway.
-func shouldFetchTracesFromFeederGateway(block *core.Block, network *utils.Network) (bool, error) {
+func shouldFetchTracesFromFeederGateway(block *core.Block, network *networks.Network) (bool, error) {
 	blockVer, err := core.ParseBlockVersion(block.ProtocolVersion)
 	if err != nil {
 		return false, err
@@ -583,7 +584,7 @@ func shouldFetchTracesFromFeederGateway(block *core.Block, network *utils.Networ
 	fetchFromFeederGW = fetchFromFeederGW ||
 		(block.Number >= 1943705 &&
 			block.Number <= 1952704 &&
-			*network == utils.Mainnet)
+			*network == networks.Mainnet)
 
 	return fetchFromFeederGW, nil
 }

--- a/rpc/v9/trace.go
+++ b/rpc/v9/trace.go
@@ -570,7 +570,10 @@ func (h *Handler) buildBlockInfo(header *core.Header) (vm.BlockInfo, *jsonrpc.Er
 
 // shouldFetchTracesFromFeederGateway determines if
 // traces for a block should be fetched from the feeder gateway.
-func shouldFetchTracesFromFeederGateway(block *core.Block, network *networks.Network) (bool, error) {
+func shouldFetchTracesFromFeederGateway(
+	block *core.Block,
+	network *networks.Network,
+) (bool, error) {
 	blockVer, err := core.ParseBlockVersion(block.ProtocolVersion)
 	if err != nil {
 		return false, err

--- a/rpc/v9/trace_test.go
+++ b/rpc/v9/trace_test.go
@@ -99,7 +99,11 @@ func TestTraceFallback(t *testing.T) {
 	})
 }
 
-func AssertTracedBlockTransactions(t *testing.T, n *networks.Network, tests map[string]expectedBlockTrace) {
+func AssertTracedBlockTransactions(
+	t *testing.T,
+	n *networks.Network,
+	tests map[string]expectedBlockTrace,
+) {
 	t.Helper()
 
 	mockCtrl := gomock.NewController(t)

--- a/rpc/v9/trace_test.go
+++ b/rpc/v9/trace_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	"github.com/NethermindEth/juno/blockchain"
+	"github.com/NethermindEth/juno/blockchain/networks"
 	"github.com/NethermindEth/juno/clients/feeder"
 	"github.com/NethermindEth/juno/core"
 	"github.com/NethermindEth/juno/core/felt"
@@ -76,7 +77,7 @@ func TestTraceFallback(t *testing.T) {
 			},
 		}
 
-		AssertTracedBlockTransactions(t, &utils.Integration, tests)
+		AssertTracedBlockTransactions(t, &networks.Integration, tests)
 	})
 
 	t.Run("Sepolia", func(t *testing.T) {
@@ -94,11 +95,11 @@ func TestTraceFallback(t *testing.T) {
 			},
 		}
 
-		AssertTracedBlockTransactions(t, &utils.Sepolia, tests)
+		AssertTracedBlockTransactions(t, &networks.Sepolia, tests)
 	})
 }
 
-func AssertTracedBlockTransactions(t *testing.T, n *utils.Network, tests map[string]expectedBlockTrace) {
+func AssertTracedBlockTransactions(t *testing.T, n *networks.Network, tests map[string]expectedBlockTrace) {
 	t.Helper()
 
 	mockCtrl := gomock.NewController(t)
@@ -150,7 +151,7 @@ func AssertTracedBlockTransactions(t *testing.T, n *utils.Network, tests map[str
 			handler = handler.WithFeeder(client)
 			blockID := blockIDNumber(t, test.blockNumber)
 			traces, httpHeader, err := handler.TraceBlockTransactions(t.Context(), &blockID)
-			if n == &utils.Sepolia && description == "newer block" {
+			if n == &networks.Sepolia && description == "newer block" {
 				// For the newer block test, we test 3 of the block traces (INVOKE, DEPLOY_ACCOUNT, DECLARE)
 				traces = []rpc.TracedBlockTransaction{traces[0], traces[7], traces[11]}
 			}
@@ -169,7 +170,7 @@ func TestTraceBlockTransactionsReturnsError(t *testing.T) {
 		mockCtrl := gomock.NewController(t)
 		mockReader := mocks.NewMockReader(mockCtrl)
 
-		network := utils.Sepolia
+		network := networks.Sepolia
 		client := feeder.NewTestClient(t, &network)
 		gateway := adaptfeeder.New(client)
 
@@ -323,7 +324,7 @@ func TestTraceTransaction(t *testing.T) {
 
 	mockReader := mocks.NewMockReader(mockCtrl)
 	mockSyncReader := mocks.NewMockSyncReader(mockCtrl)
-	mockReader.EXPECT().Network().Return(&utils.Mainnet).AnyTimes()
+	mockReader.EXPECT().Network().Return(&networks.Mainnet).AnyTimes()
 	mockVM := mocks.NewMockVM(mockCtrl)
 	handler := rpc.New(mockReader, mockSyncReader, mockVM, utils.NewNopZapLogger())
 
@@ -605,7 +606,7 @@ func TestTraceTransaction(t *testing.T) {
 	})
 
 	t.Run("reverted INVOKE tx from feeder", func(t *testing.T) {
-		n := &utils.Sepolia
+		n := &networks.Sepolia
 
 		handler := rpc.New(mockReader, mockSyncReader, mockVM, utils.NewNopZapLogger())
 
@@ -754,7 +755,7 @@ func TestTraceBlockTransactions(t *testing.T) {
 	for description, blockID := range errTests {
 		t.Run(description, func(t *testing.T) {
 			log := utils.NewNopZapLogger()
-			n := &utils.Mainnet
+			n := &networks.Mainnet
 			chain := blockchain.New(memory.New(), n)
 			handler := rpc.New(chain, nil, nil, log)
 
@@ -777,7 +778,7 @@ func TestTraceBlockTransactions(t *testing.T) {
 
 	mockCtrl := gomock.NewController(t)
 	t.Cleanup(mockCtrl.Finish)
-	n := &utils.Mainnet
+	n := &networks.Mainnet
 
 	mockReader := mocks.NewMockReader(mockCtrl)
 	mockSyncReader := mocks.NewMockSyncReader(mockCtrl)

--- a/rpc/v9/transaction.go
+++ b/rpc/v9/transaction.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	"github.com/NethermindEth/juno/adapters/sn2core"
+	"github.com/NethermindEth/juno/blockchain/networks"
 	"github.com/NethermindEth/juno/clients/gateway"
 	"github.com/NethermindEth/juno/core"
 	"github.com/NethermindEth/juno/core/felt"
@@ -367,7 +368,7 @@ func AdaptBroadcastedTransaction(
 	ctx context.Context,
 	compiler compiler.Compiler,
 	broadcastedTxn *BroadcastedTransaction,
-	network *utils.Network,
+	network *networks.Network,
 ) (core.Transaction, core.ClassDefinition, *felt.Felt, error) {
 	feederTxn := AdaptRPCTxToFeederTx(&broadcastedTxn.Transaction)
 

--- a/rpc/v9/transaction_test.go
+++ b/rpc/v9/transaction_test.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/NethermindEth/juno/adapters/sn2core"
+	"github.com/NethermindEth/juno/blockchain/networks"
 	"github.com/NethermindEth/juno/clients/feeder"
 	"github.com/NethermindEth/juno/clients/gateway"
 	"github.com/NethermindEth/juno/core"
@@ -81,12 +82,12 @@ func TestTransactionByHashNotFoundInPreConfirmedBlock(t *testing.T) {
 func TestTransactionByHash(t *testing.T) {
 	tests := map[string]struct {
 		hash     string
-		network  *utils.Network
+		network  *networks.Network
 		expected string
 	}{
 		"DECLARE v1": {
 			hash:    "0x1b4d9f09276629d496af1af8ff00173c11ff146affacb1b5c858d7aa89001ae",
-			network: &utils.Mainnet,
+			network: &networks.Mainnet,
 			expected: `{
 			"type": "DECLARE",
 			"transaction_hash": "0x1b4d9f09276629d496af1af8ff00173c11ff146affacb1b5c858d7aa89001ae",
@@ -104,7 +105,7 @@ func TestTransactionByHash(t *testing.T) {
 
 		"DECLARE v0": {
 			hash:    "0x222f8902d1eeea76fa2642a90e2411bfd71cffb299b3a299029e1937fab3fe4",
-			network: &utils.Mainnet,
+			network: &networks.Mainnet,
 			expected: `{
 				"transaction_hash": "0x222f8902d1eeea76fa2642a90e2411bfd71cffb299b3a299029e1937fab3fe4",
 				"type": "DECLARE",
@@ -118,7 +119,7 @@ func TestTransactionByHash(t *testing.T) {
 
 		"L1 Handler v0 with nonce": {
 			hash:    "0x537eacfd3c49166eec905daff61ff7feef9c133a049ea2135cb94eec840a4a8",
-			network: &utils.Mainnet,
+			network: &networks.Mainnet,
 			expected: `{
        "type": "L1_HANDLER",
        "transaction_hash": "0x537eacfd3c49166eec905daff61ff7feef9c133a049ea2135cb94eec840a4a8",
@@ -137,7 +138,7 @@ func TestTransactionByHash(t *testing.T) {
 		},
 		"L1 Handler v0 without nonce": {
 			hash:    "0x5d50b7020f7cf8033fd7d913e489f47edf74fbf3c8ada85be512c7baa6a2eab",
-			network: &utils.Mainnet,
+			network: &networks.Mainnet,
 			expected: `{
 				"type": "L1_HANDLER",
 				"transaction_hash":  "0x5d50b7020f7cf8033fd7d913e489f47edf74fbf3c8ada85be512c7baa6a2eab",
@@ -156,7 +157,7 @@ func TestTransactionByHash(t *testing.T) {
 
 		"Invoke v1": {
 			hash:    "0x2897e3cec3e24e4d341df26b8cf1ab84ea1c01a051021836b36c6639145b497",
-			network: &utils.Mainnet,
+			network: &networks.Mainnet,
 			expected: `{
        "type": "INVOKE",
        "transaction_hash": "0x2897e3cec3e24e4d341df26b8cf1ab84ea1c01a051021836b36c6639145b497",
@@ -192,7 +193,7 @@ func TestTransactionByHash(t *testing.T) {
 
 		"DEPLOY v0": {
 			hash:    "0x6486c6303dba2f364c684a2e9609211c5b8e417e767f37b527cda51e776e6f0",
-			network: &utils.Mainnet,
+			network: &networks.Mainnet,
 			expected: `{
        "type": "DEPLOY",
        "transaction_hash": "0x6486c6303dba2f364c684a2e9609211c5b8e417e767f37b527cda51e776e6f0",
@@ -211,7 +212,7 @@ func TestTransactionByHash(t *testing.T) {
 
 		"DEPLOY ACCOUNT v1": {
 			hash:    "0xd61fc89f4d1dc4dc90a014957d655d38abffd47ecea8e3fa762e3160f155f2",
-			network: &utils.Mainnet,
+			network: &networks.Mainnet,
 			expected: `{
        "type": "DEPLOY_ACCOUNT",
        "transaction_hash": "0xd61fc89f4d1dc4dc90a014957d655d38abffd47ecea8e3fa762e3160f155f2",
@@ -232,7 +233,7 @@ func TestTransactionByHash(t *testing.T) {
 
 		"INVOKE v0": {
 			hash:    "0xf1d99fb97509e0dfc425ddc2a8c5398b74231658ca58b6f8da92f39cb739e",
-			network: &utils.Mainnet,
+			network: &networks.Mainnet,
 			expected: `{
        "type": "INVOKE",
        "transaction_hash": "0xf1d99fb97509e0dfc425ddc2a8c5398b74231658ca58b6f8da92f39cb739e",
@@ -251,7 +252,7 @@ func TestTransactionByHash(t *testing.T) {
 		},
 		"DECLARE v3": {
 			hash:    "0x41d1f5206ef58a443e7d3d1ca073171ec25fa75313394318fc83a074a6631c3",
-			network: &utils.Integration,
+			network: &networks.Integration,
 			expected: `{
 		"transaction_hash": "0x41d1f5206ef58a443e7d3d1ca073171ec25fa75313394318fc83a074a6631c3",
 		"type": "DECLARE",
@@ -284,7 +285,7 @@ func TestTransactionByHash(t *testing.T) {
 		},
 		"INVOKE v3": {
 			hash:    "0x49728601e0bb2f48ce506b0cbd9c0e2a9e50d95858aa41463f46386dca489fd",
-			network: &utils.Integration,
+			network: &networks.Integration,
 			expected: `{
 				"type": "INVOKE",
 				"transaction_hash": "0x49728601e0bb2f48ce506b0cbd9c0e2a9e50d95858aa41463f46386dca489fd",
@@ -332,7 +333,7 @@ func TestTransactionByHash(t *testing.T) {
 		},
 		"DEPLOY ACCOUNT v3": {
 			hash:    "0x29fd7881f14380842414cdfdd8d6c0b1f2174f8916edcfeb1ede1eb26ac3ef0",
-			network: &utils.Integration,
+			network: &networks.Integration,
 			expected: `{
 				"transaction_hash": "0x29fd7881f14380842414cdfdd8d6c0b1f2174f8916edcfeb1ede1eb26ac3ef0",
 				"version": "0x3",
@@ -367,7 +368,7 @@ func TestTransactionByHash(t *testing.T) {
 		// https://alpha-sepolia.starknet.io/feeder_gateway/get_transaction?transactionHash=0x2db07ed11b1f6c678de9fc19ef0dfb8e71631e1cff236a34e68f51528a21282
 		"INVOKE v3 without l1_data_gas": {
 			hash:    "0x2db07ed11b1f6c678de9fc19ef0dfb8e71631e1cff236a34e68f51528a21282",
-			network: &utils.Integration,
+			network: &networks.Integration,
 			expected: `{
 				"transaction_hash": "0x2db07ed11b1f6c678de9fc19ef0dfb8e71631e1cff236a34e68f51528a21282",
 				"version": "0x3",
@@ -463,7 +464,7 @@ func TestTransactionByHash(t *testing.T) {
 }
 
 func TestTransactionByHash_PreConfirmedBlock(t *testing.T) {
-	gw := feeder.NewTestClient(t, &utils.SepoliaIntegration)
+	gw := feeder.NewTestClient(t, &networks.SepoliaIntegration)
 	adapterFeeder := adaptfeeder.New(gw)
 	mockCtrl := gomock.NewController(t)
 	t.Cleanup(mockCtrl.Finish)
@@ -513,7 +514,7 @@ func TestTransactionByHash_PreConfirmedBlock(t *testing.T) {
 func TestTransactionByBlockIdAndIndex(t *testing.T) {
 	mockCtrl := gomock.NewController(t)
 	t.Cleanup(mockCtrl.Finish)
-	n := &utils.Mainnet
+	n := &networks.Mainnet
 	mockReader := mocks.NewMockReader(mockCtrl)
 	mockSyncReader := mocks.NewMockSyncReader(mockCtrl)
 	client := feeder.NewTestClient(t, n)
@@ -674,7 +675,7 @@ func TestTransactionReceiptByHash(t *testing.T) {
 	mockCtrl := gomock.NewController(t)
 	t.Cleanup(mockCtrl.Finish)
 
-	n := &utils.Mainnet
+	n := &networks.Mainnet
 	mockReader := mocks.NewMockReader(mockCtrl)
 	mockSyncReader := mocks.NewMockSyncReader(mockCtrl)
 	handler := rpc.New(mockReader, mockSyncReader, nil, nil)
@@ -966,7 +967,7 @@ func TestTransactionReceiptByHash(t *testing.T) {
 			}
 		}`
 
-		integClient := feeder.NewTestClient(t, &utils.Integration)
+		integClient := feeder.NewTestClient(t, &networks.Integration)
 		integGw := adaptfeeder.New(integClient)
 
 		blockWithRevertedTxn, err := integGw.BlockByNumber(t.Context(), 304740)
@@ -1046,7 +1047,7 @@ func TestTransactionReceiptByHash(t *testing.T) {
 			"type": "INVOKE"
 		}`
 
-		integClient := feeder.NewTestClient(t, &utils.Integration)
+		integClient := feeder.NewTestClient(t, &networks.Integration)
 		integGw := adaptfeeder.New(integClient)
 
 		block, err := integGw.BlockByNumber(t.Context(), 319132)
@@ -1112,7 +1113,7 @@ func TestTransactionReceiptByHash(t *testing.T) {
 			}
 		}`
 
-		netClient := feeder.NewTestClient(t, &utils.SepoliaIntegration)
+		netClient := feeder.NewTestClient(t, &networks.SepoliaIntegration)
 		netGW := adaptfeeder.New(netClient)
 
 		block, err := netGW.BlockByNumber(t.Context(), 35748)
@@ -1190,7 +1191,7 @@ func TestAddTransactionUnmarshal(t *testing.T) {
 }
 
 func TestAddTransaction(t *testing.T) {
-	n := &utils.Integration
+	n := &networks.Integration
 	gw := adaptfeeder.New(feeder.NewTestClient(t, n))
 	txWithoutClass := func(hash string) rpc.BroadcastedTransaction {
 		tx, err := gw.Transaction(t.Context(), felt.NewUnsafeFromString[felt.Felt](hash))
@@ -1561,7 +1562,7 @@ func TestAddTransaction(t *testing.T) {
 		t.Cleanup(mockCtrl.Finish)
 
 		mockReader := mocks.NewMockReader(mockCtrl)
-		n := &utils.Sepolia
+		n := &networks.Sepolia
 		mockReader.EXPECT().Network().Return(n).AnyTimes()
 
 		receivedTxFeed := feed.New[core.Transaction]()
@@ -1613,19 +1614,19 @@ func TestTransactionStatus(t *testing.T) {
 	t.Cleanup(mockCtrl.Finish)
 
 	tests := []struct {
-		network           *utils.Network
+		network           *networks.Network
 		verifiedTxHash    *felt.Felt
 		nonVerifiedTxHash *felt.Felt
 		notFoundTxHash    *felt.Felt
 	}{
 		{
-			network:           &utils.Mainnet,
+			network:           &networks.Mainnet,
 			verifiedTxHash:    felt.NewUnsafeFromString[felt.Felt]("0xf1d99fb97509e0dfc425ddc2a8c5398b74231658ca58b6f8da92f39cb739e"),
 			nonVerifiedTxHash: felt.NewUnsafeFromString[felt.Felt]("0x6c40890743aa220b10e5ee68cef694c5c23cc2defd0dbdf5546e687f9982ab1"),
 			notFoundTxHash:    felt.NewUnsafeFromString[felt.Felt]("0x8c96a2b3d73294667e489bf8904c6aa7c334e38e24ad5a721c7e04439ff9"),
 		},
 		{
-			network:           &utils.Integration,
+			network:           &networks.Integration,
 			verifiedTxHash:    felt.NewUnsafeFromString[felt.Felt]("0x5e91283c1c04c3f88e4a98070df71227fb44dea04ce349c7eb379f85a10d1c3"),
 			nonVerifiedTxHash: felt.NewUnsafeFromString[felt.Felt]("0x45d9c2c8e01bacae6dec3438874576a4a1ce65f1d4247f4e9748f0e7216838"),
 			notFoundTxHash:    felt.NewUnsafeFromString[felt.Felt]("0xd7747f3d0ce84b3a19b05b987a782beac22c54e66773303e94ea78cc3c15"),
@@ -1767,7 +1768,7 @@ func TestTransactionStatus(t *testing.T) {
 		})
 
 		t.Run("transaction found in preconfirmed", func(t *testing.T) {
-			network := &utils.SepoliaIntegration
+			network := &networks.SepoliaIntegration
 			sepoliaIntClient := feeder.NewTestClient(t, network)
 			sepoliaIntGw := adaptfeeder.New(sepoliaIntClient)
 			blockNumber := uint64(1204672)
@@ -1825,7 +1826,7 @@ func TestTransactionStatus(t *testing.T) {
 		t.Run("Rejected historical tx found in feeder", func(t *testing.T) {
 			mockReader := mocks.NewMockReader(mockCtrl)
 			mockSyncReader := mocks.NewMockSyncReader(mockCtrl)
-			client := feeder.NewTestClient(t, &utils.SepoliaIntegration)
+			client := feeder.NewTestClient(t, &networks.SepoliaIntegration)
 			txHash, err := felt.NewFromString[felt.Felt]("0x1111")
 			require.NoError(t, err)
 
@@ -2149,7 +2150,7 @@ func TestAdaptBroadcastedTransaction(t *testing.T) {
 	require.NoError(t, json.Unmarshal([]byte(txnNonZeroL2GasData), &txnNonZeroL2Gas))
 
 	tx, _, _, err := rpc.AdaptBroadcastedTransaction(
-		t.Context(), nil, &txnNonZeroL2Gas, &utils.Sepolia,
+		t.Context(), nil, &txnNonZeroL2Gas, &networks.Sepolia,
 	)
 	require.NoError(t, err)
 	resultTxn, ok := (tx).(*core.DeployAccountTransaction)
@@ -2244,7 +2245,7 @@ func TestSubmittedTransactionsCache(t *testing.T) {
 
 	ctx := t.Context()
 	log := utils.NewNopZapLogger()
-	network := utils.Integration
+	network := networks.Integration
 
 	client := feeder.NewTestClient(t, &network)
 

--- a/sequencer/sequencer_test.go
+++ b/sequencer/sequencer_test.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/NethermindEth/juno/blockchain"
+	"github.com/NethermindEth/juno/blockchain/networks"
 	"github.com/NethermindEth/juno/builder"
 	"github.com/NethermindEth/juno/core"
 	"github.com/NethermindEth/juno/core/felt"
@@ -29,7 +30,7 @@ func getEmptySequencer(t *testing.T, blockTime time.Duration, seqAddr *felt.Felt
 	testDB := memory.New()
 	mockCtrl := gomock.NewController(t)
 	mockVM := mocks.NewMockVM(mockCtrl)
-	network := &utils.Mainnet
+	network := &networks.Mainnet
 	bc := blockchain.New(testDB, network)
 	emptyStateDiff := core.EmptyStateDiff()
 	require.NoError(t, bc.StoreGenesis(&emptyStateDiff, nil))
@@ -103,7 +104,7 @@ func getGenesisSequencer(
 	}
 
 	testDB := memory.New()
-	network := &utils.Mainnet
+	network := &networks.Mainnet
 	bc := blockchain.New(testDB, network)
 	log := utils.NewNopZapLogger()
 	privKey, err := ecdsa.GenerateKey(rand.Reader)
@@ -117,7 +118,7 @@ func getGenesisSequencer(
 		"../genesis/classes/universaldeployer.json", "../genesis/classes/udacnt.json",
 	}
 
-	feeTokens := utils.DefaultFeeTokenAddresses
+	feeTokens := networks.DefaultFeeTokenAddresses
 	chainInfo := vm.ChainInfo{
 		ChainID:           network.L2ChainID,
 		FeeTokenAddresses: feeTokens,

--- a/starknet/compiler/compiler_test.go
+++ b/starknet/compiler/compiler_test.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/NethermindEth/juno/adapters/sn2core"
+	"github.com/NethermindEth/juno/blockchain/networks"
 	"github.com/NethermindEth/juno/clients/feeder"
 	"github.com/NethermindEth/juno/core"
 	"github.com/NethermindEth/juno/core/felt"
@@ -26,7 +27,7 @@ func TestCompileFFI(t *testing.T) {
 	})
 
 	t.Run("ok", func(t *testing.T) {
-		cl := feeder.NewTestClient(t, &utils.Integration)
+		cl := feeder.NewTestClient(t, &networks.Integration)
 		classHash := felt.NewUnsafeFromString[felt.Felt](
 			"0xc6c634d10e2cc7b1db6b4403b477f05e39cb4900fd5ea0156d1721dbb6c59b",
 		)

--- a/starknetdata/feeder/feeder_test.go
+++ b/starknetdata/feeder/feeder_test.go
@@ -5,11 +5,11 @@ import (
 	"testing"
 
 	"github.com/NethermindEth/juno/adapters/sn2core"
+	"github.com/NethermindEth/juno/blockchain/networks"
 	"github.com/NethermindEth/juno/clients/feeder"
 	"github.com/NethermindEth/juno/core"
 	"github.com/NethermindEth/juno/core/felt"
 	adaptfeeder "github.com/NethermindEth/juno/starknetdata/feeder"
-	"github.com/NethermindEth/juno/utils"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -17,7 +17,7 @@ import (
 func TestBlockByNumber(t *testing.T) {
 	numbers := []uint64{147, 11817}
 
-	client := feeder.NewTestClient(t, &utils.Mainnet)
+	client := feeder.NewTestClient(t, &networks.Mainnet)
 	adapter := adaptfeeder.New(client)
 	ctx := t.Context()
 
@@ -38,7 +38,7 @@ func TestBlockByNumber(t *testing.T) {
 }
 
 func TestBlockLatest(t *testing.T) {
-	client := feeder.NewTestClient(t, &utils.Mainnet)
+	client := feeder.NewTestClient(t, &networks.Mainnet)
 	adapter := adaptfeeder.New(client)
 	ctx := t.Context()
 
@@ -54,7 +54,7 @@ func TestBlockLatest(t *testing.T) {
 }
 
 func TestBlockHeaderLatest(t *testing.T) {
-	client := feeder.NewTestClient(t, &utils.Mainnet)
+	client := feeder.NewTestClient(t, &networks.Mainnet)
 	adapter := adaptfeeder.New(client)
 	ctx := t.Context()
 
@@ -71,7 +71,7 @@ func TestBlockHeaderLatest(t *testing.T) {
 func TestStateUpdate(t *testing.T) {
 	numbers := []uint64{0, 1, 2, 21656}
 
-	client := feeder.NewTestClient(t, &utils.Mainnet)
+	client := feeder.NewTestClient(t, &networks.Mainnet)
 	adapter := adaptfeeder.New(client)
 	ctx := t.Context()
 
@@ -98,7 +98,7 @@ func TestClassV0(t *testing.T) {
 		"0x28d1671fb74ecb54d848d463cefccffaef6df3ae40db52130e19fe8299a7b43",
 	}
 
-	client := feeder.NewTestClient(t, &utils.Sepolia)
+	client := feeder.NewTestClient(t, &networks.Sepolia)
 	adapter := adaptfeeder.New(client)
 	ctx := t.Context()
 
@@ -118,10 +118,10 @@ func TestClassV0(t *testing.T) {
 }
 
 func TestTransaction(t *testing.T) {
-	clientGoerli := feeder.NewTestClient(t, &utils.Goerli)
+	clientGoerli := feeder.NewTestClient(t, &networks.Goerli)
 	adapterGoerli := adaptfeeder.New(clientGoerli)
 
-	clientMainnet := feeder.NewTestClient(t, &utils.Mainnet)
+	clientMainnet := feeder.NewTestClient(t, &networks.Mainnet)
 	adapterMainnet := adaptfeeder.New(clientMainnet)
 
 	ctx := t.Context()
@@ -193,7 +193,7 @@ func TestTransaction(t *testing.T) {
 }
 
 func TestClassV1(t *testing.T) {
-	client := feeder.NewTestClient(t, &utils.Integration)
+	client := feeder.NewTestClient(t, &networks.Integration)
 	adapter := adaptfeeder.New(client)
 
 	tests := []struct {
@@ -238,7 +238,7 @@ func TestClassV1(t *testing.T) {
 func TestStateUpdateWithBlock(t *testing.T) {
 	numbers := []uint64{0, 78541}
 
-	client := feeder.NewTestClient(t, &utils.Integration)
+	client := feeder.NewTestClient(t, &networks.Integration)
 	adapter := adaptfeeder.New(client)
 	ctx := t.Context()
 
@@ -262,7 +262,7 @@ func TestStateUpdateWithBlock(t *testing.T) {
 }
 
 func TestStateUpdatePendingWithBlock(t *testing.T) {
-	client := feeder.NewTestClient(t, &utils.Integration)
+	client := feeder.NewTestClient(t, &networks.Integration)
 	adapter := adaptfeeder.New(client)
 	ctx := t.Context()
 
@@ -279,7 +279,7 @@ func TestStateUpdatePendingWithBlock(t *testing.T) {
 }
 
 func TestPreConfirmedBlock(t *testing.T) {
-	client := feeder.NewTestClient(t, &utils.SepoliaIntegration)
+	client := feeder.NewTestClient(t, &networks.SepoliaIntegration)
 	adapter := adaptfeeder.New(client)
 	ctx := t.Context()
 	blockNumber := uint64(1204672)

--- a/sync/pending_polling_test.go
+++ b/sync/pending_polling_test.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/NethermindEth/juno/blockchain"
+	"github.com/NethermindEth/juno/blockchain/networks"
 	"github.com/NethermindEth/juno/clients/feeder"
 	"github.com/NethermindEth/juno/core"
 	"github.com/NethermindEth/juno/core/felt"
@@ -60,8 +61,8 @@ func (m *MockDataSource) PreConfirmedBlockByNumber(
 
 func TestPollPreLatest(t *testing.T) {
 	testDB := memory.New()
-	bc := blockchain.New(testDB, &utils.Mainnet)
-	client := feeder.NewTestClient(t, &utils.Mainnet)
+	bc := blockchain.New(testDB, &networks.Mainnet)
+	client := feeder.NewTestClient(t, &networks.Mainnet)
 	gw := adaptfeeder.New(client)
 	dataSource := NewFeederGatewayDataSource(bc, gw)
 	log := utils.NewNopZapLogger()
@@ -234,8 +235,8 @@ func TestPollPreLatest(t *testing.T) {
 
 func TestPollPreConfirmedLoop(t *testing.T) {
 	testDB := memory.New()
-	bc := blockchain.New(testDB, &utils.Sepolia)
-	client := feeder.NewTestClient(t, &utils.Sepolia)
+	bc := blockchain.New(testDB, &networks.Sepolia)
+	client := feeder.NewTestClient(t, &networks.Sepolia)
 	gw := adaptfeeder.New(client)
 	dataSource := NewFeederGatewayDataSource(bc, gw)
 	log := utils.NewNopZapLogger()
@@ -329,8 +330,8 @@ func TestPollPreConfirmedLoop(t *testing.T) {
 
 func TestPollPendingData(t *testing.T) {
 	testDB := memory.New()
-	bc := blockchain.New(testDB, &utils.Sepolia)
-	client := feeder.NewTestClient(t, &utils.Sepolia)
+	bc := blockchain.New(testDB, &networks.Sepolia)
+	client := feeder.NewTestClient(t, &networks.Sepolia)
 	gw := adaptfeeder.New(client)
 	dataSource := NewFeederGatewayDataSource(bc, gw)
 	log := utils.NewNopZapLogger()
@@ -409,8 +410,8 @@ func TestPollPendingData(t *testing.T) {
 
 func TestPollPendingDataPreConfirmedPolling(t *testing.T) {
 	testDB := memory.New()
-	bc := blockchain.New(testDB, &utils.Sepolia)
-	client := feeder.NewTestClient(t, &utils.Sepolia)
+	bc := blockchain.New(testDB, &networks.Sepolia)
+	client := feeder.NewTestClient(t, &networks.Sepolia)
 	gw := adaptfeeder.New(client)
 	dataSource := NewFeederGatewayDataSource(bc, gw)
 
@@ -470,9 +471,9 @@ func TestPollPendingDataPreConfirmedPolling(t *testing.T) {
 
 func TestStorePreConfirmed(t *testing.T) {
 	testDB := memory.New()
-	bc := blockchain.New(testDB, &utils.Mainnet)
+	bc := blockchain.New(testDB, &networks.Mainnet)
 	log := utils.NewNopZapLogger()
-	client := feeder.NewTestClient(t, &utils.Mainnet)
+	client := feeder.NewTestClient(t, &networks.Mainnet)
 	gw := adaptfeeder.New(client)
 
 	s := New(bc, NewFeederGatewayDataSource(bc, nil), log, 0, 0, false, testDB)

--- a/sync/reorg_test.go
+++ b/sync/reorg_test.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/NethermindEth/juno/blockchain"
+	"github.com/NethermindEth/juno/blockchain/networks"
 	"github.com/NethermindEth/juno/builder"
 	"github.com/NethermindEth/juno/core"
 	"github.com/NethermindEth/juno/core/felt"
@@ -32,7 +33,7 @@ const (
 	logLevel     = zap.PanicLevel
 )
 
-var network = &utils.Mainnet
+var network = &networks.Mainnet
 
 type testBlockDataSource atomic.Value
 
@@ -106,7 +107,7 @@ func initGenesis(t *testing.T) (*memory.Database, sync.CommittedBlock) {
 		"../genesis/classes/universaldeployer.json", "../genesis/classes/udacnt.json",
 	}
 
-	feeTokens := utils.DefaultFeeTokenAddresses
+	feeTokens := networks.DefaultFeeTokenAddresses
 	chainInfo := vm.ChainInfo{
 		ChainID:           network.L2ChainID,
 		FeeTokenAddresses: feeTokens,
@@ -197,7 +198,7 @@ func (b *blockGenerator) mine(t *testing.T, dataSource *testBlockDataSource, cou
 }
 
 func newTestBuilder(log utils.Logger, bc *blockchain.Blockchain) *builder.Builder {
-	feeTokens := utils.DefaultFeeTokenAddresses
+	feeTokens := networks.DefaultFeeTokenAddresses
 	chainInfo := vm.ChainInfo{
 		ChainID:           network.L2ChainID,
 		FeeTokenAddresses: feeTokens,

--- a/sync/sync_test.go
+++ b/sync/sync_test.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/NethermindEth/juno/blockchain"
+	"github.com/NethermindEth/juno/blockchain/networks"
 	"github.com/NethermindEth/juno/clients/feeder"
 	"github.com/NethermindEth/juno/core"
 	"github.com/NethermindEth/juno/core/felt"
@@ -27,7 +28,7 @@ func TestSyncBlocks(t *testing.T) {
 	mockCtrl := gomock.NewController(t)
 	t.Cleanup(mockCtrl.Finish)
 
-	client := feeder.NewTestClient(t, &utils.Mainnet)
+	client := feeder.NewTestClient(t, &networks.Mainnet)
 	gw := adaptfeeder.New(client)
 	testBlockchain := func(t *testing.T, bc *blockchain.Blockchain) {
 		t.Helper()
@@ -55,7 +56,7 @@ func TestSyncBlocks(t *testing.T) {
 	log := utils.NewNopZapLogger()
 	t.Run("sync multiple blocks in an empty db", func(t *testing.T) {
 		testDB := memory.New()
-		bc := blockchain.New(testDB, &utils.Mainnet)
+		bc := blockchain.New(testDB, &networks.Mainnet)
 		dataSource := sync.NewFeederGatewayDataSource(bc, gw)
 		synchronizer := sync.New(bc, dataSource, log, time.Duration(0), time.Duration(0), false, testDB)
 		ctx, cancel := context.WithTimeout(t.Context(), timeout)
@@ -68,7 +69,7 @@ func TestSyncBlocks(t *testing.T) {
 
 	t.Run("sync multiple blocks in a non-empty db", func(t *testing.T) {
 		testDB := memory.New()
-		bc := blockchain.New(testDB, &utils.Mainnet)
+		bc := blockchain.New(testDB, &networks.Mainnet)
 		b0, err := gw.BlockByNumber(t.Context(), 0)
 		require.NoError(t, err)
 		s0, err := gw.StateUpdate(t.Context(), 0)
@@ -87,7 +88,7 @@ func TestSyncBlocks(t *testing.T) {
 
 	t.Run("sync multiple blocks, with an unreliable gw", func(t *testing.T) {
 		testDB := memory.New()
-		bc := blockchain.New(testDB, &utils.Mainnet)
+		bc := blockchain.New(testDB, &networks.Mainnet)
 
 		mockSNData := mocks.NewMockStarknetData(mockCtrl)
 
@@ -147,16 +148,16 @@ func TestSyncBlocks(t *testing.T) {
 }
 
 func TestReorg(t *testing.T) {
-	mainClient := feeder.NewTestClient(t, &utils.Mainnet)
+	mainClient := feeder.NewTestClient(t, &networks.Mainnet)
 	mainGw := adaptfeeder.New(mainClient)
 
-	sepoliaClient := feeder.NewTestClient(t, &utils.Sepolia)
+	sepoliaClient := feeder.NewTestClient(t, &networks.Sepolia)
 	sepoliaGw := adaptfeeder.New(sepoliaClient)
 
 	testDB := memory.New()
 
 	// sync to Sepolia for 2 blocks
-	bc := blockchain.New(testDB, &utils.Sepolia)
+	bc := blockchain.New(testDB, &networks.Sepolia)
 	dataSource := sync.NewFeederGatewayDataSource(bc, sepoliaGw)
 	synchronizer := sync.New(bc, dataSource, utils.NewNopZapLogger(), 0, 0, false, testDB)
 
@@ -165,7 +166,7 @@ func TestReorg(t *testing.T) {
 	cancel()
 
 	t.Run("resync to mainnet with the same db", func(t *testing.T) {
-		bc := blockchain.New(testDB, &utils.Mainnet)
+		bc := blockchain.New(testDB, &networks.Mainnet)
 
 		// Ensure current head is Sepolia head
 		head, err := bc.HeadsHeader()
@@ -218,7 +219,7 @@ func TestSubscribeNewHeads(t *testing.T) {
 	t.Parallel()
 	testDB := memory.New()
 	log := utils.NewNopZapLogger()
-	network := utils.Mainnet
+	network := networks.Mainnet
 	chain := blockchain.New(testDB, &network)
 	feeder := feeder.NewTestClient(t, &network)
 	gw := adaptfeeder.New(feeder)
@@ -243,12 +244,12 @@ func TestSubscribeNewHeads(t *testing.T) {
 func TestPreConfirmedAfterSync(t *testing.T) {
 	t.Parallel()
 
-	client := feeder.NewTestClient(t, &utils.Mainnet)
+	client := feeder.NewTestClient(t, &networks.Mainnet)
 	gw := adaptfeeder.New(client)
 
 	testDB := memory.New()
 	log := utils.NewNopZapLogger()
-	bc := blockchain.New(testDB, &utils.Mainnet)
+	bc := blockchain.New(testDB, &networks.Mainnet)
 	dataSource := sync.NewFeederGatewayDataSource(bc, gw)
 	synchronizer := sync.New(
 		bc,
@@ -282,13 +283,13 @@ func TestPreConfirmedAfterSync(t *testing.T) {
 func TestPreConfirmed(t *testing.T) {
 	t.Parallel()
 	log := utils.NewNopZapLogger()
-	client := feeder.NewTestClient(t, &utils.Mainnet)
+	client := feeder.NewTestClient(t, &networks.Mainnet)
 	gw := adaptfeeder.New(client)
 
 	t.Run("Returns pre_confirmed data when available", func(t *testing.T) {
 		t.Parallel()
 		testDB := memory.New()
-		bc := blockchain.New(testDB, &utils.Mainnet)
+		bc := blockchain.New(testDB, &networks.Mainnet)
 		b0, err := gw.BlockByNumber(t.Context(), 0)
 		require.NoError(t, err)
 		s0, err := gw.StateUpdate(t.Context(), 0)
@@ -313,7 +314,7 @@ func TestPreConfirmed(t *testing.T) {
 	t.Run("Returns empty pre_confirmed when nothing stored", func(t *testing.T) {
 		t.Parallel()
 		testDB := memory.New()
-		bc := blockchain.New(testDB, &utils.Mainnet)
+		bc := blockchain.New(testDB, &networks.Mainnet)
 		b0, err := gw.BlockByNumber(t.Context(), 0)
 		require.NoError(t, err)
 		s0, err := gw.StateUpdate(t.Context(), 0)

--- a/vm/transaction_pkg_test.go
+++ b/vm/transaction_pkg_test.go
@@ -4,17 +4,17 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/NethermindEth/juno/blockchain/networks"
 	"github.com/NethermindEth/juno/clients/feeder"
 	"github.com/NethermindEth/juno/core/felt"
 	"github.com/NethermindEth/juno/starknet"
 	adaptfeeder "github.com/NethermindEth/juno/starknetdata/feeder"
-	"github.com/NethermindEth/juno/utils"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
 func TestTransactionMarshal(t *testing.T) {
-	client := feeder.NewTestClient(t, &utils.Integration)
+	client := feeder.NewTestClient(t, &networks.Integration)
 	gw := adaptfeeder.New(client)
 
 	tests := map[string]struct {

--- a/vm/vm_test.go
+++ b/vm/vm_test.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"testing"
 
+	"github.com/NethermindEth/juno/blockchain/networks"
 	"github.com/NethermindEth/juno/clients/feeder"
 	"github.com/NethermindEth/juno/core"
 	"github.com/NethermindEth/juno/core/deprecatedstate"
@@ -19,7 +20,7 @@ import (
 func TestCallDeprecatedCairo(t *testing.T) {
 	testDB := memory.New()
 	txn := testDB.NewIndexedBatch()
-	client := feeder.NewTestClient(t, &utils.Mainnet)
+	client := feeder.NewTestClient(t, &networks.Mainnet)
 	gw := adaptfeeder.New(client)
 
 	contractAddr := felt.NewUnsafeFromString[felt.Felt]("0xDEADBEEF")
@@ -43,9 +44,9 @@ func TestCallDeprecatedCairo(t *testing.T) {
 
 	entryPoint := felt.NewUnsafeFromString[felt.Felt]("0x39e11d48192e4333233c7eb19d10ad67c362bb28580c604d67884c85da39695")
 
-	feeTokens := utils.DefaultFeeTokenAddresses
+	feeTokens := networks.DefaultFeeTokenAddresses
 	chainInfo := ChainInfo{
-		ChainID:           utils.Mainnet.L2ChainID,
+		ChainID:           networks.Mainnet.L2ChainID,
 		FeeTokenAddresses: feeTokens,
 	}
 	ret, err := New(&chainInfo, false, nil).Call(
@@ -100,7 +101,7 @@ func TestCallDeprecatedCairo(t *testing.T) {
 func TestCallDeprecatedCairoMaxSteps(t *testing.T) {
 	testDB := memory.New()
 	txn := testDB.NewIndexedBatch()
-	client := feeder.NewTestClient(t, &utils.Mainnet)
+	client := feeder.NewTestClient(t, &networks.Mainnet)
 	gw := adaptfeeder.New(client)
 
 	contractAddr := felt.NewUnsafeFromString[felt.Felt]("0xDEADBEEF")
@@ -123,9 +124,9 @@ func TestCallDeprecatedCairoMaxSteps(t *testing.T) {
 	}, false))
 
 	entryPoint := felt.NewUnsafeFromString[felt.Felt]("0x39e11d48192e4333233c7eb19d10ad67c362bb28580c604d67884c85da39695")
-	feeTokens := utils.DefaultFeeTokenAddresses
+	feeTokens := networks.DefaultFeeTokenAddresses
 	chainInfo := ChainInfo{
-		ChainID:           utils.Mainnet.L2ChainID,
+		ChainID:           networks.Mainnet.L2ChainID,
 		FeeTokenAddresses: feeTokens,
 	}
 	_, err = New(&chainInfo, false, nil).Call(
@@ -147,7 +148,7 @@ func TestCallDeprecatedCairoMaxSteps(t *testing.T) {
 func TestCallCairo(t *testing.T) {
 	testDB := memory.New()
 	txn := testDB.NewIndexedBatch()
-	client := feeder.NewTestClient(t, &utils.Goerli)
+	client := feeder.NewTestClient(t, &networks.Goerli)
 	gw := adaptfeeder.New(client)
 
 	contractAddr := felt.NewFromUint64[felt.Felt](0xdeadbeef)
@@ -186,9 +187,9 @@ func TestCallCairo(t *testing.T) {
 	)
 	storageLocation := felt.NewFromUint64[felt.Felt](0x44)
 
-	feeTokens := utils.DefaultFeeTokenAddresses
+	feeTokens := networks.DefaultFeeTokenAddresses
 	chainInfo := ChainInfo{
-		ChainID:           utils.Mainnet.L2ChainID,
+		ChainID:           networks.Mainnet.L2ChainID,
 		FeeTokenAddresses: feeTokens,
 	}
 	vm := New(&chainInfo, false, log)
@@ -247,7 +248,7 @@ func TestCallCairo(t *testing.T) {
 func TestCallInfoErrorHandling(t *testing.T) {
 	testDB := memory.New()
 	txn := testDB.NewIndexedBatch()
-	client := feeder.NewTestClient(t, &utils.Sepolia)
+	client := feeder.NewTestClient(t, &networks.Sepolia)
 	gw := adaptfeeder.New(client)
 
 	contractAddr := felt.NewUnsafeFromString[felt.Felt]("0x123")
@@ -280,9 +281,9 @@ func TestCallInfoErrorHandling(t *testing.T) {
 	}
 
 	// Starknet version <0.13.4 should return an error
-	feeTokens := utils.DefaultFeeTokenAddresses
+	feeTokens := networks.DefaultFeeTokenAddresses
 	chainInfo := ChainInfo{
-		ChainID:           utils.Mainnet.L2ChainID,
+		ChainID:           networks.Mainnet.L2ChainID,
 		FeeTokenAddresses: feeTokens,
 	}
 	ret, err := New(&chainInfo, false, log).Call(
@@ -328,9 +329,9 @@ func TestExecute(t *testing.T) {
 	state := deprecatedstate.New(txn)
 
 	t.Run("empty transaction list", func(t *testing.T) {
-		feeTokens := utils.DefaultFeeTokenAddresses
+		feeTokens := networks.DefaultFeeTokenAddresses
 		chainInfo := ChainInfo{
-			ChainID:           utils.Mainnet.L2ChainID,
+			ChainID:           networks.Mainnet.L2ChainID,
 			FeeTokenAddresses: feeTokens,
 		}
 		_, err := New(&chainInfo, false, nil).
@@ -348,9 +349,9 @@ func TestExecute(t *testing.T) {
 		require.NoError(t, err)
 	})
 	t.Run("zero data", func(t *testing.T) {
-		feeTokens := utils.DefaultFeeTokenAddresses
+		feeTokens := networks.DefaultFeeTokenAddresses
 		chainInfo := ChainInfo{
-			ChainID:           utils.Mainnet.L2ChainID,
+			ChainID:           networks.Mainnet.L2ChainID,
 			FeeTokenAddresses: feeTokens,
 		}
 		_, err := New(&chainInfo, false, nil).Execute(nil, nil, []*felt.Felt{}, &BlockInfo{


### PR DESCRIPTION
Related to https://github.com/NethermindEth/juno/issues/1198

This PR moves the `utils/network.go` code to a separate `blockchain/networks` pkg.