### PR TITLE
feat(core): checker to detect which state implementation is being used

### DIFF
--- a/core/state_version.go
+++ b/core/state_version.go
@@ -7,6 +7,13 @@ import (
 	"github.com/NethermindEth/juno/db"
 )
 
+// Trie buckets unique to each state implementation. A non-empty bucket from
+// either set is a positive signal that the DB was built with that scheme.
+var (
+	oldStateTrieBuckets = []db.Bucket{db.StateTrie, db.ClassesTrie, db.ContractStorage}
+	newStateTrieBuckets = []db.Bucket{db.ContractTrieContract, db.ContractTrieStorage, db.ClassTrie}
+)
+
 // ValidateStateVersion checks that the state implementation selected by useNewState
 // is consistent with the data already stored in disk. It must be called before any
 // state reads or writes so that incompatible databases are rejected early.
@@ -22,28 +29,41 @@ func ValidateStateVersion(disk db.KeyValueStore, useNewState bool) error {
 		return nil
 	}
 
-	hasNewState, err := bucketHasData(disk, db.ClassTrie)
+	hasNewState, err := anyBucketHasData(disk, newStateTrieBuckets)
 	if err != nil {
-		return fmt.Errorf("probe new-state bucket: %w", err)
+		return fmt.Errorf("probe new-state buckets: %w", err)
 	}
-	hasOldState, err := bucketHasData(disk, db.ClassesTrie)
-	if err != nil {
-		return fmt.Errorf("probe state bucket: %w", err)
-	}
-
-	switch {
-	case useNewState && hasOldState:
-		return errors.New(
-			"database was built with the existing state implementation, " +
-				"but --new-state is set; remove --new-state to use this database",
-		)
-	case !useNewState && hasNewState:
+	if !useNewState && hasNewState {
 		return errors.New(
 			"database was built with the new state implementation, " +
 				"but --new-state is not set; add --new-state to use this database",
 		)
 	}
+
+	hasOldState, err := anyBucketHasData(disk, oldStateTrieBuckets)
+	if err != nil {
+		return fmt.Errorf("probe state buckets: %w", err)
+	}
+	if useNewState && hasOldState {
+		return errors.New(
+			"database was built with the existing state implementation, " +
+				"but --new-state is set; remove --new-state to use this database",
+		)
+	}
 	return nil
+}
+
+func anyBucketHasData(disk db.KeyValueStore, buckets []db.Bucket) (bool, error) {
+	for _, b := range buckets {
+		ok, err := bucketHasData(disk, b)
+		if err != nil {
+			return false, err
+		}
+		if ok {
+			return true, nil
+		}
+	}
+	return false, nil
 }
 
 func bucketHasData(disk db.KeyValueStore, bucket db.Bucket) (bool, error) {

--- a/core/state_version.go
+++ b/core/state_version.go
@@ -1,0 +1,56 @@
+package core
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/NethermindEth/juno/db"
+)
+
+// ValidateStateVersion checks that the state implementation selected by useNewState
+// is consistent with the data already stored in disk. It must be called before any
+// state reads or writes so that incompatible databases are rejected early.
+//
+// It returns an error if:
+//   - the database was built with the deprecated state and --new-state is set, or
+//   - the database was built with the new state and --new-state is not set.
+//
+// An empty database is always accepted.
+func ValidateStateVersion(disk db.KeyValueStore, useNewState bool) error {
+	// A fresh database has no conflict.
+	if _, err := GetChainHeight(disk); errors.Is(err, db.ErrKeyNotFound) {
+		return nil
+	}
+
+	hasNewState, err := bucketHasData(disk, db.ClassTrie)
+	if err != nil {
+		return fmt.Errorf("probe new-state bucket: %w", err)
+	}
+	hasOldState, err := bucketHasData(disk, db.ClassesTrie)
+	if err != nil {
+		return fmt.Errorf("probe state bucket: %w", err)
+	}
+
+	switch {
+	case useNewState && hasOldState:
+		return errors.New(
+			"database was built with the existing state implementation, " +
+				"but --new-state is set; remove --new-state to use this database",
+		)
+	case !useNewState && hasNewState:
+		return errors.New(
+			"database was built with the new state implementation, " +
+				"but --new-state is not set; add --new-state to use this database",
+		)
+	}
+	return nil
+}
+
+func bucketHasData(disk db.KeyValueStore, bucket db.Bucket) (bool, error) {
+	it, err := disk.NewIterator(bucket.Key(), true)
+	if err != nil {
+		return false, err
+	}
+	defer it.Close()
+	return it.Next(), nil
+}

--- a/core/state_version_test.go
+++ b/core/state_version_test.go
@@ -58,6 +58,46 @@ func TestValidateStateVersion(t *testing.T) {
 		require.NoError(t, ValidateStateVersion(testDB, false))
 		require.NoError(t, ValidateStateVersion(testDB, true))
 	})
+
+	t.Run("deprecated-state detected via StateTrie when ClassesTrie is empty", func(t *testing.T) {
+		testDB := memory.New()
+		seedChainHeight(t, testDB)
+		seedBucket(t, testDB, db.StateTrie)
+
+		err := ValidateStateVersion(testDB, true)
+		require.ErrorContains(t, err, "existing state")
+		require.NoError(t, ValidateStateVersion(testDB, false))
+	})
+
+	t.Run("deprecated-state detected via ContractStorage when other old buckets empty", func(t *testing.T) {
+		testDB := memory.New()
+		seedChainHeight(t, testDB)
+		seedBucket(t, testDB, db.ContractStorage)
+
+		err := ValidateStateVersion(testDB, true)
+		require.ErrorContains(t, err, "existing state")
+		require.NoError(t, ValidateStateVersion(testDB, false))
+	})
+
+	t.Run("new-state detected via ContractTrieContract when ClassTrie is empty", func(t *testing.T) {
+		testDB := memory.New()
+		seedChainHeight(t, testDB)
+		seedBucket(t, testDB, db.ContractTrieContract)
+
+		err := ValidateStateVersion(testDB, false)
+		require.ErrorContains(t, err, "new state")
+		require.NoError(t, ValidateStateVersion(testDB, true))
+	})
+
+	t.Run("new-state detected via ContractTrieStorage when ClassTrie is empty", func(t *testing.T) {
+		testDB := memory.New()
+		seedChainHeight(t, testDB)
+		seedBucket(t, testDB, db.ContractTrieStorage)
+
+		err := ValidateStateVersion(testDB, false)
+		require.ErrorContains(t, err, "new state")
+		require.NoError(t, ValidateStateVersion(testDB, true))
+	})
 }
 
 func seedChainHeight(t *testing.T, testDB db.KeyValueStore) {

--- a/core/state_version_test.go
+++ b/core/state_version_test.go
@@ -1,0 +1,76 @@
+package core
+
+import (
+	"testing"
+
+	"github.com/NethermindEth/juno/db"
+	"github.com/NethermindEth/juno/db/memory"
+	"github.com/stretchr/testify/require"
+)
+
+func TestValidateStateVersion(t *testing.T) {
+	t.Run("fresh database is always accepted", func(t *testing.T) {
+		testDB := memory.New()
+		require.NoError(t, ValidateStateVersion(testDB, false))
+		require.NoError(t, ValidateStateVersion(testDB, true))
+	})
+
+	t.Run("deprecated-state DB with new-state flag returns error", func(t *testing.T) {
+		testDB := memory.New()
+		seedChainHeight(t, testDB)
+		seedBucket(t, testDB, db.ClassesTrie)
+
+		err := ValidateStateVersion(testDB, true)
+		require.ErrorContains(t, err, "existing state")
+		require.ErrorContains(t, err, "--new-state")
+	})
+
+	t.Run("new-state DB without new-state flag returns error", func(t *testing.T) {
+		testDB := memory.New()
+		seedChainHeight(t, testDB)
+		seedBucket(t, testDB, db.ClassTrie)
+
+		err := ValidateStateVersion(testDB, false)
+		require.ErrorContains(t, err, "new state")
+		require.ErrorContains(t, err, "--new-state")
+	})
+
+	t.Run("deprecated-state DB without new-state flag is accepted", func(t *testing.T) {
+		testDB := memory.New()
+		seedChainHeight(t, testDB)
+		seedBucket(t, testDB, db.ClassesTrie)
+
+		require.NoError(t, ValidateStateVersion(testDB, false))
+	})
+
+	t.Run("new-state DB with new-state flag is accepted", func(t *testing.T) {
+		testDB := memory.New()
+		seedChainHeight(t, testDB)
+		seedBucket(t, testDB, db.ClassTrie)
+
+		require.NoError(t, ValidateStateVersion(testDB, true))
+	})
+
+	t.Run("DB with blocks but no trie data is accepted regardless of flag", func(t *testing.T) {
+		testDB := memory.New()
+		seedChainHeight(t, testDB)
+
+		require.NoError(t, ValidateStateVersion(testDB, false))
+		require.NoError(t, ValidateStateVersion(testDB, true))
+	})
+}
+
+func seedChainHeight(t *testing.T, testDB db.KeyValueStore) {
+	t.Helper()
+	batch := testDB.NewBatch()
+	require.NoError(t, WriteChainHeight(batch, 1))
+	require.NoError(t, batch.Write())
+}
+
+func seedBucket(t *testing.T, testDB db.KeyValueStore, bucket db.Bucket) {
+	t.Helper()
+	batch := testDB.NewBatch()
+	key := append(bucket.Key(), []byte("sentinel")...)
+	require.NoError(t, batch.Put(key, []byte("1")))
+	require.NoError(t, batch.Write())
+}

--- a/core/state_version_test.go
+++ b/core/state_version_test.go
@@ -15,7 +15,7 @@ func TestValidateStateVersion(t *testing.T) {
 		require.NoError(t, ValidateStateVersion(testDB, true))
 	})
 
-	t.Run("deprecated-state DB with new-state flag returns error", func(t *testing.T) {
+	t.Run("old-state DB with new-state flag returns error", func(t *testing.T) {
 		testDB := memory.New()
 		seedChainHeight(t, testDB)
 		seedBucket(t, testDB, db.ClassesTrie)
@@ -35,7 +35,7 @@ func TestValidateStateVersion(t *testing.T) {
 		require.ErrorContains(t, err, "--new-state")
 	})
 
-	t.Run("deprecated-state DB without new-state flag is accepted", func(t *testing.T) {
+	t.Run("old-state DB without new-state flag is accepted", func(t *testing.T) {
 		testDB := memory.New()
 		seedChainHeight(t, testDB)
 		seedBucket(t, testDB, db.ClassesTrie)
@@ -59,7 +59,7 @@ func TestValidateStateVersion(t *testing.T) {
 		require.NoError(t, ValidateStateVersion(testDB, true))
 	})
 
-	t.Run("deprecated-state detected via StateTrie when ClassesTrie is empty", func(t *testing.T) {
+	t.Run("old-state detected via StateTrie when ClassesTrie is empty", func(t *testing.T) {
 		testDB := memory.New()
 		seedChainHeight(t, testDB)
 		seedBucket(t, testDB, db.StateTrie)
@@ -69,7 +69,7 @@ func TestValidateStateVersion(t *testing.T) {
 		require.NoError(t, ValidateStateVersion(testDB, false))
 	})
 
-	t.Run("deprecated-state detected via ContractStorage when other old buckets empty", func(t *testing.T) {
+	t.Run("old-state detected via ContractStorage when other old buckets empty", func(t *testing.T) {
 		testDB := memory.New()
 		seedChainHeight(t, testDB)
 		seedBucket(t, testDB, db.ContractStorage)


### PR DESCRIPTION
This PR introduces a compatibility checker.
When the user tries to run Juno using the new state on the snapshot built using the old state and vice-versa, Juno will terminate on start-up an let the user know with the proper error message.
Currently, this is a standalone checker, which will be integrated into the pipeline in #3187 