### PR TITLE
fix: pruner off by one

### DIFF
--- a/cmd/juno/juno.go
+++ b/cmd/juno/juno.go
@@ -253,17 +253,18 @@ const (
 	pruneModeUsage                 = "Enables block-data and state-history pruning. Pruning is " +
 		"disabled by default; passing this flag (with or without a value) turns " +
 		"it on. The value is the size of the retention window in blocks, counted " +
-		"back from the latest L1-verified head:\n" +
-		"  --prune-mode      same as --prune-mode=0; prune up to the L1 head\n" +
-		"  --prune-mode=N    keep blocks in (l1_head - N, l2_head], prune below\n" +
-		"Blocks at or above the L2 head are always kept. The floor is anchored on " +
-		"the L1-verified head — never on the local L2 head — so pruned blocks are " +
-		"reorg-safe. RPC remains fully functional for any block inside the " +
-		"retention window; requests targeting blocks below the floor fail because " +
-		"their data has been deleted. Pruning is irreversible: data deleted under " +
-		"a small window cannot be recovered without re-syncing. Changing this " +
-		"value across restarts is safe: the window grows or shrinks accordingly. " +
-		"Growth is gradual — pruning pauses until the L1 head advances enough to " +
+		"back from the retention pivot (the lower of the L1-verified head and " +
+		"the local L2 head):\n" +
+		"  --prune-mode      same as --prune-mode=0; prune up to the pivot\n" +
+		"  --prune-mode=N    keep blocks in [pivot - N, l2_head], prune below\n" +
+		"Blocks at or above the L2 head are always kept. The pivot is at or " +
+		"below the L1-verified head, so pruned blocks are reorg-safe. RPC " +
+		"remains fully functional for any block inside the retention window; " +
+		"requests targeting blocks below the floor fail because their data has " +
+		"been deleted. Pruning is irreversible: data deleted under a small " +
+		"window cannot be recovered without re-syncing. Changing this value " +
+		"across restarts is safe: the window grows or shrinks accordingly. " +
+		"Growth is gradual — pruning pauses until the pivot advances enough to " +
 		"reach the new floor."
 	disableReceivedTxnStreamUsage = "The starknet_subscribeNewTransactions WebSocket API " +
 		"allows users to subscribe to new transactions. By default, it streams " +

--- a/pruner/pruner.go
+++ b/pruner/pruner.go
@@ -1,12 +1,13 @@
 // Package pruner implements a background service that bounds on-disk storage
 // by deleting block data older than a configurable retention window.
 //
-// The retention floor is always anchored on the latest L1-confirmed head:
-// the pruner keeps blocks in (l1Head - numRetainedBlocks, l2Head] and
-// range-deletes everything below. Anchoring the floor on L1 — never on the
-// local L2 head — guarantees pruned blocks are reorg-safe, since blocks at
-// or below the L1-confirmed height cannot be reorged. The upper bound is
-// the L2 head simply because that is the highest block the node has.
+// The retention floor is anchored on the lower of the L1-confirmed head
+// and the local L2 head: floor = min(l1Head, l2Head) - numRetainedBlocks.
+// In normal operation L1 lags L2, so the floor tracks L1; during catch-up
+// where L2 is behind L1, we conservatively anchor on L2 instead. Either
+// way the floor stays at or below L1, so pruned blocks cannot be reorged.
+// The upper bound is the L2 head simply because that is the highest block
+// the node has.
 //
 // The Pruner runs as a [service.Service]. It listens to two trigger feeds —
 // new L2 heads and new L1 heads — to know when to re-evaluate the floor;
@@ -44,11 +45,12 @@ const defaultL2HeadsPerPrune uint64 = 128
 // Pruner deletes block data older than a retention window in response to
 // new-head events. Construct via [New]; do not zero-value.
 type Pruner struct {
-	// numRetainedBlocks is the size of the retention window. The retention
-	// floor (the lowest block we keep) is l1Head - numRetainedBlocks + 1,
-	// so the pruner keeps blocks in (l1Head - numRetainedBlocks, l2Head]
-	// and deletes everything below. Anchoring the floor on L1 (not on the
-	// local L2 head) guarantees pruned blocks cannot be reorged.
+	// numRetainedBlocks is the number of blocks retained below L1 head.
+	// L1 head is always retained on top, so the floor (lowest block we
+	// keep) is l1Head - numRetainedBlocks and the pruner keeps blocks in
+	// [l1Head - numRetainedBlocks, l2Head]. Anchoring the floor on L1
+	// (not on the local L2 head) guarantees pruned blocks cannot be
+	// reorged.
 	numRetainedBlocks uint64
 	// pendingL2Heads counts how many L2 head events have advanced past the
 	// retention floor since the last actual prune. Only touched from Run's
@@ -101,12 +103,12 @@ func WithL2HeadsPerPrune(n uint64) Option {
 	}
 }
 
-// New constructs a Pruner. retainedBlocks sets the size of the retention
-// window: the floor is anchored on L1, so the pruner keeps blocks in
-// (l1Head - retainedBlocks, l2Head] and deletes everything below.
-// newHeadSub and l1HeadSub are the two trigger feeds (see [Pruner]).
-// Subscriptions are [feed.Subscription.Unsubscribe]'d when [Pruner.Run]
-// returns.
+// New constructs a Pruner. retainedBlocks is the number of blocks
+// retained below L1 head (L1 head itself is always retained), so the
+// pruner keeps blocks in [l1Head - retainedBlocks, l2Head] and deletes
+// everything below. newHeadSub and l1HeadSub are the two trigger feeds
+// (see [Pruner]). Subscriptions are [feed.Subscription.Unsubscribe]'d
+// when [Pruner.Run] returns.
 func New(
 	database db.KeyValueStore,
 	retainedBlocks uint64,
@@ -203,7 +205,7 @@ func (p *Pruner) onNewBlock(ctx context.Context, block *core.Block) error {
 	}
 	p.pendingL2Heads = 0
 
-	oldestToKeep := block.Number - p.numRetainedBlocks + 1
+	oldestToKeep := block.Number - p.numRetainedBlocks
 
 	return p.pruneUpto(ctx, oldestToKeep)
 }
@@ -223,7 +225,7 @@ func (p *Pruner) onNewL1Head(ctx context.Context, l1Head *core.L1Head) error {
 	}
 	p.pendingL2Heads = 0
 
-	oldestBlockToKeep := l1Head.BlockNumber - p.numRetainedBlocks + 1
+	oldestBlockToKeep := l1Head.BlockNumber - p.numRetainedBlocks
 
 	return p.pruneUpto(ctx, oldestBlockToKeep)
 }

--- a/pruner/pruner.go
+++ b/pruner/pruner.go
@@ -45,12 +45,11 @@ const defaultL2HeadsPerPrune uint64 = 128
 // Pruner deletes block data older than a retention window in response to
 // new-head events. Construct via [New]; do not zero-value.
 type Pruner struct {
-	// numRetainedBlocks is the number of blocks retained below L1 head.
-	// L1 head is always retained on top, so the floor (lowest block we
-	// keep) is l1Head - numRetainedBlocks and the pruner keeps blocks in
-	// [l1Head - numRetainedBlocks, l2Head]. Anchoring the floor on L1
-	// (not on the local L2 head) guarantees pruned blocks cannot be
-	// reorged.
+	// numRetainedBlocks is the number of blocks retained below the
+	// retention pivot (= min(l1Head, l2Head); see package doc). The floor
+	// (lowest block we keep) is pivot - numRetainedBlocks and the pruner
+	// keeps blocks in [pivot - numRetainedBlocks, l2Head]. The pivot
+	// stays at or below L1, so pruned blocks cannot be reorged.
 	numRetainedBlocks uint64
 	// pendingL2Heads counts how many L2 head events have advanced past the
 	// retention floor since the last actual prune. Only touched from Run's
@@ -63,13 +62,13 @@ type Pruner struct {
 	// before triggering a prune. See [defaultL2HeadsPerPrune].
 	l2HeadsPerPrune uint64
 	database        db.KeyValueStore
-	// newHeadSub fires on each new L2 head; the event acts only as a
-	// trigger to re-run the retention check. The retention floor itself is
-	// always recomputed from the L1 head, never from this event's block.
+	// newHeadSub fires on each new L2 head. During catch-up (L2 < L1) it
+	// drives the floor from this event's block number; otherwise the L1
+	// path drives the floor and this event acts only as a trigger.
 	newHeadSub *feed.Subscription[*core.Block]
-	// l1HeadSub fires on each new L1 head. L1 advances are what actually
-	// move the retention floor, since the floor is always anchored on the
-	// latest L1-confirmed height.
+	// l1HeadSub fires on each new L1 head. In normal operation (L1 < L2)
+	// L1 advances move the retention floor; during catch-up this path
+	// short-circuits and the L2 path drives the floor instead.
 	l1HeadSub *feed.Subscription[*core.L1Head]
 	listener  EventListener
 	logger    log.StructuredLogger
@@ -104,11 +103,12 @@ func WithL2HeadsPerPrune(n uint64) Option {
 }
 
 // New constructs a Pruner. retainedBlocks is the number of blocks
-// retained below L1 head (L1 head itself is always retained), so the
-// pruner keeps blocks in [l1Head - retainedBlocks, l2Head] and deletes
-// everything below. newHeadSub and l1HeadSub are the two trigger feeds
-// (see [Pruner]). Subscriptions are [feed.Subscription.Unsubscribe]'d
-// when [Pruner.Run] returns.
+// retained below the retention pivot (= min(l1Head, l2Head); the pivot
+// itself is always retained), so the pruner keeps blocks in
+// [pivot - retainedBlocks, l2Head] and deletes everything below.
+// newHeadSub and l1HeadSub are the two trigger feeds (see [Pruner]).
+// Subscriptions are [feed.Subscription.Unsubscribe]'d when [Pruner.Run]
+// returns.
 func New(
 	database db.KeyValueStore,
 	retainedBlocks uint64,

--- a/pruner/pruner_test.go
+++ b/pruner/pruner_test.go
@@ -157,13 +157,13 @@ func TestPruner_L1Path(t *testing.T) {
 		}
 		require.NoError(t, core.WriteChainHeight(database, totalBlocks))
 
-		// retention=10, L1=95 → floor = 95-10+1 = 86. Prunes [0, 86).
+		// retention=10, L1=95 → floor = 95-10 = 85. Prunes [0, 85).
 		sp := startPrunerService(t, database, 10)
 		ev := sp.sendL1AndAwait(t, 95)
-		assert.Equal(t, uint64(86), ev.oldest)
-		assert.Equal(t, uint64(86), ev.count)
+		assert.Equal(t, uint64(85), ev.oldest)
+		assert.Equal(t, uint64(85), ev.count)
 
-		for i := range uint64(86) - core.BlockHashLag {
+		for i := range uint64(85) - core.BlockHashLag {
 			testutils.AssertBlockPruned(t, database, blocks[i])
 		}
 	})
@@ -225,11 +225,11 @@ func TestPruner_L2Path(t *testing.T) {
 		require.NoError(t, core.WriteL1Head(database, &core.L1Head{BlockNumber: 95}))
 
 		// retention=10, l1Head=95 → L2 path uses the L2 block as the floor
-		// pivot. Sending L2 head 90 → floor = 90-10+1 = 81. Prunes [0, 81).
+		// pivot. Sending L2 head 90 → floor = 90-10 = 80. Prunes [0, 80).
 		sp := startPrunerService(t, database, 10, pruner.WithL2HeadsPerPrune(1))
 		ev := sp.sendL2AndAwait(t, 90)
-		assert.Equal(t, uint64(81), ev.oldest)
-		assert.Equal(t, uint64(81), ev.count)
+		assert.Equal(t, uint64(80), ev.oldest)
+		assert.Equal(t, uint64(80), ev.count)
 	})
 
 	t.Run("coalesces N L2 heads before triggering one prune", func(t *testing.T) {
@@ -242,20 +242,20 @@ func TestPruner_L2Path(t *testing.T) {
 
 		// retention=10, l1Head=95, threshold=3. With L2 heads 88, 89, 90:
 		// the first two coalesce silently; the third tips the counter and
-		// triggers a prune at floor 90-10+1 = 81.
+		// triggers a prune at floor 90-10 = 80.
 		sp := startPrunerService(t, database, 10, pruner.WithL2HeadsPerPrune(3))
 		sp.sendL2AndExpectNoOp(t, 88)
 		sp.sendL2AndExpectNoOp(t, 89)
 		ev1 := sp.sendL2AndAwait(t, 90)
-		assert.Equal(t, uint64(81), ev1.oldest)
-		assert.Equal(t, uint64(81), ev1.count)
+		assert.Equal(t, uint64(80), ev1.oldest)
+		assert.Equal(t, uint64(80), ev1.count)
 
 		// Counter resets after the prune; next two coalesce, the third
-		// triggers a second prune at floor 93-10+1 = 84, deleting [81, 84).
+		// triggers a second prune at floor 93-10 = 83, deleting [80, 83).
 		sp.sendL2AndExpectNoOp(t, 91)
 		sp.sendL2AndExpectNoOp(t, 92)
 		ev2 := sp.sendL2AndAwait(t, 93)
-		assert.Equal(t, uint64(84), ev2.oldest)
+		assert.Equal(t, uint64(83), ev2.oldest)
 		assert.Equal(t, uint64(3), ev2.count, "counter resets after each prune")
 	})
 
@@ -324,25 +324,25 @@ func TestPruner_RetentionChangeAcrossRestart(t *testing.T) {
 		}
 		require.NoError(t, core.WriteChainHeight(database, totalBlocks))
 
-		// Phase 1: retention=80, L1=99 → floor=20. Sweep prunes [0, 20).
+		// Phase 1: retention=80, L1=99 → floor=19. Sweep prunes [0, 19).
 		sp1 := startPrunerService(t, database, 80)
 		ev1 := sp1.sendL1AndAwait(t, 99)
-		assert.Equal(t, uint64(20), ev1.oldest)
-		assert.Equal(t, uint64(20), ev1.count)
+		assert.Equal(t, uint64(19), ev1.oldest)
+		assert.Equal(t, uint64(19), ev1.count)
 
-		// Phase 2: "restart" with retention=10, L1=99 → floor=90. Sweep
-		// prunes [20, 90) — 70 blocks in one dispatch.
+		// Phase 2: "restart" with retention=10, L1=99 → floor=89. Sweep
+		// prunes [19, 89) — 70 blocks in one dispatch.
 		sp2 := startPrunerService(t, database, 10)
 		ev2 := sp2.sendL1AndAwait(t, 99)
-		assert.Equal(t, uint64(90), ev2.oldest)
+		assert.Equal(t, uint64(89), ev2.oldest)
 		assert.Equal(t, uint64(70), ev2.count)
 
 		// End-state: everything below the new lag floor is fully gone,
-		// blocks ≥ 90 untouched.
-		for i := range uint64(90) - lag {
+		// blocks ≥ 89 untouched.
+		for i := range uint64(89) - lag {
 			testutils.AssertBlockPruned(t, database, blocks[i])
 		}
-		for i := uint64(90); i < totalBlocks; i++ {
+		for i := uint64(89); i < totalBlocks; i++ {
 			testutils.AssertBlockExists(t, database, blocks[i])
 		}
 	})
@@ -354,25 +354,25 @@ func TestPruner_RetentionChangeAcrossRestart(t *testing.T) {
 		}
 		require.NoError(t, core.WriteChainHeight(database, totalBlocks))
 
-		// Phase 1: retention=10, L1=50 → floor=41. Sweep prunes [0, 41).
+		// Phase 1: retention=10, L1=50 → floor=40. Sweep prunes [0, 40).
 		sp1 := startPrunerService(t, database, 10)
 		ev1 := sp1.sendL1AndAwait(t, 50)
-		assert.Equal(t, uint64(41), ev1.oldest)
-		assert.Equal(t, uint64(41), ev1.count)
+		assert.Equal(t, uint64(40), ev1.oldest)
+		assert.Equal(t, uint64(40), ev1.count)
 
-		// Phase 2: "restart" with retention=40, L1 still at 50 → new floor=11,
-		// below the existing oldestKept (41). PruneUpto early-returns; OnPrune
-		// fires with count=0 and oldest unchanged at 41.
+		// Phase 2: "restart" with retention=40, L1 still at 50 → new floor=10,
+		// below the existing oldestKept (40). PruneUpto early-returns; OnPrune
+		// fires with count=0 and oldest unchanged at 40.
 		sp2 := startPrunerService(t, database, 40)
 		ev2 := sp2.sendL1AndAwait(t, 50)
-		assert.Equal(t, uint64(41), ev2.oldest,
+		assert.Equal(t, uint64(40), ev2.oldest,
 			"growing retention must not resurrect or move oldestKept")
 		assert.Zero(t, ev2.count, "growing retention must not prune any block")
 
-		// Phase 3: L1 advances to 81 → floor=42 > 41. The window finally moves
+		// Phase 3: L1 advances to 81 → floor=41 > 40. The window finally moves
 		// by exactly one block: gradual growth, not a leap.
 		ev3 := sp2.sendL1AndAwait(t, 81)
-		assert.Equal(t, uint64(42), ev3.oldest)
+		assert.Equal(t, uint64(41), ev3.oldest)
 		assert.Equal(t, uint64(1), ev3.count)
 	})
 }


### PR DESCRIPTION
### Fix off-by-one in the pruner retention floor.

  - The floor was computed as `pivot - N + 1`, so we kept N-1 blocks below the pivot instead of N. With --prune-mode=0 this collapsed to deleting the pivot block itself — and during catch-up where L1 is ahead of L2, that meant wiping everything the node had synced.
  - Drop the +1 so the pivot is always retained: --prune-mode=0 keeps just the pivot, --prune-mode=N keeps N blocks below it.