### PR TITLE
fix(migration): check opt-out before downgrade in NewRunner

### DIFF
--- a/migration/runner.go
+++ b/migration/runner.go
@@ -85,11 +85,6 @@ func NewRunner(
 	}
 
 	targetVersion := registry.TargetVersion()
-	// Validate: check if database was migrated with a newer version of Juno (version downgrade)
-	err = validateNoVersionDowngrade(metadata.CurrentVersion, targetVersion)
-	if err != nil {
-		return nil, err
-	}
 
 	// Validate: check if any previously opted-in migrations are now missing (opt-out attempt)
 	err = validateNoOptOut(
@@ -97,6 +92,12 @@ func NewRunner(
 		metadata.LastTargetVersion,
 		registry.OptionalMigrationFlags(),
 	)
+	if err != nil {
+		return nil, err
+	}
+
+	// Validate: check if database was migrated with a newer version of Juno (version downgrade)
+	err = validateNoVersionDowngrade(metadata.CurrentVersion, targetVersion)
 	if err != nil {
 		return nil, err
 	}
@@ -218,16 +219,23 @@ func validateNoOptOut(
 		return nil
 	}
 	// Build a list of migration flags that cannot be opted out of
-	flagList := make([]string, optOutAttempts.Len())
-	i := 0
+	flagList := make([]string, 0, optOutAttempts.Len())
 	for idx := range optOutAttempts.Iter() {
+		if int(idx) >= len(optionalMigrationFlags) {
+			// Bits beyond the current registry are unknown migrations from a newer
+			// Juno; let validateNoVersionDowngrade surface that. Iter yields in
+			// ascending order, so every remaining bit is also out of range.
+			break
+		}
 		if flag := optionalMigrationFlags[idx]; flag != "" {
-			flagList[i] = fmt.Sprintf("--%s", flag)
+			flagList = append(flagList, fmt.Sprintf("--%s", flag))
 		} else {
 			// Fallback to index if flag is not available
-			flagList[i] = fmt.Sprintf("--migration-%d", idx)
+			flagList = append(flagList, fmt.Sprintf("--migration-%d", idx))
 		}
-		i++
+	}
+	if len(flagList) == 0 {
+		return nil
 	}
 
 	return fmt.Errorf(

--- a/migration/runner_test.go
+++ b/migration/runner_test.go
@@ -107,30 +107,50 @@ func TestNewRunner(t *testing.T) {
 		require.NotNil(t, runner)
 	})
 
-	t.Run("Error on opt-out attempt", func(t *testing.T) { //nolint:dupl,lll,nolintlint // shares code with version downgrade, tests different error message, nolintlint because main config does not check lll in tests
-		testDB := setupTestDB(t)
-		existingMetadata := migration.SchemaMetadata{
-			CurrentVersion:    migration.SchemaVersion(0b011), // Migrations 0 and 1 applied
-			LastTargetVersion: migration.SchemaVersion(0b111), // Migrations 0, 1 and 2 previously enabled
+	t.Run("Error on opt-out attempt", func(t *testing.T) {
+		// Optional migration at idx 2 was previously enabled and is now being opted out.
+		// The "already applied" case guards the ordering bug: CurrentVersion having a bit
+		// Target does not is misread as a downgrade when validateNoVersionDowngrade runs first.
+		tests := []struct {
+			name           string
+			currentVersion migration.SchemaVersion
+		}{
+			{
+				name:           "previously enabled optional migration had not yet completed",
+				currentVersion: migration.SchemaVersion(0b011),
+			},
+			{
+				name:           "previously enabled optional migration is already applied",
+				currentVersion: migration.SchemaVersion(0b111),
+			},
 		}
-		require.NoError(t, migration.WriteSchemaMetadata(testDB, existingMetadata))
 
-		// Create registry with migrations 0 and 1 (but not 2, which was previously enabled)
-		registry := migration.NewRegistry().
-			With(&mockMigration{}).
-			With(&mockMigration{}).
-			WithOptional(&mockMigration{}, false, "migration-2")
+		for _, tc := range tests {
+			t.Run(tc.name, func(t *testing.T) {
+				testDB := setupTestDB(t)
+				existingMetadata := migration.SchemaMetadata{
+					CurrentVersion:    tc.currentVersion,
+					LastTargetVersion: migration.SchemaVersion(0b111), // Migrations 0, 1 and 2 previously enabled
+				}
+				require.NoError(t, migration.WriteSchemaMetadata(testDB, existingMetadata))
 
-		runner, err := migration.NewRunner(
-			registry,
-			testDB,
-			&networks.Mainnet,
-			log.NewNopZapLogger(),
-		)
-		require.Error(t, err)
-		require.Nil(t, runner)
-		require.Contains(t, err.Error(), "cannot opt out of previously enabled migrations:")
-		require.Contains(t, err.Error(), "--migration-2")
+				registry := migration.NewRegistry().
+					With(&mockMigration{}).
+					With(&mockMigration{}).
+					WithOptional(&mockMigration{}, false, "migration-2")
+
+				runner, err := migration.NewRunner(
+					registry,
+					testDB,
+					&networks.Mainnet,
+					log.NewNopZapLogger(),
+				)
+				require.Error(t, err)
+				require.Nil(t, runner)
+				require.Contains(t, err.Error(), "cannot opt out of previously enabled migrations:")
+				require.Contains(t, err.Error(), "--migration-2")
+			})
+		}
 	})
 
 	t.Run("Error on version downgrade", func(t *testing.T) { //nolint:dupl,lll,nolintlint // shares code with opt-out attempt, tests different error message, nolintlint because main config does not check lll in tests


### PR DESCRIPTION
## Problem

When an optional migration that was previously opted in and fully applied is later disabled, the DB's `CurrentVersion` bit for that migration stays set while the registry's `TargetVersion` no longer has it. With the old ordering, `validateNoVersionDowngrade` ran first and saw `CurrentVersion > TargetVersion`, misreporting an opt-out as a Juno version downgrade.

Example: `LastTargetVersion=0b111`, `CurrentVersion=0b111` (migration 2 enabled and applied), then the user restarts without `--migration-2` → registry `TargetVersion=0b011` → fires "version downgrade" instead of the correct "cannot opt out of previously enabled migrations".

  ## Fix
  - Run `validateNoOptOut` before `validateNoVersionDowngrade` so opt-out attempts surface their real error.
  - Make `validateNoOptOut` tolerant of bits beyond the current registry (a true downgrade from a newer Juno): skip out-of-range bits so the subsequent downgrade check can produce the right
  message.
  - Extend the opt-out test to cover the `CurrentVersion == LastTargetVersion` case that triggered the misclassification.