### PR TITLE
feat(cmd): separate all Juno flags into categories

### DIFF
--- a/cmd/juno/juno.go
+++ b/cmd/juno/juno.go
@@ -433,7 +433,9 @@ func NewCmd(config *node.Config, run func(*cobra.Command, []string) error) *cobr
 	junoCmd.Flags().Uint(callMaxStepsF, defaultCallMaxSteps, callMaxStepsUsage)
 	junoCmd.Flags().Uint(callMaxGasF, defaultCallMaxGas, callMaxGasUsage)
 	junoCmd.Flags().Duration(rpcRequestTimeoutF, defaultRPCRequestTimeout, rpcRequestTimeoutUsage)
-	junoCmd.Flags().Bool(disableRPCBatchRequestsF, defaultDisableRPCBatchRequests, disableRPCBatchRequestsUsage)
+	junoCmd.Flags().Bool(
+		disableRPCBatchRequestsF, defaultDisableRPCBatchRequests, disableRPCBatchRequestsUsage,
+	)
 	setCategory(junoCmd, catHTTPRPC,
 		httpF, httpHostF, httpPortF, corsEnableF,
 		rpcMaxBlockScanF, callMaxStepsF, callMaxGasF,
@@ -444,7 +446,9 @@ func NewCmd(config *node.Config, run func(*cobra.Command, []string) error) *cobr
 	junoCmd.Flags().Bool(wsF, defaultWS, wsUsage)
 	junoCmd.Flags().String(wsHostF, defaultHost, wsHostUsage)
 	junoCmd.Flags().Uint16(wsPortF, defaultWSPort, wsPortUsage)
-	junoCmd.Flags().Bool(disableReceivedTxnStreamF, defaultDisableReceivedTxnStream, disableReceivedTxnStreamUsage)
+	junoCmd.Flags().Bool(
+		disableReceivedTxnStreamF, defaultDisableReceivedTxnStream, disableReceivedTxnStreamUsage,
+	)
 	setCategory(junoCmd, catWebSocket, wsF, wsHostF, wsPortF, disableReceivedTxnStreamF)
 
 	// --- Network & L1 ---
@@ -455,10 +459,16 @@ func NewCmd(config *node.Config, run func(*cobra.Command, []string) error) *cobr
 	setCategory(junoCmd, catNetwork, networkF, ethNodeF, disableL1VerificationF)
 
 	// --- Sync & Polling ---
-	junoCmd.Flags().Duration(preLatestPollIntervalF, defaultPreLatestPollInterval, preLatestPollIntervalUsage)
-	junoCmd.Flags().Duration(preConfirmedPollIntervalF, defaultPreConfirmedPollInterval, preConfirmedPollIntervalUsage)
+	junoCmd.Flags().Duration(
+		preLatestPollIntervalF, defaultPreLatestPollInterval, preLatestPollIntervalUsage,
+	)
+	junoCmd.Flags().Duration(
+		preConfirmedPollIntervalF, defaultPreConfirmedPollInterval, preConfirmedPollIntervalUsage,
+	)
 	junoCmd.Flags().String(remoteDBF, defaultRemoteDB, remoteDBUsage)
-	junoCmd.Flags().Uint(readinessBlockToleranceF, defaultReadinessBlockTolerance, readinessBlockToleranceUsage)
+	junoCmd.Flags().Uint(
+		readinessBlockToleranceF, defaultReadinessBlockTolerance, readinessBlockToleranceUsage,
+	)
 	setCategory(junoCmd, catSyncPolling,
 		preLatestPollIntervalF, preConfirmedPollIntervalF,
 		remoteDBF, readinessBlockToleranceF,
@@ -502,7 +512,9 @@ func NewCmd(config *node.Config, run func(*cobra.Command, []string) error) *cobr
 	junoCmd.Flags().String(dbPathF, defaultDBPath, dbPathUsage)
 	junoCmd.Flags().Uint(dbCacheSizeF, defaultCacheSizeMb, dbCacheSizeUsage)
 	junoCmd.Flags().Int(dbMaxHandlesF, defaultMaxHandles, dbMaxHandlesUsage)
-	junoCmd.Flags().String(dbCompactionConcurrencyF, defaultDBCompactionConcurrency, dbCompactionConcurrencyUsage)
+	junoCmd.Flags().String(
+		dbCompactionConcurrencyF, defaultDBCompactionConcurrency, dbCompactionConcurrencyUsage,
+	)
 	junoCmd.Flags().Uint(dbMemtableSizeF, defaultDBMemtableSize, dbMemtableSizeUsage)
 	junoCmd.Flags().Uint(dbMemtableCountF, defaultDBMemtableCount, dbMemtableCountUsage)
 	junoCmd.Flags().String(dbCompressionF, defaultDBCompression, dbCompressionUsage)
@@ -518,13 +530,19 @@ func NewCmd(config *node.Config, run func(*cobra.Command, []string) error) *cobr
 		defaultSubmittedTransactionsCacheEntryTTL,
 		submittedTransactionsCacheEntryTTL,
 	)
-	setCategory(junoCmd, catTxCache, submittedTransactionsCacheSizeF, submittedTransactionsCacheEntryTTLF)
+	setCategory(junoCmd, catTxCache,
+		submittedTransactionsCacheSizeF, submittedTransactionsCacheEntryTTLF,
+	)
 
 	// --- VM & Compilation ---
 	junoCmd.Flags().Uint(maxVMsF, uint(defaultMaxVMs), maxVMsUsage)
 	junoCmd.Flags().Uint(maxVMQueueF, 2*uint(defaultMaxVMs), maxVMQueueUsage)
-	junoCmd.Flags().Uint(maxConcurrentCompilationsF, defaultMaxConcurrentCompilations, maxConcurrentCompilationsUsage)
-	junoCmd.Flags().String(versionedConstantsFileF, defaultVersionedConstantsFile, versionedConstantsFileUsage)
+	junoCmd.Flags().Uint(
+		maxConcurrentCompilationsF, defaultMaxConcurrentCompilations, maxConcurrentCompilationsUsage,
+	)
+	junoCmd.Flags().String(
+		versionedConstantsFileF, defaultVersionedConstantsFile, versionedConstantsFileUsage,
+	)
 	setCategory(junoCmd, catVMCompile,
 		maxVMsF, maxVMQueueF, maxConcurrentCompilationsF, versionedConstantsFileF,
 	)
@@ -535,9 +553,16 @@ func NewCmd(config *node.Config, run func(*cobra.Command, []string) error) *cobr
 	junoCmd.Flags().String(cnGatewayURLF, defaultCNGatewayURL, networkCustomGatewayUsage)
 	junoCmd.Flags().String(cnL1ChainIDF, defaultCNL1ChainID, networkCustomL1ChainIDUsage)
 	junoCmd.Flags().String(cnL2ChainIDF, defaultCNL2ChainID, networkCustomL2ChainIDUsage)
-	junoCmd.Flags().String(cnCoreContractAddressF, defaultCNCoreContractAddressStr, networkCustomCoreContractAddressUsage)
-	junoCmd.Flags().IntSlice(cnUnverifiableRangeF, defaultCNUnverifiableRange, networkCustomUnverifiableRange)
-	junoCmd.MarkFlagsRequiredTogether(cnNameF, cnFeederURLF, cnGatewayURLF, cnL1ChainIDF, cnL2ChainIDF, cnCoreContractAddressF, cnUnverifiableRangeF) //nolint:lll
+	junoCmd.Flags().String(
+		cnCoreContractAddressF, defaultCNCoreContractAddressStr, networkCustomCoreContractAddressUsage,
+	)
+	junoCmd.Flags().IntSlice(
+		cnUnverifiableRangeF, defaultCNUnverifiableRange, networkCustomUnverifiableRange,
+	)
+	junoCmd.MarkFlagsRequiredTogether(
+		cnNameF, cnFeederURLF, cnGatewayURLF,
+		cnL1ChainIDF, cnL2ChainIDF, cnCoreContractAddressF, cnUnverifiableRangeF,
+	)
 	junoCmd.MarkFlagsMutuallyExclusive(networkF, cnNameF)
 	setCategory(junoCmd, catCustomNetwork,
 		cnNameF, cnFeederURLF, cnGatewayURLF,

--- a/cmd/juno/juno.go
+++ b/cmd/juno/juno.go
@@ -424,17 +424,79 @@ func NewCmd(config *node.Config, run func(*cobra.Command, []string) error) *cobr
 	defaultMaxVMs := 3 * runtime.GOMAXPROCS(0)
 	defaultCNUnverifiableRange := []int{} // Uint64Slice is not supported in Flags()
 
-	junoCmd.Flags().StringVar(&cfgFile, configF, defaultConfig, configFlagUsage)
+	// --- Logging ---
 	junoCmd.Flags().String(logLevelF, log.INFO.String(), logLevelFlagUsage)
 	junoCmd.Flags().Bool(logJSONF, defaultLogJSON, logJSONUsage)
+	junoCmd.Flags().Bool(colourF, defaultColour, colourUsage)
+	setCategory(junoCmd, catLogging, logLevelF, logJSONF, colourF)
+
+	// --- HTTP RPC ---
 	junoCmd.Flags().Bool(httpF, defaultHTTP, httpUsage)
 	junoCmd.Flags().String(httpHostF, defaultHost, httpHostUsage)
 	junoCmd.Flags().Uint16(httpPortF, defaultHTTPPort, httpPortUsage)
+	junoCmd.Flags().Bool(corsEnableF, defaultCorsEnable, corsEnableUsage)
+	junoCmd.Flags().Uint(rpcMaxBlockScanF, defaultRPCMaxBlockScan, rpcMaxBlockScanUsage)
+	junoCmd.Flags().Uint(callMaxStepsF, defaultCallMaxSteps, callMaxStepsUsage)
+	junoCmd.Flags().Uint(callMaxGasF, defaultCallMaxGas, callMaxGasUsage)
+	junoCmd.Flags().Duration(rpcRequestTimeoutF, defaultRPCRequestTimeout, rpcRequestTimeoutUsage)
+	junoCmd.Flags().Bool(disableRPCBatchRequestsF, defaultDisableRPCBatchRequests, disableRPCBatchRequestsUsage)
+	setCategory(junoCmd, catHTTPRPC,
+		httpF, httpHostF, httpPortF, corsEnableF,
+		rpcMaxBlockScanF, callMaxStepsF, callMaxGasF,
+		rpcRequestTimeoutF, disableRPCBatchRequestsF,
+	)
+
+	// --- WebSocket RPC ---
 	junoCmd.Flags().Bool(wsF, defaultWS, wsUsage)
 	junoCmd.Flags().String(wsHostF, defaultHost, wsHostUsage)
 	junoCmd.Flags().Uint16(wsPortF, defaultWSPort, wsPortUsage)
+	junoCmd.Flags().Bool(disableReceivedTxnStreamF, defaultDisableReceivedTxnStream, disableReceivedTxnStreamUsage)
+	setCategory(junoCmd, catWebSocket, wsF, wsHostF, wsPortF, disableReceivedTxnStreamF)
+
+	// --- gRPC ---
+	junoCmd.Flags().Bool(grpcF, defaultGRPC, grpcUsage)
+	junoCmd.Flags().String(grpcHostF, defaultHost, grpcHostUsage)
+	junoCmd.Flags().Uint16(grpcPortF, defaultGRPCPort, grpcPortUsage)
+	setCategory(junoCmd, catGRPC, grpcF, grpcHostF, grpcPortF)
+
+	// --- Metrics & Profiling ---
+	junoCmd.Flags().Bool(metricsF, defaultMetrics, metricsUsage)
+	junoCmd.Flags().String(metricsHostF, defaultHost, metricsHostUsage)
+	junoCmd.Flags().Uint16(metricsPortF, defaultMetricsPort, metricsPortUsage)
+	junoCmd.Flags().Bool(pprofF, defaultPprof, pprofUsage)
+	junoCmd.Flags().String(pprofHostF, defaultHost, pprofHostUsage)
+	junoCmd.Flags().Uint16(pprofPortF, defaultPprofPort, pprofPortUsage)
+	setCategory(junoCmd, catObservability,
+		metricsF, metricsHostF, metricsPortF,
+		pprofF, pprofHostF, pprofPortF,
+	)
+
+	// --- HTTP Update Endpoint ---
+	junoCmd.Flags().String(httpUpdateHostF, defaultHost, httpUpdateHostUsage)
+	junoCmd.Flags().Uint16(httpUpdatePortF, defaultHTTPUpdatePort, httpUpdatePortUsage)
+	setCategory(junoCmd, catHTTPUpdate, httpUpdateHostF, httpUpdatePortF)
+
+	// --- Database ---
 	junoCmd.Flags().String(dbPathF, defaultDBPath, dbPathUsage)
+	junoCmd.Flags().Uint(dbCacheSizeF, defaultCacheSizeMb, dbCacheSizeUsage)
+	junoCmd.Flags().Int(dbMaxHandlesF, defaultMaxHandles, dbMaxHandlesUsage)
+	junoCmd.Flags().String(dbCompactionConcurrencyF, defaultDBCompactionConcurrency, dbCompactionConcurrencyUsage)
+	junoCmd.Flags().Uint(dbMemtableSizeF, defaultDBMemtableSize, dbMemtableSizeUsage)
+	junoCmd.Flags().Uint(dbMemtableCountF, defaultDBMemtableCount, dbMemtableCountUsage)
+	junoCmd.Flags().String(dbCompressionF, defaultDBCompression, dbCompressionUsage)
+	setCategory(junoCmd, catDatabase,
+		dbPathF, dbCacheSizeF, dbMaxHandlesF,
+		dbCompactionConcurrencyF, dbMemtableSizeF, dbMemtableCountF, dbCompressionF,
+	)
+
+	// --- Network & L1 ---
 	junoCmd.Flags().Var(&defaultNetwork, networkF, networkUsage)
+	junoCmd.Flags().String(ethNodeF, defaultEthNode, ethNodeUsage)
+	junoCmd.Flags().Bool(disableL1VerificationF, defaultDisableL1Verification, disableL1VerificationUsage)
+	junoCmd.MarkFlagsMutuallyExclusive(ethNodeF, disableL1VerificationF)
+	setCategory(junoCmd, catNetwork, networkF, ethNodeF, disableL1VerificationF)
+
+	// --- Custom Network ---
 	junoCmd.Flags().String(cnNameF, defaultCNName, networkCustomName)
 	junoCmd.Flags().String(cnFeederURLF, defaultCNFeederURL, networkCustomFeederUsage)
 	junoCmd.Flags().String(cnGatewayURLF, defaultCNGatewayURL, networkCustomGatewayUsage)
@@ -442,78 +504,78 @@ func NewCmd(config *node.Config, run func(*cobra.Command, []string) error) *cobr
 	junoCmd.Flags().String(cnL2ChainIDF, defaultCNL2ChainID, networkCustomL2ChainIDUsage)
 	junoCmd.Flags().String(cnCoreContractAddressF, defaultCNCoreContractAddressStr, networkCustomCoreContractAddressUsage)
 	junoCmd.Flags().IntSlice(cnUnverifiableRangeF, defaultCNUnverifiableRange, networkCustomUnverifiableRange)
-	junoCmd.Flags().String(ethNodeF, defaultEthNode, ethNodeUsage)
-	junoCmd.Flags().Bool(disableL1VerificationF, defaultDisableL1Verification, disableL1VerificationUsage)
-	junoCmd.MarkFlagsMutuallyExclusive(ethNodeF, disableL1VerificationF)
-	junoCmd.Flags().Bool(pprofF, defaultPprof, pprofUsage)
-	junoCmd.Flags().String(pprofHostF, defaultHost, pprofHostUsage)
-	junoCmd.Flags().Uint16(pprofPortF, defaultPprofPort, pprofPortUsage)
-	junoCmd.Flags().Bool(colourF, defaultColour, colourUsage)
-	junoCmd.Flags().Duration(
-		preLatestPollIntervalF, defaultPreLatestPollInterval, preLatestPollIntervalUsage,
+	junoCmd.MarkFlagsRequiredTogether(cnNameF, cnFeederURLF, cnGatewayURLF, cnL1ChainIDF, cnL2ChainIDF, cnCoreContractAddressF, cnUnverifiableRangeF) //nolint:lll
+	junoCmd.MarkFlagsMutuallyExclusive(networkF, cnNameF)
+	setCategory(junoCmd, catCustomNetwork,
+		cnNameF, cnFeederURLF, cnGatewayURLF,
+		cnL1ChainIDF, cnL2ChainIDF, cnCoreContractAddressF, cnUnverifiableRangeF,
 	)
-	junoCmd.Flags().Duration(preConfirmedPollIntervalF, defaultPreConfirmedPollInterval, preConfirmedPollIntervalUsage)
+
+	// --- Gateway ---
+	junoCmd.Flags().String(gwAPIKeyF, defaultGwAPIKey, gwAPIKeyUsage)
+	junoCmd.Flags().String(gwTimeoutsF, defaultGwTimeout, gwTimeoutsUsage)
+	setCategory(junoCmd, catGateway, gwAPIKeyF, gwTimeoutsF)
+
+	// --- P2P (experimental) ---
 	junoCmd.Flags().Bool(p2pF, defaultP2p, p2pUsage)
 	junoCmd.Flags().String(p2pAddrF, defaultP2pAddr, p2pAddrUsage)
 	junoCmd.Flags().String(p2pPublicAddrF, defaultP2pPublicAddr, p2pPublicAddrUsage)
 	junoCmd.Flags().String(p2pPeersF, defaultP2pPeers, p2pPeersUsage)
 	junoCmd.Flags().Bool(p2pFeederNodeF, defaultP2pFeederNode, p2pFeederNodeUsage)
 	junoCmd.Flags().String(p2pPrivateKey, defaultP2pPrivateKey, p2pPrivateKeyUsage)
-	junoCmd.Flags().Bool(metricsF, defaultMetrics, metricsUsage)
-	junoCmd.Flags().String(metricsHostF, defaultHost, metricsHostUsage)
-	junoCmd.Flags().Uint16(metricsPortF, defaultMetricsPort, metricsPortUsage)
-	junoCmd.Flags().Bool(grpcF, defaultGRPC, grpcUsage)
-	junoCmd.Flags().String(grpcHostF, defaultHost, grpcHostUsage)
-	junoCmd.Flags().Uint16(grpcPortF, defaultGRPCPort, grpcPortUsage)
-	junoCmd.Flags().Uint(maxVMsF, uint(defaultMaxVMs), maxVMsUsage)
-	junoCmd.Flags().Uint(maxVMQueueF, 2*uint(defaultMaxVMs), maxVMQueueUsage)
-	junoCmd.Flags().String(remoteDBF, defaultRemoteDB, remoteDBUsage)
-	junoCmd.Flags().Uint(rpcMaxBlockScanF, defaultRPCMaxBlockScan, rpcMaxBlockScanUsage)
-	junoCmd.Flags().Uint(dbCacheSizeF, defaultCacheSizeMb, dbCacheSizeUsage)
-	junoCmd.Flags().String(gwAPIKeyF, defaultGwAPIKey, gwAPIKeyUsage)
-	junoCmd.Flags().Int(dbMaxHandlesF, defaultMaxHandles, dbMaxHandlesUsage)
-	junoCmd.Flags().String(
-		dbCompactionConcurrencyF, defaultDBCompactionConcurrency, dbCompactionConcurrencyUsage,
-	)
-	junoCmd.Flags().Uint(dbMemtableSizeF, defaultDBMemtableSize, dbMemtableSizeUsage)
-	junoCmd.Flags().Uint(dbMemtableCountF, defaultDBMemtableCount, dbMemtableCountUsage)
-	junoCmd.Flags().String(dbCompressionF, defaultDBCompression, dbCompressionUsage)
-	junoCmd.MarkFlagsRequiredTogether(cnNameF, cnFeederURLF, cnGatewayURLF, cnL1ChainIDF, cnL2ChainIDF, cnCoreContractAddressF, cnUnverifiableRangeF) //nolint:lll
-	junoCmd.MarkFlagsMutuallyExclusive(networkF, cnNameF)
-	junoCmd.Flags().Uint(callMaxStepsF, defaultCallMaxSteps, callMaxStepsUsage)
-	junoCmd.Flags().Uint(callMaxGasF, defaultCallMaxGas, callMaxGasUsage)
-	junoCmd.Flags().String(gwTimeoutsF, defaultGwTimeout, gwTimeoutsUsage)
-	junoCmd.Flags().Bool(corsEnableF, defaultCorsEnable, corsEnableUsage)
-	junoCmd.Flags().String(versionedConstantsFileF, defaultVersionedConstantsFile, versionedConstantsFileUsage)
 	junoCmd.MarkFlagsMutuallyExclusive(p2pFeederNodeF, p2pPeersF)
-	junoCmd.Flags().String(pluginPathF, defaultPluginPath, pluginPathUsage)
+	setCategory(junoCmd, catP2P,
+		p2pF, p2pAddrF, p2pPublicAddrF, p2pPeersF, p2pFeederNodeF, p2pPrivateKey,
+	)
+
+	// --- Sequencer ---
 	junoCmd.Flags().Bool(seqEnF, defaultSeqEn, seqEnUsage)
 	junoCmd.Flags().Uint(seqBlockTimeF, defaultSeqBlockTime, seqBlockTimeUsage)
 	junoCmd.Flags().String(seqGenesisFileF, defaultSeqGenesisFile, seqGenesisFileUsage)
 	junoCmd.Flags().Bool(seqDisableFeesF, defaultSeqDisableFees, seqDisableFeesUsage)
+	setCategory(junoCmd, catSequencer, seqEnF, seqBlockTimeF, seqGenesisFileF, seqDisableFeesF)
+
+	// --- Sync & Polling ---
+	junoCmd.Flags().Duration(preLatestPollIntervalF, defaultPreLatestPollInterval, preLatestPollIntervalUsage)
+	junoCmd.Flags().Duration(preConfirmedPollIntervalF, defaultPreConfirmedPollInterval, preConfirmedPollIntervalUsage)
+	junoCmd.Flags().String(remoteDBF, defaultRemoteDB, remoteDBUsage)
 	junoCmd.Flags().Uint(readinessBlockToleranceF, defaultReadinessBlockTolerance, readinessBlockToleranceUsage)
-	junoCmd.Flags().String(httpUpdateHostF, defaultHost, httpUpdateHostUsage)
-	junoCmd.Flags().Uint16(httpUpdatePortF, defaultHTTPUpdatePort, httpUpdatePortUsage)
+	setCategory(junoCmd, catSyncPolling,
+		preLatestPollIntervalF, preConfirmedPollIntervalF,
+		remoteDBF, readinessBlockToleranceF,
+	)
+
+	// --- Pruning ---
+	junoCmd.Flags().Uint64(pruneModeF, defaultPruneMode, pruneModeUsage)
+	// NoOptDefVal lets users pass --prune-mode without a value (treated as 0).
+	junoCmd.Flags().Lookup(pruneModeF).NoOptDefVal = "0"
+	setCategory(junoCmd, catPruning, pruneModeF)
+
+	// --- VM & Compilation ---
+	junoCmd.Flags().Uint(maxVMsF, uint(defaultMaxVMs), maxVMsUsage)
+	junoCmd.Flags().Uint(maxVMQueueF, 2*uint(defaultMaxVMs), maxVMQueueUsage)
+	junoCmd.Flags().Uint(maxConcurrentCompilationsF, defaultMaxConcurrentCompilations, maxConcurrentCompilationsUsage)
+	junoCmd.Flags().String(versionedConstantsFileF, defaultVersionedConstantsFile, versionedConstantsFileUsage)
+	setCategory(junoCmd, catVMCompile,
+		maxVMsF, maxVMQueueF, maxConcurrentCompilationsF, versionedConstantsFileF,
+	)
+
+	// --- Transaction Cache ---
 	junoCmd.Flags().Uint(submittedTransactionsCacheSizeF, defaultSubmittedTransactionsCacheSize, submittedTransactionsCacheSize)
 	junoCmd.Flags().Duration(
 		submittedTransactionsCacheEntryTTLF,
 		defaultSubmittedTransactionsCacheEntryTTL,
 		submittedTransactionsCacheEntryTTL,
 	)
+	setCategory(junoCmd, catTxCache, submittedTransactionsCacheSizeF, submittedTransactionsCacheEntryTTLF)
+
+	// --- Plugins & Misc ---
+	junoCmd.Flags().StringVar(&cfgFile, configF, defaultConfig, configFlagUsage)
+	junoCmd.Flags().String(pluginPathF, defaultPluginPath, pluginPathUsage)
 	junoCmd.Flags().Bool(newStateF, defaultNewState, newStateUsage)
-	junoCmd.Flags().Bool(
-		disableRPCBatchRequestsF, defaultDisableRPCBatchRequests, disableRPCBatchRequestsUsage,
-	)
-	junoCmd.Flags().Duration(rpcRequestTimeoutF, defaultRPCRequestTimeout, rpcRequestTimeoutUsage)
-	junoCmd.Flags().Uint(
-		maxConcurrentCompilationsF, defaultMaxConcurrentCompilations, maxConcurrentCompilationsUsage,
-	)
-	junoCmd.Flags().Bool(
-		disableReceivedTxnStreamF, defaultDisableReceivedTxnStream, disableReceivedTxnStreamUsage,
-	)
-	junoCmd.Flags().Uint64(pruneModeF, defaultPruneMode, pruneModeUsage)
-	// NoOptDefVal lets users pass --prune-mode without a value (treated as 0).
-	junoCmd.Flags().Lookup(pruneModeF).NoOptDefVal = "0"
+	setCategory(junoCmd, catMisc, configF, pluginPathF, newStateF)
+
+	junoCmd.SetUsageFunc(writeGroupedUsage)
 	junoCmd.AddCommand(GenP2PKeyPair(), DBCmd(defaultDBPath), CompileSierraCmd())
 
 	return junoCmd

--- a/cmd/juno/juno.go
+++ b/cmd/juno/juno.go
@@ -424,12 +424,6 @@ func NewCmd(config *node.Config, run func(*cobra.Command, []string) error) *cobr
 	defaultMaxVMs := 3 * runtime.GOMAXPROCS(0)
 	defaultCNUnverifiableRange := []int{} // Uint64Slice is not supported in Flags()
 
-	// --- Logging ---
-	junoCmd.Flags().String(logLevelF, log.INFO.String(), logLevelFlagUsage)
-	junoCmd.Flags().Bool(logJSONF, defaultLogJSON, logJSONUsage)
-	junoCmd.Flags().Bool(colourF, defaultColour, colourUsage)
-	setCategory(junoCmd, catLogging, logLevelF, logJSONF, colourF)
-
 	// --- HTTP RPC ---
 	junoCmd.Flags().Bool(httpF, defaultHTTP, httpUsage)
 	junoCmd.Flags().String(httpHostF, defaultHost, httpHostUsage)
@@ -453,11 +447,44 @@ func NewCmd(config *node.Config, run func(*cobra.Command, []string) error) *cobr
 	junoCmd.Flags().Bool(disableReceivedTxnStreamF, defaultDisableReceivedTxnStream, disableReceivedTxnStreamUsage)
 	setCategory(junoCmd, catWebSocket, wsF, wsHostF, wsPortF, disableReceivedTxnStreamF)
 
-	// --- gRPC ---
-	junoCmd.Flags().Bool(grpcF, defaultGRPC, grpcUsage)
-	junoCmd.Flags().String(grpcHostF, defaultHost, grpcHostUsage)
-	junoCmd.Flags().Uint16(grpcPortF, defaultGRPCPort, grpcPortUsage)
-	setCategory(junoCmd, catGRPC, grpcF, grpcHostF, grpcPortF)
+	// --- Network & L1 ---
+	junoCmd.Flags().Var(&defaultNetwork, networkF, networkUsage)
+	junoCmd.Flags().String(ethNodeF, defaultEthNode, ethNodeUsage)
+	junoCmd.Flags().Bool(disableL1VerificationF, defaultDisableL1Verification, disableL1VerificationUsage)
+	junoCmd.MarkFlagsMutuallyExclusive(ethNodeF, disableL1VerificationF)
+	setCategory(junoCmd, catNetwork, networkF, ethNodeF, disableL1VerificationF)
+
+	// --- Sync & Polling ---
+	junoCmd.Flags().Duration(preLatestPollIntervalF, defaultPreLatestPollInterval, preLatestPollIntervalUsage)
+	junoCmd.Flags().Duration(preConfirmedPollIntervalF, defaultPreConfirmedPollInterval, preConfirmedPollIntervalUsage)
+	junoCmd.Flags().String(remoteDBF, defaultRemoteDB, remoteDBUsage)
+	junoCmd.Flags().Uint(readinessBlockToleranceF, defaultReadinessBlockTolerance, readinessBlockToleranceUsage)
+	setCategory(junoCmd, catSyncPolling,
+		preLatestPollIntervalF, preConfirmedPollIntervalF,
+		remoteDBF, readinessBlockToleranceF,
+	)
+
+	// --- Gateway ---
+	junoCmd.Flags().String(gwAPIKeyF, defaultGwAPIKey, gwAPIKeyUsage)
+	junoCmd.Flags().String(gwTimeoutsF, defaultGwTimeout, gwTimeoutsUsage)
+	setCategory(junoCmd, catGateway, gwAPIKeyF, gwTimeoutsF)
+
+	// --- Pruning ---
+	junoCmd.Flags().Uint64(pruneModeF, defaultPruneMode, pruneModeUsage)
+	// NoOptDefVal lets users pass --prune-mode without a value (treated as 0).
+	junoCmd.Flags().Lookup(pruneModeF).NoOptDefVal = "0"
+	setCategory(junoCmd, catPruning, pruneModeF)
+
+	// --- Logging ---
+	junoCmd.Flags().String(logLevelF, log.INFO.String(), logLevelFlagUsage)
+	junoCmd.Flags().Bool(logJSONF, defaultLogJSON, logJSONUsage)
+	junoCmd.Flags().Bool(colourF, defaultColour, colourUsage)
+	setCategory(junoCmd, catLogging, logLevelF, logJSONF, colourF)
+
+	// --- Logs HTTP Update Endpoint ---
+	junoCmd.Flags().String(httpUpdateHostF, defaultHost, httpUpdateHostUsage)
+	junoCmd.Flags().Uint16(httpUpdatePortF, defaultHTTPUpdatePort, httpUpdatePortUsage)
+	setCategory(junoCmd, catLogsHTTPUpdate, httpUpdateHostF, httpUpdatePortF)
 
 	// --- Metrics & Profiling ---
 	junoCmd.Flags().Bool(metricsF, defaultMetrics, metricsUsage)
@@ -470,11 +497,6 @@ func NewCmd(config *node.Config, run func(*cobra.Command, []string) error) *cobr
 		metricsF, metricsHostF, metricsPortF,
 		pprofF, pprofHostF, pprofPortF,
 	)
-
-	// --- HTTP Update Endpoint ---
-	junoCmd.Flags().String(httpUpdateHostF, defaultHost, httpUpdateHostUsage)
-	junoCmd.Flags().Uint16(httpUpdatePortF, defaultHTTPUpdatePort, httpUpdatePortUsage)
-	setCategory(junoCmd, catHTTPUpdate, httpUpdateHostF, httpUpdatePortF)
 
 	// --- Database ---
 	junoCmd.Flags().String(dbPathF, defaultDBPath, dbPathUsage)
@@ -489,12 +511,23 @@ func NewCmd(config *node.Config, run func(*cobra.Command, []string) error) *cobr
 		dbCompactionConcurrencyF, dbMemtableSizeF, dbMemtableCountF, dbCompressionF,
 	)
 
-	// --- Network & L1 ---
-	junoCmd.Flags().Var(&defaultNetwork, networkF, networkUsage)
-	junoCmd.Flags().String(ethNodeF, defaultEthNode, ethNodeUsage)
-	junoCmd.Flags().Bool(disableL1VerificationF, defaultDisableL1Verification, disableL1VerificationUsage)
-	junoCmd.MarkFlagsMutuallyExclusive(ethNodeF, disableL1VerificationF)
-	setCategory(junoCmd, catNetwork, networkF, ethNodeF, disableL1VerificationF)
+	// --- Transaction Cache ---
+	junoCmd.Flags().Uint(submittedTransactionsCacheSizeF, defaultSubmittedTransactionsCacheSize, submittedTransactionsCacheSize)
+	junoCmd.Flags().Duration(
+		submittedTransactionsCacheEntryTTLF,
+		defaultSubmittedTransactionsCacheEntryTTL,
+		submittedTransactionsCacheEntryTTL,
+	)
+	setCategory(junoCmd, catTxCache, submittedTransactionsCacheSizeF, submittedTransactionsCacheEntryTTLF)
+
+	// --- VM & Compilation ---
+	junoCmd.Flags().Uint(maxVMsF, uint(defaultMaxVMs), maxVMsUsage)
+	junoCmd.Flags().Uint(maxVMQueueF, 2*uint(defaultMaxVMs), maxVMQueueUsage)
+	junoCmd.Flags().Uint(maxConcurrentCompilationsF, defaultMaxConcurrentCompilations, maxConcurrentCompilationsUsage)
+	junoCmd.Flags().String(versionedConstantsFileF, defaultVersionedConstantsFile, versionedConstantsFileUsage)
+	setCategory(junoCmd, catVMCompile,
+		maxVMsF, maxVMQueueF, maxConcurrentCompilationsF, versionedConstantsFileF,
+	)
 
 	// --- Custom Network ---
 	junoCmd.Flags().String(cnNameF, defaultCNName, networkCustomName)
@@ -510,11 +543,6 @@ func NewCmd(config *node.Config, run func(*cobra.Command, []string) error) *cobr
 		cnNameF, cnFeederURLF, cnGatewayURLF,
 		cnL1ChainIDF, cnL2ChainIDF, cnCoreContractAddressF, cnUnverifiableRangeF,
 	)
-
-	// --- Gateway ---
-	junoCmd.Flags().String(gwAPIKeyF, defaultGwAPIKey, gwAPIKeyUsage)
-	junoCmd.Flags().String(gwTimeoutsF, defaultGwTimeout, gwTimeoutsUsage)
-	setCategory(junoCmd, catGateway, gwAPIKeyF, gwTimeoutsF)
 
 	// --- P2P (experimental) ---
 	junoCmd.Flags().Bool(p2pF, defaultP2p, p2pUsage)
@@ -535,39 +563,11 @@ func NewCmd(config *node.Config, run func(*cobra.Command, []string) error) *cobr
 	junoCmd.Flags().Bool(seqDisableFeesF, defaultSeqDisableFees, seqDisableFeesUsage)
 	setCategory(junoCmd, catSequencer, seqEnF, seqBlockTimeF, seqGenesisFileF, seqDisableFeesF)
 
-	// --- Sync & Polling ---
-	junoCmd.Flags().Duration(preLatestPollIntervalF, defaultPreLatestPollInterval, preLatestPollIntervalUsage)
-	junoCmd.Flags().Duration(preConfirmedPollIntervalF, defaultPreConfirmedPollInterval, preConfirmedPollIntervalUsage)
-	junoCmd.Flags().String(remoteDBF, defaultRemoteDB, remoteDBUsage)
-	junoCmd.Flags().Uint(readinessBlockToleranceF, defaultReadinessBlockTolerance, readinessBlockToleranceUsage)
-	setCategory(junoCmd, catSyncPolling,
-		preLatestPollIntervalF, preConfirmedPollIntervalF,
-		remoteDBF, readinessBlockToleranceF,
-	)
-
-	// --- Pruning ---
-	junoCmd.Flags().Uint64(pruneModeF, defaultPruneMode, pruneModeUsage)
-	// NoOptDefVal lets users pass --prune-mode without a value (treated as 0).
-	junoCmd.Flags().Lookup(pruneModeF).NoOptDefVal = "0"
-	setCategory(junoCmd, catPruning, pruneModeF)
-
-	// --- VM & Compilation ---
-	junoCmd.Flags().Uint(maxVMsF, uint(defaultMaxVMs), maxVMsUsage)
-	junoCmd.Flags().Uint(maxVMQueueF, 2*uint(defaultMaxVMs), maxVMQueueUsage)
-	junoCmd.Flags().Uint(maxConcurrentCompilationsF, defaultMaxConcurrentCompilations, maxConcurrentCompilationsUsage)
-	junoCmd.Flags().String(versionedConstantsFileF, defaultVersionedConstantsFile, versionedConstantsFileUsage)
-	setCategory(junoCmd, catVMCompile,
-		maxVMsF, maxVMQueueF, maxConcurrentCompilationsF, versionedConstantsFileF,
-	)
-
-	// --- Transaction Cache ---
-	junoCmd.Flags().Uint(submittedTransactionsCacheSizeF, defaultSubmittedTransactionsCacheSize, submittedTransactionsCacheSize)
-	junoCmd.Flags().Duration(
-		submittedTransactionsCacheEntryTTLF,
-		defaultSubmittedTransactionsCacheEntryTTL,
-		submittedTransactionsCacheEntryTTL,
-	)
-	setCategory(junoCmd, catTxCache, submittedTransactionsCacheSizeF, submittedTransactionsCacheEntryTTLF)
+	// --- gRPC ---
+	junoCmd.Flags().Bool(grpcF, defaultGRPC, grpcUsage)
+	junoCmd.Flags().String(grpcHostF, defaultHost, grpcHostUsage)
+	junoCmd.Flags().Uint16(grpcPortF, defaultGRPCPort, grpcPortUsage)
+	setCategory(junoCmd, catGRPC, grpcF, grpcHostF, grpcPortF)
 
 	// --- Plugins & Misc ---
 	junoCmd.Flags().StringVar(&cfgFile, configF, defaultConfig, configFlagUsage)

--- a/cmd/juno/juno.go
+++ b/cmd/juno/juno.go
@@ -496,16 +496,12 @@ func NewCmd(config *node.Config, run func(*cobra.Command, []string) error) *cobr
 	junoCmd.Flags().Uint16(httpUpdatePortF, defaultHTTPUpdatePort, httpUpdatePortUsage)
 	setCategory(junoCmd, catLogsHTTPUpdate, httpUpdateHostF, httpUpdatePortF)
 
-	// --- Metrics & Profiling ---
+	// --- Metrics ---
 	junoCmd.Flags().Bool(metricsF, defaultMetrics, metricsUsage)
 	junoCmd.Flags().String(metricsHostF, defaultHost, metricsHostUsage)
 	junoCmd.Flags().Uint16(metricsPortF, defaultMetricsPort, metricsPortUsage)
-	junoCmd.Flags().Bool(pprofF, defaultPprof, pprofUsage)
-	junoCmd.Flags().String(pprofHostF, defaultHost, pprofHostUsage)
-	junoCmd.Flags().Uint16(pprofPortF, defaultPprofPort, pprofPortUsage)
-	setCategory(junoCmd, catObservability,
+	setCategory(junoCmd, catMetrics,
 		metricsF, metricsHostF, metricsPortF,
-		pprofF, pprofHostF, pprofPortF,
 	)
 
 	// --- Database ---
@@ -567,6 +563,14 @@ func NewCmd(config *node.Config, run func(*cobra.Command, []string) error) *cobr
 	setCategory(junoCmd, catCustomNetwork,
 		cnNameF, cnFeederURLF, cnGatewayURLF,
 		cnL1ChainIDF, cnL2ChainIDF, cnCoreContractAddressF, cnUnverifiableRangeF,
+	)
+
+	// --- Profiling ---
+	junoCmd.Flags().Bool(pprofF, defaultPprof, pprofUsage)
+	junoCmd.Flags().String(pprofHostF, defaultHost, pprofHostUsage)
+	junoCmd.Flags().Uint16(pprofPortF, defaultPprofPort, pprofPortUsage)
+	setCategory(junoCmd, catProfiling,
+		pprofF, pprofHostF, pprofPortF,
 	)
 
 	// --- P2P (experimental) ---

--- a/cmd/juno/usage.go
+++ b/cmd/juno/usage.go
@@ -15,24 +15,24 @@ import (
 const flagCategoryAnnotation = "juno_category"
 
 const (
-	catLogging       = "Logging"
-	catHTTPRPC       = "HTTP RPC"
-	catWebSocket     = "WebSocket RPC"
-	catGRPC          = "gRPC"
-	catObservability = "Metrics & Profiling"
-	catHTTPUpdate    = "HTTP Update Endpoint"
-	catDatabase      = "Database"
-	catNetwork       = "Network & L1"
-	catCustomNetwork = "Custom Network"
-	catGateway       = "Gateway"
-	catP2P           = "P2P (experimental)"
-	catSequencer     = "Sequencer"
-	catSyncPolling   = "Sync & Polling"
-	catPruning       = "Pruning"
-	catVMCompile     = "VM & Compilation"
-	catTxCache       = "Transaction Cache"
-	catMisc          = "Plugins & Misc"
-	catOther         = "Other"
+	catHTTPRPC        = "HTTP RPC"
+	catWebSocket      = "WebSocket RPC"
+	catNetwork        = "Network & L1"
+	catSyncPolling    = "Sync & Polling"
+	catGateway        = "Gateway"
+	catPruning        = "Pruning"
+	catLogging        = "Logging"
+	catLogsHTTPUpdate = "Logs HTTP Update Endpoint"
+	catObservability  = "Metrics & Profiling"
+	catDatabase       = "Database"
+	catTxCache        = "Transaction Cache"
+	catVMCompile      = "VM & Compilation"
+	catCustomNetwork  = "Custom Network"
+	catP2P            = "P2P (experimental)"
+	catSequencer      = "Sequencer"
+	catGRPC           = "gRPC"
+	catMisc           = "Plugins & Misc"
+	catOther          = "Other"
 )
 
 // setCategory tags every named flag on cmd with the given display category.
@@ -98,22 +98,22 @@ func writeFlagsSection(b *strings.Builder, cmd *cobra.Command) {
 	// orderedCategories controls render order. catOther is appended after these if
 	// non-empty, so a forgotten annotation is visible rather than silently dropped.
 	orderedCategories := []string{
-		catLogging,
 		catHTTPRPC,
 		catWebSocket,
-		catGRPC,
-		catObservability,
-		catHTTPUpdate,
-		catDatabase,
 		catNetwork,
-		catCustomNetwork,
+		catSyncPolling,
 		catGateway,
+		catPruning,
+		catLogging,
+		catLogsHTTPUpdate,
+		catObservability,
+		catDatabase,
+		catTxCache,
+		catVMCompile,
+		catCustomNetwork,
 		catP2P,
 		catSequencer,
-		catSyncPolling,
-		catPruning,
-		catVMCompile,
-		catTxCache,
+		catGRPC,
 		catMisc,
 	}
 

--- a/cmd/juno/usage.go
+++ b/cmd/juno/usage.go
@@ -9,10 +9,10 @@ import (
 	"github.com/spf13/pflag"
 )
 
-// flagCategoryAnnotation is the pflag annotation key used to tag a flag with a
+// FlagCategoryAnnotation is the pflag annotation key used to tag a flag with a
 // display category. The grouped usage func partitions flags by this annotation
 // when rendering --help.
-const flagCategoryAnnotation = "juno_category"
+const FlagCategoryAnnotation = "juno_category"
 
 const (
 	catHTTPRPC        = "HTTP RPC"
@@ -23,11 +23,12 @@ const (
 	catPruning        = "Pruning"
 	catLogging        = "Logging"
 	catLogsHTTPUpdate = "Logs HTTP Update Endpoint"
-	catObservability  = "Metrics & Profiling"
+	catMetrics        = "Metrics"
 	catDatabase       = "Database"
 	catTxCache        = "Transaction Cache"
 	catVMCompile      = "VM & Compilation"
 	catCustomNetwork  = "Custom Network"
+	catProfiling      = "Profiling"
 	catP2P            = "P2P (experimental)"
 	catSequencer      = "Sequencer"
 	catGRPC           = "gRPC"
@@ -35,11 +36,36 @@ const (
 	catOther          = "Other"
 )
 
+// FlagCategories returns all the categories flags can be grouped in, sorted based on Juno's today
+// more important flags.
+func FlagCategories() [18]string {
+	return [18]string{
+		catHTTPRPC,
+		catWebSocket,
+		catNetwork,
+		catSyncPolling,
+		catGateway,
+		catPruning,
+		catLogging,
+		catLogsHTTPUpdate,
+		catMetrics,
+		catDatabase,
+		catTxCache,
+		catVMCompile,
+		catCustomNetwork,
+		catProfiling,
+		catP2P,
+		catSequencer,
+		catGRPC,
+		catMisc,
+	}
+}
+
 // setCategory tags every named flag on cmd with the given display category.
 // It panics if a flag is not registered, surfacing wiring mistakes at startup.
 func setCategory(cmd *cobra.Command, category string, flagNames ...string) {
 	for _, name := range flagNames {
-		err := cmd.Flags().SetAnnotation(name, flagCategoryAnnotation, []string{category})
+		err := cmd.Flags().SetAnnotation(name, FlagCategoryAnnotation, []string{category})
 		if err != nil {
 			panic(fmt.Errorf("setCategory %q on %q: %w", category, name, err))
 		}
@@ -97,26 +123,7 @@ func writeFlagsSection(b *strings.Builder, cmd *cobra.Command) {
 
 	// orderedCategories controls render order. catOther is appended after these if
 	// non-empty, so a forgotten annotation is visible rather than silently dropped.
-	orderedCategories := []string{
-		catHTTPRPC,
-		catWebSocket,
-		catNetwork,
-		catSyncPolling,
-		catGateway,
-		catPruning,
-		catLogging,
-		catLogsHTTPUpdate,
-		catObservability,
-		catDatabase,
-		catTxCache,
-		catVMCompile,
-		catCustomNetwork,
-		catP2P,
-		catSequencer,
-		catGRPC,
-		catMisc,
-	}
-
+	orderedCategories := FlagCategories()
 	buckets := bucketFlags(cmd.LocalFlags())
 	for _, cat := range orderedCategories {
 		writeFlagSection(b, cat, buckets[cat])
@@ -181,7 +188,7 @@ func hasCategorisedFlags(fs *pflag.FlagSet) bool {
 		if found {
 			return
 		}
-		if vals, ok := f.Annotations[flagCategoryAnnotation]; ok && len(vals) > 0 {
+		if vals, ok := f.Annotations[FlagCategoryAnnotation]; ok && len(vals) > 0 {
 			found = true
 		}
 	})
@@ -199,7 +206,7 @@ func bucketFlags(fs *pflag.FlagSet) map[string][]*pflag.Flag {
 			return
 		}
 		cat := catOther
-		if vals, ok := f.Annotations[flagCategoryAnnotation]; ok && len(vals) > 0 {
+		if vals, ok := f.Annotations[FlagCategoryAnnotation]; ok && len(vals) > 0 {
 			cat = vals[0]
 		} else if f.Name == "help" {
 			cat = catMisc

--- a/cmd/juno/usage.go
+++ b/cmd/juno/usage.go
@@ -1,0 +1,232 @@
+package main
+
+import (
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+)
+
+// flagCategoryAnnotation is the pflag annotation key used to tag a flag with a
+// display category. The grouped usage func partitions flags by this annotation
+// when rendering --help.
+const flagCategoryAnnotation = "juno_category"
+
+const (
+	catLogging       = "Logging"
+	catHTTPRPC       = "HTTP RPC"
+	catWebSocket     = "WebSocket RPC"
+	catGRPC          = "gRPC"
+	catObservability = "Metrics & Profiling"
+	catHTTPUpdate    = "HTTP Update Endpoint"
+	catDatabase      = "Database"
+	catNetwork       = "Network & L1"
+	catCustomNetwork = "Custom Network"
+	catGateway       = "Gateway"
+	catP2P           = "P2P (experimental)"
+	catSequencer     = "Sequencer"
+	catSyncPolling   = "Sync & Polling"
+	catPruning       = "Pruning"
+	catVMCompile     = "VM & Compilation"
+	catTxCache       = "Transaction Cache"
+	catMisc          = "Plugins & Misc"
+	catOther         = "Other"
+)
+
+// setCategory tags every named flag on cmd with the given display category.
+// It panics if a flag is not registered, surfacing wiring mistakes at startup.
+func setCategory(cmd *cobra.Command, category string, flagNames ...string) {
+	for _, name := range flagNames {
+		err := cmd.Flags().SetAnnotation(name, flagCategoryAnnotation, []string{category})
+		if err != nil {
+			panic(fmt.Errorf("setCategory %q on %q: %w", category, name, err))
+		}
+	}
+}
+
+func writeUsageLine(b *strings.Builder, cmd *cobra.Command) {
+	b.WriteString("Usage:")
+	if cmd.Runnable() {
+		b.WriteString("\n  " + cmd.UseLine())
+	}
+	if cmd.HasAvailableSubCommands() {
+		b.WriteString("\n  " + cmd.CommandPath() + " [command]")
+	}
+	b.WriteByte('\n')
+}
+
+func writeAliases(b *strings.Builder, cmd *cobra.Command) {
+	if len(cmd.Aliases) > 0 {
+		b.WriteString("\nAliases:\n  " + cmd.NameAndAliases() + "\n")
+	}
+}
+
+func writeExamples(b *strings.Builder, cmd *cobra.Command) {
+	if cmd.HasExample() {
+		b.WriteString("\nExamples:\n" + cmd.Example + "\n")
+	}
+}
+
+func writeAvailableCommands(b *strings.Builder, cmd *cobra.Command) {
+	if !cmd.HasAvailableSubCommands() {
+		return
+	}
+	b.WriteString("\nAvailable Commands:\n")
+	pad := cmd.NamePadding()
+	for _, c := range cmd.Commands() {
+		if c.IsAvailableCommand() || c.Name() == "help" {
+			fmt.Fprintf(b, "  %s %s\n", rpad(c.Name(), pad), c.Short)
+		}
+	}
+}
+
+func writeFlagsSection(b *strings.Builder, cmd *cobra.Command) {
+	if !cmd.HasAvailableLocalFlags() {
+		return
+	}
+	if !hasCategorisedFlags(cmd.LocalFlags()) {
+		// Subcommands inherit this usage func via Cobra's parent walk but
+		// don't tag their flags. Render the standard flat list for them.
+		b.WriteString("\nFlags:\n")
+		b.WriteString(strings.TrimRight(cmd.LocalFlags().FlagUsages(), " \t\n"))
+		b.WriteByte('\n')
+		return
+	}
+
+	// orderedCategories controls render order. catOther is appended after these if
+	// non-empty, so a forgotten annotation is visible rather than silently dropped.
+	orderedCategories := []string{
+		catLogging,
+		catHTTPRPC,
+		catWebSocket,
+		catGRPC,
+		catObservability,
+		catHTTPUpdate,
+		catDatabase,
+		catNetwork,
+		catCustomNetwork,
+		catGateway,
+		catP2P,
+		catSequencer,
+		catSyncPolling,
+		catPruning,
+		catVMCompile,
+		catTxCache,
+		catMisc,
+	}
+
+	buckets := bucketFlags(cmd.LocalFlags())
+	for _, cat := range orderedCategories {
+		writeFlagSection(b, cat, buckets[cat])
+	}
+	writeFlagSection(b, catOther, buckets[catOther])
+}
+
+func writeGlobalFlags(b *strings.Builder, cmd *cobra.Command) {
+	if !cmd.HasAvailableInheritedFlags() {
+		return
+	}
+	b.WriteString("\nGlobal Flags:\n")
+	b.WriteString(strings.TrimRight(cmd.InheritedFlags().FlagUsages(), " \t\n"))
+	b.WriteByte('\n')
+}
+
+func writeAdditionalHelpTopics(b *strings.Builder, cmd *cobra.Command) {
+	if !cmd.HasHelpSubCommands() {
+		return
+	}
+	b.WriteString("\nAdditional help topics:\n")
+	pad := cmd.CommandPathPadding()
+	for _, c := range cmd.Commands() {
+		if c.IsAdditionalHelpTopicCommand() {
+			fmt.Fprintf(b, "  %s %s\n", rpad(c.CommandPath(), pad), c.Short)
+		}
+	}
+}
+
+func writeFooter(b *strings.Builder, cmd *cobra.Command) {
+	if cmd.HasAvailableSubCommands() {
+		fmt.Fprintf(
+			b,
+			"\nUse \"%s [command] --help\" for more information about a command.\n",
+			cmd.CommandPath(),
+		)
+	}
+}
+
+// writeGroupedUsage is a drop-in replacement for cobra's default usage function
+// that splits Flags into one section per juno_category annotation.
+func writeGroupedUsage(cmd *cobra.Command) error {
+	var b strings.Builder
+	writeUsageLine(&b, cmd)
+	writeAliases(&b, cmd)
+	writeExamples(&b, cmd)
+	writeAvailableCommands(&b, cmd)
+	writeFlagsSection(&b, cmd)
+	writeGlobalFlags(&b, cmd)
+	writeAdditionalHelpTopics(&b, cmd)
+	writeFooter(&b, cmd)
+	_, err := io.WriteString(cmd.OutOrStderr(), b.String())
+	return err
+}
+
+// hasCategorisedFlags reports whether any flag in the set carries the
+// juno_category annotation. Used to decide whether to render grouped sections
+// or fall back to a single flat "Flags:" block.
+func hasCategorisedFlags(fs *pflag.FlagSet) bool {
+	found := false
+	fs.VisitAll(func(f *pflag.Flag) {
+		if found {
+			return
+		}
+		if vals, ok := f.Annotations[flagCategoryAnnotation]; ok && len(vals) > 0 {
+			found = true
+		}
+	})
+	return found
+}
+
+// bucketFlags groups visible flags by their juno_category annotation. Hidden
+// flags are skipped, matching pflag.FlagUsages behaviour. Cobra adds --help
+// lazily on Execute(), so it cannot be tagged via setCategory; route it into
+// catMisc so it lands alongside --config and --plugin-path.
+func bucketFlags(fs *pflag.FlagSet) map[string][]*pflag.Flag {
+	buckets := make(map[string][]*pflag.Flag)
+	fs.VisitAll(func(f *pflag.Flag) {
+		if f.Hidden {
+			return
+		}
+		cat := catOther
+		if vals, ok := f.Annotations[flagCategoryAnnotation]; ok && len(vals) > 0 {
+			cat = vals[0]
+		} else if f.Name == "help" {
+			cat = catMisc
+		}
+		buckets[cat] = append(buckets[cat], f)
+	})
+	return buckets
+}
+
+// writeFlagSection renders one category's flags using pflag's standard column
+// alignment, by adding the matching flag pointers to a throwaway FlagSet.
+func writeFlagSection(b *strings.Builder, category string, flags []*pflag.Flag) {
+	if len(flags) == 0 {
+		return
+	}
+	tmp := pflag.NewFlagSet(category, pflag.ContinueOnError)
+	for _, f := range flags {
+		tmp.AddFlag(f)
+	}
+	fmt.Fprintf(b, "\n%s Flags:\n", category)
+	b.WriteString(strings.TrimRight(tmp.FlagUsages(), " \t\n"))
+	b.WriteByte('\n')
+}
+
+func rpad(s string, padding int) string {
+	if len(s) >= padding {
+		return s
+	}
+	return s + strings.Repeat(" ", padding-len(s))
+}

--- a/cmd/juno/usage_test.go
+++ b/cmd/juno/usage_test.go
@@ -1,0 +1,70 @@
+package main_test
+
+import (
+	"strings"
+	"testing"
+
+	juno "github.com/NethermindEth/juno/cmd/juno"
+	"github.com/NethermindEth/juno/node"
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const flagCategoryAnnotation = "juno_category"
+
+// expectedCategoryHeaders are rendered as "<header> Flags:" by groupedUsageFunc.
+// Keep this list in sync with orderedCategories in usage.go.
+var expectedCategoryHeaders = []string{
+	"Logging",
+	"HTTP RPC",
+	"WebSocket RPC",
+	"gRPC",
+	"Metrics & Profiling",
+	"HTTP Update Endpoint",
+	"Database",
+	"Network & L1",
+	"Custom Network",
+	"Gateway",
+	"P2P (experimental)",
+	"Sequencer",
+	"Sync & Polling",
+	"Pruning",
+	"VM & Compilation",
+	"Transaction Cache",
+	"Plugins & Misc",
+}
+
+func TestEveryRootFlagIsCategorised(t *testing.T) {
+	cmd := juno.NewCmd(new(node.Config), func(*cobra.Command, []string) error { return nil })
+
+	var missing []string
+	cmd.Flags().VisitAll(func(f *pflag.Flag) {
+		if vals, ok := f.Annotations[flagCategoryAnnotation]; !ok || len(vals) == 0 {
+			missing = append(missing, f.Name)
+		}
+	})
+	require.Empty(t, missing,
+		"flags missing %q annotation; tag them with setCategory in NewCmd: %v",
+		flagCategoryAnnotation, missing)
+}
+
+func TestHelpOutputIsGrouped(t *testing.T) {
+	cmd := juno.NewCmd(new(node.Config), func(*cobra.Command, []string) error { return nil })
+
+	var buf strings.Builder
+	cmd.SetOut(&buf)
+	cmd.SetErr(&buf)
+	cmd.SetArgs([]string{"--help"})
+
+	require.NoError(t, cmd.ExecuteContext(t.Context()))
+
+	out := buf.String()
+	for _, header := range expectedCategoryHeaders {
+		assert.Contains(t, out, header+" Flags:",
+			"help output is missing category header %q", header)
+	}
+	assert.NotContains(t, out, "Other Flags:",
+		"a flag fell into the Other bucket; tag it with setCategory")
+}

--- a/cmd/juno/usage_test.go
+++ b/cmd/juno/usage_test.go
@@ -12,42 +12,22 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-const flagCategoryAnnotation = "juno_category"
-
-// expectedCategoryHeaders are rendered as "<header> Flags:" by writeGroupedUsage.
-// Keep this list in sync (label and order) with orderedCategories in usage.go.
-var expectedCategoryHeaders = []string{
-	"HTTP RPC",
-	"WebSocket RPC",
-	"Network & L1",
-	"Sync & Polling",
-	"Gateway",
-	"Pruning",
-	"Logging",
-	"Logs HTTP Update Endpoint",
-	"Metrics & Profiling",
-	"Database",
-	"Transaction Cache",
-	"VM & Compilation",
-	"Custom Network",
-	"P2P (experimental)",
-	"Sequencer",
-	"gRPC",
-	"Plugins & Misc",
-}
-
 func TestEveryRootFlagIsCategorised(t *testing.T) {
 	cmd := juno.NewCmd(new(node.Config), func(*cobra.Command, []string) error { return nil })
 
 	var missing []string
 	cmd.Flags().VisitAll(func(f *pflag.Flag) {
-		if vals, ok := f.Annotations[flagCategoryAnnotation]; !ok || len(vals) == 0 {
+		if vals, ok := f.Annotations[juno.FlagCategoryAnnotation]; !ok || len(vals) == 0 {
 			missing = append(missing, f.Name)
 		}
 	})
-	require.Empty(t, missing,
+	require.Empty(
+		t,
+		missing,
 		"flags missing %q annotation; tag them with setCategory in NewCmd: %v",
-		flagCategoryAnnotation, missing)
+		juno.FlagCategoryAnnotation,
+		missing,
+	)
 }
 
 func TestHelpOutputIsGrouped(t *testing.T) {
@@ -61,10 +41,13 @@ func TestHelpOutputIsGrouped(t *testing.T) {
 	require.NoError(t, cmd.ExecuteContext(t.Context()))
 
 	out := buf.String()
-	for _, header := range expectedCategoryHeaders {
-		assert.Contains(t, out, header+" Flags:",
-			"help output is missing category header %q", header)
+	for _, header := range juno.FlagCategories() {
+		assert.Contains(
+			t,
+			out,
+			header+" Flags:",
+			"help output is missing category header %q",
+			header,
+		)
 	}
-	assert.NotContains(t, out, "Other Flags:",
-		"a flag fell into the Other bucket; tag it with setCategory")
 }

--- a/cmd/juno/usage_test.go
+++ b/cmd/juno/usage_test.go
@@ -14,25 +14,25 @@ import (
 
 const flagCategoryAnnotation = "juno_category"
 
-// expectedCategoryHeaders are rendered as "<header> Flags:" by groupedUsageFunc.
-// Keep this list in sync with orderedCategories in usage.go.
+// expectedCategoryHeaders are rendered as "<header> Flags:" by writeGroupedUsage.
+// Keep this list in sync (label and order) with orderedCategories in usage.go.
 var expectedCategoryHeaders = []string{
-	"Logging",
 	"HTTP RPC",
 	"WebSocket RPC",
-	"gRPC",
-	"Metrics & Profiling",
-	"HTTP Update Endpoint",
-	"Database",
 	"Network & L1",
-	"Custom Network",
+	"Sync & Polling",
 	"Gateway",
+	"Pruning",
+	"Logging",
+	"Logs HTTP Update Endpoint",
+	"Metrics & Profiling",
+	"Database",
+	"Transaction Cache",
+	"VM & Compilation",
+	"Custom Network",
 	"P2P (experimental)",
 	"Sequencer",
-	"Sync & Polling",
-	"Pruning",
-	"VM & Compilation",
-	"Transaction Cache",
+	"gRPC",
 	"Plugins & Misc",
 }
 

--- a/docs/docs/_config-options.md
+++ b/docs/docs/_config-options.md
@@ -1,6 +1,110 @@
 <!-- This file is generated automatically. Any manual modifications will be overwritten. -->
 
-### Other
+### HTTP RPC
+
+| Config Option | Default Value | Description |
+| - | - | - |
+| `disable-rpc-batch-requests` | `false` | Disables handling of batched RPC requests |
+| `http` | `false` | Enables the HTTP RPC server on the default port and interface |
+| `http-host` | `localhost` | The interface on which the HTTP RPC server will listen for requests |
+| `http-port` | `6060` | The port on which the HTTP server will listen for requests |
+| `rpc-call-max-gas` | `100000000` | Maximum number of Sierra gas to be executed in starknet_call requests |
+| `rpc-call-max-steps` | `4000000` | Maximum number of steps to be executed in starknet_call requests |
+| `rpc-cors-enable` | `false` | Enable CORS on RPC endpoints |
+| `rpc-max-block-scan` | `18446744073709551615` | Maximum number of blocks scanned in single starknet_getEvents call |
+| `rpc-request-timeout` | `1m` | Maximum time for an RPC request to complete |
+
+### WebSocket RPC
+
+| Config Option | Default Value | Description |
+| - | - | - |
+| `disable-received-txn-stream` | `false` | The starknet_subscribeNewTransactions WebSocket API allows users to subscribe to new transactions. By default, it streams transactions that have been accepted on L2. Users can optionally provide a set of finality statuses to be notified about, including transactions from canonical blocks, blocks with softer finality guarantees such as pre-confirmed and pre-latest, as well as transactions not yet part of any block such as received and candidate. When subscribers select the RECEIVED status, they will be notified about transactions that have been submitted through this node — these transactions are local to the node and are not sourced from the network. When this flag is enabled, the node will no longer notify subscribers about transactions submitted through it |
+| `ws` | `false` | Enables the WebSocket RPC server on the default port |
+| `ws-host` | `localhost` | The interface on which the WebSocket RPC server will listen for requests |
+| `ws-port` | `6061` | The port on which the WebSocket server will listen for requests |
+
+### Network & L1
+
+| Config Option | Default Value | Description |
+| - | - | - |
+| `disable-l1-verification` | `false` | Disables L1 verification since an Ethereum node is not provided |
+| `eth-node` |  | WebSocket endpoint of the Ethereum node. To verify the correctness of the L2 chain, Juno must connect to an Ethereum node and parse events in the Starknet contract |
+| `network` | `mainnet` | Options: mainnet, sepolia, sepolia-integration |
+
+### Sync & Polling
+
+| Config Option | Default Value | Description |
+| - | - | - |
+| `preconfirmed-poll-interval` | `500ms` | Sets how frequently pre_confirmed block will be updated(0s will disable fetching of pre_confirmed block) |
+| `prelatest-poll-interval` | `1s` | Sets polling interval for pre-latest block updates. (0s will disable polling) |
+| `readiness-block-tolerance` | `6` | Maximum blocks behind latest for /ready endpoints to return 200 OK |
+| `remote-db` |  | gRPC URL of a remote Juno node |
+
+### Gateway
+
+| Config Option | Default Value | Description |
+| - | - | - |
+| `gw-api-key` |  | API key for gateway endpoints to avoid throttling |
+| `gw-timeouts` | `5s` | Timeouts for requests made to the gateway. Can be specified in three ways:\n- Single value (e.g. '5s'): After each failure, the timeout will increase dynamically.\n- Comma-separated list (e.g. '5s,10s,20s'): Each value will be used in sequence after failures.\n- Single value with trailing comma (e.g. '5s,'): Uses a fixed timeout without dynamic adjustment |
+
+### Pruning
+
+| Config Option | Default Value | Description |
+| - | - | - |
+| `prune-mode` | `0` | Enables block-data and state-history pruning. Pruning is disabled by default; passing this flag (with or without a value) turns it on. The value is the size of the retention window in blocks, counted back from the latest L1-verified head:\n  --prune-mode      same as --prune-mode=0; prune up to the L1 head\n  --prune-mode=N    keep blocks in (l1_head - N, l2_head], prune below\nBlocks at or above the L2 head are always kept. The floor is anchored on the L1-verified head — never on the local L2 head — so pruned blocks are reorg-safe. RPC remains fully functional for any block inside the retention window; requests targeting blocks below the floor fail because their data has been deleted. Pruning is irreversible: data deleted under a small window cannot be recovered without re-syncing. Changing this value across restarts is safe: the window grows or shrinks accordingly. Growth is gradual — pruning pauses until the L1 head advances enough to reach the new floor |
+
+### Logging
+
+| Config Option | Default Value | Description |
+| - | - | - |
+| `colour` | `true` | Use `--colour=false` command to disable colourized outputs (ANSI Escape Codes) |
+| `log-json` | `false` | Use JSON encoding for log output |
+| `log-level` |  | Options: trace, debug, info, warn, error |
+
+### Logs HTTP Update Endpoint
+
+| Config Option | Default Value | Description |
+| - | - | - |
+| `http-update-host` | `localhost` | The interface on which the log level and gateway timeouts HTTP server will listen for requests |
+| `http-update-port` | `0` | The port on which the log level and gateway timeouts HTTP server will listen for requests |
+
+### Metrics
+
+| Config Option | Default Value | Description |
+| - | - | - |
+| `metrics` | `false` | Enables the Prometheus metrics endpoint on the default port |
+| `metrics-host` | `localhost` | The interface on which the Prometheus endpoint will listen for requests |
+| `metrics-port` | `9090` | The port on which the Prometheus endpoint will listen for requests |
+
+### Database
+
+| Config Option | Default Value | Description |
+| - | - | - |
+| `db-cache-size` | `1024` | Determines the amount of memory (in megabytes) allocated for caching data in the database |
+| `db-compaction-concurrency` |  | DB compaction concurrency range. Format: N (lower=1, upper=N) or M,N (lower=M, upper=N). Default: 1,GOMAXPROCS/2 |
+| `db-compression` | `zstd` | Database compression profile. Options: zstd, snappy, minlz. Use zstd for low storage |
+| `db-max-handles` | `1024` | A soft limit on the number of open files that can be used by the DB |
+| `db-memtable-count` | `2` | Determines the number of memtables the database can queue before stalling writes |
+| `db-memtable-size` | `256` | Determines the amount of memory (in MBs) allocated for database memtables |
+| `db-path` | `juno` | Location of the database files |
+
+### Transaction Cache
+
+| Config Option | Default Value | Description |
+| - | - | - |
+| `submitted-transactions-cache-entry-ttl` | `5m` | Time-to-live for each entry in the submitted transactions cache |
+| `submitted-transactions-cache-size` | `10000` | Maximum number of entries in the submitted transactions cache |
+
+### VM & Compilation
+
+| Config Option | Default Value | Description |
+| - | - | - |
+| `max-concurrent-compilations` | `8` | Maximum concurrent Sierra compilations |
+| `max-vm-queue` | `2 * max-vms` | Maximum number for requests to queue after reaching max-vms before starting to reject incoming requests |
+| `max-vms` | `3 * CPU Cores` | Maximum number for VM instances to be used for RPC calls concurrently |
+| `versioned-constants-file` |  | Use custom versioned constants from provided file |
+
+### Custom Network
 
 | Config Option | Default Value | Description |
 | - | - | - |
@@ -11,66 +115,47 @@
 | `cn-l2-chain-id` |  | Custom network L2 chain id |
 | `cn-name` |  | Custom network name |
 | `cn-unverifiable-range` | `[]` | Custom network range of blocks to skip hash verifications (e.g. `0,100`) |
-| `colour` | `true` | Use `--colour=false` command to disable colourized outputs (ANSI Escape Codes) |
-| `config` |  | The YAML configuration file |
-| `db-cache-size` | `1024` | Determines the amount of memory (in megabytes) allocated for caching data in the database |
-| `db-compaction-concurrency` |  | DB compaction concurrency range. Format: N (lower=1, upper=N) or M,N (lower=M, upper=N). Default: 1,GOMAXPROCS/2 |
-| `db-compression` | `zstd` | Database compression profile. Options: zstd, snappy, minlz. Use zstd for low storage |
-| `db-max-handles` | `1024` | A soft limit on the number of open files that can be used by the DB |
-| `db-memtable-count` | `2` | Determines the number of memtables the database can queue before stalling writes |
-| `db-memtable-size` | `256` | Determines the amount of memory (in MBs) allocated for database memtables |
-| `db-path` | `juno` | Location of the database files |
-| `disable-l1-verification` | `false` | Disables L1 verification since an Ethereum node is not provided |
-| `disable-received-txn-stream` | `false` | The starknet_subscribeNewTransactions WebSocket API allows users to subscribe to new transactions. By default, it streams transactions that have been accepted on L2. Users can optionally provide a set of finality statuses to be notified about, including transactions from canonical blocks, blocks with softer finality guarantees such as pre-confirmed and pre-latest, as well as transactions not yet part of any block such as received and candidate. When subscribers select the RECEIVED status, they will be notified about transactions that have been submitted through this node — these transactions are local to the node and are not sourced from the network. When this flag is enabled, the node will no longer notify subscribers about transactions submitted through it |
-| `disable-rpc-batch-requests` | `false` | Disables handling of batched RPC requests |
-| `eth-node` |  | WebSocket endpoint of the Ethereum node. To verify the correctness of the L2 chain, Juno must connect to an Ethereum node and parse events in the Starknet contract |
-| `grpc` | `false` | Enable the HTTP gRPC server on the default port |
-| `grpc-host` | `localhost` | The interface on which the gRPC server will listen for requests |
-| `grpc-port` | `6064` | The port on which the gRPC server will listen for requests |
-| `gw-api-key` |  | API key for gateway endpoints to avoid throttling |
-| `gw-timeouts` | `5s` | Timeouts for requests made to the gateway. Can be specified in three ways:\n- Single value (e.g. '5s'): After each failure, the timeout will increase dynamically.\n- Comma-separated list (e.g. '5s,10s,20s'): Each value will be used in sequence after failures.\n- Single value with trailing comma (e.g. '5s,'): Uses a fixed timeout without dynamic adjustment |
-| `http` | `false` | Enables the HTTP RPC server on the default port and interface |
-| `http-host` | `localhost` | The interface on which the HTTP RPC server will listen for requests |
-| `http-port` | `6060` | The port on which the HTTP server will listen for requests |
-| `http-update-host` | `localhost` | The interface on which the log level and gateway timeouts HTTP server will listen for requests |
-| `http-update-port` | `0` | The port on which the log level and gateway timeouts HTTP server will listen for requests |
-| `log-json` | `false` | Use JSON encoding for log output |
-| `log-level` |  | Options: trace, debug, info, warn, error |
-| `max-concurrent-compilations` | `8` | Maximum concurrent Sierra compilations |
-| `max-vm-queue` | `2 * max-vms` | Maximum number for requests to queue after reaching max-vms before starting to reject incoming requests |
-| `max-vms` | `3 * CPU Cores` | Maximum number for VM instances to be used for RPC calls concurrently |
-| `metrics` | `false` | Enables the Prometheus metrics endpoint on the default port |
-| `metrics-host` | `localhost` | The interface on which the Prometheus endpoint will listen for requests |
-| `metrics-port` | `9090` | The port on which the Prometheus endpoint will listen for requests |
-| `network` | `mainnet` | Options: mainnet, sepolia, sepolia-integration |
-| `new-state` | `false` | EXPERIMENTAL: Use the new state package implementation |
-| `node.PruneModeFlag` | `uint64(0)` | Enables block-data and state-history pruning. Pruning is disabled by default; passing this flag (with or without a value) turns it on. The value is the size of the retention window in blocks, counted back from the latest L1-verified head:\n  --prune-mode      same as --prune-mode=0; prune up to the L1 head\n  --prune-mode=N    keep blocks in (l1_head - N, l2_head], prune below\nBlocks at or above the L2 head are always kept. The floor is anchored on the L1-verified head — never on the local L2 head — so pruned blocks are reorg-safe. RPC remains fully functional for any block inside the retention window; requests targeting blocks below the floor fail because their data has been deleted. Pruning is irreversible: data deleted under a small window cannot be recovered without re-syncing. Changing this value across restarts is safe: the window grows or shrinks accordingly. Growth is gradual — pruning pauses until the L1 head advances enough to reach the new floor |
+
+### Profiling
+
+| Config Option | Default Value | Description |
+| - | - | - |
+| `pprof` | `false` | Enables the pprof endpoint on the default port |
+| `pprof-host` | `localhost` | The interface on which the pprof HTTP server will listen for requests |
+| `pprof-port` | `6062` | The port on which the pprof HTTP server will listen for requests |
+
+### P2P (experimental)
+
+| Config Option | Default Value | Description |
+| - | - | - |
 | `p2p` | `false` | EXPERIMENTAL: Enables p2p server |
 | `p2p-addr` |  | EXPERIMENTAL: Specify p2p listening source address as multiaddr.  Example: /ip4/0.0.0.0/tcp/7777 |
 | `p2p-feeder-node` | `false` | EXPERIMENTAL: Run juno as a feeder node which will only sync from feeder gateway and gossip the new blocks to the network |
 | `p2p-peers` |  | EXPERIMENTAL: Specify list of p2p peers split by a comma. These peers can be either Feeder or regular nodes |
 | `p2p-private-key` |  | EXPERIMENTAL: Hexadecimal representation of a private key on the Ed25519 elliptic curve |
 | `p2p-public-addr` |  | EXPERIMENTAL: Specify p2p public address as multiaddr.  Example: /ip4/35.243.XXX.XXX/tcp/7777 |
-| `plugin-path` |  | Path to the plugin .so file |
-| `pprof` | `false` | Enables the pprof endpoint on the default port |
-| `pprof-host` | `localhost` | The interface on which the pprof HTTP server will listen for requests |
-| `pprof-port` | `6062` | The port on which the pprof HTTP server will listen for requests |
-| `preconfirmed-poll-interval` | `500 * time.Millisecond` | Sets how frequently pre_confirmed block will be updated(0s will disable fetching of pre_confirmed block) |
-| `prelatest-poll-interval` | `time.Second` | Sets polling interval for pre-latest block updates. (0s will disable polling) |
-| `readiness-block-tolerance` | `6` | Maximum blocks behind latest for /ready endpoints to return 200 OK |
-| `remote-db` |  | gRPC URL of a remote Juno node |
-| `rpc-call-max-gas` | `vm.DefaultMaxGas` | Maximum number of Sierra gas to be executed in starknet_call requests |
-| `rpc-call-max-steps` | `vm.DefaultMaxSteps` | Maximum number of steps to be executed in starknet_call requests |
-| `rpc-cors-enable` | `false` | Enable CORS on RPC endpoints |
-| `rpc-max-block-scan` | `18446744073709551615` | Maximum number of blocks scanned in single starknet_getEvents call |
-| `rpc-request-timeout` | `1 * time.Minute` | Maximum time for an RPC request to complete |
+
+### Sequencer
+
+| Config Option | Default Value | Description |
+| - | - | - |
 | `seq-block-time` | `60` | Time to build a block, in seconds |
 | `seq-disable-fees` | `false` | Skip charge fee for sequencer execution |
 | `seq-enable` | `false` | Enables sequencer mode of operation |
 | `seq-genesis-file` |  | Path to the genesis file |
-| `submitted-transactions-cache-entry-ttl` | `5 * time.Minute` | Time-to-live for each entry in the submitted transactions cache |
-| `submitted-transactions-cache-size` | `10000` | Maximum number of entries in the submitted transactions cache |
-| `versioned-constants-file` |  | Use custom versioned constants from provided file |
-| `ws` | `false` | Enables the WebSocket RPC server on the default port |
-| `ws-host` | `localhost` | The interface on which the WebSocket RPC server will listen for requests |
-| `ws-port` | `6061` | The port on which the WebSocket server will listen for requests |
+
+### gRPC
+
+| Config Option | Default Value | Description |
+| - | - | - |
+| `grpc` | `false` | Enable the HTTP gRPC server on the default port |
+| `grpc-host` | `localhost` | The interface on which the gRPC server will listen for requests |
+| `grpc-port` | `6064` | The port on which the gRPC server will listen for requests |
+
+### Plugins & Misc
+
+| Config Option | Default Value | Description |
+| - | - | - |
+| `config` |  | The YAML configuration file |
+| `new-state` | `false` | EXPERIMENTAL: Use the new state package implementation |
+| `plugin-path` |  | Path to the plugin .so file |

--- a/docs/docs/_config-options.md
+++ b/docs/docs/_config-options.md
@@ -1,72 +1,76 @@
 <!-- This file is generated automatically. Any manual modifications will be overwritten. -->
 
+### Other
+
 | Config Option | Default Value | Description |
-| --- | --- | --- |
-| `cn-core-contract-address` |  | Custom network core contract address. |
-| `cn-feeder-url` |  | Custom network feeder URL. |
-| `cn-gateway-url` |  | Custom network gateway URL. |
-| `cn-l1-chain-id` |  | Custom network L1 chain id. |
-| `cn-l2-chain-id` |  | Custom network L2 chain id. |
-| `cn-name` |  | Custom network name. |
-| `cn-unverifiable-range` | `0,100` | Custom network range of blocks to skip hash verifications (e.g. 0,100). |
-| `colour` | `true` | Use `--colour=false` command to disable colourized outputs (ANSI Escape Codes). |
-| `config` |  | The YAML configuration file. |
-| `db-cache-size` | `1024` | Determines the amount of memory (in megabytes) allocated for caching data in the database. |
+| - | - | - |
+| `cn-core-contract-address` |  | Custom network core contract address |
+| `cn-feeder-url` |  | Custom network feeder URL |
+| `cn-gateway-url` |  | Custom network gateway URL |
+| `cn-l1-chain-id` |  | Custom network L1 chain id |
+| `cn-l2-chain-id` |  | Custom network L2 chain id |
+| `cn-name` |  | Custom network name |
+| `cn-unverifiable-range` | `[]` | Custom network range of blocks to skip hash verifications (e.g. `0,100`) |
+| `colour` | `true` | Use `--colour=false` command to disable colourized outputs (ANSI Escape Codes) |
+| `config` |  | The YAML configuration file |
+| `db-cache-size` | `1024` | Determines the amount of memory (in megabytes) allocated for caching data in the database |
 | `db-compaction-concurrency` |  | DB compaction concurrency range. Format: N (lower=1, upper=N) or M,N (lower=M, upper=N). Default: 1,GOMAXPROCS/2 |
-| `db-compression` | `"snappy"` | Database compression profile. Options: snappy, zstd, minlz. Use zstd for low storage. |
+| `db-compression` | `zstd` | Database compression profile. Options: zstd, snappy, minlz. Use zstd for low storage |
 | `db-max-handles` | `1024` | A soft limit on the number of open files that can be used by the DB |
-| `db-memtable-size` | `256` | Determines the amount of memory (in MBs) allocated for database memtables. |
-| `db-memtable-count` | `2` | Determines the number of memtables the database can queue before stalling writes. |
-| `db-path` | `path to your db location` | Location of the database files. |
-| `disable-l1-verification` |  | Disables L1 verification since an Ethereum node is not provided. |
-| `disable-rpc-batch-requests` |  | Disables handling of batched RPC requests. |
-| `eth-node` |  | WebSocket endpoint of the Ethereum node. To verify the correctness of the L2 chain, Juno must connect to an Ethereum node and parse events in the Starknet contract. |
-| `grpc` |  | Enable the HTTP gRPC server on the default port. |
-| `grpc-host` | `"localhost"` | The interface on which the gRPC server will listen for requests. |
-| `grpc-port` | `6064` | The port on which the gRPC server will listen for requests. |
+| `db-memtable-count` | `2` | Determines the number of memtables the database can queue before stalling writes |
+| `db-memtable-size` | `256` | Determines the amount of memory (in MBs) allocated for database memtables |
+| `db-path` | `juno` | Location of the database files |
+| `disable-l1-verification` | `false` | Disables L1 verification since an Ethereum node is not provided |
+| `disable-received-txn-stream` | `false` | The starknet_subscribeNewTransactions WebSocket API allows users to subscribe to new transactions. By default, it streams transactions that have been accepted on L2. Users can optionally provide a set of finality statuses to be notified about, including transactions from canonical blocks, blocks with softer finality guarantees such as pre-confirmed and pre-latest, as well as transactions not yet part of any block such as received and candidate. When subscribers select the RECEIVED status, they will be notified about transactions that have been submitted through this node — these transactions are local to the node and are not sourced from the network. When this flag is enabled, the node will no longer notify subscribers about transactions submitted through it |
+| `disable-rpc-batch-requests` | `false` | Disables handling of batched RPC requests |
+| `eth-node` |  | WebSocket endpoint of the Ethereum node. To verify the correctness of the L2 chain, Juno must connect to an Ethereum node and parse events in the Starknet contract |
+| `grpc` | `false` | Enable the HTTP gRPC server on the default port |
+| `grpc-host` | `localhost` | The interface on which the gRPC server will listen for requests |
+| `grpc-port` | `6064` | The port on which the gRPC server will listen for requests |
 | `gw-api-key` |  | API key for gateway endpoints to avoid throttling |
-| `gw-timeouts` | `"5s"` | Timeouts for requests made to the gateway. Can be specified in three ways: - Single value (e.g. '5s'): After each failure, the timeout will increase dynamically. - Comma-separated list (e.g. '5s,10s,20s'): Each value will be used in sequence after failures. - Single value with trailing comma (e.g. '5s,'): Uses a fixed timeout without dynamic adjustment. |
-| `help` |  | help for juno |
-| `http` |  | Enables the HTTP RPC server on the default port and interface. |
-| `http-host` | `"localhost"` | The interface on which the HTTP RPC server will listen for requests. |
-| `http-port` | `6060` | The port on which the HTTP server will listen for requests. |
-| `http-update-host` | `"localhost"` | The interface on which the log level and gateway timeouts HTTP server will listen for requests. |
-| `http-update-port` |  | The port on which the log level and gateway timeouts HTTP server will listen for requests. |
-| `log-json` |  | Use JSON encoding for log output. |
-| `log-level` | `"info"` | Options: trace, debug, info, warn, error. |
-| `max-vm-queue` | `72` | Maximum number for requests to queue after reaching max-vms before starting to reject incoming requests |
-| `max-vms` | `36` | Maximum number for VM instances to be used for RPC calls concurrently |
-| `metrics` |  | Enables the Prometheus metrics endpoint on the default port. |
-| `metrics-host` | `"localhost"` | The interface on which the Prometheus endpoint will listen for requests. |
-| `metrics-port` | `9090` | The port on which the Prometheus endpoint will listen for requests. |
-| `network` | `mainnet` | Options: mainnet, sepolia, sepolia-integration. |
-| `p2p` |  | EXPERIMENTAL: Enables p2p server. |
-| `p2p-addr` |  | EXPERIMENTAL: Specify p2p listening source address as multiaddr. Example: /ip4/0.0.0.0/tcp/7777 |
-| `p2p-feeder-node` |  | EXPERIMENTAL: Run juno as a feeder node which will only sync from feeder gateway and gossip the new blocks to the network. |
-| `p2p-peers` |  | EXPERIMENTAL: Specify list of p2p peers split by a comma. These peers can be either Feeder or regular nodes. |
-| `p2p-private-key` |  | EXPERIMENTAL: Hexadecimal representation of a private key on the Ed25519 elliptic curve. |
-| `p2p-public-addr` |  | EXPERIMENTAL: Specify p2p public address as multiaddr. Example: /ip4/35.243.XXX.XXX/tcp/7777 |
-| `pending-poll-interval` | `1s` | Sets polling interval for pending block updates before starknet v0.14.0;for pre_latest block updates from starknet v0.14.0 onward.(0s will disable polling). |
+| `gw-timeouts` | `5s` | Timeouts for requests made to the gateway. Can be specified in three ways:\n- Single value (e.g. '5s'): After each failure, the timeout will increase dynamically.\n- Comma-separated list (e.g. '5s,10s,20s'): Each value will be used in sequence after failures.\n- Single value with trailing comma (e.g. '5s,'): Uses a fixed timeout without dynamic adjustment |
+| `http` | `false` | Enables the HTTP RPC server on the default port and interface |
+| `http-host` | `localhost` | The interface on which the HTTP RPC server will listen for requests |
+| `http-port` | `6060` | The port on which the HTTP server will listen for requests |
+| `http-update-host` | `localhost` | The interface on which the log level and gateway timeouts HTTP server will listen for requests |
+| `http-update-port` | `0` | The port on which the log level and gateway timeouts HTTP server will listen for requests |
+| `log-json` | `false` | Use JSON encoding for log output |
+| `log-level` |  | Options: trace, debug, info, warn, error |
+| `max-concurrent-compilations` | `8` | Maximum concurrent Sierra compilations |
+| `max-vm-queue` | `2 * max-vms` | Maximum number for requests to queue after reaching max-vms before starting to reject incoming requests |
+| `max-vms` | `3 * CPU Cores` | Maximum number for VM instances to be used for RPC calls concurrently |
+| `metrics` | `false` | Enables the Prometheus metrics endpoint on the default port |
+| `metrics-host` | `localhost` | The interface on which the Prometheus endpoint will listen for requests |
+| `metrics-port` | `9090` | The port on which the Prometheus endpoint will listen for requests |
+| `network` | `mainnet` | Options: mainnet, sepolia, sepolia-integration |
+| `new-state` | `false` | EXPERIMENTAL: Use the new state package implementation |
+| `node.PruneModeFlag` | `uint64(0)` | Enables block-data and state-history pruning. Pruning is disabled by default; passing this flag (with or without a value) turns it on. The value is the size of the retention window in blocks, counted back from the latest L1-verified head:\n  --prune-mode      same as --prune-mode=0; prune up to the L1 head\n  --prune-mode=N    keep blocks in (l1_head - N, l2_head], prune below\nBlocks at or above the L2 head are always kept. The floor is anchored on the L1-verified head — never on the local L2 head — so pruned blocks are reorg-safe. RPC remains fully functional for any block inside the retention window; requests targeting blocks below the floor fail because their data has been deleted. Pruning is irreversible: data deleted under a small window cannot be recovered without re-syncing. Changing this value across restarts is safe: the window grows or shrinks accordingly. Growth is gradual — pruning pauses until the L1 head advances enough to reach the new floor |
+| `p2p` | `false` | EXPERIMENTAL: Enables p2p server |
+| `p2p-addr` |  | EXPERIMENTAL: Specify p2p listening source address as multiaddr.  Example: /ip4/0.0.0.0/tcp/7777 |
+| `p2p-feeder-node` | `false` | EXPERIMENTAL: Run juno as a feeder node which will only sync from feeder gateway and gossip the new blocks to the network |
+| `p2p-peers` |  | EXPERIMENTAL: Specify list of p2p peers split by a comma. These peers can be either Feeder or regular nodes |
+| `p2p-private-key` |  | EXPERIMENTAL: Hexadecimal representation of a private key on the Ed25519 elliptic curve |
+| `p2p-public-addr` |  | EXPERIMENTAL: Specify p2p public address as multiaddr.  Example: /ip4/35.243.XXX.XXX/tcp/7777 |
 | `plugin-path` |  | Path to the plugin .so file |
-| `pprof` |  | Enables the pprof endpoint on the default port. |
-| `pprof-host` | `"localhost"` | The interface on which the pprof HTTP server will listen for requests. |
-| `pprof-port` | `6062` | The port on which the pprof HTTP server will listen for requests. |
-| `preconfirmed-poll-interval` | `500ms` | Sets how frequently pre_confirmed block will be updated(0s will disable fetching of pre_confirmed block). |
+| `pprof` | `false` | Enables the pprof endpoint on the default port |
+| `pprof-host` | `localhost` | The interface on which the pprof HTTP server will listen for requests |
+| `pprof-port` | `6062` | The port on which the pprof HTTP server will listen for requests |
+| `preconfirmed-poll-interval` | `500 * time.Millisecond` | Sets how frequently pre_confirmed block will be updated(0s will disable fetching of pre_confirmed block) |
+| `prelatest-poll-interval` | `time.Second` | Sets polling interval for pre-latest block updates. (0s will disable polling) |
 | `readiness-block-tolerance` | `6` | Maximum blocks behind latest for /ready endpoints to return 200 OK |
 | `remote-db` |  | gRPC URL of a remote Juno node |
-| `rpc-call-max-gas` | `100000000` | Maximum number of Sierra gas to be executed in starknet_call requests |
-| `rpc-call-max-steps` | `4000000` | Maximum number of steps to be executed in starknet_call requests |
-| `rpc-cors-enable` |  | Enable CORS on RPC endpoints |
+| `rpc-call-max-gas` | `vm.DefaultMaxGas` | Maximum number of Sierra gas to be executed in starknet_call requests |
+| `rpc-call-max-steps` | `vm.DefaultMaxSteps` | Maximum number of steps to be executed in starknet_call requests |
+| `rpc-cors-enable` | `false` | Enable CORS on RPC endpoints |
 | `rpc-max-block-scan` | `18446744073709551615` | Maximum number of blocks scanned in single starknet_getEvents call |
+| `rpc-request-timeout` | `1 * time.Minute` | Maximum time for an RPC request to complete |
 | `seq-block-time` | `60` | Time to build a block, in seconds |
-| `seq-disable-fees` |  | Skip charge fee for sequencer execution |
-| `seq-enable` |  | Enables sequencer mode of operation |
+| `seq-disable-fees` | `false` | Skip charge fee for sequencer execution |
+| `seq-enable` | `false` | Enables sequencer mode of operation |
 | `seq-genesis-file` |  | Path to the genesis file |
-| `submitted-transactions-cache-entry-ttl` | `5m0s` | Time-to-live for each entry in the submitted transactions cache |
+| `submitted-transactions-cache-entry-ttl` | `5 * time.Minute` | Time-to-live for each entry in the submitted transactions cache |
 | `submitted-transactions-cache-size` | `10000` | Maximum number of entries in the submitted transactions cache |
-| `transaction-combined-layout` |  | EXPERIMENTAL: Enable combined (per-block) transaction storage layout. Once enabled, cannot be disabled. |
-| `version` |  | version for juno |
 | `versioned-constants-file` |  | Use custom versioned constants from provided file |
-| `ws` |  | Enables the WebSocket RPC server on the default port. |
-| `ws-host` | `"localhost"` | The interface on which the WebSocket RPC server will listen for requests. |
-| `ws-port` | `6061` | The port on which the WebSocket server will listen for requests. |          |
+| `ws` | `false` | Enables the WebSocket RPC server on the default port |
+| `ws-host` | `localhost` | The interface on which the WebSocket RPC server will listen for requests |
+| `ws-port` | `6061` | The port on which the WebSocket server will listen for requests |

--- a/docs/generate-config.js
+++ b/docs/generate-config.js
@@ -139,9 +139,28 @@ function parseValue(value) {
     return "[]";
   }
 
-  // Handle time duration represented in seconds
-  if (value.includes("* time.Second")) {
-    return value.split(" ")[0];
+  // Handle time.Duration expressions. Supports both bare `time.Unit`
+  // (e.g. `time.Second` → `1s`) and `N * time.Unit` (e.g.
+  // `500 * time.Millisecond` → `500ms`).
+  const timeUnitSuffix = {
+    Nanosecond: "ns",
+    Microsecond: "us",
+    Millisecond: "ms",
+    Second: "s",
+    Minute: "m",
+    Hour: "h",
+  };
+  const bareTime = value.match(
+    /^time\.(Nanosecond|Microsecond|Millisecond|Second|Minute|Hour)$/,
+  );
+  if (bareTime) {
+    return `1${timeUnitSuffix[bareTime[1]]}`;
+  }
+  const multipliedTime = value.match(
+    /^(\d+)\s*\*\s*time\.(Nanosecond|Microsecond|Millisecond|Second|Minute|Hour)$/,
+  );
+  if (multipliedTime) {
+    return `${multipliedTime[1]}${timeUnitSuffix[multipliedTime[2]]}`;
   }
 
   // Handle large unsigned integer value
@@ -162,6 +181,23 @@ function parseValue(value) {
   // Network type
   if (value === "networks.Mainnet") {
     return "mainnet";
+  }
+
+  // Prune-mode flag name lives in another package as a string constant.
+  if (value === "node.PruneModeFlag") {
+    return "prune-mode";
+  }
+
+  // VM default limits live in the `vm` package; hard-code their numeric
+  // values so the rendered table shows the resolved default rather than
+  // the raw Go identifier.
+  if (value === "vm.DefaultMaxSteps") return 4_000_000;
+  if (value === "vm.DefaultMaxGas") return 100_000_000;
+
+  // Strip uint64(...) / uint(...) type casts so e.g. `uint64(0)` becomes `0`.
+  const uintCast = value.match(/^uint(?:8|16|32|64)?\((.+)\)$/);
+  if (uintCast) {
+    return parseValue(uintCast[1]);
   }
 
   // Remove quotes from a string

--- a/docs/generate-config.js
+++ b/docs/generate-config.js
@@ -45,53 +45,79 @@ const extractConfigs = (codebase) => {
     variables[varName] = parseValue(value); // Ensure you define `parseValue` function to handle the values correctly
   }
 
-  // Pattern to find flags used in Juno's command-line configurations
-  const flagPattern = /junoCmd\.Flags\(\)\.[A-Za-z\d]+\((.*)\)/g;
+  // Walk lines to (a) track the current category from `// --- <Title> ---`
+  // dividers and (b) collect multi-line `junoCmd.Flags().XXX(` calls into a
+  // single buffer so the regex below can match registrations that span lines.
+  const lines = codebase.split("\n");
+  const dividerPattern = /^\s*\/\/\s*---\s*(.+?)\s*---\s*$/;
+  const flagOpenPattern = /^\s*junoCmd\.Flags\(\)\./;
+  const flagPattern = /junoCmd\.Flags\(\)\.[A-Za-z\d]+\((.*)\)/;
   const argsPattern = /([^\s,]+)/g;
   const configs = [];
+  let currentSection = "Other";
 
-  while ((match = flagPattern.exec(codebase)) !== null) {
-    const flags = match[1];
-    const args = [...flags.matchAll(argsPattern)].map((m) => m[0]);
-
-    if (args.length >= 3) {
-      let configName, defaultValue, description;
-
-      if (args[args.length - 3][0] === "&") {
-        configName = variables[args[args.length - 2]];
-        defaultValue = variables[args[args.length - 3].slice(1)];
-      } else {
-        configName = variables[args[args.length - 3]];
-        defaultValue = variables[args[args.length - 2]];
-      }
-
-      if (defaultValue === undefined) {
-        defaultValue = "";
-      }
-
-      description = variables[args[args.length - 1]] || "";
-      description = description.replace(/\.$/, ""); // Remove any trailing dot
-
-      // Additional descriptions based on specific configurations
-      if (configName === "max-vms") {
-        defaultValue = "3 * CPU Cores";
-      }
-      if (configName === "max-vm-queue") {
-        defaultValue = "2 * max-vms";
-      }
-      if (configName === "gw-timeouts") {
-        defaultValue = "5s";
-      }
-      configs.push({
-        configName,
-        defaultValue,
-        description,
-      });
+  for (let i = 0; i < lines.length; i++) {
+    const dividerMatch = lines[i].match(dividerPattern);
+    if (dividerMatch) {
+      currentSection = dividerMatch[1];
+      continue;
     }
+    if (!flagOpenPattern.test(lines[i])) continue;
+
+    // Collect lines until parens balance, so multi-line registrations like
+    //   junoCmd.Flags().Duration(\n  fooF,\n  defaultFoo,\n  fooUsage,\n)
+    // become a single buffer the existing flagPattern can match.
+    let buffer = lines[i];
+    let opens = (buffer.match(/\(/g) || []).length;
+    let closes = (buffer.match(/\)/g) || []).length;
+    while (opens > closes && i + 1 < lines.length) {
+      i++;
+      buffer += " " + lines[i].trim();
+      opens += (lines[i].match(/\(/g) || []).length;
+      closes += (lines[i].match(/\)/g) || []).length;
+    }
+
+    const flagMatch = buffer.match(flagPattern);
+    if (!flagMatch) continue;
+    const flags = flagMatch[1];
+    const args = [...flags.matchAll(argsPattern)].map((m) => m[0]);
+    if (args.length < 3) continue;
+
+    let configName, defaultValue, description;
+    if (args[args.length - 3][0] === "&") {
+      configName = variables[args[args.length - 2]];
+      defaultValue = variables[args[args.length - 3].slice(1)];
+    } else {
+      configName = variables[args[args.length - 3]];
+      defaultValue = variables[args[args.length - 2]];
+    }
+
+    if (defaultValue === undefined) {
+      defaultValue = "";
+    }
+
+    description = variables[args[args.length - 1]] || "";
+    description = description.replace(/\.$/, ""); // Remove any trailing dot
+
+    // Additional descriptions based on specific configurations
+    if (configName === "max-vms") {
+      defaultValue = "3 * CPU Cores";
+    }
+    if (configName === "max-vm-queue") {
+      defaultValue = "2 * max-vms";
+    }
+    if (configName === "gw-timeouts") {
+      defaultValue = "5s";
+    }
+    configs.push({
+      configName,
+      defaultValue,
+      description,
+      section: currentSection,
+    });
   }
 
-  // Sort configurations by name
-  return configs.sort((a, b) => a.configName.localeCompare(b.configName));
+  return configs;
 };
 
 function parseValue(value) {
@@ -147,25 +173,47 @@ function parseValue(value) {
   return value || null;
 }
 
+function formatDefault(defaultValue) {
+  if (defaultValue === "") return "";
+  if (typeof defaultValue === "boolean") {
+    return `\`${defaultValue}\``.toLowerCase();
+  }
+  return `\`${defaultValue}\``;
+}
+
 function generateConfigTable(configs) {
-  let configTable =
-    "| Config Option | Default Value | Description |\n| - | - | - |\n";
-  configs.forEach((config) => {
-    let defaultValue = config.defaultValue;
-    if (defaultValue !== "") {
-      if (typeof defaultValue === "boolean") {
-        defaultValue = `\`${defaultValue}\``.toLowerCase();
-      } else {
-        defaultValue = `\`${defaultValue}\``;
-      }
+  // Group flags by section, preserving the order in which sections first
+  // appeared in the source — that order matches the `// --- <Title> ---`
+  // dividers in cmd/juno/juno.go, which match the `--help` render order.
+  const sectionOrder = [];
+  const bySection = new Map();
+  for (const config of configs) {
+    if (!bySection.has(config.section)) {
+      sectionOrder.push(config.section);
+      bySection.set(config.section, []);
     }
-    configTable += `| \`${config.configName}\` | ${defaultValue} | ${config.description} |\n`;
+    bySection.get(config.section).push(config);
+  }
+
+  const sections = sectionOrder.map((section) => {
+    const rows = bySection
+      .get(section)
+      .slice()
+      .sort((a, b) => a.configName.localeCompare(b.configName))
+      .map(
+        (c) =>
+          `| \`${c.configName}\` | ${formatDefault(c.defaultValue)} | ${c.description} |`,
+      )
+      .join("\n");
+    return `### ${section}\n\n| Config Option | Default Value | Description |\n| - | - | - |\n${rows}\n`;
   });
 
-  // Write to file
-  let fileWarning =
+  const fileWarning =
     "<!-- This file is generated automatically. Any manual modifications will be overwritten. -->\n\n";
-  fs.writeFileSync("docs/_config-options.md", fileWarning + configTable);
+  fs.writeFileSync(
+    "docs/_config-options.md",
+    fileWarning + sections.join("\n"),
+  );
 }
 
 function fetchUrl(url) {


### PR DESCRIPTION
New usage looks:

```bash
➜  juno3 git:(rdr/try-better-cmd-help) ✗ ./build/juno --help
Starknet client implementation in Go.

Usage:
  juno [flags]
  juno [command]

Available Commands:
  compile-sierra Compile a Sierra class to CASM via stdin/stdout.
  completion  Generate the autocompletion script for the specified shell
  db          Database related operations
  genp2pkeypair Generate private key pair for p2p.
  help        Help about any command

HTTP RPC Flags:
      --disable-rpc-batch-requests     Disables handling of batched RPC requests.
      --http                           Enables the HTTP RPC server on the default port and interface.
      --http-host string               The interface on which the HTTP RPC server will listen for requests. (default "localhost")
      --http-port uint16               The port on which the HTTP server will listen for requests. (default 6060)
      --rpc-call-max-gas uint          Maximum number of Sierra gas to be executed in starknet_call requests (default 100000000)
      --rpc-call-max-steps uint        Maximum number of steps to be executed in starknet_call requests (default 4000000)
      --rpc-cors-enable                Enable CORS on RPC endpoints
      --rpc-max-block-scan uint        Maximum number of blocks scanned in single starknet_getEvents call (default 18446744073709551615)
      --rpc-request-timeout duration   Maximum time for an RPC request to complete. (default 1m0s)

WebSocket RPC Flags:
      --disable-received-txn-stream   The starknet_subscribeNewTransactions WebSocket API allows users to subscribe to new transactions. By default, it streams transactions that have been accepted on L2. Users can optionally provide a set of finality statuses to be notified about, including transactions from canonical blocks, blocks with softer finality guarantees such as pre-confirmed and pre-latest, as well as transactions not yet part of any block such as received and candidate. When subscribers select the RECEIVED status, they will be notified about transactions that have been submitted through this node — these transactions are local to the node and are not sourced from the network. When this flag is enabled, the node will no longer notify subscribers about transactions submitted through it.
      --ws                            Enables the WebSocket RPC server on the default port.
      --ws-host string                The interface on which the WebSocket RPC server will listen for requests. (default "localhost")
      --ws-port uint16                The port on which the WebSocket server will listen for requests. (default 6061)

Network & L1 Flags:
      --disable-l1-verification   Disables L1 verification since an Ethereum node is not provided.
      --eth-node string           WebSocket endpoint of the Ethereum node. To verify the correctness of the L2 chain, Juno must connect to an Ethereum node and parse events in the Starknet contract.
      --network Network           Options: mainnet, sepolia, sepolia-integration. (default mainnet)

Sync & Polling Flags:
      --preconfirmed-poll-interval duration   Sets how frequently pre_confirmed block will be updated(0s will disable fetching of pre_confirmed block). (default 500ms)
      --prelatest-poll-interval duration      Sets polling interval for pre-latest block updates. (0s will disable polling). (default 1s)
      --readiness-block-tolerance uint        Maximum blocks behind latest for /ready endpoints to return 200 OK (default 6)
      --remote-db string                      gRPC URL of a remote Juno node

Gateway Flags:
      --gw-api-key string    API key for gateway endpoints to avoid throttling
      --gw-timeouts string   Timeouts for requests made to the gateway. Can be specified in three ways:
                             - Single value (e.g. '5s'): After each failure, the timeout will increase dynamically.
                             - Comma-separated list (e.g. '5s,10s,20s'): Each value will be used in sequence after failures.
                             - Single value with trailing comma (e.g. '5s,'): Uses a fixed timeout without dynamic adjustment. (default "5s")

Pruning Flags:
      --prune-mode uint[=0]   Enables block-data and state-history pruning. Pruning is disabled by default; passing this flag (with or without a value) turns it on. The value is the size of the retention window in blocks, counted back from the latest L1-verified head:
                                --prune-mode      same as --prune-mode=0; prune up to the L1 head
                                --prune-mode=N    keep blocks in (l1_head - N, l2_head], prune below
                              Blocks at or above the L2 head are always kept. The floor is anchored on the L1-verified head — never on the local L2 head — so pruned blocks are reorg-safe. RPC remains fully functional for any block inside the retention window; requests targeting blocks below the floor fail because their data has been deleted. Pruning is irreversible: data deleted under a small window cannot be recovered without re-syncing. Changing this value across restarts is safe: the window grows or shrinks accordingly. Growth is gradual — pruning pauses until the L1 head advances enough to reach the new floor.

Logging Flags:
      --colour --colour=false   Use --colour=false command to disable colourized outputs (ANSI Escape Codes). (default true)
      --log-json                Use JSON encoding for log output.
      --log-level string        Options: trace, debug, info, warn, error. (default "info")

Logs HTTP Update Endpoint Flags:
      --http-update-host string   The interface on which the log level and gateway timeouts HTTP server will listen for requests. (default "localhost")
      --http-update-port uint16   The port on which the log level and gateway timeouts HTTP server will listen for requests.

Metrics & Profiling Flags:
      --metrics               Enables the Prometheus metrics endpoint on the default port.
      --metrics-host string   The interface on which the Prometheus endpoint will listen for requests. (default "localhost")
      --metrics-port uint16   The port on which the Prometheus endpoint will listen for requests. (default 9090)
      --pprof                 Enables the pprof endpoint on the default port.
      --pprof-host string     The interface on which the pprof HTTP server will listen for requests. (default "localhost")
      --pprof-port uint16     The port on which the pprof HTTP server will listen for requests. (default 6062)

Database Flags:
      --db-cache-size uint                 Determines the amount of memory (in megabytes) allocated for caching data in the database. (default 1024)
      --db-compaction-concurrency string   DB compaction concurrency range. Format: N (lower=1, upper=N) or M,N (lower=M, upper=N). Default: 1,GOMAXPROCS/2
      --db-compression string              Database compression profile. Options: zstd, snappy, minlz. Use zstd for low storage. (default "zstd")
      --db-max-handles int                 A soft limit on the number of open files that can be used by the DB (default 1024)
      --db-memtable-count uint             Determines the number of memtables the database can queue before stalling writes. (default 2)
      --db-memtable-size uint              Determines the amount of memory (in MBs) allocated for database memtables. (default 256)
      --db-path string                     Location of the database files. (default "/Users/rodro/Documents/Nethermind/starknet/juno3/juno")

Transaction Cache Flags:
      --submitted-transactions-cache-entry-ttl duration   Time-to-live for each entry in the submitted transactions cache (default 5m0s)
      --submitted-transactions-cache-size uint            Maximum number of entries in the submitted transactions cache (default 10000)

VM & Compilation Flags:
      --max-concurrent-compilations uint   Maximum concurrent Sierra compilations. (default 8)
      --max-vm-queue uint                  Maximum number for requests to queue after reaching max-vms before starting to reject incoming requests (default 72)
      --max-vms uint                       Maximum number for VM instances to be used for RPC calls concurrently (default 36)
      --versioned-constants-file string    Use custom versioned constants from provided file

Custom Network Flags:
      --cn-core-contract-address string   Custom network core contract address.
      --cn-feeder-url string              Custom network feeder URL.
      --cn-gateway-url string             Custom network gateway URL.
      --cn-l1-chain-id string             Custom network L1 chain id.
      --cn-l2-chain-id string             Custom network L2 chain id.
      --cn-name string                    Custom network name.
      --cn-unverifiable-range 0,100       Custom network range of blocks to skip hash verifications (e.g. 0,100).

P2P (experimental) Flags:
      --p2p                      EXPERIMENTAL: Enables p2p server.
      --p2p-addr string          EXPERIMENTAL: Specify p2p listening source address as multiaddr.  Example: /ip4/0.0.0.0/tcp/7777
      --p2p-feeder-node          EXPERIMENTAL: Run juno as a feeder node which will only sync from feeder gateway and gossip the new blocks to the network.
      --p2p-peers string         EXPERIMENTAL: Specify list of p2p peers split by a comma. These peers can be either Feeder or regular nodes.
      --p2p-private-key string   EXPERIMENTAL: Hexadecimal representation of a private key on the Ed25519 elliptic curve.
      --p2p-public-addr string   EXPERIMENTAL: Specify p2p public address as multiaddr.  Example: /ip4/35.243.XXX.XXX/tcp/7777

Sequencer Flags:
      --seq-block-time uint       Time to build a block, in seconds (default 60)
      --seq-disable-fees          Skip charge fee for sequencer execution
      --seq-enable                Enables sequencer mode of operation
      --seq-genesis-file string   Path to the genesis file

gRPC Flags:
      --grpc               Enable the HTTP gRPC server on the default port.
      --grpc-host string   The interface on which the gRPC server will listen for requests. (default "localhost")
      --grpc-port uint16   The port on which the gRPC server will listen for requests. (default 6064)

Plugins & Misc Flags:
      --config string        The YAML configuration file.
  -h, --help                 help for juno
      --new-state            EXPERIMENTAL: Use the new state package implementation
      --plugin-path string   Path to the plugin .so file

Other Flags:
  -v, --version   version for juno

Use "juno [command] --help" for more information about a command.

```
