### PR TITLE
fix(state): history writes only dirty nonce and class hash

### DIFF
--- a/core/state/object.go
+++ b/core/state/object.go
@@ -17,10 +17,8 @@ type stateObject struct {
 	addr     felt.Felt      // address of the contract
 	contract *stateContract // contract info
 
-	dirtyStorage   Storage     // storage changes
-	storageTrie    *trie2.Trie // storage trie
-	nonceDirty     bool
-	classHashDirty bool
+	dirtyStorage Storage     // storage changes
+	storageTrie  *trie2.Trie // storage trie
 }
 
 func newStateObject(state *State, addr *felt.Felt, contract *stateContract) stateObject {
@@ -34,12 +32,10 @@ func newStateObject(state *State, addr *felt.Felt, contract *stateContract) stat
 
 func (s *stateObject) setClassHash(classHash *felt.Felt) {
 	s.contract.ClassHash = *classHash
-	s.classHashDirty = true
 }
 
 func (s *stateObject) setNonce(nonce *felt.Felt) {
 	s.contract.Nonce = *nonce
-	s.nonceDirty = true
 }
 
 func (s *stateObject) getStorageTrie() (*trie2.Trie, error) {

--- a/core/state/object.go
+++ b/core/state/object.go
@@ -17,8 +17,10 @@ type stateObject struct {
 	addr     felt.Felt      // address of the contract
 	contract *stateContract // contract info
 
-	dirtyStorage Storage     // storage changes
-	storageTrie  *trie2.Trie // storage trie
+	dirtyStorage   Storage     // storage changes
+	storageTrie    *trie2.Trie // storage trie
+	nonceDirty     bool
+	classHashDirty bool
 }
 
 func newStateObject(state *State, addr *felt.Felt, contract *stateContract) stateObject {
@@ -32,10 +34,12 @@ func newStateObject(state *State, addr *felt.Felt, contract *stateContract) stat
 
 func (s *stateObject) setClassHash(classHash *felt.Felt) {
 	s.contract.ClassHash = *classHash
+	s.classHashDirty = true
 }
 
 func (s *stateObject) setNonce(nonce *felt.Felt) {
 	s.contract.Nonce = *nonce
+	s.nonceDirty = true
 }
 
 func (s *stateObject) getStorageTrie() (*trie2.Trie, error) {

--- a/core/state/state.go
+++ b/core/state/state.go
@@ -115,6 +115,7 @@ func (s *State) Update(
 
 		contract := newContractDeployed(*classHash, blockNum)
 		newObj := newStateObject(s, &addr, &contract)
+		newObj.classHashDirty = true
 		s.stateObjects[addr] = &newObj
 	}
 
@@ -386,12 +387,16 @@ func (s *State) flush(
 					}
 				}
 
-				if err := WriteNonceHistory(s.batch, &addr, blockNum, &obj.contract.Nonce); err != nil {
-					return err
+				if obj.nonceDirty {
+					if err := WriteNonceHistory(s.batch, &addr, blockNum, &obj.contract.Nonce); err != nil {
+						return err
+					}
 				}
 
-				if err := WriteClassHashHistory(s.batch, &addr, blockNum, &obj.contract.ClassHash); err != nil {
-					return err
+				if obj.classHashDirty {
+					if err := WriteClassHashHistory(s.batch, &addr, blockNum, &obj.contract.ClassHash); err != nil {
+						return err
+					}
 				}
 			}
 		}
@@ -500,6 +505,7 @@ func (s *State) updateContractStorage(blockNum uint64, storage map[felt.Felt]map
 			if _, ok := noClassContracts[addr]; ok && errors.Is(err, db.ErrKeyNotFound) {
 				contract := newContractDeployed(noClassContractsClassHash, blockNum)
 				newObj := newStateObject(s, &addr, &contract)
+				newObj.classHashDirty = true
 				obj = &newObj
 				s.stateObjects[addr] = obj
 			} else {

--- a/core/state/state.go
+++ b/core/state/state.go
@@ -115,7 +115,6 @@ func (s *State) Update(
 
 		contract := newContractDeployed(*classHash, blockNum)
 		newObj := newStateObject(s, &addr, &contract)
-		newObj.classHashDirty = true
 		s.stateObjects[addr] = &newObj
 	}
 
@@ -141,7 +140,10 @@ func (s *State) Update(
 		}
 	}
 
-	return s.flush(blockNum, &stateUpdate, dirtyClasses, true)
+	if err := s.flush(blockNum, &stateUpdate, dirtyClasses); err != nil {
+		return err
+	}
+	return s.writeHistory(blockNum, update.StateDiff)
 }
 
 // Revert a given state update. The block number is the block number of the state update.
@@ -224,7 +226,7 @@ func (s *State) Revert(header *core.Header, update *core.StateUpdate) error {
 		return fmt.Errorf("state commitment mismatch: %v (expected) != %v (actual)", update.OldRoot, &newComm)
 	}
 
-	if err := s.flush(blockNum, &stateUpdate, dirtyClasses, false); err != nil {
+	if err := s.flush(blockNum, &stateUpdate, dirtyClasses); err != nil {
 		return err
 	}
 	return s.deleteHistory(blockNum, update.StateDiff)
@@ -345,12 +347,10 @@ func (s *State) commit(protocolVersion string) (felt.Felt, stateUpdate, error) {
 	return newComm, su, nil
 }
 
-//nolint:gocyclo
 func (s *State) flush(
 	blockNum uint64,
 	update *stateUpdate,
 	classes map[felt.Felt]core.ClassDefinition,
-	storeHistory bool,
 ) error {
 	err := s.db.triedb.Update(
 		(*felt.StateRootHash)(&update.curComm),
@@ -378,34 +378,6 @@ func (s *State) flush(
 		} else { // updated
 			if err := WriteContract(s.batch, &addr, obj.contract); err != nil {
 				return err
-			}
-
-			if storeHistory {
-				for key, val := range obj.dirtyStorage {
-					err := WriteStorageHistory(s.batch, &addr, &key, blockNum, val)
-					if err != nil {
-						return err
-					}
-				}
-
-				if obj.nonceDirty {
-					err := WriteNonceHistory(s.batch, &addr, blockNum, &obj.contract.Nonce)
-					if err != nil {
-						return err
-					}
-				}
-
-				if obj.classHashDirty {
-					err := WriteClassHashHistory(
-						s.batch,
-						&addr,
-						blockNum,
-						&obj.contract.ClassHash,
-					)
-					if err != nil {
-						return err
-					}
-				}
 			}
 		}
 	}
@@ -513,7 +485,6 @@ func (s *State) updateContractStorage(blockNum uint64, storage map[felt.Felt]map
 			if _, ok := noClassContracts[addr]; ok && errors.Is(err, db.ErrKeyNotFound) {
 				contract := newContractDeployed(noClassContractsClassHash, blockNum)
 				newObj := newStateObject(s, &addr, &contract)
-				newObj.classHashDirty = true
 				obj = &newObj
 				s.stateObjects[addr] = obj
 			} else {
@@ -540,6 +511,36 @@ func (s *State) getStateObject(addr *felt.Felt) (*stateObject, error) {
 
 	s.stateObjects[*addr] = obj
 	return obj, nil
+}
+
+func (s *State) writeHistory(blockNum uint64, diff *core.StateDiff) error {
+	for addr, storage := range diff.StorageDiffs {
+		for key, val := range storage {
+			if err := WriteStorageHistory(s.batch, &addr, &key, blockNum, val); err != nil {
+				return err
+			}
+		}
+	}
+
+	for addr, nonce := range diff.Nonces {
+		if err := WriteNonceHistory(s.batch, &addr, blockNum, nonce); err != nil {
+			return err
+		}
+	}
+
+	for addr, classHash := range diff.ReplacedClasses {
+		if err := WriteClassHashHistory(s.batch, &addr, blockNum, classHash); err != nil {
+			return err
+		}
+	}
+
+	for addr, classHash := range diff.DeployedContracts {
+		if err := WriteClassHashHistory(s.batch, &addr, blockNum, classHash); err != nil {
+			return err
+		}
+	}
+
+	return nil
 }
 
 func (s *State) deleteHistory(blockNum uint64, diff *core.StateDiff) error {

--- a/core/state/state.go
+++ b/core/state/state.go
@@ -394,7 +394,12 @@ func (s *State) flush(
 				}
 
 				if obj.classHashDirty {
-					if err := WriteClassHashHistory(s.batch, &addr, blockNum, &obj.contract.ClassHash); err != nil {
+					if err := WriteClassHashHistory(
+						s.batch,
+						&addr,
+						blockNum,
+						&obj.contract.ClassHash,
+					); err != nil {
 						return err
 					}
 				}

--- a/core/state/state.go
+++ b/core/state/state.go
@@ -382,24 +382,27 @@ func (s *State) flush(
 
 			if storeHistory {
 				for key, val := range obj.dirtyStorage {
-					if err := WriteStorageHistory(s.batch, &addr, &key, blockNum, val); err != nil {
+					err := WriteStorageHistory(s.batch, &addr, &key, blockNum, val)
+					if err != nil {
 						return err
 					}
 				}
 
 				if obj.nonceDirty {
-					if err := WriteNonceHistory(s.batch, &addr, blockNum, &obj.contract.Nonce); err != nil {
+					err := WriteNonceHistory(s.batch, &addr, blockNum, &obj.contract.Nonce)
+					if err != nil {
 						return err
 					}
 				}
 
 				if obj.classHashDirty {
-					if err := WriteClassHashHistory(
+					err := WriteClassHashHistory(
 						s.batch,
 						&addr,
 						blockNum,
 						&obj.contract.ClassHash,
-					); err != nil {
+					)
+					if err != nil {
 						return err
 					}
 				}

--- a/core/state/state_test.go
+++ b/core/state/state_test.go
@@ -700,14 +700,14 @@ func TestRevert(t *testing.T) {
 }
 
 func TestStateUpdateWritesHistoryOnlyOnFieldChange(t *testing.T) {
-	addr := felt.NewUnsafeFromString[felt.Felt]("0xA")
-	classH0 := felt.NewUnsafeFromString[felt.Felt]("0xC0")
-	classH1 := felt.NewUnsafeFromString[felt.Felt]("0xC1")
-	storageKey := felt.NewUnsafeFromString[felt.Felt]("0x10")
-	val1 := felt.NewUnsafeFromString[felt.Felt]("0x42")
-	val2 := felt.NewUnsafeFromString[felt.Felt]("0x43")
-	nonce1 := felt.NewUnsafeFromString[felt.Felt]("0x1")
-	nonce2 := felt.NewUnsafeFromString[felt.Felt]("0x2")
+	addr := felt.NewFromUint64[felt.Felt](16)
+	classH0 := felt.NewFromUint64[felt.Felt](192)
+	classH1 := felt.NewFromUint64[felt.Felt](193)
+	storageKey := felt.NewFromUint64[felt.Felt](16)
+	val1 := felt.NewFromUint64[felt.Felt](66)
+	val2 := felt.NewFromUint64[felt.Felt](67)
+	nonce1 := felt.NewFromUint64[felt.Felt](1)
+	nonce2 := felt.NewFromUint64[felt.Felt](2)
 
 	updates := []*core.StateUpdate{
 		// block 0: deploy A with classHash H0 — classHash entry expected

--- a/core/state/state_test.go
+++ b/core/state/state_test.go
@@ -699,6 +699,120 @@ func TestRevert(t *testing.T) {
 	})
 }
 
+func TestStateUpdateWritesHistoryOnlyOnFieldChange(t *testing.T) {
+	addr := felt.NewUnsafeFromString[felt.Felt]("0xA")
+	classH0 := felt.NewUnsafeFromString[felt.Felt]("0xC0")
+	classH1 := felt.NewUnsafeFromString[felt.Felt]("0xC1")
+	storageKey := felt.NewUnsafeFromString[felt.Felt]("0x10")
+	val1 := felt.NewUnsafeFromString[felt.Felt]("0x42")
+	val2 := felt.NewUnsafeFromString[felt.Felt]("0x43")
+	nonce1 := felt.NewUnsafeFromString[felt.Felt]("0x1")
+	nonce2 := felt.NewUnsafeFromString[felt.Felt]("0x2")
+
+	updates := []*core.StateUpdate{
+		// block 0: deploy A with classHash H0 — classHash entry expected
+		{
+			OldRoot: &felt.Zero,
+			NewRoot: felt.NewUnsafeFromString[felt.Felt](
+				"0x2943515e306ea41bc1e477db596e403cd5187edd0eb721edf35ce41e0891e51",
+			),
+			StateDiff: &core.StateDiff{
+				DeployedContracts: map[felt.Felt]*felt.Felt{*addr: classH0},
+			},
+		},
+		// block 1: nonce change only — nonce entry expected
+		{
+			OldRoot: &felt.Zero,
+			NewRoot: felt.NewUnsafeFromString[felt.Felt](
+				"0x20120739338b51aa35c560b0006e95f9b5ccdda9818fce14cf3f5b19eb55a5c",
+			),
+			StateDiff: &core.StateDiff{
+				Nonces: map[felt.Felt]*felt.Felt{*addr: nonce1},
+			},
+		},
+		// block 2: storage only — must NOT produce nonce or classHash entries
+		{
+			OldRoot: &felt.Zero,
+			NewRoot: felt.NewUnsafeFromString[felt.Felt](
+				"0x4ff4ae4e11a385b1272fe9d505ae944aca2e2737998a334879f1acae0b33397",
+			),
+			StateDiff: &core.StateDiff{
+				StorageDiffs: map[felt.Felt]map[felt.Felt]*felt.Felt{
+					*addr: {*storageKey: val1},
+				},
+			},
+		},
+		// block 3: nonce change only — nonce entry expected
+		{
+			OldRoot: &felt.Zero,
+			NewRoot: felt.NewUnsafeFromString[felt.Felt](
+				"0xf2bd6c8daf68dcb7e1d42380627d3cf5674025f3406185a0871b48dd42a586",
+			),
+			StateDiff: &core.StateDiff{
+				Nonces: map[felt.Felt]*felt.Felt{*addr: nonce2},
+			},
+		},
+		// block 4: classHash replacement — classHash entry expected
+		{
+			OldRoot: &felt.Zero,
+			NewRoot: felt.NewUnsafeFromString[felt.Felt](
+				"0x885cc33de1055d510413c2afedc6c262d28224bacb21166a7d565a502933d6",
+			),
+			StateDiff: &core.StateDiff{
+				ReplacedClasses: map[felt.Felt]*felt.Felt{*addr: classH1},
+			},
+		},
+		// block 5: storage only — must NOT produce nonce or classHash entries
+		{
+			OldRoot: &felt.Zero,
+			NewRoot: felt.NewUnsafeFromString[felt.Felt](
+				"0x530eeec8721aae7f0df0da066530c47c62a98f97c28db4c6cf760a627935368",
+			),
+			StateDiff: &core.StateDiff{
+				StorageDiffs: map[felt.Felt]map[felt.Felt]*felt.Felt{
+					*addr: {*storageKey: val2},
+				},
+			},
+		},
+	}
+
+	stateDB := setupState(t, updates, uint64(len(updates)))
+
+	t.Run("total entry counts match exact field-change count", func(t *testing.T) {
+		assert.Equal(t, 2, countNonceHistory(t, stateDB, addr),
+			"contract should have exactly 2 nonce history entries (blocks 1, 3)")
+		assert.Equal(t, 2, countClassHashHistory(t, stateDB, addr),
+			"contract should have exactly 2 classHash history entries (blocks 0, 4)")
+		assert.Equal(t, 2, countStorageHistory(t, stateDB, addr, storageKey),
+			"storage key should have exactly 2 history entries (blocks 2, 5)")
+	})
+
+	t.Run("entries exist on the change blocks", func(t *testing.T) {
+		assert.True(t, hasNonceHistory(t, stateDB, addr, 1))
+		assert.True(t, hasNonceHistory(t, stateDB, addr, 3))
+		assert.True(t, hasClassHashHistory(t, stateDB, addr, 0))
+		assert.True(t, hasClassHashHistory(t, stateDB, addr, 4))
+		assert.True(t, hasStorageHistory(t, stateDB, addr, storageKey, 2))
+		assert.True(t, hasStorageHistory(t, stateDB, addr, storageKey, 5))
+	})
+
+	t.Run("no nonce / classHash entries on storage-only blocks", func(t *testing.T) {
+		assert.False(t, hasNonceHistory(t, stateDB, addr, 2),
+			"storage-only block must not write nonce history")
+		assert.False(t, hasNonceHistory(t, stateDB, addr, 5),
+			"storage-only block must not write nonce history")
+		assert.False(t, hasClassHashHistory(t, stateDB, addr, 2),
+			"storage-only block must not write classHash history")
+		assert.False(t, hasClassHashHistory(t, stateDB, addr, 5),
+			"storage-only block must not write classHash history")
+	})
+
+	t.Run("no nonce entry at deployment block (initial nonce is zero by default)", func(t *testing.T) {
+		assert.False(t, hasNonceHistory(t, stateDB, addr, 0),
+			"deployment block must not write a redundant zero-nonce history entry")
+	})
+}
+
 func BenchmarkStateUpdate(b *testing.B) {
 	client := feeder.NewTestClient(b, &networks.Mainnet)
 	gw := adaptfeeder.New(client)
@@ -779,4 +893,52 @@ func newTestStateDB() *StateDB {
 	memDB := memory.New()
 	trieDB := triedb.New(memDB, nil)
 	return NewStateDB(memDB, trieDB)
+}
+
+func hasNonceHistory(t *testing.T, stateDB *StateDB, addr *felt.Felt, blockNum uint64) bool {
+	t.Helper()
+	ok, err := stateDB.disk.Has(db.ContractNonceHistoryAtBlockKey(addr, blockNum))
+	require.NoError(t, err)
+	return ok
+}
+
+func hasClassHashHistory(t *testing.T, stateDB *StateDB, addr *felt.Felt, blockNum uint64) bool {
+	t.Helper()
+	ok, err := stateDB.disk.Has(db.ContractClassHashHistoryAtBlockKey(addr, blockNum))
+	require.NoError(t, err)
+	return ok
+}
+
+func hasStorageHistory(t *testing.T, stateDB *StateDB, addr, key *felt.Felt, blockNum uint64) bool {
+	t.Helper()
+	ok, err := stateDB.disk.Has(db.ContractStorageHistoryAtBlockKey(addr, key, blockNum))
+	require.NoError(t, err)
+	return ok
+}
+
+func countByPrefix(t *testing.T, stateDB *StateDB, prefix []byte) int {
+	t.Helper()
+	it, err := stateDB.disk.NewIterator(prefix, true)
+	require.NoError(t, err)
+	defer it.Close()
+	count := 0
+	for it.First(); it.Valid(); it.Next() {
+		count++
+	}
+	return count
+}
+
+func countNonceHistory(t *testing.T, stateDB *StateDB, addr *felt.Felt) int {
+	t.Helper()
+	return countByPrefix(t, stateDB, db.ContractNonceHistoryKey(addr))
+}
+
+func countClassHashHistory(t *testing.T, stateDB *StateDB, addr *felt.Felt) int {
+	t.Helper()
+	return countByPrefix(t, stateDB, db.ContractClassHashHistoryKey(addr))
+}
+
+func countStorageHistory(t *testing.T, stateDB *StateDB, addr, key *felt.Felt) int {
+	t.Helper()
+	return countByPrefix(t, stateDB, db.ContractStorageHistoryKey(addr, key))
 }

--- a/core/state/state_test.go
+++ b/core/state/state_test.go
@@ -714,7 +714,7 @@ func TestStateUpdateWritesHistoryOnlyOnFieldChange(t *testing.T) {
 		{
 			OldRoot: &felt.Zero,
 			NewRoot: felt.NewUnsafeFromString[felt.Felt](
-				"0x2943515e306ea41bc1e477db596e403cd5187edd0eb721edf35ce41e0891e51",
+				"0x15fc57d3df218117c4baa5b894357bfe195a27874f52efee3914d8594756d6c",
 			),
 			StateDiff: &core.StateDiff{
 				DeployedContracts: map[felt.Felt]*felt.Felt{*addr: classH0},
@@ -724,7 +724,7 @@ func TestStateUpdateWritesHistoryOnlyOnFieldChange(t *testing.T) {
 		{
 			OldRoot: &felt.Zero,
 			NewRoot: felt.NewUnsafeFromString[felt.Felt](
-				"0x20120739338b51aa35c560b0006e95f9b5ccdda9818fce14cf3f5b19eb55a5c",
+				"0x19be1c130f862c06576c14163ffd597ef49de2dd3eed0cd0329fc24a972f40d",
 			),
 			StateDiff: &core.StateDiff{
 				Nonces: map[felt.Felt]*felt.Felt{*addr: nonce1},
@@ -734,7 +734,7 @@ func TestStateUpdateWritesHistoryOnlyOnFieldChange(t *testing.T) {
 		{
 			OldRoot: &felt.Zero,
 			NewRoot: felt.NewUnsafeFromString[felt.Felt](
-				"0x4ff4ae4e11a385b1272fe9d505ae944aca2e2737998a334879f1acae0b33397",
+				"0x7b5f15dda7999552e8af72b55965c0f033c77f0e2d3b54a448ebbfdec22d7c4",
 			),
 			StateDiff: &core.StateDiff{
 				StorageDiffs: map[felt.Felt]map[felt.Felt]*felt.Felt{
@@ -746,7 +746,7 @@ func TestStateUpdateWritesHistoryOnlyOnFieldChange(t *testing.T) {
 		{
 			OldRoot: &felt.Zero,
 			NewRoot: felt.NewUnsafeFromString[felt.Felt](
-				"0xf2bd6c8daf68dcb7e1d42380627d3cf5674025f3406185a0871b48dd42a586",
+				"0xa6e0bf8b99f39da84226ab00e8ede81133f60c72a86215f8c62eb2e9458d95",
 			),
 			StateDiff: &core.StateDiff{
 				Nonces: map[felt.Felt]*felt.Felt{*addr: nonce2},
@@ -756,7 +756,7 @@ func TestStateUpdateWritesHistoryOnlyOnFieldChange(t *testing.T) {
 		{
 			OldRoot: &felt.Zero,
 			NewRoot: felt.NewUnsafeFromString[felt.Felt](
-				"0x885cc33de1055d510413c2afedc6c262d28224bacb21166a7d565a502933d6",
+				"0x66e9a93ed05f4561da6527bcb1c98c1a6724a585c18167711291ef6e56d3875",
 			),
 			StateDiff: &core.StateDiff{
 				ReplacedClasses: map[felt.Felt]*felt.Felt{*addr: classH1},
@@ -766,7 +766,7 @@ func TestStateUpdateWritesHistoryOnlyOnFieldChange(t *testing.T) {
 		{
 			OldRoot: &felt.Zero,
 			NewRoot: felt.NewUnsafeFromString[felt.Felt](
-				"0x530eeec8721aae7f0df0da066530c47c62a98f97c28db4c6cf760a627935368",
+				"0x4829eceed3f9be83ece51f354dbbb028172410e17ea7c4d5e98ad7c0e475e2a",
 			),
 			StateDiff: &core.StateDiff{
 				StorageDiffs: map[felt.Felt]map[felt.Felt]*felt.Felt{


### PR DESCRIPTION
In `State.flush`, the old code writes a nonce-history entry and a class-hash-history entry for every `stateObject` touched in a block — regardless of whether either field actually changed. So if a contract had only a storage change in a block, two redundant history entries were still emitted (same nonce, same classHash as the previous block).

To fix this, same pattern as in the `Revert` was applied - the history writing is detached from the `flush` method and utilises the state diff