### PR TITLE
fix(rpc): bound l1 head to chain height when l1 head is ahead of l2 head

### DIFF
--- a/rpc/v10/block_test.go
+++ b/rpc/v10/block_test.go
@@ -99,6 +99,19 @@ func createBlockTestCases(
 			blockStatus: rpc.BlockAcceptedL1,
 		},
 		{
+			description: "blockID - l1_accepted bounded to chain height when L1 is ahead",
+			block:       block,
+			commitments: commitments,
+			stateUpdate: stateUpdate,
+			blockID:     &blockIDL1Accepted,
+			l1Head: &core.L1Head{
+				BlockNumber: block.Number + 10,
+				BlockHash:   block.Hash,
+				StateRoot:   block.GlobalStateRoot,
+			},
+			blockStatus: rpc.BlockAcceptedL1,
+		},
+		{
 			description: "blockID - pre_confirmed",
 			block:       block,
 			commitments: nil,
@@ -430,6 +443,7 @@ func setupMockBlockTest(
 		mockChain.EXPECT().TransactionsByBlockNumber(block.Number).Return(
 			block.Transactions, nil).AnyTimes()
 	case blockID.IsL1Accepted():
+		mockChain.EXPECT().Height().Return(block.Number, nil).AnyTimes()
 		mockChain.EXPECT().BlockByNumber(block.Number).Return(block, nil).AnyTimes()
 		mockChain.EXPECT().BlockHeaderByNumber(block.Number).Return(block.Header, nil).AnyTimes()
 		mockChain.EXPECT().TransactionsByBlockNumber(block.Number).Return(
@@ -588,6 +602,24 @@ func TestBlockTransactionCount(t *testing.T) {
 			},
 			nil,
 		)
+		mockReader.EXPECT().Height().Return(latestBlock.Number, nil)
+		mockReader.EXPECT().BlockHeaderByNumber(latestBlockNumber).Return(latestBlock.Header, nil)
+		l1AcceptedID := rpc.BlockIDL1Accepted()
+		count, rpcErr := handler.BlockTransactionCount(&l1AcceptedID)
+		require.Nil(t, rpcErr)
+		assert.Equal(t, expectedCount, count)
+	})
+
+	t.Run("blockID - l1_accepted bounded to chain height when L1 is ahead", func(t *testing.T) {
+		mockReader.EXPECT().L1Head().Return(
+			core.L1Head{
+				BlockNumber: latestBlock.Number + 10,
+				BlockHash:   latestBlock.Hash,
+				StateRoot:   latestBlock.GlobalStateRoot,
+			},
+			nil,
+		)
+		mockReader.EXPECT().Height().Return(latestBlock.Number, nil)
 		mockReader.EXPECT().BlockHeaderByNumber(latestBlockNumber).Return(latestBlock.Header, nil)
 		l1AcceptedID := rpc.BlockIDL1Accepted()
 		count, rpcErr := handler.BlockTransactionCount(&l1AcceptedID)

--- a/rpc/v10/class_test.go
+++ b/rpc/v10/class_test.go
@@ -270,7 +270,24 @@ func TestClassHashAt(t *testing.T) {
 			},
 			nil,
 		)
+		mockReader.EXPECT().Height().Return(l1HeadBlockNumber, nil)
 		mockReader.EXPECT().StateAtBlockNumber(l1HeadBlockNumber).Return(mockState, nopCloser, nil)
+		mockState.EXPECT().ContractClassHash(gomock.Any()).Return(*expectedClassHash, nil)
+		l1AcceptedID := rpc.BlockIDL1Accepted()
+		classHash, rpcErr := handler.ClassHashAt(&l1AcceptedID, &felt.Zero)
+		require.Nil(t, rpcErr)
+		assert.Equal(t, expectedClassHash, classHash)
+	})
+
+	t.Run("blockID - l1_accepted bounded to chain height when L1 is ahead", func(t *testing.T) {
+		chainHeight := uint64(10)
+		l1HeadAhead := chainHeight + 5
+		mockReader.EXPECT().L1Head().Return(
+			core.L1Head{BlockNumber: l1HeadAhead, BlockHash: &felt.Zero, StateRoot: &felt.Zero},
+			nil,
+		)
+		mockReader.EXPECT().Height().Return(chainHeight, nil)
+		mockReader.EXPECT().StateAtBlockNumber(chainHeight).Return(mockState, nopCloser, nil)
 		mockState.EXPECT().ContractClassHash(gomock.Any()).Return(*expectedClassHash, nil)
 		l1AcceptedID := rpc.BlockIDL1Accepted()
 		classHash, rpcErr := handler.ClassHashAt(&l1AcceptedID, &felt.Zero)

--- a/rpc/v10/helpers.go
+++ b/rpc/v10/helpers.go
@@ -30,6 +30,21 @@ func isL1Verified(n uint64, l1 core.L1Head) bool {
 	return false
 }
 
+// l1AcceptedBlockNumber returns the L1-accepted block number bounded by the
+// current chain height. The L1 head can be ahead of the L2 chain during sync,
+// in which case the caller should fall back to the latest local block.
+func (h *Handler) l1AcceptedBlockNumber() (uint64, error) {
+	l1Head, err := h.bcReader.L1Head()
+	if err != nil {
+		return 0, err
+	}
+	height, err := h.bcReader.Height()
+	if err != nil {
+		return 0, err
+	}
+	return min(l1Head.BlockNumber, height), nil
+}
+
 func (h *Handler) blockByID(blockID *BlockID) (*core.Block, *jsonrpc.Error) {
 	var block *core.Block
 	var err error
@@ -46,12 +61,12 @@ func (h *Handler) blockByID(blockID *BlockID) (*core.Block, *jsonrpc.Error) {
 	case blockID.IsHash():
 		block, err = h.bcReader.BlockByHash(blockID.Hash())
 	case blockID.IsL1Accepted():
-		var l1Head core.L1Head
-		l1Head, err = h.bcReader.L1Head()
+		var blockNumber uint64
+		blockNumber, err = h.l1AcceptedBlockNumber()
 		if err != nil {
 			break
 		}
-		block, err = h.bcReader.BlockByNumber(l1Head.BlockNumber)
+		block, err = h.bcReader.BlockByNumber(blockNumber)
 	default:
 		block, err = h.bcReader.BlockByNumber(blockID.Number())
 	}
@@ -109,12 +124,12 @@ func (h *Handler) blockHeaderByID(blockID *BlockID) (*core.Header, *jsonrpc.Erro
 	case blockID.IsNumber():
 		header, err = h.bcReader.BlockHeaderByNumber(blockID.Number())
 	case blockID.IsL1Accepted():
-		var l1Head core.L1Head
-		l1Head, err = h.bcReader.L1Head()
+		var blockNumber uint64
+		blockNumber, err = h.l1AcceptedBlockNumber()
 		if err != nil {
 			break
 		}
-		header, err = h.bcReader.BlockHeaderByNumber(l1Head.BlockNumber)
+		header, err = h.bcReader.BlockHeaderByNumber(blockNumber)
 	default:
 		panic("unknown block type id")
 	}
@@ -169,12 +184,12 @@ func (h *Handler) stateByBlockID(
 	case blockID.IsNumber():
 		reader, closer, err = h.bcReader.StateAtBlockNumber(blockID.Number())
 	case blockID.IsL1Accepted():
-		var l1Head core.L1Head
-		l1Head, err = h.bcReader.L1Head()
+		var blockNumber uint64
+		blockNumber, err = h.l1AcceptedBlockNumber()
 		if err != nil {
 			break
 		}
-		reader, closer, err = h.bcReader.StateAtBlockNumber(l1Head.BlockNumber)
+		reader, closer, err = h.bcReader.StateAtBlockNumber(blockNumber)
 	default:
 		panic("unknown block id type")
 	}

--- a/rpc/v10/nonce_test.go
+++ b/rpc/v10/nonce_test.go
@@ -134,7 +134,26 @@ func TestNonce(t *testing.T) {
 			},
 			nil,
 		)
+		mockReader.EXPECT().Height().Return(l1AcceptedBlockNumber, nil)
 		mockReader.EXPECT().StateAtBlockNumber(l1AcceptedBlockNumber).Return(mockState, nopCloser, nil)
+		mockState.EXPECT().ContractNonce(&targetAddress).Return(*expectedNonce, nil)
+
+		l1AcceptedID := rpc.BlockIDL1Accepted()
+		nonce, rpcErr := handler.Nonce(&l1AcceptedID, &targetAddress)
+		require.Nil(t, rpcErr)
+		assert.Equal(t, expectedNonce, nonce)
+	})
+
+	t.Run("blockID - l1_accepted bounded to chain height when L1 is ahead", func(t *testing.T) {
+		chainHeight := uint64(10)
+		l1HeadAhead := chainHeight + 5
+
+		mockReader.EXPECT().L1Head().Return(
+			core.L1Head{BlockNumber: l1HeadAhead, BlockHash: &felt.One, StateRoot: &felt.One},
+			nil,
+		)
+		mockReader.EXPECT().Height().Return(chainHeight, nil)
+		mockReader.EXPECT().StateAtBlockNumber(chainHeight).Return(mockState, nopCloser, nil)
 		mockState.EXPECT().ContractNonce(&targetAddress).Return(*expectedNonce, nil)
 
 		l1AcceptedID := rpc.BlockIDL1Accepted()

--- a/rpc/v10/state_update.go
+++ b/rpc/v10/state_update.go
@@ -185,11 +185,11 @@ func (h *Handler) stateUpdateByID(id *BlockID) (*core.StateUpdate, error) {
 	case id.IsNumber():
 		return h.bcReader.StateUpdateByNumber(id.Number())
 	case id.IsL1Accepted():
-		l1Head, err := h.bcReader.L1Head()
+		blockNumber, err := h.l1AcceptedBlockNumber()
 		if err != nil {
 			return nil, err
 		}
-		return h.bcReader.StateUpdateByNumber(l1Head.BlockNumber)
+		return h.bcReader.StateUpdateByNumber(blockNumber)
 	default:
 		panic("unknown block type id")
 	}

--- a/rpc/v10/state_update_test.go
+++ b/rpc/v10/state_update_test.go
@@ -129,6 +129,24 @@ func TestStateUpdate(t *testing.T) {
 			},
 			nil,
 		)
+		mockReader.EXPECT().Height().Return(targetBlockNumber, nil)
+		mockReader.EXPECT().StateUpdateByNumber(targetBlockNumber).Return(update3077642, nil)
+		l1AcceptedID := rpcv10.BlockIDL1Accepted()
+		update, rpcErr := handler.StateUpdate(&l1AcceptedID, nil)
+		require.Nil(t, rpcErr)
+		assertStateUpdateEq(t, update3077642, &update)
+	})
+
+	t.Run("l1_accepted bounded to chain height when L1 is ahead", func(t *testing.T) {
+		mockReader.EXPECT().L1Head().Return(
+			core.L1Head{
+				BlockNumber: targetBlockNumber + 10,
+				BlockHash:   update3077642.BlockHash,
+				StateRoot:   update3077642.NewRoot,
+			},
+			nil,
+		)
+		mockReader.EXPECT().Height().Return(targetBlockNumber, nil)
 		mockReader.EXPECT().StateUpdateByNumber(targetBlockNumber).Return(update3077642, nil)
 		l1AcceptedID := rpcv10.BlockIDL1Accepted()
 		update, rpcErr := handler.StateUpdate(&l1AcceptedID, nil)

--- a/rpc/v10/storage_test.go
+++ b/rpc/v10/storage_test.go
@@ -271,7 +271,26 @@ func TestStorageAt(t *testing.T) {
 				},
 				nil,
 			)
+			mockReader.EXPECT().Height().Return(l1HeadBlockNumber, nil)
 			mockReader.EXPECT().StateAtBlockNumber(l1HeadBlockNumber).Return(mockState, nopCloser, nil)
+			mockState.EXPECT().ContractClassHash(&felt.Zero).Return(felt.Zero, nil)
+			mockState.EXPECT().ContractStorage(gomock.Any(), gomock.Any()).Return(expectedStorage, nil)
+
+			blockID := rpc.BlockIDL1Accepted()
+			result, rpcErr := handler.StorageAt(&felt.Address{}, &felt.Zero, &blockID, noFlags)
+			require.Nil(t, rpcErr)
+			validateStorageAtJSON(t, result, noFlags.IncludeLastUpdateBlock)
+		})
+
+		t.Run("blockID - l1_accepted bounded to chain height when L1 is ahead", func(t *testing.T) {
+			chainHeight := uint64(10)
+			l1HeadAhead := chainHeight + 5
+			mockReader.EXPECT().L1Head().Return(
+				core.L1Head{BlockNumber: l1HeadAhead, BlockHash: &felt.Zero, StateRoot: &felt.Zero},
+				nil,
+			)
+			mockReader.EXPECT().Height().Return(chainHeight, nil)
+			mockReader.EXPECT().StateAtBlockNumber(chainHeight).Return(mockState, nopCloser, nil)
 			mockState.EXPECT().ContractClassHash(&felt.Zero).Return(felt.Zero, nil)
 			mockState.EXPECT().ContractStorage(gomock.Any(), gomock.Any()).Return(expectedStorage, nil)
 
@@ -344,6 +363,7 @@ func TestStorageAt(t *testing.T) {
 				},
 				nil,
 			)
+			mockReader.EXPECT().Height().Return(l1HeadBlockNumber, nil)
 			mockReader.EXPECT().StateAtBlockNumber(l1HeadBlockNumber).Return(mockState, nopCloser, nil)
 			mockState.EXPECT().ContractClassHash(&targetAddressFelt).Return(felt.Felt{}, nil)
 			mockState.EXPECT().ContractStorage(&targetAddressFelt, &targetSlot).Return(expectedStorage, nil)

--- a/rpc/v10/transaction.go
+++ b/rpc/v10/transaction.go
@@ -436,12 +436,10 @@ func (h *Handler) TransactionByBlockIDAndIndex(
 	case blockID.IsNumber():
 		blockNumber = blockID.Number()
 	case blockID.IsL1Accepted():
-		var l1Head core.L1Head
-		l1Head, err = h.bcReader.L1Head()
+		blockNumber, err = h.l1AcceptedBlockNumber()
 		if err != nil {
 			break
 		}
-		blockNumber = l1Head.BlockNumber
 	default:
 		panic("unknown block type id")
 	}

--- a/rpc/v10/transaction_test.go
+++ b/rpc/v10/transaction_test.go
@@ -767,6 +767,31 @@ func TestTransactionByBlockIdAndIndex(t *testing.T) {
 			},
 			nil,
 		)
+		mockReader.EXPECT().Height().Return(latestBlockNumber, nil)
+		mockReader.EXPECT().TransactionByBlockNumberAndIndex(latestBlockNumber,
+			uint64(index)).DoAndReturn(func(number, index uint64) (core.Transaction, error) {
+			return latestBlock.Transactions[index], nil
+		})
+
+		expectedTxn := rpcv10.AdaptTransaction(latestBlock.Transactions[index], false)
+		blockID := rpcv10.BlockIDL1Accepted()
+		actualTxn, rpcErr := handler.TransactionByBlockIDAndIndex(&blockID, index, rpcv10.ResponseFlags{})
+		require.Nil(t, rpcErr)
+		require.Equal(t, &expectedTxn, actualTxn)
+	})
+
+	t.Run("blockID - l1_accepted bounded to chain height when L1 is ahead", func(t *testing.T) {
+		index := rand.Intn(int(latestBlock.TransactionCount))
+
+		mockReader.EXPECT().L1Head().Return(
+			core.L1Head{
+				BlockNumber: latestBlockNumber + 10,
+				BlockHash:   latestBlockHash,
+				StateRoot:   latestBlock.GlobalStateRoot,
+			},
+			nil,
+		)
+		mockReader.EXPECT().Height().Return(latestBlockNumber, nil)
 		mockReader.EXPECT().TransactionByBlockNumberAndIndex(latestBlockNumber,
 			uint64(index)).DoAndReturn(func(number, index uint64) (core.Transaction, error) {
 			return latestBlock.Transactions[index], nil

--- a/rpc/v9/block_test.go
+++ b/rpc/v9/block_test.go
@@ -244,6 +244,24 @@ func TestBlockTransactionCount(t *testing.T) {
 			},
 			nil,
 		)
+		mockReader.EXPECT().Height().Return(latestBlock.Number, nil)
+		mockReader.EXPECT().BlockHeaderByNumber(latestBlockNumber).Return(latestBlock.Header, nil)
+		l1AcceptedID := blockIDL1Accepted(t)
+		count, rpcErr := handler.BlockTransactionCount(&l1AcceptedID)
+		require.Nil(t, rpcErr)
+		assert.Equal(t, expectedCount, count)
+	})
+
+	t.Run("blockID - l1_accepted bounded to chain height when L1 is ahead", func(t *testing.T) {
+		mockReader.EXPECT().L1Head().Return(
+			core.L1Head{
+				BlockNumber: latestBlock.Number + 10,
+				BlockHash:   latestBlock.Hash,
+				StateRoot:   latestBlock.GlobalStateRoot,
+			},
+			nil,
+		)
+		mockReader.EXPECT().Height().Return(latestBlock.Number, nil)
 		mockReader.EXPECT().BlockHeaderByNumber(latestBlockNumber).Return(latestBlock.Header, nil)
 		l1AcceptedID := blockIDL1Accepted(t)
 		count, rpcErr := handler.BlockTransactionCount(&l1AcceptedID)
@@ -405,6 +423,26 @@ func TestBlockWithTxHashes(t *testing.T) {
 			BlockHash:   latestBlockHash,
 			StateRoot:   latestBlock.GlobalStateRoot,
 		}, nil).Times(2)
+		mockReader.EXPECT().Height().Return(latestBlockNumber, nil)
+
+		l1AcceptedID := blockIDL1Accepted(t)
+		block, rpcErr := handler.BlockWithTxHashes(&l1AcceptedID)
+		require.Nil(t, rpcErr)
+
+		assert.Equal(t, rpc.BlockAcceptedL1, block.Status)
+		checkBlock(t, block)
+	})
+
+	t.Run("blockID - l1_accepted bounded to chain height when L1 is ahead", func(t *testing.T) {
+		mockReader.EXPECT().BlockHeaderByNumber(latestBlockNumber).Return(latestBlock.Header, nil)
+		mockReader.EXPECT().TransactionsByBlockNumber(latestBlockNumber).Return(
+			latestBlock.Transactions, nil)
+		mockReader.EXPECT().L1Head().Return(core.L1Head{
+			BlockNumber: latestBlockNumber + 10,
+			BlockHash:   latestBlockHash,
+			StateRoot:   latestBlock.GlobalStateRoot,
+		}, nil).Times(2)
+		mockReader.EXPECT().Height().Return(latestBlockNumber, nil)
 
 		l1AcceptedID := blockIDL1Accepted(t)
 		block, rpcErr := handler.BlockWithTxHashes(&l1AcceptedID)
@@ -549,7 +587,7 @@ func TestBlockWithTxs(t *testing.T) {
 	mockSyncReader.EXPECT().PreConfirmed().Return(
 		preConfirmed,
 		nil,
-	).Times(len(latestBlock.Transactions) * 5)
+	).Times(len(latestBlock.Transactions) * 6)
 
 	mockReader.EXPECT().TransactionByHash(gomock.Any()).DoAndReturn(
 		func(hash *felt.Felt) (core.Transaction, error) {
@@ -558,7 +596,7 @@ func TestBlockWithTxs(t *testing.T) {
 			}
 			return nil, errors.New("txn not found")
 		},
-	).Times(len(latestBlock.Transactions) * 5)
+	).Times(len(latestBlock.Transactions) * 6)
 
 	t.Run("blockID - latest", func(t *testing.T) {
 		mockReader.EXPECT().HeadsHeader().Return(latestBlock.Header, nil).Times(2)
@@ -646,6 +684,32 @@ func TestBlockWithTxs(t *testing.T) {
 			BlockHash:   latestBlockHash,
 			StateRoot:   latestBlock.GlobalStateRoot,
 		}, nil).Times(4)
+		mockReader.EXPECT().Height().Return(latestBlockNumber, nil).Times(2)
+
+		l1AcceptedID := blockIDL1Accepted(t)
+		blockWithTxHashes, rpcErr := handler.BlockWithTxHashes(&l1AcceptedID)
+		require.Nil(t, rpcErr)
+
+		blockWithTxs, rpcErr := handler.BlockWithTxs(&l1AcceptedID)
+		require.Nil(t, rpcErr)
+
+		assert.Equal(t, blockWithTxHashes.BlockHeader, blockWithTxs.BlockHeader)
+		assert.Equal(t, len(blockWithTxHashes.TxnHashes), len(blockWithTxs.Transactions))
+
+		checkLatestBlock(t, blockWithTxHashes, blockWithTxs)
+	})
+
+	t.Run("blockID - l1_accepted bounded to chain height when L1 is ahead", func(t *testing.T) {
+		mockReader.EXPECT().BlockHeaderByNumber(latestBlockNumber).Return(
+			latestBlock.Header, nil).Times(2)
+		mockReader.EXPECT().TransactionsByBlockNumber(latestBlockNumber).Return(
+			latestBlock.Transactions, nil).Times(2)
+		mockReader.EXPECT().L1Head().Return(core.L1Head{
+			BlockNumber: latestBlockNumber + 10,
+			BlockHash:   latestBlockHash,
+			StateRoot:   latestBlock.GlobalStateRoot,
+		}, nil).Times(4)
+		mockReader.EXPECT().Height().Return(latestBlockNumber, nil).Times(2)
 
 		l1AcceptedID := blockIDL1Accepted(t)
 		blockWithTxHashes, rpcErr := handler.BlockWithTxHashes(&l1AcceptedID)
@@ -886,6 +950,56 @@ func TestBlockWithReceipts(t *testing.T) {
 				L2GasPrice:       header.L2GasPrice,
 			},
 			Transactions: txsWithReceipt,
+		}, resp)
+	})
+
+	t.Run("blockID - l1_accepted bounded to chain height when L1 is ahead", func(t *testing.T) {
+		block1, err := mainnetGw.BlockByNumber(t.Context(), 1)
+		require.NoError(t, err)
+
+		mockReader.EXPECT().L1Head().Return(core.L1Head{
+			BlockNumber: block1.Number + 10,
+		}, nil).Times(2)
+		mockReader.EXPECT().Height().Return(block1.Number, nil)
+		mockReader.EXPECT().BlockByNumber(block1.Number).Return(block1, nil)
+
+		blockID := blockIDL1Accepted(t)
+		resp, rpcErr := handler.BlockWithReceipts(&blockID)
+		require.Nil(t, rpcErr)
+		header := resp.BlockHeader
+
+		transactions := make([]rpc.TransactionWithReceipt, len(block1.Transactions))
+		for i, tx := range block1.Transactions {
+			receipt := block1.Receipts[i]
+			adaptedTx := rpc.AdaptTransaction(tx)
+			adaptedTx.Hash = nil
+
+			transactions[i] = rpc.TransactionWithReceipt{
+				Transaction: adaptedTx,
+				Receipt: rpc.AdaptReceipt(
+					receipt,
+					tx,
+					rpc.TxnAcceptedOnL1,
+				),
+			}
+		}
+
+		assert.Equal(t, &rpc.BlockWithReceipts{
+			Status: rpc.BlockAcceptedL1,
+			BlockHeader: rpc.BlockHeader{
+				Hash:             header.Hash,
+				ParentHash:       header.ParentHash,
+				Number:           header.Number,
+				NewRoot:          header.NewRoot,
+				Timestamp:        header.Timestamp,
+				SequencerAddress: header.SequencerAddress,
+				L1DAMode:         header.L1DAMode,
+				L1GasPrice:       header.L1GasPrice,
+				L1DataGasPrice:   header.L1DataGasPrice,
+				StarknetVersion:  header.StarknetVersion,
+				L2GasPrice:       header.L2GasPrice,
+			},
+			Transactions: transactions,
 		}, resp)
 	})
 

--- a/rpc/v9/class_test.go
+++ b/rpc/v9/class_test.go
@@ -270,7 +270,24 @@ func TestClassHashAt(t *testing.T) {
 			},
 			nil,
 		)
+		mockReader.EXPECT().Height().Return(l1HeadBlockNumber, nil)
 		mockReader.EXPECT().StateAtBlockNumber(l1HeadBlockNumber).Return(mockState, nopCloser, nil)
+		mockState.EXPECT().ContractClassHash(gomock.Any()).Return(*expectedClassHash, nil)
+		l1AcceptedID := blockIDL1Accepted(t)
+		classHash, rpcErr := handler.ClassHashAt(&l1AcceptedID, &felt.Zero)
+		require.Nil(t, rpcErr)
+		assert.Equal(t, expectedClassHash, classHash)
+	})
+
+	t.Run("blockID - l1_accepted bounded to chain height when L1 is ahead", func(t *testing.T) {
+		chainHeight := uint64(10)
+		l1HeadAhead := chainHeight + 5
+		mockReader.EXPECT().L1Head().Return(
+			core.L1Head{BlockNumber: l1HeadAhead, BlockHash: &felt.Zero, StateRoot: &felt.Zero},
+			nil,
+		)
+		mockReader.EXPECT().Height().Return(chainHeight, nil)
+		mockReader.EXPECT().StateAtBlockNumber(chainHeight).Return(mockState, nopCloser, nil)
 		mockState.EXPECT().ContractClassHash(gomock.Any()).Return(*expectedClassHash, nil)
 		l1AcceptedID := blockIDL1Accepted(t)
 		classHash, rpcErr := handler.ClassHashAt(&l1AcceptedID, &felt.Zero)

--- a/rpc/v9/helpers.go
+++ b/rpc/v9/helpers.go
@@ -33,6 +33,21 @@ func isL1Verified(n uint64, l1 core.L1Head) bool {
 	return false
 }
 
+// l1AcceptedBlockNumber returns the L1-accepted block number bounded by the
+// current chain height. The L1 head can be ahead of the L2 chain during sync,
+// in which case the caller should fall back to the latest local block.
+func (h *Handler) l1AcceptedBlockNumber() (uint64, error) {
+	l1Head, err := h.bcReader.L1Head()
+	if err != nil {
+		return 0, err
+	}
+	height, err := h.bcReader.Height()
+	if err != nil {
+		return 0, err
+	}
+	return min(l1Head.BlockNumber, height), nil
+}
+
 func (h *Handler) blockByID(blockID *BlockID) (*core.Block, *jsonrpc.Error) {
 	var block *core.Block
 	var err error
@@ -49,12 +64,12 @@ func (h *Handler) blockByID(blockID *BlockID) (*core.Block, *jsonrpc.Error) {
 	case hash:
 		block, err = h.bcReader.BlockByHash(blockID.Hash())
 	case l1Accepted:
-		var l1Head core.L1Head
-		l1Head, err = h.bcReader.L1Head()
+		var blockNumber uint64
+		blockNumber, err = h.l1AcceptedBlockNumber()
 		if err != nil {
 			break
 		}
-		block, err = h.bcReader.BlockByNumber(l1Head.BlockNumber)
+		block, err = h.bcReader.BlockByNumber(blockNumber)
 	default:
 		block, err = h.bcReader.BlockByNumber(blockID.Number())
 	}
@@ -112,12 +127,12 @@ func (h *Handler) blockHeaderByID(blockID *BlockID) (*core.Header, *jsonrpc.Erro
 	case number:
 		header, err = h.bcReader.BlockHeaderByNumber(blockID.Number())
 	case l1Accepted:
-		var l1Head core.L1Head
-		l1Head, err = h.bcReader.L1Head()
+		var blockNumber uint64
+		blockNumber, err = h.l1AcceptedBlockNumber()
 		if err != nil {
 			break
 		}
-		header, err = h.bcReader.BlockHeaderByNumber(l1Head.BlockNumber)
+		header, err = h.bcReader.BlockHeaderByNumber(blockNumber)
 	default:
 		panic("unknown block type id")
 	}
@@ -196,12 +211,12 @@ func (h *Handler) stateByBlockID(
 	case number:
 		reader, closer, err = h.bcReader.StateAtBlockNumber(blockID.Number())
 	case l1Accepted:
-		var l1Head core.L1Head
-		l1Head, err = h.bcReader.L1Head()
+		var blockNumber uint64
+		blockNumber, err = h.l1AcceptedBlockNumber()
 		if err != nil {
 			break
 		}
-		reader, closer, err = h.bcReader.StateAtBlockNumber(l1Head.BlockNumber)
+		reader, closer, err = h.bcReader.StateAtBlockNumber(blockNumber)
 	default:
 		panic("unknown block id type")
 	}

--- a/rpc/v9/nonce_test.go
+++ b/rpc/v9/nonce_test.go
@@ -134,7 +134,26 @@ func TestNonce(t *testing.T) {
 			},
 			nil,
 		)
+		mockReader.EXPECT().Height().Return(l1AcceptedBlockNumber, nil)
 		mockReader.EXPECT().StateAtBlockNumber(l1AcceptedBlockNumber).Return(mockState, nopCloser, nil)
+		mockState.EXPECT().ContractNonce(&targetAddress).Return(*expectedNonce, nil)
+
+		l1AcceptedID := blockIDL1Accepted(t)
+		nonce, rpcErr := handler.Nonce(&l1AcceptedID, &targetAddress)
+		require.Nil(t, rpcErr)
+		assert.Equal(t, expectedNonce, nonce)
+	})
+
+	t.Run("blockID - l1_accepted bounded to chain height when L1 is ahead", func(t *testing.T) {
+		chainHeight := uint64(10)
+		l1HeadAhead := chainHeight + 5
+
+		mockReader.EXPECT().L1Head().Return(
+			core.L1Head{BlockNumber: l1HeadAhead, BlockHash: &felt.One, StateRoot: &felt.One},
+			nil,
+		)
+		mockReader.EXPECT().Height().Return(chainHeight, nil)
+		mockReader.EXPECT().StateAtBlockNumber(chainHeight).Return(mockState, nopCloser, nil)
 		mockState.EXPECT().ContractNonce(&targetAddress).Return(*expectedNonce, nil)
 
 		l1AcceptedID := blockIDL1Accepted(t)

--- a/rpc/v9/state_update.go
+++ b/rpc/v9/state_update.go
@@ -164,11 +164,11 @@ func (h *Handler) stateUpdateByID(id *BlockID) (*core.StateUpdate, error) {
 	case number:
 		return h.bcReader.StateUpdateByNumber(id.Number())
 	case l1Accepted:
-		l1Head, err := h.bcReader.L1Head()
+		blockNumber, err := h.l1AcceptedBlockNumber()
 		if err != nil {
 			return nil, err
 		}
-		return h.bcReader.StateUpdateByNumber(l1Head.BlockNumber)
+		return h.bcReader.StateUpdateByNumber(blockNumber)
 	default:
 		panic("unknown block type id")
 	}

--- a/rpc/v9/state_update_test.go
+++ b/rpc/v9/state_update_test.go
@@ -161,6 +161,24 @@ func TestStateUpdate(t *testing.T) {
 			},
 			nil,
 		)
+		mockReader.EXPECT().Height().Return(uint64(21656), nil)
+		mockReader.EXPECT().StateUpdateByNumber(uint64(21656)).Return(update21656, nil)
+		l1AcceptedID := blockIDL1Accepted(t)
+		update, rpcErr := handler.StateUpdate(&l1AcceptedID)
+		require.Nil(t, rpcErr)
+		checkUpdate(t, update21656, &update)
+	})
+
+	t.Run("l1_accepted bounded to chain height when L1 is ahead", func(t *testing.T) {
+		mockReader.EXPECT().L1Head().Return(
+			core.L1Head{
+				BlockNumber: uint64(21656) + 10,
+				BlockHash:   update21656.BlockHash,
+				StateRoot:   update21656.NewRoot,
+			},
+			nil,
+		)
+		mockReader.EXPECT().Height().Return(uint64(21656), nil)
 		mockReader.EXPECT().StateUpdateByNumber(uint64(21656)).Return(update21656, nil)
 		l1AcceptedID := blockIDL1Accepted(t)
 		update, rpcErr := handler.StateUpdate(&l1AcceptedID)

--- a/rpc/v9/storage_test.go
+++ b/rpc/v9/storage_test.go
@@ -214,7 +214,26 @@ func TestStorageAt(t *testing.T) {
 			},
 			nil,
 		)
+		mockReader.EXPECT().Height().Return(l1HeadBlockNumber, nil)
 		mockReader.EXPECT().StateAtBlockNumber(l1HeadBlockNumber).Return(mockState, nopCloser, nil)
+		mockState.EXPECT().ContractClassHash(&felt.Zero).Return(felt.Zero, nil)
+		mockState.EXPECT().ContractStorage(gomock.Any(), gomock.Any()).Return(*expectedStorage, nil)
+
+		blockID := blockIDL1Accepted(t)
+		storageValue, rpcErr := handler.StorageAt(&felt.Zero, &felt.Zero, &blockID)
+		require.Nil(t, rpcErr)
+		assert.Equal(t, expectedStorage, storageValue)
+	})
+
+	t.Run("blockID - l1_accepted bounded to chain height when L1 is ahead", func(t *testing.T) {
+		chainHeight := uint64(10)
+		l1HeadAhead := chainHeight + 5
+		mockReader.EXPECT().L1Head().Return(
+			core.L1Head{BlockNumber: l1HeadAhead, BlockHash: &felt.Zero, StateRoot: &felt.Zero},
+			nil,
+		)
+		mockReader.EXPECT().Height().Return(chainHeight, nil)
+		mockReader.EXPECT().StateAtBlockNumber(chainHeight).Return(mockState, nopCloser, nil)
 		mockState.EXPECT().ContractClassHash(&felt.Zero).Return(felt.Zero, nil)
 		mockState.EXPECT().ContractStorage(gomock.Any(), gomock.Any()).Return(*expectedStorage, nil)
 

--- a/rpc/v9/transaction.go
+++ b/rpc/v9/transaction.go
@@ -586,12 +586,10 @@ func (h *Handler) TransactionByBlockIDAndIndex(
 	case number:
 		blockNumber = blockID.Number()
 	case l1Accepted:
-		var l1Head core.L1Head
-		l1Head, err = h.bcReader.L1Head()
+		blockNumber, err = h.l1AcceptedBlockNumber()
 		if err != nil {
 			break
 		}
-		blockNumber = l1Head.BlockNumber
 	default:
 		panic("unknown block type id")
 	}

--- a/rpc/v9/transaction_test.go
+++ b/rpc/v9/transaction_test.go
@@ -629,6 +629,31 @@ func TestTransactionByBlockIdAndIndex(t *testing.T) {
 			},
 			nil,
 		)
+		mockReader.EXPECT().Height().Return(latestBlockNumber, nil)
+		mockReader.EXPECT().TransactionByBlockNumberAndIndex(latestBlockNumber,
+			uint64(index)).DoAndReturn(func(number, index uint64) (core.Transaction, error) {
+			return latestBlock.Transactions[index], nil
+		})
+
+		expectedTxn := rpc.AdaptTransaction(latestBlock.Transactions[index])
+		blockID := blockIDL1Accepted(t)
+		actualTxn, rpcErr := handler.TransactionByBlockIDAndIndex(&blockID, index)
+		require.Nil(t, rpcErr)
+		require.Equal(t, expectedTxn, actualTxn)
+	})
+
+	t.Run("blockID - l1_accepted bounded to chain height when L1 is ahead", func(t *testing.T) {
+		index := rand.Intn(int(latestBlock.TransactionCount))
+
+		mockReader.EXPECT().L1Head().Return(
+			core.L1Head{
+				BlockNumber: latestBlockNumber + 10,
+				BlockHash:   latestBlockHash,
+				StateRoot:   latestBlock.GlobalStateRoot,
+			},
+			nil,
+		)
+		mockReader.EXPECT().Height().Return(latestBlockNumber, nil)
 		mockReader.EXPECT().TransactionByBlockNumberAndIndex(latestBlockNumber,
 			uint64(index)).DoAndReturn(func(number, index uint64) (core.Transaction, error) {
 			return latestBlock.Transactions[index], nil


### PR DESCRIPTION
### Problem

While the node is syncing, the L1 head can be ahead of the local chain height. Queries with the l1_accepted block tag then resolve to a block number the node doesn't have locally and return a not-found error.

The spec defines l1_accepted as:

> Tag l1_accepted refers to the latest Starknet block which was included in a state update on L1 and finalized by the consensus on L1.

Any local block at or below the L1 head already satisfies this definition, so falling back to the chain height is spec-compliant.

### Solution

Add an `l1AcceptedBlockNumber()` helper that returns `min(l1Head.BlockNumber, chainHeight)` and use it from every `IsL1Accepted()` branch in the v9 and v10 RPC handlers.