### PR TITLE
test(mempool): fix flaky TestRestoreMempool

### DIFF
--- a/mempool/mempool_test.go
+++ b/mempool/mempool_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/NethermindEth/juno/mocks"
 	adaptfeeder "github.com/NethermindEth/juno/starknetdata/feeder"
 	"github.com/NethermindEth/juno/utils/log"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
 )
@@ -155,10 +156,11 @@ func TestRestoreMempool(t *testing.T) {
 		require.Equal(t, int(i), pool.Len())
 	}
 	// check the db has stored the transactions
-	time.Sleep(100 * time.Millisecond)
-	lenDB, err = pool.LenDB()
-	require.NoError(t, err)
-	require.Equal(t, 3, lenDB)
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		lenDB, err := pool.LenDB()
+		assert.NoError(c, err)
+		assert.Equal(c, 3, lenDB)
+	}, 2*time.Second, 10*time.Millisecond)
 	// Close the mempool
 	pool.Close()
 	require.NoError(t, testDB.Close())
@@ -166,7 +168,6 @@ func TestRestoreMempool(t *testing.T) {
 	require.NoError(t, err)
 
 	poolRestored := mempool.New(testDB, chain, 1024, logger)
-	time.Sleep(100 * time.Millisecond)
 	require.NoError(t, poolRestored.LoadFromDB())
 	lenDB, err = poolRestored.LenDB()
 	require.NoError(t, err)


### PR DESCRIPTION
`TestRestoreMempool` relied on `time.Sleep(100ms)` to wait for the async `dbWriter` goroutine to persist transactions (**racy under load**).

Replaced with `require.EventuallyWithT` polling `LenDB()` until it reaches the expected count (timeout 2s, tick 10ms).
 
Went with polling instead of adding a sync method to prod code, since this need doesn't exist outside of tests.
 
Also removed a redundant sleep after `pool.Close()`. Given that `Close()` already drains the write channel via `wg.Wait()`.