### PR TITLE
chore: enable uk and us locale

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -79,8 +79,6 @@ linters:
         - nilness
     lll:
       line-length: 140 # todo(rdr): change this to 100
-    misspell:
-      locale: UK
     mnd:
       checks:
         - argument


### PR DESCRIPTION
We have a mixed of US and UK words, I don't find any strong reason why should we enforce one over the other