### PR TITLE
Migrate `Execute` callers to Simulate/Trace/BuildBlock

### DIFF
--- a/builder/executor.go
+++ b/builder/executor.go
@@ -80,7 +80,7 @@ func (e *executor) RunTxns(state *BuildState, txns []mempool.BroadcastedTransact
 	}
 
 	// Execute the transaction
-	vmResults, err := e.vm.Execute(
+	vmResults, err := e.vm.BuildBlock(
 		coreTxns,
 		declaredClasses,
 		paidFeesOnL1,
@@ -89,13 +89,10 @@ func (e *executor) RunTxns(state *BuildState, txns []mempool.BroadcastedTransact
 			BlockHashToBeRevealed: state.RevealedBlockHash,
 		},
 		stateWriter,
-		e.disableFees,
-		e.skipValidate,
-		false,
-		true,
-		false,
-		false,
-		false,
+		vm.BuildBlockOptions{
+			SkipChargeFee: e.disableFees,
+			SkipValidate:  e.skipValidate,
+		},
 	)
 	if err != nil {
 		return err

--- a/genesis/genesis.go
+++ b/genesis/genesis.go
@@ -359,8 +359,12 @@ func executeTransactions(
 	}
 
 	blockInfo := vm.BlockInfo{Header: &genesisHeader}
-	executionResults, err := v.Execute(coreTxns, nil, []*felt.Felt{new(felt.Felt).SetUint64(1)},
-		&blockInfo, genesisState, true, true, true, true, false, false, false)
+	executionResults, err := v.BuildBlock(coreTxns, nil, []*felt.Felt{new(felt.Felt).SetUint64(1)},
+		&blockInfo, genesisState, vm.BuildBlockOptions{
+			SkipChargeFee: true,
+			SkipValidate:  true,
+			ErrOnRevert:   true,
+		})
 	if err != nil {
 		return fmt.Errorf("execute transactions: %v", err)
 	}

--- a/rpc/v10/estimate_fee_test.go
+++ b/rpc/v10/estimate_fee_test.go
@@ -38,15 +38,13 @@ func TestEstimateFee(t *testing.T) {
 
 	blockInfo := vm.BlockInfo{Header: &core.Header{}}
 	t.Run("ok with zero values", func(t *testing.T) {
-		mockVM.EXPECT().Execute(
+		mockVM.EXPECT().Simulate(
 			[]core.Transaction{},
 			nil,
 			[]*felt.Felt{},
 			&blockInfo,
 			mockState,
-			true,
-			false,
-			true, true, true, true, false).
+			vm.SimulateOptions{SkipChargeFee: true, ErrOnRevert: true, IsEstimateFee: true}).
 			Return(vm.ExecutionResults{
 				OverallFees:      []*felt.Felt{},
 				DataAvailability: []core.DataAvailability{},
@@ -66,15 +64,13 @@ func TestEstimateFee(t *testing.T) {
 	})
 
 	t.Run("ok with zero values, skip validate", func(t *testing.T) {
-		mockVM.EXPECT().Execute(
+		mockVM.EXPECT().Simulate(
 			[]core.Transaction{},
 			nil,
 			[]*felt.Felt{},
 			&blockInfo,
 			mockState,
-			true,
-			true,
-			true, true, true, true, false).
+			vm.SimulateOptions{SkipChargeFee: true, SkipValidate: true, ErrOnRevert: true, IsEstimateFee: true}).
 			Return(
 				vm.ExecutionResults{
 					OverallFees:      []*felt.Felt{},
@@ -99,15 +95,13 @@ func TestEstimateFee(t *testing.T) {
 	})
 
 	t.Run("transaction execution error", func(t *testing.T) {
-		mockVM.EXPECT().Execute(
+		mockVM.EXPECT().Simulate(
 			[]core.Transaction{},
 			nil,
 			[]*felt.Felt{},
 			&blockInfo,
 			mockState,
-			true,
-			true,
-			true, true, true, true, false).
+			vm.SimulateOptions{SkipChargeFee: true, SkipValidate: true, ErrOnRevert: true, IsEstimateFee: true}).
 			Return(vm.ExecutionResults{}, vm.TransactionExecutionError{
 				Index: 44,
 				Cause: json.RawMessage("oops"),

--- a/rpc/v10/simulation.go
+++ b/rpc/v10/simulation.go
@@ -221,19 +221,19 @@ func (h *Handler) simulateTransactions(
 		BlockHashToBeRevealed: blockHashToBeRevealed,
 	}
 
-	executionResults, err := h.vm.Execute(
+	executionResults, err := h.vm.Simulate(
 		txns,
 		classes,
 		paidFeesOnL1,
 		&blockInfo,
 		state,
-		skipFeeCharge,
-		skipValidate,
-		errOnRevert,
-		true,
-		true,
-		isEstimateFee,
-		returnInitialReads,
+		vm.SimulateOptions{
+			SkipChargeFee:      skipFeeCharge,
+			SkipValidate:       skipValidate,
+			ErrOnRevert:        errOnRevert,
+			IsEstimateFee:      isEstimateFee,
+			ReturnInitialReads: returnInitialReads,
+		},
 	)
 	if err != nil {
 		return SimulateTransactionsResponse{}, httpHeader, handleExecutionError(err)

--- a/rpc/v10/simulation_test.go
+++ b/rpc/v10/simulation_test.go
@@ -63,9 +63,9 @@ func TestSimulateTransactions(t *testing.T) {
 				mockState *mocks.MockStateReader,
 			) {
 				defaultMockBehavior(mockReader, mockVM, mockState)
-				mockVM.EXPECT().Execute([]core.Transaction{}, nil, []*felt.Felt{}, &vm.BlockInfo{
+				mockVM.EXPECT().Simulate([]core.Transaction{}, nil, []*felt.Felt{}, &vm.BlockInfo{
 					Header: headsHeader,
-				}, mockState, true, false, false, true, true, false, false).
+				}, mockState, vm.SimulateOptions{SkipChargeFee: true}).
 					Return(vm.ExecutionResults{
 						OverallFees:      []*felt.Felt{},
 						DataAvailability: []core.DataAvailability{},
@@ -86,9 +86,9 @@ func TestSimulateTransactions(t *testing.T) {
 				mockState *mocks.MockStateReader,
 			) {
 				defaultMockBehavior(mockReader, mockVM, mockState)
-				mockVM.EXPECT().Execute([]core.Transaction{}, nil, []*felt.Felt{}, &vm.BlockInfo{
+				mockVM.EXPECT().Simulate([]core.Transaction{}, nil, []*felt.Felt{}, &vm.BlockInfo{
 					Header: headsHeader,
-				}, mockState, false, true, false, true, true, false, false).
+				}, mockState, vm.SimulateOptions{SkipValidate: true}).
 					Return(vm.ExecutionResults{
 						OverallFees:      []*felt.Felt{},
 						DataAvailability: []core.DataAvailability{},
@@ -108,9 +108,9 @@ func TestSimulateTransactions(t *testing.T) {
 				mockState *mocks.MockStateReader,
 			) {
 				defaultMockBehavior(mockReader, mockVM, mockState)
-				mockVM.EXPECT().Execute([]core.Transaction{}, nil, []*felt.Felt{}, &vm.BlockInfo{
+				mockVM.EXPECT().Simulate([]core.Transaction{}, nil, []*felt.Felt{}, &vm.BlockInfo{
 					Header: headsHeader,
-				}, mockState, false, true, false, true, true, false, false).
+				}, mockState, vm.SimulateOptions{SkipValidate: true}).
 					Return(vm.ExecutionResults{}, vm.TransactionExecutionError{
 						Index: 44,
 						Cause: json.RawMessage("oops"),
@@ -130,9 +130,9 @@ func TestSimulateTransactions(t *testing.T) {
 				mockState *mocks.MockStateReader,
 			) {
 				defaultMockBehavior(mockReader, mockVM, mockState)
-				mockVM.EXPECT().Execute([]core.Transaction{}, nil, []*felt.Felt{}, &vm.BlockInfo{
+				mockVM.EXPECT().Simulate([]core.Transaction{}, nil, []*felt.Felt{}, &vm.BlockInfo{
 					Header: headsHeader,
-				}, mockState, false, true, false, true, true, false, false).
+				}, mockState, vm.SimulateOptions{SkipValidate: true}).
 					Return(vm.ExecutionResults{
 						OverallFees:      []*felt.Felt{&felt.Zero},
 						DataAvailability: []core.DataAvailability{{L1Gas: 0}, {L1Gas: 0}},
@@ -454,8 +454,8 @@ func TestSimulateTransactionsWithReturnInitialReads(t *testing.T) {
 				},
 			}}
 
-			mockVM.EXPECT().Execute(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), mockState,
-				false, false, false, true, true, false, returnInitialReads,
+			mockVM.EXPECT().Simulate(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), mockState,
+				vm.SimulateOptions{ReturnInitialReads: returnInitialReads},
 			).Return(vm.ExecutionResults{
 				OverallFees:      []*felt.Felt{&felt.Zero},
 				DataAvailability: []core.DataAvailability{{L1Gas: 0}},

--- a/rpc/v10/trace.go
+++ b/rpc/v10/trace.go
@@ -163,7 +163,7 @@ func (h *Handler) TraceBlockTransactions(
 //
 //   - returnInitialReads: Whether to return initial reads in the response
 func traceTransactionsWithState(
-	vm vm.VM,
+	runner vm.VM,
 	transactions []core.Transaction,
 	executionState core.StateReader,
 	classLookupState core.StateReader,
@@ -181,19 +181,13 @@ func traceTransactionsWithState(
 		return nil, nil, httpHeader, err
 	}
 
-	executionResult, vmErr := vm.Execute(
+	executionResult, vmErr := runner.Trace(
 		transactions,
 		declaredClasses,
 		paidFeesOnL1,
 		blockInfo,
 		executionState,
-		false, // skipValidate
-		false, // skipFeeCharge
-		false, // skipNonceCharge
-		true,  // allowZeroMaxFee
-		false, // allowNoSignature
-		false, // isEstimateFee
-		returnInitialReads,
+		vm.TraceOptions{ReturnInitialReads: returnInitialReads},
 	)
 
 	httpHeader.Set(ExecutionStepsHeader, strconv.FormatUint(executionResult.NumSteps, 10))

--- a/rpc/v10/trace_test.go
+++ b/rpc/v10/trace_test.go
@@ -404,19 +404,13 @@ func TestTraceTransaction(t *testing.T) {
 		stepsUsed := uint64(123)
 		stepsUsedStr := "123"
 
-		mockVM.EXPECT().Execute(
+		mockVM.EXPECT().Trace(
 			[]core.Transaction{tx},
 			[]core.ClassDefinition{declaredClass.Class},
 			[]*felt.Felt{},
 			&vm.BlockInfo{Header: header},
 			gomock.Any(),
-			false,
-			false,
-			false,
-			true,
-			false,
-			false,
-			false).Return(vm.ExecutionResults{
+			vm.TraceOptions{}).Return(vm.ExecutionResults{
 			OverallFees: overallFee,
 			GasConsumed: gc,
 			Traces:      []vm.TransactionTrace{vmTrace},
@@ -481,19 +475,13 @@ func TestTraceTransaction(t *testing.T) {
 		stepsUsed := uint64(123)
 		stepsUsedStr := "123"
 
-		mockVM.EXPECT().Execute(
+		mockVM.EXPECT().Trace(
 			[]core.Transaction{tx},
 			nil,
 			[]*felt.Felt{},
 			&vm.BlockInfo{Header: header},
 			gomock.Any(),
-			false,
-			false,
-			false,
-			true,
-			false,
-			false,
-			false,
+			vm.TraceOptions{},
 		).
 			Return(vm.ExecutionResults{
 				OverallFees: overallFee,
@@ -575,19 +563,13 @@ func TestTraceTransaction(t *testing.T) {
 		stepsUsed := uint64(123)
 		stepsUsedStr := "123"
 
-		mockVM.EXPECT().Execute(
+		mockVM.EXPECT().Trace(
 			[]core.Transaction{tx},
 			[]core.ClassDefinition{declaredClass.Class},
 			[]*felt.Felt{},
 			&vm.BlockInfo{Header: header},
 			gomock.Any(),
-			false,
-			false,
-			false,
-			true,
-			false,
-			false,
-			false,
+			vm.TraceOptions{},
 		).
 			Return(vm.ExecutionResults{
 				OverallFees: overallFee,
@@ -733,19 +715,13 @@ func TestTraceBlockTransactions(t *testing.T) {
 		stepsUsed := uint64(123)
 		stepsUsedStr := "123"
 
-		mockVM.EXPECT().Execute(
+		mockVM.EXPECT().Trace(
 			[]core.Transaction{tx},
 			[]core.ClassDefinition{declaredClass.Class},
 			[]*felt.Felt{},
 			&vm.BlockInfo{Header: header},
 			gomock.Any(),
-			false,
-			false,
-			false,
-			true,
-			false,
-			false,
-			false).Return(vm.ExecutionResults{
+			vm.TraceOptions{}).Return(vm.ExecutionResults{
 			OverallFees:      nil,
 			DataAvailability: []core.DataAvailability{{}, {}},
 			GasConsumed:      []core.GasConsumed{{}, {}},
@@ -1419,8 +1395,8 @@ func TestTraceBlockTransactionsWithReturnInitialReads(t *testing.T) {
 
 			returnInitialReads := slices.Contains(test.simulationFlags, rpcv10.ReturnInitialReadsFlag)
 
-			mockVM.EXPECT().Execute(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), mockState,
-				false, false, false, true, false, false, returnInitialReads,
+			mockVM.EXPECT().Trace(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), mockState,
+				vm.TraceOptions{ReturnInitialReads: returnInitialReads},
 			).Return(vm.ExecutionResults{
 				OverallFees:      []*felt.Felt{&felt.Zero},
 				DataAvailability: []core.DataAvailability{{L1Gas: 0}},
@@ -1536,12 +1512,12 @@ func TestTraceBlockTransactionsInitialReadsCacheCoherence(t *testing.T) {
 
 		// First VM call: no initial reads requested.
 		gomock.InOrder(
-			mockVM.EXPECT().Execute(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), mockState,
-				false, false, false, true, false, false, false,
+			mockVM.EXPECT().Trace(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), mockState,
+				vm.TraceOptions{},
 			).Return(execResultWithReads(nil), nil),
 			// Second VM call: flag set, VM produces populated reads.
-			mockVM.EXPECT().Execute(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), mockState,
-				false, false, false, true, false, false, true,
+			mockVM.EXPECT().Trace(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), mockState,
+				vm.TraceOptions{ReturnInitialReads: true},
 			).Return(execResultWithReads(populatedVMReads()), nil),
 		)
 
@@ -1578,8 +1554,8 @@ func TestTraceBlockTransactionsInitialReadsCacheCoherence(t *testing.T) {
 		mockReader.EXPECT().StateAtBlockHash(block.ParentHash).Return(mockState, nopCloser, nil)
 		mockReader.EXPECT().HeadState().Return(mockState, nopCloser, nil)
 
-		mockVM.EXPECT().Execute(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), mockState,
-			false, false, false, true, false, false, true,
+		mockVM.EXPECT().Trace(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), mockState,
+			vm.TraceOptions{ReturnInitialReads: true},
 		).Return(execResultWithReads(populatedVMReads()), nil)
 
 		handler := rpcv10.New(mockReader, nil, mockVM, log.NewNopZapLogger())
@@ -1614,8 +1590,8 @@ func TestTraceBlockTransactionsInitialReadsCacheCoherence(t *testing.T) {
 		mockReader.EXPECT().StateAtBlockHash(block.ParentHash).Return(mockState, nopCloser, nil)
 		mockReader.EXPECT().HeadState().Return(mockState, nopCloser, nil)
 
-		mockVM.EXPECT().Execute(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), mockState,
-			false, false, false, true, false, false, true,
+		mockVM.EXPECT().Trace(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), mockState,
+			vm.TraceOptions{ReturnInitialReads: true},
 		).Return(execResultWithReads(populatedVMReads()), nil)
 
 		handler := rpcv10.New(mockReader, nil, mockVM, log.NewNopZapLogger())

--- a/rpc/v8/estimate_fee_test.go
+++ b/rpc/v8/estimate_fee_test.go
@@ -38,15 +38,13 @@ func TestEstimateFee(t *testing.T) {
 
 	blockInfo := vm.BlockInfo{Header: &core.Header{}}
 	t.Run("ok with zero values", func(t *testing.T) {
-		mockVM.EXPECT().Execute(
+		mockVM.EXPECT().Simulate(
 			[]core.Transaction{},
 			nil,
 			[]*felt.Felt{},
 			&blockInfo,
 			mockState,
-			true,
-			false,
-			true, true, true, true, false).
+			vm.SimulateOptions{SkipChargeFee: true, ErrOnRevert: true, IsEstimateFee: true}).
 			Return(
 				vm.ExecutionResults{
 					OverallFees:      []*felt.Felt{},
@@ -69,15 +67,13 @@ func TestEstimateFee(t *testing.T) {
 	})
 
 	t.Run("ok with zero values, skip validate", func(t *testing.T) {
-		mockVM.EXPECT().Execute(
+		mockVM.EXPECT().Simulate(
 			[]core.Transaction{},
 			nil,
 			[]*felt.Felt{},
 			&blockInfo,
 			mockState,
-			true,
-			true,
-			true, true, true, true, false).
+			vm.SimulateOptions{SkipChargeFee: true, SkipValidate: true, ErrOnRevert: true, IsEstimateFee: true}).
 			Return(vm.ExecutionResults{
 				OverallFees:      []*felt.Felt{},
 				DataAvailability: []core.DataAvailability{},
@@ -97,15 +93,13 @@ func TestEstimateFee(t *testing.T) {
 	})
 
 	t.Run("transaction execution error", func(t *testing.T) {
-		mockVM.EXPECT().Execute(
+		mockVM.EXPECT().Simulate(
 			[]core.Transaction{},
 			nil,
 			[]*felt.Felt{},
 			&blockInfo,
 			mockState,
-			true,
-			true,
-			true, true, true, true, false).
+			vm.SimulateOptions{SkipChargeFee: true, SkipValidate: true, ErrOnRevert: true, IsEstimateFee: true}).
 			Return(
 				vm.ExecutionResults{},
 				vm.TransactionExecutionError{

--- a/rpc/v8/simulation.go
+++ b/rpc/v8/simulation.go
@@ -120,8 +120,13 @@ func (h *Handler) simulateTransactions(
 		BlockHashToBeRevealed: blockHashToBeRevealed,
 	}
 
-	executionResults, err := h.vm.Execute(txns, classes, paidFeesOnL1, &blockInfo,
-		state, skipFeeCharge, skipValidate, errOnRevert, true, true, isEstimateFee, false)
+	executionResults, err := h.vm.Simulate(txns, classes, paidFeesOnL1, &blockInfo,
+		state, vm.SimulateOptions{
+			SkipChargeFee: skipFeeCharge,
+			SkipValidate:  skipValidate,
+			ErrOnRevert:   errOnRevert,
+			IsEstimateFee: isEstimateFee,
+		})
 	if err != nil {
 		return nil, httpHeader, handleExecutionError(err)
 	}

--- a/rpc/v8/simulation_test.go
+++ b/rpc/v8/simulation_test.go
@@ -66,9 +66,9 @@ func TestSimulateTransactions(t *testing.T) {
 				mockState *mocks.MockStateReader,
 			) {
 				defaultMockBehavior(mockReader, mockVM, mockState)
-				mockVM.EXPECT().Execute([]core.Transaction{}, nil, []*felt.Felt{}, &vm.BlockInfo{
+				mockVM.EXPECT().Simulate([]core.Transaction{}, nil, []*felt.Felt{}, &vm.BlockInfo{
 					Header: headsHeader,
-				}, mockState, true, false, false, true, true, false, false).
+				}, mockState, vm.SimulateOptions{SkipChargeFee: true}).
 					Return(vm.ExecutionResults{
 						OverallFees:      []*felt.Felt{},
 						DataAvailability: []core.DataAvailability{},
@@ -89,9 +89,9 @@ func TestSimulateTransactions(t *testing.T) {
 				mockState *mocks.MockStateReader,
 			) {
 				defaultMockBehavior(mockReader, mockVM, mockState)
-				mockVM.EXPECT().Execute([]core.Transaction{}, nil, []*felt.Felt{}, &vm.BlockInfo{
+				mockVM.EXPECT().Simulate([]core.Transaction{}, nil, []*felt.Felt{}, &vm.BlockInfo{
 					Header: headsHeader,
-				}, mockState, false, true, false, true, true, false, false).
+				}, mockState, vm.SimulateOptions{SkipValidate: true}).
 					Return(vm.ExecutionResults{
 						OverallFees:      []*felt.Felt{},
 						DataAvailability: []core.DataAvailability{},
@@ -111,9 +111,9 @@ func TestSimulateTransactions(t *testing.T) {
 				mockState *mocks.MockStateReader,
 			) {
 				defaultMockBehavior(mockReader, mockVM, mockState)
-				mockVM.EXPECT().Execute([]core.Transaction{}, nil, []*felt.Felt{}, &vm.BlockInfo{
+				mockVM.EXPECT().Simulate([]core.Transaction{}, nil, []*felt.Felt{}, &vm.BlockInfo{
 					Header: headsHeader,
-				}, mockState, false, true, false, true, true, false, false).
+				}, mockState, vm.SimulateOptions{SkipValidate: true}).
 					Return(vm.ExecutionResults{}, vm.TransactionExecutionError{
 						Index: 44,
 						Cause: json.RawMessage("oops"),
@@ -133,9 +133,9 @@ func TestSimulateTransactions(t *testing.T) {
 				mockState *mocks.MockStateReader,
 			) {
 				defaultMockBehavior(mockReader, mockVM, mockState)
-				mockVM.EXPECT().Execute([]core.Transaction{}, nil, []*felt.Felt{}, &vm.BlockInfo{
+				mockVM.EXPECT().Simulate([]core.Transaction{}, nil, []*felt.Felt{}, &vm.BlockInfo{
 					Header: headsHeader,
-				}, mockState, false, true, false, true, true, false, false).
+				}, mockState, vm.SimulateOptions{SkipValidate: true}).
 					Return(vm.ExecutionResults{
 						OverallFees:      []*felt.Felt{&felt.Zero},
 						DataAvailability: []core.DataAvailability{{L1Gas: 0}, {L1Gas: 0}},

--- a/rpc/v8/trace.go
+++ b/rpc/v8/trace.go
@@ -233,8 +233,8 @@ func (h *Handler) traceBlockTransactionWithVM(block *core.Block) (
 		BlockHashToBeRevealed: blockHashToBeRevealed,
 	}
 
-	executionResult, err := h.vm.Execute(block.Transactions, classes, paidFeesOnL1,
-		&blockInfo, state, false, false, false, true, false, false, false)
+	executionResult, err := h.vm.Trace(block.Transactions, classes, paidFeesOnL1,
+		&blockInfo, state, vm.TraceOptions{})
 
 	httpHeader.Set(ExecutionStepsHeader, strconv.FormatUint(executionResult.NumSteps, 10))
 

--- a/rpc/v8/trace_test.go
+++ b/rpc/v8/trace_test.go
@@ -370,19 +370,13 @@ func TestTraceTransaction(t *testing.T) {
 		stepsUsed := uint64(123)
 		stepsUsedStr := "123"
 
-		mockVM.EXPECT().Execute(
+		mockVM.EXPECT().Trace(
 			[]core.Transaction{tx},
 			[]core.ClassDefinition{declaredClass.Class},
 			[]*felt.Felt{},
 			&vm.BlockInfo{Header: header},
 			gomock.Any(),
-			false,
-			false,
-			false,
-			true,
-			false,
-			false,
-			false).Return(vm.ExecutionResults{
+			vm.TraceOptions{}).Return(vm.ExecutionResults{
 			OverallFees: overallFee,
 			GasConsumed: gc,
 			Traces:      []vm.TransactionTrace{*vmTrace},
@@ -602,11 +596,11 @@ func TestTraceBlockTransactions(t *testing.T) {
 		// PendingState() in v8 always returns HeadState
 		mockReader.EXPECT().HeadState().Return(headState, nopCloser, nil)
 
-		// vm.Execute is called with empty txns; use Any() for fields with dynamic content
-		mockVM.EXPECT().Execute(
+		// vm.Trace is called with empty txns; use Any() for fields with dynamic content
+		mockVM.EXPECT().Trace(
 			gomock.Any(), gomock.Any(), gomock.Any(),
 			gomock.Any(), gomock.Any(),
-			false, false, false, true, false, false, false,
+			vm.TraceOptions{},
 		).Return(vm.ExecutionResults{}, nil)
 
 		blockID := blockIDPending(t)
@@ -668,19 +662,13 @@ func TestTraceBlockTransactions(t *testing.T) {
 		stepsUsed := uint64(123)
 		stepsUsedStr := "123"
 
-		mockVM.EXPECT().Execute(
+		mockVM.EXPECT().Trace(
 			[]core.Transaction{tx},
 			[]core.ClassDefinition{declaredClass.Class},
 			[]*felt.Felt{},
 			&vm.BlockInfo{Header: header},
 			gomock.Any(),
-			false,
-			false,
-			false,
-			true,
-			false,
-			false,
-			false).Return(vm.ExecutionResults{
+			vm.TraceOptions{}).Return(vm.ExecutionResults{
 			OverallFees:      nil,
 			DataAvailability: []core.DataAvailability{{}, {}},
 			GasConsumed:      []core.GasConsumed{{}, {}},

--- a/rpc/v9/estimate_fee_test.go
+++ b/rpc/v9/estimate_fee_test.go
@@ -38,15 +38,13 @@ func TestEstimateFee(t *testing.T) {
 
 	blockInfo := vm.BlockInfo{Header: &core.Header{}}
 	t.Run("ok with zero values", func(t *testing.T) {
-		mockVM.EXPECT().Execute(
+		mockVM.EXPECT().Simulate(
 			[]core.Transaction{},
 			nil,
 			[]*felt.Felt{},
 			&blockInfo,
 			mockState,
-			true,
-			false,
-			true, true, true, true, false).
+			vm.SimulateOptions{SkipChargeFee: true, ErrOnRevert: true, IsEstimateFee: true}).
 			Return(vm.ExecutionResults{
 				OverallFees:      []*felt.Felt{},
 				DataAvailability: []core.DataAvailability{},
@@ -66,15 +64,13 @@ func TestEstimateFee(t *testing.T) {
 	})
 
 	t.Run("ok with zero values, skip validate", func(t *testing.T) {
-		mockVM.EXPECT().Execute(
+		mockVM.EXPECT().Simulate(
 			[]core.Transaction{},
 			nil,
 			[]*felt.Felt{},
 			&blockInfo,
 			mockState,
-			true,
-			true,
-			true, true, true, true, false).
+			vm.SimulateOptions{SkipChargeFee: true, SkipValidate: true, ErrOnRevert: true, IsEstimateFee: true}).
 			Return(
 				vm.ExecutionResults{
 					OverallFees:      []*felt.Felt{},
@@ -97,15 +93,13 @@ func TestEstimateFee(t *testing.T) {
 	})
 
 	t.Run("transaction execution error", func(t *testing.T) {
-		mockVM.EXPECT().Execute(
+		mockVM.EXPECT().Simulate(
 			[]core.Transaction{},
 			nil,
 			[]*felt.Felt{},
 			&blockInfo,
 			mockState,
-			true,
-			true,
-			true, true, true, true, false).
+			vm.SimulateOptions{SkipChargeFee: true, SkipValidate: true, ErrOnRevert: true, IsEstimateFee: true}).
 			Return(vm.ExecutionResults{}, vm.TransactionExecutionError{
 				Index: 44,
 				Cause: json.RawMessage("oops"),

--- a/rpc/v9/simulation.go
+++ b/rpc/v9/simulation.go
@@ -120,19 +120,18 @@ func (h *Handler) simulateTransactions(
 		BlockHashToBeRevealed: blockHashToBeRevealed,
 	}
 
-	executionResults, err := h.vm.Execute(
+	executionResults, err := h.vm.Simulate(
 		txns,
 		classes,
 		paidFeesOnL1,
 		&blockInfo,
 		state,
-		skipFeeCharge,
-		skipValidate,
-		errOnRevert,
-		true,
-		true,
-		isEstimateFee,
-		false,
+		vm.SimulateOptions{
+			SkipChargeFee: skipFeeCharge,
+			SkipValidate:  skipValidate,
+			ErrOnRevert:   errOnRevert,
+			IsEstimateFee: isEstimateFee,
+		},
 	)
 	if err != nil {
 		return nil, httpHeader, handleExecutionError(err)

--- a/rpc/v9/simulation_test.go
+++ b/rpc/v9/simulation_test.go
@@ -62,9 +62,9 @@ func TestSimulateTransactions(t *testing.T) {
 				mockState *mocks.MockStateReader,
 			) {
 				defaultMockBehavior(mockReader, mockVM, mockState)
-				mockVM.EXPECT().Execute([]core.Transaction{}, nil, []*felt.Felt{}, &vm.BlockInfo{
+				mockVM.EXPECT().Simulate([]core.Transaction{}, nil, []*felt.Felt{}, &vm.BlockInfo{
 					Header: headsHeader,
-				}, mockState, true, false, false, true, true, false, false).
+				}, mockState, vm.SimulateOptions{SkipChargeFee: true}).
 					Return(vm.ExecutionResults{
 						OverallFees:      []*felt.Felt{},
 						DataAvailability: []core.DataAvailability{},
@@ -85,9 +85,9 @@ func TestSimulateTransactions(t *testing.T) {
 				mockState *mocks.MockStateReader,
 			) {
 				defaultMockBehavior(mockReader, mockVM, mockState)
-				mockVM.EXPECT().Execute([]core.Transaction{}, nil, []*felt.Felt{}, &vm.BlockInfo{
+				mockVM.EXPECT().Simulate([]core.Transaction{}, nil, []*felt.Felt{}, &vm.BlockInfo{
 					Header: headsHeader,
-				}, mockState, false, true, false, true, true, false, false).
+				}, mockState, vm.SimulateOptions{SkipValidate: true}).
 					Return(vm.ExecutionResults{
 						OverallFees:      []*felt.Felt{},
 						DataAvailability: []core.DataAvailability{},
@@ -107,9 +107,9 @@ func TestSimulateTransactions(t *testing.T) {
 				mockState *mocks.MockStateReader,
 			) {
 				defaultMockBehavior(mockReader, mockVM, mockState)
-				mockVM.EXPECT().Execute([]core.Transaction{}, nil, []*felt.Felt{}, &vm.BlockInfo{
+				mockVM.EXPECT().Simulate([]core.Transaction{}, nil, []*felt.Felt{}, &vm.BlockInfo{
 					Header: headsHeader,
-				}, mockState, false, true, false, true, true, false, false).
+				}, mockState, vm.SimulateOptions{SkipValidate: true}).
 					Return(vm.ExecutionResults{}, vm.TransactionExecutionError{
 						Index: 44,
 						Cause: json.RawMessage("oops"),
@@ -129,9 +129,9 @@ func TestSimulateTransactions(t *testing.T) {
 				mockState *mocks.MockStateReader,
 			) {
 				defaultMockBehavior(mockReader, mockVM, mockState)
-				mockVM.EXPECT().Execute([]core.Transaction{}, nil, []*felt.Felt{}, &vm.BlockInfo{
+				mockVM.EXPECT().Simulate([]core.Transaction{}, nil, []*felt.Felt{}, &vm.BlockInfo{
 					Header: headsHeader,
-				}, mockState, false, true, false, true, true, false, false).
+				}, mockState, vm.SimulateOptions{SkipValidate: true}).
 					Return(vm.ExecutionResults{
 						OverallFees:      []*felt.Felt{&felt.Zero},
 						DataAvailability: []core.DataAvailability{{L1Gas: 0}, {L1Gas: 0}},

--- a/rpc/v9/trace.go
+++ b/rpc/v9/trace.go
@@ -188,7 +188,7 @@ func (h *Handler) Call(funcCall *FunctionCall, id *BlockID) ([]*felt.Felt, *json
 //
 // Parameters:
 //
-//   - vm: The virtual machine used for execution
+//   - runner: The virtual machine used for execution
 //
 //   - transactions: The transactions to trace
 //
@@ -199,7 +199,7 @@ func (h *Handler) Call(funcCall *FunctionCall, id *BlockID) ([]*felt.Felt, *json
 //
 //   - blockInfo: Block context for execution
 func traceTransactionsWithState(
-	vm vm.VM,
+	runner vm.VM,
 	transactions []core.Transaction,
 	executionState core.StateReader,
 	classLookupState core.StateReader,
@@ -216,19 +216,13 @@ func traceTransactionsWithState(
 		return nil, httpHeader, err
 	}
 
-	executionResult, vmErr := vm.Execute(
+	executionResult, vmErr := runner.Trace(
 		transactions,
 		declaredClasses,
 		paidFeesOnL1,
 		blockInfo,
 		executionState,
-		false, // skipValidate
-		false, // skipFeeCharge
-		false, // skipNonceCharge
-		true,  // allowZeroMaxFee
-		false, // allowNoSignature
-		false, // isEstimateFee
-		false, // returnInitialReads
+		vm.TraceOptions{},
 	)
 
 	httpHeader.Set(ExecutionStepsHeader, strconv.FormatUint(executionResult.NumSteps, 10))

--- a/rpc/v9/trace_test.go
+++ b/rpc/v9/trace_test.go
@@ -403,19 +403,13 @@ func TestTraceTransaction(t *testing.T) {
 		stepsUsed := uint64(123)
 		stepsUsedStr := "123"
 
-		mockVM.EXPECT().Execute(
+		mockVM.EXPECT().Trace(
 			[]core.Transaction{tx},
 			[]core.ClassDefinition{declaredClass.Class},
 			[]*felt.Felt{},
 			&vm.BlockInfo{Header: header},
 			gomock.Any(),
-			false,
-			false,
-			false,
-			true,
-			false,
-			false,
-			false).Return(vm.ExecutionResults{
+			vm.TraceOptions{}).Return(vm.ExecutionResults{
 			OverallFees: overallFee,
 			GasConsumed: gc,
 			Traces:      []vm.TransactionTrace{vmTrace},
@@ -481,19 +475,13 @@ func TestTraceTransaction(t *testing.T) {
 		stepsUsed := uint64(123)
 		stepsUsedStr := "123"
 
-		mockVM.EXPECT().Execute(
+		mockVM.EXPECT().Trace(
 			[]core.Transaction{tx},
 			nil,
 			[]*felt.Felt{},
 			&vm.BlockInfo{Header: header},
 			gomock.Any(),
-			false,
-			false,
-			false,
-			true,
-			false,
-			false,
-			false,
+			vm.TraceOptions{},
 		).
 			Return(vm.ExecutionResults{
 				OverallFees: overallFee,
@@ -576,19 +564,13 @@ func TestTraceTransaction(t *testing.T) {
 		stepsUsed := uint64(123)
 		stepsUsedStr := "123"
 
-		mockVM.EXPECT().Execute(
+		mockVM.EXPECT().Trace(
 			[]core.Transaction{tx},
 			[]core.ClassDefinition{declaredClass.Class},
 			[]*felt.Felt{},
 			&vm.BlockInfo{Header: header},
 			gomock.Any(),
-			false,
-			false,
-			false,
-			true,
-			false,
-			false,
-			false,
+			vm.TraceOptions{},
 		).
 			Return(vm.ExecutionResults{
 				OverallFees: overallFee,
@@ -848,19 +830,13 @@ func TestTraceBlockTransactions(t *testing.T) {
 		stepsUsed := uint64(123)
 		stepsUsedStr := "123"
 
-		mockVM.EXPECT().Execute(
+		mockVM.EXPECT().Trace(
 			[]core.Transaction{tx},
 			[]core.ClassDefinition{declaredClass.Class},
 			[]*felt.Felt{},
 			&vm.BlockInfo{Header: header},
 			gomock.Any(),
-			false,
-			false,
-			false,
-			true,
-			false,
-			false,
-			false).Return(vm.ExecutionResults{
+			vm.TraceOptions{}).Return(vm.ExecutionResults{
 			OverallFees:      nil,
 			DataAvailability: []core.DataAvailability{{}, {}},
 			GasConsumed:      []core.GasConsumed{{}, {}},


### PR DESCRIPTION
Part 2 of 4 in the `vm.Execute` refactor. See #3595 for motivation and roadmap.

This PR is purely call-site migration, it switches all callers from the positional-boolean `Execute` to the typed methods introduced in PR 1.
The `Execute` method itself is unchanged and remains in the interface.

## Changes

**Production (8 sites):**
- `rpc/v{8,9,10}/trace.go` → `Trace(opts vm.TraceOptions)`
- `rpc/v{8,9,10}/simulation.go` → `Simulate(opts vm.SimulateOptions)`
- `builder/executor.go` and `genesis/genesis.go` → `BuildBlock(opts vm.BuildBlockOptions)`

**Tests (~38 mock setups):**
- `EXPECT().Execute(...)` → `EXPECT().{Trace,Simulate,BuildBlock}(...)` across
  `rpc/v{8,9,10}/{trace,simulation,estimate_fee}_test.go`

**Drive-by:** in `rpc/v{9,10}/trace.go`, the local parameter named `vm` was renamed to `runner`; the identifier `vm` was needed for the package qualifier (`vm.TraceOptions{}`).

## Out of scope

- No changes to `vm/vm.go`, `node/throttled_vm.go`, mocks, Rust, or the FFI header.
- PR 3 will split `cairo_vm_execute` into three dedicated Rust entry points.
- PR 4 removes `Execute` from the interface and the corresponding Rust function.
