### PR TITLE
chore(rpc/v10): bump SpecVersion to 0.10.2

### DIFF
--- a/rpc/v10/handlers.go
+++ b/rpc/v10/handlers.go
@@ -188,5 +188,5 @@ func (h *Handler) Run(ctx context.Context) error {
 }
 
 func (h *Handler) SpecVersion() (string, *jsonrpc.Error) {
-	return "0.10.1", nil
+	return "0.10.2", nil
 }

--- a/rpc/v10/handlers_test.go
+++ b/rpc/v10/handlers_test.go
@@ -20,7 +20,7 @@ func TestSpecVersion(t *testing.T) {
 	handler := rpcv10.New(nil, nil, nil, nil)
 	version, rpcErr := handler.SpecVersion()
 	require.Nil(t, rpcErr)
-	require.Equal(t, "0.10.1", version)
+	require.Equal(t, "0.10.2", version)
 }
 
 func TestThrottledVMError(t *testing.T) {


### PR DESCRIPTION
.1 -> .2 bump contains only doc-related change. So it's safe to update: https://github.com/starkware-libs/starknet-specs/releases/tag/v0.10.2
