### PR TITLE
[Onboarding] Onboarding exercises

### DIFF
--- a/rpc/handlers.go
+++ b/rpc/handlers.go
@@ -346,6 +346,14 @@ func (h *Handler) MethodsV0_10() ([]jsonrpc.Method, string) {
 			Handler: h.rpcv10Handler.BlockWithReceipts,
 		},
 		{
+			Name: "juno_getBlockWithTxnHashesAndReceipts",
+			Params: []jsonrpc.Parameter{
+				{Name: "block_id"},
+				{Name: "response_flags", Optional: true},
+			},
+			Handler: h.rpcv10Handler.BlockWithTxnHashesAndReceipts,
+		},
+		{
 			Name:    "starknet_getCompiledCasm",
 			Params:  []jsonrpc.Parameter{{Name: "class_hash"}},
 			Handler: h.rpcv10Handler.CompiledCasm,

--- a/rpc/handlers.go
+++ b/rpc/handlers.go
@@ -373,6 +373,13 @@ func (h *Handler) MethodsV0_10() ([]jsonrpc.Method, string) {
 			},
 			Handler: h.rpcv10Handler.StorageProof,
 		},
+		{
+			Name: "juno_getNodesFromRoot",
+			Params: []jsonrpc.Parameter{
+				{Name: "key"},
+			},
+			Handler: h.rpcv10Handler.NodesFromRoot,
+		},
 	}, "/v0_10"
 }
 

--- a/rpc/v10/block.go
+++ b/rpc/v10/block.go
@@ -84,6 +84,20 @@ type BlockWithReceipts struct {
 	Transactions []TransactionWithReceipt `json:"transactions"`
 }
 
+// TransactionWithHashAndReceipt represents a transaction with its receipt and hash
+type TransactionWithHashAndReceipt struct {
+	Transaction *Transaction        `json:"transaction"`
+	Hash        *felt.Felt          `json:"hash"` // I kwnow Transaction already holds the Hash internally, but this is part of the onboarding
+	Receipt     *TransactionReceipt `json:"receipt"`
+}
+
+// Not on the spec
+type BlockWithTxnHashesAndReceipts struct {
+	Status BlockStatus `json:"status,omitempty"`
+	BlockHeader
+	Transactions []TransactionWithHashAndReceipt `json:"txn_and_receipts"`
+}
+
 // https://github.com/starkware-libs/starknet-specs/blob/release/v0.10.2/api/starknet_api_openrpc.json#L830-L848
 type BlockHashAndNumber struct {
 	Hash   *felt.Felt `json:"block_hash"`
@@ -239,6 +253,38 @@ func (h *Handler) BlockWithReceipts(
 		Status:       blockStatus,
 		BlockHeader:  AdaptBlockHeader(block.Header, commitments, stateDiff),
 		Transactions: txsWithReceipts,
+	}, nil
+}
+
+// BlockWithTxnHashesAndReceipts returns the block information with transaction receipts and hashes given a block ID.
+//
+// It does not follow any specification 🔥
+func (h *Handler) BlockWithTxnHashesAndReceipts(
+	id *BlockID,
+	responseFlags ResponseFlags,
+) (*BlockWithTxnHashesAndReceipts, *jsonrpc.Error) {
+	// I was faced with two options, copying the body of BlockWithReceipts, or calling it
+	// I decided to call it.
+
+	blockWithReceipts, err := h.BlockWithReceipts(id, responseFlags)
+	if err != nil {
+		return nil, err
+	}
+
+	// Adds an Extra O(n) loop, but it adds less maintenance
+	txsWithHashAndReceipts := make([]TransactionWithHashAndReceipt, len(blockWithReceipts.Transactions))
+	for idx, txn := range blockWithReceipts.Transactions {
+		txsWithHashAndReceipts[idx] = TransactionWithHashAndReceipt{
+			Transaction: txn.Transaction,
+			Hash:        txn.Receipt.Hash,
+			Receipt:     txn.Receipt,
+		}
+	}
+
+	return &BlockWithTxnHashesAndReceipts{
+		Status:       blockWithReceipts.Status,
+		BlockHeader:  blockWithReceipts.BlockHeader,
+		Transactions: txsWithHashAndReceipts,
 	}, nil
 }
 

--- a/rpc/v10/block.go
+++ b/rpc/v10/block.go
@@ -84,10 +84,11 @@ type BlockWithReceipts struct {
 	Transactions []TransactionWithReceipt `json:"transactions"`
 }
 
-// TransactionWithHashAndReceipt represents a transaction with its receipt and hash
+// TransactionWithHashAndReceipt represents a transaction with its receipt and hash.
+// Hash is duplicated on purpose for onboarding, even though Transaction already holds it.
 type TransactionWithHashAndReceipt struct {
 	Transaction *Transaction        `json:"transaction"`
-	Hash        *felt.Felt          `json:"hash"` // I kwnow Transaction already holds the Hash internally, but this is part of the onboarding
+	Hash        *felt.Felt          `json:"hash"`
 	Receipt     *TransactionReceipt `json:"receipt"`
 }
 
@@ -256,9 +257,10 @@ func (h *Handler) BlockWithReceipts(
 	}, nil
 }
 
-// BlockWithTxnHashesAndReceipts returns the block information with transaction receipts and hashes given a block ID.
+// BlockWithTxnHashesAndReceipts returns the block information with transaction
+// receipts, and hashes given a block ID.
 //
-// It does not follow any specification 🔥
+// It does not follow any specification.
 func (h *Handler) BlockWithTxnHashesAndReceipts(
 	id *BlockID,
 	responseFlags ResponseFlags,
@@ -272,7 +274,10 @@ func (h *Handler) BlockWithTxnHashesAndReceipts(
 	}
 
 	// Adds an Extra O(n) loop, but it adds less maintenance
-	txsWithHashAndReceipts := make([]TransactionWithHashAndReceipt, len(blockWithReceipts.Transactions))
+	txsWithHashAndReceipts := make(
+		[]TransactionWithHashAndReceipt,
+		len(blockWithReceipts.Transactions),
+	)
 	for idx, txn := range blockWithReceipts.Transactions {
 		txsWithHashAndReceipts[idx] = TransactionWithHashAndReceipt{
 			Transaction: txn.Transaction,

--- a/rpc/v10/block_test.go
+++ b/rpc/v10/block_test.go
@@ -1360,3 +1360,161 @@ func TestBlockWithReceiptsWithResponseFlags(t *testing.T) {
 		})
 	})
 }
+
+func TestBlockWithTxnHashesAndReceipts_ErrorCases(t *testing.T) {
+	errTests := map[string]rpc.BlockID{
+		"latest":        rpc.BlockIDLatest(),
+		"pre_confirmed": rpc.BlockIDPreConfirmed(),
+		"hash":          rpc.BlockIDFromHash(&felt.One),
+		"number":        rpc.BlockIDFromNumber(2),
+	}
+
+	for description, id := range errTests {
+		t.Run(description, func(t *testing.T) {
+			mockCtrl := gomock.NewController(t)
+			t.Cleanup(mockCtrl.Finish)
+
+			logger := log.NewNopZapLogger()
+			n := &networks.Mainnet
+			chain := blockchain.New(
+				memory.New(),
+				n,
+				blockchain.WithNewState(statetestutils.UseNewState()),
+			)
+			mockSyncReader := mocks.NewMockSyncReader(mockCtrl)
+			handler := rpc.New(chain, mockSyncReader, nil, logger)
+
+			if description == "pre_confirmed" {
+				mockSyncReader.EXPECT().PreConfirmed().Return(nil, db.ErrKeyNotFound)
+			}
+
+			block, rpcErr := handler.BlockWithTxnHashesAndReceipts(&id, rpc.ResponseFlags{})
+			assert.Nil(t, block)
+			assert.Equal(t, rpccore.ErrBlockNotFound, rpcErr)
+		})
+	}
+
+	//nolint:dupl // Similar l1head failure test structure across all error test functions
+	t.Run("l1head failure", func(t *testing.T) {
+		mockCtrl := gomock.NewController(t)
+		t.Cleanup(mockCtrl.Finish)
+
+		mockReader := mocks.NewMockReader(mockCtrl)
+		handler := rpc.New(mockReader, nil, nil, nil)
+
+		blockID := rpc.BlockIDFromNumber(777)
+		block := &core.Block{
+			Header: &core.Header{},
+		}
+
+		err := errors.New("l1 failure")
+		mockReader.EXPECT().BlockByNumber(blockID.Number()).Return(block, nil)
+		mockReader.EXPECT().L1Head().Return(core.L1Head{}, err)
+
+		resp, rpcErr := handler.BlockWithTxnHashesAndReceipts(&blockID, rpc.ResponseFlags{})
+		assert.Nil(t, resp)
+		assert.Equal(t, rpccore.ErrInternal.CloneWithData(err.Error()), rpcErr)
+	})
+}
+
+func assertBlockWithTxnHashesAndReceipts(
+	t *testing.T,
+	expectedBlock *core.Block,
+	expectedStatus rpc.BlockStatus,
+	expectedCommitments *core.BlockCommitments,
+	expectedStateUpdate *core.StateUpdate,
+	actual *rpc.BlockWithTxnHashesAndReceipts,
+	responseFlags rpc.ResponseFlags,
+) {
+	t.Helper()
+	assert.Equal(t, expectedStatus, actual.Status)
+	if expectedStatus == rpc.BlockPreConfirmed {
+		assertPreConfirmedBlockHeader(t, expectedBlock, &actual.BlockHeader)
+	} else {
+		assertCommittedBlockHeader(
+			t,
+			expectedBlock,
+			expectedCommitments,
+			expectedStateUpdate.StateDiff.Length(),
+			&actual.BlockHeader,
+		)
+	}
+
+	expectedFinalityStatus := blockStatusToTxnFinalityStatus(expectedStatus)
+	require.Equal(t, len(expectedBlock.Receipts), len(actual.Transactions))
+	for i, expectedReceipt := range expectedBlock.Receipts {
+		require.Equal(t, expectedReceipt.TransactionHash, actual.Transactions[i].Hash)
+		require.Equal(t, expectedReceipt.TransactionHash, actual.Transactions[i].Receipt.Hash)
+
+		adaptedTransaction := rpc.AdaptTransaction(
+			expectedBlock.Transactions[i],
+			responseFlags.IncludeProofFacts,
+		)
+		adaptedTransaction.Hash = nil
+		adaptedReceipt := rpc.AdaptReceipt(
+			expectedReceipt,
+			expectedBlock.Transactions[i],
+			expectedFinalityStatus,
+		)
+
+		require.Equal(t, adaptedTransaction, *actual.Transactions[i].Transaction)
+		require.Equal(t, adaptedReceipt, actual.Transactions[i].Receipt)
+	}
+}
+
+func TestBlockWithTxnHashesAndReceipts(t *testing.T) {
+	network := &networks.Mainnet
+	client := feeder.NewTestClient(t, network)
+
+	block, commitments, stateUpdate := rpc.GetTestBlockWithCommitments(t, client, 16697)
+
+	testCases := createBlockTestCases(block, commitments, stateUpdate)
+
+	clientSepolia := feeder.NewTestClient(t, &networks.Sepolia)
+	blockWithProofFacts, commitmentsPF, stateUpdatePF := rpc.GetTestBlockWithCommitments(
+		t,
+		clientSepolia,
+		4072139,
+	)
+	testCases = append(
+		testCases,
+		createBlockResponseFlagsTestCases(
+			blockWithProofFacts,
+			commitmentsPF,
+			stateUpdatePF,
+		)...,
+	)
+
+	for _, tc := range testCases {
+		t.Run(tc.description, func(t *testing.T) {
+			mockCtrl := gomock.NewController(t)
+			t.Cleanup(mockCtrl.Finish)
+			mockReader := mocks.NewMockReader(mockCtrl)
+			mockSyncReader := mocks.NewMockSyncReader(mockCtrl)
+			handler := rpc.New(mockReader, mockSyncReader, nil, nil)
+
+			setupMockBlockTest(
+				t,
+				mockReader,
+				mockSyncReader,
+				tc.block,
+				tc.commitments,
+				tc.stateUpdate,
+				tc.blockID,
+				tc.l1Head,
+			)
+
+			result, rpcErr := handler.BlockWithTxnHashesAndReceipts(tc.blockID, tc.responseFlags)
+			require.Nil(t, rpcErr)
+			assertBlockWithTxnHashesAndReceipts(
+				t,
+				tc.block,
+				tc.blockStatus,
+				tc.commitments,
+				tc.stateUpdate,
+				result,
+				tc.responseFlags,
+			)
+		})
+	}
+}

--- a/rpc/v10/block_test.go
+++ b/rpc/v10/block_test.go
@@ -802,6 +802,7 @@ func TestBlockWithTxs_ErrorCases(t *testing.T) {
 	})
 }
 
+//nolint:dupl // Shares similar structure with other tests but tests different method
 func TestBlockWithTxs(t *testing.T) {
 	network := &networks.Mainnet
 	client := feeder.NewTestClient(t, network)
@@ -952,6 +953,7 @@ func TestBlockWithReceipts_ErrorCases(t *testing.T) {
 	})
 }
 
+//nolint:dupl // Shares similar structure with other tests but tests different method
 func TestBlockWithReceipts(t *testing.T) {
 	network := &networks.Mainnet
 	client := feeder.NewTestClient(t, network)
@@ -1361,6 +1363,7 @@ func TestBlockWithReceiptsWithResponseFlags(t *testing.T) {
 	})
 }
 
+//nolint:dupl // Shares similar structure with other tests but tests different method
 func TestBlockWithTxnHashesAndReceipts_ErrorCases(t *testing.T) {
 	errTests := map[string]rpc.BlockID{
 		"latest":        rpc.BlockIDLatest(),
@@ -1462,6 +1465,7 @@ func assertBlockWithTxnHashesAndReceipts(
 	}
 }
 
+//nolint:dupl // Shares similar structure with other tests but tests different method
 func TestBlockWithTxnHashesAndReceipts(t *testing.T) {
 	network := &networks.Mainnet
 	client := feeder.NewTestClient(t, network)

--- a/rpc/v10/storage.go
+++ b/rpc/v10/storage.go
@@ -56,6 +56,11 @@ type StorageAtResponse struct {
 	LastUpdateBlock uint64    `json:"last_update_block"`
 }
 
+// Not on the spec
+type NodesFromRoot struct {
+	Nodes []*HashToNode `json:"nodes"`
+}
+
 // MarshalJSON implements the [json.Marshaler] interface for StorageAtResponse.
 func (st *StorageAtResponse) MarshalJSON() ([]byte, error) {
 	if st.includeLastUpdateBlock {
@@ -236,6 +241,48 @@ func (h *Handler) StorageProof(
 			BlockHash:         header.Hash,
 		},
 	}, nil
+}
+
+// NodesFromRootreturns the set of nodes from the root to the key for the classes Trie.
+//
+// It does not follow any specification.
+func (h *Handler) NodesFromRoot(classHash *felt.Felt) (*NodesFromRoot, *jsonrpc.Error) {
+	state, closer, err := h.bcReader.HeadState()
+	if err != nil {
+		return nil, rpccore.ErrInternal.CloneWithData(err)
+	}
+	defer h.callAndLogErr(closer, "Error closing state reader in NodesFromRoot")
+
+	classTrie, err := state.ClassTrie()
+	if err != nil {
+		return nil, rpccore.ErrInternal.CloneWithData(err)
+	}
+
+	nodes, err := getClassNodesFromRoot(classTrie, classHash)
+	if err != nil {
+		return nil, rpccore.ErrInternal.CloneWithData(err)
+	}
+
+	return &NodesFromRoot{Nodes: nodes}, nil
+}
+
+func getClassNodesFromRoot(tr core.Trie, classHash *felt.Felt) ([]*HashToNode, error) {
+	switch t := tr.(type) {
+	case *trie.Trie:
+		proof := trie.NewProofNodeSet()
+		if err := t.Prove(classHash, proof); err != nil {
+			return nil, err
+		}
+		return adaptDeprecatedTrieProofNodes(proof), nil
+	case *trie2.Trie:
+		proof := trie2.NewProofNodeSet()
+		if err := t.Prove(classHash, proof); err != nil {
+			return nil, err
+		}
+		return adaptTrieProofNodes(proof)
+	default:
+		return nil, fmt.Errorf("unknown trie type: %T", tr)
+	}
 }
 
 // Ensures each contract is unique and each storage key in each contract is unique

--- a/rpc/v10/storage.go
+++ b/rpc/v10/storage.go
@@ -266,7 +266,7 @@ func (h *Handler) NodesFromRoot(classHash *felt.Felt) (*NodesFromRoot, *jsonrpc.
 	return &NodesFromRoot{Nodes: nodes}, nil
 }
 
-func getClassNodesFromRoot(tr core.Trie, classHash *felt.Felt) ([]*HashToNode, error) {
+func getClassNodesFromRoot(tr core.TrieReader, classHash *felt.Felt) ([]*HashToNode, error) {
 	switch t := tr.(type) {
 	case *trie.Trie:
 		proof := trie.NewProofNodeSet()

--- a/rpc/v10/storage_test.go
+++ b/rpc/v10/storage_test.go
@@ -960,6 +960,74 @@ func TestStorageProof(t *testing.T) {
 	})
 }
 
+func TestNodesFromRoot(t *testing.T) {
+	mockCtrl := gomock.NewController(t)
+	t.Cleanup(mockCtrl.Finish)
+
+	key := felt.NewFromUint64[felt.Felt](1)
+	key2 := felt.NewFromUint64[felt.Felt](8)
+	value := felt.NewFromUint64[felt.Felt](51)
+	value2 := felt.NewFromUint64[felt.Felt](58)
+
+	var classTrie core.Trie
+	if !statetestutils.UseNewState() {
+		tempTrie := emptyDeprecatedTrie(t)
+		_, _ = tempTrie.Put(key, value)
+		_, _ = tempTrie.Put(key2, value2)
+		_ = tempTrie.Commit()
+		classTrie = tempTrie
+	} else {
+		newComm := felt.FromUint64[felt.StateRootHash](1)
+		trieDB := trie2.NewTestNodeDatabase(memory.New(), trie2.PathScheme)
+		tr, err := trie2.New(
+			trieutils.NewClassTrieID(felt.FromUint64[felt.StateRootHash](0)),
+			251,
+			crypto.Pedersen,
+			&trieDB,
+		)
+		require.NoError(t, err)
+		_ = tr.Update(key, value)
+		_ = tr.Update(key2, value2)
+		_, nodes := tr.Commit()
+		err = trieDB.Update((*felt.Felt)(&newComm), &felt.Zero, trienode.NewMergeNodeSet(nodes))
+		require.NoError(t, err)
+
+		classTrie, err = trie2.New(
+			trieutils.NewClassTrieID(newComm),
+			251,
+			crypto.Pedersen,
+			&trieDB,
+		)
+		require.NoError(t, err)
+	}
+
+	mockReader := mocks.NewMockReader(mockCtrl)
+	mockState := mocks.NewMockStateReader(mockCtrl)
+	mockReader.EXPECT().HeadState().Return(mockState, func() error { return nil }, nil).AnyTimes()
+	mockState.EXPECT().ClassTrie().Return(classTrie, nil).AnyTimes()
+
+	logger := log.NewNopZapLogger()
+	handler := rpc.New(mockReader, nil, nil, logger)
+
+	t.Run("returns nodes for existing key", func(t *testing.T) {
+		result, rpcErr := handler.NodesFromRoot(key)
+		require.Nil(t, rpcErr)
+		require.NotNil(t, result)
+		require.NotEmpty(t, result.Nodes)
+		for _, n := range result.Nodes {
+			require.NotNil(t, n.Hash)
+			require.NotNil(t, n.Node)
+		}
+	})
+
+	t.Run("returns nodes for non-existing key", func(t *testing.T) {
+		nonExisting := felt.NewFromUint64[felt.Felt](999)
+		result, rpcErr := handler.NodesFromRoot(nonExisting)
+		require.Nil(t, rpcErr)
+		require.NotNil(t, result)
+	})
+}
+
 func TestStorageProof_VerifyPathfinderResponse(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
Adding 3 new features:

- [X] `BlockWithTxnHashesAndReceipts` endpoint + tests  
Returns Txs, hashes and receipts.

- [x] `NodesFromRoot` endpoint + tests  
Returns trie nodes from root to key (classes trie).

- [ ] New sync package (feeder-gateway) – TBD