### PR TITLE
feat: history pruner service

### DIFF
--- a/blockchain/event_filter.go
+++ b/blockchain/event_filter.go
@@ -10,6 +10,7 @@ import (
 	"github.com/NethermindEth/juno/core/felt"
 	"github.com/NethermindEth/juno/core/pending"
 	"github.com/NethermindEth/juno/db"
+	"github.com/NethermindEth/juno/pruner"
 )
 
 var errChunkSizeReached = errors.New("chunk size reached")
@@ -26,7 +27,7 @@ type EventFilterer interface {
 }
 
 type EventFilter struct {
-	txn            db.KeyValueStore
+	database       db.KeyValueStore
 	fromBlock      uint64
 	toBlock        uint64
 	matcher        EventMatcher
@@ -44,7 +45,7 @@ const (
 )
 
 func newEventFilter(
-	txn db.KeyValueStore,
+	database db.KeyValueStore,
 	contractAddresses []felt.Address,
 	keys [][]felt.Felt,
 	fromBlock, toBlock uint64,
@@ -53,7 +54,7 @@ func newEventFilter(
 	runningFilter *core.RunningEventFilter,
 ) *EventFilter {
 	return &EventFilter{
-		txn:            txn,
+		database:       database,
 		matcher:        NewEventMatcher(contractAddresses, keys),
 		fromBlock:      fromBlock,
 		toBlock:        toBlock,
@@ -91,7 +92,7 @@ func (e *EventFilter) SetRangeEndBlockByHash(
 	filterRange EventFilterRange,
 	blockHash *felt.Felt,
 ) error {
-	header, err := core.GetBlockHeaderByHash(e.txn, blockHash)
+	header, err := core.GetBlockHeaderByHash(e.database, blockHash)
 	if err != nil {
 		return err
 	}
@@ -100,7 +101,7 @@ func (e *EventFilter) SetRangeEndBlockByHash(
 
 // SetRangeEndBlockToL1Head sets an end of the block range to latest `l1_accepted` block
 func (e *EventFilter) SetRangeEndBlockToL1Head(filterRange EventFilterRange) error {
-	l1Head, err := core.GetL1Head(e.txn)
+	l1Head, err := core.GetL1Head(e.database)
 	if err != nil {
 		return err
 	}
@@ -151,7 +152,7 @@ func (e *EventFilter) Events(
 ) ([]FilteredEvent, ContinuationToken, error) {
 	var matchedEvents []FilteredEvent
 
-	latest, err := core.GetChainHeight(e.txn)
+	latest, err := core.GetChainHeight(e.database)
 	if err != nil {
 		return nil, ContinuationToken{}, err
 	}
@@ -162,6 +163,15 @@ func (e *EventFilter) Events(
 	if cToken != nil {
 		skippedEvents = cToken.processedEvents
 		startBlock = cToken.fromBlock
+	}
+
+	// Reject queries whose canonical start block has been pruned. Skipped
+	// when startBlock is in the pre-confirmed range (> latest), where
+	// retention semantics don't apply.
+	if startBlock <= latest {
+		if err := pruner.RequireRetained(e.database, startBlock); err != nil {
+			return nil, ContinuationToken{}, err
+		}
 	}
 
 	// Case [canonicalBlock, canonicalBlock]
@@ -237,13 +247,13 @@ func (e *EventFilter) canonicalEvents(
 		lastProccessedBlock = curBlock
 
 		var header *core.Header
-		header, err = core.GetBlockHeaderByNumber(e.txn, curBlock)
+		header, err = core.GetBlockHeaderByNumber(e.database, curBlock)
 		if err != nil {
 			return nil, ContinuationToken{}, err
 		}
 
 		var receipts []*core.TransactionReceipt
-		receipts, err = core.GetReceiptsByBlockNumber(e.txn, header.Number)
+		receipts, err = core.GetReceiptsByBlockNumber(e.database, header.Number)
 		if err != nil {
 			return nil, ContinuationToken{}, err
 		}

--- a/blockchain/statebackend/deprecated.go
+++ b/blockchain/statebackend/deprecated.go
@@ -6,6 +6,7 @@ import (
 	"github.com/NethermindEth/juno/core/felt"
 	"github.com/NethermindEth/juno/db"
 	"github.com/NethermindEth/juno/db/memory"
+	"github.com/NethermindEth/juno/pruner"
 )
 
 type deprecatedStateBackend struct {
@@ -33,15 +34,12 @@ func (b *deprecatedStateBackend) HeadState() (core.StateReader, StateCloser, err
 func (b *deprecatedStateBackend) StateAtBlockNumber(
 	blockNumber uint64,
 ) (core.StateReader, StateCloser, error) {
-	//nolint:staticcheck,nolintlint // used by old state
-	txn := b.database.NewIndexedBatch()
-
-	// Note(Ege): Why do we fetch header here? To validate block exists?
-	_, err := core.GetBlockHeaderByNumber(txn, blockNumber)
+	_, err := pruner.HeaderByNumberIfStateRetained(b.database, blockNumber)
 	if err != nil {
 		return nil, nil, err
 	}
-
+	//nolint:staticcheck,nolintlint // used by old state
+	txn := b.database.NewIndexedBatch()
 	return deprecatedstate.NewHistory(
 		deprecatedstate.New(txn),
 		blockNumber,
@@ -58,12 +56,12 @@ func (b *deprecatedStateBackend) StateAtBlockHash(
 		return deprecatedstate.New(txn), NoopStateCloser, nil
 	}
 
-	txn := b.database.NewIndexedBatch() //nolint:staticcheck // indexedBatch used by old state
-	header, err := core.GetBlockHeaderByHash(txn, blockHash)
+	header, err := pruner.HeaderByHashIfStateRetained(b.database, blockHash)
 	if err != nil {
 		return nil, nil, err
 	}
 
+	txn := b.database.NewIndexedBatch() //nolint:staticcheck // indexedBatch used by old state
 	return deprecatedstate.NewHistory(
 		deprecatedstate.New(txn),
 		header.Number,

--- a/blockchain/statebackend/statebackend.go
+++ b/blockchain/statebackend/statebackend.go
@@ -5,6 +5,7 @@ import (
 	"github.com/NethermindEth/juno/core/felt"
 	"github.com/NethermindEth/juno/core/state"
 	"github.com/NethermindEth/juno/db"
+	"github.com/NethermindEth/juno/pruner"
 )
 
 type stateBackend struct {
@@ -33,7 +34,7 @@ func (b *stateBackend) HeadState() (core.StateReader, StateCloser, error) {
 func (b *stateBackend) StateAtBlockNumber(
 	blockNumber uint64,
 ) (core.StateReader, StateCloser, error) {
-	header, err := core.GetBlockHeaderByNumber(b.database, blockNumber)
+	header, err := pruner.HeaderByNumberIfStateRetained(b.database, blockNumber)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -56,12 +57,16 @@ func (b *stateBackend) StateAtBlockHash(
 		return st, NoopStateCloser, nil
 	}
 
-	blockNumber, err := core.GetBlockHeaderNumberByHash(b.database, blockHash)
+	header, err := pruner.HeaderByHashIfStateRetained(b.database, blockHash)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	return b.StateAtBlockNumber(blockNumber)
+	history, err := state.NewStateHistory(header.Number, header.GlobalStateRoot, b.stateDB)
+	if err != nil {
+		return nil, nil, err
+	}
+	return &history, NoopStateCloser, nil
 }
 
 func (b *stateBackend) Store(

--- a/cmd/juno/juno.go
+++ b/cmd/juno/juno.go
@@ -107,6 +107,8 @@ const (
 	rpcRequestTimeoutF                  = "rpc-request-timeout"
 	maxConcurrentCompilationsF          = "max-concurrent-compilations"
 	disableReceivedTxnStreamF           = "disable-received-txn-stream"
+	newStateF                           = "new-state"
+	retainedBlocksF                     = node.RetainedBlocksFlag
 
 	defaultConfig                             = ""
 	defaultLogJSON                            = false
@@ -166,7 +168,7 @@ const (
 	defaultRPCRequestTimeout                  = 1 * time.Minute
 	defaultMaxConcurrentCompilations          = 8
 	defaultDisableReceivedTxnStream           = false
-	newStateF                                 = "new-state"
+	defaultRetainedBlocks                     = uint64(0)
 
 	configFlagUsage                       = "The YAML configuration file."
 	logLevelFlagUsage                     = "Options: trace, debug, info, warn, error."
@@ -248,7 +250,22 @@ const (
 		"Use zstd for low storage."
 	rpcRequestTimeoutUsage         = "Maximum time for an RPC request to complete."
 	maxConcurrentCompilationsUsage = "Maximum concurrent Sierra compilations."
-	disableReceivedTxnStreamUsage  = "The starknet_subscribeNewTransactions WebSocket API " +
+	retainedBlocksUsage            = "Size of the retention window for block contents and state " +
+		"history, measured in blocks counted back from the latest L1-verified head. " +
+		"Pruning is disabled by default (0); set this flag to a non-zero value to enable " +
+		"the pruner. When enabled, the pruner keeps blocks in the range " +
+		"(l1_head - retained_blocks, l2_head] and deletes everything below that floor; " +
+		"blocks at or above the L2 head are always kept regardless of this value. The " +
+		"floor is anchored on the L1-verified head — never on the local L2 head — so " +
+		"pruned blocks are reorg-safe. RPC methods remains fully functional" +
+		"for any block inside the retention window; requests targeting " +
+		"blocks below the floor will fail because their data has been deleted. " +
+		"Pruning is irreversible: data deleted under a small window cannot be " +
+		"recovered without re-syncing. " +
+		"Changing this value across restarts is safe: the window grows or " +
+		"shrinks accordingly. Growth is gradual — pruning pauses until the L1 " +
+		"head advances enough to reach the new floor."
+	disableReceivedTxnStreamUsage = "The starknet_subscribeNewTransactions WebSocket API " +
 		"allows users to subscribe to new transactions. By default, it streams " +
 		"transactions that have been accepted on L2. Users can optionally provide " +
 		"a set of finality statuses to be notified about, including transactions " +
@@ -489,6 +506,7 @@ func NewCmd(config *node.Config, run func(*cobra.Command, []string) error) *cobr
 	junoCmd.Flags().Bool(
 		disableReceivedTxnStreamF, defaultDisableReceivedTxnStream, disableReceivedTxnStreamUsage,
 	)
+	junoCmd.Flags().Uint64(retainedBlocksF, defaultRetainedBlocks, retainedBlocksUsage)
 	junoCmd.AddCommand(GenP2PKeyPair(), DBCmd(defaultDBPath), CompileSierraCmd())
 
 	return junoCmd

--- a/cmd/juno/juno.go
+++ b/cmd/juno/juno.go
@@ -108,7 +108,7 @@ const (
 	maxConcurrentCompilationsF          = "max-concurrent-compilations"
 	disableReceivedTxnStreamF           = "disable-received-txn-stream"
 	newStateF                           = "new-state"
-	retainedBlocksF                     = node.RetainedBlocksFlag
+	pruneModeF                          = node.PruneModeFlag
 
 	defaultConfig                             = ""
 	defaultLogJSON                            = false
@@ -168,7 +168,7 @@ const (
 	defaultRPCRequestTimeout                  = 1 * time.Minute
 	defaultMaxConcurrentCompilations          = 8
 	defaultDisableReceivedTxnStream           = false
-	defaultRetainedBlocks                     = uint64(0)
+	defaultPruneMode                          = uint64(0)
 
 	configFlagUsage                       = "The YAML configuration file."
 	logLevelFlagUsage                     = "Options: trace, debug, info, warn, error."
@@ -250,21 +250,21 @@ const (
 		"Use zstd for low storage."
 	rpcRequestTimeoutUsage         = "Maximum time for an RPC request to complete."
 	maxConcurrentCompilationsUsage = "Maximum concurrent Sierra compilations."
-	retainedBlocksUsage            = "Size of the retention window for block contents and state " +
-		"history, measured in blocks counted back from the latest L1-verified head. " +
-		"Pruning is disabled by default (0); set this flag to a non-zero value to enable " +
-		"the pruner. When enabled, the pruner keeps blocks in the range " +
-		"(l1_head - retained_blocks, l2_head] and deletes everything below that floor; " +
-		"blocks at or above the L2 head are always kept regardless of this value. The " +
-		"floor is anchored on the L1-verified head — never on the local L2 head — so " +
-		"pruned blocks are reorg-safe. RPC methods remains fully functional" +
-		"for any block inside the retention window; requests targeting " +
-		"blocks below the floor will fail because their data has been deleted. " +
-		"Pruning is irreversible: data deleted under a small window cannot be " +
-		"recovered without re-syncing. " +
-		"Changing this value across restarts is safe: the window grows or " +
-		"shrinks accordingly. Growth is gradual — pruning pauses until the L1 " +
-		"head advances enough to reach the new floor."
+	pruneModeUsage                 = "Enables block-data and state-history pruning. Pruning is " +
+		"disabled by default; passing this flag (with or without a value) turns " +
+		"it on. The value is the size of the retention window in blocks, counted " +
+		"back from the latest L1-verified head:\n" +
+		"  --prune-mode      same as --prune-mode=0; prune up to the L1 head\n" +
+		"  --prune-mode=N    keep blocks in (l1_head - N, l2_head], prune below\n" +
+		"Blocks at or above the L2 head are always kept. The floor is anchored on " +
+		"the L1-verified head — never on the local L2 head — so pruned blocks are " +
+		"reorg-safe. RPC remains fully functional for any block inside the " +
+		"retention window; requests targeting blocks below the floor fail because " +
+		"their data has been deleted. Pruning is irreversible: data deleted under " +
+		"a small window cannot be recovered without re-syncing. Changing this " +
+		"value across restarts is safe: the window grows or shrinks accordingly. " +
+		"Growth is gradual — pruning pauses until the L1 head advances enough to " +
+		"reach the new floor."
 	disableReceivedTxnStreamUsage = "The starknet_subscribeNewTransactions WebSocket API " +
 		"allows users to subscribe to new transactions. By default, it streams " +
 		"transactions that have been accepted on L2. Users can optionally provide " +
@@ -375,6 +375,10 @@ func NewCmd(config *node.Config, run func(*cobra.Command, []string) error) *cobr
 			mapstructure.TextUnmarshallerHookFunc(), mapstructure.StringToTimeDurationHookFunc()))); err != nil {
 			return err
 		}
+
+		// Pruning is gated on the flag's *presence* (CLI, YAML, or env), not
+		// its numeric value — --prune-mode=0 is still "on, retain 0".
+		config.Prune = v.IsSet(pruneModeF)
 
 		// Set custom network
 		if v.IsSet(cnNameF) {
@@ -506,7 +510,9 @@ func NewCmd(config *node.Config, run func(*cobra.Command, []string) error) *cobr
 	junoCmd.Flags().Bool(
 		disableReceivedTxnStreamF, defaultDisableReceivedTxnStream, disableReceivedTxnStreamUsage,
 	)
-	junoCmd.Flags().Uint64(retainedBlocksF, defaultRetainedBlocks, retainedBlocksUsage)
+	junoCmd.Flags().Uint64(pruneModeF, defaultPruneMode, pruneModeUsage)
+	// NoOptDefVal lets users pass --prune-mode without a value (treated as 0).
+	junoCmd.Flags().Lookup(pruneModeF).NoOptDefVal = "0"
 	junoCmd.AddCommand(GenP2PKeyPair(), DBCmd(defaultDBPath), CompileSierraCmd())
 
 	return junoCmd

--- a/core/block.go
+++ b/core/block.go
@@ -15,6 +15,17 @@ import (
 
 type BlockSignFunc func(blockHash, stateDiffCommitment *felt.Felt) ([]*felt.Felt, error)
 
+// BlockHashLag is the Starknet protocol-defined lag for the BLOCK_HASH
+// syscall: when executing block N, contracts can read the hash of block
+// N - BlockHashLag.
+const BlockHashLag uint64 = 10
+
+// Block hash storage contract introduced with starknet v0.12.0.
+// Contract stores block number to block hash mapping,
+// and serve this information through [get_block_hash_syscall].
+// Queriable range is [first_v0_12_0_block, current_block - 10]
+var BlockHashStorageContract = &felt.One
+
 type L1Head struct {
 	BlockNumber uint64
 	BlockHash   *felt.Felt

--- a/core/typed_buckets.go
+++ b/core/typed_buckets.go
@@ -164,7 +164,7 @@ var BlockTransactionsBucket = prefix.NewPrefixedBucket(
 		key.Cbor[uint64](),
 		BlockTransactionsSerializer{},
 	),
-	prefix.Prefix(key.Uint64, prefix.End[BlockTransactions]()),
+	prefix.Prefix(key.Cbor[uint64](), prefix.End[BlockTransactions]()),
 )
 
 var BlockTransactionsTransactionPartialBucket = partial.NewPartialBucket(

--- a/node/metrics.go
+++ b/node/metrics.go
@@ -21,9 +21,10 @@ import (
 const (
 	l1MetricsTimeout = 5 * time.Second
 
-	labelMethod   = "method"
-	labelVersion  = "version"
-	namespaceSync = "sync"
+	labelMethod     = "method"
+	labelVersion    = "version"
+	namespaceSync   = "sync"
+	namespacePruner = "pruner"
 )
 
 func makeDBMetrics() db.EventListener {
@@ -364,27 +365,27 @@ func makeVMThrottlerMetrics(throttledVM *ThrottledVM) {
 
 func makePrunerMetrics() pruner.EventListener {
 	oldestBlockKept := prometheus.NewGauge(prometheus.GaugeOpts{
-		Namespace: "pruner",
+		Namespace: namespacePruner,
 		Name:      "oldest_block_kept",
 		Help:      "Block number of the oldest block retained after pruning",
 	})
 	pruneLatency := prometheus.NewSummary(prometheus.SummaryOpts{
-		Namespace: "pruner",
+		Namespace: namespacePruner,
 		Name:      "prune_latency",
 		Help:      "Time taken per prune operation in seconds",
 	})
 	blocksPruned := prometheus.NewCounter(prometheus.CounterOpts{
-		Namespace: "pruner",
+		Namespace: namespacePruner,
 		Name:      "blocks_pruned_total",
 		Help:      "Total number of blocks pruned",
 	})
 	errors := prometheus.NewCounter(prometheus.CounterOpts{
-		Namespace: "pruner",
+		Namespace: namespacePruner,
 		Name:      "errors_total",
 		Help:      "Total number of errors encountered while pruning",
 	})
 	lastRunTimestamp := prometheus.NewGauge(prometheus.GaugeOpts{
-		Namespace: "pruner",
+		Namespace: namespacePruner,
 		Name:      "last_run_timestamp_seconds",
 		Help:      "Unix timestamp of the last completed prune operation",
 	})

--- a/node/metrics.go
+++ b/node/metrics.go
@@ -13,6 +13,7 @@ import (
 	"github.com/NethermindEth/juno/jemalloc"
 	"github.com/NethermindEth/juno/jsonrpc"
 	"github.com/NethermindEth/juno/l1"
+	"github.com/NethermindEth/juno/pruner"
 	"github.com/NethermindEth/juno/sync"
 	"github.com/prometheus/client_golang/prometheus"
 )
@@ -359,4 +360,45 @@ func makeVMThrottlerMetrics(throttledVM *ThrottledVM) {
 		return float64(throttledVM.QueueLen())
 	})
 	prometheus.MustRegister(vmJobs, vmQueue)
+}
+
+func makePrunerMetrics() pruner.EventListener {
+	oldestBlockKept := prometheus.NewGauge(prometheus.GaugeOpts{
+		Namespace: "pruner",
+		Name:      "oldest_block_kept",
+		Help:      "Block number of the oldest block retained after pruning",
+	})
+	pruneLatency := prometheus.NewSummary(prometheus.SummaryOpts{
+		Namespace: "pruner",
+		Name:      "prune_latency",
+		Help:      "Time taken per prune operation in seconds",
+	})
+	blocksPruned := prometheus.NewCounter(prometheus.CounterOpts{
+		Namespace: "pruner",
+		Name:      "blocks_pruned_total",
+		Help:      "Total number of blocks pruned",
+	})
+	errors := prometheus.NewCounter(prometheus.CounterOpts{
+		Namespace: "pruner",
+		Name:      "errors_total",
+		Help:      "Total number of errors encountered while pruning",
+	})
+	lastRunTimestamp := prometheus.NewGauge(prometheus.GaugeOpts{
+		Namespace: "pruner",
+		Name:      "last_run_timestamp_seconds",
+		Help:      "Unix timestamp of the last completed prune operation",
+	})
+	prometheus.MustRegister(oldestBlockKept, pruneLatency, blocksPruned, errors, lastRunTimestamp)
+
+	return &pruner.SelectiveListener{
+		OnPruneCb: func(oldest uint64, count uint64, took time.Duration) {
+			oldestBlockKept.Set(float64(oldest))
+			blocksPruned.Add(float64(count))
+			pruneLatency.Observe(took.Seconds())
+			lastRunTimestamp.SetToCurrentTime()
+		},
+		OnPruneErrorCb: func(err error) {
+			errors.Inc()
+		},
+	}
 }

--- a/node/node.go
+++ b/node/node.go
@@ -52,12 +52,12 @@ import (
 )
 
 const (
-	upgraderDelay      = 5 * time.Minute
-	mempoolLimit       = 1024
-	githubAPIUrl       = "https://api.github.com/repos/NethermindEth/juno/releases/latest"
-	latestReleaseURL   = "https://github.com/NethermindEth/juno/releases/latest"
-	sequencerAddress   = 1337
-	RetainedBlocksFlag = "retained-blocks"
+	upgraderDelay    = 5 * time.Minute
+	mempoolLimit     = 1024
+	githubAPIUrl     = "https://api.github.com/repos/NethermindEth/juno/releases/latest"
+	latestReleaseURL = "https://github.com/NethermindEth/juno/releases/latest"
+	sequencerAddress = 1337
+	PruneModeFlag    = "prune-mode"
 )
 
 // Config is the top-level juno configuration.
@@ -135,7 +135,11 @@ type Config struct {
 	RPCRequestTimeout         time.Duration `mapstructure:"rpc-request-timeout"`
 	MaxConcurrentCompilations uint          `mapstructure:"max-concurrent-compilations"`
 	NewState                  bool          `mapstructure:"new-state"`
-	RetainedBlocks            uint64        `mapstructure:"retained-blocks"`
+
+	// Prune is true when --prune-mode was provided (any value, including 0
+	// or absent). Set in cmd PreRunE; not bound via mapstructure.
+	Prune          bool
+	RetainedBlocks uint64 `mapstructure:"prune-mode"`
 }
 
 type Node struct {
@@ -302,7 +306,7 @@ func New(cfg *Config, version string, logLevel *log.Level) (*Node, error) {
 			WithCallMaxSteps(cfg.RPCCallMaxSteps).
 			WithCallMaxGas(cfg.RPCCallMaxGas)
 		services = append(services, &seq)
-		if cfg.RetainedBlocks > 0 {
+		if cfg.Prune {
 			prunerOpts := make([]pruner.Option, 0, 1)
 			if cfg.Metrics {
 				prunerOpts = append(prunerOpts, pruner.WithListener(makePrunerMetrics()))
@@ -419,7 +423,7 @@ func New(cfg *Config, version string, logLevel *log.Level) (*Node, error) {
 		}
 		if synchronizer != nil {
 			services = append(services, synchronizer)
-			if cfg.RetainedBlocks > 0 {
+			if cfg.Prune {
 				prunerOpts := make([]pruner.Option, 0, 1)
 				if cfg.Metrics {
 					prunerOpts = append(prunerOpts, pruner.WithListener(makePrunerMetrics()))

--- a/node/node.go
+++ b/node/node.go
@@ -30,6 +30,7 @@ import (
 	"github.com/NethermindEth/juno/node/upgrader"
 	"github.com/NethermindEth/juno/p2p"
 	"github.com/NethermindEth/juno/plugin"
+	"github.com/NethermindEth/juno/pruner"
 	"github.com/NethermindEth/juno/rpc"
 	"github.com/NethermindEth/juno/rpc/rpccore"
 	rpcv10 "github.com/NethermindEth/juno/rpc/v10"
@@ -51,11 +52,12 @@ import (
 )
 
 const (
-	upgraderDelay    = 5 * time.Minute
-	mempoolLimit     = 1024
-	githubAPIUrl     = "https://api.github.com/repos/NethermindEth/juno/releases/latest"
-	latestReleaseURL = "https://github.com/NethermindEth/juno/releases/latest"
-	sequencerAddress = 1337
+	upgraderDelay      = 5 * time.Minute
+	mempoolLimit       = 1024
+	githubAPIUrl       = "https://api.github.com/repos/NethermindEth/juno/releases/latest"
+	latestReleaseURL   = "https://github.com/NethermindEth/juno/releases/latest"
+	sequencerAddress   = 1337
+	RetainedBlocksFlag = "retained-blocks"
 )
 
 // Config is the top-level juno configuration.
@@ -133,6 +135,7 @@ type Config struct {
 	RPCRequestTimeout         time.Duration `mapstructure:"rpc-request-timeout"`
 	MaxConcurrentCompilations uint          `mapstructure:"max-concurrent-compilations"`
 	NewState                  bool          `mapstructure:"new-state"`
+	RetainedBlocks            uint64        `mapstructure:"retained-blocks"`
 }
 
 type Node struct {
@@ -299,6 +302,21 @@ func New(cfg *Config, version string, logLevel *log.Level) (*Node, error) {
 			WithCallMaxSteps(cfg.RPCCallMaxSteps).
 			WithCallMaxGas(cfg.RPCCallMaxGas)
 		services = append(services, &seq)
+		if cfg.RetainedBlocks > 0 {
+			prunerOpts := make([]pruner.Option, 0, 1)
+			if cfg.Metrics {
+				prunerOpts = append(prunerOpts, pruner.WithListener(makePrunerMetrics()))
+			}
+			p := pruner.New(
+				database,
+				cfg.RetainedBlocks,
+				seq.SubscribeNewHeads().Subscription,
+				chain.SubscribeL1Head().Subscription,
+				logger,
+				prunerOpts...,
+			)
+			services = append(services, p)
+		}
 	} else {
 		if cfg.GatewayTimeouts == "" {
 			cfg.GatewayTimeouts = feeder.DefaultTimeouts
@@ -401,6 +419,21 @@ func New(cfg *Config, version string, logLevel *log.Level) (*Node, error) {
 		}
 		if synchronizer != nil {
 			services = append(services, synchronizer)
+			if cfg.RetainedBlocks > 0 {
+				prunerOpts := make([]pruner.Option, 0, 1)
+				if cfg.Metrics {
+					prunerOpts = append(prunerOpts, pruner.WithListener(makePrunerMetrics()))
+				}
+				p := pruner.New(
+					database,
+					cfg.RetainedBlocks,
+					synchronizer.SubscribeNewHeads().Subscription,
+					chain.SubscribeL1Head().Subscription,
+					logger,
+					prunerOpts...,
+				)
+				services = append(services, p)
+			}
 		}
 	}
 

--- a/pruner/accessors.go
+++ b/pruner/accessors.go
@@ -1,0 +1,351 @@
+package pruner
+
+import (
+	"context"
+	"encoding/binary"
+	"errors"
+	"fmt"
+
+	"github.com/NethermindEth/juno/core"
+	"github.com/NethermindEth/juno/core/felt"
+	"github.com/NethermindEth/juno/db"
+	"github.com/NethermindEth/juno/db/typed/key"
+	"github.com/NethermindEth/juno/db/typed/prefix"
+)
+
+// Rangeable wrappers for the plain typed buckets that are keyed by a bare
+// uint64 block number. The wrapper adds a Uint64 prefix layer so the bucket
+// exposes DeleteRange/Scan in terms of uint64 bounds. .
+var (
+	blockHeadersRange = prefix.NewPrefixedBucket(
+		core.BlockHeadersByNumberBucket,
+		prefix.Prefix(key.Uint64, prefix.End[core.Header]()),
+	)
+	blockCommitmentsRange = prefix.NewPrefixedBucket(
+		core.BlockCommitmentsBucket,
+		prefix.Prefix(key.Uint64, prefix.End[core.BlockCommitments]()),
+	)
+	stateUpdatesRange = prefix.NewPrefixedBucket(
+		core.StateUpdatesByBlockNumberBucket,
+		prefix.Prefix(key.Uint64, prefix.End[core.StateUpdate]()),
+	)
+)
+
+// PruneUpto deletes every block strictly below endExclusive. Returns the
+// number of blocks actually pruned (which may be less than the full
+// window if ctx is cancelled mid-loop).
+//
+// Resumes automatically. The lower bound of the per-block sweep is
+// derived from [earliestBlockNumberByCommitments] — i.e., wherever the
+// previous call left off — so two consecutive calls do no overlapping
+// per-block work. If a previous call exited mid-loop (ctx cancelled),
+// the next call picks up from the same block. If endExclusive is at or
+// below the current oldest kept block, the call is a no-op.
+//
+// Deleted for every block in [oldestKept, endExclusive):
+//
+//   - block commitments
+//   - state update
+//   - block transactions and their hash → (block, index) reverse lookups
+//   - L1 handler message-hash → tx-hash reverse lookups
+//   - contract storage / nonce / class-hash history snapshots
+//
+// Retained below endExclusive (intentional carve-outs):
+//
+//  1. Block headers in [endExclusive-BlockHashLag, endExclusive). The
+//     get_block_hash_syscall (see [core.BlockHashLag]), run during
+//     execution of any block in [endExclusive, endExclusive+BlockHashLag),
+//     reads a header by number from this window — pruning it would break
+//     the syscall.
+//
+//  2. The hash → number mapping for endExclusive-1. Resolving
+//     StateAtBlockHash(endExclusive.parentHash) needs this single mapping;
+//     it is cleaned up by the next PruneUpto call's oldestKept-1 sweep, so
+//     at rest exactly one extra mapping survives below endExclusive.
+//
+// ctx cancellation aborts the per-block loop after the current iteration;
+// any work already queued plus the range delete for the partial window is
+// still flushed, so the next call resumes from where this one stopped.
+//
+// Returns (blocksPruned, oldestKept, err): blocksPruned is how many
+// blocks this call removed, and oldestKept is the lowest block number
+// still present after the call (= blockNum reached by the loop, which
+// equals endExclusive on full completion). On the no-op paths
+// (empty database, endExclusive ≤ existing oldest), oldestKept reflects
+// the unchanged pre-call state — 0 if the database is empty.
+func PruneUpto(
+	ctx context.Context,
+	database db.KeyValueStore,
+	endExclusive uint64,
+	targetBatchByteSize int,
+) (blocksPruned, oldestKept uint64, err error) {
+	start, err := earliestBlockNumberByCommitments(database)
+	if errors.Is(err, db.ErrKeyNotFound) {
+		return 0, 0, nil
+	}
+	if err != nil {
+		return 0, 0, err
+	}
+	if start >= endExclusive {
+		return 0, start, nil
+	}
+
+	blockNum, err := pruneHashKeyedUpto(ctx, database, start, endExclusive, targetBatchByteSize)
+	if err != nil {
+		return 0, 0, err
+	}
+
+	batch := database.NewBatch()
+	if err := PruneBlockDataUpto(batch, blockNum); err != nil {
+		return 0, 0, err
+	}
+	if err := batch.Write(); err != nil {
+		return 0, 0, err
+	}
+
+	return blockNum - start, blockNum, nil
+}
+
+// pruneHashKeyedUpto deletes the hash-keyed indexes for every block in
+// [start, endExclusive), iterating per-block and rotating the batch
+// whenever its size exceeds targetBatchByteSize. Also point-deletes the
+// carve-out left at start-1 by the previous PruneUpto call. Owns its
+// own batch lifecycle and writes the final batch before returning.
+//
+// Indexes touched:
+//
+//   - BlockHeaderNumberByHash (skipping endExclusive-1, the carve-out
+//     for StateAtBlockHash(endExclusive.parentHash))
+//   - TransactionBlockNumbersAndIndicesByHash
+//   - L1HandlerTxnHashByMsgHash (only for L1 handler txs)
+//   - ContractStorageHistory / ContractNonceHistory / ContractClassHashHistory
+//
+// Returns the last blockNum reached (= endExclusive on completion, or
+// earlier if ctx was cancelled mid-loop).
+func pruneHashKeyedUpto(
+	ctx context.Context,
+	database db.KeyValueStore,
+	start,
+	endExclusive uint64,
+	targetBatchByteSize int,
+) (uint64, error) {
+	batch := database.NewBatch()
+	// Clean up the carve-out left by the previous PruneUpto call.
+	if start > 0 {
+		header, err := core.GetBlockHeaderByNumber(database, start-1)
+		if err != nil {
+			return 0, err
+		}
+		if err := core.DeleteBlockHeaderNumberByHash(batch, header.Hash); err != nil {
+			return 0, err
+		}
+	}
+
+	blockNum := start
+	for ; blockNum < endExclusive; blockNum++ {
+		if err := ctx.Err(); err != nil {
+			break
+		}
+
+		su, err := core.GetStateUpdateByBlockNum(database, blockNum)
+		if err != nil {
+			return 0, err
+		}
+
+		// Skip endExclusive-1: its hash→number mapping is the carve-out
+		// resolved by StateAtBlockHash(endExclusive.parentHash). Cleaned up
+		// by the next PruneUpto call via the start-1 branch above.
+		if blockNum != endExclusive-1 {
+			if err := core.DeleteBlockHeaderNumberByHash(batch, su.BlockHash); err != nil {
+				return 0, err
+			}
+		}
+
+		if err := deleteTransactionHashReverseLookups(database, batch, blockNum); err != nil {
+			return 0, err
+		}
+
+		if err := pruneStateHistoryFromUpdate(batch, blockNum, su); err != nil {
+			return 0, err
+		}
+
+		if batch.Size() >= targetBatchByteSize {
+			if err := batch.Write(); err != nil {
+				return 0, err
+			}
+			batch = database.NewBatch()
+		}
+	}
+
+	return blockNum, batch.Write()
+}
+
+// DeleteTransactionHashReverseLookups deletes the hash-keyed indexes that
+// point back to a block's transactions:
+//
+//   - bucket 9: transaction hash → (block number, index)
+//   - bucket 24 (only for L1 handler txs): L1 message hash → tx hash
+func deleteTransactionHashReverseLookups(
+	reader db.KeyValueReader,
+	writer db.KeyValueWriter,
+	blockNumber uint64,
+) error {
+	for tx, err := range core.GetTransactionsByBlockNumberIter(reader, blockNumber) {
+		if err != nil {
+			return err
+		}
+		txHash := (*felt.TransactionHash)(tx.Hash())
+		err := core.TransactionBlockNumbersAndIndicesByHashBucket.Delete(writer, txHash)
+		if err != nil {
+			return err
+		}
+		if l1handler, ok := tx.(*core.L1HandlerTransaction); ok {
+			err := core.DeleteL1HandlerTxnHashByMsgHash(writer, l1handler.MessageHash())
+			if err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}
+
+// PruneBlockDataUpto prunes the number-keyed block data for every block
+// strictly below rangeEndExclusive.
+//
+// Deleted for every block below rangeEndExclusive:
+//
+//   - block commitments
+//   - state update
+//   - block transactions
+//   - aggregated bloom filters fully below rangeEndExclusive
+//
+// Retained below rangeEndExclusive (intentional carve-out):
+//
+//   - Block headers in [rangeEndExclusive-BlockHashLag, rangeEndExclusive).
+//     The get_block_hash_syscall, run during execution of any block in
+//     [rangeEndExclusive, rangeEndExclusive+BlockHashLag), reads a header
+//     by number from this window — pruning it would break the syscall.
+func PruneBlockDataUpto(w db.KeyValueRangeDeleter, rangeEndExclusive uint64) error {
+	// When rangeEndExclusive <= BlockHashLag the whole range falls inside
+	// the lag carve-out, so no headers may be deleted.
+	headerEnd := uint64(0)
+	if rangeEndExclusive > core.BlockHashLag {
+		headerEnd = rangeEndExclusive - core.BlockHashLag
+	}
+	err := blockHeadersRange.Prefix().DeleteRange(w, 0, headerEnd)
+	if err != nil {
+		return err
+	}
+
+	err = blockCommitmentsRange.Prefix().DeleteRange(w, 0, rangeEndExclusive)
+	if err != nil {
+		return err
+	}
+
+	err = stateUpdatesRange.Prefix().DeleteRange(w, 0, rangeEndExclusive)
+	if err != nil {
+		return err
+	}
+
+	err = core.BlockTransactionsBucket.Prefix().DeleteRange(w, 0, rangeEndExclusive)
+	if err != nil {
+		return err
+	}
+
+	return pruneAggregatedBloomFiltersUpto(w, rangeEndExclusive)
+}
+
+// pruneStateHistoryFromUpdate deletes the state-history entries written
+// for a single block. Each entry records the value of a (contract, slot)
+// or (contract,) tuple *just before* the block was applied, keyed by block
+// number; reads at any later block already use the post-block value, so
+// these per-block snapshots are only needed to reconstruct historical
+// state at the exact block being pruned. Once we drop that block the
+// snapshot is unreachable.
+//
+// Buckets touched (all keyed by suffix block number):
+//
+//   - ContractStorageHistory:  contract + slot + block → old slot value
+//   - ContractNonceHistory:    contract + block         → old nonce
+//   - ContractClassHashHistory: contract + block        → old class hash
+//
+// stateUpdate is used as the index of which (addr, slot) / addr tuples the
+// block touched — only those have history entries to delete.
+func pruneStateHistoryFromUpdate(
+	w db.KeyValueWriter,
+	blockNumber uint64,
+	stateUpdate *core.StateUpdate,
+) error {
+	for addr, storageChanges := range stateUpdate.StateDiff.StorageDiffs {
+		for slot := range storageChanges {
+			err := core.DeleteContractStorageHistory(w, &addr, &slot, blockNumber)
+			if err != nil {
+				return err
+			}
+		}
+	}
+
+	for addr := range stateUpdate.StateDiff.Nonces {
+		err := core.DeleteContractNonceHistory(w, &addr, blockNumber)
+		if err != nil {
+			return err
+		}
+	}
+
+	for addr := range stateUpdate.StateDiff.ReplacedClasses {
+		err := core.DeleteContractClassHashHistory(w, &addr, blockNumber)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// pruneAggregatedBloomFiltersUpto deletes every aggregated bloom filter
+// whose entire range lies strictly below rangeEndExclusive.
+func pruneAggregatedBloomFiltersUpto(w db.KeyValueRangeDeleter, rangeEndExclusive uint64) error {
+	if rangeEndExclusive < core.NumBlocksPerFilter {
+		return nil
+	}
+
+	// The largest filter boundary at or below rangeEndExclusive — the
+	// `from` of the first filter we keep, i.e. the oldest block surviving
+	// this prune.
+	oldestKept := rangeEndExclusive - rangeEndExclusive%core.NumBlocksPerFilter
+
+	startKey := db.AggregatedBloomFilterKey(0, core.NumBlocksPerFilter-1)
+	endKey := db.AggregatedBloomFilterKey(oldestKept, oldestKept+core.NumBlocksPerFilter-1)
+	return w.DeleteRange(startKey, endKey)
+}
+
+// earliestBlockNumberByCommitments returns the lowest block number
+// present in [db.BlockCommitments] — the oldest block still fully
+// retained.
+//
+// BlockCommitments is the source of truth for "oldest kept" because
+// the BlockHeadersByNumber carry intentional carve-outs that sit
+// below the true retention floor (see [PruneUpto]).
+//
+// BlockCommitments has no such carve-out, so its lowest entry equals
+// oldestKept exactly.
+func earliestBlockNumberByCommitments(r db.KeyValueReader) (uint64, error) {
+	// Bucket (1 byte) + uint64BE (8 bytes)
+	const blockCommitmentsKeyByteSize = 9
+	for entry, err := range blockCommitmentsRange.Prefix().Scan(r) {
+		if err != nil {
+			return 0, err
+		}
+
+		if len(entry.Key) != blockCommitmentsKeyByteSize {
+			return 0, fmt.Errorf(
+				"invalid key size. expected: %v, actual %v",
+				blockCommitmentsKeyByteSize,
+				len(entry.Key),
+			)
+		}
+
+		return binary.BigEndian.Uint64(entry.Key[1:9]), nil
+	}
+	return 0, db.ErrKeyNotFound
+}

--- a/pruner/accessors.go
+++ b/pruner/accessors.go
@@ -316,4 +316,3 @@ func pruneAggregatedBloomFiltersUpto(w db.KeyValueRangeDeleter, rangeEndExclusiv
 	endKey := db.AggregatedBloomFilterKey(oldestKept, oldestKept+core.NumBlocksPerFilter-1)
 	return w.DeleteRange(startKey, endKey)
 }
-

--- a/pruner/accessors.go
+++ b/pruner/accessors.go
@@ -59,7 +59,7 @@ var (
 //  2. The hash → number mapping for endExclusive-1. Resolving
 //     StateAtBlockHash(endExclusive.parentHash) needs this single mapping;
 //     it is cleaned up by the next PruneUpto call's oldestKept-1 sweep, so
-//     at rest exactly one extra mapping survives below endExclusive.
+//     between calls exactly one extra mapping survives below endExclusive.
 //
 // ctx cancellation aborts the per-block loop after the current iteration;
 // any work already queued plus the range delete for the partial window is

--- a/pruner/accessors.go
+++ b/pruner/accessors.go
@@ -2,9 +2,7 @@ package pruner
 
 import (
 	"context"
-	"encoding/binary"
 	"errors"
-	"fmt"
 
 	"github.com/NethermindEth/juno/core"
 	"github.com/NethermindEth/juno/core/felt"
@@ -36,7 +34,7 @@ var (
 // window if ctx is cancelled mid-loop).
 //
 // Resumes automatically. The lower bound of the per-block sweep is
-// derived from [earliestBlockNumberByCommitments] — i.e., wherever the
+// derived from [OldestRetainedBlock] — i.e., wherever the
 // previous call left off — so two consecutive calls do no overlapping
 // per-block work. If a previous call exited mid-loop (ctx cancelled),
 // the next call picks up from the same block. If endExclusive is at or
@@ -79,7 +77,7 @@ func PruneUpto(
 	endExclusive uint64,
 	targetBatchByteSize int,
 ) (blocksPruned, oldestKept uint64, err error) {
-	start, err := earliestBlockNumberByCommitments(database)
+	start, err := OldestRetainedBlock(database)
 	if errors.Is(err, db.ErrKeyNotFound) {
 		return 0, 0, nil
 	}
@@ -104,6 +102,52 @@ func PruneUpto(
 	}
 
 	return blockNum - start, blockNum, nil
+}
+
+// PruneBlockDataUpto prunes the number-keyed block data for every block
+// strictly below rangeEndExclusive.
+//
+// Deleted for every block below rangeEndExclusive:
+//
+//   - block commitments
+//   - state update
+//   - block transactions
+//   - aggregated bloom filters fully below rangeEndExclusive
+//
+// Retained below rangeEndExclusive (intentional carve-out):
+//
+//   - Block headers in [rangeEndExclusive-BlockHashLag, rangeEndExclusive).
+//     The get_block_hash_syscall, run during execution of any block in
+//     [rangeEndExclusive, rangeEndExclusive+BlockHashLag), reads a header
+//     by number from this window — pruning it would break the syscall.
+func PruneBlockDataUpto(w db.KeyValueRangeDeleter, rangeEndExclusive uint64) error {
+	// When rangeEndExclusive <= BlockHashLag the whole range falls inside
+	// the lag carve-out, so no headers may be deleted.
+	headerEnd := uint64(0)
+	if rangeEndExclusive > core.BlockHashLag {
+		headerEnd = rangeEndExclusive - core.BlockHashLag
+	}
+	err := blockHeadersRange.Prefix().DeleteRange(w, 0, headerEnd)
+	if err != nil {
+		return err
+	}
+
+	err = blockCommitmentsRange.Prefix().DeleteRange(w, 0, rangeEndExclusive)
+	if err != nil {
+		return err
+	}
+
+	err = stateUpdatesRange.Prefix().DeleteRange(w, 0, rangeEndExclusive)
+	if err != nil {
+		return err
+	}
+
+	err = core.BlockTransactionsBucket.Prefix().DeleteRange(w, 0, rangeEndExclusive)
+	if err != nil {
+		return err
+	}
+
+	return pruneAggregatedBloomFiltersUpto(w, rangeEndExclusive)
 }
 
 // pruneHashKeyedUpto deletes the hash-keyed indexes for every block in
@@ -210,52 +254,6 @@ func deleteTransactionHashReverseLookups(
 	return nil
 }
 
-// PruneBlockDataUpto prunes the number-keyed block data for every block
-// strictly below rangeEndExclusive.
-//
-// Deleted for every block below rangeEndExclusive:
-//
-//   - block commitments
-//   - state update
-//   - block transactions
-//   - aggregated bloom filters fully below rangeEndExclusive
-//
-// Retained below rangeEndExclusive (intentional carve-out):
-//
-//   - Block headers in [rangeEndExclusive-BlockHashLag, rangeEndExclusive).
-//     The get_block_hash_syscall, run during execution of any block in
-//     [rangeEndExclusive, rangeEndExclusive+BlockHashLag), reads a header
-//     by number from this window — pruning it would break the syscall.
-func PruneBlockDataUpto(w db.KeyValueRangeDeleter, rangeEndExclusive uint64) error {
-	// When rangeEndExclusive <= BlockHashLag the whole range falls inside
-	// the lag carve-out, so no headers may be deleted.
-	headerEnd := uint64(0)
-	if rangeEndExclusive > core.BlockHashLag {
-		headerEnd = rangeEndExclusive - core.BlockHashLag
-	}
-	err := blockHeadersRange.Prefix().DeleteRange(w, 0, headerEnd)
-	if err != nil {
-		return err
-	}
-
-	err = blockCommitmentsRange.Prefix().DeleteRange(w, 0, rangeEndExclusive)
-	if err != nil {
-		return err
-	}
-
-	err = stateUpdatesRange.Prefix().DeleteRange(w, 0, rangeEndExclusive)
-	if err != nil {
-		return err
-	}
-
-	err = core.BlockTransactionsBucket.Prefix().DeleteRange(w, 0, rangeEndExclusive)
-	if err != nil {
-		return err
-	}
-
-	return pruneAggregatedBloomFiltersUpto(w, rangeEndExclusive)
-}
-
 // pruneStateHistoryFromUpdate deletes the state-history entries written
 // for a single block. Each entry records the value of a (contract, slot)
 // or (contract,) tuple *just before* the block was applied, keyed by block
@@ -319,33 +317,3 @@ func pruneAggregatedBloomFiltersUpto(w db.KeyValueRangeDeleter, rangeEndExclusiv
 	return w.DeleteRange(startKey, endKey)
 }
 
-// earliestBlockNumberByCommitments returns the lowest block number
-// present in [db.BlockCommitments] — the oldest block still fully
-// retained.
-//
-// BlockCommitments is the source of truth for "oldest kept" because
-// the BlockHeadersByNumber carry intentional carve-outs that sit
-// below the true retention floor (see [PruneUpto]).
-//
-// BlockCommitments has no such carve-out, so its lowest entry equals
-// oldestKept exactly.
-func earliestBlockNumberByCommitments(r db.KeyValueReader) (uint64, error) {
-	// Bucket (1 byte) + uint64BE (8 bytes)
-	const blockCommitmentsKeyByteSize = 9
-	for entry, err := range blockCommitmentsRange.Prefix().Scan(r) {
-		if err != nil {
-			return 0, err
-		}
-
-		if len(entry.Key) != blockCommitmentsKeyByteSize {
-			return 0, fmt.Errorf(
-				"invalid key size. expected: %v, actual %v",
-				blockCommitmentsKeyByteSize,
-				len(entry.Key),
-			)
-		}
-
-		return binary.BigEndian.Uint64(entry.Key[1:9]), nil
-	}
-	return 0, db.ErrKeyNotFound
-}

--- a/pruner/accessors_internal_test.go
+++ b/pruner/accessors_internal_test.go
@@ -1,0 +1,125 @@
+package pruner
+
+import (
+	"testing"
+
+	"github.com/NethermindEth/juno/core"
+	"github.com/NethermindEth/juno/core/felt"
+	"github.com/NethermindEth/juno/db"
+	_ "github.com/NethermindEth/juno/encoder/registry"
+	"github.com/NethermindEth/juno/pruner/testutils"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDeleteTransactionHashReverseLookups(t *testing.T) {
+	database := testutils.NewPebbleTestDB(t)
+
+	blocks := make([]*testutils.StoredBlock, 3)
+	for i := range uint64(3) {
+		blocks[i] = testutils.StoreBlock(t, database, i)
+	}
+
+	testutils.WithBatch(t, database, func(batch db.Batch) error {
+		return deleteTransactionHashReverseLookups(database, batch, 1)
+	})
+
+	// Block 1's tx hash reverse lookups (bucket 9) and L1 handler msg hash
+	// (bucket 24) should be gone.
+	for _, txHash := range blocks[1].TxHashes {
+		_, err := core.TransactionBlockNumbersAndIndicesByHashBucket.Get(
+			database,
+			(*felt.TransactionHash)(txHash),
+		)
+		assert.Error(t, err)
+	}
+	for _, msgHash := range blocks[1].L1HandlerMsgHashes {
+		_, err := core.GetL1HandlerTxnHashByMsgHash(database, msgHash)
+		assert.Error(t, err)
+	}
+
+	// Header hash → number lookup is *not* this function's responsibility,
+	// so it must still be present for block 1.
+	assert.True(t, testutils.BlockHeaderHashExists(database, blocks[1].Header.Hash))
+
+	// Neighbouring blocks must be untouched.
+	for _, b := range []*testutils.StoredBlock{blocks[0], blocks[2]} {
+		for _, txHash := range b.TxHashes {
+			_, err := core.TransactionBlockNumbersAndIndicesByHashBucket.Get(
+				database,
+				(*felt.TransactionHash)(txHash),
+			)
+			assert.NoError(t, err)
+		}
+		for _, msgHash := range b.L1HandlerMsgHashes {
+			_, err := core.GetL1HandlerTxnHashByMsgHash(database, msgHash)
+			assert.NoError(t, err)
+		}
+	}
+}
+
+func TestPruneAggregatedBloomFiltersUpto(t *testing.T) {
+	n := core.NumBlocksPerFilter
+
+	writeFilters := func(t *testing.T, database db.KeyValueWriter) {
+		t.Helper()
+		for i := range uint64(3) {
+			filter := core.NewAggregatedFilter(i * n)
+			require.NoError(t, core.WriteAggregatedBloomFilter(database, &filter))
+		}
+	}
+
+	bloomFilterExists := func(database db.KeyValueReader, from, to uint64) bool {
+		_, err := core.GetAggregatedBloomFilter(database, from, to)
+		return err == nil
+	}
+
+	t.Run("deletes filters fully below the boundary", func(t *testing.T) {
+		database := testutils.NewPebbleTestDB(t)
+		writeFilters(t, database)
+
+		testutils.WithBatch(t, database, func(batch db.Batch) error {
+			return pruneAggregatedBloomFiltersUpto(batch, 2*n)
+		})
+
+		assert.False(t, bloomFilterExists(database, 0, n-1))
+		assert.False(t, bloomFilterExists(database, n, 2*n-1))
+		assert.True(t, bloomFilterExists(database, 2*n, 3*n-1))
+	})
+
+	t.Run("partial range does not delete the containing filter", func(t *testing.T) {
+		database := testutils.NewPebbleTestDB(t)
+		writeFilters(t, database)
+
+		testutils.WithBatch(t, database, func(batch db.Batch) error {
+			return pruneAggregatedBloomFiltersUpto(batch, n/2)
+		})
+
+		assert.True(t, bloomFilterExists(database, 0, n-1))
+		assert.True(t, bloomFilterExists(database, n, 2*n-1))
+		assert.True(t, bloomFilterExists(database, 2*n, 3*n-1))
+	})
+
+	t.Run("rangeEndExclusive at filter boundary keeps that filter", func(t *testing.T) {
+		// rangeEndExclusive = n means filter [0, n-1] is fully below
+		// (to = n-1 < n) and filter [n, 2n-1] starts at n, so it's kept.
+		database := testutils.NewPebbleTestDB(t)
+		writeFilters(t, database)
+
+		testutils.WithBatch(t, database, func(batch db.Batch) error {
+			return pruneAggregatedBloomFiltersUpto(batch, n)
+		})
+
+		assert.False(t, bloomFilterExists(database, 0, n-1))
+		assert.True(t, bloomFilterExists(database, n, 2*n-1))
+		assert.True(t, bloomFilterExists(database, 2*n, 3*n-1))
+	})
+
+	t.Run("no-op when range below one filter span", func(t *testing.T) {
+		database := testutils.NewPebbleTestDB(t)
+
+		testutils.WithBatch(t, database, func(batch db.Batch) error {
+			return pruneAggregatedBloomFiltersUpto(batch, 0)
+		})
+	})
+}

--- a/pruner/accessors_test.go
+++ b/pruner/accessors_test.go
@@ -15,14 +15,14 @@ import (
 
 func TestOldestRetainedBlock(t *testing.T) {
 	t.Run("empty database returns ErrKeyNotFound", func(t *testing.T) {
-		database := testutils.NewTestDB(t)
+		database := testutils.NewPebbleTestDB(t)
 
 		_, err := OldestRetainedBlock(database)
 		assert.ErrorIs(t, err, db.ErrKeyNotFound)
 	})
 
 	t.Run("returns lowest block number with commitments", func(t *testing.T) {
-		database := testutils.NewTestDB(t)
+		database := testutils.NewPebbleTestDB(t)
 
 		for i := uint64(5); i <= 7; i++ {
 			testutils.StoreBlock(t, database, i)
@@ -35,7 +35,7 @@ func TestOldestRetainedBlock(t *testing.T) {
 }
 
 func TestDeleteTransactionHashReverseLookups(t *testing.T) {
-	database := testutils.NewTestDB(t)
+	database := testutils.NewPebbleTestDB(t)
 
 	blocks := make([]*testutils.StoredBlock, 3)
 	for i := range uint64(3) {
@@ -97,7 +97,7 @@ func TestPruneAggregatedBloomFiltersUpto(t *testing.T) {
 	}
 
 	t.Run("deletes filters fully below the boundary", func(t *testing.T) {
-		database := testutils.NewTestDB(t)
+		database := testutils.NewPebbleTestDB(t)
 		writeFilters(t, database)
 
 		testutils.WithBatch(t, database, func(batch db.Batch) error {
@@ -110,7 +110,7 @@ func TestPruneAggregatedBloomFiltersUpto(t *testing.T) {
 	})
 
 	t.Run("partial range does not delete the containing filter", func(t *testing.T) {
-		database := testutils.NewTestDB(t)
+		database := testutils.NewPebbleTestDB(t)
 		writeFilters(t, database)
 
 		testutils.WithBatch(t, database, func(batch db.Batch) error {
@@ -125,7 +125,7 @@ func TestPruneAggregatedBloomFiltersUpto(t *testing.T) {
 	t.Run("rangeEndExclusive at filter boundary keeps that filter", func(t *testing.T) {
 		// rangeEndExclusive = n means filter [0, n-1] is fully below
 		// (to = n-1 < n) and filter [n, 2n-1] starts at n, so it's kept.
-		database := testutils.NewTestDB(t)
+		database := testutils.NewPebbleTestDB(t)
 		writeFilters(t, database)
 
 		testutils.WithBatch(t, database, func(batch db.Batch) error {
@@ -138,7 +138,7 @@ func TestPruneAggregatedBloomFiltersUpto(t *testing.T) {
 	})
 
 	t.Run("no-op when range below one filter span", func(t *testing.T) {
-		database := testutils.NewTestDB(t)
+		database := testutils.NewPebbleTestDB(t)
 
 		testutils.WithBatch(t, database, func(batch db.Batch) error {
 			return pruneAggregatedBloomFiltersUpto(batch, 0)
@@ -167,7 +167,7 @@ func TestPruneUpto(t *testing.T) {
 	lag := core.BlockHashLag
 	require.GreaterOrEqual(t, endExclusive, lag)
 
-	database := testutils.NewTestDB(t)
+	database := testutils.NewPebbleTestDB(t)
 	blocks := make([]*testutils.StoredBlock, totalBlocks)
 	for i := range totalBlocks {
 		blocks[i] = testutils.StoreBlock(t, database, i)
@@ -187,7 +187,7 @@ func TestPruneUpto(t *testing.T) {
 
 func TestPruneUpto_NoOp(t *testing.T) {
 	t.Run("empty database returns 0", func(t *testing.T) {
-		database := testutils.NewTestDB(t)
+		database := testutils.NewPebbleTestDB(t)
 		pruned, oldestKept, err := PruneUpto(t.Context(), database, 20, defaultTargetBatchByteSize)
 		require.NoError(t, err)
 		assert.Zero(t, pruned)
@@ -205,7 +205,7 @@ func TestPruneUpto_NoOp(t *testing.T) {
 	}
 	for _, tc := range cases {
 		t.Run(tc.name+" is a no-op", func(t *testing.T) {
-			database := testutils.NewTestDB(t)
+			database := testutils.NewPebbleTestDB(t)
 			blocks := make([]*testutils.StoredBlock, 30)
 			for i := tc.chainStart; i < 30; i++ {
 				blocks[i] = testutils.StoreBlock(t, database, i)
@@ -254,7 +254,7 @@ func TestPruneUpto_ResumeAfterMidwayCancel(t *testing.T) {
 	const endExclusive uint64 = 25
 	const cancelAfter = 10 // cancel after the 10th state-update Get
 
-	database := testutils.NewTestDB(t)
+	database := testutils.NewPebbleTestDB(t)
 	blocks := make([]*testutils.StoredBlock, totalBlocks)
 	for i := range totalBlocks {
 		blocks[i] = testutils.StoreBlock(t, database, i)
@@ -296,7 +296,7 @@ func TestPruneUpto_RollingCarveOut(t *testing.T) {
 	const totalBlocks uint64 = 40
 	lag := core.BlockHashLag
 
-	database := testutils.NewTestDB(t)
+	database := testutils.NewPebbleTestDB(t)
 	blocks := make([]*testutils.StoredBlock, totalBlocks)
 	for i := range totalBlocks {
 		blocks[i] = testutils.StoreBlock(t, database, i)
@@ -325,7 +325,7 @@ func TestPruneBlockDataUpto(t *testing.T) {
 	const endExclusive uint64 = 20
 	lag := core.BlockHashLag
 
-	database := testutils.NewTestDB(t)
+	database := testutils.NewPebbleTestDB(t)
 	for i := range totalBlocks {
 		testutils.StoreBlock(t, database, i)
 	}

--- a/pruner/accessors_test.go
+++ b/pruner/accessors_test.go
@@ -1,150 +1,19 @@
-package pruner
+package pruner_test
 
 import (
 	"context"
 	"testing"
 
 	"github.com/NethermindEth/juno/core"
-	"github.com/NethermindEth/juno/core/felt"
 	"github.com/NethermindEth/juno/db"
 	_ "github.com/NethermindEth/juno/encoder/registry"
+	"github.com/NethermindEth/juno/pruner"
 	"github.com/NethermindEth/juno/pruner/testutils"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
-func TestOldestRetainedBlock(t *testing.T) {
-	t.Run("empty database returns ErrKeyNotFound", func(t *testing.T) {
-		database := testutils.NewPebbleTestDB(t)
-
-		_, err := OldestRetainedBlock(database)
-		assert.ErrorIs(t, err, db.ErrKeyNotFound)
-	})
-
-	t.Run("returns lowest block number with commitments", func(t *testing.T) {
-		database := testutils.NewPebbleTestDB(t)
-
-		for i := uint64(5); i <= 7; i++ {
-			testutils.StoreBlock(t, database, i)
-		}
-
-		num, err := OldestRetainedBlock(database)
-		require.NoError(t, err)
-		assert.Equal(t, uint64(5), num)
-	})
-}
-
-func TestDeleteTransactionHashReverseLookups(t *testing.T) {
-	database := testutils.NewPebbleTestDB(t)
-
-	blocks := make([]*testutils.StoredBlock, 3)
-	for i := range uint64(3) {
-		blocks[i] = testutils.StoreBlock(t, database, i)
-	}
-
-	testutils.WithBatch(t, database, func(batch db.Batch) error {
-		return deleteTransactionHashReverseLookups(database, batch, 1)
-	})
-
-	// Block 1's tx hash reverse lookups (bucket 9) and L1 handler msg hash
-	// (bucket 24) should be gone.
-	for _, txHash := range blocks[1].TxHashes {
-		_, err := core.TransactionBlockNumbersAndIndicesByHashBucket.Get(
-			database,
-			(*felt.TransactionHash)(txHash),
-		)
-		assert.Error(t, err)
-	}
-	for _, msgHash := range blocks[1].L1HandlerMsgHashes {
-		_, err := core.GetL1HandlerTxnHashByMsgHash(database, msgHash)
-		assert.Error(t, err)
-	}
-
-	// Header hash → number lookup is *not* this function's responsibility,
-	// so it must still be present for block 1.
-	assert.True(t, testutils.BlockHeaderHashExists(database, blocks[1].Header.Hash))
-
-	// Neighbouring blocks must be untouched.
-	for _, b := range []*testutils.StoredBlock{blocks[0], blocks[2]} {
-		for _, txHash := range b.TxHashes {
-			_, err := core.TransactionBlockNumbersAndIndicesByHashBucket.Get(
-				database,
-				(*felt.TransactionHash)(txHash),
-			)
-			assert.NoError(t, err)
-		}
-		for _, msgHash := range b.L1HandlerMsgHashes {
-			_, err := core.GetL1HandlerTxnHashByMsgHash(database, msgHash)
-			assert.NoError(t, err)
-		}
-	}
-}
-
-func TestPruneAggregatedBloomFiltersUpto(t *testing.T) {
-	n := core.NumBlocksPerFilter
-
-	writeFilters := func(t *testing.T, database db.KeyValueWriter) {
-		t.Helper()
-		for i := range uint64(3) {
-			filter := core.NewAggregatedFilter(i * n)
-			require.NoError(t, core.WriteAggregatedBloomFilter(database, &filter))
-		}
-	}
-
-	bloomFilterExists := func(database db.KeyValueReader, from, to uint64) bool {
-		_, err := core.GetAggregatedBloomFilter(database, from, to)
-		return err == nil
-	}
-
-	t.Run("deletes filters fully below the boundary", func(t *testing.T) {
-		database := testutils.NewPebbleTestDB(t)
-		writeFilters(t, database)
-
-		testutils.WithBatch(t, database, func(batch db.Batch) error {
-			return pruneAggregatedBloomFiltersUpto(batch, 2*n)
-		})
-
-		assert.False(t, bloomFilterExists(database, 0, n-1))
-		assert.False(t, bloomFilterExists(database, n, 2*n-1))
-		assert.True(t, bloomFilterExists(database, 2*n, 3*n-1))
-	})
-
-	t.Run("partial range does not delete the containing filter", func(t *testing.T) {
-		database := testutils.NewPebbleTestDB(t)
-		writeFilters(t, database)
-
-		testutils.WithBatch(t, database, func(batch db.Batch) error {
-			return pruneAggregatedBloomFiltersUpto(batch, n/2)
-		})
-
-		assert.True(t, bloomFilterExists(database, 0, n-1))
-		assert.True(t, bloomFilterExists(database, n, 2*n-1))
-		assert.True(t, bloomFilterExists(database, 2*n, 3*n-1))
-	})
-
-	t.Run("rangeEndExclusive at filter boundary keeps that filter", func(t *testing.T) {
-		// rangeEndExclusive = n means filter [0, n-1] is fully below
-		// (to = n-1 < n) and filter [n, 2n-1] starts at n, so it's kept.
-		database := testutils.NewPebbleTestDB(t)
-		writeFilters(t, database)
-
-		testutils.WithBatch(t, database, func(batch db.Batch) error {
-			return pruneAggregatedBloomFiltersUpto(batch, n)
-		})
-
-		assert.False(t, bloomFilterExists(database, 0, n-1))
-		assert.True(t, bloomFilterExists(database, n, 2*n-1))
-		assert.True(t, bloomFilterExists(database, 2*n, 3*n-1))
-	})
-
-	t.Run("no-op when range below one filter span", func(t *testing.T) {
-		database := testutils.NewPebbleTestDB(t)
-
-		testutils.WithBatch(t, database, func(batch db.Batch) error {
-			return pruneAggregatedBloomFiltersUpto(batch, 0)
-		})
-	})
-}
+const testTargetBatchByteSize = 96 * db.Megabyte
 
 // TestPruneUpto verifies the complete prune lifecycle with realistic block
 // counts: what survives, what gets deleted, and the two intentional
@@ -172,11 +41,11 @@ func TestPruneUpto(t *testing.T) {
 	for i := range totalBlocks {
 		blocks[i] = testutils.StoreBlock(t, database, i)
 	}
-	pruned, oldestKept, err := PruneUpto(
+	pruned, oldestKept, err := pruner.PruneUpto(
 		t.Context(),
 		database,
 		endExclusive,
-		defaultTargetBatchByteSize,
+		testTargetBatchByteSize,
 	)
 	require.NoError(t, err)
 	assert.Equal(t, endExclusive, pruned)
@@ -188,7 +57,7 @@ func TestPruneUpto(t *testing.T) {
 func TestPruneUpto_NoOp(t *testing.T) {
 	t.Run("empty database returns 0", func(t *testing.T) {
 		database := testutils.NewPebbleTestDB(t)
-		pruned, oldestKept, err := PruneUpto(t.Context(), database, 20, defaultTargetBatchByteSize)
+		pruned, oldestKept, err := pruner.PruneUpto(t.Context(), database, 20, testTargetBatchByteSize)
 		require.NoError(t, err)
 		assert.Zero(t, pruned)
 		assert.Zero(t, oldestKept)
@@ -210,11 +79,11 @@ func TestPruneUpto_NoOp(t *testing.T) {
 			for i := tc.chainStart; i < 30; i++ {
 				blocks[i] = testutils.StoreBlock(t, database, i)
 			}
-			pruned, oldestKept, err := PruneUpto(
+			pruned, oldestKept, err := pruner.PruneUpto(
 				t.Context(),
 				database,
 				tc.endExclusive,
-				defaultTargetBatchByteSize,
+				testTargetBatchByteSize,
 			)
 			require.NoError(t, err)
 			assert.Zero(t, pruned)
@@ -263,14 +132,14 @@ func TestPruneUpto_ResumeAfterMidwayCancel(t *testing.T) {
 	ctx, cancel := context.WithCancel(t.Context())
 	wrapped := &cancelAfterGets{KeyValueStore: database, cancel: cancel, after: cancelAfter}
 
-	pruned1, oldestKept1, err := PruneUpto(ctx, wrapped, endExclusive, defaultTargetBatchByteSize)
+	pruned1, oldestKept1, err := pruner.PruneUpto(ctx, wrapped, endExclusive, testTargetBatchByteSize)
 	require.NoError(t, err)
 	require.Greater(t, pruned1, uint64(0), "first call should make progress before cancel")
 	require.Less(t, pruned1, endExclusive, "first call must not finish the full window")
 	assert.Equal(t, pruned1, oldestKept1, "oldestKept after partial prune == pruned (start was 0)")
 
-	pruned2, oldestKept2, err := PruneUpto(
-		t.Context(), database, endExclusive, defaultTargetBatchByteSize,
+	pruned2, oldestKept2, err := pruner.PruneUpto(
+		t.Context(), database, endExclusive, testTargetBatchByteSize,
 	)
 	require.NoError(t, err)
 	assert.Equal(t, endExclusive, oldestKept2)
@@ -303,14 +172,14 @@ func TestPruneUpto_RollingCarveOut(t *testing.T) {
 	}
 
 	// Call 1: prune up to 20.
-	pruned, oldestKept, err := PruneUpto(t.Context(), database, 20, defaultTargetBatchByteSize)
+	pruned, oldestKept, err := pruner.PruneUpto(t.Context(), database, 20, testTargetBatchByteSize)
 	require.NoError(t, err)
 	assert.Equal(t, uint64(20), pruned)
 	assert.Equal(t, uint64(20), oldestKept)
 	testutils.AssertPostPruneState(t, database, blocks, 20, lag)
 
 	// Call 2: prune up to 30. OldestRetainedBlock returns 20 now, so we prune 10 more.
-	pruned, oldestKept, err = PruneUpto(context.Background(), database, 30, defaultTargetBatchByteSize)
+	pruned, oldestKept, err = pruner.PruneUpto(t.Context(), database, 30, testTargetBatchByteSize)
 	require.NoError(t, err)
 	assert.Equal(t, uint64(10), pruned)
 	assert.Equal(t, uint64(30), oldestKept)
@@ -331,7 +200,7 @@ func TestPruneBlockDataUpto(t *testing.T) {
 	}
 
 	testutils.WithBatch(t, database, func(batch db.Batch) error {
-		return PruneBlockDataUpto(batch, endExclusive)
+		return pruner.PruneBlockDataUpto(batch, endExclusive)
 	})
 
 	// Headers below the lag floor: gone.

--- a/pruner/accessors_test.go
+++ b/pruner/accessors_test.go
@@ -1,0 +1,480 @@
+package pruner
+
+import (
+	"context"
+	"testing"
+
+	"github.com/NethermindEth/juno/core"
+	"github.com/NethermindEth/juno/core/felt"
+	"github.com/NethermindEth/juno/db"
+	_ "github.com/NethermindEth/juno/encoder/registry"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestEarliestBlockNumberByCommitments(t *testing.T) {
+	t.Run("empty database returns ErrKeyNotFound", func(t *testing.T) {
+		database := newTestDB(t)
+
+		_, err := earliestBlockNumberByCommitments(database)
+		assert.ErrorIs(t, err, db.ErrKeyNotFound)
+	})
+
+	t.Run("returns lowest block number with commitments", func(t *testing.T) {
+		database := newTestDB(t)
+
+		for i := uint64(5); i <= 7; i++ {
+			storeBlock(t, database, i)
+		}
+
+		num, err := earliestBlockNumberByCommitments(database)
+		require.NoError(t, err)
+		assert.Equal(t, uint64(5), num)
+	})
+}
+
+func TestDeleteTransactionHashReverseLookups(t *testing.T) {
+	database := newTestDB(t)
+
+	blocks := make([]*storedBlock, 3)
+	for i := range uint64(3) {
+		blocks[i] = storeBlock(t, database, i)
+	}
+
+	withBatch(t, database, func(batch db.Batch) error {
+		return deleteTransactionHashReverseLookups(database, batch, 1)
+	})
+
+	// Block 1's tx hash reverse lookups (bucket 9) and L1 handler msg hash
+	// (bucket 24) should be gone.
+	for _, txHash := range blocks[1].TxHashes {
+		_, err := core.TransactionBlockNumbersAndIndicesByHashBucket.Get(
+			database,
+			(*felt.TransactionHash)(txHash),
+		)
+		assert.Error(t, err)
+	}
+	for _, msgHash := range blocks[1].L1HandlerMsgHashes {
+		_, err := core.GetL1HandlerTxnHashByMsgHash(database, msgHash)
+		assert.Error(t, err)
+	}
+
+	// Header hash → number lookup is *not* this function's responsibility,
+	// so it must still be present for block 1.
+	assert.True(t, blockHeaderHashExists(database, blocks[1].Header.Hash))
+
+	// Neighbouring blocks must be untouched.
+	for _, b := range []*storedBlock{blocks[0], blocks[2]} {
+		for _, txHash := range b.TxHashes {
+			_, err := core.TransactionBlockNumbersAndIndicesByHashBucket.Get(
+				database,
+				(*felt.TransactionHash)(txHash),
+			)
+			assert.NoError(t, err)
+		}
+		for _, msgHash := range b.L1HandlerMsgHashes {
+			_, err := core.GetL1HandlerTxnHashByMsgHash(database, msgHash)
+			assert.NoError(t, err)
+		}
+	}
+}
+
+func TestPruneAggregatedBloomFiltersUpto(t *testing.T) {
+	n := core.NumBlocksPerFilter
+
+	writeFilters := func(t *testing.T, database db.KeyValueWriter) {
+		t.Helper()
+		for i := range uint64(3) {
+			filter := core.NewAggregatedFilter(i * n)
+			require.NoError(t, core.WriteAggregatedBloomFilter(database, &filter))
+		}
+	}
+
+	bloomFilterExists := func(database db.KeyValueReader, from, to uint64) bool {
+		_, err := core.GetAggregatedBloomFilter(database, from, to)
+		return err == nil
+	}
+
+	t.Run("deletes filters fully below the boundary", func(t *testing.T) {
+		database := newTestDB(t)
+		writeFilters(t, database)
+
+		withBatch(t, database, func(batch db.Batch) error {
+			return pruneAggregatedBloomFiltersUpto(batch, 2*n)
+		})
+
+		assert.False(t, bloomFilterExists(database, 0, n-1))
+		assert.False(t, bloomFilterExists(database, n, 2*n-1))
+		assert.True(t, bloomFilterExists(database, 2*n, 3*n-1))
+	})
+
+	t.Run("partial range does not delete the containing filter", func(t *testing.T) {
+		database := newTestDB(t)
+		writeFilters(t, database)
+
+		withBatch(t, database, func(batch db.Batch) error {
+			return pruneAggregatedBloomFiltersUpto(batch, n/2)
+		})
+
+		assert.True(t, bloomFilterExists(database, 0, n-1))
+		assert.True(t, bloomFilterExists(database, n, 2*n-1))
+		assert.True(t, bloomFilterExists(database, 2*n, 3*n-1))
+	})
+
+	t.Run("rangeEndExclusive at filter boundary keeps that filter", func(t *testing.T) {
+		// rangeEndExclusive = n means filter [0, n-1] is fully below
+		// (to = n-1 < n) and filter [n, 2n-1] starts at n, so it's kept.
+		database := newTestDB(t)
+		writeFilters(t, database)
+
+		withBatch(t, database, func(batch db.Batch) error {
+			return pruneAggregatedBloomFiltersUpto(batch, n)
+		})
+
+		assert.False(t, bloomFilterExists(database, 0, n-1))
+		assert.True(t, bloomFilterExists(database, n, 2*n-1))
+		assert.True(t, bloomFilterExists(database, 2*n, 3*n-1))
+	})
+
+	t.Run("no-op when range below one filter span", func(t *testing.T) {
+		database := newTestDB(t)
+
+		withBatch(t, database, func(batch db.Batch) error {
+			return pruneAggregatedBloomFiltersUpto(batch, 0)
+		})
+	})
+}
+
+// TestPruneUpto verifies the complete prune lifecycle with realistic block
+// counts: what survives, what gets deleted, and the two intentional
+// carve-outs (BlockHashLag headers and the single hash→number mapping at
+// endExclusive-1).
+//
+// Setup: 30 blocks (0..29). BlockHashLag = 10. Call PruneUpto(20).
+//
+// Expected after the call:
+//
+//	Blocks [0, 10):  fully pruned (below the lag floor).
+//	Blocks [10, 20): commitments / state updates / txs / tx-hash lookups /
+//	                 state history pruned. Headers KEPT (lag carve-out).
+//	                 Hash→number mapping KEPT only for block 19; pruned
+//	                 for blocks 10..18.
+//	Blocks [20, 30): untouched.
+func TestPruneUpto(t *testing.T) {
+	const totalBlocks uint64 = 30
+	const endExclusive uint64 = 20
+	lag := core.BlockHashLag
+	require.GreaterOrEqual(t, endExclusive, lag)
+
+	database := newTestDB(t)
+	blocks := make([]*storedBlock, totalBlocks)
+	for i := range totalBlocks {
+		blocks[i] = storeBlock(t, database, i)
+	}
+	pruned, oldestKept, err := PruneUpto(
+		t.Context(),
+		database,
+		endExclusive,
+		defaultTargetBatchByteSize,
+	)
+	require.NoError(t, err)
+	assert.Equal(t, endExclusive, pruned)
+	assert.Equal(t, endExclusive, oldestKept)
+
+	// Subtests below are read-only assertions on the shared post-prune state.
+
+	t.Run("blocks below the lag floor are completely gone", func(t *testing.T) {
+		for i := range endExclusive - lag {
+			assertBlockPruned(t, database, blocks[i])
+		}
+	})
+
+	t.Run("blocks in the lag window keep their header", func(t *testing.T) {
+		for i := endExclusive - lag; i < endExclusive; i++ { // 10..19
+			assert.True(t, blockHeaderExists(database, i),
+				"header at block %d must be kept (BlockHashLag carve-out)", i)
+		}
+	})
+
+	t.Run("blocks in the lag window have all non-header data deleted", func(t *testing.T) {
+		for i := endExclusive - lag; i < endExclusive; i++ { // 10..19
+			assert.False(t, blockCommitmentsExist(database, i),
+				"block %d commitments should be deleted", i)
+			assert.False(t, stateUpdateExists(database, i),
+				"block %d state update should be deleted", i)
+			assert.False(t, transactionsExist(database, i),
+				"block %d transactions should be deleted", i)
+			for j, txHash := range blocks[i].TxHashes {
+				_, err := core.TransactionBlockNumbersAndIndicesByHashBucket.Get(
+					database,
+					(*felt.TransactionHash)(txHash),
+				)
+				assert.Error(t, err, "block %d tx %d hash lookup should be deleted", i, j)
+			}
+			for _, msgHash := range blocks[i].L1HandlerMsgHashes {
+				_, err := core.GetL1HandlerTxnHashByMsgHash(database, msgHash)
+				assert.Error(t, err, "block %d L1 handler msg hash should be deleted", i)
+			}
+			assertStateHistoryPruned(t, database, i, blocks[i].StateUpdate)
+		}
+	})
+
+	t.Run("hash→number carve-out preserved at endExclusive-1 only", func(t *testing.T) {
+		for i := range endExclusive - 1 { // 0..18
+			assert.False(t, blockHeaderHashExists(database, blocks[i].Header.Hash),
+				"hash→number for block %d should be deleted", i)
+		}
+		assert.True(t, blockHeaderHashExists(database, blocks[endExclusive-1].Header.Hash))
+	})
+
+	t.Run("get_block_hash_syscall scenario", func(t *testing.T) {
+		// After the prune, oldestKept = endExclusive (no commitments below it).
+		// The syscall executes blocks in [endExclusive, endExclusive+lag) and
+		// for each, reads the header at (current - BlockHashLag), which lands
+		// somewhere in [endExclusive-lag, endExclusive). All those headers
+		// must be readable.
+		for i := endExclusive - lag; i < endExclusive; i++ {
+			h, err := core.GetBlockHeaderByNumber(database, i)
+			require.NoError(t, err, "syscall path: header at block %d must be readable", i)
+			assert.Equal(t, i, h.Number)
+		}
+	})
+
+	t.Run("StateAtBlockHash(oldestKept.parentHash) scenario", func(t *testing.T) {
+		// oldestKept after prune is endExclusive=20. Its parent is block 19,
+		// whose hash is blocks[19].Header.Hash. The chain must resolve:
+		// hash → number (carve-out) → header (lag carve-out).
+		parentHash := blocks[endExclusive-1].Header.Hash
+		header, err := core.GetBlockHeaderByHash(database, parentHash)
+		require.NoError(t, err)
+		assert.Equal(t, endExclusive-1, header.Number)
+	})
+
+	t.Run("blocks beyond endExclusive untouched", func(t *testing.T) {
+		for i := endExclusive; i < totalBlocks; i++ {
+			assertBlockExists(t, database, blocks[i])
+		}
+	})
+}
+
+func TestPruneUpto_NoOp(t *testing.T) {
+	t.Run("empty database returns 0", func(t *testing.T) {
+		database := newTestDB(t)
+		pruned, oldestKept, err := PruneUpto(t.Context(), database, 20, defaultTargetBatchByteSize)
+		require.NoError(t, err)
+		assert.Zero(t, pruned)
+		assert.Zero(t, oldestKept)
+	})
+
+	cases := []struct {
+		name           string
+		chainStart     uint64
+		endExclusive   uint64
+		wantOldestKept uint64
+	}{
+		{"endExclusive at oldestKept", 5, 5, 5},
+		{"endExclusive below oldestKept", 10, 5, 10},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name+" is a no-op", func(t *testing.T) {
+			database := newTestDB(t)
+			blocks := make([]*storedBlock, 30)
+			for i := tc.chainStart; i < 30; i++ {
+				blocks[i] = storeBlock(t, database, i)
+			}
+			pruned, oldestKept, err := PruneUpto(
+				t.Context(),
+				database,
+				tc.endExclusive,
+				defaultTargetBatchByteSize,
+			)
+			require.NoError(t, err)
+			assert.Zero(t, pruned)
+			assert.Equal(t, tc.wantOldestKept, oldestKept)
+			for i := tc.chainStart; i < 30; i++ {
+				assertBlockExists(t, database, blocks[i])
+			}
+		})
+	}
+}
+
+// cancelAfterGets wraps a KeyValueStore and cancels the supplied context
+// after the n-th Get call. pruneHashKeyedUpto issues exactly one Get per
+// loop iteration (core.GetStateUpdateByBlockNum), so this lets a test
+// stop the sweep at a precise block boundary.
+type cancelAfterGets struct {
+	db.KeyValueStore
+	cancel context.CancelFunc
+	after  int
+	count  int
+}
+
+func (c *cancelAfterGets) Get(key []byte, cb func([]byte) error) error {
+	c.count++
+	if c.count == c.after {
+		c.cancel()
+	}
+	return c.KeyValueStore.Get(key, cb)
+}
+
+// TestPruneUpto_ResumeAfterMidwayCancel verifies that cancelling PruneUpto
+// after some blocks have been processed and re-running picks up exactly
+// where the first call stopped — no block is processed twice, none is
+// skipped. Asserted by summing the per-call blocksPruned counts.
+func TestPruneUpto_ResumeAfterMidwayCancel(t *testing.T) {
+	const totalBlocks uint64 = 30
+	const endExclusive uint64 = 25
+	const cancelAfter = 10 // cancel after the 10th state-update Get
+
+	database := newTestDB(t)
+	blocks := make([]*storedBlock, totalBlocks)
+	for i := range totalBlocks {
+		blocks[i] = storeBlock(t, database, i)
+	}
+
+	ctx, cancel := context.WithCancel(t.Context())
+	wrapped := &cancelAfterGets{KeyValueStore: database, cancel: cancel, after: cancelAfter}
+
+	pruned1, oldestKept1, err := PruneUpto(ctx, wrapped, endExclusive, defaultTargetBatchByteSize)
+	require.NoError(t, err)
+	require.Greater(t, pruned1, uint64(0), "first call should make progress before cancel")
+	require.Less(t, pruned1, endExclusive, "first call must not finish the full window")
+	assert.Equal(t, pruned1, oldestKept1, "oldestKept after partial prune == pruned (start was 0)")
+
+	pruned2, oldestKept2, err := PruneUpto(
+		t.Context(), database, endExclusive, defaultTargetBatchByteSize,
+	)
+	require.NoError(t, err)
+	assert.Equal(t, endExclusive, oldestKept2)
+
+	assert.Equal(t, endExclusive, pruned1+pruned2,
+		"sum of blocks pruned across both calls must equal the full window — "+
+			"any duplicate or skipped block would break this invariant")
+
+	// End-state: blocks below the lag floor are gone, blocks ≥ endExclusive intact.
+	for i := range endExclusive - core.BlockHashLag {
+		assertBlockPruned(t, database, blocks[i])
+	}
+	for i := endExclusive; i < totalBlocks; i++ {
+		assertBlockExists(t, database, blocks[i])
+	}
+}
+
+// TestPruneUpto_RollingCarveOut verifies that across two consecutive
+// PruneUpto calls, the hash→number carve-out rolls forward correctly:
+// after each call exactly one extra mapping survives below oldestKept,
+// and the previous extra is cleaned up by the next call's start-1 sweep.
+func TestPruneUpto_RollingCarveOut(t *testing.T) {
+	const totalBlocks uint64 = 40
+	lag := core.BlockHashLag
+
+	database := newTestDB(t)
+	blocks := make([]*storedBlock, totalBlocks)
+	for i := range totalBlocks {
+		blocks[i] = storeBlock(t, database, i)
+	}
+
+	// Call 1: prune up to 20.
+	pruned, oldestKept, err := PruneUpto(t.Context(), database, 20, defaultTargetBatchByteSize)
+	require.NoError(t, err)
+	assert.Equal(t, uint64(20), pruned)
+	assert.Equal(t, uint64(20), oldestKept)
+
+	// After call 1: only block 19 keeps its hash→number mapping.
+	for i := range uint64(19) {
+		assert.False(t, blockHeaderHashExists(database, blocks[i].Header.Hash),
+			"after call 1: hash→number for block %d should be gone", i)
+	}
+	assert.True(t, blockHeaderHashExists(database, blocks[19].Header.Hash),
+		"after call 1: block 19's hash→number is the carve-out")
+	// And lag headers [10, 20) are kept.
+	for i := uint64(20) - lag; i < 20; i++ {
+		assert.True(t, blockHeaderExists(database, i),
+			"after call 1: header at block %d should be in the lag window", i)
+	}
+
+	// Call 2: prune up to 30.
+	pruned, oldestKept, err = PruneUpto(context.Background(), database, 30, defaultTargetBatchByteSize)
+	require.NoError(t, err)
+	// earliestBlockNumberByCommitments returns 20 now, so we prune 10 more.
+	assert.Equal(t, uint64(10), pruned)
+	assert.Equal(t, uint64(30), oldestKept)
+
+	// After call 2: block 19's mapping has been swept by the start-1 cleanup.
+	assert.False(t, blockHeaderHashExists(database, blocks[19].Header.Hash),
+		"after call 2: block 19's mapping should have been cleaned up")
+	for i := uint64(20); i < 29; i++ {
+		assert.False(t, blockHeaderHashExists(database, blocks[i].Header.Hash),
+			"after call 2: hash→number for block %d should be gone", i)
+	}
+	assert.True(t, blockHeaderHashExists(database, blocks[29].Header.Hash),
+		"after call 2: block 29's hash→number is the new carve-out")
+
+	// Header lag has rolled forward to [20, 30); the previous lag window
+	// [10, 20) is now fully gone.
+	for i := uint64(10); i < 20; i++ {
+		assert.False(t, blockHeaderExists(database, i),
+			"after call 2: header at block %d should be pruned (no longer in lag)", i)
+	}
+	for i := uint64(30) - lag; i < 30; i++ {
+		assert.True(t, blockHeaderExists(database, i),
+			"after call 2: header at block %d should be in the new lag window", i)
+	}
+
+	// Blocks beyond endExclusive still intact.
+	for i := uint64(30); i < totalBlocks; i++ {
+		assertBlockExists(t, database, blocks[i])
+	}
+}
+
+// TestPruneBlockDataUpto exercises the range-tombstone half on its own,
+// confirming the BlockHashLag carve-out for headers without the per-block
+// hash-keyed work that PruneUpto wraps around it.
+func TestPruneBlockDataUpto(t *testing.T) {
+	const totalBlocks uint64 = 30
+	const endExclusive uint64 = 20
+	lag := core.BlockHashLag
+
+	database := newTestDB(t)
+	for i := range totalBlocks {
+		storeBlock(t, database, i)
+	}
+
+	withBatch(t, database, func(batch db.Batch) error {
+		return PruneBlockDataUpto(batch, endExclusive)
+	})
+
+	// Headers below the lag floor: gone.
+	for i := range endExclusive - lag {
+		assert.False(t, blockHeaderExists(database, i),
+			"header at block %d should be deleted", i)
+	}
+	// Headers in the lag window: kept.
+	for i := endExclusive - lag; i < endExclusive; i++ {
+		assert.True(t, blockHeaderExists(database, i),
+			"header at block %d should be kept (lag carve-out)", i)
+	}
+	// Headers beyond endExclusive: untouched.
+	for i := endExclusive; i < totalBlocks; i++ {
+		assert.True(t, blockHeaderExists(database, i),
+			"header at block %d should be untouched", i)
+	}
+
+	// Number-keyed buckets without a lag: deleted across the full window.
+	for i := range endExclusive {
+		assert.False(t, blockCommitmentsExist(database, i),
+			"commitments at block %d should be deleted", i)
+		assert.False(t, stateUpdateExists(database, i),
+			"state update at block %d should be deleted", i)
+		assert.False(t, transactionsExist(database, i),
+			"transactions at block %d should be deleted", i)
+	}
+	for i := endExclusive; i < totalBlocks; i++ {
+		assert.True(t, blockCommitmentsExist(database, i),
+			"commitments at block %d should be untouched", i)
+		assert.True(t, stateUpdateExists(database, i),
+			"state update at block %d should be untouched", i)
+		assert.True(t, transactionsExist(database, i),
+			"transactions at block %d should be untouched", i)
+	}
+}

--- a/pruner/accessors_test.go
+++ b/pruner/accessors_test.go
@@ -307,52 +307,14 @@ func TestPruneUpto_RollingCarveOut(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, uint64(20), pruned)
 	assert.Equal(t, uint64(20), oldestKept)
+	testutils.AssertPostPruneState(t, database, blocks, 20, lag)
 
-	// After call 1: only block 19 keeps its hash→number mapping.
-	for i := range uint64(19) {
-		assert.False(t, testutils.BlockHeaderHashExists(database, blocks[i].Header.Hash),
-			"after call 1: hash→number for block %d should be gone", i)
-	}
-	assert.True(t, testutils.BlockHeaderHashExists(database, blocks[19].Header.Hash),
-		"after call 1: block 19's hash→number is the carve-out")
-	// And lag headers [10, 20) are kept.
-	for i := uint64(20) - lag; i < 20; i++ {
-		assert.True(t, testutils.BlockHeaderExists(database, i),
-			"after call 1: header at block %d should be in the lag window", i)
-	}
-
-	// Call 2: prune up to 30.
+	// Call 2: prune up to 30. OldestRetainedBlock returns 20 now, so we prune 10 more.
 	pruned, oldestKept, err = PruneUpto(context.Background(), database, 30, defaultTargetBatchByteSize)
 	require.NoError(t, err)
-	// OldestRetainedBlock returns 20 now, so we prune 10 more.
 	assert.Equal(t, uint64(10), pruned)
 	assert.Equal(t, uint64(30), oldestKept)
-
-	// After call 2: block 19's mapping has been swept by the start-1 cleanup.
-	assert.False(t, testutils.BlockHeaderHashExists(database, blocks[19].Header.Hash),
-		"after call 2: block 19's mapping should have been cleaned up")
-	for i := uint64(20); i < 29; i++ {
-		assert.False(t, testutils.BlockHeaderHashExists(database, blocks[i].Header.Hash),
-			"after call 2: hash→number for block %d should be gone", i)
-	}
-	assert.True(t, testutils.BlockHeaderHashExists(database, blocks[29].Header.Hash),
-		"after call 2: block 29's hash→number is the new carve-out")
-
-	// Header lag has rolled forward to [20, 30); the previous lag window
-	// [10, 20) is now fully gone.
-	for i := uint64(10); i < 20; i++ {
-		assert.False(t, testutils.BlockHeaderExists(database, i),
-			"after call 2: header at block %d should be pruned (no longer in lag)", i)
-	}
-	for i := uint64(30) - lag; i < 30; i++ {
-		assert.True(t, testutils.BlockHeaderExists(database, i),
-			"after call 2: header at block %d should be in the new lag window", i)
-	}
-
-	// Blocks beyond endExclusive still intact.
-	for i := uint64(30); i < totalBlocks; i++ {
-		testutils.AssertBlockExists(t, database, blocks[i])
-	}
+	testutils.AssertPostPruneState(t, database, blocks, 30, lag)
 }
 
 // TestPruneBlockDataUpto exercises the range-tombstone half on its own,

--- a/pruner/accessors_test.go
+++ b/pruner/accessors_test.go
@@ -12,11 +12,11 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestEarliestBlockNumberByCommitments(t *testing.T) {
+func TestOldestRetainedBlock(t *testing.T) {
 	t.Run("empty database returns ErrKeyNotFound", func(t *testing.T) {
 		database := newTestDB(t)
 
-		_, err := earliestBlockNumberByCommitments(database)
+		_, err := OldestRetainedBlock(database)
 		assert.ErrorIs(t, err, db.ErrKeyNotFound)
 	})
 
@@ -27,7 +27,7 @@ func TestEarliestBlockNumberByCommitments(t *testing.T) {
 			storeBlock(t, database, i)
 		}
 
-		num, err := earliestBlockNumberByCommitments(database)
+		num, err := OldestRetainedBlock(database)
 		require.NoError(t, err)
 		assert.Equal(t, uint64(5), num)
 	})
@@ -396,7 +396,7 @@ func TestPruneUpto_RollingCarveOut(t *testing.T) {
 	// Call 2: prune up to 30.
 	pruned, oldestKept, err = PruneUpto(context.Background(), database, 30, defaultTargetBatchByteSize)
 	require.NoError(t, err)
-	// earliestBlockNumberByCommitments returns 20 now, so we prune 10 more.
+	// OldestRetainedBlock returns 20 now, so we prune 10 more.
 	assert.Equal(t, uint64(10), pruned)
 	assert.Equal(t, uint64(30), oldestKept)
 

--- a/pruner/accessors_test.go
+++ b/pruner/accessors_test.go
@@ -8,23 +8,24 @@ import (
 	"github.com/NethermindEth/juno/core/felt"
 	"github.com/NethermindEth/juno/db"
 	_ "github.com/NethermindEth/juno/encoder/registry"
+	"github.com/NethermindEth/juno/pruner/testutils"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
 func TestOldestRetainedBlock(t *testing.T) {
 	t.Run("empty database returns ErrKeyNotFound", func(t *testing.T) {
-		database := newTestDB(t)
+		database := testutils.NewTestDB(t)
 
 		_, err := OldestRetainedBlock(database)
 		assert.ErrorIs(t, err, db.ErrKeyNotFound)
 	})
 
 	t.Run("returns lowest block number with commitments", func(t *testing.T) {
-		database := newTestDB(t)
+		database := testutils.NewTestDB(t)
 
 		for i := uint64(5); i <= 7; i++ {
-			storeBlock(t, database, i)
+			testutils.StoreBlock(t, database, i)
 		}
 
 		num, err := OldestRetainedBlock(database)
@@ -34,14 +35,14 @@ func TestOldestRetainedBlock(t *testing.T) {
 }
 
 func TestDeleteTransactionHashReverseLookups(t *testing.T) {
-	database := newTestDB(t)
+	database := testutils.NewTestDB(t)
 
-	blocks := make([]*storedBlock, 3)
+	blocks := make([]*testutils.StoredBlock, 3)
 	for i := range uint64(3) {
-		blocks[i] = storeBlock(t, database, i)
+		blocks[i] = testutils.StoreBlock(t, database, i)
 	}
 
-	withBatch(t, database, func(batch db.Batch) error {
+	testutils.WithBatch(t, database, func(batch db.Batch) error {
 		return deleteTransactionHashReverseLookups(database, batch, 1)
 	})
 
@@ -61,10 +62,10 @@ func TestDeleteTransactionHashReverseLookups(t *testing.T) {
 
 	// Header hash → number lookup is *not* this function's responsibility,
 	// so it must still be present for block 1.
-	assert.True(t, blockHeaderHashExists(database, blocks[1].Header.Hash))
+	assert.True(t, testutils.BlockHeaderHashExists(database, blocks[1].Header.Hash))
 
 	// Neighbouring blocks must be untouched.
-	for _, b := range []*storedBlock{blocks[0], blocks[2]} {
+	for _, b := range []*testutils.StoredBlock{blocks[0], blocks[2]} {
 		for _, txHash := range b.TxHashes {
 			_, err := core.TransactionBlockNumbersAndIndicesByHashBucket.Get(
 				database,
@@ -96,10 +97,10 @@ func TestPruneAggregatedBloomFiltersUpto(t *testing.T) {
 	}
 
 	t.Run("deletes filters fully below the boundary", func(t *testing.T) {
-		database := newTestDB(t)
+		database := testutils.NewTestDB(t)
 		writeFilters(t, database)
 
-		withBatch(t, database, func(batch db.Batch) error {
+		testutils.WithBatch(t, database, func(batch db.Batch) error {
 			return pruneAggregatedBloomFiltersUpto(batch, 2*n)
 		})
 
@@ -109,10 +110,10 @@ func TestPruneAggregatedBloomFiltersUpto(t *testing.T) {
 	})
 
 	t.Run("partial range does not delete the containing filter", func(t *testing.T) {
-		database := newTestDB(t)
+		database := testutils.NewTestDB(t)
 		writeFilters(t, database)
 
-		withBatch(t, database, func(batch db.Batch) error {
+		testutils.WithBatch(t, database, func(batch db.Batch) error {
 			return pruneAggregatedBloomFiltersUpto(batch, n/2)
 		})
 
@@ -124,10 +125,10 @@ func TestPruneAggregatedBloomFiltersUpto(t *testing.T) {
 	t.Run("rangeEndExclusive at filter boundary keeps that filter", func(t *testing.T) {
 		// rangeEndExclusive = n means filter [0, n-1] is fully below
 		// (to = n-1 < n) and filter [n, 2n-1] starts at n, so it's kept.
-		database := newTestDB(t)
+		database := testutils.NewTestDB(t)
 		writeFilters(t, database)
 
-		withBatch(t, database, func(batch db.Batch) error {
+		testutils.WithBatch(t, database, func(batch db.Batch) error {
 			return pruneAggregatedBloomFiltersUpto(batch, n)
 		})
 
@@ -137,9 +138,9 @@ func TestPruneAggregatedBloomFiltersUpto(t *testing.T) {
 	})
 
 	t.Run("no-op when range below one filter span", func(t *testing.T) {
-		database := newTestDB(t)
+		database := testutils.NewTestDB(t)
 
-		withBatch(t, database, func(batch db.Batch) error {
+		testutils.WithBatch(t, database, func(batch db.Batch) error {
 			return pruneAggregatedBloomFiltersUpto(batch, 0)
 		})
 	})
@@ -166,10 +167,10 @@ func TestPruneUpto(t *testing.T) {
 	lag := core.BlockHashLag
 	require.GreaterOrEqual(t, endExclusive, lag)
 
-	database := newTestDB(t)
-	blocks := make([]*storedBlock, totalBlocks)
+	database := testutils.NewTestDB(t)
+	blocks := make([]*testutils.StoredBlock, totalBlocks)
 	for i := range totalBlocks {
-		blocks[i] = storeBlock(t, database, i)
+		blocks[i] = testutils.StoreBlock(t, database, i)
 	}
 	pruned, oldestKept, err := PruneUpto(
 		t.Context(),
@@ -181,85 +182,12 @@ func TestPruneUpto(t *testing.T) {
 	assert.Equal(t, endExclusive, pruned)
 	assert.Equal(t, endExclusive, oldestKept)
 
-	// Subtests below are read-only assertions on the shared post-prune state.
-
-	t.Run("blocks below the lag floor are completely gone", func(t *testing.T) {
-		for i := range endExclusive - lag {
-			assertBlockPruned(t, database, blocks[i])
-		}
-	})
-
-	t.Run("blocks in the lag window keep their header", func(t *testing.T) {
-		for i := endExclusive - lag; i < endExclusive; i++ { // 10..19
-			assert.True(t, blockHeaderExists(database, i),
-				"header at block %d must be kept (BlockHashLag carve-out)", i)
-		}
-	})
-
-	t.Run("blocks in the lag window have all non-header data deleted", func(t *testing.T) {
-		for i := endExclusive - lag; i < endExclusive; i++ { // 10..19
-			assert.False(t, blockCommitmentsExist(database, i),
-				"block %d commitments should be deleted", i)
-			assert.False(t, stateUpdateExists(database, i),
-				"block %d state update should be deleted", i)
-			assert.False(t, transactionsExist(database, i),
-				"block %d transactions should be deleted", i)
-			for j, txHash := range blocks[i].TxHashes {
-				_, err := core.TransactionBlockNumbersAndIndicesByHashBucket.Get(
-					database,
-					(*felt.TransactionHash)(txHash),
-				)
-				assert.Error(t, err, "block %d tx %d hash lookup should be deleted", i, j)
-			}
-			for _, msgHash := range blocks[i].L1HandlerMsgHashes {
-				_, err := core.GetL1HandlerTxnHashByMsgHash(database, msgHash)
-				assert.Error(t, err, "block %d L1 handler msg hash should be deleted", i)
-			}
-			assertStateHistoryPruned(t, database, i, blocks[i].StateUpdate)
-		}
-	})
-
-	t.Run("hash→number carve-out preserved at endExclusive-1 only", func(t *testing.T) {
-		for i := range endExclusive - 1 { // 0..18
-			assert.False(t, blockHeaderHashExists(database, blocks[i].Header.Hash),
-				"hash→number for block %d should be deleted", i)
-		}
-		assert.True(t, blockHeaderHashExists(database, blocks[endExclusive-1].Header.Hash))
-	})
-
-	t.Run("get_block_hash_syscall scenario", func(t *testing.T) {
-		// After the prune, oldestKept = endExclusive (no commitments below it).
-		// The syscall executes blocks in [endExclusive, endExclusive+lag) and
-		// for each, reads the header at (current - BlockHashLag), which lands
-		// somewhere in [endExclusive-lag, endExclusive). All those headers
-		// must be readable.
-		for i := endExclusive - lag; i < endExclusive; i++ {
-			h, err := core.GetBlockHeaderByNumber(database, i)
-			require.NoError(t, err, "syscall path: header at block %d must be readable", i)
-			assert.Equal(t, i, h.Number)
-		}
-	})
-
-	t.Run("StateAtBlockHash(oldestKept.parentHash) scenario", func(t *testing.T) {
-		// oldestKept after prune is endExclusive=20. Its parent is block 19,
-		// whose hash is blocks[19].Header.Hash. The chain must resolve:
-		// hash → number (carve-out) → header (lag carve-out).
-		parentHash := blocks[endExclusive-1].Header.Hash
-		header, err := core.GetBlockHeaderByHash(database, parentHash)
-		require.NoError(t, err)
-		assert.Equal(t, endExclusive-1, header.Number)
-	})
-
-	t.Run("blocks beyond endExclusive untouched", func(t *testing.T) {
-		for i := endExclusive; i < totalBlocks; i++ {
-			assertBlockExists(t, database, blocks[i])
-		}
-	})
+	testutils.AssertPostPruneState(t, database, blocks, endExclusive, lag)
 }
 
 func TestPruneUpto_NoOp(t *testing.T) {
 	t.Run("empty database returns 0", func(t *testing.T) {
-		database := newTestDB(t)
+		database := testutils.NewTestDB(t)
 		pruned, oldestKept, err := PruneUpto(t.Context(), database, 20, defaultTargetBatchByteSize)
 		require.NoError(t, err)
 		assert.Zero(t, pruned)
@@ -277,10 +205,10 @@ func TestPruneUpto_NoOp(t *testing.T) {
 	}
 	for _, tc := range cases {
 		t.Run(tc.name+" is a no-op", func(t *testing.T) {
-			database := newTestDB(t)
-			blocks := make([]*storedBlock, 30)
+			database := testutils.NewTestDB(t)
+			blocks := make([]*testutils.StoredBlock, 30)
 			for i := tc.chainStart; i < 30; i++ {
-				blocks[i] = storeBlock(t, database, i)
+				blocks[i] = testutils.StoreBlock(t, database, i)
 			}
 			pruned, oldestKept, err := PruneUpto(
 				t.Context(),
@@ -292,7 +220,7 @@ func TestPruneUpto_NoOp(t *testing.T) {
 			assert.Zero(t, pruned)
 			assert.Equal(t, tc.wantOldestKept, oldestKept)
 			for i := tc.chainStart; i < 30; i++ {
-				assertBlockExists(t, database, blocks[i])
+				testutils.AssertBlockExists(t, database, blocks[i])
 			}
 		})
 	}
@@ -326,10 +254,10 @@ func TestPruneUpto_ResumeAfterMidwayCancel(t *testing.T) {
 	const endExclusive uint64 = 25
 	const cancelAfter = 10 // cancel after the 10th state-update Get
 
-	database := newTestDB(t)
-	blocks := make([]*storedBlock, totalBlocks)
+	database := testutils.NewTestDB(t)
+	blocks := make([]*testutils.StoredBlock, totalBlocks)
 	for i := range totalBlocks {
-		blocks[i] = storeBlock(t, database, i)
+		blocks[i] = testutils.StoreBlock(t, database, i)
 	}
 
 	ctx, cancel := context.WithCancel(t.Context())
@@ -353,10 +281,10 @@ func TestPruneUpto_ResumeAfterMidwayCancel(t *testing.T) {
 
 	// End-state: blocks below the lag floor are gone, blocks ≥ endExclusive intact.
 	for i := range endExclusive - core.BlockHashLag {
-		assertBlockPruned(t, database, blocks[i])
+		testutils.AssertBlockPruned(t, database, blocks[i])
 	}
 	for i := endExclusive; i < totalBlocks; i++ {
-		assertBlockExists(t, database, blocks[i])
+		testutils.AssertBlockExists(t, database, blocks[i])
 	}
 }
 
@@ -368,10 +296,10 @@ func TestPruneUpto_RollingCarveOut(t *testing.T) {
 	const totalBlocks uint64 = 40
 	lag := core.BlockHashLag
 
-	database := newTestDB(t)
-	blocks := make([]*storedBlock, totalBlocks)
+	database := testutils.NewTestDB(t)
+	blocks := make([]*testutils.StoredBlock, totalBlocks)
 	for i := range totalBlocks {
-		blocks[i] = storeBlock(t, database, i)
+		blocks[i] = testutils.StoreBlock(t, database, i)
 	}
 
 	// Call 1: prune up to 20.
@@ -382,14 +310,14 @@ func TestPruneUpto_RollingCarveOut(t *testing.T) {
 
 	// After call 1: only block 19 keeps its hash→number mapping.
 	for i := range uint64(19) {
-		assert.False(t, blockHeaderHashExists(database, blocks[i].Header.Hash),
+		assert.False(t, testutils.BlockHeaderHashExists(database, blocks[i].Header.Hash),
 			"after call 1: hash→number for block %d should be gone", i)
 	}
-	assert.True(t, blockHeaderHashExists(database, blocks[19].Header.Hash),
+	assert.True(t, testutils.BlockHeaderHashExists(database, blocks[19].Header.Hash),
 		"after call 1: block 19's hash→number is the carve-out")
 	// And lag headers [10, 20) are kept.
 	for i := uint64(20) - lag; i < 20; i++ {
-		assert.True(t, blockHeaderExists(database, i),
+		assert.True(t, testutils.BlockHeaderExists(database, i),
 			"after call 1: header at block %d should be in the lag window", i)
 	}
 
@@ -401,29 +329,29 @@ func TestPruneUpto_RollingCarveOut(t *testing.T) {
 	assert.Equal(t, uint64(30), oldestKept)
 
 	// After call 2: block 19's mapping has been swept by the start-1 cleanup.
-	assert.False(t, blockHeaderHashExists(database, blocks[19].Header.Hash),
+	assert.False(t, testutils.BlockHeaderHashExists(database, blocks[19].Header.Hash),
 		"after call 2: block 19's mapping should have been cleaned up")
 	for i := uint64(20); i < 29; i++ {
-		assert.False(t, blockHeaderHashExists(database, blocks[i].Header.Hash),
+		assert.False(t, testutils.BlockHeaderHashExists(database, blocks[i].Header.Hash),
 			"after call 2: hash→number for block %d should be gone", i)
 	}
-	assert.True(t, blockHeaderHashExists(database, blocks[29].Header.Hash),
+	assert.True(t, testutils.BlockHeaderHashExists(database, blocks[29].Header.Hash),
 		"after call 2: block 29's hash→number is the new carve-out")
 
 	// Header lag has rolled forward to [20, 30); the previous lag window
 	// [10, 20) is now fully gone.
 	for i := uint64(10); i < 20; i++ {
-		assert.False(t, blockHeaderExists(database, i),
+		assert.False(t, testutils.BlockHeaderExists(database, i),
 			"after call 2: header at block %d should be pruned (no longer in lag)", i)
 	}
 	for i := uint64(30) - lag; i < 30; i++ {
-		assert.True(t, blockHeaderExists(database, i),
+		assert.True(t, testutils.BlockHeaderExists(database, i),
 			"after call 2: header at block %d should be in the new lag window", i)
 	}
 
 	// Blocks beyond endExclusive still intact.
 	for i := uint64(30); i < totalBlocks; i++ {
-		assertBlockExists(t, database, blocks[i])
+		testutils.AssertBlockExists(t, database, blocks[i])
 	}
 }
 
@@ -435,46 +363,46 @@ func TestPruneBlockDataUpto(t *testing.T) {
 	const endExclusive uint64 = 20
 	lag := core.BlockHashLag
 
-	database := newTestDB(t)
+	database := testutils.NewTestDB(t)
 	for i := range totalBlocks {
-		storeBlock(t, database, i)
+		testutils.StoreBlock(t, database, i)
 	}
 
-	withBatch(t, database, func(batch db.Batch) error {
+	testutils.WithBatch(t, database, func(batch db.Batch) error {
 		return PruneBlockDataUpto(batch, endExclusive)
 	})
 
 	// Headers below the lag floor: gone.
 	for i := range endExclusive - lag {
-		assert.False(t, blockHeaderExists(database, i),
+		assert.False(t, testutils.BlockHeaderExists(database, i),
 			"header at block %d should be deleted", i)
 	}
 	// Headers in the lag window: kept.
 	for i := endExclusive - lag; i < endExclusive; i++ {
-		assert.True(t, blockHeaderExists(database, i),
+		assert.True(t, testutils.BlockHeaderExists(database, i),
 			"header at block %d should be kept (lag carve-out)", i)
 	}
 	// Headers beyond endExclusive: untouched.
 	for i := endExclusive; i < totalBlocks; i++ {
-		assert.True(t, blockHeaderExists(database, i),
+		assert.True(t, testutils.BlockHeaderExists(database, i),
 			"header at block %d should be untouched", i)
 	}
 
 	// Number-keyed buckets without a lag: deleted across the full window.
 	for i := range endExclusive {
-		assert.False(t, blockCommitmentsExist(database, i),
+		assert.False(t, testutils.BlockCommitmentsExist(database, i),
 			"commitments at block %d should be deleted", i)
-		assert.False(t, stateUpdateExists(database, i),
+		assert.False(t, testutils.StateUpdateExists(database, i),
 			"state update at block %d should be deleted", i)
-		assert.False(t, transactionsExist(database, i),
+		assert.False(t, testutils.TransactionsExist(database, i),
 			"transactions at block %d should be deleted", i)
 	}
 	for i := endExclusive; i < totalBlocks; i++ {
-		assert.True(t, blockCommitmentsExist(database, i),
+		assert.True(t, testutils.BlockCommitmentsExist(database, i),
 			"commitments at block %d should be untouched", i)
-		assert.True(t, stateUpdateExists(database, i),
+		assert.True(t, testutils.StateUpdateExists(database, i),
 			"state update at block %d should be untouched", i)
-		assert.True(t, transactionsExist(database, i),
+		assert.True(t, testutils.TransactionsExist(database, i),
 			"transactions at block %d should be untouched", i)
 	}
 }

--- a/pruner/event_listener.go
+++ b/pruner/event_listener.go
@@ -1,0 +1,29 @@
+package pruner
+
+import "time"
+
+type EventListener interface {
+	OnPrune(oldestBlockKept uint64, blocksPruned uint64, took time.Duration)
+	OnPruneError(err error)
+}
+
+type SelectiveListener struct {
+	OnPruneCb      func(oldestBlockKept uint64, blocksPruned uint64, took time.Duration)
+	OnPruneErrorCb func(err error)
+}
+
+func (l *SelectiveListener) OnPrune(
+	oldestBlockKept uint64,
+	blocksPruned uint64,
+	took time.Duration,
+) {
+	if l.OnPruneCb != nil {
+		l.OnPruneCb(oldestBlockKept, blocksPruned, took)
+	}
+}
+
+func (l *SelectiveListener) OnPruneError(err error) {
+	if l.OnPruneErrorCb != nil {
+		l.OnPruneErrorCb(err)
+	}
+}

--- a/pruner/pruner.go
+++ b/pruner/pruner.go
@@ -1,0 +1,220 @@
+// Package pruner implements a background service that bounds on-disk storage
+// by deleting block data older than a configurable retention window.
+//
+// The retention floor is always anchored on the latest L1-confirmed head:
+// the pruner keeps blocks in (l1Head - numRetainedBlocks, l2Head] and
+// range-deletes everything below. Anchoring the floor on L1 — never on the
+// local L2 head — guarantees pruned blocks are reorg-safe, since blocks at
+// or below the L1-confirmed height cannot be reorged. The upper bound is
+// the L2 head simply because that is the highest block the node has.
+//
+// The Pruner runs as a [service.Service]. It listens to two trigger feeds —
+// new L2 heads and new L1 heads — to know when to re-evaluate the floor;
+// the events themselves are only triggers, the retention bound is always
+// recomputed from the L1 head.
+package pruner
+
+import (
+	"context"
+	"time"
+
+	"github.com/NethermindEth/juno/core"
+	"github.com/NethermindEth/juno/db"
+	"github.com/NethermindEth/juno/feed"
+	"github.com/NethermindEth/juno/service"
+	"github.com/NethermindEth/juno/utils/log"
+	"go.uber.org/zap"
+)
+
+var _ service.Service = (*Pruner)(nil)
+
+// defaultTargetBatchByteSize is the soft upper bound on accumulated batch
+// bytes during a [PruneRange] sweep before the batch is flushed and a fresh
+// one is started.
+const defaultTargetBatchByteSize = 96 * db.Megabyte
+
+// defaultL2HeadsPerPrune is how many L2 head events the L2 path coalesces
+// before triggering a prune, so per-block deletes don't pile up tombstones
+// during catch-up. Override via [WithL2HeadsPerPrune]. The L1-driven path
+// resets the counter once it prunes, since its sweep from earliestPresent
+// covers any leftover coalesced events.
+const defaultL2HeadsPerPrune uint64 = 128
+
+// Pruner deletes block data older than a retention window in response to
+// new-head events. Construct via [New]; do not zero-value.
+type Pruner struct {
+	// numRetainedBlocks is the size of the retention window. The retention
+	// floor (the lowest block we keep) is l1Head - numRetainedBlocks + 1,
+	// so the pruner keeps blocks in (l1Head - numRetainedBlocks, l2Head]
+	// and deletes everything below. Anchoring the floor on L1 (not on the
+	// local L2 head) guarantees pruned blocks cannot be reorged.
+	numRetainedBlocks uint64
+	// pendingL2Heads counts how many L2 head events have advanced past the
+	// retention floor since the last actual prune. Only touched from Run's
+	// dispatch loop, so no synchronization needed.
+	pendingL2Heads uint64
+	// targetBatchByteSize is the flush threshold inside [PruneRange]'s
+	// per-block loop. See [DefaultTargetBatchByteSize].
+	targetBatchByteSize int
+	// l2HeadsPerPrune is how many L2 head events the L2 path coalesces
+	// before triggering a prune. See [defaultL2HeadsPerPrune].
+	l2HeadsPerPrune uint64
+	database        db.KeyValueStore
+	// newHeadSub fires on each new L2 head; the event acts only as a
+	// trigger to re-run the retention check. The retention floor itself is
+	// always recomputed from the L1 head, never from this event's block.
+	newHeadSub *feed.Subscription[*core.Block]
+	// l1HeadSub fires on each new L1 head. L1 advances are what actually
+	// move the retention floor, since the floor is always anchored on the
+	// latest L1-confirmed height.
+	l1HeadSub *feed.Subscription[*core.L1Head]
+	listener  EventListener
+	logger    log.StructuredLogger
+}
+
+type options struct {
+	targetBatchByteSize int
+	l2HeadsPerPrune     uint64
+	listener            EventListener
+}
+
+type Option func(*options)
+
+func WithListener(listener EventListener) Option {
+	return func(o *options) {
+		o.listener = listener
+	}
+}
+
+func WithTargetBatchByteSize(size int) Option {
+	return func(o *options) {
+		o.targetBatchByteSize = size
+	}
+}
+
+// WithL2HeadsPerPrune overrides how many L2 head events the L2 path
+// coalesces before triggering a prune. See [defaultL2HeadsPerPrune].
+func WithL2HeadsPerPrune(n uint64) Option {
+	return func(o *options) {
+		o.l2HeadsPerPrune = n
+	}
+}
+
+// New constructs a Pruner. retainedBlocks sets the size of the retention
+// window: the floor is anchored on L1, so the pruner keeps blocks in
+// (l1Head - retainedBlocks, l2Head] and deletes everything below.
+// newHeadSub and l1HeadSub are the two trigger feeds (see [Pruner]).
+// Subscriptions are [feed.Subscription.Unsubscribe]'d when [Pruner.Run]
+// returns.
+func New(
+	database db.KeyValueStore,
+	retainedBlocks uint64,
+	newHeadSub *feed.Subscription[*core.Block],
+	l1HeadSub *feed.Subscription[*core.L1Head],
+	logger log.StructuredLogger,
+	opts ...Option,
+) *Pruner {
+	o := options{
+		targetBatchByteSize: defaultTargetBatchByteSize,
+		l2HeadsPerPrune:     defaultL2HeadsPerPrune,
+		listener:            &SelectiveListener{},
+	}
+	for _, opt := range opts {
+		opt(&o)
+	}
+	return &Pruner{
+		numRetainedBlocks:   retainedBlocks,
+		targetBatchByteSize: o.targetBatchByteSize,
+		l2HeadsPerPrune:     o.l2HeadsPerPrune,
+		database:            database,
+		newHeadSub:          newHeadSub,
+		l1HeadSub:           l1HeadSub,
+		listener:            o.listener,
+		logger:              logger,
+	}
+}
+
+// Run drives the prune loop until ctx is cancelled. It dispatches each new
+// L2 or L1 head event to the corresponding handler. Errors from a handler
+// are logged but do not stop the loop — errors returned from service terminates the node.
+func (p *Pruner) Run(ctx context.Context) error {
+	defer p.newHeadSub.Unsubscribe()
+	defer p.l1HeadSub.Unsubscribe()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return nil
+		case block := <-p.newHeadSub.Recv():
+			if err := p.onNewBlock(ctx, block); err != nil {
+				p.listener.OnPruneError(err)
+				p.logger.Error("Pruner.Run.onNewBlock", zap.Error(err))
+			}
+		case l1Head := <-p.l1HeadSub.Recv():
+			if err := p.onNewL1Head(ctx, l1Head); err != nil {
+				p.listener.OnPruneError(err)
+				p.logger.Error("Pruner.Run.onNewL1Head", zap.Error(err))
+			}
+		}
+	}
+}
+
+func (p *Pruner) onNewBlock(ctx context.Context, block *core.Block) error {
+	l1Head, err := core.GetL1Head(p.database)
+	if err != nil {
+		return err
+	}
+
+	if l1Head.BlockNumber <= block.Number || block.Number < p.numRetainedBlocks {
+		return nil
+	}
+
+	p.pendingL2Heads++
+	if p.pendingL2Heads < p.l2HeadsPerPrune {
+		return nil
+	}
+	p.pendingL2Heads = 0
+
+	oldestToKeep := block.Number - p.numRetainedBlocks + 1
+
+	return p.pruneUpto(ctx, oldestToKeep)
+}
+
+func (p *Pruner) onNewL1Head(ctx context.Context, l1Head *core.L1Head) error {
+	chainHeight, err := core.GetChainHeight(p.database)
+	if err != nil {
+		return err
+	}
+
+	if l1Head.BlockNumber >= chainHeight || l1Head.BlockNumber < p.numRetainedBlocks {
+		return nil
+	}
+	p.pendingL2Heads = 0
+
+	oldestBlockToKeep := l1Head.BlockNumber - p.numRetainedBlocks + 1
+
+	return p.pruneUpto(ctx, oldestBlockToKeep)
+}
+
+func (p *Pruner) pruneUpto(ctx context.Context, oldestBlockToKeep uint64) error {
+	start := time.Now()
+
+	blocksPruned, oldestKept, err := PruneUpto(
+		ctx,
+		p.database,
+		oldestBlockToKeep,
+		p.targetBatchByteSize,
+	)
+	if err != nil {
+		return err
+	}
+
+	elapsed := time.Since(start)
+	p.listener.OnPrune(oldestKept, blocksPruned, elapsed)
+	p.logger.Info("Pruner",
+		zap.Uint64("oldest_kept", oldestKept),
+		zap.Uint64("block_pruned", blocksPruned),
+		zap.Duration("elapsed", elapsed),
+	)
+	return nil
+}

--- a/pruner/pruner_test.go
+++ b/pruner/pruner_test.go
@@ -1,4 +1,4 @@
-package pruner
+package pruner_test
 
 import (
 	"context"
@@ -9,6 +9,7 @@ import (
 	"github.com/NethermindEth/juno/db"
 	_ "github.com/NethermindEth/juno/encoder/registry"
 	"github.com/NethermindEth/juno/feed"
+	"github.com/NethermindEth/juno/pruner"
 	"github.com/NethermindEth/juno/pruner/testutils"
 	"github.com/NethermindEth/juno/utils/log"
 	"github.com/stretchr/testify/assert"
@@ -36,22 +37,28 @@ func startPrunerService(
 	t *testing.T,
 	database db.KeyValueStore,
 	retention uint64,
-	extraOpts ...Option,
+	extraOpts ...pruner.Option,
 ) *servicePruner {
 	t.Helper()
 	l1Feed := feed.New[*core.L1Head]()
 	l2Feed := feed.New[*core.Block]()
 	pruned := make(chan pruneEvent, 16)
 
-	opts := append([]Option{
-		WithListener(&SelectiveListener{
+	opts := append([]pruner.Option{
+		pruner.WithListener(&pruner.SelectiveListener{
 			OnPruneCb: func(oldest, count uint64, _ time.Duration) {
 				pruned <- pruneEvent{oldest: oldest, count: count}
+			},
+			// Handler errors are logged-and-continued by Run, so without this
+			// hook a broken test setup would surface only as an OnPrune
+			// timeout. Fail loud instead.
+			OnPruneErrorCb: func(err error) {
+				t.Errorf("pruner handler error: %v", err)
 			},
 		}),
 	}, extraOpts...)
 
-	p := New(
+	p := pruner.New(
 		database,
 		retention,
 		l2Feed.Subscribe(),
@@ -66,7 +73,9 @@ func startPrunerService(
 
 	t.Cleanup(func() {
 		cancel()
-		<-done
+		if err := <-done; err != nil {
+			t.Errorf("pruner Run returned error: %v", err)
+		}
 	})
 
 	return &servicePruner{l1Feed: l1Feed, l2Feed: l2Feed, pruned: pruned}
@@ -102,12 +111,41 @@ func (sp *servicePruner) sendL2AndAwait(t *testing.T, blockNum uint64) pruneEven
 	}
 }
 
+// noOpQuietWindow is how long the sendAndExpectNoOp helpers wait before declaring "no prune fired."
+const noOpQuietWindow = 200 * time.Millisecond
+
+// sendL1AndExpectNoOp broadcasts an L1 head and verifies no prune dispatch
+// fires within noOpQuietWindow. Use for events that hit a guard
+// short-circuit before reaching pruneUpto, since no-op dispatches don't
+// fire OnPrune and so provide no listener barrier.
+func (sp *servicePruner) sendL1AndExpectNoOp(t *testing.T, blockNum uint64) {
+	t.Helper()
+	sp.l1Feed.Send(&core.L1Head{BlockNumber: blockNum})
+	select {
+	case ev := <-sp.pruned:
+		t.Fatalf("unexpected prune after L1 head %d: %+v", blockNum, ev)
+	case <-time.After(noOpQuietWindow):
+	}
+}
+
+// sendL2AndExpectNoOp broadcasts an L2 head and verifies no prune dispatch
+// fires within noOpQuietWindow. Use for events that hit a guard
+// short-circuit before reaching pruneUpto.
+func (sp *servicePruner) sendL2AndExpectNoOp(t *testing.T, blockNum uint64) {
+	t.Helper()
+	sp.l2Feed.Send(&core.Block{Header: &core.Header{Number: blockNum}})
+	select {
+	case ev := <-sp.pruned:
+		t.Fatalf("unexpected prune after L2 head %d: %+v", blockNum, ev)
+	case <-time.After(noOpQuietWindow):
+	}
+}
+
 // TestPruner_L1Path covers the L1 head dispatch handler. The L1 path is
 // gated by two guards (L1 ahead of chainHeight, L1 inside retention
-// window) and only triggers a prune once both pass. The happy path is
-// service-driven; the no-op guards are driven via direct onNewL1Head
-// calls because no-op dispatches don't fire OnPrune, so the listener
-// barrier doesn't apply.
+// window) and only triggers a prune once both pass. All cases are
+// service-driven; the happy path uses the OnPrune barrier, the
+// guard-no-op cases use sendL1AndExpectNoOp's quiet-window check.
 func TestPruner_L1Path(t *testing.T) {
 	const totalBlocks uint64 = 100
 
@@ -137,19 +175,8 @@ func TestPruner_L1Path(t *testing.T) {
 		}
 		require.NoError(t, core.WriteChainHeight(database, 50))
 
-		var prunes int
-		p := New(
-			database,
-			10,
-			nil, nil,
-			log.NewNopZapLogger(),
-			WithListener(&SelectiveListener{
-				OnPruneCb: func(uint64, uint64, time.Duration) { prunes++ },
-			}),
-		)
-
-		require.NoError(t, p.onNewL1Head(t.Context(), &core.L1Head{BlockNumber: 50}))
-		assert.Zero(t, prunes)
+		sp := startPrunerService(t, database, 10)
+		sp.sendL1AndExpectNoOp(t, 50)
 	})
 	t.Run("L1 head inside the retention window is a no-op", func(t *testing.T) {
 		database := testutils.NewPebbleTestDB(t)
@@ -159,19 +186,10 @@ func TestPruner_L1Path(t *testing.T) {
 		}
 		require.NoError(t, core.WriteChainHeight(database, totalBlocks))
 
-		var prunes int
-		p := New(
-			database,
-			1000, // retention way larger than current L1 head
-			nil, nil,
-			log.NewNopZapLogger(),
-			WithListener(&SelectiveListener{
-				OnPruneCb: func(uint64, uint64, time.Duration) { prunes++ },
-			}),
-		)
+		// retention way larger than current L1 head → guard short-circuits.
+		sp := startPrunerService(t, database, 1000)
+		sp.sendL1AndExpectNoOp(t, 50)
 
-		require.NoError(t, p.onNewL1Head(t.Context(), &core.L1Head{BlockNumber: 50}))
-		assert.Zero(t, prunes)
 		for i := range totalBlocks {
 			testutils.AssertBlockExists(t, database, blocks[i])
 		}
@@ -181,9 +199,9 @@ func TestPruner_L1Path(t *testing.T) {
 // TestPruner_L2Path covers the L2 head dispatch handler. The L2 path is
 // gated by three guards (L2 ahead of L1, block too shallow for retention,
 // coalesce threshold not reached) and only triggers a prune once all
-// three pass. The happy path is service-driven; the no-op guards are
-// driven via direct onNewBlock calls because no-op dispatches don't fire
-// OnPrune, so the listener barrier doesn't apply.
+// three pass. All cases are service-driven; the happy path and the
+// coalesce test use the OnPrune barrier on the trigger event, the
+// guard-no-op cases use sendL2AndExpectNoOp's quiet-window check.
 func TestPruner_L2Path(t *testing.T) {
 	const totalBlocks uint64 = 100
 
@@ -197,50 +215,37 @@ func TestPruner_L2Path(t *testing.T) {
 
 		// retention=10, l1Head=95 → L2 path uses the L2 block as the floor
 		// pivot. Sending L2 head 90 → floor = 90-10+1 = 81. Prunes [0, 81).
-		sp := startPrunerService(t, database, 10, WithL2HeadsPerPrune(1))
+		sp := startPrunerService(t, database, 10, pruner.WithL2HeadsPerPrune(1))
 		ev := sp.sendL2AndAwait(t, 90)
 		assert.Equal(t, uint64(81), ev.oldest)
 		assert.Equal(t, uint64(81), ev.count)
 	})
 
 	t.Run("coalesces N L2 heads before triggering one prune", func(t *testing.T) {
-		// Direct onNewBlock calls — silent no-op dispatches have no listener
-		// barrier, so we drive the dispatch synchronously.
 		database := testutils.NewPebbleTestDB(t)
 		for i := range totalBlocks {
 			testutils.StoreBlock(t, database, i)
 		}
+		require.NoError(t, core.WriteChainHeight(database, totalBlocks))
 		require.NoError(t, core.WriteL1Head(database, &core.L1Head{BlockNumber: 95}))
 
-		var prunes int
-		p := New(
-			database,
-			10,
-			nil, nil,
-			log.NewNopZapLogger(),
-			WithL2HeadsPerPrune(3),
-			WithListener(&SelectiveListener{
-				OnPruneCb: func(uint64, uint64, time.Duration) { prunes++ },
-			}),
-		)
+		// retention=10, l1Head=95, threshold=3. With L2 heads 88, 89, 90:
+		// the first two coalesce silently; the third tips the counter and
+		// triggers a prune at floor 90-10+1 = 81.
+		sp := startPrunerService(t, database, 10, pruner.WithL2HeadsPerPrune(3))
+		sp.sendL2AndExpectNoOp(t, 88)
+		sp.sendL2AndExpectNoOp(t, 89)
+		ev1 := sp.sendL2AndAwait(t, 90)
+		assert.Equal(t, uint64(81), ev1.oldest)
+		assert.Equal(t, uint64(81), ev1.count)
 
-		// First two L2 heads coalesce silently; the third one tips the
-		// counter and triggers a prune.
-		for i := uint64(88); i <= 90; i++ {
-			require.NoError(t, p.onNewBlock(t.Context(), &core.Block{
-				Header: &core.Header{Number: i},
-			}))
-		}
-		assert.Equal(t, 1, prunes, "exactly one prune dispatch after threshold reached")
-
-		// The next two events coalesce again (counter reset after the prune);
-		// the third triggers a second prune.
-		for i := uint64(91); i <= 93; i++ {
-			require.NoError(t, p.onNewBlock(t.Context(), &core.Block{
-				Header: &core.Header{Number: i},
-			}))
-		}
-		assert.Equal(t, 2, prunes, "counter resets after each prune")
+		// Counter resets after the prune; next two coalesce, the third
+		// triggers a second prune at floor 93-10+1 = 84, deleting [81, 84).
+		sp.sendL2AndExpectNoOp(t, 91)
+		sp.sendL2AndExpectNoOp(t, 92)
+		ev2 := sp.sendL2AndAwait(t, 93)
+		assert.Equal(t, uint64(84), ev2.oldest)
+		assert.Equal(t, uint64(3), ev2.count, "counter resets after each prune")
 	})
 
 	noopCases := []struct {
@@ -248,16 +253,9 @@ func TestPruner_L2Path(t *testing.T) {
 		l1Head    uint64
 		retention uint64
 		l2Block   uint64
-		why       string
 	}{
-		{
-			name: "L2 ahead of L1", l1Head: 50, retention: 10, l2Block: 60,
-			why: "L2 ahead of L1 — block not yet L1-confirmed, floor can't move",
-		},
-		{
-			name: "block shallower than retention", l1Head: 95, retention: 50, l2Block: 20,
-			why: "block.Number < retention would underflow oldestToKeep",
-		},
+		{name: "L2 ahead of L1", l1Head: 50, retention: 10, l2Block: 60},
+		{name: "block shallower than retention", l1Head: 95, retention: 50, l2Block: 20},
 	}
 	for _, tc := range noopCases {
 		t.Run(tc.name+" is a no-op", func(t *testing.T) {
@@ -265,24 +263,11 @@ func TestPruner_L2Path(t *testing.T) {
 			for i := range totalBlocks {
 				testutils.StoreBlock(t, database, i)
 			}
+			require.NoError(t, core.WriteChainHeight(database, totalBlocks))
 			require.NoError(t, core.WriteL1Head(database, &core.L1Head{BlockNumber: tc.l1Head}))
 
-			var prunes int
-			p := New(
-				database,
-				tc.retention,
-				nil, nil,
-				log.NewNopZapLogger(),
-				WithL2HeadsPerPrune(1),
-				WithListener(&SelectiveListener{
-					OnPruneCb: func(uint64, uint64, time.Duration) { prunes++ },
-				}),
-			)
-
-			require.NoError(t, p.onNewBlock(t.Context(), &core.Block{
-				Header: &core.Header{Number: tc.l2Block},
-			}))
-			assert.Zero(t, prunes, tc.why)
+			sp := startPrunerService(t, database, tc.retention, pruner.WithL2HeadsPerPrune(1))
+			sp.sendL2AndExpectNoOp(t, tc.l2Block)
 		})
 	}
 }

--- a/pruner/pruner_test.go
+++ b/pruner/pruner_test.go
@@ -112,7 +112,7 @@ func TestPruner_L1Path(t *testing.T) {
 	const totalBlocks uint64 = 100
 
 	t.Run("L1 head triggers prune and reports via listener", func(t *testing.T) {
-		database := testutils.NewTestDB(t)
+		database := testutils.NewPebbleTestDB(t)
 		blocks := make([]*testutils.StoredBlock, totalBlocks)
 		for i := range totalBlocks {
 			blocks[i] = testutils.StoreBlock(t, database, i)
@@ -131,7 +131,7 @@ func TestPruner_L1Path(t *testing.T) {
 	})
 
 	t.Run("L1 head at or beyond chainHeight is a no-op", func(t *testing.T) {
-		database := testutils.NewTestDB(t)
+		database := testutils.NewPebbleTestDB(t)
 		for i := range totalBlocks {
 			testutils.StoreBlock(t, database, i)
 		}
@@ -152,7 +152,7 @@ func TestPruner_L1Path(t *testing.T) {
 		assert.Zero(t, prunes)
 	})
 	t.Run("L1 head inside the retention window is a no-op", func(t *testing.T) {
-		database := testutils.NewTestDB(t)
+		database := testutils.NewPebbleTestDB(t)
 		blocks := make([]*testutils.StoredBlock, totalBlocks)
 		for i := range totalBlocks {
 			blocks[i] = testutils.StoreBlock(t, database, i)
@@ -188,7 +188,7 @@ func TestPruner_L2Path(t *testing.T) {
 	const totalBlocks uint64 = 100
 
 	t.Run("threshold=1 fires a prune on every L2 head", func(t *testing.T) {
-		database := testutils.NewTestDB(t)
+		database := testutils.NewPebbleTestDB(t)
 		for i := range totalBlocks {
 			testutils.StoreBlock(t, database, i)
 		}
@@ -206,7 +206,7 @@ func TestPruner_L2Path(t *testing.T) {
 	t.Run("coalesces N L2 heads before triggering one prune", func(t *testing.T) {
 		// Direct onNewBlock calls — silent no-op dispatches have no listener
 		// barrier, so we drive the dispatch synchronously.
-		database := testutils.NewTestDB(t)
+		database := testutils.NewPebbleTestDB(t)
 		for i := range totalBlocks {
 			testutils.StoreBlock(t, database, i)
 		}
@@ -261,7 +261,7 @@ func TestPruner_L2Path(t *testing.T) {
 	}
 	for _, tc := range noopCases {
 		t.Run(tc.name+" is a no-op", func(t *testing.T) {
-			database := testutils.NewTestDB(t)
+			database := testutils.NewPebbleTestDB(t)
 			for i := range totalBlocks {
 				testutils.StoreBlock(t, database, i)
 			}
@@ -307,7 +307,7 @@ func TestPruner_RetentionChangeAcrossRestart(t *testing.T) {
 	lag := core.BlockHashLag
 
 	t.Run("shrinking retention drains backlog on next L1 event", func(t *testing.T) {
-		database := testutils.NewTestDB(t)
+		database := testutils.NewPebbleTestDB(t)
 		blocks := make([]*testutils.StoredBlock, totalBlocks)
 		for i := range totalBlocks {
 			blocks[i] = testutils.StoreBlock(t, database, i)
@@ -338,7 +338,7 @@ func TestPruner_RetentionChangeAcrossRestart(t *testing.T) {
 	})
 
 	t.Run("growing retention pauses pruning until L1 catches up", func(t *testing.T) {
-		database := testutils.NewTestDB(t)
+		database := testutils.NewPebbleTestDB(t)
 		for i := range totalBlocks {
 			testutils.StoreBlock(t, database, i)
 		}

--- a/pruner/pruner_test.go
+++ b/pruner/pruner_test.go
@@ -1,0 +1,367 @@
+package pruner
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/NethermindEth/juno/core"
+	"github.com/NethermindEth/juno/db"
+	_ "github.com/NethermindEth/juno/encoder/registry"
+	"github.com/NethermindEth/juno/feed"
+	"github.com/NethermindEth/juno/utils/log"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// pruneEvent is the payload reported via OnPrune; tests use the sync
+// channel as a barrier to wait for each prune dispatch in service mode.
+type pruneEvent struct {
+	oldest uint64
+	count  uint64
+}
+
+// servicePruner runs a Pruner via Pruner.Run as a real service and exposes
+// the two trigger feeds plus a barrier channel that fires on every prune
+// dispatch (including no-op prunes where blocksPruned == 0). t.Cleanup
+// cancels Run and waits for it to exit.
+type servicePruner struct {
+	l1Feed *feed.Feed[*core.L1Head]
+	l2Feed *feed.Feed[*core.Block]
+	pruned chan pruneEvent
+}
+
+func startPrunerService(
+	t *testing.T,
+	database db.KeyValueStore,
+	retention uint64,
+	extraOpts ...Option,
+) *servicePruner {
+	t.Helper()
+	l1Feed := feed.New[*core.L1Head]()
+	l2Feed := feed.New[*core.Block]()
+	pruned := make(chan pruneEvent, 16)
+
+	opts := append([]Option{
+		WithListener(&SelectiveListener{
+			OnPruneCb: func(oldest, count uint64, _ time.Duration) {
+				pruned <- pruneEvent{oldest: oldest, count: count}
+			},
+		}),
+	}, extraOpts...)
+
+	p := New(
+		database,
+		retention,
+		l2Feed.Subscribe(),
+		l1Feed.Subscribe(),
+		log.NewNopZapLogger(),
+		opts...,
+	)
+
+	ctx, cancel := context.WithCancel(t.Context())
+	done := make(chan error, 1)
+	go func() { done <- p.Run(ctx) }()
+
+	t.Cleanup(func() {
+		cancel()
+		<-done
+	})
+
+	return &servicePruner{l1Feed: l1Feed, l2Feed: l2Feed, pruned: pruned}
+}
+
+// sendL1AndAwait broadcasts an L1 head to the pruner and waits for the
+// resulting prune dispatch. Blocks until OnPrune fires (5s timeout).
+func (sp *servicePruner) sendL1AndAwait(t *testing.T, blockNum uint64) pruneEvent {
+	t.Helper()
+	sp.l1Feed.Send(&core.L1Head{BlockNumber: blockNum})
+	select {
+	case ev := <-sp.pruned:
+		return ev
+	case <-time.After(5 * time.Second):
+		t.Fatalf("timed out waiting for prune dispatch after L1 head %d", blockNum)
+		return pruneEvent{}
+	}
+}
+
+// sendL2AndAwait broadcasts an L2 head to the pruner and waits for the
+// resulting prune dispatch. Use only when the configured
+// WithL2HeadsPerPrune is 1 (every L2 head triggers OnPrune); higher
+// thresholds coalesce events silently and provide no listener barrier.
+func (sp *servicePruner) sendL2AndAwait(t *testing.T, blockNum uint64) pruneEvent {
+	t.Helper()
+	sp.l2Feed.Send(&core.Block{Header: &core.Header{Number: blockNum}})
+	select {
+	case ev := <-sp.pruned:
+		return ev
+	case <-time.After(5 * time.Second):
+		t.Fatalf("timed out waiting for prune dispatch after L2 head %d", blockNum)
+		return pruneEvent{}
+	}
+}
+
+// TestPruner_L1Path covers the L1 head dispatch handler. The L1 path is
+// gated by two guards (L1 ahead of chainHeight, L1 inside retention
+// window) and only triggers a prune once both pass. The happy path is
+// service-driven; the no-op guards are driven via direct onNewL1Head
+// calls because no-op dispatches don't fire OnPrune, so the listener
+// barrier doesn't apply.
+func TestPruner_L1Path(t *testing.T) {
+	const totalBlocks uint64 = 100
+
+	t.Run("L1 head triggers prune and reports via listener", func(t *testing.T) {
+		database := newTestDB(t)
+		blocks := make([]*storedBlock, totalBlocks)
+		for i := range totalBlocks {
+			blocks[i] = storeBlock(t, database, i)
+		}
+		require.NoError(t, core.WriteChainHeight(database, totalBlocks))
+
+		// retention=10, L1=95 → floor = 95-10+1 = 86. Prunes [0, 86).
+		sp := startPrunerService(t, database, 10)
+		ev := sp.sendL1AndAwait(t, 95)
+		assert.Equal(t, uint64(86), ev.oldest)
+		assert.Equal(t, uint64(86), ev.count)
+
+		for i := range uint64(86) - core.BlockHashLag {
+			assertBlockPruned(t, database, blocks[i])
+		}
+	})
+
+	t.Run("L1 head at or beyond chainHeight is a no-op", func(t *testing.T) {
+		database := newTestDB(t)
+		for i := range totalBlocks {
+			storeBlock(t, database, i)
+		}
+		require.NoError(t, core.WriteChainHeight(database, 50))
+
+		var prunes int
+		p := New(
+			database,
+			10,
+			nil, nil,
+			log.NewNopZapLogger(),
+			WithListener(&SelectiveListener{
+				OnPruneCb: func(uint64, uint64, time.Duration) { prunes++ },
+			}),
+		)
+
+		require.NoError(t, p.onNewL1Head(t.Context(), &core.L1Head{BlockNumber: 50}))
+		assert.Zero(t, prunes)
+	})
+	t.Run("L1 head inside the retention window is a no-op", func(t *testing.T) {
+		database := newTestDB(t)
+		blocks := make([]*storedBlock, totalBlocks)
+		for i := range totalBlocks {
+			blocks[i] = storeBlock(t, database, i)
+		}
+		require.NoError(t, core.WriteChainHeight(database, totalBlocks))
+
+		var prunes int
+		p := New(
+			database,
+			1000, // retention way larger than current L1 head
+			nil, nil,
+			log.NewNopZapLogger(),
+			WithListener(&SelectiveListener{
+				OnPruneCb: func(uint64, uint64, time.Duration) { prunes++ },
+			}),
+		)
+
+		require.NoError(t, p.onNewL1Head(t.Context(), &core.L1Head{BlockNumber: 50}))
+		assert.Zero(t, prunes)
+		for i := range totalBlocks {
+			assertBlockExists(t, database, blocks[i])
+		}
+	})
+}
+
+// TestPruner_L2Path covers the L2 head dispatch handler. The L2 path is
+// gated by three guards (L2 ahead of L1, block too shallow for retention,
+// coalesce threshold not reached) and only triggers a prune once all
+// three pass. The happy path is service-driven; the no-op guards are
+// driven via direct onNewBlock calls because no-op dispatches don't fire
+// OnPrune, so the listener barrier doesn't apply.
+func TestPruner_L2Path(t *testing.T) {
+	const totalBlocks uint64 = 100
+
+	t.Run("threshold=1 fires a prune on every L2 head", func(t *testing.T) {
+		database := newTestDB(t)
+		for i := range totalBlocks {
+			storeBlock(t, database, i)
+		}
+		require.NoError(t, core.WriteChainHeight(database, totalBlocks))
+		require.NoError(t, core.WriteL1Head(database, &core.L1Head{BlockNumber: 95}))
+
+		// retention=10, l1Head=95 → L2 path uses the L2 block as the floor
+		// pivot. Sending L2 head 90 → floor = 90-10+1 = 81. Prunes [0, 81).
+		sp := startPrunerService(t, database, 10, WithL2HeadsPerPrune(1))
+		ev := sp.sendL2AndAwait(t, 90)
+		assert.Equal(t, uint64(81), ev.oldest)
+		assert.Equal(t, uint64(81), ev.count)
+	})
+
+	t.Run("coalesces N L2 heads before triggering one prune", func(t *testing.T) {
+		// Direct onNewBlock calls — silent no-op dispatches have no listener
+		// barrier, so we drive the dispatch synchronously.
+		database := newTestDB(t)
+		for i := range totalBlocks {
+			storeBlock(t, database, i)
+		}
+		require.NoError(t, core.WriteL1Head(database, &core.L1Head{BlockNumber: 95}))
+
+		var prunes int
+		p := New(
+			database,
+			10,
+			nil, nil,
+			log.NewNopZapLogger(),
+			WithL2HeadsPerPrune(3),
+			WithListener(&SelectiveListener{
+				OnPruneCb: func(uint64, uint64, time.Duration) { prunes++ },
+			}),
+		)
+
+		// First two L2 heads coalesce silently; the third one tips the
+		// counter and triggers a prune.
+		for i := uint64(88); i <= 90; i++ {
+			require.NoError(t, p.onNewBlock(t.Context(), &core.Block{
+				Header: &core.Header{Number: i},
+			}))
+		}
+		assert.Equal(t, 1, prunes, "exactly one prune dispatch after threshold reached")
+
+		// The next two events coalesce again (counter reset after the prune);
+		// the third triggers a second prune.
+		for i := uint64(91); i <= 93; i++ {
+			require.NoError(t, p.onNewBlock(t.Context(), &core.Block{
+				Header: &core.Header{Number: i},
+			}))
+		}
+		assert.Equal(t, 2, prunes, "counter resets after each prune")
+	})
+
+	noopCases := []struct {
+		name      string
+		l1Head    uint64
+		retention uint64
+		l2Block   uint64
+		why       string
+	}{
+		{
+			name: "L2 ahead of L1", l1Head: 50, retention: 10, l2Block: 60,
+			why: "L2 ahead of L1 — block not yet L1-confirmed, floor can't move",
+		},
+		{
+			name: "block shallower than retention", l1Head: 95, retention: 50, l2Block: 20,
+			why: "block.Number < retention would underflow oldestToKeep",
+		},
+	}
+	for _, tc := range noopCases {
+		t.Run(tc.name+" is a no-op", func(t *testing.T) {
+			database := newTestDB(t)
+			for i := range totalBlocks {
+				storeBlock(t, database, i)
+			}
+			require.NoError(t, core.WriteL1Head(database, &core.L1Head{BlockNumber: tc.l1Head}))
+
+			var prunes int
+			p := New(
+				database,
+				tc.retention,
+				nil, nil,
+				log.NewNopZapLogger(),
+				WithL2HeadsPerPrune(1),
+				WithListener(&SelectiveListener{
+					OnPruneCb: func(uint64, uint64, time.Duration) { prunes++ },
+				}),
+			)
+
+			require.NoError(t, p.onNewBlock(t.Context(), &core.Block{
+				Header: &core.Header{Number: tc.l2Block},
+			}))
+			assert.Zero(t, prunes, tc.why)
+		})
+	}
+}
+
+// TestPruner_RetentionChangeAcrossRestart simulates a node restart with a
+// different --retained-blocks value. Drives the pruner via the real
+// service: a goroutine running Pruner.Run consumes L1 head events from
+// the feed, and each phase is synchronized via the OnPrune listener.
+//
+//  1. Shrinking the window (80 → 10) triggers a backlog sweep on the
+//     next L1 event: blocks between the old and new floor are pruned in
+//     a single dispatch.
+//  2. Growing the window (10 → 40) is a no-op until L1 advances past
+//     the new (lower) floor — the window grows gradually, one L1 step
+//     at a time. The pruneUpto wrapper still calls OnPrune (with
+//     blocksPruned == 0) on the no-op paths, so the barrier works.
+//
+// numRetainedBlocks is held only in memory, never persisted, so a restart
+// with a different value is just a new Pruner on the same DB.
+func TestPruner_RetentionChangeAcrossRestart(t *testing.T) {
+	const totalBlocks uint64 = 100
+	lag := core.BlockHashLag
+
+	t.Run("shrinking retention drains backlog on next L1 event", func(t *testing.T) {
+		database := newTestDB(t)
+		blocks := make([]*storedBlock, totalBlocks)
+		for i := range totalBlocks {
+			blocks[i] = storeBlock(t, database, i)
+		}
+		require.NoError(t, core.WriteChainHeight(database, totalBlocks))
+
+		// Phase 1: retention=80, L1=99 → floor=20. Sweep prunes [0, 20).
+		sp1 := startPrunerService(t, database, 80)
+		ev1 := sp1.sendL1AndAwait(t, 99)
+		assert.Equal(t, uint64(20), ev1.oldest)
+		assert.Equal(t, uint64(20), ev1.count)
+
+		// Phase 2: "restart" with retention=10, L1=99 → floor=90. Sweep
+		// prunes [20, 90) — 70 blocks in one dispatch.
+		sp2 := startPrunerService(t, database, 10)
+		ev2 := sp2.sendL1AndAwait(t, 99)
+		assert.Equal(t, uint64(90), ev2.oldest)
+		assert.Equal(t, uint64(70), ev2.count)
+
+		// End-state: everything below the new lag floor is fully gone,
+		// blocks ≥ 90 untouched.
+		for i := range uint64(90) - lag {
+			assertBlockPruned(t, database, blocks[i])
+		}
+		for i := uint64(90); i < totalBlocks; i++ {
+			assertBlockExists(t, database, blocks[i])
+		}
+	})
+
+	t.Run("growing retention pauses pruning until L1 catches up", func(t *testing.T) {
+		database := newTestDB(t)
+		for i := range totalBlocks {
+			storeBlock(t, database, i)
+		}
+		require.NoError(t, core.WriteChainHeight(database, totalBlocks))
+
+		// Phase 1: retention=10, L1=50 → floor=41. Sweep prunes [0, 41).
+		sp1 := startPrunerService(t, database, 10)
+		ev1 := sp1.sendL1AndAwait(t, 50)
+		assert.Equal(t, uint64(41), ev1.oldest)
+		assert.Equal(t, uint64(41), ev1.count)
+
+		// Phase 2: "restart" with retention=40, L1 still at 50 → new floor=11,
+		// below the existing oldestKept (41). PruneUpto early-returns; OnPrune
+		// fires with count=0 and oldest unchanged at 41.
+		sp2 := startPrunerService(t, database, 40)
+		ev2 := sp2.sendL1AndAwait(t, 50)
+		assert.Equal(t, uint64(41), ev2.oldest,
+			"growing retention must not resurrect or move oldestKept")
+		assert.Zero(t, ev2.count, "growing retention must not prune any block")
+
+		// Phase 3: L1 advances to 81 → floor=42 > 41. The window finally moves
+		// by exactly one block: gradual growth, not a leap.
+		ev3 := sp2.sendL1AndAwait(t, 81)
+		assert.Equal(t, uint64(42), ev3.oldest)
+		assert.Equal(t, uint64(1), ev3.count)
+	})
+}

--- a/pruner/pruner_test.go
+++ b/pruner/pruner_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/NethermindEth/juno/db"
 	_ "github.com/NethermindEth/juno/encoder/registry"
 	"github.com/NethermindEth/juno/feed"
+	"github.com/NethermindEth/juno/pruner/testutils"
 	"github.com/NethermindEth/juno/utils/log"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -111,10 +112,10 @@ func TestPruner_L1Path(t *testing.T) {
 	const totalBlocks uint64 = 100
 
 	t.Run("L1 head triggers prune and reports via listener", func(t *testing.T) {
-		database := newTestDB(t)
-		blocks := make([]*storedBlock, totalBlocks)
+		database := testutils.NewTestDB(t)
+		blocks := make([]*testutils.StoredBlock, totalBlocks)
 		for i := range totalBlocks {
-			blocks[i] = storeBlock(t, database, i)
+			blocks[i] = testutils.StoreBlock(t, database, i)
 		}
 		require.NoError(t, core.WriteChainHeight(database, totalBlocks))
 
@@ -125,14 +126,14 @@ func TestPruner_L1Path(t *testing.T) {
 		assert.Equal(t, uint64(86), ev.count)
 
 		for i := range uint64(86) - core.BlockHashLag {
-			assertBlockPruned(t, database, blocks[i])
+			testutils.AssertBlockPruned(t, database, blocks[i])
 		}
 	})
 
 	t.Run("L1 head at or beyond chainHeight is a no-op", func(t *testing.T) {
-		database := newTestDB(t)
+		database := testutils.NewTestDB(t)
 		for i := range totalBlocks {
-			storeBlock(t, database, i)
+			testutils.StoreBlock(t, database, i)
 		}
 		require.NoError(t, core.WriteChainHeight(database, 50))
 
@@ -151,10 +152,10 @@ func TestPruner_L1Path(t *testing.T) {
 		assert.Zero(t, prunes)
 	})
 	t.Run("L1 head inside the retention window is a no-op", func(t *testing.T) {
-		database := newTestDB(t)
-		blocks := make([]*storedBlock, totalBlocks)
+		database := testutils.NewTestDB(t)
+		blocks := make([]*testutils.StoredBlock, totalBlocks)
 		for i := range totalBlocks {
-			blocks[i] = storeBlock(t, database, i)
+			blocks[i] = testutils.StoreBlock(t, database, i)
 		}
 		require.NoError(t, core.WriteChainHeight(database, totalBlocks))
 
@@ -172,7 +173,7 @@ func TestPruner_L1Path(t *testing.T) {
 		require.NoError(t, p.onNewL1Head(t.Context(), &core.L1Head{BlockNumber: 50}))
 		assert.Zero(t, prunes)
 		for i := range totalBlocks {
-			assertBlockExists(t, database, blocks[i])
+			testutils.AssertBlockExists(t, database, blocks[i])
 		}
 	})
 }
@@ -187,9 +188,9 @@ func TestPruner_L2Path(t *testing.T) {
 	const totalBlocks uint64 = 100
 
 	t.Run("threshold=1 fires a prune on every L2 head", func(t *testing.T) {
-		database := newTestDB(t)
+		database := testutils.NewTestDB(t)
 		for i := range totalBlocks {
-			storeBlock(t, database, i)
+			testutils.StoreBlock(t, database, i)
 		}
 		require.NoError(t, core.WriteChainHeight(database, totalBlocks))
 		require.NoError(t, core.WriteL1Head(database, &core.L1Head{BlockNumber: 95}))
@@ -205,9 +206,9 @@ func TestPruner_L2Path(t *testing.T) {
 	t.Run("coalesces N L2 heads before triggering one prune", func(t *testing.T) {
 		// Direct onNewBlock calls — silent no-op dispatches have no listener
 		// barrier, so we drive the dispatch synchronously.
-		database := newTestDB(t)
+		database := testutils.NewTestDB(t)
 		for i := range totalBlocks {
-			storeBlock(t, database, i)
+			testutils.StoreBlock(t, database, i)
 		}
 		require.NoError(t, core.WriteL1Head(database, &core.L1Head{BlockNumber: 95}))
 
@@ -260,9 +261,9 @@ func TestPruner_L2Path(t *testing.T) {
 	}
 	for _, tc := range noopCases {
 		t.Run(tc.name+" is a no-op", func(t *testing.T) {
-			database := newTestDB(t)
+			database := testutils.NewTestDB(t)
 			for i := range totalBlocks {
-				storeBlock(t, database, i)
+				testutils.StoreBlock(t, database, i)
 			}
 			require.NoError(t, core.WriteL1Head(database, &core.L1Head{BlockNumber: tc.l1Head}))
 
@@ -306,10 +307,10 @@ func TestPruner_RetentionChangeAcrossRestart(t *testing.T) {
 	lag := core.BlockHashLag
 
 	t.Run("shrinking retention drains backlog on next L1 event", func(t *testing.T) {
-		database := newTestDB(t)
-		blocks := make([]*storedBlock, totalBlocks)
+		database := testutils.NewTestDB(t)
+		blocks := make([]*testutils.StoredBlock, totalBlocks)
 		for i := range totalBlocks {
-			blocks[i] = storeBlock(t, database, i)
+			blocks[i] = testutils.StoreBlock(t, database, i)
 		}
 		require.NoError(t, core.WriteChainHeight(database, totalBlocks))
 
@@ -329,17 +330,17 @@ func TestPruner_RetentionChangeAcrossRestart(t *testing.T) {
 		// End-state: everything below the new lag floor is fully gone,
 		// blocks ≥ 90 untouched.
 		for i := range uint64(90) - lag {
-			assertBlockPruned(t, database, blocks[i])
+			testutils.AssertBlockPruned(t, database, blocks[i])
 		}
 		for i := uint64(90); i < totalBlocks; i++ {
-			assertBlockExists(t, database, blocks[i])
+			testutils.AssertBlockExists(t, database, blocks[i])
 		}
 	})
 
 	t.Run("growing retention pauses pruning until L1 catches up", func(t *testing.T) {
-		database := newTestDB(t)
+		database := testutils.NewTestDB(t)
 		for i := range totalBlocks {
-			storeBlock(t, database, i)
+			testutils.StoreBlock(t, database, i)
 		}
 		require.NoError(t, core.WriteChainHeight(database, totalBlocks))
 

--- a/pruner/retention.go
+++ b/pruner/retention.go
@@ -1,0 +1,104 @@
+package pruner
+
+import (
+	"encoding/binary"
+	"errors"
+	"fmt"
+
+	"github.com/NethermindEth/juno/core"
+	"github.com/NethermindEth/juno/core/felt"
+	"github.com/NethermindEth/juno/db"
+)
+
+// ErrBlockPruned is the sentinel matched by [errors.Is] for any
+// [BlockPrunedError]. Use [errors.As] when the requested-block /
+// oldest-retained fields are needed.
+var ErrBlockPruned = errors.New("block has been pruned")
+
+// BlockPrunedError reports that a requested block has been removed by
+// the pruner. OldestRetained is zero when the node has no retained blocks
+// (empty database) or when the lookup itself failed.
+type BlockPrunedError struct {
+	BlockNumber    uint64
+	OldestRetained uint64
+}
+
+func (e *BlockPrunedError) Error() string {
+	if e.OldestRetained == 0 {
+		return fmt.Sprintf("block %d is below the node's retention floor", e.BlockNumber)
+	}
+	return fmt.Sprintf("block %d has been pruned; oldest retained block is %d", e.BlockNumber, e.OldestRetained)
+}
+
+func (e *BlockPrunedError) Is(target error) bool { return target == ErrBlockPruned }
+
+// RequireRetained returns nil if blockNumber is fully retained, otherwise
+// a [*BlockPrunedError]. Retention is probed via BlockCommitments — the
+// source of truth for "block has not been pruned", since it has no
+// carve-out (see [PruneUpto]).
+func RequireRetained(r db.KeyValueReader, blockNumber uint64) error {
+	_, err := core.GetBlockCommitmentByBlockNum(r, blockNumber)
+	if err == nil {
+		return nil
+	}
+	if !errors.Is(err, db.ErrKeyNotFound) {
+		return err
+	}
+	oldest, oldestErr := OldestRetainedBlock(r)
+	if oldestErr != nil {
+		oldest = 0
+	}
+	return &BlockPrunedError{BlockNumber: blockNumber, OldestRetained: oldest}
+}
+
+// HeaderByNumberIfStateRetained returns the header for blockNumber only if
+// state at that block is queryable. Use this for state access only; for
+// block-level data (transactions, receipts, etc.) use [RequireRetained] + the
+// plain core accessors instead — the two checks diverge at oldestKept-1,
+// where state is preserved by carve-out but block-level data is not.
+// See [PruneUpto] for the carve-out semantics. Returns db.ErrKeyNotFound
+// when state at blockNumber is not available.
+func HeaderByNumberIfStateRetained(r db.KeyValueReader, blockNumber uint64) (*core.Header, error) {
+	header, err := core.GetBlockHeaderByNumber(r, blockNumber)
+	if err != nil {
+		return nil, err
+	}
+	if _, err := core.GetBlockHeaderNumberByHash(r, header.Hash); err != nil {
+		return nil, err
+	}
+	return header, nil
+}
+
+// HeaderByHashIfStateRetained returns the header for blockHash only if
+// state at that block is queryable. Use this for state access only; for
+// block-level data use [RequireRetained] + the plain core accessors instead.
+// See [PruneUpto] for the carve-out semantics. Returns db.ErrKeyNotFound
+// when state at blockHash is not available.
+func HeaderByHashIfStateRetained(r db.KeyValueReader, blockHash *felt.Felt) (*core.Header, error) {
+	return core.GetBlockHeaderByHash(r, blockHash)
+}
+
+// OldestRetainedBlock returns the lowest block number still fully retained,
+// found by scanning BlockCommitments — the source of truth, since it has
+// no carve-out (see [PruneUpto]). Returns db.ErrKeyNotFound on an empty
+// database.
+func OldestRetainedBlock(r db.KeyValueReader) (uint64, error) {
+	// Bucket (1 byte) + uint64BE (8 bytes)
+	const blockCommitmentsKeyByteSize = 9
+	for entry, err := range blockCommitmentsRange.Prefix().Scan(r) {
+		if err != nil {
+			return 0, err
+		}
+
+		if len(entry.Key) != blockCommitmentsKeyByteSize {
+			return 0, fmt.Errorf(
+				"invalid key size. expected: %v, actual %v",
+				blockCommitmentsKeyByteSize,
+				len(entry.Key),
+			)
+		}
+
+		return binary.BigEndian.Uint64(entry.Key[1:9]), nil
+	}
+	return 0, db.ErrKeyNotFound
+}

--- a/pruner/retention.go
+++ b/pruner/retention.go
@@ -27,7 +27,10 @@ func (e *BlockPrunedError) Error() string {
 	if e.OldestRetained == 0 {
 		return fmt.Sprintf("block %d is below the node's retention floor", e.BlockNumber)
 	}
-	return fmt.Sprintf("block %d has been pruned; oldest retained block is %d", e.BlockNumber, e.OldestRetained)
+	return fmt.Sprintf("block %d has been pruned; oldest retained block is %d",
+		e.BlockNumber,
+		e.OldestRetained,
+	)
 }
 
 func (e *BlockPrunedError) Is(target error) bool { return target == ErrBlockPruned }

--- a/pruner/retention_test.go
+++ b/pruner/retention_test.go
@@ -42,7 +42,7 @@ func TestBlockPrunedError(t *testing.T) {
 
 func TestRequireRetained(t *testing.T) {
 	t.Run("retained block returns nil", func(t *testing.T) {
-		database := testutils.NewTestDB(t)
+		database := testutils.NewPebbleTestDB(t)
 		for i := range uint64(5) {
 			testutils.StoreBlock(t, database, i)
 		}
@@ -50,7 +50,7 @@ func TestRequireRetained(t *testing.T) {
 	})
 
 	t.Run("pruned block surfaces oldest retained", func(t *testing.T) {
-		database := testutils.NewTestDB(t)
+		database := testutils.NewPebbleTestDB(t)
 		for i := range uint64(5) {
 			testutils.StoreBlock(t, database, i)
 		}
@@ -72,7 +72,7 @@ func TestRequireRetained(t *testing.T) {
 	})
 
 	t.Run("empty DB reports unknown oldest", func(t *testing.T) {
-		database := testutils.NewTestDB(t)
+		database := testutils.NewPebbleTestDB(t)
 		err := pruner.RequireRetained(database, 5)
 		require.Error(t, err)
 
@@ -86,7 +86,7 @@ func TestRequireRetained(t *testing.T) {
 
 func TestHeaderByNumberIfStateRetained(t *testing.T) {
 	t.Run("fully retained block returns the header", func(t *testing.T) {
-		database := testutils.NewTestDB(t)
+		database := testutils.NewPebbleTestDB(t)
 		blocks := make([]*testutils.StoredBlock, 5)
 		for i := range uint64(5) {
 			blocks[i] = testutils.StoreBlock(t, database, i)
@@ -99,7 +99,7 @@ func TestHeaderByNumberIfStateRetained(t *testing.T) {
 	t.Run("block with header but no hash→number is treated as state-pruned", func(t *testing.T) {
 		// This mirrors the lag-window state of pruned blocks: header kept,
 		// hash→number swept. State accessors must NOT serve these.
-		database := testutils.NewTestDB(t)
+		database := testutils.NewPebbleTestDB(t)
 		blocks := make([]*testutils.StoredBlock, 5)
 		for i := range uint64(5) {
 			blocks[i] = testutils.StoreBlock(t, database, i)
@@ -113,7 +113,7 @@ func TestHeaderByNumberIfStateRetained(t *testing.T) {
 	})
 
 	t.Run("missing block returns ErrKeyNotFound", func(t *testing.T) {
-		database := testutils.NewTestDB(t)
+		database := testutils.NewPebbleTestDB(t)
 		_, err := pruner.HeaderByNumberIfStateRetained(database, 0)
 		require.ErrorIs(t, err, db.ErrKeyNotFound)
 	})
@@ -121,7 +121,7 @@ func TestHeaderByNumberIfStateRetained(t *testing.T) {
 
 func TestHeaderByHashIfStateRetained(t *testing.T) {
 	t.Run("fully retained block returns the header", func(t *testing.T) {
-		database := testutils.NewTestDB(t)
+		database := testutils.NewPebbleTestDB(t)
 		blocks := make([]*testutils.StoredBlock, 5)
 		for i := range uint64(5) {
 			blocks[i] = testutils.StoreBlock(t, database, i)
@@ -132,14 +132,14 @@ func TestHeaderByHashIfStateRetained(t *testing.T) {
 	})
 
 	t.Run("missing hash returns ErrKeyNotFound", func(t *testing.T) {
-		database := testutils.NewTestDB(t)
+		database := testutils.NewPebbleTestDB(t)
 		unknownHash := felt.NewRandom[felt.Felt]()
 		_, err := pruner.HeaderByHashIfStateRetained(database, unknownHash)
 		require.ErrorIs(t, err, db.ErrKeyNotFound)
 	})
 
 	t.Run("block whose hash→number was deleted is unreachable by hash", func(t *testing.T) {
-		database := testutils.NewTestDB(t)
+		database := testutils.NewPebbleTestDB(t)
 		blocks := make([]*testutils.StoredBlock, 5)
 		for i := range uint64(5) {
 			blocks[i] = testutils.StoreBlock(t, database, i)

--- a/pruner/retention_test.go
+++ b/pruner/retention_test.go
@@ -151,3 +151,24 @@ func TestHeaderByHashIfStateRetained(t *testing.T) {
 		require.ErrorIs(t, err, db.ErrKeyNotFound)
 	})
 }
+
+func TestOldestRetainedBlock(t *testing.T) {
+	t.Run("empty database returns ErrKeyNotFound", func(t *testing.T) {
+		database := testutils.NewPebbleTestDB(t)
+
+		_, err := pruner.OldestRetainedBlock(database)
+		assert.ErrorIs(t, err, db.ErrKeyNotFound)
+	})
+
+	t.Run("returns lowest block number with commitments", func(t *testing.T) {
+		database := testutils.NewPebbleTestDB(t)
+
+		for i := uint64(5); i <= 7; i++ {
+			testutils.StoreBlock(t, database, i)
+		}
+
+		num, err := pruner.OldestRetainedBlock(database)
+		require.NoError(t, err)
+		assert.Equal(t, uint64(5), num)
+	})
+}

--- a/pruner/retention_test.go
+++ b/pruner/retention_test.go
@@ -1,0 +1,153 @@
+package pruner_test
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/NethermindEth/juno/core/felt"
+	"github.com/NethermindEth/juno/db"
+	_ "github.com/NethermindEth/juno/encoder/registry"
+	"github.com/NethermindEth/juno/pruner"
+	"github.com/NethermindEth/juno/pruner/testutils"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBlockPrunedError(t *testing.T) {
+	t.Run("Is matches the ErrBlockPruned sentinel", func(t *testing.T) {
+		e := &pruner.BlockPrunedError{BlockNumber: 5, OldestRetained: 10}
+		assert.True(t, errors.Is(e, pruner.ErrBlockPruned))
+		assert.False(t, errors.Is(e, db.ErrKeyNotFound))
+	})
+
+	t.Run("As surfaces the block-number / oldest-retained fields", func(t *testing.T) {
+		var target *pruner.BlockPrunedError
+		err := error(&pruner.BlockPrunedError{BlockNumber: 5, OldestRetained: 10})
+		require.True(t, errors.As(err, &target))
+		assert.Equal(t, uint64(5), target.BlockNumber)
+		assert.Equal(t, uint64(10), target.OldestRetained)
+	})
+
+	t.Run("message format depends on whether OldestRetained is known", func(t *testing.T) {
+		// OldestRetained=0 means the lookup itself failed (e.g. empty DB),
+		// so the message must not claim a specific oldest block.
+		unknown := &pruner.BlockPrunedError{BlockNumber: 5}
+		assert.Contains(t, unknown.Error(), "below the node's retention floor")
+		assert.NotContains(t, unknown.Error(), "oldest retained")
+
+		known := &pruner.BlockPrunedError{BlockNumber: 5, OldestRetained: 10}
+		assert.Contains(t, known.Error(), "oldest retained block is 10")
+	})
+}
+
+func TestRequireRetained(t *testing.T) {
+	t.Run("retained block returns nil", func(t *testing.T) {
+		database := testutils.NewTestDB(t)
+		for i := range uint64(5) {
+			testutils.StoreBlock(t, database, i)
+		}
+		require.NoError(t, pruner.RequireRetained(database, 3))
+	})
+
+	t.Run("pruned block surfaces oldest retained", func(t *testing.T) {
+		database := testutils.NewTestDB(t)
+		for i := range uint64(5) {
+			testutils.StoreBlock(t, database, i)
+		}
+		// Drop the commitment for block 0 — RequireRetained probes the
+		// commitment bucket as the source of truth for "still retained".
+		testutils.WithBatch(t, database, func(batch db.Batch) error {
+			return batch.Delete(db.BlockCommitmentsKey(0))
+		})
+
+		err := pruner.RequireRetained(database, 0)
+		require.Error(t, err)
+		assert.True(t, errors.Is(err, pruner.ErrBlockPruned))
+
+		var bpe *pruner.BlockPrunedError
+		require.True(t, errors.As(err, &bpe))
+		assert.Equal(t, uint64(0), bpe.BlockNumber)
+		assert.Equal(t, uint64(1), bpe.OldestRetained,
+			"OldestRetainedBlock should report block 1 once block 0's commitment is gone")
+	})
+
+	t.Run("empty DB reports unknown oldest", func(t *testing.T) {
+		database := testutils.NewTestDB(t)
+		err := pruner.RequireRetained(database, 5)
+		require.Error(t, err)
+
+		var bpe *pruner.BlockPrunedError
+		require.True(t, errors.As(err, &bpe))
+		assert.Equal(t, uint64(5), bpe.BlockNumber)
+		assert.Zero(t, bpe.OldestRetained,
+			"OldestRetained=0 signals the lookup itself failed, not block 0")
+	})
+}
+
+func TestHeaderByNumberIfStateRetained(t *testing.T) {
+	t.Run("fully retained block returns the header", func(t *testing.T) {
+		database := testutils.NewTestDB(t)
+		blocks := make([]*testutils.StoredBlock, 5)
+		for i := range uint64(5) {
+			blocks[i] = testutils.StoreBlock(t, database, i)
+		}
+		header, err := pruner.HeaderByNumberIfStateRetained(database, 3)
+		require.NoError(t, err)
+		assert.Equal(t, blocks[3].Header.Hash, header.Hash)
+	})
+
+	t.Run("block with header but no hash→number is treated as state-pruned", func(t *testing.T) {
+		// This mirrors the lag-window state of pruned blocks: header kept,
+		// hash→number swept. State accessors must NOT serve these.
+		database := testutils.NewTestDB(t)
+		blocks := make([]*testutils.StoredBlock, 5)
+		for i := range uint64(5) {
+			blocks[i] = testutils.StoreBlock(t, database, i)
+		}
+		testutils.WithBatch(t, database, func(batch db.Batch) error {
+			return batch.Delete(db.BlockHeaderNumbersByHashKey(blocks[1].Header.Hash))
+		})
+
+		_, err := pruner.HeaderByNumberIfStateRetained(database, 1)
+		require.ErrorIs(t, err, db.ErrKeyNotFound)
+	})
+
+	t.Run("missing block returns ErrKeyNotFound", func(t *testing.T) {
+		database := testutils.NewTestDB(t)
+		_, err := pruner.HeaderByNumberIfStateRetained(database, 0)
+		require.ErrorIs(t, err, db.ErrKeyNotFound)
+	})
+}
+
+func TestHeaderByHashIfStateRetained(t *testing.T) {
+	t.Run("fully retained block returns the header", func(t *testing.T) {
+		database := testutils.NewTestDB(t)
+		blocks := make([]*testutils.StoredBlock, 5)
+		for i := range uint64(5) {
+			blocks[i] = testutils.StoreBlock(t, database, i)
+		}
+		header, err := pruner.HeaderByHashIfStateRetained(database, blocks[2].Header.Hash)
+		require.NoError(t, err)
+		assert.Equal(t, uint64(2), header.Number)
+	})
+
+	t.Run("missing hash returns ErrKeyNotFound", func(t *testing.T) {
+		database := testutils.NewTestDB(t)
+		unknownHash := felt.NewRandom[felt.Felt]()
+		_, err := pruner.HeaderByHashIfStateRetained(database, unknownHash)
+		require.ErrorIs(t, err, db.ErrKeyNotFound)
+	})
+
+	t.Run("block whose hash→number was deleted is unreachable by hash", func(t *testing.T) {
+		database := testutils.NewTestDB(t)
+		blocks := make([]*testutils.StoredBlock, 5)
+		for i := range uint64(5) {
+			blocks[i] = testutils.StoreBlock(t, database, i)
+		}
+		testutils.WithBatch(t, database, func(batch db.Batch) error {
+			return batch.Delete(db.BlockHeaderNumbersByHashKey(blocks[1].Header.Hash))
+		})
+		_, err := pruner.HeaderByHashIfStateRetained(database, blocks[1].Header.Hash)
+		require.ErrorIs(t, err, db.ErrKeyNotFound)
+	})
+}

--- a/pruner/test_helpers_test.go
+++ b/pruner/test_helpers_test.go
@@ -1,0 +1,324 @@
+package pruner
+
+import (
+	"testing"
+
+	"github.com/NethermindEth/juno/core"
+	"github.com/NethermindEth/juno/core/felt"
+	"github.com/NethermindEth/juno/db"
+	"github.com/NethermindEth/juno/db/pebblev2"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// newTestDB returns an isolated pebble-backed KeyValueStore for the test.
+// We use pebble (not the in-memory db) because pebble's batch DeleteRange
+// performs a real range delete, while the memory implementation only
+// scans keys with the start byte sequence as a literal prefix.
+func newTestDB(t *testing.T) db.KeyValueStore {
+	t.Helper()
+	database, err := pebblev2.New(t.TempDir())
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		require.NoError(t, database.Close())
+	})
+	return database
+}
+
+// storedBlock holds all data written for a block, so assertions can verify
+// every pruned bucket.
+type storedBlock struct {
+	Header   *core.Header
+	TxHashes []*felt.Felt
+	// L1HandlerMsgHashes are the message hashes for any L1 handler txs in this block.
+	L1HandlerMsgHashes [][]byte
+	// StateUpdate is the state update written for this block.
+	StateUpdate *core.StateUpdate
+}
+
+// Two fixed addresses that appear across multiple blocks to simulate
+// realistic state history where the same contract is touched repeatedly.
+var (
+	sharedAddr1 = new(felt.Felt).SetUint64(0xA001)
+	sharedAddr2 = new(felt.Felt).SetUint64(0xA002)
+	sharedSlot  = new(felt.Felt).SetUint64(0x5001)
+)
+
+// storeBlock writes a complete block into the database covering all pruned buckets:
+//   - Bucket 7:  BlockHeaderNumbersByHash
+//   - Bucket 8:  BlockHeadersByNumber
+//   - Bucket 9:  TransactionBlockNumbersAndIndicesByHash
+//   - Bucket 12: StateUpdatesByBlockNumber
+//   - Bucket 21: BlockCommitments
+//   - Bucket 24: L1HandlerTxnHashByMsgHash (one L1 handler tx per block)
+//   - Bucket 40: BlockTransactions
+//   - Bucket 14: ContractStorageHistory
+//   - Bucket 15: ContractNonceHistory
+//   - Bucket 16: ContractClassHashHistory
+func storeBlock(t *testing.T, database db.KeyValueStore, blockNum uint64) *storedBlock {
+	t.Helper()
+
+	header := &core.Header{
+		Number:           blockNum,
+		Hash:             felt.NewRandom[felt.Felt](),
+		ParentHash:       felt.NewRandom[felt.Felt](),
+		GlobalStateRoot:  felt.NewRandom[felt.Felt](),
+		SequencerAddress: felt.NewRandom[felt.Felt](),
+		TransactionCount: 3,
+	}
+
+	// Create transactions: 2 invoke + 1 L1 handler.
+	invokeTx1 := &core.InvokeTransaction{
+		TransactionHash: felt.NewRandom[felt.Felt](),
+		Version:         new(core.TransactionVersion).SetUint64(1),
+	}
+	invokeTx2 := &core.InvokeTransaction{
+		TransactionHash: felt.NewRandom[felt.Felt](),
+		Version:         new(core.TransactionVersion).SetUint64(1),
+	}
+	l1HandlerTx := &core.L1HandlerTransaction{
+		TransactionHash:    felt.NewRandom[felt.Felt](),
+		ContractAddress:    felt.NewRandom[felt.Felt](),
+		EntryPointSelector: felt.NewRandom[felt.Felt](),
+		Nonce:              new(felt.Felt).SetUint64(blockNum),
+		CallData:           []*felt.Felt{felt.NewRandom[felt.Felt](), felt.NewRandom[felt.Felt]()},
+		Version:            new(core.TransactionVersion).SetUint64(0),
+	}
+
+	txs := []core.Transaction{invokeTx1, invokeTx2, l1HandlerTx}
+	txHashes := []*felt.Felt{invokeTx1.Hash(), invokeTx2.Hash(), l1HandlerTx.Hash()}
+
+	receipts := make([]*core.TransactionReceipt, 3)
+	for i, tx := range txs {
+		receipts[i] = &core.TransactionReceipt{
+			TransactionHash: tx.Hash(),
+			Fee:             new(felt.Felt).SetUint64(100),
+		}
+	}
+
+	commitments := &core.BlockCommitments{
+		TransactionCommitment: felt.NewRandom[felt.Felt](),
+		EventCommitment:       felt.NewRandom[felt.Felt](),
+		ReceiptCommitment:     felt.NewRandom[felt.Felt](),
+		StateDiffCommitment:   felt.NewRandom[felt.Felt](),
+	}
+
+	// Build state diff with overlapping addresses across blocks.
+	// sharedAddr1: storage + nonce change in every block
+	// sharedAddr2: class hash change in every block
+	// Plus a unique address per block for variety.
+	uniqueAddr := new(felt.Felt).SetUint64(0xB000 + blockNum)
+	uniqueSlot := new(felt.Felt).SetUint64(0xC000 + blockNum)
+	oldValue := new(felt.Felt).SetUint64(blockNum * 100)
+
+	storageDiffs := map[felt.Felt]map[felt.Felt]*felt.Felt{
+		*sharedAddr1: {
+			*sharedSlot: oldValue,
+		},
+		*uniqueAddr: {
+			*uniqueSlot: oldValue,
+		},
+	}
+
+	nonces := map[felt.Felt]*felt.Felt{
+		*sharedAddr1: oldValue,
+	}
+
+	replacedClasses := map[felt.Felt]*felt.Felt{
+		*sharedAddr2: oldValue,
+	}
+
+	stateUpdate := &core.StateUpdate{
+		BlockHash: header.Hash,
+		NewRoot:   felt.NewRandom[felt.Felt](),
+		OldRoot:   felt.NewRandom[felt.Felt](),
+		StateDiff: &core.StateDiff{
+			StorageDiffs:      storageDiffs,
+			Nonces:            nonces,
+			ReplacedClasses:   replacedClasses,
+			DeployedContracts: make(map[felt.Felt]*felt.Felt),
+		},
+	}
+
+	// Write block data.
+	require.NoError(t, core.WriteBlockHeaderByNumber(database, header))
+	require.NoError(t, core.WriteBlockHeaderNumberByHash(database, header.Hash, blockNum))
+	require.NoError(t, core.WriteBlockCommitment(database, blockNum, commitments))
+	require.NoError(t, core.WriteStateUpdateByBlockNum(database, blockNum, stateUpdate))
+	require.NoError(t, core.WriteTransactionsAndReceipts(database, blockNum, txs, receipts))
+
+	// Write L1 handler msg hash → tx hash (bucket 24).
+	msgHash := l1HandlerTx.MessageHash()
+	require.NoError(
+		t,
+		core.WriteL1HandlerTxnHashByMsgHash(database, msgHash, l1HandlerTx.TransactionHash),
+	)
+
+	// Write state history entries (buckets 14, 15, 16).
+	for addr, slots := range storageDiffs {
+		for slot := range slots {
+			require.NoError(
+				t,
+				core.WriteContractStorageHistory(database, &addr, &slot, oldValue, blockNum),
+			)
+		}
+	}
+	for addr := range nonces {
+		require.NoError(t, core.WriteContractNonceHistory(database, &addr, oldValue, blockNum))
+	}
+	for addr := range replacedClasses {
+		require.NoError(t, core.WriteContractClassHashHistory(database, &addr, oldValue, blockNum))
+	}
+
+	return &storedBlock{
+		Header:             header,
+		TxHashes:           txHashes,
+		L1HandlerMsgHashes: [][]byte{msgHash},
+		StateUpdate:        stateUpdate,
+	}
+}
+
+func withBatch(t *testing.T, database db.KeyValueStore, fn func(db.Batch) error) {
+	t.Helper()
+	batch := database.NewBatch()
+	require.NoError(t, fn(batch))
+	require.NoError(t, batch.Write())
+}
+
+// assertBlockExists verifies all data for a block is present.
+//
+//nolint:dupl // symmetric with assertBlockPruned.
+func assertBlockExists(t *testing.T, database db.KeyValueReader, block *storedBlock) {
+	t.Helper()
+	blockNum := block.Header.Number
+
+	assert.True(t, blockHeaderExists(database, blockNum))
+	assert.True(t, blockHeaderHashExists(database, block.Header.Hash))
+	assert.True(t, blockCommitmentsExist(database, blockNum))
+	assert.True(t, stateUpdateExists(database, blockNum))
+	assert.True(t, transactionsExist(database, blockNum))
+
+	for i, txHash := range block.TxHashes {
+		_, err := core.TransactionBlockNumbersAndIndicesByHashBucket.Get(
+			database, (*felt.TransactionHash)(txHash))
+		assert.NoError(t, err, "block %d tx %d hash lookup should exist", blockNum, i)
+	}
+
+	for _, msgHash := range block.L1HandlerMsgHashes {
+		_, err := core.GetL1HandlerTxnHashByMsgHash(database, msgHash)
+		assert.NoError(t, err, "block %d L1 handler msg hash should exist", blockNum)
+	}
+
+	assertStateHistoryExists(t, database, blockNum, block.StateUpdate)
+}
+
+// assertBlockPruned verifies all data for a block is gone.
+//
+//nolint:dupl // symmetric with assertBlockExists.
+func assertBlockPruned(t *testing.T, database db.KeyValueReader, block *storedBlock) {
+	t.Helper()
+	blockNum := block.Header.Number
+
+	// Bucket 8: header by number
+	assert.False(t, blockHeaderExists(database, blockNum))
+	// Bucket 7: hash → number reverse lookup
+	assert.False(t, blockHeaderHashExists(database, block.Header.Hash))
+	// Bucket 21: commitments
+	assert.False(t, blockCommitmentsExist(database, blockNum))
+	// Bucket 12: state update
+	assert.False(t, stateUpdateExists(database, blockNum))
+	// Bucket 40: transactions
+	assert.False(t, transactionsExist(database, blockNum))
+
+	// Bucket 9: tx hash reverse lookups
+	for i, txHash := range block.TxHashes {
+		_, err := core.TransactionBlockNumbersAndIndicesByHashBucket.Get(
+			database,
+			(*felt.TransactionHash)(txHash),
+		)
+		assert.Error(t, err, "block %d tx %d hash lookup should be deleted", blockNum, i)
+	}
+
+	// Bucket 24: L1 handler msg hash → tx hash
+	for _, msgHash := range block.L1HandlerMsgHashes {
+		_, err := core.GetL1HandlerTxnHashByMsgHash(database, msgHash)
+		assert.Error(t, err, "block %d L1 handler msg hash should be deleted", blockNum)
+	}
+
+	// Buckets 14, 15, 16: state history
+	assertStateHistoryPruned(t, database, blockNum, block.StateUpdate)
+}
+
+//nolint:dupl // symmetric with assertStateHistoryPruned.
+func assertStateHistoryExists(
+	t *testing.T,
+	r db.KeyValueReader,
+	blockNum uint64,
+	su *core.StateUpdate,
+) {
+	t.Helper()
+	for addr, slots := range su.StateDiff.StorageDiffs {
+		for slot := range slots {
+			key := db.ContractStorageHistoryAtBlockKey(&addr, &slot, blockNum)
+			assert.NoError(t, r.Get(key, func([]byte) error { return nil }))
+		}
+	}
+	for addr := range su.StateDiff.Nonces {
+		key := db.ContractNonceHistoryAtBlockKey(&addr, blockNum)
+		assert.NoError(t, r.Get(key, func([]byte) error { return nil }))
+	}
+	for addr := range su.StateDiff.ReplacedClasses {
+		key := db.ContractClassHashHistoryAtBlockKey(&addr, blockNum)
+		assert.NoError(t, r.Get(key, func([]byte) error { return nil }))
+	}
+}
+
+//nolint:dupl // symmetric with assertStateHistoryExists; see note there.
+func assertStateHistoryPruned(
+	t *testing.T,
+	r db.KeyValueReader,
+	blockNum uint64,
+	su *core.StateUpdate,
+) {
+	t.Helper()
+	for addr, slots := range su.StateDiff.StorageDiffs {
+		for slot := range slots {
+			key := db.ContractStorageHistoryAtBlockKey(&addr, &slot, blockNum)
+			assert.Error(t, r.Get(key, func([]byte) error { return nil }))
+		}
+	}
+	for addr := range su.StateDiff.Nonces {
+		key := db.ContractNonceHistoryAtBlockKey(&addr, blockNum)
+		assert.Error(t, r.Get(key, func([]byte) error { return nil }))
+	}
+	for addr := range su.StateDiff.ReplacedClasses {
+		key := db.ContractClassHashHistoryAtBlockKey(&addr, blockNum)
+		assert.Error(t, r.Get(key, func([]byte) error { return nil }))
+	}
+}
+
+// Helpers for individual bucket checks.
+func blockHeaderExists(database db.KeyValueReader, blockNum uint64) bool {
+	_, err := core.GetBlockHeaderByNumber(database, blockNum)
+	return err == nil
+}
+
+func blockHeaderHashExists(database db.KeyValueReader, hash *felt.Felt) bool {
+	_, err := core.BlockHeaderNumbersByHashBucket.Get(database, hash)
+	return err == nil
+}
+
+func blockCommitmentsExist(database db.KeyValueReader, blockNum uint64) bool {
+	_, err := core.GetBlockCommitmentByBlockNum(database, blockNum)
+	return err == nil
+}
+
+func stateUpdateExists(database db.KeyValueReader, blockNum uint64) bool {
+	_, err := core.GetStateUpdateByBlockNum(database, blockNum)
+	return err == nil
+}
+
+func transactionsExist(database db.KeyValueReader, blockNum uint64) bool {
+	_, err := core.GetTransactionByBlockAndIndex(database, blockNum, 0)
+	return err == nil
+}

--- a/pruner/testutils/helpers.go
+++ b/pruner/testutils/helpers.go
@@ -1,4 +1,8 @@
-package pruner
+// Package testutils provides shared fixtures for tests that exercise the
+// pruner's data layout. Both the pruner package's own tests and the
+// historyprunner migration test depend on the same on-disk shape, so the
+// helpers live here to avoid duplication.
+package testutils
 
 import (
 	"testing"
@@ -11,11 +15,11 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// newTestDB returns an isolated pebble-backed KeyValueStore for the test.
+// NewTestDB returns an isolated pebble-backed KeyValueStore for the test.
 // We use pebble (not the in-memory db) because pebble's batch DeleteRange
 // performs a real range delete, while the memory implementation only
 // scans keys with the start byte sequence as a literal prefix.
-func newTestDB(t *testing.T) db.KeyValueStore {
+func NewTestDB(t *testing.T) db.KeyValueStore {
 	t.Helper()
 	database, err := pebblev2.New(t.TempDir())
 	require.NoError(t, err)
@@ -25,9 +29,9 @@ func newTestDB(t *testing.T) db.KeyValueStore {
 	return database
 }
 
-// storedBlock holds all data written for a block, so assertions can verify
+// StoredBlock holds all data written for a block, so assertions can verify
 // every pruned bucket.
-type storedBlock struct {
+type StoredBlock struct {
 	Header   *core.Header
 	TxHashes []*felt.Felt
 	// L1HandlerMsgHashes are the message hashes for any L1 handler txs in this block.
@@ -39,12 +43,12 @@ type storedBlock struct {
 // Two fixed addresses that appear across multiple blocks to simulate
 // realistic state history where the same contract is touched repeatedly.
 var (
-	sharedAddr1 = new(felt.Felt).SetUint64(0xA001)
-	sharedAddr2 = new(felt.Felt).SetUint64(0xA002)
-	sharedSlot  = new(felt.Felt).SetUint64(0x5001)
+	SharedAddr1 = new(felt.Felt).SetUint64(0xA001) //nolint:mnd // test fixture
+	SharedAddr2 = new(felt.Felt).SetUint64(0xA002) //nolint:mnd // test fixture
+	SharedSlot  = new(felt.Felt).SetUint64(0x5001) //nolint:mnd // test fixture
 )
 
-// storeBlock writes a complete block into the database covering all pruned buckets:
+// StoreBlock writes a complete block into the database covering all pruned buckets:
 //   - Bucket 7:  BlockHeaderNumbersByHash
 //   - Bucket 8:  BlockHeadersByNumber
 //   - Bucket 9:  TransactionBlockNumbersAndIndicesByHash
@@ -55,7 +59,7 @@ var (
 //   - Bucket 14: ContractStorageHistory
 //   - Bucket 15: ContractNonceHistory
 //   - Bucket 16: ContractClassHashHistory
-func storeBlock(t *testing.T, database db.KeyValueStore, blockNum uint64) *storedBlock {
+func StoreBlock(t *testing.T, database db.KeyValueStore, blockNum uint64) *StoredBlock {
 	t.Helper()
 
 	header := &core.Header{
@@ -92,7 +96,7 @@ func storeBlock(t *testing.T, database db.KeyValueStore, blockNum uint64) *store
 	for i, tx := range txs {
 		receipts[i] = &core.TransactionReceipt{
 			TransactionHash: tx.Hash(),
-			Fee:             new(felt.Felt).SetUint64(100),
+			Fee:             new(felt.Felt).SetUint64(100), //nolint:mnd // test fixture
 		}
 	}
 
@@ -104,16 +108,16 @@ func storeBlock(t *testing.T, database db.KeyValueStore, blockNum uint64) *store
 	}
 
 	// Build state diff with overlapping addresses across blocks.
-	// sharedAddr1: storage + nonce change in every block
-	// sharedAddr2: class hash change in every block
+	// SharedAddr1: storage + nonce change in every block
+	// SharedAddr2: class hash change in every block
 	// Plus a unique address per block for variety.
-	uniqueAddr := new(felt.Felt).SetUint64(0xB000 + blockNum)
-	uniqueSlot := new(felt.Felt).SetUint64(0xC000 + blockNum)
-	oldValue := new(felt.Felt).SetUint64(blockNum * 100)
+	uniqueAddr := new(felt.Felt).SetUint64(0xB000 + blockNum) //nolint:mnd // test fixture
+	uniqueSlot := new(felt.Felt).SetUint64(0xC000 + blockNum) //nolint:mnd // test fixture
+	oldValue := new(felt.Felt).SetUint64(blockNum * 100)      //nolint:mnd // test fixture
 
 	storageDiffs := map[felt.Felt]map[felt.Felt]*felt.Felt{
-		*sharedAddr1: {
-			*sharedSlot: oldValue,
+		*SharedAddr1: {
+			*SharedSlot: oldValue,
 		},
 		*uniqueAddr: {
 			*uniqueSlot: oldValue,
@@ -121,11 +125,11 @@ func storeBlock(t *testing.T, database db.KeyValueStore, blockNum uint64) *store
 	}
 
 	nonces := map[felt.Felt]*felt.Felt{
-		*sharedAddr1: oldValue,
+		*SharedAddr1: oldValue,
 	}
 
 	replacedClasses := map[felt.Felt]*felt.Felt{
-		*sharedAddr2: oldValue,
+		*SharedAddr2: oldValue,
 	}
 
 	stateUpdate := &core.StateUpdate{
@@ -170,7 +174,7 @@ func storeBlock(t *testing.T, database db.KeyValueStore, blockNum uint64) *store
 		require.NoError(t, core.WriteContractClassHashHistory(database, &addr, oldValue, blockNum))
 	}
 
-	return &storedBlock{
+	return &StoredBlock{
 		Header:             header,
 		TxHashes:           txHashes,
 		L1HandlerMsgHashes: [][]byte{msgHash},
@@ -178,25 +182,25 @@ func storeBlock(t *testing.T, database db.KeyValueStore, blockNum uint64) *store
 	}
 }
 
-func withBatch(t *testing.T, database db.KeyValueStore, fn func(db.Batch) error) {
+func WithBatch(t *testing.T, database db.KeyValueStore, fn func(db.Batch) error) {
 	t.Helper()
 	batch := database.NewBatch()
 	require.NoError(t, fn(batch))
 	require.NoError(t, batch.Write())
 }
 
-// assertBlockExists verifies all data for a block is present.
+// AssertBlockExists verifies all data for a block is present.
 //
-//nolint:dupl // symmetric with assertBlockPruned.
-func assertBlockExists(t *testing.T, database db.KeyValueReader, block *storedBlock) {
+//nolint:dupl // symmetric with AssertBlockPruned.
+func AssertBlockExists(t *testing.T, database db.KeyValueReader, block *StoredBlock) {
 	t.Helper()
 	blockNum := block.Header.Number
 
-	assert.True(t, blockHeaderExists(database, blockNum))
-	assert.True(t, blockHeaderHashExists(database, block.Header.Hash))
-	assert.True(t, blockCommitmentsExist(database, blockNum))
-	assert.True(t, stateUpdateExists(database, blockNum))
-	assert.True(t, transactionsExist(database, blockNum))
+	assert.True(t, BlockHeaderExists(database, blockNum))
+	assert.True(t, BlockHeaderHashExists(database, block.Header.Hash))
+	assert.True(t, BlockCommitmentsExist(database, blockNum))
+	assert.True(t, StateUpdateExists(database, blockNum))
+	assert.True(t, TransactionsExist(database, blockNum))
 
 	for i, txHash := range block.TxHashes {
 		_, err := core.TransactionBlockNumbersAndIndicesByHashBucket.Get(
@@ -209,26 +213,26 @@ func assertBlockExists(t *testing.T, database db.KeyValueReader, block *storedBl
 		assert.NoError(t, err, "block %d L1 handler msg hash should exist", blockNum)
 	}
 
-	assertStateHistoryExists(t, database, blockNum, block.StateUpdate)
+	AssertStateHistoryExists(t, database, blockNum, block.StateUpdate)
 }
 
-// assertBlockPruned verifies all data for a block is gone.
+// AssertBlockPruned verifies all data for a block is gone.
 //
-//nolint:dupl // symmetric with assertBlockExists.
-func assertBlockPruned(t *testing.T, database db.KeyValueReader, block *storedBlock) {
+//nolint:dupl // symmetric with AssertBlockExists.
+func AssertBlockPruned(t *testing.T, database db.KeyValueReader, block *StoredBlock) {
 	t.Helper()
 	blockNum := block.Header.Number
 
 	// Bucket 8: header by number
-	assert.False(t, blockHeaderExists(database, blockNum))
+	assert.False(t, BlockHeaderExists(database, blockNum))
 	// Bucket 7: hash → number reverse lookup
-	assert.False(t, blockHeaderHashExists(database, block.Header.Hash))
+	assert.False(t, BlockHeaderHashExists(database, block.Header.Hash))
 	// Bucket 21: commitments
-	assert.False(t, blockCommitmentsExist(database, blockNum))
+	assert.False(t, BlockCommitmentsExist(database, blockNum))
 	// Bucket 12: state update
-	assert.False(t, stateUpdateExists(database, blockNum))
+	assert.False(t, StateUpdateExists(database, blockNum))
 	// Bucket 40: transactions
-	assert.False(t, transactionsExist(database, blockNum))
+	assert.False(t, TransactionsExist(database, blockNum))
 
 	// Bucket 9: tx hash reverse lookups
 	for i, txHash := range block.TxHashes {
@@ -246,11 +250,11 @@ func assertBlockPruned(t *testing.T, database db.KeyValueReader, block *storedBl
 	}
 
 	// Buckets 14, 15, 16: state history
-	assertStateHistoryPruned(t, database, blockNum, block.StateUpdate)
+	AssertStateHistoryPruned(t, database, blockNum, block.StateUpdate)
 }
 
-//nolint:dupl // symmetric with assertStateHistoryPruned.
-func assertStateHistoryExists(
+//nolint:dupl // symmetric with AssertStateHistoryPruned.
+func AssertStateHistoryExists(
 	t *testing.T,
 	r db.KeyValueReader,
 	blockNum uint64,
@@ -273,8 +277,8 @@ func assertStateHistoryExists(
 	}
 }
 
-//nolint:dupl // symmetric with assertStateHistoryExists; see note there.
-func assertStateHistoryPruned(
+//nolint:dupl // symmetric with AssertStateHistoryExists; see note there.
+func AssertStateHistoryPruned(
 	t *testing.T,
 	r db.KeyValueReader,
 	blockNum uint64,
@@ -298,27 +302,111 @@ func assertStateHistoryPruned(
 }
 
 // Helpers for individual bucket checks.
-func blockHeaderExists(database db.KeyValueReader, blockNum uint64) bool {
+func BlockHeaderExists(database db.KeyValueReader, blockNum uint64) bool {
 	_, err := core.GetBlockHeaderByNumber(database, blockNum)
 	return err == nil
 }
 
-func blockHeaderHashExists(database db.KeyValueReader, hash *felt.Felt) bool {
+func BlockHeaderHashExists(database db.KeyValueReader, hash *felt.Felt) bool {
 	_, err := core.BlockHeaderNumbersByHashBucket.Get(database, hash)
 	return err == nil
 }
 
-func blockCommitmentsExist(database db.KeyValueReader, blockNum uint64) bool {
+func BlockCommitmentsExist(database db.KeyValueReader, blockNum uint64) bool {
 	_, err := core.GetBlockCommitmentByBlockNum(database, blockNum)
 	return err == nil
 }
 
-func stateUpdateExists(database db.KeyValueReader, blockNum uint64) bool {
+func StateUpdateExists(database db.KeyValueReader, blockNum uint64) bool {
 	_, err := core.GetStateUpdateByBlockNum(database, blockNum)
 	return err == nil
 }
 
-func transactionsExist(database db.KeyValueReader, blockNum uint64) bool {
+func TransactionsExist(database db.KeyValueReader, blockNum uint64) bool {
 	_, err := core.GetTransactionByBlockAndIndex(database, blockNum, 0)
 	return err == nil
+}
+
+// AssertPostPruneState validates the on-disk shape after a successful
+// prune that retains blocks [oldestKept, len(blocks)) and applies the
+// BlockHashLag carve-out plus the hash→number carve-out at oldestKept-1.
+func AssertPostPruneState(
+	t *testing.T,
+	database db.KeyValueReader,
+	blocks []*StoredBlock,
+	oldestKept uint64,
+	lag uint64,
+) {
+	t.Helper()
+	require.GreaterOrEqual(t, oldestKept, lag,
+		"oldestKept must be ≥ lag for the carve-out to apply")
+	require.GreaterOrEqual(t, uint64(len(blocks)), oldestKept,
+		"blocks slice must cover at least [0, oldestKept)")
+
+	t.Run("blocks below the lag floor are completely gone", func(t *testing.T) {
+		for i := range oldestKept - lag {
+			AssertBlockPruned(t, database, blocks[i])
+		}
+	})
+
+	t.Run("blocks in the lag window keep their header", func(t *testing.T) {
+		for i := oldestKept - lag; i < oldestKept; i++ {
+			h, err := core.GetBlockHeaderByNumber(database, i)
+			require.NoError(t, err,
+				"header at block %d must be readable (BlockHashLag carve-out)", i)
+			assert.Equal(t, i, h.Number)
+		}
+	})
+
+	t.Run("blocks in the lag window have all non-header data deleted", func(t *testing.T) {
+		for i := oldestKept - lag; i < oldestKept; i++ {
+			assert.False(t, BlockCommitmentsExist(database, i),
+				"block %d commitments should be deleted", i)
+			assert.False(t, StateUpdateExists(database, i),
+				"block %d state update should be deleted", i)
+			assert.False(t, TransactionsExist(database, i),
+				"block %d transactions should be deleted", i)
+			for j, txHash := range blocks[i].TxHashes {
+				_, err := core.TransactionBlockNumbersAndIndicesByHashBucket.Get(
+					database,
+					(*felt.TransactionHash)(txHash),
+				)
+				assert.Error(t, err,
+					"block %d tx %d hash lookup should be deleted", i, j)
+			}
+			for _, msgHash := range blocks[i].L1HandlerMsgHashes {
+				_, err := core.GetL1HandlerTxnHashByMsgHash(database, msgHash)
+				assert.Error(t, err,
+					"block %d L1 handler msg hash should be deleted", i)
+			}
+			AssertStateHistoryPruned(t, database, i, blocks[i].StateUpdate)
+		}
+	})
+
+	t.Run("hash→number carve-out preserved at oldestKept-1 only", func(t *testing.T) {
+		for i := range oldestKept - 1 {
+			assert.False(t,
+				BlockHeaderHashExists(database, blocks[i].Header.Hash),
+				"hash→number for block %d should be deleted", i)
+		}
+		assert.True(t,
+			BlockHeaderHashExists(database, blocks[oldestKept-1].Header.Hash),
+			"hash→number carve-out for block %d should be kept", oldestKept-1)
+	})
+
+	// First retained block is oldestKept; its parent is oldestKept-1,
+	// which must resolve hash → number → header via the carve-out + lag
+	// carve-out.
+	t.Run("StateAtBlockHash(oldestKept.parentHash) scenario", func(t *testing.T) {
+		parentHash := blocks[oldestKept-1].Header.Hash
+		header, err := core.GetBlockHeaderByHash(database, parentHash)
+		require.NoError(t, err)
+		assert.Equal(t, oldestKept-1, header.Number)
+	})
+
+	t.Run("blocks beyond oldestKept untouched", func(t *testing.T) {
+		for i := oldestKept; i < uint64(len(blocks)); i++ {
+			AssertBlockExists(t, database, blocks[i])
+		}
+	})
 }

--- a/pruner/testutils/helpers.go
+++ b/pruner/testutils/helpers.go
@@ -15,11 +15,11 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// NewTestDB returns an isolated pebble-backed KeyValueStore for the test.
+// NewPebbleTestDB returns an isolated pebble-backed KeyValueStore for the test.
 // We use pebble (not the in-memory db) because pebble's batch DeleteRange
 // performs a real range delete, while the memory implementation only
 // scans keys with the start byte sequence as a literal prefix.
-func NewTestDB(t *testing.T) db.KeyValueStore {
+func NewPebbleTestDB(t *testing.T) db.KeyValueStore {
 	t.Helper()
 	database, err := pebblev2.New(t.TempDir())
 	require.NoError(t, err)

--- a/pruner/testutils/helpers.go
+++ b/pruner/testutils/helpers.go
@@ -43,9 +43,9 @@ type StoredBlock struct {
 // Two fixed addresses that appear across multiple blocks to simulate
 // realistic state history where the same contract is touched repeatedly.
 var (
-	SharedAddr1 = new(felt.Felt).SetUint64(0xA001) //nolint:mnd // test fixture
-	SharedAddr2 = new(felt.Felt).SetUint64(0xA002) //nolint:mnd // test fixture
-	SharedSlot  = new(felt.Felt).SetUint64(0x5001) //nolint:mnd // test fixture
+	SharedAddr1 = felt.NewFromUint64[felt.Felt](0xA001) //nolint:mnd // test fixture
+	SharedAddr2 = felt.NewFromUint64[felt.Felt](0xA002) //nolint:mnd // test fixture
+	SharedSlot  = felt.NewFromUint64[felt.Felt](0x5001) //nolint:mnd // test fixture
 )
 
 // StoreBlock writes a complete block into the database covering all pruned buckets:
@@ -74,19 +74,19 @@ func StoreBlock(t *testing.T, database db.KeyValueStore, blockNum uint64) *Store
 	// Create transactions: 2 invoke + 1 L1 handler.
 	invokeTx1 := &core.InvokeTransaction{
 		TransactionHash: felt.NewRandom[felt.Felt](),
-		Version:         new(core.TransactionVersion).SetUint64(1),
+		Version:         new(core.TransactionVersion).SetUint64(3),
 	}
 	invokeTx2 := &core.InvokeTransaction{
 		TransactionHash: felt.NewRandom[felt.Felt](),
-		Version:         new(core.TransactionVersion).SetUint64(1),
+		Version:         new(core.TransactionVersion).SetUint64(3),
 	}
 	l1HandlerTx := &core.L1HandlerTransaction{
 		TransactionHash:    felt.NewRandom[felt.Felt](),
 		ContractAddress:    felt.NewRandom[felt.Felt](),
 		EntryPointSelector: felt.NewRandom[felt.Felt](),
-		Nonce:              new(felt.Felt).SetUint64(blockNum),
+		Nonce:              felt.NewFromUint64[felt.Felt](blockNum),
 		CallData:           []*felt.Felt{felt.NewRandom[felt.Felt](), felt.NewRandom[felt.Felt]()},
-		Version:            new(core.TransactionVersion).SetUint64(0),
+		Version:            new(core.TransactionVersion).SetUint64(3),
 	}
 
 	txs := []core.Transaction{invokeTx1, invokeTx2, l1HandlerTx}
@@ -96,7 +96,7 @@ func StoreBlock(t *testing.T, database db.KeyValueStore, blockNum uint64) *Store
 	for i, tx := range txs {
 		receipts[i] = &core.TransactionReceipt{
 			TransactionHash: tx.Hash(),
-			Fee:             new(felt.Felt).SetUint64(100), //nolint:mnd // test fixture
+			Fee:             felt.NewFromUint64[felt.Felt](100), //nolint:mnd // test fixture
 		}
 	}
 
@@ -111,9 +111,9 @@ func StoreBlock(t *testing.T, database db.KeyValueStore, blockNum uint64) *Store
 	// SharedAddr1: storage + nonce change in every block
 	// SharedAddr2: class hash change in every block
 	// Plus a unique address per block for variety.
-	uniqueAddr := new(felt.Felt).SetUint64(0xB000 + blockNum) //nolint:mnd // test fixture
-	uniqueSlot := new(felt.Felt).SetUint64(0xC000 + blockNum) //nolint:mnd // test fixture
-	oldValue := new(felt.Felt).SetUint64(blockNum * 100)      //nolint:mnd // test fixture
+	uniqueAddr := felt.NewFromUint64[felt.Felt](0xB000 + blockNum) //nolint:mnd // test fixture
+	uniqueSlot := felt.NewFromUint64[felt.Felt](0xC000 + blockNum) //nolint:mnd // test fixture
+	oldValue := felt.NewFromUint64[felt.Felt](blockNum * 100)      //nolint:mnd // test fixture
 
 	storageDiffs := map[felt.Felt]map[felt.Felt]*felt.Felt{
 		*SharedAddr1: {

--- a/rpc/v10/events.go
+++ b/rpc/v10/events.go
@@ -170,7 +170,7 @@ func (h *Handler) Events(args *EventArgs) (EventsChunk, *jsonrpc.Error) {
 
 	filteredEvents, cTokenValue, err := filter.Events(cToken, args.ChunkSize)
 	if err != nil {
-		return EventsChunk{}, rpccore.ErrInternal
+		return EventsChunk{}, rpccore.ErrInternal.CloneWithData(err.Error())
 	}
 
 	emittedEvents := make([]EmittedEvent, len(filteredEvents))

--- a/rpc/v10/helpers.go
+++ b/rpc/v10/helpers.go
@@ -132,12 +132,11 @@ func (h *Handler) blockHeaderByID(blockID *BlockID) (*core.Header, *jsonrpc.Erro
 }
 
 func (h *Handler) getRevealedBlockHash(blockNumber uint64) (*felt.Felt, error) {
-	const blockHashLag = 10
-	if blockNumber < blockHashLag {
+	if blockNumber < core.BlockHashLag {
 		return nil, nil
 	}
 
-	header, err := h.bcReader.BlockHeaderByNumber(blockNumber - blockHashLag)
+	header, err := h.bcReader.BlockHeaderByNumber(blockNumber - core.BlockHashLag)
 	if err != nil {
 		return nil, err
 	}

--- a/rpc/v8/events.go
+++ b/rpc/v8/events.go
@@ -106,7 +106,7 @@ func (h *Handler) Events(args EventsArg) (*EventsChunk, *jsonrpc.Error) {
 
 	filteredEvents, cTokenValue, err := filter.Events(cToken, args.ChunkSize)
 	if err != nil {
-		return nil, rpccore.ErrInternal
+		return nil, rpccore.ErrInternal.CloneWithData(err.Error())
 	}
 
 	emittedEvents := make([]EmittedEvent, len(filteredEvents))

--- a/rpc/v8/helpers.go
+++ b/rpc/v8/helpers.go
@@ -136,12 +136,11 @@ func adaptExecutionResources(resources *core.ExecutionResources) *ExecutionResou
 }
 
 func (h *Handler) getRevealedBlockHash(blockNumber uint64) (*felt.Felt, error) {
-	const blockHashLag = 10
-	if blockNumber < blockHashLag {
+	if blockNumber < core.BlockHashLag {
 		return nil, nil
 	}
 
-	header, err := h.bcReader.BlockHeaderByNumber(blockNumber - blockHashLag)
+	header, err := h.bcReader.BlockHeaderByNumber(blockNumber - core.BlockHashLag)
 	if err != nil {
 		return nil, err
 	}

--- a/rpc/v8/pending_wrapper_test.go
+++ b/rpc/v8/pending_wrapper_test.go
@@ -34,7 +34,7 @@ func TestPendingWrapper_Pending(t *testing.T) {
 	t.Run("Returns empty pending placeholder based on latest header", func(t *testing.T) {
 		mockReader.EXPECT().HeadsHeader().Return(latestBlock.Header, nil)
 		mockReader.EXPECT().BlockHeaderByNumber(
-			latestBlock.Header.Number+1-sync.BlockHashLag,
+			latestBlock.Header.Number+1-core.BlockHashLag,
 		).Return(&core.Header{Hash: felt.NewFromUint64[felt.Felt](1234567)}, nil).Times(2)
 
 		expectedPending, err := sync.MakeEmptyPendingForParent(

--- a/rpc/v8/state_update_test.go
+++ b/rpc/v8/state_update_test.go
@@ -14,7 +14,6 @@ import (
 	"github.com/NethermindEth/juno/rpc/rpccore"
 	rpc "github.com/NethermindEth/juno/rpc/v8"
 	adaptfeeder "github.com/NethermindEth/juno/starknetdata/feeder"
-	"github.com/NethermindEth/juno/sync"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
@@ -194,7 +193,7 @@ func TestStateUpdate(t *testing.T) {
 		update, rpcErr := handler.StateUpdate(blockIDPending(t))
 		require.Nil(t, rpcErr)
 		expectedStateDiff := core.EmptyStateDiff()
-		expectedStateDiff.StorageDiffs[*sync.BlockHashStorageContract] = map[felt.Felt]*felt.Felt{
+		expectedStateDiff.StorageDiffs[*core.BlockHashStorageContract] = map[felt.Felt]*felt.Felt{
 			felt.FromUint64[felt.Felt](blockToRegisterHash.Number): blockToRegisterHash.Hash,
 		}
 		checkUpdate(t, &core.StateUpdate{

--- a/rpc/v9/events.go
+++ b/rpc/v9/events.go
@@ -133,7 +133,7 @@ func (h *Handler) Events(args EventArgs) (EventsChunk, *jsonrpc.Error) {
 
 	filteredEvents, cTokenValue, err := filter.Events(cToken, args.ChunkSize)
 	if err != nil {
-		return EventsChunk{}, rpccore.ErrInternal
+		return EventsChunk{}, rpccore.ErrInternal.CloneWithData(err.Error())
 	}
 
 	emittedEvents := make([]EmittedEvent, len(filteredEvents))

--- a/rpc/v9/helpers.go
+++ b/rpc/v9/helpers.go
@@ -149,12 +149,11 @@ func adaptExecutionResources(resources *core.ExecutionResources) *ExecutionResou
 }
 
 func (h *Handler) getRevealedBlockHash(blockNumber uint64) (*felt.Felt, error) {
-	const blockHashLag = 10
-	if blockNumber < blockHashLag {
+	if blockNumber < core.BlockHashLag {
 		return nil, nil
 	}
 
-	header, err := h.bcReader.BlockHeaderByNumber(blockNumber - blockHashLag)
+	header, err := h.bcReader.BlockHeaderByNumber(blockNumber - core.BlockHashLag)
 	if err != nil {
 		return nil, err
 	}

--- a/sync/helpers.go
+++ b/sync/helpers.go
@@ -9,10 +9,6 @@ import (
 	"github.com/NethermindEth/juno/core/pending"
 )
 
-const BlockHashLag uint64 = 10
-
-var BlockHashStorageContract = &felt.One
-
 // makeStateDiffForEmptyBlock constructs a minimal state diff for an empty block.
 // It optionally writes a historical block hash mapping when blockNumber >= blockHashLag.
 func makeStateDiffForEmptyBlock(bc blockchain.Reader, blockNumber uint64) (*core.StateDiff, error) {
@@ -26,16 +22,16 @@ func makeStateDiffForEmptyBlock(bc blockchain.Reader, blockNumber uint64) (*core
 		MigratedClasses:   make(map[felt.SierraClassHash]felt.CasmClassHash, 0),
 	}
 
-	if blockNumber < BlockHashLag {
+	if blockNumber < core.BlockHashLag {
 		return stateDiff, nil
 	}
 
-	header, err := bc.BlockHeaderByNumber(blockNumber - BlockHashLag)
+	header, err := bc.BlockHeaderByNumber(blockNumber - core.BlockHashLag)
 	if err != nil {
 		return nil, err
 	}
 
-	stateDiff.StorageDiffs[*BlockHashStorageContract] = map[felt.Felt]*felt.Felt{
+	stateDiff.StorageDiffs[*core.BlockHashStorageContract] = map[felt.Felt]*felt.Felt{
 		*new(felt.Felt).SetUint64(header.Number): header.Hash,
 	}
 	return stateDiff, nil


### PR DESCRIPTION
## Summary

Adds a `pruner` service that bounds on-disk storage by deleting block data and state history below a configurable retention window. With `--retained-blocks=N`, the node keeps blocks in `(l1_head - N, l2_head]` and prunes everything below.

- **RPC stays fully functional inside the retention window.** Any block in `(l1_head - N, l2_head]` answers normally (events, traces, state-at-block, etc.). Below the floor: `event_filter` surfaces a typed `ErrBlockPruned`; `statebackend` returns `db.ErrKeyNotFound` (i.e. block-not-found), same as if the block never existed.
- **Floor is anchored on the L1-verified head, never on the local L2 head.** Pruned blocks are reorg-safe by construction — anything at or below the L1 head cannot be reorged out. New L2 heads only act as triggers; the floor itself is always recomputed from L1.
- **Retention can be changed across restarts.** Lowering `--retained-blocks` shrinks the window on the next sweep. Raising it grows the window gradually — the pruner pauses until the L1 head advances enough to reach the new floor; nothing is "un-pruned".
- **Disabled by default.** `--retained-blocks=0` keeps existing behaviour.
- **Irreversible.** Data deleted under a small window cannot be recovered without re-syncing.

## Open for discussion

`starknet_getEvents` with an unset `from_block` currently errors with `ErrBlockPruned` instead of silently clamping to the oldest retained block. Strict over silent — an unbounded query against a pruned node has clearly lost data, and we'd rather surface that than return a partial result the caller doesn't know is partial. Happy to flip to clamp-to-oldest if reviewers prefer.

## Details

See the package doc on `pruner/pruner.go` and the contract on `PruneUpto` in `pruner/accessors.go` for the exact deletion set, the two intentional carve-outs (BlockHashLag headers and the parent-hash mapping), and resume semantics on cancellation.

Touches outside `pruner/`:
- `blockchain/event_filter.go`, `blockchain/statebackend/*` — gate reads on retention via `pruner.RequireRetained` / `pruner.HeaderBy*IfStateRetained`.
- `core/block.go` — `BlockHashLag` and `BlockHashStorageContract` moved here from `sync` so the pruner carve-out and RPC `getRevealedBlockHash` share one source of truth.
- `node/node.go`, `cmd/juno/juno.go` — `--retained-blocks` flag and service wiring (sequencer and sync paths).
- `node/metrics.go` — Prometheus listener for prune events.