### PR TITLE
feat: pruning migration

### DIFF
--- a/migration/historyprunner/committer.go
+++ b/migration/historyprunner/committer.go
@@ -8,6 +8,8 @@ import (
 	"go.uber.org/zap"
 )
 
+// committer is a pipeline stage that writes batches to the database and
+// releases the batch semaphore slot.
 type committer struct {
 	logger         log.StructuredLogger
 	batchSemaphore semaphore.ResourceSemaphore[db.Batch]

--- a/migration/historyprunner/committer.go
+++ b/migration/historyprunner/committer.go
@@ -1,0 +1,48 @@
+package historyprunner
+
+import (
+	"github.com/NethermindEth/juno/db"
+	"github.com/NethermindEth/juno/migration/pipeline"
+	"github.com/NethermindEth/juno/migration/semaphore"
+	"github.com/NethermindEth/juno/utils/log"
+	"go.uber.org/zap"
+)
+
+type committer struct {
+	logger         log.StructuredLogger
+	batchSemaphore semaphore.ResourceSemaphore[db.Batch]
+}
+
+var _ pipeline.State[db.Batch, struct{}] = (*committer)(nil)
+
+func newCommitter(
+	logger log.StructuredLogger,
+	batchSemaphore semaphore.ResourceSemaphore[db.Batch],
+) *committer {
+	return &committer{
+		logger:         logger,
+		batchSemaphore: batchSemaphore,
+	}
+}
+
+func (c *committer) Run(_ int, batch db.Batch, _ chan<- struct{}) error {
+	c.logger.Debug(
+		"writing batch",
+		zap.Int("batch_size", batch.Size()),
+	)
+	defer c.logger.Debug(
+		"wrote batch",
+		zap.Int("batch_size", batch.Size()),
+	)
+
+	if err := batch.Write(); err != nil {
+		return err
+	}
+
+	c.batchSemaphore.Put()
+	return nil
+}
+
+func (c *committer) Done(int, chan<- struct{}) error {
+	return nil
+}

--- a/migration/historyprunner/copy.go
+++ b/migration/historyprunner/copy.go
@@ -51,7 +51,10 @@ func copyStateHistory(
 				fillStorageHistoryKey(scratch.historyKey[:], &addr, &slot, blockBE),
 				fillStorageScratchKey(scratch.scratchKey[:], &addr, &slot, blockBE),
 			); err != nil {
-				return err
+				return fmt.Errorf(
+					"copying storage history at block %d, addr %x, slot %x: %w",
+					blockNum, addr, slot, err,
+				)
 			}
 		}
 	}
@@ -61,7 +64,10 @@ func copyStateHistory(
 			fillNonceHistoryKey(scratch.historyKey[:], &addr, blockBE),
 			fillNonceScratchKey(scratch.scratchKey[:], &addr, blockBE),
 		); err != nil {
-			return err
+			return fmt.Errorf(
+				"copying nonce history at block %d, addr %x: %w",
+				blockNum, addr, err,
+			)
 		}
 	}
 
@@ -70,7 +76,10 @@ func copyStateHistory(
 			fillClassHashHistoryKey(scratch.historyKey[:], &addr, blockBE),
 			fillClassHashScratchKey(scratch.scratchKey[:], &addr, blockBE),
 		); err != nil {
-			return err
+			return fmt.Errorf(
+				"copying class hash history at block %d, addr %x: %w",
+				blockNum, addr, err,
+			)
 		}
 	}
 

--- a/migration/historyprunner/copy.go
+++ b/migration/historyprunner/copy.go
@@ -1,0 +1,106 @@
+package historyprunner
+
+import (
+	"encoding/binary"
+	"fmt"
+
+	"github.com/NethermindEth/juno/core"
+	"github.com/NethermindEth/juno/db"
+)
+
+// copyScratch holds the reusable byte buffers for one worker's copy
+// operations. Each worker owns one copyScratch; buffers are overwritten on
+// every entry and consumed (via batch.Put) before the next iteration
+// touches them, so reuse is safe. Allocated once at stager/restorer
+// construction.
+type copyScratch struct {
+	historyKey [historyKeyBufLen]byte
+	scratchKey [scratchKeyBufLen]byte
+	value      [historyValueLen]byte
+}
+
+type copyDirection bool
+
+const (
+	historyToScratch copyDirection = false
+	scratchToHistory copyDirection = true
+)
+
+func copyStateHistory(
+	reader db.KeyValueReader,
+	batch db.Batch,
+	scratch *copyScratch,
+	diff *core.StateDiff,
+	blockNum uint64,
+	direction copyDirection,
+) error {
+	var blockBE [blockNumberSuffixLen]byte
+	binary.BigEndian.PutUint64(blockBE[:], blockNum)
+
+	move := func(historyKey, scratchKey []byte) error {
+		src, dst := historyKey, scratchKey
+		if direction == scratchToHistory {
+			src, dst = dst, src
+		}
+		return copyValue(reader, batch, scratch.value[:], src, dst)
+	}
+
+	for addr, slots := range diff.StorageDiffs {
+		for slot := range slots {
+			if err := move(
+				fillStorageHistoryKey(scratch.historyKey[:], &addr, &slot, blockBE),
+				fillStorageScratchKey(scratch.scratchKey[:], &addr, &slot, blockBE),
+			); err != nil {
+				return err
+			}
+		}
+	}
+
+	for addr := range diff.Nonces {
+		if err := move(
+			fillNonceHistoryKey(scratch.historyKey[:], &addr, blockBE),
+			fillNonceScratchKey(scratch.scratchKey[:], &addr, blockBE),
+		); err != nil {
+			return err
+		}
+	}
+
+	for addr := range diff.ReplacedClasses {
+		if err := move(
+			fillClassHashHistoryKey(scratch.historyKey[:], &addr, blockBE),
+			fillClassHashScratchKey(scratch.scratchKey[:], &addr, blockBE),
+		); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// copyValue reads source into buf, then writes buf to dest. buf is the
+// caller's reusable felt-sized scratch (32 bytes); after Put returns, the
+// underlying batch has copied buf, so the caller may overwrite it safely.
+func copyValue(
+	reader db.KeyValueReader,
+	writer db.KeyValueWriter,
+	buf,
+	source,
+	dest []byte,
+) error {
+	err := reader.Get(source, func(data []byte) error {
+		if len(data) != len(buf) {
+			return fmt.Errorf(
+				"history value size mismatch at key %x: want %d bytes, got %d",
+				source, len(buf), len(data),
+			)
+		}
+
+		copy(buf, data)
+		return nil
+	})
+	if err != nil {
+		return err
+	}
+
+	return writer.Put(dest, buf)
+}

--- a/migration/historyprunner/keys.go
+++ b/migration/historyprunner/keys.go
@@ -1,0 +1,143 @@
+package historyprunner
+
+import (
+	"github.com/NethermindEth/juno/core/felt"
+	"github.com/NethermindEth/juno/db"
+)
+
+// migrationScratchTag is the leading byte of every history-pruner scratch
+// key. We reuse db.Temporary, the canonical scratch bucket also used by
+// deprecated migrations. Production iterators scoped to a single-byte bucket
+// prefix (e.g. NewIterator([]byte{14}, ...) for ContractStorageHistory)
+// cannot observe scratch keys.
+var migrationScratchTag = byte(db.Temporary)
+
+// Scratch keys carry their source bucket tag as byte 1, making them
+// self-describing:
+//
+//	scratchKey = [Temporary][originalBucketTag][...rest of original key after
+//	                                            its own bucket tag byte]
+//
+// Concretely:
+//
+//	storage   : [Temporary][14][addr:32][slot:32][block:8]   = 74 bytes
+//	nonce     : [Temporary][15][addr:32][block:8]            = 42 bytes
+//	classhash : [Temporary][16][addr:32][block:8]            = 42 bytes
+//
+// Phase 2 (scratch → history) needs no out-of-band mapping: read the
+// original tag from byte 1 of the scratch key, prepend it to the rest, done.
+const scratchPrefixLen = 2
+
+const blockNumberSuffixLen = 8
+
+// History-bucket key sizes. These mirror the production schema:
+//
+//	storage   : [bucket][addr:32][slot:32][block:8] = 73
+//	nonce     : [bucket][addr:32][block:8]          = 41
+//	classhash : [bucket][addr:32][block:8]          = 41
+const (
+	storageHistoryKeyLen   = 1 + 2*felt.Bytes + blockNumberSuffixLen
+	nonceHistoryKeyLen     = 1 + felt.Bytes + blockNumberSuffixLen
+	classHashHistoryKeyLen = 1 + felt.Bytes + blockNumberSuffixLen
+
+	// historyKeyBufLen sizes a buffer big enough for any history-bucket key
+	// in this migration — caller can reuse one buffer across all three.
+	historyKeyBufLen = storageHistoryKeyLen
+
+	// historyValueLen is the felt-sized payload of every history bucket.
+	historyValueLen = felt.Bytes
+
+	storageScratchKeyLen   = 1 + storageHistoryKeyLen
+	nonceScratchKeyLen     = 1 + nonceHistoryKeyLen
+	classHashScratchKeyLen = 1 + classHashHistoryKeyLen
+
+	// scratchKeyBufLen sizes a buffer big enough for any scratch key —
+	// callers can reuse one buffer across all three sub-namespaces.
+	scratchKeyBufLen = storageScratchKeyLen
+)
+
+// fillStorageScratchKey writes [Temporary][14][addr:32][slot:32][block:8] into
+// dst and returns dst[:74]. dst must have cap ≥ storageScratchKeyLen.
+func fillStorageScratchKey(
+	buf []byte,
+	addr, slot *felt.Felt,
+	blockBE [blockNumberSuffixLen]byte,
+) []byte {
+	buf[0] = migrationScratchTag
+	buf[1] = byte(db.ContractStorageHistory)
+	addrBytes := addr.Bytes()
+	copy(buf[scratchPrefixLen:], addrBytes[:])
+	slotBytes := slot.Bytes()
+	copy(buf[scratchPrefixLen+felt.Bytes:], slotBytes[:])
+	copy(buf[scratchPrefixLen+2*felt.Bytes:], blockBE[:])
+	return buf[:storageScratchKeyLen]
+}
+
+// fillNonceScratchKey writes [Temporary][15][addr:32][block:8] into dst.
+func fillNonceScratchKey(
+	buf []byte,
+	addr *felt.Felt,
+	blockBE [blockNumberSuffixLen]byte,
+) []byte {
+	buf[0] = migrationScratchTag
+	buf[1] = byte(db.ContractNonceHistory)
+	addrBytes := addr.Bytes()
+	copy(buf[scratchPrefixLen:], addrBytes[:])
+	copy(buf[scratchPrefixLen+felt.Bytes:], blockBE[:])
+	return buf[:nonceScratchKeyLen]
+}
+
+// fillClassHashScratchKey writes [Temporary][16][addr:32][block:8] into dst.
+func fillClassHashScratchKey(
+	buf []byte,
+	addr *felt.Felt,
+	blockBE [blockNumberSuffixLen]byte,
+) []byte {
+	buf[0] = migrationScratchTag
+	buf[1] = byte(db.ContractClassHashHistory)
+	addrBytes := addr.Bytes()
+	copy(buf[scratchPrefixLen:], addrBytes[:])
+	copy(buf[scratchPrefixLen+felt.Bytes:], blockBE[:])
+	return buf[:classHashScratchKeyLen]
+}
+
+// fillStorageHistoryKey writes [bucket][addr:32][slot:32][block:8] into dst.
+func fillStorageHistoryKey(
+	buf []byte,
+	addr, slot *felt.Felt,
+	blockBE [blockNumberSuffixLen]byte,
+) []byte {
+	buf[0] = byte(db.ContractStorageHistory)
+	addrBytes := addr.Bytes()
+	copy(buf[1:], addrBytes[:])
+	slotBytes := slot.Bytes()
+	copy(buf[1+felt.Bytes:], slotBytes[:])
+	copy(buf[1+2*felt.Bytes:], blockBE[:])
+	return buf[:storageHistoryKeyLen]
+}
+
+// fillNonceHistoryKey writes [bucket][addr:32][block:8] into dst.
+func fillNonceHistoryKey(
+	buf []byte,
+	addr *felt.Felt,
+	blockBE [blockNumberSuffixLen]byte,
+) []byte {
+	buf[0] = byte(db.ContractNonceHistory)
+	addrBytes := addr.Bytes()
+	copy(buf[1:], addrBytes[:])
+	copy(buf[1+felt.Bytes:], blockBE[:])
+	return buf[:nonceHistoryKeyLen]
+}
+
+// fillClassHashHistoryKey writes [bucket][addr:32][block:8] into dst.
+func fillClassHashHistoryKey(
+	buf []byte,
+	addr *felt.Felt,
+	blockBE [blockNumberSuffixLen]byte,
+) []byte {
+	buf[0] = byte(db.ContractClassHashHistory)
+	addrBytes := addr.Bytes()
+	copy(buf[1:], addrBytes[:])
+	copy(buf[1+felt.Bytes:], blockBE[:])
+	return buf[:classHashHistoryKeyLen]
+}

--- a/migration/historyprunner/keys.go
+++ b/migration/historyprunner/keys.go
@@ -63,6 +63,7 @@ func fillStorageScratchKey(
 	addr, slot *felt.Felt,
 	blockBE [blockNumberSuffixLen]byte,
 ) []byte {
+	buf = buf[:storageScratchKeyLen]
 	buf[0] = migrationScratchTag
 	buf[1] = byte(db.ContractStorageHistory)
 	addrBytes := addr.Bytes()
@@ -70,7 +71,7 @@ func fillStorageScratchKey(
 	slotBytes := slot.Bytes()
 	copy(buf[scratchPrefixLen+felt.Bytes:], slotBytes[:])
 	copy(buf[scratchPrefixLen+2*felt.Bytes:], blockBE[:])
-	return buf[:storageScratchKeyLen]
+	return buf
 }
 
 // fillNonceScratchKey writes [Temporary][15][addr:32][block:8] into dst.
@@ -79,12 +80,13 @@ func fillNonceScratchKey(
 	addr *felt.Felt,
 	blockBE [blockNumberSuffixLen]byte,
 ) []byte {
+	buf = buf[:nonceScratchKeyLen]
 	buf[0] = migrationScratchTag
 	buf[1] = byte(db.ContractNonceHistory)
 	addrBytes := addr.Bytes()
 	copy(buf[scratchPrefixLen:], addrBytes[:])
 	copy(buf[scratchPrefixLen+felt.Bytes:], blockBE[:])
-	return buf[:nonceScratchKeyLen]
+	return buf
 }
 
 // fillClassHashScratchKey writes [Temporary][16][addr:32][block:8] into dst.
@@ -93,12 +95,13 @@ func fillClassHashScratchKey(
 	addr *felt.Felt,
 	blockBE [blockNumberSuffixLen]byte,
 ) []byte {
+	buf = buf[:classHashScratchKeyLen]
 	buf[0] = migrationScratchTag
 	buf[1] = byte(db.ContractClassHashHistory)
 	addrBytes := addr.Bytes()
 	copy(buf[scratchPrefixLen:], addrBytes[:])
 	copy(buf[scratchPrefixLen+felt.Bytes:], blockBE[:])
-	return buf[:classHashScratchKeyLen]
+	return buf
 }
 
 // fillStorageHistoryKey writes [bucket][addr:32][slot:32][block:8] into dst.
@@ -107,13 +110,14 @@ func fillStorageHistoryKey(
 	addr, slot *felt.Felt,
 	blockBE [blockNumberSuffixLen]byte,
 ) []byte {
+	buf = buf[:storageHistoryKeyLen]
 	buf[0] = byte(db.ContractStorageHistory)
 	addrBytes := addr.Bytes()
 	copy(buf[1:], addrBytes[:])
 	slotBytes := slot.Bytes()
 	copy(buf[1+felt.Bytes:], slotBytes[:])
 	copy(buf[1+2*felt.Bytes:], blockBE[:])
-	return buf[:storageHistoryKeyLen]
+	return buf
 }
 
 // fillNonceHistoryKey writes [bucket][addr:32][block:8] into dst.
@@ -122,11 +126,12 @@ func fillNonceHistoryKey(
 	addr *felt.Felt,
 	blockBE [blockNumberSuffixLen]byte,
 ) []byte {
+	buf = buf[:nonceHistoryKeyLen]
 	buf[0] = byte(db.ContractNonceHistory)
 	addrBytes := addr.Bytes()
 	copy(buf[1:], addrBytes[:])
 	copy(buf[1+felt.Bytes:], blockBE[:])
-	return buf[:nonceHistoryKeyLen]
+	return buf
 }
 
 // fillClassHashHistoryKey writes [bucket][addr:32][block:8] into dst.
@@ -135,9 +140,10 @@ func fillClassHashHistoryKey(
 	addr *felt.Felt,
 	blockBE [blockNumberSuffixLen]byte,
 ) []byte {
+	buf = buf[:classHashHistoryKeyLen]
 	buf[0] = byte(db.ContractClassHashHistory)
 	addrBytes := addr.Bytes()
 	copy(buf[1:], addrBytes[:])
 	copy(buf[1+felt.Bytes:], blockBE[:])
-	return buf[:classHashHistoryKeyLen]
+	return buf
 }

--- a/migration/historyprunner/migrator.go
+++ b/migration/historyprunner/migrator.go
@@ -50,10 +50,10 @@ type Migrator struct {
 	restorerProgress  uint64
 }
 
-// New constructs a history pruner migrator that retains the most recent
-// retainedBlocks blocks. retainedBlocks == 0 is valid and prunes every
-// block at or below the L1-confirmed head, keeping only the reorg-safe
-// window above it.
+// New constructs a history pruner migrator. retainedBlocks is the number
+// of blocks retained below the L1-confirmed head; the head itself is
+// always retained on top. retainedBlocks == 0 keeps only the L1 head plus
+// the reorg-safe window above it.
 func New(retainedBlocks uint64) *Migrator {
 	return &Migrator{
 		numRetainedBlocks: retainedBlocks,
@@ -112,7 +112,7 @@ func (m *Migrator) Migrate(
 		// Chain shorter than the retention window — nothing to prune yet.
 		return nil, nil
 	}
-	oldestBlockKept := minHead - m.numRetainedBlocks + 1
+	oldestBlockKept := minHead - m.numRetainedBlocks
 
 	start := time.Now()
 	logger.Info("Starting history pruning migration",

--- a/migration/historyprunner/migrator.go
+++ b/migration/historyprunner/migrator.go
@@ -212,7 +212,8 @@ func (m *Migrator) setupBeforeRestorer(database db.KeyValueStore, oldestBlockKep
 	if err != nil {
 		return fmt.Errorf("getting block header at %d: %w", oldestBlockKept-1, err)
 	}
-	if err := core.WriteBlockHeaderNumberByHash(batch, header.Hash, oldestBlockKept-uint64(1)); err != nil {
+	err = core.WriteBlockHeaderNumberByHash(batch, header.Hash, oldestBlockKept-uint64(1))
+	if err != nil {
 		return fmt.Errorf(
 			"writing block header number by hash at %d: %w",
 			oldestBlockKept-1, err,

--- a/migration/historyprunner/migrator.go
+++ b/migration/historyprunner/migrator.go
@@ -148,7 +148,7 @@ func (m *Migrator) Migrate(
 		return state, nil
 	}
 
-	if err := m.setupBeforeRestorer(database); err != nil {
+	if err := m.setupBeforeRestorer(database, oldestBlockKept); err != nil {
 		return nil, fmt.Errorf("setting up before restorer: %w", err)
 	}
 
@@ -197,15 +197,26 @@ func (m *Migrator) setupBeforeStager(
 }
 
 // setupBeforeRestorer wipes the live history buckets so the per-block restore
-// can copy staged keepers back. Gated by restorerProgress so a resumed
+// can copy staged keepers back, and seeds the reverse-lookup for the block
+// immediately below the keeper window. Gated by restorerProgress so a resumed
 // restorer doesn't re-wipe partial work.
-func (m *Migrator) setupBeforeRestorer(database db.KeyValueStore) error {
+func (m *Migrator) setupBeforeRestorer(database db.KeyValueStore, oldestBlockKept uint64) error {
 	if m.restorerProgress != 0 {
 		return nil
 	}
 	batch := database.NewBatch()
 	if err := wipeStorageHistoryBuckets(batch); err != nil {
 		return fmt.Errorf("wiping storage history buckets: %w", err)
+	}
+	header, err := core.GetBlockHeaderByNumber(database, oldestBlockKept-uint64(1))
+	if err != nil {
+		return fmt.Errorf("getting block header at %d: %w", oldestBlockKept-1, err)
+	}
+	if err := core.WriteBlockHeaderNumberByHash(batch, header.Hash, oldestBlockKept-uint64(1)); err != nil {
+		return fmt.Errorf(
+			"writing block header number by hash at %d: %w",
+			oldestBlockKept-1, err,
+		)
 	}
 	if err := batch.Write(); err != nil {
 		return fmt.Errorf("writing batch: %w", err)
@@ -291,23 +302,6 @@ func (m *Migrator) runRestorer(
 	loggerCancel := progresslogger.CallEveryInterval(ctx, timeLogRate, progressTracker.LogProgress)
 	defer loggerCancel()
 
-	header, err := core.GetBlockHeaderByNumber(database, oldestBlockKept-uint64(1))
-	if err != nil {
-		return nil, false, fmt.Errorf("getting block header at %d: %w", oldestBlockKept-1, err)
-	}
-
-	batch := database.NewBatch()
-	err = core.WriteBlockHeaderNumberByHash(batch, header.Hash, oldestBlockKept-uint64(1))
-	if err != nil {
-		return nil, false, fmt.Errorf(
-			"writing block header number by hash at %d: %w",
-			oldestBlockKept-1, err,
-		)
-	}
-	if err := batch.Write(); err != nil {
-		return nil, false, fmt.Errorf("writing reverse-lookup seed batch: %w", err)
-	}
-
 	resumeFrom, err := migrateRange(
 		ctx,
 		logger,
@@ -332,7 +326,7 @@ func (m *Migrator) runRestorer(
 	}
 
 	// Restorer completed: wipe the scratch namespace.
-	batch = database.NewBatch()
+	batch := database.NewBatch()
 	if err := wipeScratchSpace(batch); err != nil {
 		return nil, false, fmt.Errorf("wiping scratch space: %w", err)
 	}

--- a/migration/historyprunner/migrator.go
+++ b/migration/historyprunner/migrator.go
@@ -126,7 +126,7 @@ func (m *Migrator) Migrate(
 		zap.Uint64("l1_head", l1Head.BlockNumber),
 	)
 
-	if err := m.setupBeforeStager(database, logger, oldestBlockKept); err != nil {
+	if err := m.setupBeforeStager(database, oldestBlockKept); err != nil {
 		return nil, err
 	}
 
@@ -183,14 +183,11 @@ func (m *Migrator) Migrate(
 // delete restored data and corrupt the db.
 func (m *Migrator) setupBeforeStager(
 	database db.KeyValueStore,
-	logger log.StructuredLogger,
 	oldestBlockKept uint64,
 ) error {
 	if m.restorerProgress != 0 {
 		return nil
 	}
-	logger.Info("Range-deleting number-keyed buckets")
-	startTime := time.Now()
 	batch := database.NewBatch()
 	if err := pruner.PruneBlockDataUpto(batch, oldestBlockKept); err != nil {
 		return err
@@ -201,8 +198,6 @@ func (m *Migrator) setupBeforeStager(
 	if err := batch.Write(); err != nil {
 		return err
 	}
-	logger.Info("Range-deleted number-keyed buckets",
-		zap.Duration("elapsed", time.Since(startTime)))
 	return nil
 }
 

--- a/migration/historyprunner/migrator.go
+++ b/migration/historyprunner/migrator.go
@@ -51,8 +51,9 @@ type Migrator struct {
 }
 
 // New constructs a history pruner migrator that retains the most recent
-// retainedBlocks blocks. Callers should only register this migration when
-// retainedBlocks > 0; a zero value makes Migrate a no-op.
+// retainedBlocks blocks. retainedBlocks == 0 is valid and prunes every
+// block at or below the L1-confirmed head, keeping only the reorg-safe
+// window above it.
 func New(retainedBlocks uint64) *Migrator {
 	return &Migrator{
 		numRetainedBlocks: retainedBlocks,
@@ -87,13 +88,7 @@ func (m *Migrator) Migrate(
 	network *networks.Network,
 	logger log.StructuredLogger,
 ) ([]byte, error) {
-	if m.numRetainedBlocks == 0 {
-		// Invariant violation: registerMigrations gates registration on
-		// RetainedBlocks > 0. Don't ask for a re-run — the config would need
-		// to change first, which restarts the process anyway.
-		return nil, errors.New("retainedBlocks must be non-zero positive integer")
-	}
-	if m.configured != 0 && m.configured != m.numRetainedBlocks {
+	if m.configured != m.numRetainedBlocks {
 		logger.Info("Resuming pruning migration; new retention ignored until completion",
 			zap.Uint64("active_retained_blocks", m.numRetainedBlocks),
 			zap.Uint64("requested_retained_blocks", m.configured),

--- a/migration/historyprunner/migrator.go
+++ b/migration/historyprunner/migrator.go
@@ -101,11 +101,11 @@ func (m *Migrator) Migrate(
 			// No chain data yet; the rolling pruner takes over once blocks arrive.
 			return nil, nil
 		}
-		return nil, err
+		return nil, fmt.Errorf("getting chain height: %w", err)
 	}
 	l1Head, err := core.GetL1Head(database)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("getting L1 head: %w", err)
 	}
 	minHead := min(l1Head.BlockNumber, chainHeight)
 	if minHead < m.numRetainedBlocks {
@@ -122,7 +122,7 @@ func (m *Migrator) Migrate(
 	)
 
 	if err := m.setupBeforeStager(database, oldestBlockKept); err != nil {
-		return nil, err
+		return nil, fmt.Errorf("setting up before stager: %w", err)
 	}
 
 	maxWorkers := runtime.GOMAXPROCS(0)
@@ -142,14 +142,14 @@ func (m *Migrator) Migrate(
 		maxWorkers,
 	)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("running stager: %w", err)
 	}
 	if !done {
 		return state, nil
 	}
 
 	if err := m.setupBeforeRestorer(database); err != nil {
-		return nil, err
+		return nil, fmt.Errorf("setting up before restorer: %w", err)
 	}
 
 	state, done, err = m.runRestorer(
@@ -162,7 +162,7 @@ func (m *Migrator) Migrate(
 		maxWorkers,
 	)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("running restorer: %w", err)
 	}
 	if !done {
 		return state, nil
@@ -185,13 +185,13 @@ func (m *Migrator) setupBeforeStager(
 	}
 	batch := database.NewBatch()
 	if err := pruner.PruneBlockDataUpto(batch, oldestBlockKept); err != nil {
-		return err
+		return fmt.Errorf("pruning block data upto %d: %w", oldestBlockKept, err)
 	}
 	if err := wipeReverseLookupBuckets(batch); err != nil {
-		return err
+		return fmt.Errorf("wiping reverse lookup buckets: %w", err)
 	}
 	if err := batch.Write(); err != nil {
-		return err
+		return fmt.Errorf("writing batch: %w", err)
 	}
 	return nil
 }
@@ -205,9 +205,12 @@ func (m *Migrator) setupBeforeRestorer(database db.KeyValueStore) error {
 	}
 	batch := database.NewBatch()
 	if err := wipeStorageHistoryBuckets(batch); err != nil {
-		return err
+		return fmt.Errorf("wiping storage history buckets: %w", err)
 	}
-	return batch.Write()
+	if err := batch.Write(); err != nil {
+		return fmt.Errorf("writing batch: %w", err)
+	}
+	return nil
 }
 
 // runStager stages the keeper-window history into the scratch namespace.
@@ -251,7 +254,10 @@ func (m *Migrator) runStager(
 		newStager(database, batchSemaphore, maxWorkers, progressTracker),
 	)
 	if err != nil {
-		return nil, false, err
+		return nil, false, fmt.Errorf(
+			"staging range [%d, %d]: %w",
+			m.stagerProgress, chainHeight, err,
+		)
 	}
 
 	if resumeFrom <= chainHeight {
@@ -287,16 +293,19 @@ func (m *Migrator) runRestorer(
 
 	header, err := core.GetBlockHeaderByNumber(database, oldestBlockKept-uint64(1))
 	if err != nil {
-		return nil, false, err
+		return nil, false, fmt.Errorf("getting block header at %d: %w", oldestBlockKept-1, err)
 	}
 
 	batch := database.NewBatch()
 	err = core.WriteBlockHeaderNumberByHash(batch, header.Hash, oldestBlockKept-uint64(1))
 	if err != nil {
-		return nil, false, err
+		return nil, false, fmt.Errorf(
+			"writing block header number by hash at %d: %w",
+			oldestBlockKept-1, err,
+		)
 	}
 	if err := batch.Write(); err != nil {
-		return nil, false, err
+		return nil, false, fmt.Errorf("writing reverse-lookup seed batch: %w", err)
 	}
 
 	resumeFrom, err := migrateRange(
@@ -309,7 +318,10 @@ func (m *Migrator) runRestorer(
 		newRestorer(database, batchSemaphore, maxWorkers, progressTracker),
 	)
 	if err != nil {
-		return nil, false, err
+		return nil, false, fmt.Errorf(
+			"restoring range [%d, %d]: %w",
+			m.restorerProgress, chainHeight, err,
+		)
 	}
 
 	if resumeFrom <= chainHeight {
@@ -322,10 +334,10 @@ func (m *Migrator) runRestorer(
 	// Restorer completed: wipe the scratch namespace.
 	batch = database.NewBatch()
 	if err := wipeScratchSpace(batch); err != nil {
-		return nil, false, err
+		return nil, false, fmt.Errorf("wiping scratch space: %w", err)
 	}
 	if err := batch.Write(); err != nil {
-		return nil, false, err
+		return nil, false, fmt.Errorf("writing scratch-wipe batch: %w", err)
 	}
 	return nil, true, nil
 }
@@ -357,7 +369,7 @@ func migrateRange(
 
 	_, wait := committerPipeline.Run(ctx)
 	if res := wait(); res.Err != nil {
-		return 0, res.Err
+		return 0, fmt.Errorf("running pipeline: %w", res.Err)
 	}
 
 	return nextBlockNumber, nil
@@ -377,30 +389,30 @@ func wipeScratchSpace(batch db.Batch) error {
 
 func wipeReverseLookupBuckets(batch db.Batch) error {
 	if err := wipeBucket(batch, byte(db.TransactionBlockNumbersAndIndicesByHash)); err != nil {
-		return err
+		return fmt.Errorf("wiping TransactionBlockNumbersAndIndicesByHash: %w", err)
 	}
 
 	if err := wipeBucket(batch, byte(db.L1HandlerTxnHashByMsgHash)); err != nil {
-		return err
+		return fmt.Errorf("wiping L1HandlerTxnHashByMsgHash: %w", err)
 	}
 
 	if err := wipeBucket(batch, byte(db.BlockHeaderNumbersByHash)); err != nil {
-		return err
+		return fmt.Errorf("wiping BlockHeaderNumbersByHash: %w", err)
 	}
 	return nil
 }
 
 func wipeStorageHistoryBuckets(batch db.Batch) error {
 	if err := wipeBucket(batch, byte(db.ContractStorageHistory)); err != nil {
-		return err
+		return fmt.Errorf("wiping ContractStorageHistory: %w", err)
 	}
 
 	if err := wipeBucket(batch, byte(db.ContractClassHashHistory)); err != nil {
-		return err
+		return fmt.Errorf("wiping ContractClassHashHistory: %w", err)
 	}
 
 	if err := wipeBucket(batch, byte(db.ContractNonceHistory)); err != nil {
-		return err
+		return fmt.Errorf("wiping ContractNonceHistory: %w", err)
 	}
 	return nil
 }
@@ -408,5 +420,8 @@ func wipeStorageHistoryBuckets(batch db.Batch) error {
 func wipeBucket(batch db.Batch, bucket byte) error {
 	prefix := []byte{bucket}
 	end := dbutils.UpperBound(prefix)
-	return batch.DeleteRange(prefix, end)
+	if err := batch.DeleteRange(prefix, end); err != nil {
+		return fmt.Errorf("deleting range bucket=%d: %w", bucket, err)
+	}
+	return nil
 }

--- a/migration/historyprunner/migrator.go
+++ b/migration/historyprunner/migrator.go
@@ -1,0 +1,422 @@
+package historyprunner
+
+import (
+	"context"
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"runtime"
+	"time"
+
+	"github.com/NethermindEth/juno/blockchain/networks"
+	"github.com/NethermindEth/juno/core"
+	"github.com/NethermindEth/juno/db"
+	"github.com/NethermindEth/juno/db/dbutils"
+	"github.com/NethermindEth/juno/migration"
+	"github.com/NethermindEth/juno/migration/pipeline"
+	"github.com/NethermindEth/juno/migration/progresslogger"
+	"github.com/NethermindEth/juno/migration/semaphore"
+	"github.com/NethermindEth/juno/pruner"
+	"github.com/NethermindEth/juno/utils/log"
+	"go.uber.org/zap"
+)
+
+const (
+	// batchByteSize is the initially allocated size of a batch.
+	batchByteSize = 128 * db.Megabyte
+
+	// targetBatchByteSize is the threshold at which a batch is written to the database.
+	targetBatchByteSize = 96 * db.Megabyte
+
+	// timeLogRate is the rate at which we log the progress.
+	timeLogRate = 30 * time.Second
+)
+
+var _ migration.Migration = (*Migrator)(nil)
+
+// intermediateStateSize is the on-disk encoding length:
+//
+//	[0:8]   stagerProgress    (uint64 BE)
+//	[8:16]  restorerProgress  (uint64 BE)
+//	[16:24] numRetainedBlocks (uint64 BE) — pinned from the first run so that
+//	                                       a config change between runs does
+//	                                       not retarget the cutoff mid-flight.
+const intermediateStateSize = 24
+
+type Migrator struct {
+	numRetainedBlocks uint64 // active value; overridden by Before from persisted state on resume
+	configured        uint64 // value passed to New (what the running process is configured for)
+	stagerProgress    uint64
+	restorerProgress  uint64
+}
+
+// New constructs a history pruner migrator that retains the most recent
+// retainedBlocks blocks. Callers should only register this migration when
+// retainedBlocks > 0; a zero value makes Migrate a no-op.
+func New(retainedBlocks uint64) *Migrator {
+	return &Migrator{
+		numRetainedBlocks: retainedBlocks,
+		configured:        retainedBlocks,
+	}
+}
+
+// Before restores stager/restorer progress and the originally-configured retention
+// window from the persisted intermediate state. A nil/empty state means a
+// fresh run — the constructor defaults stand. If retainedBlocks was changed
+// between runs, the persisted (original) value wins; Migrate logs the
+// divergence so the operator can see why the new value is being ignored.
+func (m *Migrator) Before(state []byte) error {
+	if len(state) == 0 {
+		return nil
+	}
+	if len(state) != intermediateStateSize {
+		return fmt.Errorf("historyprunner: invalid intermediate state size: got %d, want %d",
+			len(state),
+			intermediateStateSize,
+		)
+	}
+	m.stagerProgress = binary.BigEndian.Uint64(state[0:8])
+	m.restorerProgress = binary.BigEndian.Uint64(state[8:16])
+	m.numRetainedBlocks = binary.BigEndian.Uint64(state[16:24])
+	return nil
+}
+
+func (m *Migrator) Migrate(
+	ctx context.Context,
+	database db.KeyValueStore,
+	network *networks.Network,
+	logger log.StructuredLogger,
+) ([]byte, error) {
+	if m.numRetainedBlocks == 0 {
+		// Invariant violation: registerMigrations gates registration on
+		// RetainedBlocks > 0. Don't ask for a re-run — the config would need
+		// to change first, which restarts the process anyway.
+		return nil, errors.New("retainedBlocks must be non-zero positive integer")
+	}
+	if m.configured != 0 && m.configured != m.numRetainedBlocks {
+		logger.Info("Resuming pruning migration; new retention ignored until completion",
+			zap.Uint64("active_retained_blocks", m.numRetainedBlocks),
+			zap.Uint64("requested_retained_blocks", m.configured),
+		)
+	}
+
+	chainHeight, err := core.GetChainHeight(database)
+	if err != nil {
+		if errors.Is(err, db.ErrKeyNotFound) {
+			// No chain data yet; the rolling pruner takes over once blocks arrive.
+			return nil, nil
+		}
+		return nil, err
+	}
+	l1Head, err := core.GetL1Head(database)
+	if err != nil {
+		return nil, err
+	}
+	minHead := min(l1Head.BlockNumber, chainHeight)
+	if minHead < m.numRetainedBlocks {
+		// Chain shorter than the retention window — nothing to prune yet.
+		return nil, nil
+	}
+	oldestBlockKept := minHead - m.numRetainedBlocks + 1
+
+	start := time.Now()
+	logger.Info("Starting history pruning migration",
+		zap.Uint64("chain_height", chainHeight),
+		zap.Uint64("oldest_block_kept", oldestBlockKept),
+		zap.Uint64("l1_head", l1Head.BlockNumber),
+	)
+
+	if err := m.setupBeforeStager(database, logger, oldestBlockKept); err != nil {
+		return nil, err
+	}
+
+	maxWorkers := runtime.GOMAXPROCS(0)
+	batchSemaphore := semaphore.New(
+		maxWorkers+1,
+		func() db.Batch {
+			return database.NewBatchWithSize(int(batchByteSize))
+		},
+	)
+	state, done, err := m.runStager(
+		ctx,
+		database,
+		batchSemaphore,
+		logger,
+		oldestBlockKept,
+		chainHeight,
+		maxWorkers,
+	)
+	if err != nil {
+		return nil, err
+	}
+	if !done {
+		return state, nil
+	}
+
+	if err := m.setupBeforeRestorer(database); err != nil {
+		return nil, err
+	}
+
+	state, done, err = m.runRestorer(
+		ctx,
+		database,
+		batchSemaphore,
+		logger,
+		oldestBlockKept,
+		chainHeight,
+		maxWorkers,
+	)
+	if err != nil {
+		return nil, err
+	}
+	if !done {
+		return state, nil
+	}
+
+	logger.Info("History pruning migration completed", zap.Duration("elapsed", time.Since(start)))
+	return nil, nil
+}
+
+// setupBeforeStager range-deletes the cold number-keyed buckets and wipes the
+// reverse-lookup buckets. Gated by restorerProgress because the restorer rebuilds
+// the reverse-lookup buckets — re-running this after the restorer has started would
+// delete restored data and corrupt the db.
+func (m *Migrator) setupBeforeStager(
+	database db.KeyValueStore,
+	logger log.StructuredLogger,
+	oldestBlockKept uint64,
+) error {
+	if m.restorerProgress != 0 {
+		return nil
+	}
+	logger.Info("Range-deleting number-keyed buckets")
+	startTime := time.Now()
+	batch := database.NewBatch()
+	if err := pruner.PruneBlockDataUpto(batch, oldestBlockKept); err != nil {
+		return err
+	}
+	if err := wipeReverseLookupBuckets(batch); err != nil {
+		return err
+	}
+	if err := batch.Write(); err != nil {
+		return err
+	}
+	logger.Info("Range-deleted number-keyed buckets",
+		zap.Duration("elapsed", time.Since(startTime)))
+	return nil
+}
+
+// setupBeforeRestorer wipes the live history buckets so the per-block restore
+// can copy staged keepers back. Gated by restorerProgress so a resumed
+// restorer doesn't re-wipe partial work.
+func (m *Migrator) setupBeforeRestorer(database db.KeyValueStore) error {
+	if m.restorerProgress != 0 {
+		return nil
+	}
+	batch := database.NewBatch()
+	if err := wipeStorageHistoryBuckets(batch); err != nil {
+		return err
+	}
+	return batch.Write()
+}
+
+// runStager stages the keeper-window history into the scratch namespace.
+// The first invocation also range-deletes the cold (pre-cutoff) number-keyed
+// buckets and wipes the reverse-lookup buckets; they remain empty until
+// runRestorer rebuilds them.
+//
+// done=false signals the stager was interrupted (state is the resume blob);
+// done=true signals completion.
+func (m *Migrator) runStager(
+	ctx context.Context,
+	database db.KeyValueStore,
+	batchSemaphore semaphore.ResourceSemaphore[db.Batch],
+	logger log.StructuredLogger,
+	oldestBlockKept, chainHeight uint64,
+	maxWorkers int,
+) ([]byte, bool, error) {
+	if m.stagerProgress > chainHeight {
+		logger.Info("Stager already completed in a previous run, skipping")
+		return nil, true, nil
+	}
+	m.stagerProgress = max(oldestBlockKept, m.stagerProgress)
+
+	// Progress is reported relative to the keeper window [oldestBlockKept,
+	// chainHeight] — passing absolute block numbers would start the readout
+	// near 100% and never visibly advance.
+	keeperWindow := chainHeight - oldestBlockKept + 1
+	progressTracker := progresslogger.NewBlockProgressTracker(
+		"stager", logger, keeperWindow, m.stagerProgress-oldestBlockKept,
+	)
+	loggerCancel := progresslogger.CallEveryInterval(ctx, timeLogRate, progressTracker.LogProgress)
+	defer loggerCancel()
+
+	resumeFrom, err := migrateRange(
+		ctx,
+		logger,
+		batchSemaphore,
+		m.stagerProgress,
+		chainHeight,
+		maxWorkers,
+		newStager(database, batchSemaphore, maxWorkers, progressTracker),
+	)
+	if err != nil {
+		return nil, false, err
+	}
+
+	if resumeFrom <= chainHeight {
+		logger.Info("Stager interrupted",
+			zap.Uint64("resume_from", resumeFrom),
+		)
+		return encodeIntermediateState(resumeFrom, 0, m.numRetainedBlocks), false, nil
+	}
+	return nil, true, nil
+}
+
+// runRestorer wipes the live history buckets, then for each keeper block
+// copies its state history back from scratch and rebuilds the
+// (hash → block-number) reverse-lookup indices. On successful completion
+// the scratch namespace is wiped before returning.
+func (m *Migrator) runRestorer(
+	ctx context.Context,
+	database db.KeyValueStore,
+	batchSemaphore semaphore.ResourceSemaphore[db.Batch],
+	logger log.StructuredLogger,
+	oldestBlockKept,
+	chainHeight uint64,
+	maxWorkers int,
+) ([]byte, bool, error) {
+	m.restorerProgress = max(oldestBlockKept, m.restorerProgress)
+
+	keeperWindow := chainHeight - oldestBlockKept + 1
+	progressTracker := progresslogger.NewBlockProgressTracker(
+		"restorer", logger, keeperWindow, m.restorerProgress-oldestBlockKept,
+	)
+	loggerCancel := progresslogger.CallEveryInterval(ctx, timeLogRate, progressTracker.LogProgress)
+	defer loggerCancel()
+
+	header, err := core.GetBlockHeaderByNumber(database, oldestBlockKept-uint64(1))
+	if err != nil {
+		return nil, false, err
+	}
+
+	batch := database.NewBatch()
+	err = core.WriteBlockHeaderNumberByHash(batch, header.Hash, oldestBlockKept-uint64(1))
+	if err != nil {
+		return nil, false, err
+	}
+	if err := batch.Write(); err != nil {
+		return nil, false, err
+	}
+
+	resumeFrom, err := migrateRange(
+		ctx,
+		logger,
+		batchSemaphore,
+		m.restorerProgress,
+		chainHeight,
+		maxWorkers,
+		newRestorer(database, batchSemaphore, maxWorkers, progressTracker),
+	)
+	if err != nil {
+		return nil, false, err
+	}
+
+	if resumeFrom <= chainHeight {
+		logger.Info("Restorer interrupted",
+			zap.Uint64("resume_from", resumeFrom),
+		)
+		return encodeIntermediateState(chainHeight+1, resumeFrom, m.numRetainedBlocks), false, nil
+	}
+
+	// Restorer completed: wipe the scratch namespace.
+	batch = database.NewBatch()
+	if err := wipeScratchSpace(batch); err != nil {
+		return nil, false, err
+	}
+	if err := batch.Write(); err != nil {
+		return nil, false, err
+	}
+	return nil, true, nil
+}
+
+func migrateRange(
+	ctx context.Context,
+	logger log.StructuredLogger,
+	batchSemaphore semaphore.ResourceSemaphore[db.Batch],
+	fromBlock,
+	toBlock uint64,
+	maxWorkers int,
+	processor pipeline.State[uint64, db.Batch],
+) (uint64, error) {
+	nextBlockNumber := fromBlock
+	blockNumberSource := pipeline.Source(func(yield func(uint64) bool) {
+		for ; nextBlockNumber <= toBlock; nextBlockNumber++ {
+			if !yield(nextBlockNumber) {
+				return
+			}
+		}
+	})
+
+	processorPipeline := pipeline.New(blockNumberSource, maxWorkers, processor)
+	committerPipeline := pipeline.New(
+		processorPipeline,
+		maxWorkers,
+		newCommitter(logger, batchSemaphore),
+	)
+
+	_, wait := committerPipeline.Run(ctx)
+	if res := wait(); res.Err != nil {
+		return 0, res.Err
+	}
+
+	return nextBlockNumber, nil
+}
+
+func encodeIntermediateState(stagerCompletion, restorerCompletion, retainedBlocks uint64) []byte {
+	buf := make([]byte, intermediateStateSize)
+	binary.BigEndian.PutUint64(buf[0:8], stagerCompletion)
+	binary.BigEndian.PutUint64(buf[8:16], restorerCompletion)
+	binary.BigEndian.PutUint64(buf[16:24], retainedBlocks)
+	return buf
+}
+
+func wipeScratchSpace(batch db.Batch) error {
+	return wipeBucket(batch, migrationScratchTag)
+}
+
+func wipeReverseLookupBuckets(batch db.Batch) error {
+	if err := wipeBucket(batch, byte(db.TransactionBlockNumbersAndIndicesByHash)); err != nil {
+		return err
+	}
+
+	if err := wipeBucket(batch, byte(db.L1HandlerTxnHashByMsgHash)); err != nil {
+		return err
+	}
+
+	if err := wipeBucket(batch, byte(db.BlockHeaderNumbersByHash)); err != nil {
+		return err
+	}
+	return nil
+}
+
+func wipeStorageHistoryBuckets(batch db.Batch) error {
+	if err := wipeBucket(batch, byte(db.ContractStorageHistory)); err != nil {
+		return err
+	}
+
+	if err := wipeBucket(batch, byte(db.ContractClassHashHistory)); err != nil {
+		return err
+	}
+
+	if err := wipeBucket(batch, byte(db.ContractNonceHistory)); err != nil {
+		return err
+	}
+	return nil
+}
+
+func wipeBucket(batch db.Batch, bucket byte) error {
+	prefix := []byte{bucket}
+	end := dbutils.UpperBound(prefix)
+	return batch.DeleteRange(prefix, end)
+}

--- a/migration/historyprunner/migrator_test.go
+++ b/migration/historyprunner/migrator_test.go
@@ -47,25 +47,33 @@ func setupChain(
 // historyprunner migrator is a different code path (range-tombstone wipe
 // + scratch-stage + restore) but converges on the same on-disk shape as
 // PruneUpto for the keep window and the carve-outs.
-//
-// Setup: 30 blocks, retainedBlocks=10. With chainHeight=l1Head=29 the
-// migrator picks oldestBlockKept = 29 - 10 + 1 = 20, equivalent to
-// PruneUpto(20) in the pruner tests.
 func TestMigrate_FullRun(t *testing.T) {
 	const totalBlocks uint64 = 30
-	const retainedBlocks uint64 = 10
-	const oldestBlockKept = totalBlocks - retainedBlocks // 20
 	lag := core.BlockHashLag
-	require.GreaterOrEqual(t, oldestBlockKept, lag)
 
-	database, blocks := setupChain(t, totalBlocks)
+	tests := []struct {
+		name            string
+		retainedBlocks  uint64
+		oldestBlockKept uint64
+	}{
+		{name: "standard", retainedBlocks: 10, oldestBlockKept: totalBlocks - 10 - 1},
+		{name: "zero retained", retainedBlocks: 0, oldestBlockKept: totalBlocks - 1},
+	}
 
-	m := historyprunner.New(retainedBlocks)
-	state, err := m.Migrate(t.Context(), database, &networks.Mainnet, log.NewNopZapLogger())
-	require.NoError(t, err)
-	require.Nil(t, state, "fully completed migration must not return intermediate state")
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			require.GreaterOrEqual(t, tc.oldestBlockKept, lag)
 
-	testutils.AssertPostPruneState(t, database, blocks, oldestBlockKept, lag)
+			database, blocks := setupChain(t, totalBlocks)
+
+			m := historyprunner.New(tc.retainedBlocks)
+			state, err := m.Migrate(t.Context(), database, &networks.Mainnet, log.NewNopZapLogger())
+			require.NoError(t, err)
+			require.Nil(t, state, "fully completed migration must not return intermediate state")
+
+			testutils.AssertPostPruneState(t, database, blocks, tc.oldestBlockKept, lag)
+		})
+	}
 }
 
 // TestMigrate_NoOpWhenChainShorterThanRetention covers the early exit when
@@ -163,7 +171,7 @@ func runCancellable(
 func TestMigrate_CancelAndResume(t *testing.T) {
 	const totalBlocks uint64 = 30
 	const retainedBlocks uint64 = 10
-	const oldestBlockKept = totalBlocks - retainedBlocks // 20
+	const oldestBlockKept = totalBlocks - retainedBlocks - 1 // 19
 	lag := core.BlockHashLag
 
 	database, blocks := setupChain(t, totalBlocks)

--- a/migration/historyprunner/migrator_test.go
+++ b/migration/historyprunner/migrator_test.go
@@ -27,7 +27,7 @@ func setupChain(
 	totalBlocks uint64,
 ) (db.KeyValueStore, []*testutils.StoredBlock) {
 	t.Helper()
-	database := testutils.NewTestDB(t)
+	database := testutils.NewPebbleTestDB(t)
 	blocks := make([]*testutils.StoredBlock, totalBlocks)
 	for i := range totalBlocks {
 		blocks[i] = testutils.StoreBlock(t, database, i)
@@ -91,7 +91,7 @@ func TestMigrate_NoOpWhenChainShorterThanRetention(t *testing.T) {
 // TestMigrate_NoOpOnEmptyDB covers the early exit when the chain head
 // pointer is missing. This is the cold-start path on a fresh node.
 func TestMigrate_NoOpOnEmptyDB(t *testing.T) {
-	database := testutils.NewTestDB(t)
+	database := testutils.NewPebbleTestDB(t)
 	m := historyprunner.New(10)
 	state, err := m.Migrate(t.Context(), database, &networks.Mainnet, log.NewNopZapLogger())
 	require.NoError(t, err)

--- a/migration/historyprunner/migrator_test.go
+++ b/migration/historyprunner/migrator_test.go
@@ -178,14 +178,15 @@ func TestMigrate_CancelAndResume(t *testing.T) {
 
 	// Cancel every 2 blocks until the migration completes. Each iteration
 	// must either return a non-nil intermediate state (still going) or
-	// nil (done).
+	// nil (done). The number of attempts is not deterministic — concurrent
+	// workers in the pipeline race against ctx cancellation. We only assert that cancellation
+	// was actually exercised (>= 2 attempts) and that the loop terminates.
 	var (
 		state    []byte
 		attempts int
 	)
 	for {
 		attempts++
-		require.LessOrEqual(t, attempts, 10, "should converge in well under 10 attempts")
 		state = runCancellable(t, state, database, 2, retainedBlocks)
 		if state == nil {
 			break

--- a/migration/historyprunner/migrator_test.go
+++ b/migration/historyprunner/migrator_test.go
@@ -1,0 +1,192 @@
+package historyprunner_test
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+
+	"github.com/NethermindEth/juno/blockchain/networks"
+	"github.com/NethermindEth/juno/core"
+	"github.com/NethermindEth/juno/core/felt"
+	"github.com/NethermindEth/juno/db"
+	_ "github.com/NethermindEth/juno/encoder/registry"
+	"github.com/NethermindEth/juno/migration/historyprunner"
+	"github.com/NethermindEth/juno/pruner/testutils"
+	"github.com/NethermindEth/juno/utils/log"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// setupChain stores totalBlocks blocks plus the chain-height and L1-head
+// pointers the migrator reads to compute its cutoff. The L1 head is set to
+// the tip so that minHead = chainHeight and oldestBlockKept reflects
+// retainedBlocks alone, matching the simple PruneUpto setup in the pruner
+// tests.
+func setupChain(
+	t *testing.T,
+	totalBlocks uint64,
+) (db.KeyValueStore, []*testutils.StoredBlock) {
+	t.Helper()
+	database := testutils.NewTestDB(t)
+	blocks := make([]*testutils.StoredBlock, totalBlocks)
+	for i := range totalBlocks {
+		blocks[i] = testutils.StoreBlock(t, database, i)
+	}
+	tip := totalBlocks - 1
+	require.NoError(t, core.WriteChainHeight(database, tip))
+	require.NoError(t, core.WriteL1Head(database, &core.L1Head{
+		BlockNumber: tip,
+		BlockHash:   blocks[tip].Header.Hash,
+		StateRoot:   felt.NewRandom[felt.Felt](),
+	}))
+	return database, blocks
+}
+
+// TestMigrate_FullRun is the migration-side mirror of TestPruneUpto from
+// the pruner package: same DB layout, same expected post-state. The
+// historyprunner migrator is a different code path (range-tombstone wipe
+// + scratch-stage + restore) but converges on the same on-disk shape as
+// PruneUpto for the keep window and the carve-outs.
+//
+// Setup: 30 blocks, retainedBlocks=10. With chainHeight=l1Head=29 the
+// migrator picks oldestBlockKept = 29 - 10 + 1 = 20, equivalent to
+// PruneUpto(20) in the pruner tests.
+func TestMigrate_FullRun(t *testing.T) {
+	const totalBlocks uint64 = 30
+	const retainedBlocks uint64 = 10
+	const oldestBlockKept = totalBlocks - retainedBlocks // 20
+	lag := core.BlockHashLag
+	require.GreaterOrEqual(t, oldestBlockKept, lag)
+
+	database, blocks := setupChain(t, totalBlocks)
+
+	m := historyprunner.New(retainedBlocks)
+	state, err := m.Migrate(t.Context(), database, &networks.Mainnet, log.NewNopZapLogger())
+	require.NoError(t, err)
+	require.Nil(t, state, "fully completed migration must not return intermediate state")
+
+	testutils.AssertPostPruneState(t, database, blocks, oldestBlockKept, lag)
+}
+
+// TestMigrate_NoOpWhenChainShorterThanRetention covers the early exit when
+// minHead < retainedBlocks: nothing to prune yet. The rolling pruner takes
+// over once blocks arrive past the threshold.
+func TestMigrate_NoOpWhenChainShorterThanRetention(t *testing.T) {
+	const totalBlocks uint64 = 5
+	const retainedBlocks uint64 = 10
+
+	database, blocks := setupChain(t, totalBlocks)
+
+	m := historyprunner.New(retainedBlocks)
+	state, err := m.Migrate(t.Context(), database, &networks.Mainnet, log.NewNopZapLogger())
+	require.NoError(t, err)
+	require.Nil(t, state)
+
+	// All blocks intact.
+	for _, b := range blocks {
+		testutils.AssertBlockExists(t, database, b)
+	}
+}
+
+// TestMigrate_NoOpOnEmptyDB covers the early exit when the chain head
+// pointer is missing. This is the cold-start path on a fresh node.
+func TestMigrate_NoOpOnEmptyDB(t *testing.T) {
+	database := testutils.NewTestDB(t)
+	m := historyprunner.New(10)
+	state, err := m.Migrate(t.Context(), database, &networks.Mainnet, log.NewNopZapLogger())
+	require.NoError(t, err)
+	require.Nil(t, state)
+}
+
+// cancelAfterBlocks wraps a KeyValueStore and cancels the supplied context
+// after the n-th state-update Get. Both stager and restorer call
+// GetStateUpdateByBlockNum exactly once at the top of each block, so
+// counting only Gets against the StateUpdatesByBlockNumber bucket gives a
+// per-block cancellation point that is decoupled from how many state-diff
+// entries (storage / nonce / replaced-class) any given block happens to
+// have. Other Gets (chain height, l1 head, parent header, transactions)
+// are ignored.
+//
+// The pipeline runs maxWorkers Get-callers concurrently, so the counter
+// uses atomic.Int64 — a non-atomic ++/== pair would let the trigger value
+// be skipped or fired multiple times under racing increments.
+type cancelAfterBlocks struct {
+	db.KeyValueStore
+	cancel context.CancelFunc
+	after  int64
+	count  atomic.Int64
+}
+
+func (c *cancelAfterBlocks) Get(key []byte, cb func([]byte) error) error {
+	if len(key) > 0 && key[0] == byte(db.StateUpdatesByBlockNumber) {
+		if c.count.Add(1) == c.after {
+			c.cancel()
+		}
+	}
+	return c.KeyValueStore.Get(key, cb)
+}
+
+// runCancellable runs Migrate with a wrapped DB that cancels the context
+// after `cancelAfter` per-block state-update Gets. Returns the
+// intermediate state blob the migrator persisted, or nil if it ran to
+// completion.
+func runCancellable(
+	t *testing.T,
+	prevState []byte,
+	database db.KeyValueStore,
+	cancelAfter int,
+	retainedBlocks uint64,
+) []byte {
+	t.Helper()
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+	wrapped := &cancelAfterBlocks{KeyValueStore: database, cancel: cancel, after: int64(cancelAfter)}
+
+	m := historyprunner.New(retainedBlocks)
+	require.NoError(t, m.Before(prevState))
+	state, err := m.Migrate(ctx, wrapped, &networks.Mainnet, log.NewNopZapLogger())
+	require.NoError(t, err)
+	return state
+}
+
+// TestMigrate_CancelAndResume verifies that a migration interrupted partway
+// through can be resumed by reconstructing a Migrator with the persisted
+// intermediate state. The end-state must be identical to a single-shot
+// run: blocks below the lag floor gone, lag-window headers kept,
+// hash→number carve-out at oldestBlockKept-1, blocks ≥ oldestBlockKept
+// fully restored.
+//
+// The test cancels MULTIPLE times to also exercise cancellation crossing
+// the stager→restorer phase boundary. The keeper window has 10 blocks;
+// stager and restorer each visit it once, so there are 20 per-block
+// state-update Gets total, and cancelling every 2 forces several resumes.
+func TestMigrate_CancelAndResume(t *testing.T) {
+	const totalBlocks uint64 = 30
+	const retainedBlocks uint64 = 10
+	const oldestBlockKept = totalBlocks - retainedBlocks // 20
+	lag := core.BlockHashLag
+
+	database, blocks := setupChain(t, totalBlocks)
+
+	// Cancel every 2 blocks until the migration completes. Each iteration
+	// must either return a non-nil intermediate state (still going) or
+	// nil (done).
+	var (
+		state    []byte
+		attempts int
+	)
+	for {
+		attempts++
+		require.LessOrEqual(t, attempts, 10, "should converge in well under 10 attempts")
+		state = runCancellable(t, state, database, 2, retainedBlocks)
+		if state == nil {
+			break
+		}
+	}
+	assert.GreaterOrEqual(t, attempts, 2,
+		"the test should actually exercise cancellation, not complete on the first try")
+
+	// End-state after multiple cancel/resume cycles must be byte-for-byte
+	// identical to a single-shot run.
+	testutils.AssertPostPruneState(t, database, blocks, oldestBlockKept, lag)
+}

--- a/migration/historyprunner/restorer.go
+++ b/migration/historyprunner/restorer.go
@@ -1,0 +1,111 @@
+package historyprunner
+
+import (
+	"fmt"
+
+	"github.com/NethermindEth/juno/core"
+	"github.com/NethermindEth/juno/core/felt"
+	"github.com/NethermindEth/juno/db"
+	"github.com/NethermindEth/juno/migration/pipeline"
+	"github.com/NethermindEth/juno/migration/progresslogger"
+	"github.com/NethermindEth/juno/migration/semaphore"
+)
+
+type restorer struct {
+	reader          db.KeyValueReader
+	batchSemaphore  semaphore.ResourceSemaphore[db.Batch]
+	batches         []db.Batch
+	scratchPool     []copyScratch
+	progressTracker *progresslogger.BlockProgressTracker
+}
+
+func newRestorer(
+	reader db.KeyValueReader,
+	batchSemaphore semaphore.ResourceSemaphore[db.Batch],
+	maxWorkers int,
+	progressTracker *progresslogger.BlockProgressTracker,
+) *restorer {
+	batches := make([]db.Batch, maxWorkers)
+	for i := range batches {
+		batches[i] = batchSemaphore.GetBlocking()
+	}
+	return &restorer{
+		reader:          reader,
+		batchSemaphore:  batchSemaphore,
+		batches:         batches,
+		scratchPool:     make([]copyScratch, maxWorkers),
+		progressTracker: progressTracker,
+	}
+}
+
+var _ pipeline.State[uint64, db.Batch] = (*restorer)(nil)
+
+func (r *restorer) Run(index int, blockNumber uint64, outputs chan<- db.Batch) error {
+	update, err := core.GetStateUpdateByBlockNum(r.reader, blockNumber)
+	if err != nil {
+		return fmt.Errorf("load state update for block %d: %w", blockNumber, err)
+	}
+
+	batch := r.batches[index]
+
+	if err := copyStateHistory(
+		r.reader,
+		batch,
+		&r.scratchPool[index],
+		update.StateDiff,
+		blockNumber,
+		scratchToHistory,
+	); err != nil {
+		return err
+	}
+
+	err = core.WriteBlockHeaderNumberByHash(batch, update.BlockHash, blockNumber)
+	if err != nil {
+		return err
+	}
+
+	var idx uint64
+	for tx, iterErr := range core.GetTransactionsByBlockNumberIter(r.reader, blockNumber) {
+		if iterErr != nil {
+			return fmt.Errorf("rebuild tx indices: block %d iter: %w", blockNumber, iterErr)
+		}
+
+		txHash := (*felt.TransactionHash)(tx.Hash())
+		key := db.BlockNumIndexKey{Number: blockNumber, Index: idx}
+		err := core.TransactionBlockNumbersAndIndicesByHashBucket.Put(
+			batch, txHash, &key,
+		)
+		if err != nil {
+			return fmt.Errorf(
+				"rebuild tx indices: bucket 9 put block %d idx %d: %w",
+				blockNumber, idx, err,
+			)
+		}
+
+		if l1, ok := tx.(*core.L1HandlerTransaction); ok {
+			err := core.WriteL1HandlerTxnHashByMsgHash(batch, l1.MessageHash(), l1.Hash())
+			if err != nil {
+				return fmt.Errorf(
+					"rebuild tx indices: bucket 24 put block %d idx %d: %w",
+					blockNumber,
+					idx,
+					err,
+				)
+			}
+		}
+		idx++
+	}
+
+	if batch.Size() >= targetBatchByteSize {
+		outputs <- batch
+		r.batches[index] = r.batchSemaphore.GetBlocking()
+	}
+
+	r.progressTracker.IncrementCompletedBlocks(1)
+	return nil
+}
+
+func (r *restorer) Done(index int, outputs chan<- db.Batch) error {
+	outputs <- r.batches[index]
+	return nil
+}

--- a/migration/historyprunner/stager.go
+++ b/migration/historyprunner/stager.go
@@ -1,0 +1,73 @@
+package historyprunner
+
+import (
+	"fmt"
+
+	"github.com/NethermindEth/juno/core"
+	"github.com/NethermindEth/juno/db"
+	"github.com/NethermindEth/juno/migration/pipeline"
+	"github.com/NethermindEth/juno/migration/progresslogger"
+	"github.com/NethermindEth/juno/migration/semaphore"
+)
+
+type stager struct {
+	reader          db.KeyValueReader
+	batchSemaphore  semaphore.ResourceSemaphore[db.Batch]
+	batches         []db.Batch
+	scratchPool     []copyScratch
+	progressTracker *progresslogger.BlockProgressTracker
+}
+
+func newStager(
+	reader db.KeyValueReader,
+	batchSemaphore semaphore.ResourceSemaphore[db.Batch],
+	maxWorkers int,
+	progressTracker *progresslogger.BlockProgressTracker,
+) *stager {
+	batches := make([]db.Batch, maxWorkers)
+	for i := range batches {
+		batches[i] = batchSemaphore.GetBlocking()
+	}
+	return &stager{
+		reader:          reader,
+		batchSemaphore:  batchSemaphore,
+		batches:         batches,
+		scratchPool:     make([]copyScratch, maxWorkers),
+		progressTracker: progressTracker,
+	}
+}
+
+var _ pipeline.State[uint64, db.Batch] = (*stager)(nil)
+
+func (s *stager) Run(index int, blockNumber uint64, outputs chan<- db.Batch) error {
+	update, err := core.GetStateUpdateByBlockNum(s.reader, blockNumber)
+	if err != nil {
+		return fmt.Errorf("load state update for block %d: %w", blockNumber, err)
+	}
+
+	batch := s.batches[index]
+
+	if err := copyStateHistory(
+		s.reader,
+		batch,
+		&s.scratchPool[index],
+		update.StateDiff,
+		blockNumber,
+		historyToScratch,
+	); err != nil {
+		return err
+	}
+
+	if batch.Size() >= targetBatchByteSize {
+		outputs <- batch
+		s.batches[index] = s.batchSemaphore.GetBlocking()
+	}
+
+	s.progressTracker.IncrementCompletedBlocks(1)
+	return nil
+}
+
+func (s *stager) Done(index int, outputs chan<- db.Batch) error {
+	outputs <- s.batches[index]
+	return nil
+}

--- a/migration/progresslogger/block_progress_tracker.go
+++ b/migration/progresslogger/block_progress_tracker.go
@@ -10,6 +10,7 @@ import (
 
 // BlockProgressTracker tracks the progress of a migration by block number.
 type BlockProgressTracker struct {
+	name            string
 	logger          log.StructuredLogger
 	totalBlocks     uint64
 	completedBlocks atomic.Uint64
@@ -19,11 +20,13 @@ type BlockProgressTracker struct {
 // NewBlockProgressTracker creates a new progress tracker for block-based migrations.
 // initialCompletedBlocks allows resuming from a previous migration state.
 func NewBlockProgressTracker(
+	name string,
 	logger log.StructuredLogger,
 	totalBlocks uint64,
 	initialCompletedBlocks uint64,
 ) *BlockProgressTracker {
 	tracker := &BlockProgressTracker{
+		name:           name,
 		logger:         logger,
 		totalBlocks:    totalBlocks,
 		startTimestamp: time.Now(),
@@ -45,6 +48,7 @@ func (t *BlockProgressTracker) LogProgress() {
 	percentage := float64(t.completedBlocks.Load()) / float64(t.totalBlocks) * 100
 	t.logger.Info(
 		"Migration progress",
+		zap.String("name", t.name),
 		zap.Float64("percentage", percentage),
 		zap.Duration("elapsed", t.Elapsed()),
 	)

--- a/node/migration.go
+++ b/node/migration.go
@@ -20,8 +20,8 @@ func registerMigrations(cfg *Config) *migration.Registry {
 		With(&blocktransactions.Migrator{}).
 		WithOptional(
 			historyprunner.New(cfg.RetainedBlocks),
-			cfg.RetainedBlocks > 0,
-			RetainedBlocksFlag,
+			cfg.Prune,
+			PruneModeFlag,
 		)
 
 	return registry

--- a/node/migration.go
+++ b/node/migration.go
@@ -8,6 +8,7 @@ import (
 	"github.com/NethermindEth/juno/migration"
 	"github.com/NethermindEth/juno/migration/blocktransactions"
 	"github.com/NethermindEth/juno/migration/deprecated" //nolint:staticcheck,nolintlint,lll // ignore statick check package will be removed in future, nolinlint because main config does not check
+	"github.com/NethermindEth/juno/migration/historyprunner"
 	"github.com/NethermindEth/juno/utils/log"
 )
 
@@ -15,11 +16,13 @@ import (
 // This is where all migrations should be registered. Optional migrations can use
 // config variables from cfg to determine if they should be enabled.
 func registerMigrations(cfg *Config) *migration.Registry {
-	// cfg parameter is reserved for optional migrations based on config
-	_ = cfg
-
 	registry := migration.NewRegistry().
 		With(&blocktransactions.Migrator{})
+	registry = registry.WithOptional(
+		historyprunner.New(cfg.RetainedBlocks),
+		cfg.RetainedBlocks > 0,
+		RetainedBlocksFlag,
+	)
 
 	return registry
 }

--- a/node/migration.go
+++ b/node/migration.go
@@ -17,12 +17,12 @@ import (
 // config variables from cfg to determine if they should be enabled.
 func registerMigrations(cfg *Config) *migration.Registry {
 	registry := migration.NewRegistry().
-		With(&blocktransactions.Migrator{})
-	registry = registry.WithOptional(
-		historyprunner.New(cfg.RetainedBlocks),
-		cfg.RetainedBlocks > 0,
-		RetainedBlocksFlag,
-	)
+		With(&blocktransactions.Migrator{}).
+		WithOptional(
+			historyprunner.New(cfg.RetainedBlocks),
+			cfg.RetainedBlocks > 0,
+			RetainedBlocksFlag,
+		)
 
 	return registry
 }


### PR DESCRIPTION
Adds optional migration for history-pruning (migration/historyprunner) that brings an existing node's database in line with the rolling pruner's retention window. Activated whenever `--prune-mode` is passed (with or without a value, including `--prune-mode=0`); no-op otherwise.
                                                                                                                                                                                        
The migration runs in two pipelined, resumable phases. The keeper window is anchored on the L1-verified head (matching the rolling pruner's reorg-safe floor): with `minHead = min(l1Head, chainHeight)` and `retainedBlocks` taken from the `--prune-mode=N` value (defaulting to 0 when the flag is passed bare), the window covers `[minHead - retainedBlocks + 1, chainHeight]`. If `minHead < retainedBlocks` the chain is shorter than the window and the migration no-ops, leaving the rolling pruner to take over once blocks arrive.
- Stager — range-deletes the cold number-keyed buckets and wipes reverse-lookup buckets (`TransactionBlockNumbersAndIndicesByHash`, `L1HandlerTxnHashByMsgHash`, `BlockHeaderNumbersByHash`), then copies in-window entries from the live history buckets (`ContractStorageHistory`, `ContractClassHashHistory`, `ContractNonceHistory`) into a scratch namespace.
- Restorer — wipes the live history buckets, copies keepers back from scratch, and rebuilds the reverse-lookup indices per block. Wipes the scratch namespace on completion.

Resume state (`stagerProgress` | `restorerProgress` | `numRetainedBlocks`, 24 bytes BE) is persisted between runs; the originally-configured retention pins the cutoff so a --prune-mode change mid-flight cannot retarget an in-progress migration (logged when ignored).