### PR TITLE
fix(p2p): reject unknown proto3 enum values in network adapters

### DIFF
--- a/adapters/p2p2consensus/p2p_consensus_adapters_test.go
+++ b/adapters/p2p2consensus/p2p_consensus_adapters_test.go
@@ -10,6 +10,7 @@ import (
 	transactiontestutils "github.com/NethermindEth/juno/adapters/testutils"
 	"github.com/NethermindEth/juno/blockchain/networks"
 	"github.com/NethermindEth/juno/starknet/compiler"
+	"github.com/starknet-io/starknet-p2p-specs/p2p/proto/common"
 	"github.com/starknet-io/starknet-p2p-specs/p2p/proto/consensus/consensus"
 	"github.com/stretchr/testify/require"
 )
@@ -92,4 +93,20 @@ func TestAdaptProposalTransaction(t *testing.T) {
 
 func TestAdaptProposalFin(t *testing.T) {
 	testP2PToConsensusToP2P(t, testutils.GetTestProposalFin, p2p2consensus.AdaptProposalFin, consensus2p2p.AdaptProposalFin)
+}
+
+func TestAdaptBlockInfo_UnknownL1DaMode(t *testing.T) {
+	_, p2pBlockInfo := testutils.GetTestBlockInfo(t)
+	p2pBlockInfo.L1DaMode = common.L1DataAvailabilityMode(99)
+
+	_, err := p2p2consensus.AdaptBlockInfo(p2pBlockInfo)
+	require.ErrorContains(t, err, "unknown l1_da_mode value: 99")
+}
+
+func TestAdaptProposalCommitment_UnknownL1DaMode(t *testing.T) {
+	_, p2pProposalCommitment := testutils.GetTestProposalCommitment(t)
+	p2pProposalCommitment.L1DaMode = common.L1DataAvailabilityMode(99)
+
+	_, err := p2p2consensus.AdaptProposalCommitment(p2pProposalCommitment)
+	require.ErrorContains(t, err, "unknown l1_da_mode value: 99")
 }

--- a/adapters/p2p2consensus/validation.go
+++ b/adapters/p2p2consensus/validation.go
@@ -2,7 +2,9 @@ package p2p2consensus
 
 import (
 	"errors"
+	"fmt"
 
+	"github.com/starknet-io/starknet-p2p-specs/p2p/proto/common"
 	p2pconsensus "github.com/starknet-io/starknet-p2p-specs/p2p/proto/consensus/consensus"
 )
 
@@ -34,6 +36,9 @@ func validateBlockInfo(b *p2pconsensus.BlockInfo) error {
 	}
 	if b.EthToStrkRate == nil {
 		return errors.New("eth_to_strk_rate must be set")
+	}
+	if _, ok := common.L1DataAvailabilityMode_name[int32(b.L1DaMode)]; !ok {
+		return fmt.Errorf("unknown l1_da_mode value: %d", b.L1DaMode)
 	}
 	return nil
 }
@@ -97,6 +102,9 @@ func validateProposalCommitment(p *p2pconsensus.ProposalCommitment) error { //no
 	}
 	if p.NextL2GasPriceFri == nil {
 		return errors.New("next_l2_gas_price_fri must be set")
+	}
+	if _, ok := common.L1DataAvailabilityMode_name[int32(p.L1DaMode)]; !ok {
+		return fmt.Errorf("unknown l1_da_mode value: %d", p.L1DaMode)
 	}
 	return nil
 }

--- a/consensus/p2p/vote/vote.go
+++ b/consensus/p2p/vote/vote.go
@@ -2,6 +2,7 @@ package vote
 
 import (
 	"errors"
+	"fmt"
 
 	"github.com/NethermindEth/juno/consensus/starknet"
 	"github.com/NethermindEth/juno/consensus/types"
@@ -20,6 +21,10 @@ type starknetVoteAdapter struct{}
 var StarknetVoteAdapter VoteAdapter[starknet.Hash, starknet.Address] = starknetVoteAdapter{}
 
 func (a starknetVoteAdapter) ToVote(vote *consensus.Vote) (starknet.Vote, error) {
+	if _, ok := consensus.Vote_VoteType_name[int32(vote.GetVoteType())]; !ok {
+		return starknet.Vote{}, fmt.Errorf("unknown vote_type value: %d", vote.GetVoteType())
+	}
+
 	var id *starknet.Hash
 	if proposalCommitment := vote.GetProposalCommitment().GetElements(); proposalCommitment != nil {
 		id = felt.NewFromBytes[starknet.Hash](proposalCommitment)

--- a/consensus/p2p/vote/vote_test.go
+++ b/consensus/p2p/vote/vote_test.go
@@ -302,4 +302,18 @@ func TestStarknetVoteAdapter_ErrorCases(t *testing.T) {
 			})
 		}
 	})
+
+	t.Run("ToVote rejects unknown VoteType", func(t *testing.T) {
+		voterBytes := createTestHashBytes(42)
+		result, err := StarknetVoteAdapter.ToVote(&consensus.Vote{
+			VoteType:    consensus.Vote_VoteType(99),
+			BlockNumber: 100,
+			Round:       5,
+			Voter:       &common.Address{Elements: voterBytes},
+		})
+
+		assert.Error(t, err, "ToVote should return error for unknown VoteType")
+		assert.Contains(t, err.Error(), "unknown vote_type value: 99")
+		assert.Equal(t, starknet.Vote{}, result)
+	})
 }

--- a/p2p/server/server.go
+++ b/p2p/server/server.go
@@ -602,6 +602,9 @@ func (h *Server) processIterationRequestMulti(iteration *synccommon.Iteration, f
 }
 
 func (h *Server) newIterator(it *synccommon.Iteration) (*iterator, error) {
+	if _, ok := synccommon.Iteration_Direction_name[int32(it.Direction)]; !ok {
+		return nil, fmt.Errorf("unknown direction value: %d", it.Direction)
+	}
 	forward := it.Direction == synccommon.Iteration_Forward
 	// todo restrict limit max value ?
 	switch v := it.Start.(type) {

--- a/p2p/server/server_test.go
+++ b/p2p/server/server_test.go
@@ -1,41 +1,122 @@
-package server
+package server_test
 
 import (
+	"bufio"
+	"context"
+	"io"
+	"slices"
 	"testing"
+	"time"
 
+	"github.com/NethermindEth/juno/blockchain/networks"
+	"github.com/NethermindEth/juno/db"
+	"github.com/NethermindEth/juno/mocks"
+	"github.com/NethermindEth/juno/p2p/server"
+	"github.com/NethermindEth/juno/p2p/starknetp2p"
+	"github.com/NethermindEth/juno/utils/log"
+	"github.com/libp2p/go-libp2p"
+	"github.com/libp2p/go-libp2p/core/host"
+	"github.com/libp2p/go-libp2p/core/network"
+	"github.com/libp2p/go-libp2p/core/peer"
 	synccommon "github.com/starknet-io/starknet-p2p-specs/p2p/proto/sync/common"
+	"github.com/starknet-io/starknet-p2p-specs/p2p/proto/sync/header"
 	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+	"google.golang.org/protobuf/encoding/protodelim"
+	"google.golang.org/protobuf/proto"
 )
 
-func TestNewIterator_Direction(t *testing.T) {
-	tests := []struct {
-		name      string
-		direction synccommon.Iteration_Direction
-		wantErr   string
-	}{
-		{"forward", synccommon.Iteration_Forward, ""},
-		{"backward", synccommon.Iteration_Backward, ""},
-		{"unknown", synccommon.Iteration_Direction(99), "unknown direction value: 99"},
+const streamReadTimeout = 5 * time.Second
+
+func TestServer_HeadersRequest(t *testing.T) {
+	starknetNetwork := &networks.Sepolia
+	protoID := starknetp2p.Sync(starknetNetwork, starknetp2p.HeadersSyncSubProtocol)
+
+	setup := func(t *testing.T) (*mocks.MockReader, host.Host, host.Host) {
+		t.Helper()
+		mockCtrl := gomock.NewController(t)
+		reader := mocks.NewMockReader(mockCtrl)
+		reader.EXPECT().Network().Return(starknetNetwork).AnyTimes()
+
+		serverHost, err := libp2p.New()
+		require.NoError(t, err)
+		t.Cleanup(func() { _ = serverHost.Close() })
+
+		clientHost, err := libp2p.New()
+		require.NoError(t, err)
+		t.Cleanup(func() { _ = clientHost.Close() })
+
+		require.NoError(t, clientHost.Connect(t.Context(), peer.AddrInfo{
+			ID:    serverHost.ID(),
+			Addrs: serverHost.Addrs(),
+		}))
+
+		srv := server.New(serverHost, reader, log.NewNopZapLogger())
+		ctx, cancel := context.WithCancel(t.Context())
+		done := make(chan struct{})
+		go func() {
+			_ = srv.Run(ctx)
+			close(done)
+		}()
+		t.Cleanup(func() {
+			cancel()
+			<-done
+		})
+
+		require.Eventually(t, func() bool {
+			return slices.Contains(serverHost.Mux().Protocols(), protoID)
+		}, 2*time.Second, 10*time.Millisecond, "headers handler not registered")
+
+		return reader, serverHost, clientHost
 	}
 
-	h := &Server{}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			it := &synccommon.Iteration{
-				Direction: tt.direction,
+	openRequestStream := func(
+		t *testing.T,
+		clientHost, serverHost host.Host,
+		direction synccommon.Iteration_Direction,
+	) network.Stream {
+		t.Helper()
+		stream, err := clientHost.NewStream(t.Context(), serverHost.ID(), protoID)
+		require.NoError(t, err)
+		t.Cleanup(func() { _ = stream.Close() })
+
+		req := &header.BlockHeadersRequest{
+			Iteration: &synccommon.Iteration{
+				Direction: direction,
 				Start:     &synccommon.Iteration_BlockNumber{BlockNumber: 1},
 				Limit:     1,
 				Step:      1,
-			}
-
-			iter, err := h.newIterator(it)
-			if tt.wantErr != "" {
-				require.ErrorContains(t, err, tt.wantErr)
-				require.Nil(t, iter)
-			} else {
-				require.NoError(t, err)
-				require.NotNil(t, iter)
-			}
-		})
+			},
+		}
+		reqBytes, err := proto.Marshal(req)
+		require.NoError(t, err)
+		_, err = stream.Write(reqBytes)
+		require.NoError(t, err)
+		require.NoError(t, stream.CloseWrite())
+		require.NoError(t, stream.SetReadDeadline(time.Now().Add(streamReadTimeout)))
+		return stream
 	}
+
+	t.Run("responds with fin message for known direction", func(t *testing.T) {
+		reader, serverHost, clientHost := setup(t)
+		// Reader has no block 1 — iterator marks reachedEnd and the server sends the fin message.
+		reader.EXPECT().BlockHeaderByNumber(uint64(1)).Return(nil, db.ErrKeyNotFound)
+
+		stream := openRequestStream(t, clientHost, serverHost, synccommon.Iteration_Forward)
+
+		var resp header.BlockHeadersResponse
+		require.NoError(t, protodelim.UnmarshalFrom(bufio.NewReader(stream), &resp))
+		require.IsType(t, &header.BlockHeadersResponse_Fin{}, resp.HeaderMessage)
+	})
+
+	t.Run("drops request for unknown direction", func(t *testing.T) {
+		_, serverHost, clientHost := setup(t)
+		// No reader EXPECTs: validation must fail before any DB call.
+
+		stream := openRequestStream(t, clientHost, serverHost, synccommon.Iteration_Direction(99))
+
+		data, err := io.ReadAll(stream)
+		require.NoError(t, err, "expected clean EOF when server drops the request")
+		require.Empty(t, data, "server must not write any response for an unknown direction")
+	})
 }

--- a/p2p/server/server_test.go
+++ b/p2p/server/server_test.go
@@ -1,0 +1,41 @@
+package server
+
+import (
+	"testing"
+
+	synccommon "github.com/starknet-io/starknet-p2p-specs/p2p/proto/sync/common"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewIterator_Direction(t *testing.T) {
+	tests := []struct {
+		name      string
+		direction synccommon.Iteration_Direction
+		wantErr   string
+	}{
+		{"forward", synccommon.Iteration_Forward, ""},
+		{"backward", synccommon.Iteration_Backward, ""},
+		{"unknown", synccommon.Iteration_Direction(99), "unknown direction value: 99"},
+	}
+
+	h := &Server{}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			it := &synccommon.Iteration{
+				Direction: tt.direction,
+				Start:     &synccommon.Iteration_BlockNumber{BlockNumber: 1},
+				Limit:     1,
+				Step:      1,
+			}
+
+			iter, err := h.newIterator(it)
+			if tt.wantErr != "" {
+				require.ErrorContains(t, err, tt.wantErr)
+				require.Nil(t, iter)
+			} else {
+				require.NoError(t, err)
+				require.NotNil(t, iter)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## [Issue](https://github.com/NethermindEth/juno/issues/3075)

Proto3 preserves unknown enum values on unmarshal instead of rejecting them. A peer can send an enum field with a value not defined, letting garbage flow through.

## Fix

Validate at the adapter boundary using the generated `_name` map. Unknown value gives an error.

Decided not to implement a generic `protoenum.Validate()` helper function, since the inline validation was short, easy to read, and only appears in 4 places.
