### PR TITLE
refactor(state): use backward compatible class encoding

### DIFF
--- a/core/deprecatedstate/state.go
+++ b/core/deprecatedstate/state.go
@@ -16,7 +16,6 @@ import (
 	"github.com/NethermindEth/juno/core/felt"
 	"github.com/NethermindEth/juno/core/trie"
 	"github.com/NethermindEth/juno/db"
-	"github.com/NethermindEth/juno/encoder"
 	"github.com/sourcegraph/conc/pool"
 )
 
@@ -353,30 +352,19 @@ func (s *State) putClass(
 	class core.ClassDefinition,
 	declaredAt uint64,
 ) error {
-	classKey := db.ClassKey(classHash)
-
-	err := s.txn.Get(classKey, func(data []byte) error { return nil })
+	_, err := core.GetClass(s.txn, classHash)
 	if errors.Is(err, db.ErrKeyNotFound) {
-		classEncoded, encErr := encoder.Marshal(core.DeclaredClassDefinition{
+		return core.WriteClass(s.txn, classHash, &core.DeclaredClassDefinition{
 			At:    declaredAt,
 			Class: class,
 		})
-		if encErr != nil {
-			return encErr
-		}
-
-		return s.txn.Put(classKey, classEncoded)
 	}
 	return err
 }
 
 // Class returns the class object corresponding to the given classHash
 func (s *State) Class(classHash *felt.Felt) (*core.DeclaredClassDefinition, error) {
-	var class *core.DeclaredClassDefinition
-	err := s.txn.Get(db.ClassKey(classHash), func(data []byte) error {
-		return encoder.Unmarshal(data, &class)
-	})
-	return class, err
+	return core.GetClass(s.txn, classHash)
 }
 
 func (s *State) CompiledClassHash(

--- a/core/state/accessors.go
+++ b/core/state/accessors.go
@@ -6,6 +6,7 @@ import (
 	"github.com/NethermindEth/juno/core"
 	"github.com/NethermindEth/juno/core/felt"
 	"github.com/NethermindEth/juno/db"
+	"github.com/NethermindEth/juno/encoder"
 )
 
 func GetStateObject(r db.KeyValueReader, state *State, addr *felt.Felt) (*stateObject, error) {
@@ -88,21 +89,13 @@ func DeleteClassHashHistory(w db.KeyValueWriter, addr *felt.Felt, blockNum uint6
 func WriteClass(
 	w db.KeyValueWriter,
 	classHash *felt.Felt,
-	class core.ClassDefinition,
-	declaredAt uint64,
+	class *core.DeclaredClassDefinition,
 ) error {
-	key := db.ClassKey(classHash)
-
-	dc := core.DeclaredClassDefinition{
-		At:    declaredAt,
-		Class: class,
-	}
-	enc, err := dc.MarshalBinary()
+	enc, err := encoder.Marshal(class)
 	if err != nil {
 		return err
 	}
-
-	return w.Put(key, enc)
+	return w.Put(db.ClassKey(classHash), enc)
 }
 
 func DeleteClass(w db.KeyValueWriter, classHash *felt.Felt) error {
@@ -114,7 +107,9 @@ func GetClass(r db.KeyValueReader, classHash *felt.Felt) (*core.DeclaredClassDef
 	key := db.ClassKey(classHash)
 
 	var class core.DeclaredClassDefinition
-	if err := r.Get(key, class.UnmarshalBinary); err != nil {
+	if err := r.Get(key, func(data []byte) error {
+		return encoder.Unmarshal(data, &class)
+	}); err != nil {
 		return nil, err
 	}
 

--- a/core/state/state.go
+++ b/core/state/state.go
@@ -388,7 +388,11 @@ func (s *State) flush(
 				return err
 			}
 		} else {
-			if err := WriteClass(s.batch, &classHash, &core.DeclaredClassDefinition{At: blockNum, Class: class}); err != nil {
+			err := WriteClass(s.batch, &classHash, &core.DeclaredClassDefinition{
+				At:    blockNum,
+				Class: class,
+			})
+			if err != nil {
 				return err
 			}
 		}

--- a/core/state/state.go
+++ b/core/state/state.go
@@ -388,7 +388,7 @@ func (s *State) flush(
 				return err
 			}
 		} else {
-			if err := WriteClass(s.batch, &classHash, class, blockNum); err != nil {
+			if err := WriteClass(s.batch, &classHash, &core.DeclaredClassDefinition{At: blockNum, Class: class}); err != nil {
 				return err
 			}
 		}


### PR DESCRIPTION
1. The new state's `Class` bucket encoding now matches the deprecated state's: WriteClass / GetClass use plain `encoder.Marshal`/`Unmarshal `of the whole `DeclaredClassDefinition` instead of the `[8B At][CBOR(Class)]` binary prefix — the fixed-offset `.At` had no consumer that actually benefited from it. Both implementations now write byte-identical Class entries, so the upcoming deprecated→new state migration can skip class re-encoding entirely.
2. As a small consistency follow-on, `core/deprecatedstate/state.go`'s `putClass` and `Class` are routed through the existing (until now unused) `core.WriteClass` / `core.GetClass` accessors. Direct batch access for the `Class` bucket are gone from both sides; the original control flow in `putClass` (check ErrKeyNotFound → write, else propagate) is preserved exactly.