### PR TITLE
[Onboarding] NodesFromRoot endpoint

### DIFF
--- a/rpc/handlers.go
+++ b/rpc/handlers.go
@@ -365,6 +365,13 @@ func (h *Handler) MethodsV0_10() ([]jsonrpc.Method, string) {
 			},
 			Handler: h.rpcv10Handler.StorageProof,
 		},
+		{
+			Name: "juno_getNodesFromRoot",
+			Params: []jsonrpc.Parameter{
+				{Name: "key"},
+			},
+			Handler: h.rpcv10Handler.NodesFromRoot,
+		},
 	}, "/v0_10"
 }
 

--- a/rpc/v10/storage.go
+++ b/rpc/v10/storage.go
@@ -56,6 +56,11 @@ type StorageAtResponse struct {
 	LastUpdateBlock uint64    `json:"last_update_block"`
 }
 
+// Not on the spec
+type NodesFromRoot struct {
+	Nodes []*HashToNode `json:"nodes"`
+}
+
 // MarshalJSON implements the [json.Marshaler] interface for StorageAtResponse.
 func (st *StorageAtResponse) MarshalJSON() ([]byte, error) {
 	if st.includeLastUpdateBlock {
@@ -236,6 +241,48 @@ func (h *Handler) StorageProof(
 			BlockHash:         header.Hash,
 		},
 	}, nil
+}
+
+// NodesFromRootreturns the set of nodes from the root to the key for the classes Trie.
+//
+// It does not follow any specification.
+func (h *Handler) NodesFromRoot(classHash *felt.Felt) (*NodesFromRoot, *jsonrpc.Error) {
+	state, closer, err := h.bcReader.HeadState()
+	if err != nil {
+		return nil, rpccore.ErrInternal.CloneWithData(err)
+	}
+	defer h.callAndLogErr(closer, "Error closing state reader in NodesFromRoot")
+
+	classTrie, err := state.ClassTrie()
+	if err != nil {
+		return nil, rpccore.ErrInternal.CloneWithData(err)
+	}
+
+	nodes, err := getClassNodesFromRoot(classTrie, classHash)
+	if err != nil {
+		return nil, rpccore.ErrInternal.CloneWithData(err)
+	}
+
+	return &NodesFromRoot{Nodes: nodes}, nil
+}
+
+func getClassNodesFromRoot(tr core.TrieReader, classHash *felt.Felt) ([]*HashToNode, error) {
+	switch t := tr.(type) {
+	case *trie.Trie:
+		proof := trie.NewProofNodeSet()
+		if err := t.Prove(classHash, proof); err != nil {
+			return nil, err
+		}
+		return adaptDeprecatedTrieProofNodes(proof), nil
+	case *trie2.Trie:
+		proof := trie2.NewProofNodeSet()
+		if err := t.Prove(classHash, proof); err != nil {
+			return nil, err
+		}
+		return adaptTrieProofNodes(proof)
+	default:
+		return nil, fmt.Errorf("unknown trie type: %T", tr)
+	}
 }
 
 // Ensures each contract is unique and each storage key in each contract is unique

--- a/rpc/v10/storage_test.go
+++ b/rpc/v10/storage_test.go
@@ -960,6 +960,74 @@ func TestStorageProof(t *testing.T) {
 	})
 }
 
+func TestNodesFromRoot(t *testing.T) {
+	mockCtrl := gomock.NewController(t)
+	t.Cleanup(mockCtrl.Finish)
+
+	key := felt.NewFromUint64[felt.Felt](1)
+	key2 := felt.NewFromUint64[felt.Felt](8)
+	value := felt.NewFromUint64[felt.Felt](51)
+	value2 := felt.NewFromUint64[felt.Felt](58)
+
+	var classTrie core.Trie
+	if !statetestutils.UseNewState() {
+		tempTrie := emptyDeprecatedTrie(t)
+		_, _ = tempTrie.Put(key, value)
+		_, _ = tempTrie.Put(key2, value2)
+		_ = tempTrie.Commit()
+		classTrie = tempTrie
+	} else {
+		newComm := felt.FromUint64[felt.StateRootHash](1)
+		trieDB := trie2.NewTestNodeDatabase(memory.New(), trie2.PathScheme)
+		tr, err := trie2.New(
+			trieutils.NewClassTrieID(felt.FromUint64[felt.StateRootHash](0)),
+			251,
+			crypto.Pedersen,
+			&trieDB,
+		)
+		require.NoError(t, err)
+		_ = tr.Update(key, value)
+		_ = tr.Update(key2, value2)
+		_, nodes := tr.Commit()
+		err = trieDB.Update((*felt.Felt)(&newComm), &felt.Zero, trienode.NewMergeNodeSet(nodes))
+		require.NoError(t, err)
+
+		classTrie, err = trie2.New(
+			trieutils.NewClassTrieID(newComm),
+			251,
+			crypto.Pedersen,
+			&trieDB,
+		)
+		require.NoError(t, err)
+	}
+
+	mockReader := mocks.NewMockReader(mockCtrl)
+	mockState := mocks.NewMockStateReader(mockCtrl)
+	mockReader.EXPECT().HeadState().Return(mockState, func() error { return nil }, nil).AnyTimes()
+	mockState.EXPECT().ClassTrie().Return(classTrie, nil).AnyTimes()
+
+	logger := log.NewNopZapLogger()
+	handler := rpc.New(mockReader, nil, nil, logger)
+
+	t.Run("returns nodes for existing key", func(t *testing.T) {
+		result, rpcErr := handler.NodesFromRoot(key)
+		require.Nil(t, rpcErr)
+		require.NotNil(t, result)
+		require.NotEmpty(t, result.Nodes)
+		for _, n := range result.Nodes {
+			require.NotNil(t, n.Hash)
+			require.NotNil(t, n.Node)
+		}
+	})
+
+	t.Run("returns nodes for non-existing key", func(t *testing.T) {
+		nonExisting := felt.NewFromUint64[felt.Felt](999)
+		result, rpcErr := handler.NodesFromRoot(nonExisting)
+		require.Nil(t, rpcErr)
+		require.NotNil(t, result)
+	})
+}
+
 func TestStorageProof_VerifyPathfinderResponse(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
**DO NOT MERGE**
`NodesFromRoot` endpoint + tests
Returns trie nodes from root to key (classes trie).