### PR TITLE
docs: remove mentions of newdb snapshots

### DIFF
--- a/.github/workflows/check-snapshot-age.yml
+++ b/.github/workflows/check-snapshot-age.yml
@@ -15,8 +15,6 @@ jobs:
         network:
           - name: "Mainnet"
             url: "https://juno-snapshots.nethermind.io/files/mainnet/latest"
-          - name: "Mainnet CL"
-            url: "https://juno-snapshots.nethermind.io/files/mainnet-newdb/latest"
           - name: "Sepolia"
             url: "https://juno-snapshots.nethermind.io/files/sepolia/latest"
           - name: "Sepolia Integration"

--- a/docs/docs/snapshots.md
+++ b/docs/docs/snapshots.md
@@ -8,12 +8,11 @@ You can download a snapshot of the Juno database to reduce the network syncing t
 
 Snapshots are provided in a compressed `.tar.zst` format for faster downloads and reduced storage requirements. It also allows you to directly stream the decompressed file to your computer without needing to download it first.
 
-| Network                | Download Link                                                                                                 |
-| ---------------------- | ------------------------------------------------------------------------------------------------------------- |
-| Mainnet                | [**juno_mainnet.tar.zst**](https://juno-snapshots.nethermind.io/files/mainnet/latest)                         |
-| Mainnet (New Database) | [**juno_mainnet-newdb.tar.zst**](https://juno-snapshots.nethermind.io/files/mainnet-newdb/latest)             |
-| Sepolia                | [**juno_sepolia.tar.zst**](https://juno-snapshots.nethermind.io/files/sepolia/latest)                         |
-| Sepolia-Integration    | [**juno_sepolia_integration.tar.zst**](https://juno-snapshots.nethermind.io/files/sepolia-integration/latest) |
+| Network             | Download Link                                                                                                 |
+| ------------------- | ------------------------------------------------------------------------------------------------------------- |
+| Mainnet             | [**juno_mainnet.tar.zst**](https://juno-snapshots.nethermind.io/files/mainnet/latest)                         |
+| Sepolia             | [**juno_sepolia.tar.zst**](https://juno-snapshots.nethermind.io/files/sepolia/latest)                         |
+| Sepolia-Integration | [**juno_sepolia_integration.tar.zst**](https://juno-snapshots.nethermind.io/files/sepolia-integration/latest) |
 
 ## Getting snapshot sizes
 
@@ -23,9 +22,6 @@ Thu Feb  5 15:35:59 CET 2026
 
 $curl -s -I -L https://juno-snapshots.nethermind.io/files/mainnet/latest | gawk -v IGNORECASE=1 '/^Content-Length/ { printf "%.2f GB\n", $2/1024/1024/1024 }'
 351.23 GB
-
-$curl -s -I -L https://juno-snapshots.nethermind.io/files/mainnet-newdb/latest | gawk -v IGNORECASE=1 '/^Content-Length/ { printf "%.2f GB\n", $2/1024/1024/1024 }'
-334.14 GB
 
 $curl -s -I -L https://juno-snapshots.nethermind.io/files/sepolia/latest | gawk -v IGNORECASE=1 '/^Content-Length/ { printf "%.2f GB\n", $2/1024/1024/1024 }'
 49.51 GB

--- a/docs/docs/snapshots.md
+++ b/docs/docs/snapshots.md
@@ -18,16 +18,16 @@ Snapshots are provided in a compressed `.tar.zst` format for faster downloads an
 
 ```bash
 $date
-Thu Feb  5 15:35:59 CET 2026
+Fri May  8 00:34:15 CEST 2026
 
 $curl -s -I -L https://juno-snapshots.nethermind.io/files/mainnet/latest | gawk -v IGNORECASE=1 '/^Content-Length/ { printf "%.2f GB\n", $2/1024/1024/1024 }'
-351.23 GB
+397.68 GB
 
 $curl -s -I -L https://juno-snapshots.nethermind.io/files/sepolia/latest | gawk -v IGNORECASE=1 '/^Content-Length/ { printf "%.2f GB\n", $2/1024/1024/1024 }'
-49.51 GB
+66.99 GB
 
 $curl -s -I -L https://juno-snapshots.nethermind.io/files/sepolia-integration/latest | gawk -v IGNORECASE=1 '/^Content-Length/ { printf "%.2f GB\n", $2/1024/1024/1024 }'
-17.78 GB
+30.91 GB
 ```
 
 ## Run Juno with a snapshot

--- a/docs/versioned_docs/version-0.15.0/snapshots.md
+++ b/docs/versioned_docs/version-0.15.0/snapshots.md
@@ -8,12 +8,11 @@ You can download a snapshot of the Juno database to reduce the network syncing t
 
 Snapshots are provided in a compressed `.tar.zst` format for faster downloads and reduced storage requirements. It also allows you to directly stream the decompressed file to your computer without needing to download it first.
 
-| Network                | Download Link                                                                                                 |
-| ---------------------- | ------------------------------------------------------------------------------------------------------------- |
-| Mainnet                | [**juno_mainnet.tar.zst**](https://juno-snapshots.nethermind.io/files/mainnet/latest)                         |
-| Mainnet (New Database) | [**juno_mainnet-newdb.tar.zst**](https://juno-snapshots.nethermind.io/files/mainnet-newdb/latest)             |
-| Sepolia                | [**juno_sepolia.tar.zst**](https://juno-snapshots.nethermind.io/files/sepolia/latest)                         |
-| Sepolia-Integration    | [**juno_sepolia_integration.tar.zst**](https://juno-snapshots.nethermind.io/files/sepolia-integration/latest) |
+| Network             | Download Link                                                                                                 |
+| ------------------- | ------------------------------------------------------------------------------------------------------------- |
+| Mainnet             | [**juno_mainnet.tar.zst**](https://juno-snapshots.nethermind.io/files/mainnet/latest)                         |
+| Sepolia             | [**juno_sepolia.tar.zst**](https://juno-snapshots.nethermind.io/files/sepolia/latest)                         |
+| Sepolia-Integration | [**juno_sepolia_integration.tar.zst**](https://juno-snapshots.nethermind.io/files/sepolia-integration/latest) |
 
 ## Getting snapshot sizes
 
@@ -23,9 +22,6 @@ Thu Feb  5 15:35:59 CET 2026
 
 $curl -s -I -L https://juno-snapshots.nethermind.io/files/mainnet/latest | gawk -v IGNORECASE=1 '/^Content-Length/ { printf "%.2f GB\n", $2/1024/1024/1024 }'
 351.23 GB
-
-$curl -s -I -L https://juno-snapshots.nethermind.io/files/mainnet-newdb/latest | gawk -v IGNORECASE=1 '/^Content-Length/ { printf "%.2f GB\n", $2/1024/1024/1024 }'
-334.14 GB
 
 $curl -s -I -L https://juno-snapshots.nethermind.io/files/sepolia/latest | gawk -v IGNORECASE=1 '/^Content-Length/ { printf "%.2f GB\n", $2/1024/1024/1024 }'
 49.51 GB

--- a/docs/versioned_docs/version-0.15.0/snapshots.md
+++ b/docs/versioned_docs/version-0.15.0/snapshots.md
@@ -18,16 +18,16 @@ Snapshots are provided in a compressed `.tar.zst` format for faster downloads an
 
 ```bash
 $date
-Thu Feb  5 15:35:59 CET 2026
+Fri May  8 00:34:15 CEST 2026
 
 $curl -s -I -L https://juno-snapshots.nethermind.io/files/mainnet/latest | gawk -v IGNORECASE=1 '/^Content-Length/ { printf "%.2f GB\n", $2/1024/1024/1024 }'
-351.23 GB
+397.68 GB
 
 $curl -s -I -L https://juno-snapshots.nethermind.io/files/sepolia/latest | gawk -v IGNORECASE=1 '/^Content-Length/ { printf "%.2f GB\n", $2/1024/1024/1024 }'
-49.51 GB
+66.99 GB
 
 $curl -s -I -L https://juno-snapshots.nethermind.io/files/sepolia-integration/latest | gawk -v IGNORECASE=1 '/^Content-Length/ { printf "%.2f GB\n", $2/1024/1024/1024 }'
-17.78 GB
+30.91 GB
 ```
 
 ## Run Juno with a snapshot

--- a/docs/versioned_docs/version-0.16.0/snapshots.md
+++ b/docs/versioned_docs/version-0.16.0/snapshots.md
@@ -8,12 +8,11 @@ You can download a snapshot of the Juno database to reduce the network syncing t
 
 Snapshots are provided in a compressed `.tar.zst` format for faster downloads and reduced storage requirements. It also allows you to directly stream the decompressed file to your computer without needing to download it first.
 
-| Network                | Download Link                                                                                                 |
-| ---------------------- | ------------------------------------------------------------------------------------------------------------- |
-| Mainnet                | [**juno_mainnet.tar.zst**](https://juno-snapshots.nethermind.io/files/mainnet/latest)                         |
-| Mainnet (New Database) | [**juno_mainnet-newdb.tar.zst**](https://juno-snapshots.nethermind.io/files/mainnet-newdb/latest)             |
-| Sepolia                | [**juno_sepolia.tar.zst**](https://juno-snapshots.nethermind.io/files/sepolia/latest)                         |
-| Sepolia-Integration    | [**juno_sepolia_integration.tar.zst**](https://juno-snapshots.nethermind.io/files/sepolia-integration/latest) |
+| Network             | Download Link                                                                                                 |
+| ------------------- | ------------------------------------------------------------------------------------------------------------- |
+| Mainnet             | [**juno_mainnet.tar.zst**](https://juno-snapshots.nethermind.io/files/mainnet/latest)                         |
+| Sepolia             | [**juno_sepolia.tar.zst**](https://juno-snapshots.nethermind.io/files/sepolia/latest)                         |
+| Sepolia-Integration | [**juno_sepolia_integration.tar.zst**](https://juno-snapshots.nethermind.io/files/sepolia-integration/latest) |
 
 ## Getting snapshot sizes
 
@@ -23,9 +22,6 @@ Thu Feb  5 15:35:59 CET 2026
 
 $curl -s -I -L https://juno-snapshots.nethermind.io/files/mainnet/latest | gawk -v IGNORECASE=1 '/^Content-Length/ { printf "%.2f GB\n", $2/1024/1024/1024 }'
 351.23 GB
-
-$curl -s -I -L https://juno-snapshots.nethermind.io/files/mainnet-newdb/latest | gawk -v IGNORECASE=1 '/^Content-Length/ { printf "%.2f GB\n", $2/1024/1024/1024 }'
-334.14 GB
 
 $curl -s -I -L https://juno-snapshots.nethermind.io/files/sepolia/latest | gawk -v IGNORECASE=1 '/^Content-Length/ { printf "%.2f GB\n", $2/1024/1024/1024 }'
 49.51 GB

--- a/docs/versioned_docs/version-0.16.0/snapshots.md
+++ b/docs/versioned_docs/version-0.16.0/snapshots.md
@@ -18,16 +18,16 @@ Snapshots are provided in a compressed `.tar.zst` format for faster downloads an
 
 ```bash
 $date
-Thu Feb  5 15:35:59 CET 2026
+Fri May  8 00:34:15 CEST 2026
 
 $curl -s -I -L https://juno-snapshots.nethermind.io/files/mainnet/latest | gawk -v IGNORECASE=1 '/^Content-Length/ { printf "%.2f GB\n", $2/1024/1024/1024 }'
-351.23 GB
+397.68 GB
 
 $curl -s -I -L https://juno-snapshots.nethermind.io/files/sepolia/latest | gawk -v IGNORECASE=1 '/^Content-Length/ { printf "%.2f GB\n", $2/1024/1024/1024 }'
-49.51 GB
+66.99 GB
 
 $curl -s -I -L https://juno-snapshots.nethermind.io/files/sepolia-integration/latest | gawk -v IGNORECASE=1 '/^Content-Length/ { printf "%.2f GB\n", $2/1024/1024/1024 }'
-17.78 GB
+30.91 GB
 ```
 
 ## Run Juno with a snapshot


### PR DESCRIPTION
since 0.16.0, we dropped support for the old, non-cl db layout. With this, we can remove the `-newdb` variant, as it is not needed anymore. 