### PR TITLE
fix(node): catch up L1 head before history pruning migration

### DIFF
--- a/l1/l1.go
+++ b/l1/l1.go
@@ -167,6 +167,21 @@ func (c *Client) Run(ctx context.Context) error {
 	return c.watchL1StateUpdates(ctx)
 }
 
+// CatchUpL1Head runs the startup phase (chain ID check + backward
+// catch-up scan that writes the L1 head via setL1Head) without entering
+// the live subscription loop. Intended for callers that need an L1 head
+// present in the database before subsequent steps — notably the history
+// pruning migration, which runs before the regular L1 service starts.
+// The Client closes its Subscriber on return; do not reuse the instance
+// afterward.
+func (c *Client) CatchUpL1Head(ctx context.Context) error {
+	defer c.l1.Close()
+	if err := c.checkChainID(ctx); err != nil {
+		return err
+	}
+	return c.catchUpL1HeadUpdates(ctx)
+}
+
 func (c *Client) watchL1StateUpdates(ctx context.Context) error {
 	buffer := 128
 

--- a/l1/l1.go
+++ b/l1/l1.go
@@ -167,13 +167,9 @@ func (c *Client) Run(ctx context.Context) error {
 	return c.watchL1StateUpdates(ctx)
 }
 
-// CatchUpL1Head runs the startup phase (chain ID check + backward
-// catch-up scan that writes the L1 head via setL1Head) without entering
-// the live subscription loop. Intended for callers that need an L1 head
-// present in the database before subsequent steps — notably the history
-// pruning migration, which runs before the regular L1 service starts.
-// The Client closes its Subscriber on return; do not reuse the instance
-// afterward.
+// CatchUpL1Head verifies the chain ID then writes the L1 head to the
+// database, without entering the live subscription loop. Closes the
+// underlying Subscriber on return; the Client must not be reused.
 func (c *Client) CatchUpL1Head(ctx context.Context) error {
 	defer c.l1.Close()
 	if err := c.checkChainID(ctx); err != nil {

--- a/l1/l1_test.go
+++ b/l1/l1_test.go
@@ -281,6 +281,54 @@ func TestEventListenerCatchUp(t *testing.T) {
 	require.Equal(t, *want, persisted)
 }
 
+// TestCatchUpL1Head is the regression for the history-pruning migration
+// bootstrap (node/migration.go). The migration crashes with a bare "key
+// not found" if it runs before any L1 head is on disk; the fix calls
+// Client.CatchUpL1Head in node/migration.go to write one up front. This
+// test pins the contract that CatchUpL1Head used by that path actually
+// persists the head — if a future change drops the setL1Head call inside
+// catchUpL1HeadUpdates, or short-circuits Client.CatchUpL1Head before it
+// reaches catch-up, chain.L1Head() below fails and the bug returns.
+func TestCatchUpL1Head(t *testing.T) {
+	t.Parallel()
+
+	ctrl := gomock.NewController(t)
+	nopLog := log.NewNopZapLogger()
+	network := networks.Mainnet
+	chain := blockchain.New(
+		memory.New(),
+		&network,
+		blockchain.WithNewState(statetestutils.UseNewState()),
+	)
+
+	subscriber := mocks.NewMockSubscriber(ctrl)
+	subscriber.EXPECT().ChainID(gomock.Any()).Return(network.L1ChainID, nil).AnyTimes()
+	subscriber.EXPECT().LatestHeight(gomock.Any()).Return(uint64(10), nil).AnyTimes()
+	subscriber.EXPECT().FinalisedHeight(gomock.Any()).Return(uint64(5), nil).AnyTimes()
+	subscriber.
+		EXPECT().
+		FilterLogStateUpdate(gomock.Any(), uint64(0), uint64(10)).
+		Return([]*contract.StarknetLogStateUpdate{{
+			BlockNumber: new(big.Int).SetUint64(7),
+			BlockHash:   new(big.Int).SetUint64(7),
+			GlobalRoot:  new(big.Int).SetUint64(7),
+			Raw:         types.Log{BlockNumber: 3},
+		}}, nil).
+		AnyTimes()
+	subscriber.EXPECT().Close().AnyTimes()
+
+	client := l1.NewClient(subscriber, chain, nopLog)
+	require.NoError(t, client.CatchUpL1Head(t.Context()))
+
+	persisted, err := chain.L1Head()
+	require.NoError(t, err)
+	require.Equal(t, core.L1Head{
+		BlockNumber: 7,
+		BlockHash:   new(felt.Felt).SetUint64(7),
+		StateRoot:   new(felt.Felt).SetUint64(7),
+	}, persisted)
+}
+
 func newTestL1Client(service service) *rpc.Server {
 	server := rpc.NewServer()
 	if err := server.RegisterName("eth", service); err != nil {

--- a/l1/l1_test.go
+++ b/l1/l1_test.go
@@ -329,6 +329,26 @@ func TestCatchUpL1Head(t *testing.T) {
 	}, persisted)
 }
 
+func TestCatchUpL1Head_ChainIDMismatch(t *testing.T) {
+	t.Parallel()
+
+	ctrl := gomock.NewController(t)
+	nopLog := log.NewNopZapLogger()
+	network := networks.Mainnet
+	chain := blockchain.New(
+		memory.New(),
+		&network,
+		blockchain.WithNewState(statetestutils.UseNewState()),
+	)
+
+	subscriber := mocks.NewMockSubscriber(ctrl)
+	subscriber.EXPECT().ChainID(gomock.Any()).Return(big.NewInt(999), nil)
+	subscriber.EXPECT().Close()
+
+	err := l1.NewClient(subscriber, chain, nopLog).CatchUpL1Head(t.Context())
+	require.ErrorContains(t, err, "mismatched L1 and L2 networks")
+}
+
 func newTestL1Client(service service) *rpc.Server {
 	server := rpc.NewServer()
 	if err := server.RegisterName("eth", service); err != nil {

--- a/node/export_test.go
+++ b/node/export_test.go
@@ -1,0 +1,7 @@
+package node
+
+// Test-only exports for external _test packages.
+var (
+	FetchL1HeadIfMissing = fetchL1HeadIfMissing
+	MigrateIfNeeded      = migrateIfNeeded
+)

--- a/node/export_test.go
+++ b/node/export_test.go
@@ -1,7 +1,0 @@
-package node
-
-// Test-only exports for external _test packages.
-var (
-	FetchL1HeadIfMissing = fetchL1HeadIfMissing
-	MigrateIfNeeded      = migrateIfNeeded
-)

--- a/node/migration.go
+++ b/node/migration.go
@@ -51,15 +51,9 @@ func migrateIfNeeded(
 			return fmt.Errorf("deprecated migration failed: %w", err)
 		}
 
-		// The history pruning migration reads the L1 head to compute the
-		// reorg-safe cutoff. On a fresh sync the L1 client (which writes the
-		// head) only starts as a regular service AFTER this point, so a
-		// pruning-enabled node restarted mid-sync would fail with a cryptic
-		// "key not found". Bootstrap the head via a one-shot catch-up here,
-		// reusing the operator's existing --eth-node so no extra config is
-		// required. Skipped if the head is already on disk from a previous run.
+		// Make sure there is an available L1 head before starting pruning migration
 		if config.Prune {
-			if err := bootstrapL1HeadIfMissing(ctx, database, config, chain, logger); err != nil {
+			if err := fetchL1HeadIfMissing(ctx, database, config, chain, logger); err != nil {
 				return fmt.Errorf("bootstrap L1 head for pruning: %w", err)
 			}
 		}
@@ -91,30 +85,27 @@ func migrateIfNeeded(
 	return migrateFn()
 }
 
-// bootstrapL1HeadIfMissing ensures an L1 head is persisted before the
-// history pruning migration reads it. No-op when the head is already on
-// disk. Otherwise it builds a one-shot L1 client against the operator's
-// existing --eth-node and runs the same catch-up scan the regular L1
-// service runs on startup. Returns an explicit error if the catch-up
-// completes without finding any finalised LogStateUpdate, so the operator
-// sees a clear cause instead of a downstream "key not found".
-func bootstrapL1HeadIfMissing(
+// fetchL1HeadIfMissing writes an L1 head to disk before the history pruning
+// migration reads it. No-op when one is already stored.
+func fetchL1HeadIfMissing(
 	ctx context.Context,
 	database db.KeyValueStore,
 	config *Config,
 	chain *blockchain.Blockchain,
 	logger log.StructuredLogger,
 ) error {
-	if _, err := core.GetL1Head(database); err == nil {
+	_, err := core.GetL1Head(database)
+	if err == nil {
 		return nil
-	} else if !errors.Is(err, db.ErrKeyNotFound) {
+	}
+	if !errors.Is(err, db.ErrKeyNotFound) {
 		return err
 	}
 
-	logger.Info("Bootstrapping L1 head for pruning migration via --eth-node catch-up")
+	logger.Info("Fetching the L1 head before running the prune migration")
 	client, err := newL1Client(config.EthNode, config.Metrics, chain, logger)
 	if err != nil {
-		return err
+		return fmt.Errorf("creating a new L1 client: %w", err)
 	}
 	if err := client.CatchUpL1Head(ctx); err != nil {
 		return err
@@ -122,8 +113,7 @@ func bootstrapL1HeadIfMissing(
 
 	if _, err := core.GetL1Head(database); err != nil {
 		if errors.Is(err, db.ErrKeyNotFound) {
-			return errors.New("catch-up completed without a finalised LogStateUpdate; " +
-				"retry once L1 has a finalised Starknet state update")
+			return errors.New("couldn't find a finalized Starknet state update on L1")
 		}
 		return err
 	}

--- a/node/migration.go
+++ b/node/migration.go
@@ -2,8 +2,11 @@ package node
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
+	"github.com/NethermindEth/juno/blockchain"
+	"github.com/NethermindEth/juno/core"
 	"github.com/NethermindEth/juno/db"
 	"github.com/NethermindEth/juno/migration"
 	"github.com/NethermindEth/juno/migration/blocktransactions"
@@ -32,26 +35,40 @@ func registerMigrations(cfg *Config) *migration.Registry {
 // migration progress via health check endpoints.
 func migrateIfNeeded(
 	ctx context.Context,
-	db db.KeyValueStore,
+	database db.KeyValueStore,
 	config *Config,
+	chain *blockchain.Blockchain,
 	logger log.Logger,
 ) error {
 	migrateFn := func() error {
 		// Run deprecated migrations first
 		if err := deprecated.MigrateIfNeeded(
 			ctx,
-			db,
+			database,
 			&config.Network,
 			logger,
 		); err != nil {
 			return fmt.Errorf("deprecated migration failed: %w", err)
 		}
 
+		// The history pruning migration reads the L1 head to compute the
+		// reorg-safe cutoff. On a fresh sync the L1 client (which writes the
+		// head) only starts as a regular service AFTER this point, so a
+		// pruning-enabled node restarted mid-sync would fail with a cryptic
+		// "key not found". Bootstrap the head via a one-shot catch-up here,
+		// reusing the operator's existing --eth-node so no extra config is
+		// required. Skipped if the head is already on disk from a previous run.
+		if config.Prune {
+			if err := bootstrapL1HeadIfMissing(ctx, database, config, chain, logger); err != nil {
+				return fmt.Errorf("bootstrap L1 head for pruning: %w", err)
+			}
+		}
+
 		// Run new migrations
 		registry := registerMigrations(config)
 		runner, err := migration.NewRunner(
 			registry,
-			db,
+			database,
 			&config.Network,
 			logger,
 		)
@@ -72,4 +89,42 @@ func migrateIfNeeded(
 	}
 
 	return migrateFn()
+}
+
+// bootstrapL1HeadIfMissing ensures an L1 head is persisted before the
+// history pruning migration reads it. No-op when the head is already on
+// disk. Otherwise it builds a one-shot L1 client against the operator's
+// existing --eth-node and runs the same catch-up scan the regular L1
+// service runs on startup. Returns an explicit error if the catch-up
+// completes without finding any finalised LogStateUpdate, so the operator
+// sees a clear cause instead of a downstream "key not found".
+func bootstrapL1HeadIfMissing(
+	ctx context.Context,
+	database db.KeyValueStore,
+	config *Config,
+	chain *blockchain.Blockchain,
+	logger log.StructuredLogger,
+) error {
+	if _, err := core.GetL1Head(database); err == nil {
+		return nil
+	} else if !errors.Is(err, db.ErrKeyNotFound) {
+		return err
+	}
+
+	logger.Info("Bootstrapping L1 head for pruning migration via --eth-node catch-up")
+	client, err := newL1Client(config.EthNode, config.Metrics, chain, logger)
+	if err != nil {
+		return err
+	}
+	if err := client.CatchUpL1Head(ctx); err != nil {
+		return err
+	}
+
+	if _, err := core.GetL1Head(database); err != nil {
+		if errors.Is(err, db.ErrKeyNotFound) {
+			return errors.New("catch-up completed without a finalised LogStateUpdate; retry once L1 has a finalised Starknet state update")
+		}
+		return err
+	}
+	return nil
 }

--- a/node/migration.go
+++ b/node/migration.go
@@ -122,7 +122,8 @@ func bootstrapL1HeadIfMissing(
 
 	if _, err := core.GetL1Head(database); err != nil {
 		if errors.Is(err, db.ErrKeyNotFound) {
-			return errors.New("catch-up completed without a finalised LogStateUpdate; retry once L1 has a finalised Starknet state update")
+			return errors.New("catch-up completed without a finalised LogStateUpdate; " +
+				"retry once L1 has a finalised Starknet state update")
 		}
 		return err
 	}

--- a/node/migration.go
+++ b/node/migration.go
@@ -54,7 +54,7 @@ func migrateIfNeeded(
 		// Make sure there is an available L1 head before starting pruning migration
 		if config.Prune {
 			if err := fetchL1HeadIfMissing(ctx, database, config, chain, logger); err != nil {
-				return fmt.Errorf("bootstrap L1 head for pruning: %w", err)
+				return fmt.Errorf("fetch L1 head for pruning: %w", err)
 			}
 		}
 

--- a/node/migration_test.go
+++ b/node/migration_test.go
@@ -3,6 +3,7 @@ package node
 import (
 	"testing"
 
+	"github.com/NethermindEth/juno/blockchain/networks"
 	"github.com/NethermindEth/juno/core"
 	"github.com/NethermindEth/juno/core/felt"
 	"github.com/NethermindEth/juno/db/memory"
@@ -28,4 +29,14 @@ func TestFetchL1HeadIfMissing_WrapsL1ClientError(t *testing.T) {
 	cfg := &Config{EthNode: ""}
 	err := fetchL1HeadIfMissing(t.Context(), database, cfg, nil, log.NewNopZapLogger())
 	require.ErrorContains(t, err, "creating a new L1 client")
+}
+
+func TestMigrateIfNeeded_WrapsPruneFetchError(t *testing.T) {
+	cfg := &Config{
+		Prune:   true,
+		EthNode: "",
+		Network: networks.Sepolia,
+	}
+	err := migrateIfNeeded(t.Context(), memory.New(), cfg, nil, log.NewNopZapLogger())
+	require.ErrorContains(t, err, "fetch L1 head for pruning")
 }

--- a/node/migration_test.go
+++ b/node/migration_test.go
@@ -22,3 +22,10 @@ func TestFetchL1HeadIfMissing_SkipsL1FetchWhenHeadPresent(t *testing.T) {
 	cfg := &Config{EthNode: ""}
 	require.NoError(t, fetchL1HeadIfMissing(t.Context(), database, cfg, nil, log.NewNopZapLogger()))
 }
+
+func TestFetchL1HeadIfMissing_WrapsL1ClientError(t *testing.T) {
+	database := memory.New()
+	cfg := &Config{EthNode: ""}
+	err := fetchL1HeadIfMissing(t.Context(), database, cfg, nil, log.NewNopZapLogger())
+	require.ErrorContains(t, err, "creating a new L1 client")
+}

--- a/node/migration_test.go
+++ b/node/migration_test.go
@@ -1,0 +1,24 @@
+package node
+
+import (
+	"testing"
+
+	"github.com/NethermindEth/juno/core"
+	"github.com/NethermindEth/juno/core/felt"
+	"github.com/NethermindEth/juno/db/memory"
+	_ "github.com/NethermindEth/juno/encoder/registry"
+	"github.com/NethermindEth/juno/utils/log"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFetchL1HeadIfMissing_SkipsL1FetchWhenHeadPresent(t *testing.T) {
+	database := memory.New()
+	require.NoError(t, core.WriteL1Head(database, &core.L1Head{
+		BlockNumber: 1,
+		BlockHash:   felt.NewRandom[felt.Felt](),
+		StateRoot:   felt.NewRandom[felt.Felt](),
+	}))
+
+	cfg := &Config{EthNode: ""}
+	require.NoError(t, fetchL1HeadIfMissing(t.Context(), database, cfg, nil, log.NewNopZapLogger()))
+}

--- a/node/migration_test.go
+++ b/node/migration_test.go
@@ -14,14 +14,19 @@ import (
 
 func TestFetchL1HeadIfMissing_SkipsL1FetchWhenHeadPresent(t *testing.T) {
 	database := memory.New()
-	require.NoError(t, core.WriteL1Head(database, &core.L1Head{
+	want := &core.L1Head{
 		BlockNumber: 1,
 		BlockHash:   felt.NewRandom[felt.Felt](),
 		StateRoot:   felt.NewRandom[felt.Felt](),
-	}))
+	}
+	require.NoError(t, core.WriteL1Head(database, want))
 
 	cfg := &Config{EthNode: ""}
 	require.NoError(t, fetchL1HeadIfMissing(t.Context(), database, cfg, nil, log.NewNopZapLogger()))
+
+	got, err := core.GetL1Head(database)
+	require.NoError(t, err)
+	require.Equal(t, *want, got)
 }
 
 func TestFetchL1HeadIfMissing_WrapsL1ClientError(t *testing.T) {

--- a/node/migration_test.go
+++ b/node/migration_test.go
@@ -1,4 +1,6 @@
-package node_test
+// Uses package node (not node_test) to test unexported helpers directly.
+// It avoids changing the API or production code just for testing
+package node
 
 import (
 	"testing"
@@ -8,42 +10,40 @@ import (
 	"github.com/NethermindEth/juno/core/felt"
 	"github.com/NethermindEth/juno/db/memory"
 	_ "github.com/NethermindEth/juno/encoder/registry"
-	"github.com/NethermindEth/juno/node"
 	"github.com/NethermindEth/juno/utils/log"
 	"github.com/stretchr/testify/require"
 )
 
 func TestFetchL1HeadIfMissing_SkipsL1FetchWhenHeadPresent(t *testing.T) {
 	database := memory.New()
-	want := &core.L1Head{
+	expected := &core.L1Head{
 		BlockNumber: 1,
 		BlockHash:   felt.NewRandom[felt.Felt](),
 		StateRoot:   felt.NewRandom[felt.Felt](),
 	}
-	require.NoError(t, core.WriteL1Head(database, want))
+	require.NoError(t, core.WriteL1Head(database, expected))
 
-	logger := log.NewNopZapLogger()
-	cfg := &node.Config{EthNode: ""}
-	require.NoError(t, node.FetchL1HeadIfMissing(t.Context(), database, cfg, nil, logger))
+	cfg := &Config{EthNode: ""}
+	require.NoError(t, fetchL1HeadIfMissing(t.Context(), database, cfg, nil, log.NewNopZapLogger()))
 
-	got, err := core.GetL1Head(database)
+	received, err := core.GetL1Head(database)
 	require.NoError(t, err)
-	require.Equal(t, *want, got)
+	require.Equal(t, *expected, received)
 }
 
 func TestFetchL1HeadIfMissing_WrapsL1ClientError(t *testing.T) {
 	database := memory.New()
-	cfg := &node.Config{EthNode: ""}
-	err := node.FetchL1HeadIfMissing(t.Context(), database, cfg, nil, log.NewNopZapLogger())
+	cfg := &Config{EthNode: ""}
+	err := fetchL1HeadIfMissing(t.Context(), database, cfg, nil, log.NewNopZapLogger())
 	require.ErrorContains(t, err, "creating a new L1 client")
 }
 
 func TestMigrateIfNeeded_WrapsPruneFetchError(t *testing.T) {
-	cfg := &node.Config{
+	cfg := &Config{
 		Prune:   true,
 		EthNode: "",
 		Network: networks.Sepolia,
 	}
-	err := node.MigrateIfNeeded(t.Context(), memory.New(), cfg, nil, log.NewNopZapLogger())
+	err := migrateIfNeeded(t.Context(), memory.New(), cfg, nil, log.NewNopZapLogger())
 	require.ErrorContains(t, err, "fetch L1 head for pruning")
 }

--- a/node/migration_test.go
+++ b/node/migration_test.go
@@ -1,4 +1,4 @@
-package node
+package node_test
 
 import (
 	"testing"
@@ -8,6 +8,7 @@ import (
 	"github.com/NethermindEth/juno/core/felt"
 	"github.com/NethermindEth/juno/db/memory"
 	_ "github.com/NethermindEth/juno/encoder/registry"
+	"github.com/NethermindEth/juno/node"
 	"github.com/NethermindEth/juno/utils/log"
 	"github.com/stretchr/testify/require"
 )
@@ -21,8 +22,9 @@ func TestFetchL1HeadIfMissing_SkipsL1FetchWhenHeadPresent(t *testing.T) {
 	}
 	require.NoError(t, core.WriteL1Head(database, want))
 
-	cfg := &Config{EthNode: ""}
-	require.NoError(t, fetchL1HeadIfMissing(t.Context(), database, cfg, nil, log.NewNopZapLogger()))
+	logger := log.NewNopZapLogger()
+	cfg := &node.Config{EthNode: ""}
+	require.NoError(t, node.FetchL1HeadIfMissing(t.Context(), database, cfg, nil, logger))
 
 	got, err := core.GetL1Head(database)
 	require.NoError(t, err)
@@ -31,17 +33,17 @@ func TestFetchL1HeadIfMissing_SkipsL1FetchWhenHeadPresent(t *testing.T) {
 
 func TestFetchL1HeadIfMissing_WrapsL1ClientError(t *testing.T) {
 	database := memory.New()
-	cfg := &Config{EthNode: ""}
-	err := fetchL1HeadIfMissing(t.Context(), database, cfg, nil, log.NewNopZapLogger())
+	cfg := &node.Config{EthNode: ""}
+	err := node.FetchL1HeadIfMissing(t.Context(), database, cfg, nil, log.NewNopZapLogger())
 	require.ErrorContains(t, err, "creating a new L1 client")
 }
 
 func TestMigrateIfNeeded_WrapsPruneFetchError(t *testing.T) {
-	cfg := &Config{
+	cfg := &node.Config{
 		Prune:   true,
 		EthNode: "",
 		Network: networks.Sepolia,
 	}
-	err := migrateIfNeeded(t.Context(), memory.New(), cfg, nil, log.NewNopZapLogger())
+	err := node.MigrateIfNeeded(t.Context(), memory.New(), cfg, nil, log.NewNopZapLogger())
 	require.ErrorContains(t, err, "fetch L1 head for pruning")
 }

--- a/node/node.go
+++ b/node/node.go
@@ -170,6 +170,14 @@ func New(cfg *Config, version string, logLevel *log.Level) (*Node, error) {
 		return nil, err
 	}
 
+	// History pruning needs an L1-finalised cutoff to know which blocks are
+	// safe to drop. The cutoff is established by the L1 client, so disabling
+	// L1 verification makes pruning unsafe — reject the combination up front
+	// instead of crashing later when the migration cannot find an L1 head.
+	if cfg.Prune && cfg.DisableL1Verification {
+		return nil, errors.New("--prune-mode requires L1 verification; remove --disable-l1-verification or disable --prune-mode")
+	}
+
 	dbIsRemote := cfg.RemoteDB != ""
 	var database db.KeyValueStore
 	if dbIsRemote {
@@ -659,7 +667,7 @@ func (n *Node) Run(ctx context.Context) {
 		n.StartService(wg, ctx, cancel, s)
 	}
 
-	err = migrateIfNeeded(ctx, n.db, n.cfg, n.logger)
+	err = migrateIfNeeded(ctx, n.db, n.cfg, n.blockchain, n.logger)
 	if err != nil {
 		if errors.Is(err, context.Canceled) {
 			n.logger.Info("DB Migration cancelled")

--- a/node/node.go
+++ b/node/node.go
@@ -175,7 +175,8 @@ func New(cfg *Config, version string, logLevel *log.Level) (*Node, error) {
 	// L1 verification makes pruning unsafe — reject the combination up front
 	// instead of crashing later when the migration cannot find an L1 head.
 	if cfg.Prune && cfg.DisableL1Verification {
-		return nil, errors.New("--prune-mode requires L1 verification; remove --disable-l1-verification or disable --prune-mode")
+		return nil, errors.New("--prune-mode requires L1 verification; " +
+			"remove --disable-l1-verification or disable --prune-mode")
 	}
 
 	dbIsRemote := cfg.RemoteDB != ""

--- a/node/node_test.go
+++ b/node/node_test.go
@@ -112,3 +112,11 @@ func TestNetworkVerificationOnNonEmptyDB(t *testing.T) {
 		})
 	}
 }
+
+func TestNew_RejectsPruneWithoutL1Verification(t *testing.T) {
+	_, err := node.New(&node.Config{
+		Prune:                 true,
+		DisableL1Verification: true,
+	}, "test", log.NewLevel(log.INFO))
+	require.ErrorContains(t, err, "prune-mode requires L1 verification")
+}


### PR DESCRIPTION
Fixes the `key not found` crash when starting Juno with `--prune-mode` on a node where the L1 head hasn't been written yet.

Why it crashed: the pruning migration needs the L1 head to know which old blocks are safe to delete. The L1 head is written by the L1 client, which only starts AFTER migrations. So on a partially-synced DB the migration reads something nothing has written yet, and dies.

Fix: fetch the L1 head once from `--eth-node` before the migration runs. Same endpoint that's already required for L1 verification. No new flag.

Also rejects `--prune-mode` + `--disable-l1-verification` up front since pruning needs L1 finality (was a silent footgun before).