### PR TITLE
fix(running event filter): window-roll consistency on lazy load and reorg deletes stale filters

### DIFF
--- a/blockchain/statebackend/deprecated.go
+++ b/blockchain/statebackend/deprecated.go
@@ -79,6 +79,7 @@ func (b *deprecatedStateBackend) Store(
 		if err := verifyBlockSuccession(txn, block); err != nil {
 			return err
 		}
+
 		err := deprecatedstate.New(txn).Update(
 			block.Header,
 			stateUpdate,
@@ -89,14 +90,15 @@ func (b *deprecatedStateBackend) Store(
 			return err
 		}
 
-		if err := writeBlockContent(
+		err = writeBlockContent(
 			b.database,
 			txn,
 			block,
 			stateUpdate,
 			blockCommitments,
 			newClasses,
-		); err != nil {
+		)
+		if err != nil {
 			return err
 		}
 
@@ -222,14 +224,15 @@ func (b *deprecatedStateBackend) Finalise(
 			}
 		}
 
-		if err := writeBlockContent(
+		err = writeBlockContent(
 			txn,
 			txn,
 			block,
 			stateUpdate,
 			commitments,
 			newClasses,
-		); err != nil {
+		)
+		if err != nil {
 			return err
 		}
 

--- a/blockchain/statebackend/deprecated.go
+++ b/blockchain/statebackend/deprecated.go
@@ -75,7 +75,7 @@ func (b *deprecatedStateBackend) Store(
 	newClasses map[felt.Felt]core.ClassDefinition,
 ) error {
 	//nolint:staticcheck,nolintlint // used by old state
-	err := b.database.Update(func(txn db.IndexedBatch) error {
+	return b.database.Update(func(txn db.IndexedBatch) error {
 		if err := verifyBlockSuccession(txn, block); err != nil {
 			return err
 		}
@@ -89,28 +89,24 @@ func (b *deprecatedStateBackend) Store(
 			return err
 		}
 
-		return writeBlockContent(
+		if err := writeBlockContent(
 			b.database,
 			txn,
 			block,
 			stateUpdate,
 			blockCommitments,
 			newClasses,
-		)
-	})
-	if err != nil {
-		return err
-	}
+		); err != nil {
+			return err
+		}
 
-	return b.runningFilter.Insert(
-		block.EventsBloom,
-		block.Number,
-	)
+		return b.runningFilter.InsertWithBatch(txn, block.EventsBloom, block.Number)
+	})
 }
 
 func (b *deprecatedStateBackend) RevertHead() error {
 	//nolint:staticcheck,nolintlint // used by old state
-	err := b.database.Update(func(txn db.IndexedBatch) error {
+	return b.database.Update(func(txn db.IndexedBatch) error {
 		blockNumber, err := core.GetChainHeight(txn)
 		if err != nil {
 			return err
@@ -130,12 +126,12 @@ func (b *deprecatedStateBackend) RevertHead() error {
 			return err
 		}
 
-		return deleteBlockContent(txn, txn, stateUpdate, blockNumber)
+		if err := deleteBlockContent(txn, txn, stateUpdate, blockNumber); err != nil {
+			return err
+		}
+
+		return b.runningFilter.OnReorgWithBatch(txn)
 	})
-	if err != nil {
-		return err
-	}
-	return b.runningFilter.OnReorg()
 }
 
 func (b *deprecatedStateBackend) GetReverseStateDiff() (core.StateDiff, error) {
@@ -207,7 +203,7 @@ func (b *deprecatedStateBackend) Finalise(
 	sign core.BlockSignFunc,
 ) error {
 	//nolint:staticcheck,nolintlint // used by old state
-	err := b.database.Update(func(txn db.IndexedBatch) error {
+	return b.database.Update(func(txn db.IndexedBatch) error {
 		err := updateStateRoots(deprecatedstate.New(txn), block, stateUpdate, newClasses)
 		if err != nil {
 			return err
@@ -226,20 +222,19 @@ func (b *deprecatedStateBackend) Finalise(
 			}
 		}
 
-		return writeBlockContent(
+		if err := writeBlockContent(
 			txn,
 			txn,
 			block,
 			stateUpdate,
 			commitments,
 			newClasses,
-		)
-	})
-	if err != nil {
-		return err
-	}
+		); err != nil {
+			return err
+		}
 
-	return b.runningFilter.Insert(block.EventsBloom, block.Number)
+		return b.runningFilter.InsertWithBatch(txn, block.EventsBloom, block.Number)
+	})
 }
 
 func (b *deprecatedStateBackend) VerifyBlockHash(

--- a/blockchain/statebackend/statebackend.go
+++ b/blockchain/statebackend/statebackend.go
@@ -75,7 +75,7 @@ func (b *stateBackend) Store(
 	stateUpdate *core.StateUpdate,
 	newClasses map[felt.Felt]core.ClassDefinition,
 ) error {
-	err := b.database.Write(func(batch db.Batch) error {
+	return b.database.Write(func(batch db.Batch) error {
 		if err := verifyBlockSuccession(b.database, block); err != nil {
 			return err
 		}
@@ -88,24 +88,23 @@ func (b *stateBackend) Store(
 			return err
 		}
 
-		return writeBlockContent(
+		if err := writeBlockContent(
 			b.database,
 			batch,
 			block,
 			stateUpdate,
 			blockCommitments,
 			newClasses,
-		)
-	})
-	if err != nil {
-		return err
-	}
+		); err != nil {
+			return err
+		}
 
-	return b.runningFilter.Insert(block.EventsBloom, block.Number)
+		return b.runningFilter.InsertWithBatch(batch, block.EventsBloom, block.Number)
+	})
 }
 
 func (b *stateBackend) RevertHead() error {
-	err := b.database.Write(func(batch db.Batch) error {
+	return b.database.Write(func(batch db.Batch) error {
 		blockNumber, err := core.GetChainHeight(b.database)
 		if err != nil {
 			return err
@@ -130,12 +129,12 @@ func (b *stateBackend) RevertHead() error {
 			return err
 		}
 
-		return deleteBlockContent(b.database, batch, stateUpdate, blockNumber)
+		if err := deleteBlockContent(b.database, batch, stateUpdate, blockNumber); err != nil {
+			return err
+		}
+
+		return b.runningFilter.OnReorgWithBatch(batch)
 	})
-	if err != nil {
-		return err
-	}
-	return b.runningFilter.OnReorg()
 }
 
 func (b *stateBackend) GetReverseStateDiff() (core.StateDiff, error) {
@@ -203,7 +202,7 @@ func (b *stateBackend) Finalise(
 	newClasses map[felt.Felt]core.ClassDefinition,
 	sign core.BlockSignFunc,
 ) error {
-	err := b.database.Write(func(batch db.Batch) error {
+	return b.database.Write(func(batch db.Batch) error {
 		st, err := state.New(stateUpdate.OldRoot, b.stateDB, batch)
 		if err != nil {
 			return err
@@ -225,20 +224,19 @@ func (b *stateBackend) Finalise(
 			}
 		}
 
-		return writeBlockContent(
+		if err := writeBlockContent(
 			b.database,
 			batch,
 			block,
 			stateUpdate,
 			commitments,
 			newClasses,
-		)
-	})
-	if err != nil {
-		return err
-	}
+		); err != nil {
+			return err
+		}
 
-	return b.runningFilter.Insert(block.EventsBloom, block.Number)
+		return b.runningFilter.InsertWithBatch(batch, block.EventsBloom, block.Number)
+	})
 }
 
 func (b *stateBackend) VerifyBlockHash(

--- a/blockchain/statebackend/statebackend.go
+++ b/blockchain/statebackend/statebackend.go
@@ -88,14 +88,15 @@ func (b *stateBackend) Store(
 			return err
 		}
 
-		if err := writeBlockContent(
+		err = writeBlockContent(
 			b.database,
 			batch,
 			block,
 			stateUpdate,
 			blockCommitments,
 			newClasses,
-		); err != nil {
+		)
+		if err != nil {
 			return err
 		}
 
@@ -224,14 +225,15 @@ func (b *stateBackend) Finalise(
 			}
 		}
 
-		if err := writeBlockContent(
+		err = writeBlockContent(
 			b.database,
 			batch,
 			block,
 			stateUpdate,
 			commitments,
 			newClasses,
-		); err != nil {
+		)
+		if err != nil {
 			return err
 		}
 

--- a/core/accessors.go
+++ b/core/accessors.go
@@ -506,6 +506,10 @@ func WriteAggregatedBloomFilter(w db.KeyValueWriter, filter *AggregatedBloomFilt
 	return w.Put(db.AggregatedBloomFilterKey(filter.FromBlock(), filter.ToBlock()), enc)
 }
 
+func DeleteAggregatedBloomFilter(w db.KeyValueWriter, fromBlock, toBlock uint64) error {
+	return w.Delete(db.AggregatedBloomFilterKey(fromBlock, toBlock))
+}
+
 func GetRunningEventFilter(r db.KeyValueReader) (*RunningEventFilter, error) {
 	var filter RunningEventFilter
 	err := r.Get(db.RunningEventFilter.Key(), func(data []byte) error {

--- a/core/running_event_filter.go
+++ b/core/running_event_filter.go
@@ -83,7 +83,7 @@ func (f *RunningEventFilter) Insert(
 	defer f.mu.Unlock()
 
 	if err := f.ensureInit(); err != nil {
-		return fmt.Errorf("couldn't initialize the running event filter: %w", err)
+		return err
 	}
 
 	if err := f.inner.Insert(bloom, blockNumber); err != nil {
@@ -127,7 +127,7 @@ func (f *RunningEventFilter) BlocksForKeysInto(keys [][]byte, out *bitset.BitSet
 	defer f.mu.RUnlock()
 
 	if err := f.ensureInit(); err != nil {
-		return fmt.Errorf("couldn't initialize the running event filter: %w", err)
+		return err
 	}
 
 	return f.inner.BlocksForKeysInto(keys, out)
@@ -203,7 +203,7 @@ func (f *RunningEventFilter) OnReorg() error {
 	defer f.mu.Unlock()
 
 	if err := f.ensureInit(); err != nil {
-		return fmt.Errorf("couldn't initialize the running event filter: %w", err)
+		return err
 	}
 
 	currRangeStart := f.inner.FromBlock()
@@ -234,7 +234,7 @@ func (f *RunningEventFilter) Write() error {
 	defer f.mu.Unlock()
 
 	if err := f.ensureInit(); err != nil {
-		return fmt.Errorf("couldn't initialize the running event filter: %w", err)
+		return err
 	}
 
 	return WriteRunningEventFilter(f.database, f)

--- a/core/running_event_filter.go
+++ b/core/running_event_filter.go
@@ -79,6 +79,24 @@ func (f *RunningEventFilter) Insert(
 	bloom *bloom.BloomFilter,
 	blockNumber uint64,
 ) error {
+	return f.insert(f.database, bloom, blockNumber)
+}
+
+// InsertWithBatch is like [RunningEventFilter.Insert] but routes the
+// window-rollover persistence through the supplied batch.
+func (f *RunningEventFilter) InsertWithBatch(
+	batch db.Batch,
+	bloom *bloom.BloomFilter,
+	blockNumber uint64,
+) error {
+	return f.insert(batch, bloom, blockNumber)
+}
+
+func (f *RunningEventFilter) insert(
+	writer db.KeyValueWriter,
+	bloom *bloom.BloomFilter,
+	blockNumber uint64,
+) error {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 
@@ -94,7 +112,7 @@ func (f *RunningEventFilter) Insert(
 	}
 
 	if blockNumber == f.inner.ToBlock() {
-		if err := WriteAggregatedBloomFilter(f.database, f.inner); err != nil {
+		if err := WriteAggregatedBloomFilter(writer, f.inner); err != nil {
 			return fmt.Errorf(
 				"persisting aggregated filter for window [%d,%d]: %w",
 				f.inner.FromBlock(), f.inner.ToBlock(), err,
@@ -197,8 +215,22 @@ func (f *RunningEventFilter) InnerFilter() *AggregatedBloomFilter {
 	return f.inner
 }
 
-// Clear erases the bloom filter data for the specified block
+// OnReorg reverts the last processed block from the running filter. Writes
+// the persisted-filter deletion on backward boundary cross directly to
+// f.database; use [RunningEventFilter.OnReorgWithBatch] to commit it
+// atomically with the caller's revert batch.
 func (f *RunningEventFilter) OnReorg() error {
+	return f.onReorg(f.database)
+}
+
+// OnReorgWithBatch is like [RunningEventFilter.OnReorg] but routes the
+// stale-filter deletion through the supplied batch, so it commits or
+// rolls back atomically with the caller's chain-state revert.
+func (f *RunningEventFilter) OnReorgWithBatch(batch db.Batch) error {
+	return f.onReorg(batch)
+}
+
+func (f *RunningEventFilter) onReorg(writer db.KeyValueWriter) error {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 
@@ -208,8 +240,19 @@ func (f *RunningEventFilter) OnReorg() error {
 
 	currRangeStart := f.inner.FromBlock()
 	curBlock := f.next - 1
-	// Falls into previous filters range
+	// Falls into previous filter's range
 	if curBlock == currRangeStart-1 {
+		// Drop the persisted filter; in-memory clears are about to be discarded
+		// on swap and a future rollover will repopulate this window.
+		if err := DeleteAggregatedBloomFilter(
+			writer, f.inner.FromBlock(), f.inner.ToBlock(),
+		); err != nil {
+			return fmt.Errorf(
+				"deleting stale persisted filter for window [%d,%d]: %w",
+				f.inner.FromBlock(), f.inner.ToBlock(), err,
+			)
+		}
+
 		rangeStartAligned := curBlock - (curBlock % NumBlocksPerFilter)
 		rangeEndAligned := rangeStartAligned + NumBlocksPerFilter - 1
 

--- a/core/running_event_filter.go
+++ b/core/running_event_filter.go
@@ -83,7 +83,7 @@ func (f *RunningEventFilter) Insert(
 	defer f.mu.Unlock()
 
 	if err := f.ensureInit(); err != nil {
-		return err
+		return fmt.Errorf("ensureInit before block %d: %w", blockNumber, err)
 	}
 
 	if err := f.inner.Insert(bloom, blockNumber); err != nil {

--- a/core/running_event_filter.go
+++ b/core/running_event_filter.go
@@ -83,7 +83,7 @@ func (f *RunningEventFilter) Insert(
 	defer f.mu.Unlock()
 
 	if err := f.ensureInit(); err != nil {
-		return fmt.Errorf("ensureInit before block %d: %w", blockNumber, err)
+		return fmt.Errorf("couldn't initialize the running event filter: %w", err)
 	}
 
 	if err := f.inner.Insert(bloom, blockNumber); err != nil {
@@ -127,7 +127,7 @@ func (f *RunningEventFilter) BlocksForKeysInto(keys [][]byte, out *bitset.BitSet
 	defer f.mu.RUnlock()
 
 	if err := f.ensureInit(); err != nil {
-		return fmt.Errorf("ensureInit: %w", err)
+		return fmt.Errorf("couldn't initialize the running event filter: %w", err)
 	}
 
 	return f.inner.BlocksForKeysInto(keys, out)
@@ -203,7 +203,7 @@ func (f *RunningEventFilter) OnReorg() error {
 	defer f.mu.Unlock()
 
 	if err := f.ensureInit(); err != nil {
-		return fmt.Errorf("ensureInit: %w", err)
+		return fmt.Errorf("couldn't initialize the running event filter: %w", err)
 	}
 
 	currRangeStart := f.inner.FromBlock()
@@ -234,7 +234,7 @@ func (f *RunningEventFilter) Write() error {
 	defer f.mu.Unlock()
 
 	if err := f.ensureInit(); err != nil {
-		return fmt.Errorf("ensureInit: %w", err)
+		return fmt.Errorf("couldn't initialize the running event filter: %w", err)
 	}
 
 	return WriteRunningEventFilter(f.database, f)

--- a/core/running_event_filter.go
+++ b/core/running_event_filter.go
@@ -127,7 +127,7 @@ func (f *RunningEventFilter) BlocksForKeysInto(keys [][]byte, out *bitset.BitSet
 	defer f.mu.RUnlock()
 
 	if err := f.ensureInit(); err != nil {
-		return err
+		return fmt.Errorf("ensureInit: %w", err)
 	}
 
 	return f.inner.BlocksForKeysInto(keys, out)
@@ -203,7 +203,7 @@ func (f *RunningEventFilter) OnReorg() error {
 	defer f.mu.Unlock()
 
 	if err := f.ensureInit(); err != nil {
-		return err
+		return fmt.Errorf("ensureInit: %w", err)
 	}
 
 	currRangeStart := f.inner.FromBlock()
@@ -234,7 +234,7 @@ func (f *RunningEventFilter) Write() error {
 	defer f.mu.Unlock()
 
 	if err := f.ensureInit(); err != nil {
-		return err
+		return fmt.Errorf("ensureInit: %w", err)
 	}
 
 	return WriteRunningEventFilter(f.database, f)

--- a/core/running_event_filter_test.go
+++ b/core/running_event_filter_test.go
@@ -179,6 +179,185 @@ func TestRunningEventFilter_LazyInitialization_Preload(t *testing.T) {
 	})
 }
 
+func TestRunningEventFilter_InsertWithBatch_AtWindowBoundary(t *testing.T) {
+	// Regression for the deterministic failure at block k*NumBlocksPerFilter-1.
+	// statebackend used to commit chain height in one batch and then call
+	// runningFilter.Insert separately. On the first call after restart at a
+	// boundary, ensureInit's GetChainHeight saw the just-committed boundary
+	// block, fillRunningEventFilter consumed it and rotated the inner window,
+	// and the outer Insert then tried to add the same block to the new
+	// (empty) window — "block X doesn't belong to range [X+1, Y]". The fix
+	// wires the insert into the same batch as the chain-height update, so
+	// GetChainHeight reads the pre-batch value during ensureInit.
+
+	boundary := core.NumBlocksPerFilter - 1
+	headerKeys := [][]byte{{0xAB}}
+
+	setup := func(t *testing.T) (db.KeyValueStore, *core.Header) {
+		t.Helper()
+		testDB := memory.New()
+		// Snapshot caught up through block boundary-1 (next = boundary), so
+		// when GetChainHeight catches up to the boundary the initializer
+		// takes the same-window-resume branch and fills exactly one block —
+		// the boundary block — which is what tipped the fill over the edge.
+		storedFilter := core.NewAggregatedFilter(0)
+		snap := core.NewRunningEventFilterHot(testDB, &storedFilter, boundary)
+		require.NoError(t, core.WriteRunningEventFilter(testDB, snap))
+		header := &core.Header{
+			Number:      boundary,
+			Hash:        felt.NewRandom[felt.Felt](),
+			EventsBloom: testBloomWithKeys(t, headerKeys),
+		}
+		return testDB, header
+	}
+
+	t.Run("non-batched Insert on lazy filter fails at the boundary", func(t *testing.T) {
+		// Documents why InsertWithBatch is the only safe entry point for
+		// lazy filters during block ingestion. When chain height has been
+		// committed before Insert, ensureInit's GetChainHeight sees the
+		// boundary block, fill rotates the inner window, and the outer
+		// insert then can't place the same block in the rolled-over range.
+		testDB, header := setup(t)
+		require.NoError(t, core.WriteBlockHeaderByNumber(testDB, header))
+		require.NoError(t, core.WriteChainHeight(testDB, boundary))
+
+		rf := core.NewRunningEventFilterLazy(testDB, core.InitializeRunningEventFilter)
+		err := rf.Insert(header.EventsBloom, boundary)
+		require.ErrorContains(t, err,
+			"inserting block 8191 into window [8192,16383]: block number is not within range")
+	})
+
+	t.Run(
+		"fix: header and chain height buffered in same batch as InsertWithBatch",
+		func(t *testing.T) {
+			testDB, header := setup(t)
+			require.NoError(t, core.WriteChainHeight(testDB, boundary-1))
+
+			rf := core.NewRunningEventFilterLazy(testDB, core.InitializeRunningEventFilter)
+			require.NoError(t, testDB.Write(func(batch db.Batch) error {
+				if err := core.WriteBlockHeaderByNumber(batch, header); err != nil {
+					return err
+				}
+				if err := core.WriteChainHeight(batch, boundary); err != nil {
+					return err
+				}
+				return rf.InsertWithBatch(batch, header.EventsBloom, boundary)
+			}))
+
+			require.Equal(t, boundary+1, rf.NextBlock())
+			require.Equal(t, boundary+1, rf.FromBlock())
+			require.Equal(t, 2*core.NumBlocksPerFilter-1, rf.ToBlock())
+
+			stored, err := core.GetAggregatedBloomFilter(testDB, 0, boundary)
+			require.NoError(t, err)
+			require.True(t, stored.BlocksForKeys(headerKeys).Test(uint(boundary)),
+				"completed window persisted via the batch with boundary bit set")
+		},
+	)
+}
+
+func TestRunningEventFilter_OnReorgWithBatch_AtWindowBoundary(t *testing.T) {
+	// Regression for OnReorg + lazy-init at a window boundary. If the
+	// chain-height revert is committed before OnReorg runs on a still-lazy
+	// filter, ensureInit reads the post-revert height and advances the
+	// filter as if caught up; OnReorg then reverts one block too many, and
+	// at a boundary that extra revert crosses into the previous window and
+	// clears a bit for a block still on chain.
+	//
+	// OnReorgWithBatch inside the revert's writeFn keeps ensureInit on the
+	// pre-revert height, so the subsequent clear targets exactly the
+	// reverted block.
+
+	boundary := core.NumBlocksPerFilter - 1
+	headerKeys := [][]byte{{0xCD}}
+
+	setup := func(t *testing.T) (db.KeyValueStore, *core.Header) {
+		t.Helper()
+		testDB := memory.New()
+
+		// Persisted previous window with bits for headerKeys at every block.
+		// This is the window the running filter has already rolled over.
+		prevWindow := core.NewAggregatedFilter(0)
+		for i := uint64(0); i <= boundary; i++ {
+			require.NoError(t, prevWindow.Insert(testBloomWithKeys(t, headerKeys), i))
+		}
+		require.NoError(t, core.WriteAggregatedBloomFilter(testDB, &prevWindow))
+
+		// Stored running filter snapshot: caught up through `boundary`,
+		// inner is the fresh empty next window. boundary+1 is the block
+		// about to be reverted.
+		nextInner := core.NewAggregatedFilter(boundary + 1)
+		snap := core.NewRunningEventFilterHot(testDB, &nextInner, boundary+1)
+		require.NoError(t, core.WriteRunningEventFilter(testDB, snap))
+
+		header := &core.Header{
+			Number:      boundary + 1,
+			Hash:        felt.NewRandom[felt.Felt](),
+			EventsBloom: testBloomWithKeys(t, headerKeys),
+		}
+		return testDB, header
+	}
+
+	t.Run(
+		"non-batched OnReorg on lazy filter silently over-clears at the boundary",
+		func(t *testing.T) {
+			testDB, header := setup(t)
+			require.NoError(t, core.WriteBlockHeaderByNumber(testDB, header))
+			// Post-revert chain height already committed — pre-fix would commit
+			// this in a batch and then call OnReorg separately.
+			require.NoError(t, core.WriteChainHeight(testDB, boundary))
+
+			rf := core.NewRunningEventFilterLazy(testDB, core.InitializeRunningEventFilter)
+			require.NoError(t, rf.OnReorg())
+
+			// ensureInit saw post-revert chain height = boundary, took the
+			// "caught up" branch (stored.next == latest+1), and left the filter
+			// at f.next = boundary+1, f.inner = [boundary+1, 2N-1]. onReorg
+			// then crossed back into [0, boundary], loaded it, and cleared bit
+			// `boundary` — a block that's still on chain.
+			require.Equal(t, boundary, rf.NextBlock())
+			require.Equal(t, uint64(0), rf.FromBlock())
+			require.Equal(t, boundary, rf.ToBlock())
+			require.False(t, rf.BlocksForKeys(headerKeys).Test(uint(boundary)),
+				"filter wrongly cleared the bit for a block still on chain")
+		},
+	)
+
+	t.Run("fix: OnReorgWithBatch inside writeFn preserves on-chain block bits", func(t *testing.T) {
+		testDB, header := setup(t)
+		require.NoError(t, core.WriteBlockHeaderByNumber(testDB, header))
+		require.NoError(t, core.WriteChainHeight(testDB, boundary+1))
+
+		rf := core.NewRunningEventFilterLazy(testDB, core.InitializeRunningEventFilter)
+		require.NoError(t, testDB.Write(func(batch db.Batch) error {
+			// Mirror statebackend.RevertHead: delete reverted block's header,
+			// revert chain height, OnReorgWithBatch — all in one batch.
+			if err := core.DeleteBlockHeaderByNumber(batch, header.Number); err != nil {
+				return err
+			}
+			if err := core.WriteChainHeight(batch, boundary); err != nil {
+				return err
+			}
+			return rf.OnReorgWithBatch(batch)
+		}))
+
+		// ensureInit saw pre-revert chain height = boundary+1, filled one
+		// block ([boundary+1, boundary+1]) into the empty next window, and
+		// onReorg then cleared exactly the reverted block. No boundary
+		// cross, no over-clear of [0, boundary].
+		require.Equal(t, boundary+1, rf.NextBlock())
+		require.Equal(t, boundary+1, rf.FromBlock())
+		require.False(t, rf.BlocksForKeys(headerKeys).Test(0),
+			"reverted block's bit (relative position 0) must be cleared")
+
+		// Previous window on disk is untouched.
+		stored, err := core.GetAggregatedBloomFilter(testDB, 0, boundary)
+		require.NoError(t, err)
+		require.True(t, stored.BlocksForKeys(headerKeys).Test(uint(boundary)),
+			"previous window's boundary block bit must remain on disk")
+	})
+}
+
 func TestRunningEventFilter_InsertAndPersist(t *testing.T) {
 	testDB := memory.New()
 	filter := core.NewAggregatedFilter(0)
@@ -259,12 +438,64 @@ func TestRunningEventFilter_Reorg(t *testing.T) {
 		require.Equal(t, 2*core.NumBlocksPerFilter, rf.InnerFilter().FromBlock())
 		require.Equal(t, 3*core.NumBlocksPerFilter-1, rf.InnerFilter().ToBlock())
 
+		// Both completed windows persisted before reorg.
+		_, err := core.GetAggregatedBloomFilter(testDB, 0, core.NumBlocksPerFilter-1)
+		require.NoError(t, err)
+		_, err = core.GetAggregatedBloomFilter(
+			testDB, core.NumBlocksPerFilter, 2*core.NumBlocksPerFilter-1)
+		require.NoError(t, err)
+
 		for range core.NumBlocksPerFilter + 1 {
 			require.NoError(t, rf.OnReorg())
 		}
 		require.Equal(t, core.NumBlocksPerFilter-1, rf.NextBlock())
 		require.Equal(t, core.NumBlocksPerFilter-1, rf.InnerFilter().ToBlock())
 		require.Equal(t, uint64(0), rf.InnerFilter().FromBlock())
+
+		// Reorged-out window must be dropped
+		_, err = core.GetAggregatedBloomFilter(
+			testDB, core.NumBlocksPerFilter, 2*core.NumBlocksPerFilter-1)
+		require.ErrorIs(t, err, db.ErrKeyNotFound)
+		// The window we landed in remains.
+		_, err = core.GetAggregatedBloomFilter(testDB, 0, core.NumBlocksPerFilter-1)
+		require.NoError(t, err)
+	})
+
+	t.Run("Deep reorg with batch atomically deletes stale persisted filter", func(t *testing.T) {
+		testDB := memory.New()
+		rf := populateRunningFilter(t, testDB, 2*core.NumBlocksPerFilter-1)
+		require.Equal(t, 2*core.NumBlocksPerFilter, rf.NextBlock())
+		require.Equal(t, 2*core.NumBlocksPerFilter, rf.InnerFilter().FromBlock())
+		require.Equal(t, 3*core.NumBlocksPerFilter-1, rf.InnerFilter().ToBlock())
+
+		// Both completed windows persisted before reorg.
+		_, err := core.GetAggregatedBloomFilter(testDB, 0, core.NumBlocksPerFilter-1)
+		require.NoError(t, err)
+		_, err = core.GetAggregatedBloomFilter(
+			testDB, core.NumBlocksPerFilter, 2*core.NumBlocksPerFilter-1)
+		require.NoError(t, err)
+
+		err = testDB.Write(func(batch db.Batch) error {
+			for range core.NumBlocksPerFilter + 1 {
+				if err := rf.OnReorgWithBatch(batch); err != nil {
+					return err
+				}
+			}
+			return nil
+		})
+		require.NoError(t, err)
+
+		require.Equal(t, core.NumBlocksPerFilter-1, rf.NextBlock())
+		require.Equal(t, core.NumBlocksPerFilter-1, rf.InnerFilter().ToBlock())
+		require.Equal(t, uint64(0), rf.InnerFilter().FromBlock())
+
+		// Reorged-out window must be dropped
+		_, err = core.GetAggregatedBloomFilter(
+			testDB, core.NumBlocksPerFilter, 2*core.NumBlocksPerFilter-1)
+		require.ErrorIs(t, err, db.ErrKeyNotFound)
+		// The window we landed in remains.
+		_, err = core.GetAggregatedBloomFilter(testDB, 0, core.NumBlocksPerFilter-1)
+		require.NoError(t, err)
 	})
 }
 

--- a/pruner/running_event_filter.go
+++ b/pruner/running_event_filter.go
@@ -61,7 +61,6 @@ func InitializeRunningEventFilter(database db.KeyValueStore) (*core.RunningEvent
 		}
 	}
 
-	// Multi-window gap, future-dated snapshot, or no snapshot — rebuild.
 	rf, err := rebuildRunningEventFilter(snap, database, latest, floor)
 	if err != nil {
 		return nil, fmt.Errorf(

--- a/pruner/running_event_filter.go
+++ b/pruner/running_event_filter.go
@@ -61,6 +61,7 @@ func InitializeRunningEventFilter(database db.KeyValueStore) (*core.RunningEvent
 		}
 	}
 
+	// Multi-window gap, future-dated snapshot, or no snapshot — rebuild.
 	rf, err := rebuildRunningEventFilter(snap, database, latest, floor)
 	if err != nil {
 		return nil, fmt.Errorf(


### PR DESCRIPTION
##  Summary

  - Atomic `Insert` / `OnReorg` with chain-state batch. `RunningEventFilter` gains `InsertWithBatch` / `OnReorgWithBatch`. `Store`, `Finalise`, and `RevertHead` now route the running-filter write through the same `db.Write` batch as `writeBlockContent` / `deleteBlockContent`, so the persisted aggregated filter and the chain head commit or roll back together. Addresses issue reported [here](https://github.com/NethermindEth/juno/pull/3638#discussion_r3241745246).
  - `OnReorg` deletes the stale persisted filter. On a backward window boundary cross, `onReorg` calls `DeleteAggregatedBloomFilter` for the current window before swapping back to the previous one. This drops the obsolete persisted filter; a future rollover repopulates the window. The delete is routed through the caller's batch via `OnReorgWithBatch`, so it commits atomically with the chain-state revert.