### PR TITLE
refactor(core): abstract hash calculation engine

### DIFF
--- a/blockchain/blockchain.go
+++ b/blockchain/blockchain.go
@@ -332,7 +332,7 @@ func (b *Blockchain) SanityCheckNewHeight(block *core.Block, stateUpdate *core.S
 		return nil, err
 	}
 
-	return core.VerifyBlockHash(block, b.network, stateUpdate.StateDiff, core.DeprecatedTrieBackend)
+	return b.stateBackend.VerifyBlockHash(block, b.network, stateUpdate.StateDiff)
 }
 
 // HeadState returns a StateReader that provides a stable view to the latest state

--- a/blockchain/blockchain.go
+++ b/blockchain/blockchain.go
@@ -332,7 +332,7 @@ func (b *Blockchain) SanityCheckNewHeight(block *core.Block, stateUpdate *core.S
 		return nil, err
 	}
 
-	return b.stateBackend.VerifyBlockHash(block, b.network, stateUpdate.StateDiff)
+	return b.stateBackend.VerifyBlockHash(block, stateUpdate.StateDiff)
 }
 
 // HeadState returns a StateReader that provides a stable view to the latest state

--- a/blockchain/blockchain.go
+++ b/blockchain/blockchain.go
@@ -332,7 +332,7 @@ func (b *Blockchain) SanityCheckNewHeight(block *core.Block, stateUpdate *core.S
 		return nil, err
 	}
 
-	return core.VerifyBlockHash(block, b.network, stateUpdate.StateDiff)
+	return core.VerifyBlockHash(block, b.network, stateUpdate.StateDiff, core.DeprecatedTrieBackend)
 }
 
 // HeadState returns a StateReader that provides a stable view to the latest state

--- a/blockchain/statebackend/block_ops.go
+++ b/blockchain/statebackend/block_ops.go
@@ -52,13 +52,14 @@ func updateBlockHash(
 	block *core.Block,
 	stateUpdate *core.StateUpdate,
 	network *networks.Network,
+	trieBackend core.TrieBackend,
 ) (*core.BlockCommitments, error) {
 	blockHash, commitments, err := core.BlockHash(
 		block,
 		stateUpdate.StateDiff,
 		network,
 		block.SequencerAddress,
-		core.DeprecatedTrieBackend,
+		trieBackend,
 	)
 	if err != nil {
 		return nil, err

--- a/blockchain/statebackend/block_ops.go
+++ b/blockchain/statebackend/block_ops.go
@@ -52,7 +52,7 @@ func updateBlockHash(
 	block *core.Block,
 	stateUpdate *core.StateUpdate,
 	network *networks.Network,
-	trieBackend core.TrieBackend,
+	trieBackend core.TempTrieBackend,
 ) (*core.BlockCommitments, error) {
 	blockHash, commitments, err := core.BlockHash(
 		block,

--- a/blockchain/statebackend/block_ops.go
+++ b/blockchain/statebackend/block_ops.go
@@ -58,6 +58,7 @@ func updateBlockHash(
 		stateUpdate.StateDiff,
 		network,
 		block.SequencerAddress,
+		core.DeprecatedTrieBackend,
 	)
 	if err != nil {
 		return nil, err

--- a/blockchain/statebackend/deprecated.go
+++ b/blockchain/statebackend/deprecated.go
@@ -1,7 +1,6 @@
 package statebackend
 
 import (
-	"github.com/NethermindEth/juno/blockchain/networks"
 	"github.com/NethermindEth/juno/core"
 	"github.com/NethermindEth/juno/core/deprecatedstate"
 	"github.com/NethermindEth/juno/core/felt"
@@ -247,8 +246,7 @@ func (b *deprecatedStateBackend) Finalise(
 
 func (b *deprecatedStateBackend) VerifyBlockHash(
 	block *core.Block,
-	network *networks.Network,
 	stateDiff *core.StateDiff,
 ) (*core.BlockCommitments, error) {
-	return core.VerifyBlockHash(block, network, stateDiff, core.DeprecatedTrieBackend)
+	return core.VerifyBlockHash(block, b.network, stateDiff, core.DeprecatedTrieBackend)
 }

--- a/blockchain/statebackend/deprecated.go
+++ b/blockchain/statebackend/deprecated.go
@@ -1,6 +1,7 @@
 package statebackend
 
 import (
+	"github.com/NethermindEth/juno/blockchain/networks"
 	"github.com/NethermindEth/juno/core"
 	"github.com/NethermindEth/juno/core/deprecatedstate"
 	"github.com/NethermindEth/juno/core/felt"
@@ -177,7 +178,7 @@ func (b *deprecatedStateBackend) Simulate(
 		return SimulateResult{}, err
 	}
 
-	commitments, err := updateBlockHash(block, stateUpdate, b.network)
+	commitments, err := updateBlockHash(block, stateUpdate, b.network, core.DeprecatedTrieBackend)
 	if err != nil {
 		return SimulateResult{}, err
 	}
@@ -215,7 +216,7 @@ func (b *deprecatedStateBackend) Finalise(
 			return err
 		}
 
-		commitments, err := updateBlockHash(block, stateUpdate, b.network)
+		commitments, err := updateBlockHash(block, stateUpdate, b.network, core.DeprecatedTrieBackend)
 		if err != nil {
 			return err
 		}
@@ -242,4 +243,12 @@ func (b *deprecatedStateBackend) Finalise(
 	}
 
 	return b.runningFilter.Insert(block.EventsBloom, block.Number)
+}
+
+func (b *deprecatedStateBackend) VerifyBlockHash(
+	block *core.Block,
+	network *networks.Network,
+	stateDiff *core.StateDiff,
+) (*core.BlockCommitments, error) {
+	return core.VerifyBlockHash(block, network, stateDiff, core.DeprecatedTrieBackend)
 }

--- a/blockchain/statebackend/statebackend.go
+++ b/blockchain/statebackend/statebackend.go
@@ -1,7 +1,6 @@
 package statebackend
 
 import (
-	"github.com/NethermindEth/juno/blockchain/networks"
 	"github.com/NethermindEth/juno/core"
 	"github.com/NethermindEth/juno/core/felt"
 	"github.com/NethermindEth/juno/core/state"
@@ -168,7 +167,7 @@ func (b *stateBackend) Simulate(
 		return SimulateResult{}, err
 	}
 
-	commitments, err := updateBlockHash(block, stateUpdate, b.network, core.NewTrieBackend)
+	commitments, err := updateBlockHash(block, stateUpdate, b.network, core.TrieBackend)
 	if err != nil {
 		return SimulateResult{}, err
 	}
@@ -208,7 +207,7 @@ func (b *stateBackend) Finalise(
 			return err
 		}
 
-		commitments, err := updateBlockHash(block, stateUpdate, b.network, core.NewTrieBackend)
+		commitments, err := updateBlockHash(block, stateUpdate, b.network, core.TrieBackend)
 		if err != nil {
 			return err
 		}
@@ -239,8 +238,7 @@ func (b *stateBackend) Finalise(
 
 func (b *stateBackend) VerifyBlockHash(
 	block *core.Block,
-	network *networks.Network,
 	stateDiff *core.StateDiff,
 ) (*core.BlockCommitments, error) {
-	return core.VerifyBlockHash(block, network, stateDiff, core.NewTrieBackend)
+	return core.VerifyBlockHash(block, b.network, stateDiff, core.TrieBackend)
 }

--- a/blockchain/statebackend/statebackend.go
+++ b/blockchain/statebackend/statebackend.go
@@ -1,6 +1,7 @@
 package statebackend
 
 import (
+	"github.com/NethermindEth/juno/blockchain/networks"
 	"github.com/NethermindEth/juno/core"
 	"github.com/NethermindEth/juno/core/felt"
 	"github.com/NethermindEth/juno/core/state"
@@ -167,7 +168,7 @@ func (b *stateBackend) Simulate(
 		return SimulateResult{}, err
 	}
 
-	commitments, err := updateBlockHash(block, stateUpdate, b.network)
+	commitments, err := updateBlockHash(block, stateUpdate, b.network, core.NewTrieBackend)
 	if err != nil {
 		return SimulateResult{}, err
 	}
@@ -207,7 +208,7 @@ func (b *stateBackend) Finalise(
 			return err
 		}
 
-		commitments, err := updateBlockHash(block, stateUpdate, b.network)
+		commitments, err := updateBlockHash(block, stateUpdate, b.network, core.NewTrieBackend)
 		if err != nil {
 			return err
 		}
@@ -234,4 +235,12 @@ func (b *stateBackend) Finalise(
 	}
 
 	return b.runningFilter.Insert(block.EventsBloom, block.Number)
+}
+
+func (b *stateBackend) VerifyBlockHash(
+	block *core.Block,
+	network *networks.Network,
+	stateDiff *core.StateDiff,
+) (*core.BlockCommitments, error) {
+	return core.VerifyBlockHash(block, network, stateDiff, core.NewTrieBackend)
 }

--- a/blockchain/statebackend/types.go
+++ b/blockchain/statebackend/types.go
@@ -36,7 +36,6 @@ type StateBackend interface {
 	) error
 	VerifyBlockHash(
 		b *core.Block,
-		network *networks.Network,
 		stateDiff *core.StateDiff,
 	) (*core.BlockCommitments, error)
 }

--- a/blockchain/statebackend/types.go
+++ b/blockchain/statebackend/types.go
@@ -34,6 +34,11 @@ type StateBackend interface {
 		newClasses map[felt.Felt]core.ClassDefinition,
 		sign core.BlockSignFunc,
 	) error
+	VerifyBlockHash(
+		b *core.Block,
+		network *networks.Network,
+		stateDiff *core.StateDiff,
+	) (*core.BlockCommitments, error)
 }
 
 // StateCloser is called to release resources associated with a state reader.

--- a/cmd/juno/dbcmd.go
+++ b/cmd/juno/dbcmd.go
@@ -323,7 +323,11 @@ func dbSize(cmd *cobra.Command, args []string) error {
 	return nil
 }
 
-func getNetwork(head *core.Block, stateDiff *core.StateDiff, trieBackend core.TempTrieBackend) string {
+func getNetwork(
+	head *core.Block,
+	stateDiff *core.StateDiff,
+	trieBackend core.TempTrieBackend,
+) string {
 	networks := []*networks.Network{
 		&networks.Mainnet,
 		&networks.Sepolia,

--- a/cmd/juno/dbcmd.go
+++ b/cmd/juno/dbcmd.go
@@ -43,20 +43,18 @@ func DBCmd(defaultDBPath string) *cobra.Command {
 	}
 
 	dbCmd.PersistentFlags().String(dbPathF, defaultDBPath, dbPathUsage)
+	dbCmd.PersistentFlags().Bool(newStateF, defaultNewState, newStateUsage)
 	dbCmd.AddCommand(DBInfoCmd(), DBSizeCmd(), DBRevertCmd())
 	return dbCmd
 }
 
 func DBInfoCmd() *cobra.Command {
-	cmd := &cobra.Command{
+	return &cobra.Command{
 		Use:   "info",
 		Short: "Retrieve database information",
 		Long:  `This subcommand retrieves and displays blockchain information stored in the database.`,
 		RunE:  dbInfo,
 	}
-	cmd.Flags().Bool(newStateF, defaultNewState, newStateUsage)
-
-	return cmd
 }
 
 func DBSizeCmd() *cobra.Command {
@@ -76,7 +74,6 @@ func DBRevertCmd() *cobra.Command {
 		RunE:  dbRevert,
 	}
 	cmd.Flags().Uint64(dbRevertToBlockF, 0, "New head (this block won't be reverted)")
-	cmd.Flags().Bool(newStateF, defaultNewState, newStateUsage)
 
 	return cmd
 }

--- a/cmd/juno/dbcmd.go
+++ b/cmd/juno/dbcmd.go
@@ -325,7 +325,7 @@ func getNetwork(head *core.Block, stateDiff *core.StateDiff) string {
 	}
 
 	for _, network := range networks {
-		if _, err := core.VerifyBlockHash(head, network, stateDiff); err == nil {
+		if _, err := core.VerifyBlockHash(head, network, stateDiff, core.DeprecatedTrieBackend); err == nil {
 			return network.Name
 		}
 	}

--- a/cmd/juno/dbcmd.go
+++ b/cmd/juno/dbcmd.go
@@ -48,12 +48,15 @@ func DBCmd(defaultDBPath string) *cobra.Command {
 }
 
 func DBInfoCmd() *cobra.Command {
-	return &cobra.Command{
+	cmd := &cobra.Command{
 		Use:   "info",
 		Short: "Retrieve database information",
 		Long:  `This subcommand retrieves and displays blockchain information stored in the database.`,
 		RunE:  dbInfo,
 	}
+	cmd.Flags().Bool(newStateF, defaultNewState, newStateUsage)
+
+	return cmd
 }
 
 func DBSizeCmd() *cobra.Command {
@@ -124,8 +127,17 @@ func dbInfo(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("failed to get schema metadata: %v", err)
 	}
 
+	newState, err := cmd.Flags().GetBool(newStateF)
+	if err != nil {
+		return err
+	}
+	trieBackend := core.DeprecatedTrieBackend
+	if newState {
+		trieBackend = core.NewTrieBackend
+	}
+
 	info.SchemaVersion = schemaVersion
-	info.Network = getNetwork(headBlock, stateUpdate.StateDiff)
+	info.Network = getNetwork(headBlock, stateUpdate.StateDiff, trieBackend)
 	info.ChainHeight = headBlock.Number
 	info.LatestBlockHash = headBlock.Hash
 	info.LatestStateRoot = headBlock.GlobalStateRoot
@@ -314,7 +326,7 @@ func dbSize(cmd *cobra.Command, args []string) error {
 	return nil
 }
 
-func getNetwork(head *core.Block, stateDiff *core.StateDiff) string {
+func getNetwork(head *core.Block, stateDiff *core.StateDiff, trieBackend core.TrieBackend) string {
 	networks := []*networks.Network{
 		&networks.Mainnet,
 		&networks.Sepolia,
@@ -325,7 +337,7 @@ func getNetwork(head *core.Block, stateDiff *core.StateDiff) string {
 	}
 
 	for _, network := range networks {
-		if _, err := core.VerifyBlockHash(head, network, stateDiff, core.DeprecatedTrieBackend); err == nil {
+		if _, err := core.VerifyBlockHash(head, network, stateDiff, trieBackend); err == nil {
 			return network.Name
 		}
 	}

--- a/cmd/juno/dbcmd.go
+++ b/cmd/juno/dbcmd.go
@@ -130,7 +130,7 @@ func dbInfo(cmd *cobra.Command, args []string) error {
 	}
 	trieBackend := core.DeprecatedTrieBackend
 	if newState {
-		trieBackend = core.NewTrieBackend
+		trieBackend = core.TrieBackend
 	}
 
 	info.SchemaVersion = schemaVersion
@@ -323,7 +323,7 @@ func dbSize(cmd *cobra.Command, args []string) error {
 	return nil
 }
 
-func getNetwork(head *core.Block, stateDiff *core.StateDiff, trieBackend core.TrieBackend) string {
+func getNetwork(head *core.Block, stateDiff *core.StateDiff, trieBackend core.TempTrieBackend) string {
 	networks := []*networks.Network{
 		&networks.Mainnet,
 		&networks.Sepolia,

--- a/cmd/juno/dbcmd_test.go
+++ b/cmd/juno/dbcmd_test.go
@@ -40,6 +40,7 @@ func TestDBCmd(t *testing.T) {
 
 		cmd := juno.DBRevertCmd()
 		cmd.Flags().String("db-path", "", "")
+		cmd.Flags().Bool("new-state", false, "")
 
 		dbPath := prepareDB(t, &network, syncToBlock)
 
@@ -72,10 +73,14 @@ func TestDBCmd(t *testing.T) {
 
 func executeCmdInDB(t *testing.T, cmd *cobra.Command) {
 	cmd.Flags().String("db-path", "", "")
+	cmd.Flags().Bool("new-state", false, "")
 
 	dbPath := prepareDB(t, &networks.Mainnet, 0)
 
 	require.NoError(t, cmd.Flags().Set("db-path", dbPath))
+	if statetestutils.UseNewState() {
+		require.NoError(t, cmd.Flags().Set("new-state", "true"))
+	}
 	require.NoError(t, cmd.Execute())
 }
 

--- a/core/block.go
+++ b/core/block.go
@@ -102,7 +102,7 @@ func VerifyBlockHash(
 	b *Block,
 	network *networks.Network,
 	stateDiff *StateDiff,
-	backend TrieBackend,
+	backend TempTrieBackend,
 ) (*BlockCommitments, error) {
 	if len(b.Transactions) != len(b.Receipts) {
 		return nil, fmt.Errorf("len of transactions: %v do not match len of receipts: %v",
@@ -162,7 +162,7 @@ func BlockHash(
 	stateDiff *StateDiff,
 	network *networks.Network,
 	overrideSeqAddr *felt.Felt,
-	backend TrieBackend,
+	backend TempTrieBackend,
 ) (felt.Felt, *BlockCommitments, error) {
 	metaInfo := network.BlockHashMetaInfo
 
@@ -192,7 +192,7 @@ func BlockHash(
 func pre07Hash(
 	b *Block,
 	chain *felt.Felt,
-	backend TrieBackend,
+	backend TempTrieBackend,
 ) (felt.Felt, *BlockCommitments, error) {
 	txCommitment, err := transactionCommitmentPedersen(
 		b.Transactions,
@@ -221,7 +221,7 @@ func pre07Hash(
 func post0134Hash(
 	b *Block,
 	stateDiff *StateDiff,
-	backend TrieBackend,
+	backend TempTrieBackend,
 ) (felt.Felt, *BlockCommitments, error) {
 	var txCommitment, eCommitment, rCommitment, sdCommitment felt.Felt
 	var sdLength uint64
@@ -292,7 +292,7 @@ func post0134Hash(
 func Post0132Hash(
 	b *Block,
 	stateDiff *StateDiff,
-	backend TrieBackend,
+	backend TempTrieBackend,
 ) (felt.Felt, *BlockCommitments, error) {
 	var txCommitment, eCommitment, rCommitment, sdCommitment felt.Felt
 	var sdLength uint64
@@ -380,7 +380,7 @@ func Post0132Hash(
 func post07Hash(
 	b *Block,
 	overrideSeqAddr *felt.Felt,
-	backend TrieBackend,
+	backend TempTrieBackend,
 ) (felt.Felt, *BlockCommitments, error) {
 	seqAddr := b.SequencerAddress
 	if overrideSeqAddr != nil {

--- a/core/block.go
+++ b/core/block.go
@@ -102,7 +102,7 @@ func VerifyBlockHash(
 	b *Block,
 	network *networks.Network,
 	stateDiff *StateDiff,
-	engine TrieBackend,
+	backend TrieBackend,
 ) (*BlockCommitments, error) {
 	if len(b.Transactions) != len(b.Receipts) {
 		return nil, fmt.Errorf("len of transactions: %v do not match len of receipts: %v",
@@ -139,7 +139,7 @@ func VerifyBlockHash(
 			overrideSeq = fallbackSeq
 		}
 
-		hash, commitments, err := BlockHash(b, stateDiff, network, overrideSeq, engine)
+		hash, commitments, err := BlockHash(b, stateDiff, network, overrideSeq, backend)
 		if err != nil {
 			return nil, err
 		}
@@ -162,7 +162,7 @@ func BlockHash(
 	stateDiff *StateDiff,
 	network *networks.Network,
 	overrideSeqAddr *felt.Felt,
-	engine TrieBackend,
+	backend TrieBackend,
 ) (felt.Felt, *BlockCommitments, error) {
 	metaInfo := network.BlockHashMetaInfo
 
@@ -173,19 +173,19 @@ func BlockHash(
 
 	// if block.version >= 0.13.4
 	if blockVer.GreaterThanEqual(Ver0_13_4) {
-		return post0134Hash(b, stateDiff, engine)
+		return post0134Hash(b, stateDiff, backend)
 	}
 
 	// if 0.13.2 <= block.version < 0.13.4
 	if blockVer.GreaterThanEqual(Ver0_13_2) {
-		return Post0132Hash(b, stateDiff, engine)
+		return Post0132Hash(b, stateDiff, backend)
 	}
 
 	// following statements applied only if block.version < 0.13.2
 	if b.Number < metaInfo.First07Block {
-		return pre07Hash(b, network.L2ChainIDFelt(), engine)
+		return pre07Hash(b, network.L2ChainIDFelt(), backend)
 	}
-	return post07Hash(b, overrideSeqAddr, engine)
+	return post07Hash(b, overrideSeqAddr, backend)
 }
 
 // pre07Hash computes the block hash for blocks generated before Cairo 0.7.0

--- a/core/block.go
+++ b/core/block.go
@@ -102,6 +102,7 @@ func VerifyBlockHash(
 	b *Block,
 	network *networks.Network,
 	stateDiff *StateDiff,
+	engine TrieBackend,
 ) (*BlockCommitments, error) {
 	if len(b.Transactions) != len(b.Receipts) {
 		return nil, fmt.Errorf("len of transactions: %v do not match len of receipts: %v",
@@ -138,7 +139,7 @@ func VerifyBlockHash(
 			overrideSeq = fallbackSeq
 		}
 
-		hash, commitments, err := BlockHash(b, stateDiff, network, overrideSeq)
+		hash, commitments, err := BlockHash(b, stateDiff, network, overrideSeq, engine)
 		if err != nil {
 			return nil, err
 		}
@@ -161,6 +162,7 @@ func BlockHash(
 	stateDiff *StateDiff,
 	network *networks.Network,
 	overrideSeqAddr *felt.Felt,
+	engine TrieBackend,
 ) (felt.Felt, *BlockCommitments, error) {
 	metaInfo := network.BlockHashMetaInfo
 
@@ -171,24 +173,24 @@ func BlockHash(
 
 	// if block.version >= 0.13.4
 	if blockVer.GreaterThanEqual(Ver0_13_4) {
-		return post0134Hash(b, stateDiff)
+		return post0134Hash(b, stateDiff, engine)
 	}
 
 	// if 0.13.2 <= block.version < 0.13.4
 	if blockVer.GreaterThanEqual(Ver0_13_2) {
-		return Post0132Hash(b, stateDiff)
+		return Post0132Hash(b, stateDiff, engine)
 	}
 
 	// following statements applied only if block.version < 0.13.2
 	if b.Number < metaInfo.First07Block {
-		return pre07Hash(b, network.L2ChainIDFelt())
+		return pre07Hash(b, network.L2ChainIDFelt(), engine)
 	}
-	return post07Hash(b, overrideSeqAddr)
+	return post07Hash(b, overrideSeqAddr, engine)
 }
 
 // pre07Hash computes the block hash for blocks generated before Cairo 0.7.0
-func pre07Hash(b *Block, chain *felt.Felt) (felt.Felt, *BlockCommitments, error) {
-	txCommitment, err := transactionCommitmentPedersen(b.Transactions, b.Header.ProtocolVersion)
+func pre07Hash(b *Block, chain *felt.Felt, engine TrieBackend) (felt.Felt, *BlockCommitments, error) {
+	txCommitment, err := transactionCommitmentPedersen(b.Transactions, b.Header.ProtocolVersion, engine)
 	if err != nil {
 		return felt.Felt{}, nil, err
 	}
@@ -208,20 +210,20 @@ func pre07Hash(b *Block, chain *felt.Felt) (felt.Felt, *BlockCommitments, error)
 	), &BlockCommitments{TransactionCommitment: &txCommitment}, nil
 }
 
-func post0134Hash(b *Block, stateDiff *StateDiff) (felt.Felt, *BlockCommitments, error) {
+func post0134Hash(b *Block, stateDiff *StateDiff, engine TrieBackend) (felt.Felt, *BlockCommitments, error) {
 	var txCommitment, eCommitment, rCommitment, sdCommitment felt.Felt
 	var sdLength uint64
 	var tErr, eErr, rErr error
 
 	wg := conc.NewWaitGroup()
 	wg.Go(func() {
-		txCommitment, tErr = transactionCommitmentPoseidon0134(b.Transactions)
+		txCommitment, tErr = transactionCommitmentPoseidon0134(b.Transactions, engine)
 	})
 	wg.Go(func() {
-		eCommitment, eErr = eventCommitmentPoseidon(b.Receipts)
+		eCommitment, eErr = eventCommitmentPoseidon(b.Receipts, engine)
 	})
 	wg.Go(func() {
-		rCommitment, rErr = receiptCommitment(b.Receipts)
+		rCommitment, rErr = receiptCommitment(b.Receipts, engine)
 	})
 
 	wg.Go(func() {
@@ -275,20 +277,20 @@ func post0134Hash(b *Block, stateDiff *StateDiff) (felt.Felt, *BlockCommitments,
 		}, nil
 }
 
-func Post0132Hash(b *Block, stateDiff *StateDiff) (felt.Felt, *BlockCommitments, error) {
+func Post0132Hash(b *Block, stateDiff *StateDiff, engine TrieBackend) (felt.Felt, *BlockCommitments, error) {
 	var txCommitment, eCommitment, rCommitment, sdCommitment felt.Felt
 	var sdLength uint64
 	var tErr, eErr, rErr error
 
 	wg := conc.NewWaitGroup()
 	wg.Go(func() {
-		txCommitment, tErr = transactionCommitmentPoseidon0132(b.Transactions)
+		txCommitment, tErr = transactionCommitmentPoseidon0132(b.Transactions, engine)
 	})
 	wg.Go(func() {
-		eCommitment, eErr = eventCommitmentPoseidon(b.Receipts)
+		eCommitment, eErr = eventCommitmentPoseidon(b.Receipts, engine)
 	})
 	wg.Go(func() {
-		rCommitment, rErr = receiptCommitment(b.Receipts)
+		rCommitment, rErr = receiptCommitment(b.Receipts, engine)
 	})
 
 	wg.Go(func() {
@@ -359,7 +361,7 @@ func Post0132Hash(b *Block, stateDiff *StateDiff) (felt.Felt, *BlockCommitments,
 }
 
 // post07Hash computes the block hash for blocks generated after Cairo 0.7.0
-func post07Hash(b *Block, overrideSeqAddr *felt.Felt) (felt.Felt, *BlockCommitments, error) {
+func post07Hash(b *Block, overrideSeqAddr *felt.Felt, engine TrieBackend) (felt.Felt, *BlockCommitments, error) {
 	seqAddr := b.SequencerAddress
 	if overrideSeqAddr != nil {
 		seqAddr = overrideSeqAddr
@@ -370,15 +372,15 @@ func post07Hash(b *Block, overrideSeqAddr *felt.Felt) (felt.Felt, *BlockCommitme
 	var tErr, eErr, rErr error
 
 	wg.Go(func() {
-		txCommitment, tErr = transactionCommitmentPedersen(b.Transactions, b.Header.ProtocolVersion)
+		txCommitment, tErr = transactionCommitmentPedersen(b.Transactions, b.Header.ProtocolVersion, engine)
 	})
 	wg.Go(func() {
-		eCommitment, eErr = eventCommitmentPedersen(b.Receipts)
+		eCommitment, eErr = eventCommitmentPedersen(b.Receipts, engine)
 	})
 	wg.Go(func() {
 		// even though rCommitment is not required for pre 0.13.2 hash
 		// we need to calculate it for BlockCommitments that will be stored in db
-		rCommitment, rErr = receiptCommitment(b.Receipts)
+		rCommitment, rErr = receiptCommitment(b.Receipts, engine)
 	})
 	wg.Wait()
 

--- a/core/block.go
+++ b/core/block.go
@@ -189,8 +189,16 @@ func BlockHash(
 }
 
 // pre07Hash computes the block hash for blocks generated before Cairo 0.7.0
-func pre07Hash(b *Block, chain *felt.Felt, engine TrieBackend) (felt.Felt, *BlockCommitments, error) {
-	txCommitment, err := transactionCommitmentPedersen(b.Transactions, b.Header.ProtocolVersion, engine)
+func pre07Hash(
+	b *Block,
+	chain *felt.Felt,
+	backend TrieBackend,
+) (felt.Felt, *BlockCommitments, error) {
+	txCommitment, err := transactionCommitmentPedersen(
+		b.Transactions,
+		b.Header.ProtocolVersion,
+		backend,
+	)
 	if err != nil {
 		return felt.Felt{}, nil, err
 	}
@@ -210,20 +218,24 @@ func pre07Hash(b *Block, chain *felt.Felt, engine TrieBackend) (felt.Felt, *Bloc
 	), &BlockCommitments{TransactionCommitment: &txCommitment}, nil
 }
 
-func post0134Hash(b *Block, stateDiff *StateDiff, engine TrieBackend) (felt.Felt, *BlockCommitments, error) {
+func post0134Hash(
+	b *Block,
+	stateDiff *StateDiff,
+	backend TrieBackend,
+) (felt.Felt, *BlockCommitments, error) {
 	var txCommitment, eCommitment, rCommitment, sdCommitment felt.Felt
 	var sdLength uint64
 	var tErr, eErr, rErr error
 
 	wg := conc.NewWaitGroup()
 	wg.Go(func() {
-		txCommitment, tErr = transactionCommitmentPoseidon0134(b.Transactions, engine)
+		txCommitment, tErr = transactionCommitmentPoseidon0134(b.Transactions, backend)
 	})
 	wg.Go(func() {
-		eCommitment, eErr = eventCommitmentPoseidon(b.Receipts, engine)
+		eCommitment, eErr = eventCommitmentPoseidon(b.Receipts, backend)
 	})
 	wg.Go(func() {
-		rCommitment, rErr = receiptCommitment(b.Receipts, engine)
+		rCommitment, rErr = receiptCommitment(b.Receipts, backend)
 	})
 
 	wg.Go(func() {
@@ -277,20 +289,24 @@ func post0134Hash(b *Block, stateDiff *StateDiff, engine TrieBackend) (felt.Felt
 		}, nil
 }
 
-func Post0132Hash(b *Block, stateDiff *StateDiff, engine TrieBackend) (felt.Felt, *BlockCommitments, error) {
+func Post0132Hash(
+	b *Block,
+	stateDiff *StateDiff,
+	backend TrieBackend,
+) (felt.Felt, *BlockCommitments, error) {
 	var txCommitment, eCommitment, rCommitment, sdCommitment felt.Felt
 	var sdLength uint64
 	var tErr, eErr, rErr error
 
 	wg := conc.NewWaitGroup()
 	wg.Go(func() {
-		txCommitment, tErr = transactionCommitmentPoseidon0132(b.Transactions, engine)
+		txCommitment, tErr = transactionCommitmentPoseidon0132(b.Transactions, backend)
 	})
 	wg.Go(func() {
-		eCommitment, eErr = eventCommitmentPoseidon(b.Receipts, engine)
+		eCommitment, eErr = eventCommitmentPoseidon(b.Receipts, backend)
 	})
 	wg.Go(func() {
-		rCommitment, rErr = receiptCommitment(b.Receipts, engine)
+		rCommitment, rErr = receiptCommitment(b.Receipts, backend)
 	})
 
 	wg.Go(func() {
@@ -361,7 +377,11 @@ func Post0132Hash(b *Block, stateDiff *StateDiff, engine TrieBackend) (felt.Felt
 }
 
 // post07Hash computes the block hash for blocks generated after Cairo 0.7.0
-func post07Hash(b *Block, overrideSeqAddr *felt.Felt, engine TrieBackend) (felt.Felt, *BlockCommitments, error) {
+func post07Hash(
+	b *Block,
+	overrideSeqAddr *felt.Felt,
+	backend TrieBackend,
+) (felt.Felt, *BlockCommitments, error) {
 	seqAddr := b.SequencerAddress
 	if overrideSeqAddr != nil {
 		seqAddr = overrideSeqAddr
@@ -372,15 +392,19 @@ func post07Hash(b *Block, overrideSeqAddr *felt.Felt, engine TrieBackend) (felt.
 	var tErr, eErr, rErr error
 
 	wg.Go(func() {
-		txCommitment, tErr = transactionCommitmentPedersen(b.Transactions, b.Header.ProtocolVersion, engine)
+		txCommitment, tErr = transactionCommitmentPedersen(
+			b.Transactions,
+			b.Header.ProtocolVersion,
+			backend,
+		)
 	})
 	wg.Go(func() {
-		eCommitment, eErr = eventCommitmentPedersen(b.Receipts, engine)
+		eCommitment, eErr = eventCommitmentPedersen(b.Receipts, backend)
 	})
 	wg.Go(func() {
 		// even though rCommitment is not required for pre 0.13.2 hash
 		// we need to calculate it for BlockCommitments that will be stored in db
-		rCommitment, rErr = receiptCommitment(b.Receipts, engine)
+		rCommitment, rErr = receiptCommitment(b.Receipts, backend)
 	})
 	wg.Wait()
 

--- a/core/block_pkg_test.go
+++ b/core/block_pkg_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/NethermindEth/juno/core/felt"
+	statetestutils "github.com/NethermindEth/juno/core/state/testutils"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -11,7 +12,7 @@ import (
 //nolint:dupl
 func TestTransactionCommitmentPoseidon0134(t *testing.T) {
 	t.Run("nil", func(t *testing.T) {
-		c, err := transactionCommitmentPoseidon0134(nil, DeprecatedTrieBackend)
+		c, err := transactionCommitmentPoseidon0134(nil, testTrieBackend())
 		require.NoError(t, err)
 		assert.Equal(t, felt.Zero, c)
 	})
@@ -47,7 +48,7 @@ func TestTransactionCommitmentPoseidon0134(t *testing.T) {
 			txs = append(txs, invoke, deployAccount, declare)
 		}
 
-		c, err := transactionCommitmentPoseidon0134(txs, DeprecatedTrieBackend)
+		c, err := transactionCommitmentPoseidon0134(txs, testTrieBackend())
 		require.NoError(t, err)
 		expected := felt.UnsafeFromString[felt.Felt](
 			"0x4ca6d4ceb367bf070d896a1479190d3c7b751f525e69a46ee2c83f0afe7cb8",
@@ -65,7 +66,7 @@ func TestTransactionCommitmentPoseidon0134(t *testing.T) {
 			},
 		}
 
-		c, err := transactionCommitmentPoseidon0134(txs, DeprecatedTrieBackend)
+		c, err := transactionCommitmentPoseidon0134(txs, testTrieBackend())
 		require.NoError(t, err)
 		expected := felt.UnsafeFromString[felt.Felt](
 			"0x5ecb75d7a86984ec8ef9d5fbbe49ef8737c37246d33cf73037df1ceb412244e",
@@ -76,7 +77,7 @@ func TestTransactionCommitmentPoseidon0134(t *testing.T) {
 
 func TestTransactionCommitmentPoseidon0132(t *testing.T) { //nolint:dupl
 	t.Run("nil", func(t *testing.T) {
-		c, err := transactionCommitmentPoseidon0132(nil, DeprecatedTrieBackend)
+		c, err := transactionCommitmentPoseidon0132(nil, testTrieBackend())
 		require.NoError(t, err)
 		assert.Equal(t, felt.Zero, c)
 	})
@@ -113,7 +114,7 @@ func TestTransactionCommitmentPoseidon0132(t *testing.T) { //nolint:dupl
 			txs = append(txs, invoke, deployAccount, declare)
 		}
 
-		c, err := transactionCommitmentPoseidon0132(txs, DeprecatedTrieBackend)
+		c, err := transactionCommitmentPoseidon0132(txs, testTrieBackend())
 		require.NoError(t, err)
 		expected := felt.UnsafeFromString[felt.Felt](
 			"0x68303856fce63d62acb85da0766b370c03754aa316b0b5bce05982f9561b73d",
@@ -130,11 +131,18 @@ func TestTransactionCommitmentPoseidon0132(t *testing.T) { //nolint:dupl
 			},
 		}
 
-		c, err := transactionCommitmentPoseidon0132(txs, DeprecatedTrieBackend)
+		c, err := transactionCommitmentPoseidon0132(txs, testTrieBackend())
 		require.NoError(t, err)
 		expected := felt.UnsafeFromString[felt.Felt](
 			"0x6e067f82eefc8efa75b4ad389253757f4992eee0f81f0b43815fa56135ca801",
 		)
 		assert.Equal(t, expected, c, "expected: %s, got: %s", expected, c)
 	})
+}
+
+func testTrieBackend() TrieBackend {
+	if statetestutils.UseNewState() {
+		return NewTrieBackend
+	}
+	return DeprecatedTrieBackend
 }

--- a/core/block_pkg_test.go
+++ b/core/block_pkg_test.go
@@ -140,9 +140,9 @@ func TestTransactionCommitmentPoseidon0132(t *testing.T) { //nolint:dupl
 	})
 }
 
-func testTrieBackend() TrieBackend {
+func testTrieBackend() TempTrieBackend {
 	if statetestutils.UseNewState() {
-		return NewTrieBackend
+		return TrieBackend
 	}
 	return DeprecatedTrieBackend
 }

--- a/core/block_pkg_test.go
+++ b/core/block_pkg_test.go
@@ -11,7 +11,7 @@ import (
 //nolint:dupl
 func TestTransactionCommitmentPoseidon0134(t *testing.T) {
 	t.Run("nil", func(t *testing.T) {
-		c, err := transactionCommitmentPoseidon0134(nil)
+		c, err := transactionCommitmentPoseidon0134(nil, DeprecatedTrieBackend)
 		require.NoError(t, err)
 		assert.Equal(t, felt.Zero, c)
 	})
@@ -47,7 +47,7 @@ func TestTransactionCommitmentPoseidon0134(t *testing.T) {
 			txs = append(txs, invoke, deployAccount, declare)
 		}
 
-		c, err := transactionCommitmentPoseidon0134(txs)
+		c, err := transactionCommitmentPoseidon0134(txs, DeprecatedTrieBackend)
 		require.NoError(t, err)
 		expected := felt.UnsafeFromString[felt.Felt](
 			"0x4ca6d4ceb367bf070d896a1479190d3c7b751f525e69a46ee2c83f0afe7cb8",
@@ -65,7 +65,7 @@ func TestTransactionCommitmentPoseidon0134(t *testing.T) {
 			},
 		}
 
-		c, err := transactionCommitmentPoseidon0134(txs)
+		c, err := transactionCommitmentPoseidon0134(txs, DeprecatedTrieBackend)
 		require.NoError(t, err)
 		expected := felt.UnsafeFromString[felt.Felt](
 			"0x5ecb75d7a86984ec8ef9d5fbbe49ef8737c37246d33cf73037df1ceb412244e",
@@ -76,7 +76,7 @@ func TestTransactionCommitmentPoseidon0134(t *testing.T) {
 
 func TestTransactionCommitmentPoseidon0132(t *testing.T) { //nolint:dupl
 	t.Run("nil", func(t *testing.T) {
-		c, err := transactionCommitmentPoseidon0132(nil)
+		c, err := transactionCommitmentPoseidon0132(nil, DeprecatedTrieBackend)
 		require.NoError(t, err)
 		assert.Equal(t, felt.Zero, c)
 	})
@@ -113,7 +113,7 @@ func TestTransactionCommitmentPoseidon0132(t *testing.T) { //nolint:dupl
 			txs = append(txs, invoke, deployAccount, declare)
 		}
 
-		c, err := transactionCommitmentPoseidon0132(txs)
+		c, err := transactionCommitmentPoseidon0132(txs, DeprecatedTrieBackend)
 		require.NoError(t, err)
 		expected := felt.UnsafeFromString[felt.Felt](
 			"0x68303856fce63d62acb85da0766b370c03754aa316b0b5bce05982f9561b73d",
@@ -130,7 +130,7 @@ func TestTransactionCommitmentPoseidon0132(t *testing.T) { //nolint:dupl
 			},
 		}
 
-		c, err := transactionCommitmentPoseidon0132(txs)
+		c, err := transactionCommitmentPoseidon0132(txs, DeprecatedTrieBackend)
 		require.NoError(t, err)
 		expected := felt.UnsafeFromString[felt.Felt](
 			"0x6e067f82eefc8efa75b4ad389253757f4992eee0f81f0b43815fa56135ca801",

--- a/core/block_test.go
+++ b/core/block_test.go
@@ -179,7 +179,7 @@ func TestBlockHash(t *testing.T) {
 			block, err := gw.BlockByNumber(t.Context(), tc.number)
 			require.NoError(t, err)
 
-			commitments, err := core.VerifyBlockHash(block, &tc.chain, nil)
+			commitments, err := core.VerifyBlockHash(block, &tc.chain, nil, core.DeprecatedTrieBackend)
 			assert.NoError(t, err)
 			assert.NotNil(t, commitments)
 		})
@@ -196,7 +196,7 @@ func TestBlockHash(t *testing.T) {
 		mainnetBlock1.Hash = h1
 
 		expectedErr := "can not verify hash in block header"
-		commitments, err := core.VerifyBlockHash(mainnetBlock1, &networks.Mainnet, nil)
+		commitments, err := core.VerifyBlockHash(mainnetBlock1, &networks.Mainnet, nil, core.DeprecatedTrieBackend)
 		assert.EqualError(t, err, expectedErr)
 		assert.Nil(t, commitments)
 	})
@@ -207,7 +207,7 @@ func TestBlockHash(t *testing.T) {
 		block119802, err := goerliGW.BlockByNumber(t.Context(), 119802)
 		require.NoError(t, err)
 
-		commitments, err := core.VerifyBlockHash(block119802, &networks.Goerli, nil)
+		commitments, err := core.VerifyBlockHash(block119802, &networks.Goerli, nil, core.DeprecatedTrieBackend)
 		assert.NoError(t, err)
 		assert.NotNil(t, commitments)
 	})
@@ -221,7 +221,7 @@ func TestBlockHash(t *testing.T) {
 		expectedErr := fmt.Sprintf("len of transactions: %v do not match len of receipts: %v",
 			len(mainnetBlock1.Transactions), len(mainnetBlock1.Receipts))
 
-		commitments, err := core.VerifyBlockHash(mainnetBlock1, &networks.Mainnet, nil)
+		commitments, err := core.VerifyBlockHash(mainnetBlock1, &networks.Mainnet, nil, core.DeprecatedTrieBackend)
 		assert.EqualError(t, err, expectedErr)
 		assert.Nil(t, commitments)
 	})
@@ -235,7 +235,7 @@ func TestBlockHash(t *testing.T) {
 			"transaction hash (%v) at index: %v does not match receipt's hash (%v)",
 			mainnetBlock1.Transactions[1].Hash().String(), 1,
 			mainnetBlock1.Receipts[1].TransactionHash)
-		commitments, err := core.VerifyBlockHash(mainnetBlock1, &networks.Mainnet, nil)
+		commitments, err := core.VerifyBlockHash(mainnetBlock1, &networks.Mainnet, nil, core.DeprecatedTrieBackend)
 		assert.EqualError(t, err, expectedErr)
 		assert.Nil(t, commitments)
 	})
@@ -260,7 +260,7 @@ func Test0132BlockHash(t *testing.T) {
 			su, err := gw.StateUpdate(t.Context(), test.blockNum)
 			require.NoError(t, err)
 
-			c, err := core.VerifyBlockHash(b, &networks.SepoliaIntegration, su.StateDiff)
+			c, err := core.VerifyBlockHash(b, &networks.SepoliaIntegration, su.StateDiff, core.DeprecatedTrieBackend)
 			require.NoError(t, err)
 			assert.NotNil(t, c)
 		})
@@ -285,7 +285,7 @@ func Test0134BlockHash(t *testing.T) {
 			su, err := gw.StateUpdate(t.Context(), test.blockNum)
 			require.NoError(t, err)
 
-			c, err := core.VerifyBlockHash(b, &networks.SepoliaIntegration, su.StateDiff)
+			c, err := core.VerifyBlockHash(b, &networks.SepoliaIntegration, su.StateDiff, core.DeprecatedTrieBackend)
 			require.NoError(t, err)
 			assert.NotNil(t, c)
 		})

--- a/core/block_test.go
+++ b/core/block_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/NethermindEth/juno/clients/feeder"
 	"github.com/NethermindEth/juno/core"
 	"github.com/NethermindEth/juno/core/felt"
+	statetestutils "github.com/NethermindEth/juno/core/state/testutils"
 	adaptfeeder "github.com/NethermindEth/juno/starknetdata/feeder"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -179,7 +180,7 @@ func TestBlockHash(t *testing.T) {
 			block, err := gw.BlockByNumber(t.Context(), tc.number)
 			require.NoError(t, err)
 
-			commitments, err := core.VerifyBlockHash(block, &tc.chain, nil, core.DeprecatedTrieBackend)
+			commitments, err := core.VerifyBlockHash(block, &tc.chain, nil, testTrieBackend())
 			assert.NoError(t, err)
 			assert.NotNil(t, commitments)
 		})
@@ -196,7 +197,7 @@ func TestBlockHash(t *testing.T) {
 		mainnetBlock1.Hash = h1
 
 		expectedErr := "can not verify hash in block header"
-		commitments, err := core.VerifyBlockHash(mainnetBlock1, &networks.Mainnet, nil, core.DeprecatedTrieBackend)
+		commitments, err := core.VerifyBlockHash(mainnetBlock1, &networks.Mainnet, nil, testTrieBackend())
 		assert.EqualError(t, err, expectedErr)
 		assert.Nil(t, commitments)
 	})
@@ -207,7 +208,7 @@ func TestBlockHash(t *testing.T) {
 		block119802, err := goerliGW.BlockByNumber(t.Context(), 119802)
 		require.NoError(t, err)
 
-		commitments, err := core.VerifyBlockHash(block119802, &networks.Goerli, nil, core.DeprecatedTrieBackend)
+		commitments, err := core.VerifyBlockHash(block119802, &networks.Goerli, nil, testTrieBackend())
 		assert.NoError(t, err)
 		assert.NotNil(t, commitments)
 	})
@@ -221,7 +222,7 @@ func TestBlockHash(t *testing.T) {
 		expectedErr := fmt.Sprintf("len of transactions: %v do not match len of receipts: %v",
 			len(mainnetBlock1.Transactions), len(mainnetBlock1.Receipts))
 
-		commitments, err := core.VerifyBlockHash(mainnetBlock1, &networks.Mainnet, nil, core.DeprecatedTrieBackend)
+		commitments, err := core.VerifyBlockHash(mainnetBlock1, &networks.Mainnet, nil, testTrieBackend())
 		assert.EqualError(t, err, expectedErr)
 		assert.Nil(t, commitments)
 	})
@@ -235,7 +236,7 @@ func TestBlockHash(t *testing.T) {
 			"transaction hash (%v) at index: %v does not match receipt's hash (%v)",
 			mainnetBlock1.Transactions[1].Hash().String(), 1,
 			mainnetBlock1.Receipts[1].TransactionHash)
-		commitments, err := core.VerifyBlockHash(mainnetBlock1, &networks.Mainnet, nil, core.DeprecatedTrieBackend)
+		commitments, err := core.VerifyBlockHash(mainnetBlock1, &networks.Mainnet, nil, testTrieBackend())
 		assert.EqualError(t, err, expectedErr)
 		assert.Nil(t, commitments)
 	})
@@ -260,7 +261,7 @@ func Test0132BlockHash(t *testing.T) {
 			su, err := gw.StateUpdate(t.Context(), test.blockNum)
 			require.NoError(t, err)
 
-			c, err := core.VerifyBlockHash(b, &networks.SepoliaIntegration, su.StateDiff, core.DeprecatedTrieBackend)
+			c, err := core.VerifyBlockHash(b, &networks.SepoliaIntegration, su.StateDiff, testTrieBackend())
 			require.NoError(t, err)
 			assert.NotNil(t, c)
 		})
@@ -285,9 +286,16 @@ func Test0134BlockHash(t *testing.T) {
 			su, err := gw.StateUpdate(t.Context(), test.blockNum)
 			require.NoError(t, err)
 
-			c, err := core.VerifyBlockHash(b, &networks.SepoliaIntegration, su.StateDiff, core.DeprecatedTrieBackend)
+			c, err := core.VerifyBlockHash(b, &networks.SepoliaIntegration, su.StateDiff, testTrieBackend())
 			require.NoError(t, err)
 			assert.NotNil(t, c)
 		})
 	}
+}
+
+func testTrieBackend() core.TrieBackend {
+	if statetestutils.UseNewState() {
+		return core.NewTrieBackend
+	}
+	return core.DeprecatedTrieBackend
 }

--- a/core/block_test.go
+++ b/core/block_test.go
@@ -293,9 +293,9 @@ func Test0134BlockHash(t *testing.T) {
 	}
 }
 
-func testTrieBackend() core.TrieBackend {
+func testTrieBackend() core.TempTrieBackend {
 	if statetestutils.UseNewState() {
-		return core.NewTrieBackend
+		return core.TrieBackend
 	}
 	return core.DeprecatedTrieBackend
 }

--- a/core/deprecatedstate/history.go
+++ b/core/deprecatedstate/history.go
@@ -121,14 +121,14 @@ func (s *stateHistory) CompiledClassHashV2(
 	return s.state.CompiledClassHashV2(classHash)
 }
 
-func (s *stateHistory) ClassTrie() (core.Trie, error) {
+func (s *stateHistory) ClassTrie() (core.TrieReader, error) {
 	return nil, ErrHistoricalTrieNotSupported
 }
 
-func (s *stateHistory) ContractTrie() (core.Trie, error) {
+func (s *stateHistory) ContractTrie() (core.TrieReader, error) {
 	return nil, ErrHistoricalTrieNotSupported
 }
 
-func (s *stateHistory) ContractStorageTrie(addr *felt.Felt) (core.Trie, error) {
+func (s *stateHistory) ContractStorageTrie(addr *felt.Felt) (core.TrieReader, error) {
 	return nil, ErrHistoricalTrieNotSupported
 }

--- a/core/deprecatedstate/state.go
+++ b/core/deprecatedstate/state.go
@@ -132,18 +132,18 @@ func (s *State) Commitment(protocolVersion string) (felt.Felt, error) {
 	return root, nil
 }
 
-func (s *State) ClassTrie() (core.Trie, error) {
+func (s *State) ClassTrie() (core.TrieReader, error) {
 	// We don't need to call the closer function here because we are only reading the trie
 	tr, _, err := s.classesTrie()
 	return tr, err
 }
 
-func (s *State) ContractTrie() (core.Trie, error) {
+func (s *State) ContractTrie() (core.TrieReader, error) {
 	tr, _, err := s.storage()
 	return tr, err
 }
 
-func (s *State) ContractStorageTrie(addr *felt.Felt) (core.Trie, error) {
+func (s *State) ContractStorageTrie(addr *felt.Felt) (core.TrieReader, error) {
 	return storage(addr, s.txn)
 }
 

--- a/core/pending/state.go
+++ b/core/pending/state.go
@@ -117,15 +117,15 @@ func (p *State) CompiledClassHashV2(
 	return p.head.CompiledClassHashV2(classHash)
 }
 
-func (p *State) ClassTrie() (core.Trie, error) {
+func (p *State) ClassTrie() (core.TrieReader, error) {
 	return nil, ErrHistoricalTrieNotSupported
 }
 
-func (p *State) ContractTrie() (core.Trie, error) {
+func (p *State) ContractTrie() (core.TrieReader, error) {
 	return nil, ErrHistoricalTrieNotSupported
 }
 
-func (p *State) ContractStorageTrie(addr *felt.Felt) (core.Trie, error) {
+func (p *State) ContractStorageTrie(addr *felt.Felt) (core.TrieReader, error) {
 	return nil, ErrHistoricalTrieNotSupported
 }
 

--- a/core/receipt.go
+++ b/core/receipt.go
@@ -67,10 +67,10 @@ func messagesSentHash(messages []*L2ToL1Message) felt.Felt {
 	return crypto.PoseidonArray(chain...)
 }
 
-func receiptCommitment(receipts []*TransactionReceipt, engine TrieBackend) (felt.Felt, error) {
+func receiptCommitment(receipts []*TransactionReceipt, backend TrieBackend) (felt.Felt, error) {
 	return calculateCommitment(
 		receipts,
-		engine.Poseidon(),
+		backend.Poseidon,
 		func(receipt *TransactionReceipt) felt.Felt {
 			return receipt.hash()
 		},

--- a/core/receipt.go
+++ b/core/receipt.go
@@ -70,7 +70,7 @@ func messagesSentHash(messages []*L2ToL1Message) felt.Felt {
 func receiptCommitment(receipts []*TransactionReceipt, backend TrieBackend) (felt.Felt, error) {
 	return calculateCommitment(
 		receipts,
-		backend.Poseidon,
+		backend.RunOnTempTriePoseidon,
 		func(receipt *TransactionReceipt) felt.Felt {
 			return receipt.hash()
 		},

--- a/core/receipt.go
+++ b/core/receipt.go
@@ -82,7 +82,7 @@ type processFunc[T any] func(T) felt.Felt
 // General function for parallel processing of items and calculation of a commitment
 func calculateCommitment[T any](
 	items []T,
-	runOnTempTrie runOnTempTrieFn,
+	runOnTempTrie onTempTrieFunc,
 	process processFunc[T],
 ) (felt.Felt, error) {
 	var commitment *felt.Felt

--- a/core/receipt.go
+++ b/core/receipt.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/NethermindEth/juno/core/crypto"
 	"github.com/NethermindEth/juno/core/felt"
-	"github.com/NethermindEth/juno/core/trie2"
 )
 
 type GasConsumed struct {
@@ -68,29 +67,26 @@ func messagesSentHash(messages []*L2ToL1Message) felt.Felt {
 	return crypto.PoseidonArray(chain...)
 }
 
-func receiptCommitment(receipts []*TransactionReceipt) (felt.Felt, error) {
+func receiptCommitment(receipts []*TransactionReceipt, engine TrieBackend) (felt.Felt, error) {
 	return calculateCommitment(
 		receipts,
-		trie2.RunOnTempTriePoseidon,
+		engine.Poseidon(),
 		func(receipt *TransactionReceipt) felt.Felt {
 			return receipt.hash()
 		},
 	)
 }
 
-type (
-	onTempTrieFunc     func(uint8, func(*trie2.Trie) error) error
-	processFunc[T any] func(T) felt.Felt
-)
+type processFunc[T any] func(T) felt.Felt
 
 // General function for parallel processing of items and calculation of a commitment
 func calculateCommitment[T any](
 	items []T,
-	runOnTempTrie onTempTrieFunc,
+	runOnTempTrie runOnTempTrieFn,
 	process processFunc[T],
 ) (felt.Felt, error) {
 	var commitment *felt.Felt
-	return *commitment, runOnTempTrie(commitmentTrieHeight, func(trie *trie2.Trie) error {
+	return *commitment, runOnTempTrie(commitmentTrieHeight, func(trie Trie) error {
 		numWorkers := min(runtime.GOMAXPROCS(0), len(items))
 		results := make([]felt.Felt, len(items))
 		var wg sync.WaitGroup

--- a/core/receipt.go
+++ b/core/receipt.go
@@ -67,7 +67,7 @@ func messagesSentHash(messages []*L2ToL1Message) felt.Felt {
 	return crypto.PoseidonArray(chain...)
 }
 
-func receiptCommitment(receipts []*TransactionReceipt, backend TrieBackend) (felt.Felt, error) {
+func receiptCommitment(receipts []*TransactionReceipt, backend TempTrieBackend) (felt.Felt, error) {
 	return calculateCommitment(
 		receipts,
 		backend.RunOnTempTriePoseidon,

--- a/core/receipt_test.go
+++ b/core/receipt_test.go
@@ -94,7 +94,7 @@ func BenchmarkReceiptCommitment(b *testing.B) {
 	var err error
 	b.ResetTimer()
 	for range b.N {
-		f, err = receiptCommitment(receipts)
+		f, err = receiptCommitment(receipts, DeprecatedTrieBackend)
 		require.NoError(b, err)
 	}
 	benchReceiptR = f

--- a/core/receipt_test.go
+++ b/core/receipt_test.go
@@ -94,7 +94,7 @@ func BenchmarkReceiptCommitment(b *testing.B) {
 	var err error
 	b.ResetTimer()
 	for range b.N {
-		f, err = receiptCommitment(receipts, DeprecatedTrieBackend)
+		f, err = receiptCommitment(receipts, testTrieBackend())
 		require.NoError(b, err)
 	}
 	benchReceiptR = f

--- a/core/state/history.go
+++ b/core/state/history.go
@@ -98,15 +98,15 @@ func (s *stateHistory) Class(classHash *felt.Felt) (*core.DeclaredClassDefinitio
 	return declaredClass, nil
 }
 
-func (s *stateHistory) ClassTrie() (core.Trie, error) {
+func (s *stateHistory) ClassTrie() (core.TrieReader, error) {
 	return nil, ErrHistoricalTrieNotSupported
 }
 
-func (s *stateHistory) ContractTrie() (core.Trie, error) {
+func (s *stateHistory) ContractTrie() (core.TrieReader, error) {
 	return nil, ErrHistoricalTrieNotSupported
 }
 
-func (s *stateHistory) ContractStorageTrie(addr *felt.Felt) (core.Trie, error) {
+func (s *stateHistory) ContractStorageTrie(addr *felt.Felt) (core.TrieReader, error) {
 	return nil, ErrHistoricalTrieNotSupported
 }
 

--- a/core/state/state_reader.go
+++ b/core/state/state_reader.go
@@ -105,15 +105,15 @@ func (s *StateReader) Class(classHash *felt.Felt) (*core.DeclaredClassDefinition
 	return GetClass(s.db.disk, classHash)
 }
 
-func (s *StateReader) ClassTrie() (core.Trie, error) {
+func (s *StateReader) ClassTrie() (core.TrieReader, error) {
 	return s.classTrie, nil
 }
 
-func (s *StateReader) ContractTrie() (core.Trie, error) {
+func (s *StateReader) ContractTrie() (core.TrieReader, error) {
 	return s.contractTrie, nil
 }
 
-func (s *StateReader) ContractStorageTrie(addr *felt.Felt) (core.Trie, error) {
+func (s *StateReader) ContractStorageTrie(addr *felt.Felt) (core.TrieReader, error) {
 	return s.db.ContractStorageTrie(&s.initRoot, addr)
 }
 

--- a/core/state_interfaces.go
+++ b/core/state_interfaces.go
@@ -55,10 +55,10 @@ type StateReader interface {
 	// CompiledClassHashV2 returns the CASM class hash for a Sierra class hash (blake2s-based, V2).
 	CompiledClassHashV2(classHash *felt.SierraClassHash) (felt.CasmClassHash, error)
 	// ClassTrie returns the trie of all declared classes, keyed by class hash.
-	ClassTrie() (Trie, error)
+	ClassTrie() (TrieReader, error)
 	// ContractTrie returns the global contracts trie, keyed by contract address.
-	ContractTrie() (Trie, error)
+	ContractTrie() (TrieReader, error)
 	// ContractStorageTrie returns the storage trie for the contract at addr.
 	// todo: change addr *felt.Felt to *felt.Address
-	ContractStorageTrie(addr *felt.Felt) (Trie, error)
+	ContractStorageTrie(addr *felt.Felt) (TrieReader, error)
 }

--- a/core/transaction.go
+++ b/core/transaction.go
@@ -11,7 +11,7 @@ import (
 	"github.com/NethermindEth/juno/blockchain/networks"
 	"github.com/NethermindEth/juno/core/crypto"
 	"github.com/NethermindEth/juno/core/felt"
-	"github.com/NethermindEth/juno/core/trie"
+	"github.com/NethermindEth/juno/core/trie2"
 	"github.com/bits-and-blooms/bloom/v3"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/fxamacker/cbor/v2"
@@ -728,7 +728,7 @@ func transactionCommitmentPedersen(
 			return crypto.Pedersen(transaction.Hash(), &signatureHash)
 		}
 	}
-	return calculateCommitment(transactions, trie.RunOnTempTriePedersen, hashFunc)
+	return calculateCommitment(transactions, trie2.RunOnTempTriePedersen, hashFunc)
 }
 
 // transactionCommitmentPoseidon0134 handles empty signatures compared to
@@ -737,7 +737,7 @@ func transactionCommitmentPedersen(
 func transactionCommitmentPoseidon0134(transactions []Transaction) (felt.Felt, error) {
 	return calculateCommitment(
 		transactions,
-		trie.RunOnTempTriePoseidon,
+		trie2.RunOnTempTriePoseidon,
 		func(transaction Transaction) felt.Felt {
 			var digest crypto.PoseidonDigest
 			digest.Update(transaction.Hash())
@@ -755,7 +755,7 @@ func transactionCommitmentPoseidon0134(transactions []Transaction) (felt.Felt, e
 func transactionCommitmentPoseidon0132(transactions []Transaction) (felt.Felt, error) {
 	return calculateCommitment(
 		transactions,
-		trie.RunOnTempTriePoseidon,
+		trie2.RunOnTempTriePoseidon,
 		func(transaction Transaction) felt.Felt {
 			var digest crypto.PoseidonDigest
 			digest.Update(transaction.Hash())
@@ -793,7 +793,7 @@ func eventCommitmentPoseidon(receipts []*TransactionReceipt) (felt.Felt, error) 
 	}
 	return calculateCommitment(
 		items,
-		trie.RunOnTempTriePoseidon,
+		trie2.RunOnTempTriePoseidon,
 		func(item *eventWithTxHash) felt.Felt {
 			return crypto.PoseidonArray(
 				slices.Concat(
@@ -823,7 +823,7 @@ func eventCommitmentPedersen(receipts []*TransactionReceipt) (felt.Felt, error) 
 	for _, receipt := range receipts {
 		events = append(events, receipt.Events...)
 	}
-	return calculateCommitment(events, trie.RunOnTempTriePedersen, func(event *Event) felt.Felt {
+	return calculateCommitment(events, trie2.RunOnTempTriePedersen, func(event *Event) felt.Felt {
 		keysHash := crypto.PedersenArray(event.Keys...)
 		dataHash := crypto.PedersenArray(event.Data...)
 		return crypto.PedersenArray(

--- a/core/transaction.go
+++ b/core/transaction.go
@@ -705,7 +705,7 @@ const commitmentTrieHeight = 64
 func transactionCommitmentPedersen(
 	transactions []Transaction,
 	protocolVersion string,
-	backend TrieBackend,
+	backend TempTrieBackend,
 ) (felt.Felt, error) {
 	blockVersion, err := ParseBlockVersion(protocolVersion)
 	if err != nil {
@@ -736,7 +736,7 @@ func transactionCommitmentPedersen(
 // Empty signatures are interpreted as [] instead of [0]
 func transactionCommitmentPoseidon0134(
 	transactions []Transaction,
-	backend TrieBackend,
+	backend TempTrieBackend,
 ) (felt.Felt, error) {
 	return calculateCommitment(
 		transactions,
@@ -757,7 +757,7 @@ func transactionCommitmentPoseidon0134(
 // 0.13.2 <= block.version < 0.13.4
 func transactionCommitmentPoseidon0132(
 	transactions []Transaction,
-	backend TrieBackend,
+	backend TempTrieBackend,
 ) (felt.Felt, error) {
 	return calculateCommitment(
 		transactions,
@@ -785,7 +785,7 @@ type eventWithTxHash struct {
 // eventCommitmentPoseidon computes the event commitment for a block.
 func eventCommitmentPoseidon(
 	receipts []*TransactionReceipt,
-	backend TrieBackend,
+	backend TempTrieBackend,
 ) (felt.Felt, error) {
 	eventCounter := 0
 	for _, receipt := range receipts {
@@ -825,7 +825,7 @@ func eventCommitmentPoseidon(
 // eventCommitmentPedersen computes the event commitment for a block.
 func eventCommitmentPedersen(
 	receipts []*TransactionReceipt,
-	backend TrieBackend,
+	backend TempTrieBackend,
 ) (felt.Felt, error) {
 	eventCounter := 0
 	for _, receipt := range receipts {

--- a/core/transaction.go
+++ b/core/transaction.go
@@ -728,7 +728,7 @@ func transactionCommitmentPedersen(
 			return crypto.Pedersen(transaction.Hash(), &signatureHash)
 		}
 	}
-	return calculateCommitment(transactions, backend.Pedersen, hashFunc)
+	return calculateCommitment(transactions, backend.RunOnTempTriePedersen, hashFunc)
 }
 
 // transactionCommitmentPoseidon0134 handles empty signatures compared to
@@ -740,7 +740,7 @@ func transactionCommitmentPoseidon0134(
 ) (felt.Felt, error) {
 	return calculateCommitment(
 		transactions,
-		backend.Poseidon,
+		backend.RunOnTempTriePoseidon,
 		func(transaction Transaction) felt.Felt {
 			var digest crypto.PoseidonDigest
 			digest.Update(transaction.Hash())
@@ -761,7 +761,7 @@ func transactionCommitmentPoseidon0132(
 ) (felt.Felt, error) {
 	return calculateCommitment(
 		transactions,
-		backend.Poseidon,
+		backend.RunOnTempTriePoseidon,
 		func(transaction Transaction) felt.Felt {
 			var digest crypto.PoseidonDigest
 			digest.Update(transaction.Hash())
@@ -802,7 +802,7 @@ func eventCommitmentPoseidon(
 	}
 	return calculateCommitment(
 		items,
-		backend.Poseidon,
+		backend.RunOnTempTriePoseidon,
 		func(item *eventWithTxHash) felt.Felt {
 			return crypto.PoseidonArray(
 				slices.Concat(
@@ -835,7 +835,7 @@ func eventCommitmentPedersen(
 	for _, receipt := range receipts {
 		events = append(events, receipt.Events...)
 	}
-	return calculateCommitment(events, backend.Pedersen, func(event *Event) felt.Felt {
+	return calculateCommitment(events, backend.RunOnTempTriePedersen, func(event *Event) felt.Felt {
 		keysHash := crypto.PedersenArray(event.Keys...)
 		dataHash := crypto.PedersenArray(event.Data...)
 		return crypto.PedersenArray(

--- a/core/transaction.go
+++ b/core/transaction.go
@@ -705,7 +705,7 @@ const commitmentTrieHeight = 64
 func transactionCommitmentPedersen(
 	transactions []Transaction,
 	protocolVersion string,
-	engine TrieBackend,
+	backend TrieBackend,
 ) (felt.Felt, error) {
 	blockVersion, err := ParseBlockVersion(protocolVersion)
 	if err != nil {
@@ -728,7 +728,7 @@ func transactionCommitmentPedersen(
 			return crypto.Pedersen(transaction.Hash(), &signatureHash)
 		}
 	}
-	return calculateCommitment(transactions, engine.Pedersen(), hashFunc)
+	return calculateCommitment(transactions, backend.Pedersen, hashFunc)
 }
 
 // transactionCommitmentPoseidon0134 handles empty signatures compared to
@@ -740,7 +740,7 @@ func transactionCommitmentPoseidon0134(
 ) (felt.Felt, error) {
 	return calculateCommitment(
 		transactions,
-		backend.Poseidon(),
+		backend.Poseidon,
 		func(transaction Transaction) felt.Felt {
 			var digest crypto.PoseidonDigest
 			digest.Update(transaction.Hash())
@@ -761,7 +761,7 @@ func transactionCommitmentPoseidon0132(
 ) (felt.Felt, error) {
 	return calculateCommitment(
 		transactions,
-		backend.Poseidon(),
+		backend.Poseidon,
 		func(transaction Transaction) felt.Felt {
 			var digest crypto.PoseidonDigest
 			digest.Update(transaction.Hash())
@@ -802,7 +802,7 @@ func eventCommitmentPoseidon(
 	}
 	return calculateCommitment(
 		items,
-		backend.Poseidon(),
+		backend.Poseidon,
 		func(item *eventWithTxHash) felt.Felt {
 			return crypto.PoseidonArray(
 				slices.Concat(
@@ -835,7 +835,7 @@ func eventCommitmentPedersen(
 	for _, receipt := range receipts {
 		events = append(events, receipt.Events...)
 	}
-	return calculateCommitment(events, backend.Pedersen(), func(event *Event) felt.Felt {
+	return calculateCommitment(events, backend.Pedersen, func(event *Event) felt.Felt {
 		keysHash := crypto.PedersenArray(event.Keys...)
 		dataHash := crypto.PedersenArray(event.Data...)
 		return crypto.PedersenArray(

--- a/core/transaction.go
+++ b/core/transaction.go
@@ -734,10 +734,13 @@ func transactionCommitmentPedersen(
 // transactionCommitmentPoseidon0134 handles empty signatures compared to
 // transactionCommitmentPoseidon0132.
 // Empty signatures are interpreted as [] instead of [0]
-func transactionCommitmentPoseidon0134(transactions []Transaction, engine TrieBackend) (felt.Felt, error) {
+func transactionCommitmentPoseidon0134(
+	transactions []Transaction,
+	backend TrieBackend,
+) (felt.Felt, error) {
 	return calculateCommitment(
 		transactions,
-		engine.Poseidon(),
+		backend.Poseidon(),
 		func(transaction Transaction) felt.Felt {
 			var digest crypto.PoseidonDigest
 			digest.Update(transaction.Hash())
@@ -752,10 +755,13 @@ func transactionCommitmentPoseidon0134(transactions []Transaction, engine TrieBa
 
 // transactionCommitmentPoseidon0132 is used to calculate tx commitment for
 // 0.13.2 <= block.version < 0.13.4
-func transactionCommitmentPoseidon0132(transactions []Transaction, engine TrieBackend) (felt.Felt, error) {
+func transactionCommitmentPoseidon0132(
+	transactions []Transaction,
+	backend TrieBackend,
+) (felt.Felt, error) {
 	return calculateCommitment(
 		transactions,
-		engine.Poseidon(),
+		backend.Poseidon(),
 		func(transaction Transaction) felt.Felt {
 			var digest crypto.PoseidonDigest
 			digest.Update(transaction.Hash())
@@ -777,7 +783,10 @@ type eventWithTxHash struct {
 }
 
 // eventCommitmentPoseidon computes the event commitment for a block.
-func eventCommitmentPoseidon(receipts []*TransactionReceipt, engine TrieBackend) (felt.Felt, error) {
+func eventCommitmentPoseidon(
+	receipts []*TransactionReceipt,
+	backend TrieBackend,
+) (felt.Felt, error) {
 	eventCounter := 0
 	for _, receipt := range receipts {
 		eventCounter += len(receipt.Events)
@@ -793,7 +802,7 @@ func eventCommitmentPoseidon(receipts []*TransactionReceipt, engine TrieBackend)
 	}
 	return calculateCommitment(
 		items,
-		engine.Poseidon(),
+		backend.Poseidon(),
 		func(item *eventWithTxHash) felt.Felt {
 			return crypto.PoseidonArray(
 				slices.Concat(
@@ -814,7 +823,10 @@ func eventCommitmentPoseidon(receipts []*TransactionReceipt, engine TrieBackend)
 }
 
 // eventCommitmentPedersen computes the event commitment for a block.
-func eventCommitmentPedersen(receipts []*TransactionReceipt, engine TrieBackend) (felt.Felt, error) {
+func eventCommitmentPedersen(
+	receipts []*TransactionReceipt,
+	backend TrieBackend,
+) (felt.Felt, error) {
 	eventCounter := 0
 	for _, receipt := range receipts {
 		eventCounter += len(receipt.Events)
@@ -823,7 +835,7 @@ func eventCommitmentPedersen(receipts []*TransactionReceipt, engine TrieBackend)
 	for _, receipt := range receipts {
 		events = append(events, receipt.Events...)
 	}
-	return calculateCommitment(events, engine.Pedersen(), func(event *Event) felt.Felt {
+	return calculateCommitment(events, backend.Pedersen(), func(event *Event) felt.Felt {
 		keysHash := crypto.PedersenArray(event.Keys...)
 		dataHash := crypto.PedersenArray(event.Data...)
 		return crypto.PedersenArray(

--- a/core/transaction.go
+++ b/core/transaction.go
@@ -11,7 +11,6 @@ import (
 	"github.com/NethermindEth/juno/blockchain/networks"
 	"github.com/NethermindEth/juno/core/crypto"
 	"github.com/NethermindEth/juno/core/felt"
-	"github.com/NethermindEth/juno/core/trie2"
 	"github.com/bits-and-blooms/bloom/v3"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/fxamacker/cbor/v2"
@@ -706,6 +705,7 @@ const commitmentTrieHeight = 64
 func transactionCommitmentPedersen(
 	transactions []Transaction,
 	protocolVersion string,
+	engine TrieBackend,
 ) (felt.Felt, error) {
 	blockVersion, err := ParseBlockVersion(protocolVersion)
 	if err != nil {
@@ -728,16 +728,16 @@ func transactionCommitmentPedersen(
 			return crypto.Pedersen(transaction.Hash(), &signatureHash)
 		}
 	}
-	return calculateCommitment(transactions, trie2.RunOnTempTriePedersen, hashFunc)
+	return calculateCommitment(transactions, engine.Pedersen(), hashFunc)
 }
 
 // transactionCommitmentPoseidon0134 handles empty signatures compared to
 // transactionCommitmentPoseidon0132.
 // Empty signatures are interpreted as [] instead of [0]
-func transactionCommitmentPoseidon0134(transactions []Transaction) (felt.Felt, error) {
+func transactionCommitmentPoseidon0134(transactions []Transaction, engine TrieBackend) (felt.Felt, error) {
 	return calculateCommitment(
 		transactions,
-		trie2.RunOnTempTriePoseidon,
+		engine.Poseidon(),
 		func(transaction Transaction) felt.Felt {
 			var digest crypto.PoseidonDigest
 			digest.Update(transaction.Hash())
@@ -752,10 +752,10 @@ func transactionCommitmentPoseidon0134(transactions []Transaction) (felt.Felt, e
 
 // transactionCommitmentPoseidon0132 is used to calculate tx commitment for
 // 0.13.2 <= block.version < 0.13.4
-func transactionCommitmentPoseidon0132(transactions []Transaction) (felt.Felt, error) {
+func transactionCommitmentPoseidon0132(transactions []Transaction, engine TrieBackend) (felt.Felt, error) {
 	return calculateCommitment(
 		transactions,
-		trie2.RunOnTempTriePoseidon,
+		engine.Poseidon(),
 		func(transaction Transaction) felt.Felt {
 			var digest crypto.PoseidonDigest
 			digest.Update(transaction.Hash())
@@ -777,7 +777,7 @@ type eventWithTxHash struct {
 }
 
 // eventCommitmentPoseidon computes the event commitment for a block.
-func eventCommitmentPoseidon(receipts []*TransactionReceipt) (felt.Felt, error) {
+func eventCommitmentPoseidon(receipts []*TransactionReceipt, engine TrieBackend) (felt.Felt, error) {
 	eventCounter := 0
 	for _, receipt := range receipts {
 		eventCounter += len(receipt.Events)
@@ -793,7 +793,7 @@ func eventCommitmentPoseidon(receipts []*TransactionReceipt) (felt.Felt, error) 
 	}
 	return calculateCommitment(
 		items,
-		trie2.RunOnTempTriePoseidon,
+		engine.Poseidon(),
 		func(item *eventWithTxHash) felt.Felt {
 			return crypto.PoseidonArray(
 				slices.Concat(
@@ -814,7 +814,7 @@ func eventCommitmentPoseidon(receipts []*TransactionReceipt) (felt.Felt, error) 
 }
 
 // eventCommitmentPedersen computes the event commitment for a block.
-func eventCommitmentPedersen(receipts []*TransactionReceipt) (felt.Felt, error) {
+func eventCommitmentPedersen(receipts []*TransactionReceipt, engine TrieBackend) (felt.Felt, error) {
 	eventCounter := 0
 	for _, receipt := range receipts {
 		eventCounter += len(receipt.Events)
@@ -823,7 +823,7 @@ func eventCommitmentPedersen(receipts []*TransactionReceipt) (felt.Felt, error) 
 	for _, receipt := range receipts {
 		events = append(events, receipt.Events...)
 	}
-	return calculateCommitment(events, trie2.RunOnTempTriePedersen, func(event *Event) felt.Felt {
+	return calculateCommitment(events, engine.Pedersen(), func(event *Event) felt.Felt {
 		keysHash := crypto.PedersenArray(event.Keys...)
 		dataHash := crypto.PedersenArray(event.Data...)
 		return crypto.PedersenArray(

--- a/core/trie_interfaces.go
+++ b/core/trie_interfaces.go
@@ -3,14 +3,57 @@ package core
 import (
 	"github.com/NethermindEth/juno/core/crypto"
 	"github.com/NethermindEth/juno/core/felt"
+	"github.com/NethermindEth/juno/core/trie"
+	"github.com/NethermindEth/juno/core/trie2"
 )
 
 // Trie provides access to a Merkle-Patricia trie used to store and commit state data.
 type Trie interface {
 	// Get returns the value stored at key in the trie.
 	Get(key *felt.Felt) (felt.Felt, error)
+	// Update sets the value at key in the trie to value.
+	Update(key, value *felt.Felt) error
 	// Hash returns the root hash of the trie, committing all current entries.
 	Hash() (felt.Felt, error)
 	// HashFn returns the hash function used by the trie for node hashing.
 	HashFn() crypto.HashFn
+}
+
+type TrieBackend uint8
+
+const (
+	DeprecatedTrieBackend TrieBackend = iota
+	NewTrieBackend
+)
+
+type runOnTempTrieFn func(height uint8, do func(Trie) error) error
+
+func (e TrieBackend) Pedersen() runOnTempTrieFn {
+	switch e {
+	case NewTrieBackend:
+		return func(h uint8, do func(Trie) error) error {
+			return trie2.RunOnTempTriePedersen(h, func(t *trie2.Trie) error { return do(t) })
+		}
+	case DeprecatedTrieBackend:
+		return func(h uint8, do func(Trie) error) error {
+			return trie.RunOnTempTriePedersen(h, func(t *trie.Trie) error { return do(t) })
+		}
+	default:
+		panic("unsupported trie backend")
+	}
+}
+
+func (e TrieBackend) Poseidon() runOnTempTrieFn {
+	switch e {
+	case NewTrieBackend:
+		return func(h uint8, do func(Trie) error) error {
+			return trie2.RunOnTempTriePoseidon(h, func(t *trie2.Trie) error { return do(t) })
+		}
+	case DeprecatedTrieBackend:
+		return func(h uint8, do func(Trie) error) error {
+			return trie.RunOnTempTriePoseidon(h, func(t *trie.Trie) error { return do(t) })
+		}
+	default:
+		panic("unsupported trie backend")
+	}
 }

--- a/core/trie_interfaces.go
+++ b/core/trie_interfaces.go
@@ -12,7 +12,7 @@ import (
 type TrieReader interface {
 	// Get returns the value stored at key in the trie. Missing keys map to felt.Zero.
 	Get(key *felt.Felt) (felt.Felt, error)
-	// Hash returns the root hash of the trie, committing all current entries.
+	// Hash returns the root hash of the trie.
 	Hash() (felt.Felt, error)
 	// HashFn returns the hash function used by the trie for node hashing.
 	HashFn() crypto.HashFn
@@ -29,7 +29,7 @@ type onTempTrieFunc func(height uint8, do func(Trie) error) error
 
 // TrieBackend selects which trie implementation backs the temporary tries
 // used during commitment hashing.
-type TrieBackend struct {
+type TempTrieBackend struct {
 	// Pedersen runs do on Pedersen-hashed trie.
 	RunOnTempTriePedersen onTempTrieFunc
 	// Poseidon runs do on Poseidon-hashed trie.
@@ -37,7 +37,7 @@ type TrieBackend struct {
 }
 
 var (
-	DeprecatedTrieBackend = TrieBackend{
+	DeprecatedTrieBackend = TempTrieBackend{
 		RunOnTempTriePedersen: func(h uint8, do func(Trie) error) error {
 			return trie.RunOnTempTriePedersen(h, func(t *trie.Trie) error { return do(t) })
 		},
@@ -45,7 +45,7 @@ var (
 			return trie.RunOnTempTriePoseidon(h, func(t *trie.Trie) error { return do(t) })
 		},
 	}
-	NewTrieBackend = TrieBackend{
+	TrieBackend = TempTrieBackend{
 		RunOnTempTriePedersen: func(h uint8, do func(Trie) error) error {
 			return trie2.RunOnTempTriePedersen(h, func(t *trie2.Trie) error { return do(t) })
 		},

--- a/core/trie_interfaces.go
+++ b/core/trie_interfaces.go
@@ -7,53 +7,50 @@ import (
 	"github.com/NethermindEth/juno/core/trie2"
 )
 
-// Trie provides access to a Merkle-Patricia trie used to store and commit state data.
-type Trie interface {
-	// Get returns the value stored at key in the trie.
+// TrieReader provides read-only access to a trie. It is the
+// view returned from state readers for proof generation and storage lookups.
+type TrieReader interface {
+	// Get returns the value stored at key in the trie. Missing keys map to felt.Zero.
 	Get(key *felt.Felt) (felt.Felt, error)
-	// Update sets the value at key in the trie to value.
-	Update(key, value *felt.Felt) error
 	// Hash returns the root hash of the trie, committing all current entries.
 	Hash() (felt.Felt, error)
 	// HashFn returns the hash function used by the trie for node hashing.
 	HashFn() crypto.HashFn
 }
 
-type TrieBackend uint8
-
-const (
-	DeprecatedTrieBackend TrieBackend = iota
-	NewTrieBackend
-)
+// Trie is the mutable view of a trie.
+type Trie interface {
+	TrieReader
+	// Update sets the value at key in the trie. A zero value deletes the key.
+	Update(key, value *felt.Felt) error
+}
 
 type runOnTempTrieFn func(height uint8, do func(Trie) error) error
 
-func (e TrieBackend) Pedersen() runOnTempTrieFn {
-	switch e {
-	case NewTrieBackend:
-		return func(h uint8, do func(Trie) error) error {
-			return trie2.RunOnTempTriePedersen(h, func(t *trie2.Trie) error { return do(t) })
-		}
-	case DeprecatedTrieBackend:
-		return func(h uint8, do func(Trie) error) error {
-			return trie.RunOnTempTriePedersen(h, func(t *trie.Trie) error { return do(t) })
-		}
-	default:
-		panic("unsupported trie backend")
-	}
+// TrieBackend selects which trie implementation backs the temporary tries
+// used during commitment hashing.
+type TrieBackend struct {
+	// Pedersen runs do on Pedersen-hashed trie.
+	Pedersen runOnTempTrieFn
+	// Poseidon runs do on Poseidon-hashed trie.
+	Poseidon runOnTempTrieFn
 }
 
-func (e TrieBackend) Poseidon() runOnTempTrieFn {
-	switch e {
-	case NewTrieBackend:
-		return func(h uint8, do func(Trie) error) error {
-			return trie2.RunOnTempTriePoseidon(h, func(t *trie2.Trie) error { return do(t) })
-		}
-	case DeprecatedTrieBackend:
-		return func(h uint8, do func(Trie) error) error {
+var (
+	DeprecatedTrieBackend = TrieBackend{
+		Pedersen: func(h uint8, do func(Trie) error) error {
+			return trie.RunOnTempTriePedersen(h, func(t *trie.Trie) error { return do(t) })
+		},
+		Poseidon: func(h uint8, do func(Trie) error) error {
 			return trie.RunOnTempTriePoseidon(h, func(t *trie.Trie) error { return do(t) })
-		}
-	default:
-		panic("unsupported trie backend")
+		},
 	}
-}
+	NewTrieBackend = TrieBackend{
+		Pedersen: func(h uint8, do func(Trie) error) error {
+			return trie2.RunOnTempTriePedersen(h, func(t *trie2.Trie) error { return do(t) })
+		},
+		Poseidon: func(h uint8, do func(Trie) error) error {
+			return trie2.RunOnTempTriePoseidon(h, func(t *trie2.Trie) error { return do(t) })
+		},
+	}
+)

--- a/core/trie_interfaces.go
+++ b/core/trie_interfaces.go
@@ -31,25 +31,25 @@ type onTempTrieFunc func(height uint8, do func(Trie) error) error
 // used during commitment hashing.
 type TrieBackend struct {
 	// Pedersen runs do on Pedersen-hashed trie.
-	Pedersen onTempTrieFunc
+	RunOnTempTriePedersen onTempTrieFunc
 	// Poseidon runs do on Poseidon-hashed trie.
-	Poseidon onTempTrieFunc
+	RunOnTempTriePoseidon onTempTrieFunc
 }
 
 var (
 	DeprecatedTrieBackend = TrieBackend{
-		Pedersen: func(h uint8, do func(Trie) error) error {
+		RunOnTempTriePedersen: func(h uint8, do func(Trie) error) error {
 			return trie.RunOnTempTriePedersen(h, func(t *trie.Trie) error { return do(t) })
 		},
-		Poseidon: func(h uint8, do func(Trie) error) error {
+		RunOnTempTriePoseidon: func(h uint8, do func(Trie) error) error {
 			return trie.RunOnTempTriePoseidon(h, func(t *trie.Trie) error { return do(t) })
 		},
 	}
 	NewTrieBackend = TrieBackend{
-		Pedersen: func(h uint8, do func(Trie) error) error {
+		RunOnTempTriePedersen: func(h uint8, do func(Trie) error) error {
 			return trie2.RunOnTempTriePedersen(h, func(t *trie2.Trie) error { return do(t) })
 		},
-		Poseidon: func(h uint8, do func(Trie) error) error {
+		RunOnTempTriePoseidon: func(h uint8, do func(Trie) error) error {
 			return trie2.RunOnTempTriePoseidon(h, func(t *trie2.Trie) error { return do(t) })
 		},
 	}

--- a/core/trie_interfaces.go
+++ b/core/trie_interfaces.go
@@ -25,15 +25,15 @@ type Trie interface {
 	Update(key, value *felt.Felt) error
 }
 
-type runOnTempTrieFn func(height uint8, do func(Trie) error) error
+type onTempTrieFunc func(height uint8, do func(Trie) error) error
 
 // TrieBackend selects which trie implementation backs the temporary tries
 // used during commitment hashing.
 type TrieBackend struct {
 	// Pedersen runs do on Pedersen-hashed trie.
-	Pedersen runOnTempTrieFn
+	Pedersen onTempTrieFunc
 	// Poseidon runs do on Poseidon-hashed trie.
-	Poseidon runOnTempTrieFn
+	Poseidon onTempTrieFunc
 }
 
 var (

--- a/migration/deprecated/migration.go
+++ b/migration/deprecated/migration.go
@@ -563,6 +563,8 @@ func calculateBlockCommitments(txn db.IndexedBatch, network *networks.Network) e
 			return err
 		}
 		txnLock.Lock()
+		// Pinned to DeprecatedTrieBackend: this migration backfills commitments for
+		// blocks originally hashed under the legacy trie
 		commitments, err := core.VerifyBlockHash(block, network, nil, core.DeprecatedTrieBackend)
 		txnLock.Unlock()
 		if err != nil {

--- a/migration/deprecated/migration.go
+++ b/migration/deprecated/migration.go
@@ -563,7 +563,7 @@ func calculateBlockCommitments(txn db.IndexedBatch, network *networks.Network) e
 			return err
 		}
 		txnLock.Lock()
-		commitments, err := core.VerifyBlockHash(block, network, nil)
+		commitments, err := core.VerifyBlockHash(block, network, nil, core.DeprecatedTrieBackend)
 		txnLock.Unlock()
 		if err != nil {
 			return err

--- a/mocks/mock_blockchain.go
+++ b/mocks/mock_blockchain.go
@@ -13,7 +13,7 @@ import (
 	reflect "reflect"
 
 	blockchain "github.com/NethermindEth/juno/blockchain"
-	"github.com/NethermindEth/juno/blockchain/networks"
+	networks "github.com/NethermindEth/juno/blockchain/networks"
 	core "github.com/NethermindEth/juno/core"
 	felt "github.com/NethermindEth/juno/core/felt"
 	pending "github.com/NethermindEth/juno/core/pending"

--- a/mocks/mock_state.go
+++ b/mocks/mock_state.go
@@ -57,10 +57,10 @@ func (mr *MockStateMockRecorder) Class(classHash any) *gomock.Call {
 }
 
 // ClassTrie mocks base method.
-func (m *MockState) ClassTrie() (core.Trie, error) {
+func (m *MockState) ClassTrie() (core.TrieReader, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ClassTrie")
-	ret0, _ := ret[0].(core.Trie)
+	ret0, _ := ret[0].(core.TrieReader)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -177,10 +177,10 @@ func (mr *MockStateMockRecorder) ContractStorageLastUpdatedBlock(addr, key any) 
 }
 
 // ContractStorageTrie mocks base method.
-func (m *MockState) ContractStorageTrie(addr *felt.Felt) (core.Trie, error) {
+func (m *MockState) ContractStorageTrie(addr *felt.Felt) (core.TrieReader, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ContractStorageTrie", addr)
-	ret0, _ := ret[0].(core.Trie)
+	ret0, _ := ret[0].(core.TrieReader)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -192,10 +192,10 @@ func (mr *MockStateMockRecorder) ContractStorageTrie(addr any) *gomock.Call {
 }
 
 // ContractTrie mocks base method.
-func (m *MockState) ContractTrie() (core.Trie, error) {
+func (m *MockState) ContractTrie() (core.TrieReader, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ContractTrie")
-	ret0, _ := ret[0].(core.Trie)
+	ret0, _ := ret[0].(core.TrieReader)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }

--- a/mocks/mock_state_reader.go
+++ b/mocks/mock_state_reader.go
@@ -57,10 +57,10 @@ func (mr *MockStateReaderMockRecorder) Class(classHash any) *gomock.Call {
 }
 
 // ClassTrie mocks base method.
-func (m *MockStateReader) ClassTrie() (core.Trie, error) {
+func (m *MockStateReader) ClassTrie() (core.TrieReader, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ClassTrie")
-	ret0, _ := ret[0].(core.Trie)
+	ret0, _ := ret[0].(core.TrieReader)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -162,10 +162,10 @@ func (mr *MockStateReaderMockRecorder) ContractStorageLastUpdatedBlock(addr, key
 }
 
 // ContractStorageTrie mocks base method.
-func (m *MockStateReader) ContractStorageTrie(addr *felt.Felt) (core.Trie, error) {
+func (m *MockStateReader) ContractStorageTrie(addr *felt.Felt) (core.TrieReader, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ContractStorageTrie", addr)
-	ret0, _ := ret[0].(core.Trie)
+	ret0, _ := ret[0].(core.TrieReader)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -177,10 +177,10 @@ func (mr *MockStateReaderMockRecorder) ContractStorageTrie(addr any) *gomock.Cal
 }
 
 // ContractTrie mocks base method.
-func (m *MockStateReader) ContractTrie() (core.Trie, error) {
+func (m *MockStateReader) ContractTrie() (core.TrieReader, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ContractTrie")
-	ret0, _ := ret[0].(core.Trie)
+	ret0, _ := ret[0].(core.TrieReader)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }

--- a/node/node.go
+++ b/node/node.go
@@ -225,7 +225,7 @@ func New(cfg *Config, version string, logLevel *log.Level) (*Node, error) {
 		}
 
 		// We assume that there is at least one transaction in the block or that it is a pre-0.7 block.
-		if _, err = core.VerifyBlockHash(head, &cfg.Network, stateUpdate.StateDiff); err != nil {
+		if _, err = core.VerifyBlockHash(head, &cfg.Network, stateUpdate.StateDiff, core.DeprecatedTrieBackend); err != nil {
 			return nil, errors.New("unable to verify latest block hash; are the database and --network option compatible?")
 		}
 	}

--- a/node/node.go
+++ b/node/node.go
@@ -229,7 +229,12 @@ func New(cfg *Config, version string, logLevel *log.Level) (*Node, error) {
 		if cfg.NewState {
 			trieBackend = core.NewTrieBackend
 		}
-		if _, err = core.VerifyBlockHash(head, &cfg.Network, stateUpdate.StateDiff, trieBackend); err != nil {
+		if _, err = core.VerifyBlockHash(
+			head,
+			&cfg.Network,
+			stateUpdate.StateDiff,
+			trieBackend,
+		); err != nil {
 			return nil, errors.New("unable to verify latest block hash; are the database and --network option compatible?")
 		}
 	}

--- a/node/node.go
+++ b/node/node.go
@@ -227,7 +227,7 @@ func New(cfg *Config, version string, logLevel *log.Level) (*Node, error) {
 		// We assume that there is at least one transaction in the block or that it is a pre-0.7 block.
 		trieBackend := core.DeprecatedTrieBackend
 		if cfg.NewState {
-			trieBackend = core.NewTrieBackend
+			trieBackend = core.TrieBackend
 		}
 		if _, err = core.VerifyBlockHash(
 			head,

--- a/node/node.go
+++ b/node/node.go
@@ -225,7 +225,11 @@ func New(cfg *Config, version string, logLevel *log.Level) (*Node, error) {
 		}
 
 		// We assume that there is at least one transaction in the block or that it is a pre-0.7 block.
-		if _, err = core.VerifyBlockHash(head, &cfg.Network, stateUpdate.StateDiff, core.DeprecatedTrieBackend); err != nil {
+		trieBackend := core.DeprecatedTrieBackend
+		if cfg.NewState {
+			trieBackend = core.NewTrieBackend
+		}
+		if _, err = core.VerifyBlockHash(head, &cfg.Network, stateUpdate.StateDiff, trieBackend); err != nil {
 			return nil, errors.New("unable to verify latest block hash; are the database and --network option compatible?")
 		}
 	}

--- a/p2p/server/server.go
+++ b/p2p/server/server.go
@@ -240,6 +240,7 @@ func (h *Server) onHeadersRequest(
 			if err != nil {
 				return nil, err
 			}
+			// TODO: switch to core.NewTrieBackend once the legacy trie and state are removed.
 			_, commitments, err = core.Post0132Hash(block, stateUpdate.StateDiff, core.DeprecatedTrieBackend)
 			if err != nil {
 				return nil, err

--- a/p2p/server/server.go
+++ b/p2p/server/server.go
@@ -240,7 +240,7 @@ func (h *Server) onHeadersRequest(
 			if err != nil {
 				return nil, err
 			}
-			_, commitments, err = core.Post0132Hash(block, stateUpdate.StateDiff)
+			_, commitments, err = core.Post0132Hash(block, stateUpdate.StateDiff, core.DeprecatedTrieBackend)
 			if err != nil {
 				return nil, err
 			}

--- a/p2p/sync/sync.go
+++ b/p2p/sync/sync.go
@@ -443,7 +443,7 @@ func (s *BlockFetcher) adaptAndSanityCheckBlock(
 
 			if blockVer.LessThan(core.Ver0_13_2) && s.network.L2ChainID == "SN_SEPOLIA" {
 				expectedHash := hashstorage.SepoliaBlockHashesMap[coreBlock.Number]
-				post0132Hash, _, err := core.Post0132Hash(coreBlock, stateDiff)
+				post0132Hash, _, err := core.Post0132Hash(coreBlock, stateDiff, core.DeprecatedTrieBackend)
 				if err != nil {
 					bodyCh <- BlockBody{Err: fmt.Errorf("failed to compute p2p hash: %w", err)}
 					return

--- a/p2p/sync/sync.go
+++ b/p2p/sync/sync.go
@@ -443,6 +443,7 @@ func (s *BlockFetcher) adaptAndSanityCheckBlock(
 
 			if blockVer.LessThan(core.Ver0_13_2) && s.network.L2ChainID == "SN_SEPOLIA" {
 				expectedHash := hashstorage.SepoliaBlockHashesMap[coreBlock.Number]
+				// TODO: switch to core.NewTrieBackend once the legacy trie and state are removed.
 				post0132Hash, _, err := core.Post0132Hash(coreBlock, stateDiff, core.DeprecatedTrieBackend)
 				if err != nil {
 					bodyCh <- BlockBody{Err: fmt.Errorf("failed to compute p2p hash: %w", err)}

--- a/rpc/v10/storage.go
+++ b/rpc/v10/storage.go
@@ -304,7 +304,7 @@ func (h *Handler) isBlockSupported(blockID *BlockID, chainHeight uint64) *jsonrp
 	return nil
 }
 
-func getClassProof(tr core.Trie, classes []felt.Felt) ([]*HashToNode, error) {
+func getClassProof(tr core.TrieReader, classes []felt.Felt) ([]*HashToNode, error) {
 	switch t := tr.(type) {
 	case *trie.Trie:
 		classProof := trie.NewProofNodeSet()
@@ -328,7 +328,7 @@ func getClassProof(tr core.Trie, classes []felt.Felt) ([]*HashToNode, error) {
 }
 
 func getContractProof(
-	tr core.Trie,
+	tr core.TrieReader,
 	state core.StateReader,
 	contracts []felt.Felt,
 ) (*ContractProof, error) {

--- a/rpc/v10/storage_test.go
+++ b/rpc/v10/storage_test.go
@@ -569,7 +569,7 @@ func TestStorageProof(t *testing.T) {
 		blockNumber = uint64(1313)
 	)
 
-	var classTrie, contractTrie core.Trie
+	var classTrie, contractTrie core.TrieReader
 	var trieRoot felt.Felt
 
 	if !statetestutils.UseNewState() {
@@ -1581,7 +1581,7 @@ func emptyDeprecatedTrie(t *testing.T) *trie.Trie {
 	return tempTrie
 }
 
-func emptyTrie(t *testing.T) core.Trie {
+func emptyTrie(t *testing.T) core.TrieReader {
 	if statetestutils.UseNewState() {
 		tempTrie, err := trie2.NewEmptyPedersen()
 		require.NoError(t, err)

--- a/rpc/v8/storage.go
+++ b/rpc/v8/storage.go
@@ -209,7 +209,7 @@ func (h *Handler) isBlockSupported(blockID *BlockID, chainHeight uint64) *jsonrp
 	return nil
 }
 
-func getClassProof(tr core.Trie, classes []felt.Felt) ([]*HashToNode, error) {
+func getClassProof(tr core.TrieReader, classes []felt.Felt) ([]*HashToNode, error) {
 	switch t := tr.(type) {
 	case *trie.Trie:
 		classProof := trie.NewProofNodeSet()
@@ -233,7 +233,7 @@ func getClassProof(tr core.Trie, classes []felt.Felt) ([]*HashToNode, error) {
 }
 
 func getContractProof(
-	tr core.Trie,
+	tr core.TrieReader,
 	state core.StateReader,
 	contracts []felt.Felt,
 ) (*ContractProof, error) {

--- a/rpc/v8/storage_test.go
+++ b/rpc/v8/storage_test.go
@@ -217,7 +217,7 @@ func TestStorageProof(t *testing.T) {
 		blockNumber = uint64(1313)
 	)
 
-	var classTrie, contractTrie core.Trie
+	var classTrie, contractTrie core.TrieReader
 	trieRoot := felt.Zero
 
 	if !statetestutils.UseNewState() {
@@ -993,7 +993,7 @@ func emptyDeprecatedTrie(t *testing.T) *trie.Trie {
 	return tempTrie
 }
 
-func emptyTrie(t *testing.T) core.Trie {
+func emptyTrie(t *testing.T) core.TrieReader {
 	if statetestutils.UseNewState() {
 		tempTrie, err := trie2.NewEmptyPedersen()
 		require.NoError(t, err)

--- a/rpc/v9/storage.go
+++ b/rpc/v9/storage.go
@@ -210,7 +210,7 @@ func (h *Handler) isBlockSupported(blockID *BlockID, chainHeight uint64) *jsonrp
 	return nil
 }
 
-func getClassProof(tr core.Trie, classes []felt.Felt) ([]*HashToNode, error) {
+func getClassProof(tr core.TrieReader, classes []felt.Felt) ([]*HashToNode, error) {
 	switch t := tr.(type) {
 	case *trie.Trie:
 		classProof := trie.NewProofNodeSet()
@@ -234,7 +234,7 @@ func getClassProof(tr core.Trie, classes []felt.Felt) ([]*HashToNode, error) {
 }
 
 func getContractProof(
-	tr core.Trie,
+	tr core.TrieReader,
 	state core.StateReader,
 	contracts []felt.Felt,
 ) (*ContractProof, error) {

--- a/rpc/v9/storage_test.go
+++ b/rpc/v9/storage_test.go
@@ -243,7 +243,7 @@ func TestStorageProof(t *testing.T) {
 		blockNumber = uint64(1313)
 	)
 
-	var classTrie, contractTrie core.Trie
+	var classTrie, contractTrie core.TrieReader
 	trieRoot := felt.Zero
 
 	if !statetestutils.UseNewState() {
@@ -1028,7 +1028,7 @@ func emptyDeprecatedTrie(t *testing.T) *trie.Trie {
 	return tempTrie
 }
 
-func emptyTrie(t *testing.T) core.Trie {
+func emptyTrie(t *testing.T) core.TrieReader {
 	if statetestutils.UseNewState() {
 		tempTrie, err := trie2.NewEmptyPedersen()
 		require.NoError(t, err)


### PR DESCRIPTION
Both tries calculate the exact same hash. This PR ties the hash calculation engine on receipts, txs and blocks to the used state version - if Juno runs using legacy state, legacy trie is used for hash calculation. If Juno runs using new state, the new `trie2` implementation is used.