### PR TITLE
[Onboarding] `BlockWithTxnHashesAndReceipts` endpoint

### DIFF
--- a/rpc/handlers.go
+++ b/rpc/handlers.go
@@ -346,6 +346,14 @@ func (h *Handler) MethodsV0_10() ([]jsonrpc.Method, string) {
 			Handler: h.rpcv10Handler.BlockWithReceipts,
 		},
 		{
+			Name: "juno_getBlockWithTxnHashesAndReceipts",
+			Params: []jsonrpc.Parameter{
+				{Name: "block_id"},
+				{Name: "response_flags", Optional: true},
+			},
+			Handler: h.rpcv10Handler.BlockWithTxnHashesAndReceipts,
+		},
+		{
 			Name:    "starknet_getCompiledCasm",
 			Params:  []jsonrpc.Parameter{{Name: "class_hash"}},
 			Handler: h.rpcv10Handler.CompiledCasm,

--- a/rpc/v10/block.go
+++ b/rpc/v10/block.go
@@ -84,6 +84,21 @@ type BlockWithReceipts struct {
 	Transactions []TransactionWithReceipt `json:"transactions"`
 }
 
+// TransactionWithHashAndReceipt represents a transaction with its receipt and hash.
+// Hash is duplicated on purpose for onboarding, even though Transaction already holds it.
+type TransactionWithHashAndReceipt struct {
+	Transaction *Transaction        `json:"transaction"`
+	Hash        *felt.Felt          `json:"hash"`
+	Receipt     *TransactionReceipt `json:"receipt"`
+}
+
+// Not on the spec
+type BlockWithTxnHashesAndReceipts struct {
+	Status BlockStatus `json:"status,omitempty"`
+	BlockHeader
+	Transactions []TransactionWithHashAndReceipt `json:"txn_and_receipts"`
+}
+
 // https://github.com/starkware-libs/starknet-specs/blob/release/v0.10.2/api/starknet_api_openrpc.json#L830-L848
 type BlockHashAndNumber struct {
 	Hash   *felt.Felt `json:"block_hash"`
@@ -239,6 +254,42 @@ func (h *Handler) BlockWithReceipts(
 		Status:       blockStatus,
 		BlockHeader:  AdaptBlockHeader(block.Header, commitments, stateDiff),
 		Transactions: txsWithReceipts,
+	}, nil
+}
+
+// BlockWithTxnHashesAndReceipts returns the block information with transaction
+// receipts, and hashes given a block ID.
+//
+// It does not follow any specification.
+func (h *Handler) BlockWithTxnHashesAndReceipts(
+	id *BlockID,
+	responseFlags ResponseFlags,
+) (*BlockWithTxnHashesAndReceipts, *jsonrpc.Error) {
+	// I was faced with two options, copying the body of BlockWithReceipts, or calling it
+	// I decided to call it.
+
+	blockWithReceipts, err := h.BlockWithReceipts(id, responseFlags)
+	if err != nil {
+		return nil, err
+	}
+
+	// Adds an Extra O(n) loop, but it adds less maintenance
+	txsWithHashAndReceipts := make(
+		[]TransactionWithHashAndReceipt,
+		len(blockWithReceipts.Transactions),
+	)
+	for idx, txn := range blockWithReceipts.Transactions {
+		txsWithHashAndReceipts[idx] = TransactionWithHashAndReceipt{
+			Transaction: txn.Transaction,
+			Hash:        txn.Receipt.Hash,
+			Receipt:     txn.Receipt,
+		}
+	}
+
+	return &BlockWithTxnHashesAndReceipts{
+		Status:       blockWithReceipts.Status,
+		BlockHeader:  blockWithReceipts.BlockHeader,
+		Transactions: txsWithHashAndReceipts,
 	}, nil
 }
 

--- a/rpc/v10/block_test.go
+++ b/rpc/v10/block_test.go
@@ -802,6 +802,7 @@ func TestBlockWithTxs_ErrorCases(t *testing.T) {
 	})
 }
 
+//nolint:dupl // Shares similar structure with other tests but tests different method
 func TestBlockWithTxs(t *testing.T) {
 	network := &networks.Mainnet
 	client := feeder.NewTestClient(t, network)
@@ -952,6 +953,7 @@ func TestBlockWithReceipts_ErrorCases(t *testing.T) {
 	})
 }
 
+//nolint:dupl // Shares similar structure with other tests but tests different method
 func TestBlockWithReceipts(t *testing.T) {
 	network := &networks.Mainnet
 	client := feeder.NewTestClient(t, network)
@@ -1359,4 +1361,164 @@ func TestBlockWithReceiptsWithResponseFlags(t *testing.T) {
 			}
 		})
 	})
+}
+
+//nolint:dupl // Shares similar structure with other tests but tests different method
+func TestBlockWithTxnHashesAndReceipts_ErrorCases(t *testing.T) {
+	errTests := map[string]rpc.BlockID{
+		"latest":        rpc.BlockIDLatest(),
+		"pre_confirmed": rpc.BlockIDPreConfirmed(),
+		"hash":          rpc.BlockIDFromHash(&felt.One),
+		"number":        rpc.BlockIDFromNumber(2),
+	}
+
+	for description, id := range errTests {
+		t.Run(description, func(t *testing.T) {
+			mockCtrl := gomock.NewController(t)
+			t.Cleanup(mockCtrl.Finish)
+
+			logger := log.NewNopZapLogger()
+			n := &networks.Mainnet
+			chain := blockchain.New(
+				memory.New(),
+				n,
+				blockchain.WithNewState(statetestutils.UseNewState()),
+			)
+			mockSyncReader := mocks.NewMockSyncReader(mockCtrl)
+			handler := rpc.New(chain, mockSyncReader, nil, logger)
+
+			if description == "pre_confirmed" {
+				mockSyncReader.EXPECT().PreConfirmed().Return(nil, db.ErrKeyNotFound)
+			}
+
+			block, rpcErr := handler.BlockWithTxnHashesAndReceipts(&id, rpc.ResponseFlags{})
+			assert.Nil(t, block)
+			assert.Equal(t, rpccore.ErrBlockNotFound, rpcErr)
+		})
+	}
+
+	//nolint:dupl // Similar l1head failure test structure across all error test functions
+	t.Run("l1head failure", func(t *testing.T) {
+		mockCtrl := gomock.NewController(t)
+		t.Cleanup(mockCtrl.Finish)
+
+		mockReader := mocks.NewMockReader(mockCtrl)
+		handler := rpc.New(mockReader, nil, nil, nil)
+
+		blockID := rpc.BlockIDFromNumber(777)
+		block := &core.Block{
+			Header: &core.Header{},
+		}
+
+		err := errors.New("l1 failure")
+		mockReader.EXPECT().BlockByNumber(blockID.Number()).Return(block, nil)
+		mockReader.EXPECT().L1Head().Return(core.L1Head{}, err)
+
+		resp, rpcErr := handler.BlockWithTxnHashesAndReceipts(&blockID, rpc.ResponseFlags{})
+		assert.Nil(t, resp)
+		assert.Equal(t, rpccore.ErrInternal.CloneWithData(err.Error()), rpcErr)
+	})
+}
+
+func assertBlockWithTxnHashesAndReceipts(
+	t *testing.T,
+	expectedBlock *core.Block,
+	expectedStatus rpc.BlockStatus,
+	expectedCommitments *core.BlockCommitments,
+	expectedStateUpdate *core.StateUpdate,
+	actual *rpc.BlockWithTxnHashesAndReceipts,
+	responseFlags rpc.ResponseFlags,
+) {
+	t.Helper()
+	assert.Equal(t, expectedStatus, actual.Status)
+	if expectedStatus == rpc.BlockPreConfirmed {
+		assertPreConfirmedBlockHeader(t, expectedBlock, &actual.BlockHeader)
+	} else {
+		assertCommittedBlockHeader(
+			t,
+			expectedBlock,
+			expectedCommitments,
+			expectedStateUpdate.StateDiff.Length(),
+			&actual.BlockHeader,
+		)
+	}
+
+	expectedFinalityStatus := blockStatusToTxnFinalityStatus(expectedStatus)
+	require.Equal(t, len(expectedBlock.Receipts), len(actual.Transactions))
+	for i, expectedReceipt := range expectedBlock.Receipts {
+		require.Equal(t, expectedReceipt.TransactionHash, actual.Transactions[i].Hash)
+		require.Equal(t, expectedReceipt.TransactionHash, actual.Transactions[i].Receipt.Hash)
+
+		adaptedTransaction := rpc.AdaptTransaction(
+			expectedBlock.Transactions[i],
+			responseFlags.IncludeProofFacts,
+		)
+		adaptedTransaction.Hash = nil
+		adaptedReceipt := rpc.AdaptReceipt(
+			expectedReceipt,
+			expectedBlock.Transactions[i],
+			expectedFinalityStatus,
+		)
+
+		require.Equal(t, adaptedTransaction, *actual.Transactions[i].Transaction)
+		require.Equal(t, adaptedReceipt, actual.Transactions[i].Receipt)
+	}
+}
+
+//nolint:dupl // Shares similar structure with other tests but tests different method
+func TestBlockWithTxnHashesAndReceipts(t *testing.T) {
+	network := &networks.Mainnet
+	client := feeder.NewTestClient(t, network)
+
+	block, commitments, stateUpdate := rpc.GetTestBlockWithCommitments(t, client, 16697)
+
+	testCases := createBlockTestCases(block, commitments, stateUpdate)
+
+	clientSepolia := feeder.NewTestClient(t, &networks.Sepolia)
+	blockWithProofFacts, commitmentsPF, stateUpdatePF := rpc.GetTestBlockWithCommitments(
+		t,
+		clientSepolia,
+		4072139,
+	)
+	testCases = append(
+		testCases,
+		createBlockResponseFlagsTestCases(
+			blockWithProofFacts,
+			commitmentsPF,
+			stateUpdatePF,
+		)...,
+	)
+
+	for _, tc := range testCases {
+		t.Run(tc.description, func(t *testing.T) {
+			mockCtrl := gomock.NewController(t)
+			t.Cleanup(mockCtrl.Finish)
+			mockReader := mocks.NewMockReader(mockCtrl)
+			mockSyncReader := mocks.NewMockSyncReader(mockCtrl)
+			handler := rpc.New(mockReader, mockSyncReader, nil, nil)
+
+			setupMockBlockTest(
+				t,
+				mockReader,
+				mockSyncReader,
+				tc.block,
+				tc.commitments,
+				tc.stateUpdate,
+				tc.blockID,
+				tc.l1Head,
+			)
+
+			result, rpcErr := handler.BlockWithTxnHashesAndReceipts(tc.blockID, tc.responseFlags)
+			require.Nil(t, rpcErr)
+			assertBlockWithTxnHashesAndReceipts(
+				t,
+				tc.block,
+				tc.blockStatus,
+				tc.commitments,
+				tc.stateUpdate,
+				result,
+				tc.responseFlags,
+			)
+		})
+	}
 }


### PR DESCRIPTION
**DO NOT MERGE**
`BlockWithTxnHashesAndReceipts` endpoint + tests
Returns Txs, hashes and receipts.