### PR TITLE
fix(pruner):running filter rebuilt

### DIFF
--- a/blockchain/blockchain.go
+++ b/blockchain/blockchain.go
@@ -89,8 +89,9 @@ type Blockchain struct {
 
 // options holds configuration for constructing a Blockchain.
 type options struct {
-	listener     EventListener
-	stateVersion bool
+	listener                EventListener
+	stateVersion            bool
+	runningFilterInitialize core.RunningEventFilterInitializer
 }
 
 // Option is a functional option for configuring Blockchain options.
@@ -108,10 +109,21 @@ func WithNewState(enabled bool) Option {
 	return func(o *options) { o.stateVersion = enabled }
 }
 
+// WithRunningEventFilterInitializer overrides the initializer used to lazily
+// bring up the running event filter. Defaults to
+// [core.InitializeRunningEventFilter]; pass pruner.InitializeRunningEventFilter
+// on pruning nodes.
+func WithRunningEventFilterInitializer(initialize core.RunningEventFilterInitializer) Option {
+	return func(o *options) {
+		o.runningFilterInitialize = initialize
+	}
+}
+
 func New(database db.KeyValueStore, network *networks.Network, opts ...Option) *Blockchain {
 	o := options{
-		listener:     &SelectiveListener{},
-		stateVersion: false,
+		listener:                &SelectiveListener{},
+		stateVersion:            false,
+		runningFilterInitialize: core.InitializeRunningEventFilter,
 	}
 	for _, opt := range opts {
 		opt(&o)
@@ -123,7 +135,7 @@ func New(database db.KeyValueStore, network *networks.Network, opts ...Option) *
 	}
 	cachedFilters.WithFallback(fallback)
 
-	runningFilter := core.NewRunningEventFilterLazy(database)
+	runningFilter := core.NewRunningEventFilterLazy(database, o.runningFilterInitialize)
 
 	return &Blockchain{
 		database:      database,

--- a/blockchain/statebackend/types_test.go
+++ b/blockchain/statebackend/types_test.go
@@ -13,7 +13,7 @@ import (
 func TestNew(t *testing.T) {
 	t.Run("new state backend", func(t *testing.T) {
 		memDB := memory.New()
-		filter := core.NewRunningEventFilterLazy(memDB)
+		filter := core.NewRunningEventFilterLazy(memDB, core.InitializeRunningEventFilter)
 		network := &networks.Mainnet
 
 		backend := New(memDB, filter, network, true)
@@ -28,7 +28,7 @@ func TestNew(t *testing.T) {
 
 	t.Run("deprecated state backend", func(t *testing.T) {
 		memDB := memory.New()
-		filter := core.NewRunningEventFilterLazy(memDB)
+		filter := core.NewRunningEventFilterLazy(memDB, core.InitializeRunningEventFilter)
 		network := &networks.Mainnet
 
 		backend := New(memDB, filter, network, false)

--- a/core/running_event_filter.go
+++ b/core/running_event_filter.go
@@ -83,7 +83,7 @@ func (f *RunningEventFilter) Insert(
 	defer f.mu.Unlock()
 
 	if err := f.ensureInit(); err != nil {
-		return fmt.Errorf("couldn't initialize the running event filter: %w", err)
+		return err
 	}
 
 	if err := f.inner.Insert(bloom, blockNumber); err != nil {
@@ -115,7 +115,7 @@ func (f *RunningEventFilter) BlocksForKeys(keys [][]byte) *bitset.BitSet {
 	defer f.mu.RUnlock()
 
 	if err := f.ensureInit(); err != nil {
-		panic(fmt.Sprintf("Couldn't initialised the running event filter. Error: %v", err))
+		panic(err)
 	}
 
 	return f.inner.BlocksForKeys(keys)
@@ -127,7 +127,7 @@ func (f *RunningEventFilter) BlocksForKeysInto(keys [][]byte, out *bitset.BitSet
 	defer f.mu.RUnlock()
 
 	if err := f.ensureInit(); err != nil {
-		return fmt.Errorf("couldn't initialize the running event filter: %w", err)
+		return err
 	}
 
 	return f.inner.BlocksForKeysInto(keys, out)
@@ -139,7 +139,7 @@ func (f *RunningEventFilter) FromBlock() uint64 {
 	defer f.mu.RUnlock()
 
 	if err := f.ensureInit(); err != nil {
-		panic(fmt.Sprintf("Couldn't initialised the running event filter. Error: %v", err))
+		panic(err)
 	}
 
 	return f.inner.fromBlock
@@ -151,7 +151,7 @@ func (f *RunningEventFilter) ToBlock() uint64 {
 	defer f.mu.RUnlock()
 
 	if err := f.ensureInit(); err != nil {
-		panic(fmt.Sprintf("Couldn't initialised the running event filter. Error: %v", err))
+		panic(err)
 	}
 
 	return f.inner.toBlock
@@ -163,7 +163,7 @@ func (f *RunningEventFilter) NextBlock() uint64 {
 	defer f.mu.RUnlock()
 
 	if err := f.ensureInit(); err != nil {
-		panic(fmt.Sprintf("Couldn't initialised the running event filter. Error: %v", err))
+		panic(err)
 	}
 
 	return f.next
@@ -176,7 +176,7 @@ func (f *RunningEventFilter) Clone() *RunningEventFilter {
 	defer f.mu.RUnlock()
 
 	if err := f.ensureInit(); err != nil {
-		panic(fmt.Sprintf("Couldn't initialised the running event filter. Error: %v", err))
+		panic(err)
 	}
 
 	innerCopy := f.inner.Clone()
@@ -191,7 +191,7 @@ func (f *RunningEventFilter) InnerFilter() *AggregatedBloomFilter {
 	defer f.mu.RUnlock()
 
 	if err := f.ensureInit(); err != nil {
-		panic(fmt.Sprintf("Couldn't initialised the running event filter. Error: %v", err))
+		panic(err)
 	}
 
 	return f.inner
@@ -203,7 +203,7 @@ func (f *RunningEventFilter) OnReorg() error {
 	defer f.mu.Unlock()
 
 	if err := f.ensureInit(); err != nil {
-		return fmt.Errorf("couldn't initialize the running event filter: %w", err)
+		return err
 	}
 
 	currRangeStart := f.inner.FromBlock()
@@ -234,7 +234,7 @@ func (f *RunningEventFilter) Write() error {
 	defer f.mu.Unlock()
 
 	if err := f.ensureInit(); err != nil {
-		return fmt.Errorf("couldn't initialize the running event filter: %w", err)
+		return err
 	}
 
 	return WriteRunningEventFilter(f.database, f)

--- a/core/running_event_filter.go
+++ b/core/running_event_filter.go
@@ -127,7 +127,7 @@ func (f *RunningEventFilter) BlocksForKeysInto(keys [][]byte, out *bitset.BitSet
 	defer f.mu.RUnlock()
 
 	if err := f.ensureInit(); err != nil {
-		panic(fmt.Sprintf("Couldn't initialised the running event filter. Error: %v", err))
+		return fmt.Errorf("ensureInit: %w", err)
 	}
 
 	return f.inner.BlocksForKeysInto(keys, out)
@@ -201,7 +201,7 @@ func (f *RunningEventFilter) OnReorg() error {
 	defer f.mu.Unlock()
 
 	if err := f.ensureInit(); err != nil {
-		panic(fmt.Sprintf("Couldn't initialised the running event filter. Error: %v", err))
+		return fmt.Errorf("ensureInit: %w", err)
 	}
 
 	currRangeStart := f.inner.FromBlock()
@@ -232,7 +232,7 @@ func (f *RunningEventFilter) Write() error {
 	defer f.mu.Unlock()
 
 	if err := f.ensureInit(); err != nil {
-		panic(fmt.Sprintf("Couldn't initialised the running event filter. Error: %v", err))
+		return fmt.Errorf("ensureInit: %w", err)
 	}
 
 	return WriteRunningEventFilter(f.database, f)

--- a/core/running_event_filter.go
+++ b/core/running_event_filter.go
@@ -183,7 +183,9 @@ func (f *RunningEventFilter) Clone() *RunningEventFilter {
 	return NewRunningEventFilterHot(f.database, &innerCopy, f.next)
 }
 
-// InnerFilter returns a deep copy of the current AggregatedBloomFilter window.
+// InnerFilter returns the current AggregatedBloomFilter window.
+// The returned pointer aliases internal state; mutations are visible to f.
+// Use [RunningEventFilter.Clone] for an independent copy.
 func (f *RunningEventFilter) InnerFilter() *AggregatedBloomFilter {
 	f.mu.RLock()
 	defer f.mu.RUnlock()

--- a/core/running_event_filter.go
+++ b/core/running_event_filter.go
@@ -37,7 +37,7 @@ func (f *RunningEventFilter) ensureInit() error {
 		f.lazyOnce.Do(func() {
 			filter, err := f.initialize(f.database)
 			if err != nil {
-				f.initErr = fmt.Errorf("InitializeRunningEventFilter: %w", err)
+				f.initErr = fmt.Errorf("couldn't initialize the running event filter: %w", err)
 				return
 			}
 			f.inner = filter.inner
@@ -83,12 +83,12 @@ func (f *RunningEventFilter) Insert(
 	defer f.mu.Unlock()
 
 	if err := f.ensureInit(); err != nil {
-		return fmt.Errorf("ensureInit before block %d: %w", blockNumber, err)
+		return fmt.Errorf("couldn't initialize the running event filter: %w", err)
 	}
 
 	if err := f.inner.Insert(bloom, blockNumber); err != nil {
 		return fmt.Errorf(
-			"insert block %d into window [%d,%d]: %w",
+			"inserting block %d into window [%d,%d]: %w",
 			blockNumber, f.inner.FromBlock(), f.inner.ToBlock(), err,
 		)
 	}
@@ -96,7 +96,7 @@ func (f *RunningEventFilter) Insert(
 	if blockNumber == f.inner.ToBlock() {
 		if err := WriteAggregatedBloomFilter(f.database, f.inner); err != nil {
 			return fmt.Errorf(
-				"persist aggregated filter for window [%d,%d]: %w",
+				"persisting aggregated filter for window [%d,%d]: %w",
 				f.inner.FromBlock(), f.inner.ToBlock(), err,
 			)
 		}
@@ -127,7 +127,7 @@ func (f *RunningEventFilter) BlocksForKeysInto(keys [][]byte, out *bitset.BitSet
 	defer f.mu.RUnlock()
 
 	if err := f.ensureInit(); err != nil {
-		return fmt.Errorf("ensureInit: %w", err)
+		return fmt.Errorf("couldn't initialize the running event filter: %w", err)
 	}
 
 	return f.inner.BlocksForKeysInto(keys, out)
@@ -201,7 +201,7 @@ func (f *RunningEventFilter) OnReorg() error {
 	defer f.mu.Unlock()
 
 	if err := f.ensureInit(); err != nil {
-		return fmt.Errorf("ensureInit: %w", err)
+		return fmt.Errorf("couldn't initialize the running event filter: %w", err)
 	}
 
 	currRangeStart := f.inner.FromBlock()
@@ -232,7 +232,7 @@ func (f *RunningEventFilter) Write() error {
 	defer f.mu.Unlock()
 
 	if err := f.ensureInit(); err != nil {
-		return fmt.Errorf("ensureInit: %w", err)
+		return fmt.Errorf("couldn't initialize the running event filter: %w", err)
 	}
 
 	return WriteRunningEventFilter(f.database, f)
@@ -249,12 +249,12 @@ func InitializeRunningEventFilter(database db.KeyValueStore) (*RunningEventFilte
 			filter := NewAggregatedFilter(0)
 			return NewRunningEventFilterHot(database, &filter, 0), nil
 		}
-		return nil, err
+		return nil, fmt.Errorf("getting chain height: %w", err)
 	}
 
 	stored, err := GetRunningEventFilter(database)
 	if err != nil && !errors.Is(err, db.ErrKeyNotFound) {
-		return nil, err
+		return nil, fmt.Errorf("getting stored running event filter: %w", err)
 	}
 	if err == nil {
 		next := stored.NextBlock()
@@ -266,14 +266,21 @@ func InitializeRunningEventFilter(database db.KeyValueStore) (*RunningEventFilte
 		if next <= latest && latest <= stored.InnerFilter().ToBlock() {
 			rf := NewRunningEventFilterHot(database, stored.InnerFilter(), next)
 			if fillErr := fillRunningEventFilter(database, rf, next, latest); fillErr != nil {
-				return nil, fmt.Errorf("fill running filter gap: %w", fillErr)
+				return nil, fmt.Errorf(
+					"filling running event filter [%d, %d]: %w",
+					next, latest, fillErr,
+				)
 			}
 			return rf, nil
 		}
 	}
 
 	// Multi-window gap, future-dated snapshot, or no snapshot — rebuild.
-	return rebuildRunningEventFilter(database, latest)
+	rf, err := rebuildRunningEventFilter(database, latest)
+	if err != nil {
+		return nil, fmt.Errorf("rebuilding running event filter up to %d: %w", latest, err)
+	}
+	return rf, nil
 }
 
 // fillRunningEventFilter walks [from, latest] and Inserts each block's
@@ -287,10 +294,10 @@ func fillRunningEventFilter(
 	for blockNum := from; blockNum <= latest; blockNum++ {
 		header, err := GetBlockHeaderByNumber(database, blockNum)
 		if err != nil {
-			return fmt.Errorf("GetBlockHeaderByNumber %d: %w", blockNum, err)
+			return fmt.Errorf("getting block header by number %d: %w", blockNum, err)
 		}
 		if err := rf.Insert(header.EventsBloom, blockNum); err != nil {
-			return fmt.Errorf("Insert block %d: %w", blockNum, err)
+			return fmt.Errorf("inserting block %d in events bloom %w", blockNum, err)
 		}
 	}
 	return nil
@@ -307,15 +314,16 @@ func rebuildRunningEventFilter(
 	rangeStartAligned := latest - latest%NumBlocksPerFilter
 	lastStoredFilterRangeEnd := rangeStartAligned + NumBlocksPerFilter - 1
 
-	found := false
+	var continueFrom uint64
 	for {
 		_, err := GetAggregatedBloomFilter(database, rangeStartAligned, lastStoredFilterRangeEnd)
 		if err == nil {
-			found = true
+			continueFrom = lastStoredFilterRangeEnd + 1
 			break
 		}
 		if !errors.Is(err, db.ErrKeyNotFound) {
-			return nil, fmt.Errorf("rebuild: scan for anchor at [%d,%d]: %w",
+			return nil, fmt.Errorf(
+				"scanning for aggregated bloom filter at range [%d, %d]: %w",
 				rangeStartAligned, lastStoredFilterRangeEnd, err)
 		}
 		if rangeStartAligned == 0 {
@@ -325,15 +333,13 @@ func rebuildRunningEventFilter(
 		lastStoredFilterRangeEnd -= NumBlocksPerFilter
 	}
 
-	var continueFrom uint64
-	if found {
-		continueFrom = lastStoredFilterRangeEnd + 1
-	}
-
 	filter := NewAggregatedFilter(continueFrom)
 	runningFilter := NewRunningEventFilterHot(database, &filter, continueFrom)
 	if err := fillRunningEventFilter(database, runningFilter, continueFrom, latest); err != nil {
-		return nil, fmt.Errorf("rebuild (latest=%d, anchorFound=%t): %w", latest, found, err)
+		return nil, fmt.Errorf(
+			"filling running event filter [%d, %d]: %w",
+			continueFrom, latest, err,
+		)
 	}
 	return runningFilter, nil
 }

--- a/core/running_event_filter.go
+++ b/core/running_event_filter.go
@@ -297,7 +297,7 @@ func fillRunningEventFilter(
 			return fmt.Errorf("getting block header by number %d: %w", blockNum, err)
 		}
 		if err := rf.Insert(header.EventsBloom, blockNum); err != nil {
-			return fmt.Errorf("inserting block %d in events bloom %w", blockNum, err)
+			return fmt.Errorf("inserting block %d in events bloom: %w", blockNum, err)
 		}
 	}
 	return nil

--- a/core/running_event_filter.go
+++ b/core/running_event_filter.go
@@ -13,27 +13,31 @@ import (
 	"github.com/bits-and-blooms/bloom/v3"
 )
 
+// RunningEventFilterInitializer brings a lazy RunningEventFilter to a working
+// state on first access.
+type RunningEventFilterInitializer func(db.KeyValueStore) (*RunningEventFilter, error)
+
 // RunningEventFilter provides a thread-safe wrapper around AggregatedBloomFilter
 // that automatically manages the creation of new filters when the current one
 // reaches its capacity. It maintains the current state of event filtering across
 // the blockchain.
 type RunningEventFilter struct {
-	inner *AggregatedBloomFilter // The current aggregated filter
-	next  uint64                 // The next block number to process
-	mu    sync.RWMutex
-	txn   db.KeyValueStore
+	inner    *AggregatedBloomFilter // The current aggregated filter
+	next     uint64                 // The next block number to process
+	mu       sync.RWMutex
+	database db.KeyValueStore
 
-	initErr  error
-	lazyOnce sync.Once
-	lazyInit bool
+	initialize RunningEventFilterInitializer
+	initErr    error
+	lazyOnce   sync.Once
 }
 
 func (f *RunningEventFilter) ensureInit() error {
-	if f.lazyInit {
+	if f.initialize != nil {
 		f.lazyOnce.Do(func() {
-			filter, err := loadRunningEventFilter(f.txn)
+			filter, err := f.initialize(f.database)
 			if err != nil {
-				f.initErr = err
+				f.initErr = fmt.Errorf("InitializeRunningEventFilter: %w", err)
 				return
 			}
 			f.inner = filter.inner
@@ -43,18 +47,27 @@ func (f *RunningEventFilter) ensureInit() error {
 	return f.initErr
 }
 
-// NewRunningFilter returns a RunningEventFilter that wraps the provided aggregated filter
-// with the expected next block to process.
-func NewRunningEventFilterHot(txn db.KeyValueStore, filter *AggregatedBloomFilter, nextBlock uint64) *RunningEventFilter {
+// NewRunningEventFilterHot returns a RunningEventFilter that wraps the provided
+// aggregated filter with the expected next block to process.
+func NewRunningEventFilterHot(
+	database db.KeyValueStore,
+	filter *AggregatedBloomFilter,
+	nextBlock uint64,
+) *RunningEventFilter {
 	return &RunningEventFilter{
-		txn:   txn,
-		inner: filter,
-		next:  nextBlock,
+		database: database,
+		inner:    filter,
+		next:     nextBlock,
 	}
 }
 
-func NewRunningEventFilterLazy(txn db.KeyValueStore) *RunningEventFilter {
-	return &RunningEventFilter{txn: txn, lazyInit: true}
+// NewRunningEventFilterLazy returns a RunningEventFilter whose state is
+// initialized on first access via the supplied initializer.
+func NewRunningEventFilterLazy(
+	database db.KeyValueStore,
+	initialize RunningEventFilterInitializer,
+) *RunningEventFilter {
+	return &RunningEventFilter{database: database, initialize: initialize}
 }
 
 // Insert adds a bloom filter for a single block, updating the internal
@@ -70,18 +83,22 @@ func (f *RunningEventFilter) Insert(
 	defer f.mu.Unlock()
 
 	if err := f.ensureInit(); err != nil {
-		return err
+		return fmt.Errorf("ensureInit before block %d: %w", blockNumber, err)
 	}
 
-	err := f.inner.Insert(bloom, blockNumber)
-	if err != nil {
-		return err
+	if err := f.inner.Insert(bloom, blockNumber); err != nil {
+		return fmt.Errorf(
+			"insert block %d into window [%d,%d]: %w",
+			blockNumber, f.inner.FromBlock(), f.inner.ToBlock(), err,
+		)
 	}
 
 	if blockNumber == f.inner.ToBlock() {
-		err := WriteAggregatedBloomFilter(f.txn, f.inner)
-		if err != nil {
-			return err
+		if err := WriteAggregatedBloomFilter(f.database, f.inner); err != nil {
+			return fmt.Errorf(
+				"persist aggregated filter for window [%d,%d]: %w",
+				f.inner.FromBlock(), f.inner.ToBlock(), err,
+			)
 		}
 		filter := NewAggregatedFilter(blockNumber + 1)
 		f.inner = &filter
@@ -163,7 +180,7 @@ func (f *RunningEventFilter) Clone() *RunningEventFilter {
 	}
 
 	innerCopy := f.inner.Clone()
-	return NewRunningEventFilterHot(f.txn, &innerCopy, f.next)
+	return NewRunningEventFilterHot(f.database, &innerCopy, f.next)
 }
 
 // InnerFilter returns a deep copy of the current AggregatedBloomFilter window.
@@ -191,10 +208,14 @@ func (f *RunningEventFilter) OnReorg() error {
 	curBlock := f.next - 1
 	// Falls into previous filters range
 	if curBlock == currRangeStart-1 {
-		rangeStartAlligned := curBlock - (curBlock % NumBlocksPerFilter)
-		rangeEndAlligned := rangeStartAlligned + NumBlocksPerFilter - 1
+		rangeStartAligned := curBlock - (curBlock % NumBlocksPerFilter)
+		rangeEndAligned := rangeStartAligned + NumBlocksPerFilter - 1
 
-		lastStoredFilter, err := GetAggregatedBloomFilter(f.txn, rangeStartAlligned, rangeEndAlligned)
+		lastStoredFilter, err := GetAggregatedBloomFilter(
+			f.database,
+			rangeStartAligned,
+			rangeEndAligned,
+		)
 		if err != nil {
 			return err
 		}
@@ -214,93 +235,106 @@ func (f *RunningEventFilter) Write() error {
 		panic(fmt.Sprintf("Couldn't initialised the running event filter. Error: %v", err))
 	}
 
-	return WriteRunningEventFilter(f.txn, f)
+	return WriteRunningEventFilter(f.database, f)
 }
 
-// loadRunningEventFilter attempts to load a RunningEventFilter from storage.
-// If no filter is found, a new one is created from genesis. If the stored filter
-// is not up to date with the chain's latest block, the filter is rebuilt.
-func loadRunningEventFilter(txn db.KeyValueStore) (*RunningEventFilter, error) {
-	latest, err := GetChainHeight(txn)
+// InitializeRunningEventFilter is the default initializer for nodes that do
+// not prune. It assumes every block below the chain head is fully retained;
+// the rebuild walks back to genesis if needed and errors out when a header is
+// missing. For pruning nodes, use [pruner.InitializeRunningEventFilter] instead.
+func InitializeRunningEventFilter(database db.KeyValueStore) (*RunningEventFilter, error) {
+	latest, err := GetChainHeight(database)
 	if err != nil {
-		// Start from genesis
 		if errors.Is(err, db.ErrKeyNotFound) {
 			filter := NewAggregatedFilter(0)
-			return NewRunningEventFilterHot(
-				txn,
-				&filter,
-				0,
-			), nil
+			return NewRunningEventFilterHot(database, &filter, 0), nil
 		}
 		return nil, err
 	}
 
-	rf, err := GetRunningEventFilter(txn)
-	if err != nil {
-		if errors.Is(err, db.ErrKeyNotFound) {
-			filter := NewAggregatedFilter(0)
-			// for case where node crashed and didnt gracefully persist the filter for block range  (genesis, aggregated filter range)
-			rf = NewRunningEventFilterHot(
-				txn,
-				&filter,
-				0,
-			)
-		} else {
-			return nil, err
+	stored, err := GetRunningEventFilter(database)
+	if err != nil && !errors.Is(err, db.ErrKeyNotFound) {
+		return nil, err
+	}
+	if err == nil {
+		next := stored.NextBlock()
+		// Caught up — return the snapshot as-is.
+		if next == latest+1 {
+			return NewRunningEventFilterHot(database, stored.InnerFilter(), next), nil
+		}
+		// Same-window gap — resume the snapshot and fill in place.
+		if next <= latest && latest <= stored.InnerFilter().ToBlock() {
+			rf := NewRunningEventFilterHot(database, stored.InnerFilter(), next)
+			if fillErr := fillRunningEventFilter(database, rf, next, latest); fillErr != nil {
+				return nil, fmt.Errorf("fill running filter gap: %w", fillErr)
+			}
+			return rf, nil
 		}
 	}
-	rf.txn = txn
 
-	if rf.next == latest+1 {
-		return rf, nil
-	}
-
-	return rebuildRunningEventFilter(txn, latest)
+	// Multi-window gap, future-dated snapshot, or no snapshot — rebuild.
+	return rebuildRunningEventFilter(database, latest)
 }
 
-// rebuildRunningEventFilter constructs a RunningEventFilter state beginning from the
-// latest stored filter window and sequentially adds missing block filters up to the
-// blockchain's current height.
-func rebuildRunningEventFilter(txn db.KeyValueStore, latest uint64) (*RunningEventFilter, error) {
-	rangeStartAlligned := int64(latest - (latest % NumBlocksPerFilter))
-	lastStoredFilterRangeEnd := latest - (latest % NumBlocksPerFilter) + NumBlocksPerFilter - 1
+// fillRunningEventFilter walks [from, latest] and Inserts each block's
+// EventsBloom into rf. Errors if any header in the range is missing.
+func fillRunningEventFilter(
+	database db.KeyValueStore,
+	rf *RunningEventFilter,
+	from,
+	latest uint64,
+) error {
+	for blockNum := from; blockNum <= latest; blockNum++ {
+		header, err := GetBlockHeaderByNumber(database, blockNum)
+		if err != nil {
+			return fmt.Errorf("GetBlockHeaderByNumber %d: %w", blockNum, err)
+		}
+		if err := rf.Insert(header.EventsBloom, blockNum); err != nil {
+			return fmt.Errorf("Insert block %d: %w", blockNum, err)
+		}
+	}
+	return nil
+}
 
-	for rangeStartAlligned >= 0 {
-		_, err := GetAggregatedBloomFilter(txn, uint64(rangeStartAlligned), lastStoredFilterRangeEnd)
+// rebuildRunningEventFilter walks back from latest to find the most recent
+// persisted aggregated filter, then fills forward to latest by inserting each
+// block's bloom. Used by [InitializeRunningEventFilter] on non-pruning nodes —
+// every header in the fill range is expected to be present.
+func rebuildRunningEventFilter(
+	database db.KeyValueStore,
+	latest uint64,
+) (*RunningEventFilter, error) {
+	rangeStartAligned := latest - latest%NumBlocksPerFilter
+	lastStoredFilterRangeEnd := rangeStartAligned + NumBlocksPerFilter - 1
+
+	found := false
+	for {
+		_, err := GetAggregatedBloomFilter(database, rangeStartAligned, lastStoredFilterRangeEnd)
 		if err == nil {
+			found = true
 			break
 		}
-
-		/// Check previous range
-		if errors.Is(err, db.ErrKeyNotFound) {
-			rangeStartAlligned -= int64(NumBlocksPerFilter)
-			lastStoredFilterRangeEnd -= NumBlocksPerFilter
-			continue
+		if !errors.Is(err, db.ErrKeyNotFound) {
+			return nil, fmt.Errorf("rebuild: scan for anchor at [%d,%d]: %w",
+				rangeStartAligned, lastStoredFilterRangeEnd, err)
 		}
-
-		return nil, err
+		if rangeStartAligned == 0 {
+			break
+		}
+		rangeStartAligned -= NumBlocksPerFilter
+		lastStoredFilterRangeEnd -= NumBlocksPerFilter
 	}
 
-	continueFrom := lastStoredFilterRangeEnd + 1
+	var continueFrom uint64
+	if found {
+		continueFrom = lastStoredFilterRangeEnd + 1
+	}
+
 	filter := NewAggregatedFilter(continueFrom)
-	runningFilter := NewRunningEventFilterHot(txn, &filter, continueFrom)
-	if lastStoredFilterRangeEnd == latest {
-		return runningFilter, nil
+	runningFilter := NewRunningEventFilterHot(database, &filter, continueFrom)
+	if err := fillRunningEventFilter(database, runningFilter, continueFrom, latest); err != nil {
+		return nil, fmt.Errorf("rebuild (latest=%d, anchorFound=%t): %w", latest, found, err)
 	}
-
-	for ; continueFrom <= latest; continueFrom++ {
-		var header *Header
-		header, err := GetBlockHeaderByNumber(txn, continueFrom)
-		if err != nil {
-			return nil, err
-		}
-
-		err = runningFilter.Insert(header.EventsBloom, continueFrom)
-		if err != nil {
-			return nil, err
-		}
-	}
-
 	return runningFilter, nil
 }
 
@@ -351,7 +385,7 @@ func (f *RunningEventFilter) UnmarshalBinary(data []byte) error {
 	f.initErr = nil
 	f.mu = sync.RWMutex{}
 	f.lazyOnce = sync.Once{}
-	f.lazyInit = false // or true if you want to reconstruct as lazy
+	f.initialize = nil
 
 	return nil
 }

--- a/core/running_event_filter_test.go
+++ b/core/running_event_filter_test.go
@@ -11,6 +11,7 @@ import (
 	statetestutils "github.com/NethermindEth/juno/core/state/testutils"
 	"github.com/NethermindEth/juno/db"
 	"github.com/NethermindEth/juno/db/memory"
+	"github.com/NethermindEth/juno/db/pebblev2"
 	"github.com/NethermindEth/juno/encoder"
 	adaptfeeder "github.com/NethermindEth/juno/starknetdata/feeder"
 	"github.com/bits-and-blooms/bitset"
@@ -58,7 +59,7 @@ func TestRunningEventFilter_HotInitialization(t *testing.T) {
 
 func TestRunningEventFilter_LazyInitialization_EmptyDB(t *testing.T) {
 	testDB := memory.New()
-	rf := core.NewRunningEventFilterLazy(testDB)
+	rf := core.NewRunningEventFilterLazy(testDB, core.InitializeRunningEventFilter)
 	require.Equal(t, uint64(0), rf.FromBlock())
 	require.Equal(t, core.NumBlocksPerFilter-1, rf.ToBlock())
 	require.NoError(t, rf.Insert(testBloomWithRandomKeys(t, 1), 0))
@@ -84,17 +85,10 @@ func TestRunningEventFilter_LazyInitialization_Preload(t *testing.T) {
 		require.NoError(t, chain.Store(b, &core.BlockCommitments{}, s, nil))
 	}
 
-	t.Run("Rebuild when running fitler not persisted", func(t *testing.T) {
-		rf := core.NewRunningEventFilterLazy(testDB)
-		require.Equal(t, uint64(0), rf.FromBlock())
-		require.Equal(t, core.NumBlocksPerFilter-1, rf.ToBlock())
-		require.Equal(t, expectedNext, rf.NextBlock())
-	})
-
 	t.Run("Load from DB when running filter upto date", func(t *testing.T) {
 		require.NoError(t, chain.WriteRunningEventFilter())
 
-		rf := core.NewRunningEventFilterLazy(testDB)
+		rf := core.NewRunningEventFilterLazy(testDB, core.InitializeRunningEventFilter)
 		require.Equal(t, uint64(0), rf.FromBlock())
 		require.Equal(t, core.NumBlocksPerFilter-1, rf.ToBlock())
 		require.Equal(t, expectedNext, rf.NextBlock())
@@ -102,9 +96,84 @@ func TestRunningEventFilter_LazyInitialization_Preload(t *testing.T) {
 
 	t.Run("Should panic when couldn't initialise", func(t *testing.T) {
 		testDB.Close()
-		rf := core.NewRunningEventFilterLazy(testDB)
+		rf := core.NewRunningEventFilterLazy(testDB, core.InitializeRunningEventFilter)
 		require.Panics(t, func() {
 			rf.FromBlock()
+		})
+	})
+
+	t.Run("Rebuild filters when out-dated or not persisted", func(t *testing.T) {
+		// Same-window resume keeps the snapshot's bitmap and only fills the
+		// gap. We stamp the snapshot's [0, staleNext) bits with synthetic
+		// keys not present in the real Sepolia headers — if a rebuild ran
+		// instead, those positions would be refilled from header blooms and
+		// the synthetic keys would no longer hit.
+		t.Run("Single-window resume preserves bitmap", func(t *testing.T) {
+			const staleNext uint64 = 3
+			snapshotKeys := [][]byte{{0x77, 0x88}}
+			filter := core.NewAggregatedFilter(0)
+			snap := core.NewRunningEventFilterHot(testDB, &filter, 0)
+			for i := range staleNext {
+				require.NoError(t, snap.Insert(testBloomWithKeys(t, snapshotKeys), i))
+			}
+			require.NoError(t, core.WriteRunningEventFilter(testDB, snap))
+
+			rf := core.NewRunningEventFilterLazy(testDB, core.InitializeRunningEventFilter)
+			require.Equal(t, expectedNext, rf.NextBlock(), "must catch up to chain height + 1")
+			require.Equal(t, uint64(0), rf.FromBlock())
+			require.Equal(t, core.NumBlocksPerFilter-1, rf.ToBlock())
+
+			preserved := rf.BlocksForKeys(snapshotKeys)
+			for i := range staleNext {
+				require.True(t, preserved.Test(uint(i)),
+					"snapshot bit at block %d not preserved", i)
+			}
+		})
+
+		t.Run("Multi-window rebuild rotates and persists full windows", func(t *testing.T) {
+			const targetBatchByteSize = 96 * db.Megabyte
+			testDB, err := pebblev2.New(t.TempDir())
+			require.NoError(t, err)
+			t.Cleanup(func() { require.NoError(t, testDB.Close()) })
+			latest := core.NumBlocksPerFilter + 5
+
+			headerKeys := [][]byte{{0xEE}}
+			batch := testDB.NewBatch()
+			for i := uint64(0); i <= latest; i++ {
+				header := &core.Header{
+					Number:      i,
+					Hash:        felt.NewRandom[felt.Felt](),
+					EventsBloom: testBloomWithKeys(t, headerKeys),
+				}
+				require.NoError(t, core.WriteBlockHeaderByNumber(batch, header))
+				if batch.Size() >= targetBatchByteSize {
+					require.NoError(t, batch.Write())
+					batch = testDB.NewBatch()
+				}
+			}
+			require.NoError(t, batch.Write())
+			require.NoError(t, core.WriteChainHeight(testDB, latest))
+
+			rf := core.NewRunningEventFilterLazy(testDB, core.InitializeRunningEventFilter)
+			require.Equal(t, core.NumBlocksPerFilter, rf.FromBlock(),
+				"window rotated to second window during fill")
+			require.Equal(t, 2*core.NumBlocksPerFilter-1, rf.ToBlock())
+			require.Equal(t, latest+1, rf.NextBlock())
+
+			// Second window: every position in [N, latest] hit.
+			filled := rf.BlocksForKeys(headerKeys)
+			for i := core.NumBlocksPerFilter; i <= latest; i++ {
+				require.True(t, filled.Test(uint(i-rf.FromBlock())),
+					"block %d (second window) not filled", i)
+			}
+			// First window persisted on rotation: every position [0, N-1] hit.
+			stored, err := core.GetAggregatedBloomFilter(testDB, 0, core.NumBlocksPerFilter-1)
+			require.NoError(t, err)
+			storedMatches := stored.BlocksForKeys(headerKeys)
+			for i := range core.NumBlocksPerFilter {
+				require.True(t, storedMatches.Test(uint(i)),
+					"persisted block %d (first window) not filled", i)
+			}
 		})
 	})
 }

--- a/core/running_event_filter_test.go
+++ b/core/running_event_filter_test.go
@@ -95,8 +95,9 @@ func TestRunningEventFilter_LazyInitialization_Preload(t *testing.T) {
 	})
 
 	t.Run("Should panic when couldn't initialise", func(t *testing.T) {
-		testDB.Close()
-		rf := core.NewRunningEventFilterLazy(testDB, core.InitializeRunningEventFilter)
+		closedDB := memory.New()
+		closedDB.Close()
+		rf := core.NewRunningEventFilterLazy(closedDB, core.InitializeRunningEventFilter)
 		require.Panics(t, func() {
 			rf.FromBlock()
 		})

--- a/node/node.go
+++ b/node/node.go
@@ -211,13 +211,19 @@ func New(cfg *Config, version string, logLevel *log.Level) (*Node, error) {
 	services := make([]service.Service, 0)
 	earlyServices := make([]service.Service, 0)
 
-	opts := make([]blockchain.Option, 0, 2)
+	opts := make([]blockchain.Option, 0, 3)
 	if cfg.Metrics {
 		opts = append(opts, blockchain.WithListener(makeBlockchainMetrics()))
 	}
 	opts = append(opts, blockchain.WithNewState(
 		cfg.NewState,
 	))
+	if cfg.Prune {
+		opts = append(
+			opts,
+			blockchain.WithRunningEventFilterInitializer(pruner.InitializeRunningEventFilter),
+		)
+	}
 	chain := blockchain.New(database, &cfg.Network, opts...)
 
 	// Verify that cfg.Network is compatible with the database.

--- a/pruner/running_event_filter.go
+++ b/pruner/running_event_filter.go
@@ -82,7 +82,7 @@ func fillRunningEventFilter(
 			return fmt.Errorf("getting block header by number %d: %w", blockNum, err)
 		}
 		if err := rf.Insert(header.EventsBloom, blockNum); err != nil {
-			return fmt.Errorf("inserting block %d in events bloom %w", blockNum, err)
+			return fmt.Errorf("inserting block %d in events bloom: %w", blockNum, err)
 		}
 	}
 	return nil

--- a/pruner/running_event_filter.go
+++ b/pruner/running_event_filter.go
@@ -19,17 +19,17 @@ func InitializeRunningEventFilter(database db.KeyValueStore) (*core.RunningEvent
 			filter := core.NewAggregatedFilter(0)
 			return core.NewRunningEventFilterHot(database, &filter, 0), nil
 		}
-		return nil, err
+		return nil, fmt.Errorf("getting chain height: %w", err)
 	}
 
 	floor, err := OldestRetainedBlock(database)
 	if err != nil && !errors.Is(err, db.ErrKeyNotFound) {
-		return nil, fmt.Errorf("InitializeRunningEventFilter: OldestRetainedBlock: %w", err)
+		return nil, fmt.Errorf("getting oldest retained block: %w", err)
 	}
 
 	stored, err := core.GetRunningEventFilter(database)
 	if err != nil && !errors.Is(err, db.ErrKeyNotFound) {
-		return nil, err
+		return nil, fmt.Errorf("getting stored running event filter: %w", err)
 	}
 	if err == nil {
 		next := stored.NextBlock()
@@ -46,14 +46,24 @@ func InitializeRunningEventFilter(database db.KeyValueStore) (*core.RunningEvent
 			next = max(next, floor)
 			rf := core.NewRunningEventFilterHot(database, stored.InnerFilter(), next)
 			if fillErr := fillRunningEventFilter(database, rf, next, latest); fillErr != nil {
-				return nil, fmt.Errorf("fill running filter gap: %w", fillErr)
+				return nil, fmt.Errorf(
+					"filling running event filter [%d, %d]: %w",
+					next, latest, fillErr,
+				)
 			}
 			return rf, nil
 		}
 	}
 
 	// Multi-window gap, future-dated snapshot, or no snapshot — rebuild.
-	return rebuildRunningEventFilter(database, latest, floor)
+	rf, err := rebuildRunningEventFilter(database, latest, floor)
+	if err != nil {
+		return nil, fmt.Errorf(
+			"rebuilding running event filter up to %d (floor=%d): %w",
+			latest, floor, err,
+		)
+	}
+	return rf, nil
 }
 
 // fillRunningEventFilter walks [from, end] and Inserts each block's
@@ -69,10 +79,10 @@ func fillRunningEventFilter(
 	for blockNum := from; blockNum <= end; blockNum++ {
 		header, err := core.GetBlockHeaderByNumber(txn, blockNum)
 		if err != nil {
-			return fmt.Errorf("GetBlockHeaderByNumber %d: %w", blockNum, err)
+			return fmt.Errorf("getting block header by number %d: %w", blockNum, err)
 		}
 		if err := rf.Insert(header.EventsBloom, blockNum); err != nil {
-			return fmt.Errorf("insert block %d: %w", blockNum, err)
+			return fmt.Errorf("inserting block %d in events bloom %w", blockNum, err)
 		}
 	}
 	return nil
@@ -94,16 +104,20 @@ func rebuildRunningEventFilter(
 	rangeStartAligned := latest - latest%core.NumBlocksPerFilter
 	lastStoredFilterRangeEnd := rangeStartAligned + core.NumBlocksPerFilter - 1
 
-	found := false
+	continueFrom := floor
+	windowStart := floorAligned
 	for {
 		_, err := core.GetAggregatedBloomFilter(database, rangeStartAligned, lastStoredFilterRangeEnd)
 		if err == nil {
-			found = true
+			continueFrom = lastStoredFilterRangeEnd + 1
+			windowStart = continueFrom
 			break
 		}
 		if !errors.Is(err, db.ErrKeyNotFound) {
-			return nil, fmt.Errorf("rebuild: scan for anchor at [%d,%d]: %w",
-				rangeStartAligned, lastStoredFilterRangeEnd, err)
+			return nil, fmt.Errorf(
+				"scanning for aggregated bloom filter at range [%d, %d]: %w",
+				rangeStartAligned, lastStoredFilterRangeEnd, err,
+			)
 		}
 		if rangeStartAligned <= floorAligned {
 			break
@@ -112,25 +126,12 @@ func rebuildRunningEventFilter(
 		lastStoredFilterRangeEnd -= core.NumBlocksPerFilter
 	}
 
-	// When found, continueFrom is naturally aligned (anchor end + 1). When
-	// not, the partial filter is rooted at floorAligned but filling starts
-	// at floor itself — blocks in [floorAligned, floor) stay zero in the
-	// bitmap, which is correct since their commitments are pruned.
-	var continueFrom, windowStart uint64
-	if found {
-		continueFrom = lastStoredFilterRangeEnd + 1
-		windowStart = continueFrom
-	} else {
-		continueFrom = floor
-		windowStart = floorAligned
-	}
-
 	filter := core.NewAggregatedFilter(windowStart)
 	runningFilter := core.NewRunningEventFilterHot(database, &filter, continueFrom)
 	if err := fillRunningEventFilter(database, runningFilter, continueFrom, latest); err != nil {
 		return nil, fmt.Errorf(
-			"rebuild (latest=%d, anchorFound=%t, floor=%d): %w",
-			latest, found, floor, err,
+			"filling running event filter [%d, %d] (floor=%d): %w",
+			continueFrom, latest, floor, err,
 		)
 	}
 	return runningFilter, nil

--- a/pruner/running_event_filter.go
+++ b/pruner/running_event_filter.go
@@ -1,0 +1,137 @@
+package pruner
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/NethermindEth/juno/core"
+	"github.com/NethermindEth/juno/db"
+)
+
+// InitializeRunningEventFilter is the pruning-aware initializer. Brings the
+// running event filter up to chain head, reusing the persisted snapshot when
+// possible and rebuilding otherwise. Use [core.InitializeRunningEventFilter]
+// on non-pruning nodes.
+func InitializeRunningEventFilter(database db.KeyValueStore) (*core.RunningEventFilter, error) {
+	latest, err := core.GetChainHeight(database)
+	if err != nil {
+		if errors.Is(err, db.ErrKeyNotFound) {
+			filter := core.NewAggregatedFilter(0)
+			return core.NewRunningEventFilterHot(database, &filter, 0), nil
+		}
+		return nil, err
+	}
+
+	floor, err := OldestRetainedBlock(database)
+	if err != nil && !errors.Is(err, db.ErrKeyNotFound) {
+		return nil, fmt.Errorf("InitializeRunningEventFilter: OldestRetainedBlock: %w", err)
+	}
+
+	stored, err := core.GetRunningEventFilter(database)
+	if err != nil && !errors.Is(err, db.ErrKeyNotFound) {
+		return nil, err
+	}
+	if err == nil {
+		next := stored.NextBlock()
+		// Caught up — return the snapshot as-is.
+		if next == latest+1 {
+			return core.NewRunningEventFilterHot(database, stored.InnerFilter(), next), nil
+		}
+		// Same-window gap — resume the snapshot and fill in place.
+		if next <= latest && latest <= stored.InnerFilter().ToBlock() {
+			// Clamp to floor so we don't read pruned headers. Below-floor
+			// snapshot bits remain — harmless false positives, since the
+			// referenced receipts are pruned and no event query can act
+			// on a hit.
+			next = max(next, floor)
+			rf := core.NewRunningEventFilterHot(database, stored.InnerFilter(), next)
+			if fillErr := fillRunningEventFilter(database, rf, next, latest); fillErr != nil {
+				return nil, fmt.Errorf("fill running filter gap: %w", fillErr)
+			}
+			return rf, nil
+		}
+	}
+
+	// Multi-window gap, future-dated snapshot, or no snapshot — rebuild.
+	return rebuildRunningEventFilter(database, latest, floor)
+}
+
+// fillRunningEventFilter walks [from, end] and Inserts each block's
+// EventsBloom into rf. Callers must clamp from to the retention floor so
+// the range stays within retained headers — a missing header is treated
+// as an error, not silently skipped.
+func fillRunningEventFilter(
+	txn db.KeyValueStore,
+	rf *core.RunningEventFilter,
+	from,
+	end uint64,
+) error {
+	for blockNum := from; blockNum <= end; blockNum++ {
+		header, err := core.GetBlockHeaderByNumber(txn, blockNum)
+		if err != nil {
+			return fmt.Errorf("GetBlockHeaderByNumber %d: %w", blockNum, err)
+		}
+		if err := rf.Insert(header.EventsBloom, blockNum); err != nil {
+			return fmt.Errorf("insert block %d: %w", blockNum, err)
+		}
+	}
+	return nil
+}
+
+// rebuildRunningEventFilter walks back from latest to find the most recent
+// persisted aggregated filter, then fills forward to latest. The backward
+// walk is bounded by floorAligned so we don't read pruned filters. When
+// no anchor is found, the window is rooted at floorAligned and filling
+// starts at floor itself, leaving the pruned prefix [floorAligned, floor)
+// as zero bitmap rows.
+func rebuildRunningEventFilter(
+	database db.KeyValueStore,
+	latest,
+	floor uint64,
+) (*core.RunningEventFilter, error) {
+	floorAligned := floor - floor%core.NumBlocksPerFilter
+
+	rangeStartAligned := latest - latest%core.NumBlocksPerFilter
+	lastStoredFilterRangeEnd := rangeStartAligned + core.NumBlocksPerFilter - 1
+
+	found := false
+	for {
+		_, err := core.GetAggregatedBloomFilter(database, rangeStartAligned, lastStoredFilterRangeEnd)
+		if err == nil {
+			found = true
+			break
+		}
+		if !errors.Is(err, db.ErrKeyNotFound) {
+			return nil, fmt.Errorf("rebuild: scan for anchor at [%d,%d]: %w",
+				rangeStartAligned, lastStoredFilterRangeEnd, err)
+		}
+		if rangeStartAligned <= floorAligned {
+			break
+		}
+		rangeStartAligned -= core.NumBlocksPerFilter
+		lastStoredFilterRangeEnd -= core.NumBlocksPerFilter
+	}
+
+	// When found, continueFrom is naturally aligned (anchor end + 1). When
+	// not, the partial filter is rooted at floorAligned but filling starts
+	// at floor itself — blocks in [floorAligned, floor) stay zero in the
+	// bitmap, which is correct since their commitments are pruned.
+	var continueFrom, windowStart uint64
+	if found {
+		continueFrom = lastStoredFilterRangeEnd + 1
+		windowStart = continueFrom
+	} else {
+		continueFrom = floor
+		windowStart = floorAligned
+	}
+
+	filter := core.NewAggregatedFilter(windowStart)
+	runningFilter := core.NewRunningEventFilterHot(database, &filter, continueFrom)
+	if err := fillRunningEventFilter(database, runningFilter, continueFrom, latest); err != nil {
+		return nil, fmt.Errorf(
+			"rebuild (latest=%d, anchorFound=%t, floor=%d): %w",
+			latest, found, floor, err,
+		)
+	}
+	return runningFilter, nil
+}

--- a/pruner/running_event_filter.go
+++ b/pruner/running_event_filter.go
@@ -13,7 +13,13 @@ import (
 // possible and rebuilding otherwise. Use [core.InitializeRunningEventFilter]
 // on non-pruning nodes.
 func InitializeRunningEventFilter(database db.KeyValueStore) (*core.RunningEventFilter, error) {
-	latest, err := core.GetChainHeight(database)
+	// Pin a consistent read view: a concurrent pruner advance between the
+	// floor read and the per-header reads would otherwise surface as a
+	// spurious ErrKeyNotFound on blocks we clamped to be retained.
+	snap := database.NewSnapshot()
+	defer snap.Close()
+
+	latest, err := core.GetChainHeight(snap)
 	if err != nil {
 		if errors.Is(err, db.ErrKeyNotFound) {
 			filter := core.NewAggregatedFilter(0)
@@ -22,12 +28,12 @@ func InitializeRunningEventFilter(database db.KeyValueStore) (*core.RunningEvent
 		return nil, fmt.Errorf("getting chain height: %w", err)
 	}
 
-	floor, err := OldestRetainedBlock(database)
+	floor, err := OldestRetainedBlock(snap)
 	if err != nil && !errors.Is(err, db.ErrKeyNotFound) {
 		return nil, fmt.Errorf("getting oldest retained block: %w", err)
 	}
 
-	stored, err := core.GetRunningEventFilter(database)
+	stored, err := core.GetRunningEventFilter(snap)
 	if err != nil && !errors.Is(err, db.ErrKeyNotFound) {
 		return nil, fmt.Errorf("getting stored running event filter: %w", err)
 	}
@@ -45,7 +51,7 @@ func InitializeRunningEventFilter(database db.KeyValueStore) (*core.RunningEvent
 			// on a hit.
 			next = max(next, floor)
 			rf := core.NewRunningEventFilterHot(database, stored.InnerFilter(), next)
-			if fillErr := fillRunningEventFilter(database, rf, next, latest); fillErr != nil {
+			if fillErr := fillRunningEventFilter(snap, rf, next, latest); fillErr != nil {
 				return nil, fmt.Errorf(
 					"filling running event filter [%d, %d]: %w",
 					next, latest, fillErr,
@@ -56,7 +62,7 @@ func InitializeRunningEventFilter(database db.KeyValueStore) (*core.RunningEvent
 	}
 
 	// Multi-window gap, future-dated snapshot, or no snapshot — rebuild.
-	rf, err := rebuildRunningEventFilter(database, latest, floor)
+	rf, err := rebuildRunningEventFilter(snap, database, latest, floor)
 	if err != nil {
 		return nil, fmt.Errorf(
 			"rebuilding running event filter up to %d (floor=%d): %w",
@@ -67,17 +73,18 @@ func InitializeRunningEventFilter(database db.KeyValueStore) (*core.RunningEvent
 }
 
 // fillRunningEventFilter walks [from, end] and Inserts each block's
-// EventsBloom into rf. Callers must clamp from to the retention floor so
-// the range stays within retained headers — a missing header is treated
-// as an error, not silently skipped.
+// EventsBloom into rf. Reads go through reader (a consistent snapshot) so
+// the range stays within retained headers under concurrent pruning; writes
+// go through rf's live database. Callers must clamp from to the retention
+// floor — a missing header is treated as an error, not silently skipped.
 func fillRunningEventFilter(
-	txn db.KeyValueStore,
+	reader db.KeyValueReader,
 	rf *core.RunningEventFilter,
 	from,
 	end uint64,
 ) error {
 	for blockNum := from; blockNum <= end; blockNum++ {
-		header, err := core.GetBlockHeaderByNumber(txn, blockNum)
+		header, err := core.GetBlockHeaderByNumber(reader, blockNum)
 		if err != nil {
 			return fmt.Errorf("getting block header by number %d: %w", blockNum, err)
 		}
@@ -89,12 +96,14 @@ func fillRunningEventFilter(
 }
 
 // rebuildRunningEventFilter walks back from latest to find the most recent
-// persisted aggregated filter, then fills forward to latest. The backward
-// walk is bounded by floorAligned so we don't read pruned filters. When
-// no anchor is found, the window is rooted at floorAligned and filling
-// starts at floor itself, leaving the pruned prefix [floorAligned, floor)
-// as zero bitmap rows.
+// persisted aggregated filter, then fills forward to latest. Reads go
+// through reader (a consistent snapshot); the returned filter is wired to
+// database for subsequent writes. The backward walk is bounded by
+// floorAligned so we don't read pruned filters. When no anchor is found,
+// the window is rooted at floorAligned and filling starts at floor itself,
+// leaving the pruned prefix [floorAligned, floor) as zero bitmap rows.
 func rebuildRunningEventFilter(
+	reader db.KeyValueReader,
 	database db.KeyValueStore,
 	latest,
 	floor uint64,
@@ -107,7 +116,7 @@ func rebuildRunningEventFilter(
 	continueFrom := floor
 	windowStart := floorAligned
 	for {
-		_, err := core.GetAggregatedBloomFilter(database, rangeStartAligned, lastStoredFilterRangeEnd)
+		_, err := core.GetAggregatedBloomFilter(reader, rangeStartAligned, lastStoredFilterRangeEnd)
 		if err == nil {
 			continueFrom = lastStoredFilterRangeEnd + 1
 			windowStart = continueFrom
@@ -128,7 +137,7 @@ func rebuildRunningEventFilter(
 
 	filter := core.NewAggregatedFilter(windowStart)
 	runningFilter := core.NewRunningEventFilterHot(database, &filter, continueFrom)
-	if err := fillRunningEventFilter(database, runningFilter, continueFrom, latest); err != nil {
+	if err := fillRunningEventFilter(reader, runningFilter, continueFrom, latest); err != nil {
 		return nil, fmt.Errorf(
 			"filling running event filter [%d, %d] (floor=%d): %w",
 			continueFrom, latest, floor, err,

--- a/pruner/running_event_filter_test.go
+++ b/pruner/running_event_filter_test.go
@@ -1,0 +1,299 @@
+package pruner_test
+
+import (
+	"testing"
+
+	"github.com/NethermindEth/juno/core"
+	"github.com/NethermindEth/juno/core/felt"
+	"github.com/NethermindEth/juno/db"
+	"github.com/NethermindEth/juno/db/memory"
+	"github.com/NethermindEth/juno/pruner"
+	"github.com/NethermindEth/juno/pruner/testutils"
+	"github.com/bits-and-blooms/bloom/v3"
+	"github.com/stretchr/testify/require"
+)
+
+func testBloomWithRandomKey(t *testing.T) *bloom.BloomFilter {
+	t.Helper()
+	filter := bloom.New(core.EventsBloomLength, core.EventsBloomHashFuncs)
+	key := felt.NewRandom[felt.Felt]()
+	filter.Add(key.Marshal())
+	return filter
+}
+
+func testBloomWithKeys(t *testing.T, keys [][]byte) *bloom.BloomFilter {
+	t.Helper()
+	filter := bloom.New(core.EventsBloomLength, core.EventsBloomHashFuncs)
+	for _, key := range keys {
+		filter.Add(key)
+	}
+	return filter
+}
+
+// storeBlockWithBloom writes a full block via testutils.StoreBlock and then
+// overlays EventsBloom on its header so the rebuild path actually inserts
+// data into the running filter when it visits the block.
+func storeBlockWithBloom(
+	t *testing.T,
+	database db.KeyValueStore,
+	blockNum uint64,
+	bloomFilter *bloom.BloomFilter,
+) {
+	t.Helper()
+	block := testutils.StoreBlock(t, database, blockNum)
+	block.Header.EventsBloom = bloomFilter
+	require.NoError(t, core.WriteBlockHeaderByNumber(database, block.Header))
+}
+
+func TestRunningEventFilter_LazyInitialization_EmptyDB(t *testing.T) {
+	testDB := memory.New()
+	rf := core.NewRunningEventFilterLazy(testDB, pruner.InitializeRunningEventFilter)
+	require.Equal(t, uint64(0), rf.FromBlock())
+	require.Equal(t, core.NumBlocksPerFilter-1, rf.ToBlock())
+	require.NoError(t, rf.Insert(testBloomWithRandomKey(t), 0))
+}
+
+// TestRunningEventFilter_LazyInitialization_CaughtUp covers the
+// short-circuit branch: snapshot.next == latest+1 → init returns the
+// on-disk snapshot without filling or rebuilding.
+func TestRunningEventFilter_LazyInitialization_CaughtUp(t *testing.T) {
+	const latest uint64 = 50
+	database := testutils.NewPebbleTestDB(t)
+
+	sharedBloom := testBloomWithRandomKey(t)
+	for i := uint64(0); i <= latest; i++ {
+		storeBlockWithBloom(t, database, i, sharedBloom)
+	}
+	require.NoError(t, core.WriteChainHeight(database, latest))
+
+	filter := core.NewAggregatedFilter(0)
+	snap := core.NewRunningEventFilterHot(database, &filter, 0)
+	for i := uint64(0); i <= latest; i++ {
+		require.NoError(t, snap.Insert(sharedBloom, i))
+	}
+	require.NoError(t, core.WriteRunningEventFilter(database, snap))
+
+	rf := core.NewRunningEventFilterLazy(database, pruner.InitializeRunningEventFilter)
+	require.Equal(t, uint64(0), rf.FromBlock())
+	require.Equal(t, core.NumBlocksPerFilter-1, rf.ToBlock())
+	require.Equal(t, latest+1, rf.NextBlock())
+}
+
+// TestRunningEventFilter_LazyInitialization_RebuildAnchorless_FillFromFloor
+// exercises the rebuild fallthrough: no persisted snapshot and no
+// aggregated-filter anchor, so the window roots at floorAligned and
+// filling starts at floor itself. The pruned prefix [0, pruneTo) stays
+// zero in the bitmap.
+func TestRunningEventFilter_LazyInitialization_RebuildAnchorless_FillFromFloor(t *testing.T) {
+	const (
+		latest  uint64 = 50
+		pruneTo uint64 = 30
+	)
+	database := testutils.NewPebbleTestDB(t)
+
+	retainedKeys := [][]byte{{0xEE}}
+	for blockNum := uint64(0); blockNum <= latest; blockNum++ {
+		b := testBloomWithRandomKey(t)
+		if blockNum >= pruneTo {
+			b = testBloomWithKeys(t, retainedKeys)
+		}
+		storeBlockWithBloom(t, database, blockNum, b)
+	}
+	require.NoError(t, core.WriteChainHeight(database, latest))
+
+	_, _, err := pruner.PruneUpto(t.Context(), database, pruneTo, testTargetBatchByteSize)
+	require.NoError(t, err)
+
+	rf := core.NewRunningEventFilterLazy(database, pruner.InitializeRunningEventFilter)
+	require.Equal(t, uint64(0), rf.FromBlock(),
+		"window rooted at floorAligned (= 0 since floor < NumBlocksPerFilter)")
+	require.Equal(t, core.NumBlocksPerFilter-1, rf.ToBlock())
+	require.Equal(t, latest+1, rf.NextBlock())
+
+	matches := rf.BlocksForKeys(retainedKeys)
+	for i := pruneTo; i <= latest; i++ {
+		require.True(t, matches.Test(uint(i)),
+			"retained block %d must be hit by the rebuilt filter", i)
+	}
+	for i := range pruneTo {
+		require.False(t, matches.Test(uint(i)),
+			"pruned block %d must remain unset", i)
+	}
+}
+
+// setupSameWindowResume builds the shared fixture for the same-window
+// resume tests and returns the lazy filter plus both key sets.
+func setupSameWindowResume(
+	t *testing.T,
+	latest,
+	pruneTo,
+	snapshotNext uint64,
+) (rf *core.RunningEventFilter, headerKeys, snapshotKeys [][]byte) {
+	t.Helper()
+	database := testutils.NewPebbleTestDB(t)
+
+	// Two orthogonal probe tags. headerKeys is stamped into on-disk
+	// headers (fill path sets these bits); snapshotKeys is stamped into
+	// the persisted snapshot (resume path preserves these bits). Distinct
+	// values so each assertion isolates one path.
+	headerKeys = [][]byte{{0xAA, 0xBB}}
+	snapshotKeys = [][]byte{{0x11, 0x22}}
+
+	// Headers at and past snapshotNext carry headerKeys so an unclamped
+	// fill would deterministically set bits in [snapshotNext, pruneTo).
+	for i := uint64(0); i <= latest; i++ {
+		var b *bloom.BloomFilter
+		if i >= snapshotNext {
+			b = testBloomWithKeys(t, headerKeys)
+		} else {
+			b = testBloomWithRandomKey(t)
+		}
+
+		storeBlockWithBloom(t, database, i, b)
+	}
+	require.NoError(t, core.WriteChainHeight(database, latest))
+
+	// Persisted snapshot stamped with snapshotKeys for [0, snapshotNext);
+	// init's resume branch keeps these bits, rebuild would refill them.
+	filter := core.NewAggregatedFilter(0)
+	snap := core.NewRunningEventFilterHot(database, &filter, 0)
+	for i := range snapshotNext {
+		require.NoError(t, snap.Insert(testBloomWithKeys(t, snapshotKeys), i))
+	}
+	require.NoError(t, core.WriteRunningEventFilter(database, snap))
+
+	_, _, err := pruner.PruneUpto(t.Context(), database, pruneTo, testTargetBatchByteSize)
+	require.NoError(t, err)
+
+	rf = core.NewRunningEventFilterLazy(database, pruner.InitializeRunningEventFilter)
+	return rf, headerKeys, snapshotKeys
+}
+
+// TestRunningEventFilter_LazyInitialization_SameWindowResume covers
+// the no-clamp same-window resume: floor (= pruneTo) sits below
+// snapshot.next, so the snapshot bitmap is kept and [snapshotNext, latest]
+// is filled from on-disk headers.
+func TestRunningEventFilter_LazyInitialization_SameWindowResume(t *testing.T) {
+	const (
+		latest       uint64 = 50
+		pruneTo      uint64 = 10
+		snapshotNext uint64 = 20
+	)
+	rf, headerKeys, snapshotKeys := setupSameWindowResume(t, latest, pruneTo, snapshotNext)
+
+	require.Equal(t, latest+1, rf.NextBlock())
+	require.Equal(t, uint64(0), rf.FromBlock())
+	require.Equal(t, core.NumBlocksPerFilter-1, rf.ToBlock())
+
+	preserved := rf.BlocksForKeys(snapshotKeys)
+	for i := range snapshotNext {
+		require.True(t, preserved.Test(uint(i)),
+			"snapshot bit at block %d not preserved", i)
+	}
+	filled := rf.BlocksForKeys(headerKeys)
+	for i := snapshotNext; i <= latest; i++ {
+		require.True(t, filled.Test(uint(i)),
+			"retained block %d must be filled from header bloom", i)
+	}
+}
+
+// TestRunningEventFilter_LazyInitialization_SameWindowResumeClamped covers
+// the clamp branch: floor (= pruneTo) sits above snapshot.next, so the
+// max(next, floor) clamp kicks in. Snapshot bits in [0, snapshotNext) still
+// survive on the inner bitmap; positions [snapshotNext, floor) stay zero;
+// [floor, latest] is filled.
+func TestRunningEventFilter_LazyInitialization_SameWindowResumeClamped(t *testing.T) {
+	const (
+		latest       uint64 = 50
+		pruneTo      uint64 = 30
+		snapshotNext uint64 = 20
+	)
+	rf, headerKeys, snapshotKeys := setupSameWindowResume(t, latest, pruneTo, snapshotNext)
+
+	require.Equal(t, latest+1, rf.NextBlock())
+	require.Equal(t, uint64(0), rf.FromBlock())
+
+	preserved := rf.BlocksForKeys(snapshotKeys)
+	for i := range snapshotNext {
+		require.True(t, preserved.Test(uint(i)),
+			"snapshot bit at block %d not preserved across clamp", i)
+	}
+	filled := rf.BlocksForKeys(headerKeys)
+	for i := pruneTo; i <= latest; i++ {
+		require.True(t, filled.Test(uint(i)),
+			"retained block %d must be filled from header bloom", i)
+	}
+	for i := snapshotNext; i < pruneTo; i++ {
+		require.False(t, filled.Test(uint(i)),
+			"clamped gap block %d must remain unset", i)
+	}
+}
+
+// TestRunningEventFilter_LazyInitialization_MultiWindowRebuildAfterPrune
+// covers the rebuild path when the chain spans past a filter-window
+// boundary. Rebuild starts at floor (= pruneTo), walks through the first
+// window, rotates at N-1, and lands in the second window. Full blocks
+// only for [0, pruneTo] (so PruneUpto's per-block sweep has real
+// hash-keyed data to delete); headers-only for the rest, batched into
+// a single pebble write.
+func TestRunningEventFilter_LazyInitialization_MultiWindowRebuildAfterPrune(t *testing.T) {
+	const pruneTo uint64 = 50
+	latest := core.NumBlocksPerFilter + 5
+	database := testutils.NewPebbleTestDB(t)
+
+	headerKeys := [][]byte{{0xEE}}
+	sharedBloom := testBloomWithKeys(t, headerKeys)
+	// Full block fixture only for blocks PruneUpto will iterate; the
+	// per-block sweep reads hash-keyed data so it needs the full shape.
+	for i := uint64(0); i <= pruneTo; i++ {
+		storeBlockWithBloom(t, database, i, sharedBloom)
+	}
+	// Past pruneTo, only the header (for rebuild fill) and the
+	// commitment (so OldestRetainedBlock keeps reflecting retained
+	// state) are written.
+	batch := database.NewBatch()
+	for i := pruneTo + 1; i <= latest; i++ {
+		header := &core.Header{
+			Number:      i,
+			Hash:        felt.NewRandom[felt.Felt](),
+			EventsBloom: sharedBloom,
+		}
+		require.NoError(t, core.WriteBlockHeaderByNumber(batch, header))
+		require.NoError(t, core.WriteBlockCommitment(batch, i, &core.BlockCommitments{}))
+		if batch.Size() >= testTargetBatchByteSize {
+			require.NoError(t, batch.Write())
+			batch = database.NewBatch()
+		}
+	}
+	require.NoError(t, batch.Write())
+	require.NoError(t, core.WriteChainHeight(database, latest))
+
+	_, _, err := pruner.PruneUpto(t.Context(), database, pruneTo, testTargetBatchByteSize)
+	require.NoError(t, err)
+
+	rf := core.NewRunningEventFilterLazy(database, pruner.InitializeRunningEventFilter)
+	require.Equal(t, core.NumBlocksPerFilter, rf.FromBlock(),
+		"window rotated to second window after fill crossed N-1")
+	require.Equal(t, 2*core.NumBlocksPerFilter-1, rf.ToBlock())
+	require.Equal(t, latest+1, rf.NextBlock())
+
+	// Second (current) window: positions [N, latest] hit.
+	filled := rf.BlocksForKeys(headerKeys)
+	for i := core.NumBlocksPerFilter; i <= latest; i++ {
+		require.True(t, filled.Test(uint(i-rf.FromBlock())),
+			"block %d (second window) not filled", i)
+	}
+	// First window persisted on rotation: positions [pruneTo, N-1] hit
+	// (filled from headers), [0, pruneTo) zero (pruned prefix skipped).
+	stored, err := core.GetAggregatedBloomFilter(database, 0, core.NumBlocksPerFilter-1)
+	require.NoError(t, err)
+	storedMatches := stored.BlocksForKeys(headerKeys)
+	for i := pruneTo; i < core.NumBlocksPerFilter; i++ {
+		require.True(t, storedMatches.Test(uint(i)),
+			"block %d (past floor, first window) not filled", i)
+	}
+	for i := range pruneTo {
+		require.False(t, storedMatches.Test(uint(i)),
+			"pruned block %d must remain unset", i)
+	}
+}


### PR DESCRIPTION
## Problem

On a pruning node, the running event filter's lazy loader rebuilt from the most recent persisted anchor by walking back through aggregated filter windows and then filling forward block-by-block via `GetBlockHeaderByNumber`. Both of those reads can land below `OldestRetainedBlock`.

  ## Summary

  - Split running-event-filter initialization into a pluggable `RunningEventFilterInitializer`. `blockchain.New` defaults to `core.InitializeRunningEventFilter`; nodes started with `--prune` wire in `pruner.InitializeRunningEventFilter` via the new `WithRunningEventFilterInitializer` option.
  - Add a same-window fast path to both initializers: when the persisted snapshot's `next` is still inside the current aggregated window, resume it in place and fill `[next, latest]` instead of rebuilding from the prior anchor.
  - Pruner initializer clamps the fill range to `OldestRetainedBlock` and bounds the backward anchor scan by `floorAligned`, so we never read pruned headers or pruned aggregated filters. When no
  anchor is found, the rebuilt window is rooted at `floorAligned` with `[floorAligned, floor)` left as zero bitmap rows (those receipts are pruned, so any hit there would be unactionable anyway).
  - Replace `panic` paths in `BlocksForKeysInto`, `OnReorg`, and `Write` with wrapped error returns; wrap errors throughout `Insert` and the initializers with window/block context to make rebuild failures diagnosable.

  ## Tests
  - Extend `core/running_event_filter_test.go` for the same-window resume path.
  - Add `pruner/running_event_filter_test.go` covering floor-clamped fill, missing-anchor rebuild at floor, and below-floor snapshot handling.