### PR TITLE
refactor(state): make new state history write to its own buckets

### DIFF
--- a/cmd/juno/dbcmd.go
+++ b/cmd/juno/dbcmd.go
@@ -223,6 +223,11 @@ func dbSize(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("--%v cannot be empty", dbPathF)
 	}
 
+	newState, err := cmd.Flags().GetBool(newStateF)
+	if err != nil {
+		return err
+	}
+
 	pebbleDB, err := openDB(dbPath)
 	if err != nil {
 		return err
@@ -239,6 +244,19 @@ func dbSize(cmd *cobra.Command, args []string) error {
 		withHistoryCount    uint
 		withoutHistoryCount uint
 	)
+
+	historyBuckets := []db.Bucket{
+		db.DeprecatedContractStorageHistory,
+		db.DeprecatedContractNonceHistory,
+		db.DeprecatedContractClassHashHistory,
+	}
+	if newState {
+		historyBuckets = []db.Bucket{
+			db.ContractStorageHistory,
+			db.ContractNonceHistory,
+			db.ContractClassHashHistory,
+		}
+	}
 
 	buckets := db.BucketValues()
 	items := make([][]string, 0, len(buckets)+3)
@@ -266,12 +284,7 @@ func dbSize(cmd *cobra.Command, args []string) error {
 			withHistoryCount += bucketItem.Count
 		}
 
-		if utils.AnyOf(
-			b,
-			db.DeprecatedContractStorageHistory,
-			db.DeprecatedContractNonceHistory,
-			db.DeprecatedContractClassHashHistory,
-		) {
+		if utils.AnyOf(b, historyBuckets...) {
 			withHistorySize += bucketItem.Size
 			withHistoryCount += bucketItem.Count
 		}

--- a/cmd/juno/dbcmd.go
+++ b/cmd/juno/dbcmd.go
@@ -223,11 +223,6 @@ func dbSize(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("--%v cannot be empty", dbPathF)
 	}
 
-	newState, err := cmd.Flags().GetBool(newStateF)
-	if err != nil {
-		return err
-	}
-
 	pebbleDB, err := openDB(dbPath)
 	if err != nil {
 		return err
@@ -249,13 +244,9 @@ func dbSize(cmd *cobra.Command, args []string) error {
 		db.DeprecatedContractStorageHistory,
 		db.DeprecatedContractNonceHistory,
 		db.DeprecatedContractClassHashHistory,
-	}
-	if newState {
-		historyBuckets = []db.Bucket{
-			db.ContractStorageHistory,
-			db.ContractNonceHistory,
-			db.ContractClassHashHistory,
-		}
+		db.ContractStorageHistory,
+		db.ContractNonceHistory,
+		db.ContractClassHashHistory,
 	}
 
 	buckets := db.BucketValues()

--- a/cmd/juno/dbcmd.go
+++ b/cmd/juno/dbcmd.go
@@ -266,7 +266,12 @@ func dbSize(cmd *cobra.Command, args []string) error {
 			withHistoryCount += bucketItem.Count
 		}
 
-		if utils.AnyOf(b, db.ContractStorageHistory, db.ContractNonceHistory, db.ContractClassHashHistory) {
+		if utils.AnyOf(
+			b,
+			db.DeprecatedContractStorageHistory,
+			db.DeprecatedContractNonceHistory,
+			db.DeprecatedContractClassHashHistory,
+		) {
 			withHistorySize += bucketItem.Size
 			withHistoryCount += bucketItem.Count
 		}

--- a/core/accessors.go
+++ b/core/accessors.go
@@ -125,68 +125,68 @@ func GetStateUpdateByHash(r db.KeyValueReader, hash *felt.Felt) (*StateUpdate, e
 	return GetStateUpdateByBlockNum(r, blockNum)
 }
 
-// WriteContractStorageHistory writes the old value of a storage location
+// WriteDeprecatedContractStorageHistory writes the old value of a storage location
 // for the given contract which changed on height `height`.
-func WriteContractStorageHistory(
+func WriteDeprecatedContractStorageHistory(
 	w db.KeyValueWriter,
 	contractAddress,
 	storageLocation,
 	oldValue *felt.Felt,
 	height uint64,
 ) error {
-	key := db.ContractStorageHistoryAtBlockKey(contractAddress, storageLocation, height)
+	key := db.DeprecatedContractStorageHistoryAtBlockKey(contractAddress, storageLocation, height)
 	return w.Put(key, oldValue.Marshal())
 }
 
-// DeleteContractStorageHistory deletes the history at the given height
-func DeleteContractStorageHistory(
+// DeleteDeprecatedContractStorageHistory deletes the history at the given height
+func DeleteDeprecatedContractStorageHistory(
 	w db.KeyValueWriter,
 	contractAddress,
 	storageLocation *felt.Felt,
 	height uint64,
 ) error {
-	key := db.ContractStorageHistoryAtBlockKey(contractAddress, storageLocation, height)
+	key := db.DeprecatedContractStorageHistoryAtBlockKey(contractAddress, storageLocation, height)
 	return w.Delete(key)
 }
 
-// WriteContractNonceHistory writes the old value of a nonce
+// WriteDeprecatedContractNonceHistory writes the old value of a nonce
 // for the given contract which changed on height `height`
-func WriteContractNonceHistory(
+func WriteDeprecatedContractNonceHistory(
 	w db.KeyValueWriter,
 	contractAddress,
 	oldValue *felt.Felt,
 	height uint64,
 ) error {
-	key := db.ContractNonceHistoryAtBlockKey(contractAddress, height)
+	key := db.DeprecatedContractNonceHistoryAtBlockKey(contractAddress, height)
 	return w.Put(key, oldValue.Marshal())
 }
 
-// DeleteContractNonceHistory deletes the history at the given height
-func DeleteContractNonceHistory(
+// DeleteDeprecatedContractNonceHistory deletes the history at the given height
+func DeleteDeprecatedContractNonceHistory(
 	w db.KeyValueWriter,
 	contractAddress *felt.Felt,
 	height uint64,
 ) error {
-	key := db.ContractNonceHistoryAtBlockKey(contractAddress, height)
+	key := db.DeprecatedContractNonceHistoryAtBlockKey(contractAddress, height)
 	return w.Delete(key)
 }
 
-func WriteContractClassHashHistory(
+func WriteDeprecatedContractClassHashHistory(
 	w db.KeyValueWriter,
 	contractAddress,
 	oldValue *felt.Felt,
 	height uint64,
 ) error {
-	key := db.ContractClassHashHistoryAtBlockKey(contractAddress, height)
+	key := db.DeprecatedContractClassHashHistoryAtBlockKey(contractAddress, height)
 	return w.Put(key, oldValue.Marshal())
 }
 
-func DeleteContractClassHashHistory(
+func DeleteDeprecatedContractClassHashHistory(
 	w db.KeyValueWriter,
 	contractAddress *felt.Felt,
 	height uint64,
 ) error {
-	key := db.ContractClassHashHistoryAtBlockKey(contractAddress, height)
+	key := db.DeprecatedContractClassHashHistoryAtBlockKey(contractAddress, height)
 	return w.Delete(key)
 }
 

--- a/core/deprecatedstate/state.go
+++ b/core/deprecatedstate/state.go
@@ -81,7 +81,7 @@ func (s *State) ContractStorageLastUpdatedBlock(
 	key *felt.Felt,
 ) (uint64, error) {
 	return s.lastUpdatedBlockNumber(
-		db.ContractStorageHistoryKey((*felt.Felt)(addr), key),
+		db.DeprecatedContractStorageHistoryKey((*felt.Felt)(addr), key),
 		math.MaxUint64,
 	)
 }
@@ -305,7 +305,7 @@ func (s *State) updateContracts(
 		}
 
 		if logChanges {
-			if err = core.WriteContractClassHashHistory(
+			if err = core.WriteDeprecatedContractClassHashHistory(
 				s.txn, &addr, &oldClassHash, blockNumber,
 			); err != nil {
 				return err
@@ -321,7 +321,8 @@ func (s *State) updateContracts(
 		}
 
 		if logChanges {
-			if err = core.WriteContractNonceHistory(s.txn, &addr, &oldNonce, blockNumber); err != nil {
+			err = core.WriteDeprecatedContractNonceHistory(s.txn, &addr, &oldNonce, blockNumber)
+			if err != nil {
 				return err
 			}
 		}
@@ -405,7 +406,7 @@ func (s *State) updateStorageBuffered(
 
 	onValueChanged := func(location, oldValue *felt.Felt) error {
 		if logChanges {
-			return core.WriteContractStorageHistory(
+			return core.WriteDeprecatedContractStorageHistory(
 				bufferedState.txn,
 				contractAddr,
 				location,
@@ -833,7 +834,8 @@ func (s *State) performStateDeletions(blockNumber uint64, diff *core.StateDiff) 
 	// storage diffs
 	for addr, storageDiffs := range diff.StorageDiffs {
 		for key := range storageDiffs {
-			if err := core.DeleteContractStorageHistory(s.txn, &addr, &key, blockNumber); err != nil {
+			err := core.DeleteDeprecatedContractStorageHistory(s.txn, &addr, &key, blockNumber)
+			if err != nil {
 				return err
 			}
 		}
@@ -841,14 +843,14 @@ func (s *State) performStateDeletions(blockNumber uint64, diff *core.StateDiff) 
 
 	// nonces
 	for addr := range diff.Nonces {
-		if err := core.DeleteContractNonceHistory(s.txn, &addr, blockNumber); err != nil {
+		if err := core.DeleteDeprecatedContractNonceHistory(s.txn, &addr, blockNumber); err != nil {
 			return err
 		}
 	}
 
 	// replaced classes
 	for addr := range diff.ReplacedClasses {
-		if err := core.DeleteContractClassHashHistory(s.txn, &addr, blockNumber); err != nil {
+		if err := core.DeleteDeprecatedContractClassHashHistory(s.txn, &addr, blockNumber); err != nil {
 			return err
 		}
 	}
@@ -900,7 +902,7 @@ func (s *State) ContractStorageAt(
 	storageLocation *felt.Felt,
 	height uint64,
 ) (felt.Felt, error) {
-	key := db.ContractStorageHistoryKey(contractAddress, storageLocation)
+	key := db.DeprecatedContractStorageHistoryKey(contractAddress, storageLocation)
 	value, err := s.valueAt(key, height)
 	if err != nil {
 		return felt.Felt{}, err
@@ -917,7 +919,7 @@ func (s *State) ContractStorageLastUpdatedAt(
 	blockNumber uint64,
 ) (uint64, error) {
 	return s.lastUpdatedBlockNumber(
-		db.ContractStorageHistoryKey((*felt.Felt)(addr), key),
+		db.DeprecatedContractStorageHistoryKey((*felt.Felt)(addr), key),
 		blockNumber,
 	)
 }
@@ -926,7 +928,7 @@ func (s *State) ContractNonceAt(
 	contractAddress *felt.Felt,
 	height uint64,
 ) (felt.Felt, error) {
-	key := db.ContractNonceHistoryKey(contractAddress)
+	key := db.DeprecatedContractNonceHistoryKey(contractAddress)
 	value, err := s.valueAt(key, height)
 	if err != nil {
 		return felt.Felt{}, err
@@ -938,7 +940,7 @@ func (s *State) ContractClassHashAt(
 	contractAddress *felt.Felt,
 	height uint64,
 ) (felt.Felt, error) {
-	key := db.ContractClassHashHistoryKey(contractAddress)
+	key := db.DeprecatedContractClassHashHistoryKey(contractAddress)
 	value, err := s.valueAt(key, height)
 	if err != nil {
 		return felt.Felt{}, err

--- a/core/deprecatedstate/state_test.go
+++ b/core/deprecatedstate/state_test.go
@@ -337,24 +337,30 @@ func TestHistory(t *testing.T) {
 	}{
 		"contract storage": {
 			logger: func(txn db.KeyValueWriter, location, oldValue *felt.Felt, height uint64) error {
-				return core.WriteContractStorageHistory(txn, contractAddress, location, oldValue, height)
+				return core.WriteDeprecatedContractStorageHistory(
+					txn,
+					contractAddress,
+					location,
+					oldValue,
+					height,
+				)
 			},
 			getter: func(location *felt.Felt, height uint64) (felt.Felt, error) {
 				return state.ContractStorageAt(contractAddress, location, height)
 			},
 			deleter: func(txn db.KeyValueWriter, location *felt.Felt, height uint64) error {
-				return core.DeleteContractStorageHistory(txn, contractAddress, location, height)
+				return core.DeleteDeprecatedContractStorageHistory(txn, contractAddress, location, height)
 			},
 		},
 		"contract nonce": {
-			logger:  core.WriteContractNonceHistory,
+			logger:  core.WriteDeprecatedContractNonceHistory,
 			getter:  state.ContractNonceAt,
-			deleter: core.DeleteContractNonceHistory,
+			deleter: core.DeleteDeprecatedContractNonceHistory,
 		},
 		"contract class hash": {
-			logger:  core.WriteContractClassHashHistory,
+			logger:  core.WriteDeprecatedContractClassHashHistory,
 			getter:  state.ContractClassHashAt,
-			deleter: core.DeleteContractClassHashHistory,
+			deleter: core.DeleteDeprecatedContractClassHashHistory,
 		},
 	} {
 		location := felt.NewFromUint64[felt.Felt](456)

--- a/db/buckets.go
+++ b/db/buckets.go
@@ -84,12 +84,16 @@ const (
 	// For these three history buckets, the block number is when the current value was set, and
 	// the value is the old value before that.
 
-	// ContractClassHashHistory + Contract address + block number -> old class hash.
+	// DeprecatedContractClassHashHistory + Contract address + block number -> old class hash.
+	DeprecatedContractClassHashHistory = Bucket(deprecatedContractClassHashHistory)
+	// DeprecatedContractNonceHistory + Contract address + block number -> old nonce.
+	DeprecatedContractNonceHistory = Bucket(deprecatedContractNonceHistory)
+	// DeprecatedContractStorageHistory + Contract address + storage slot + block number -> old value.
+	DeprecatedContractStorageHistory = Bucket(deprecatedContractStorageHistory)
+
 	ContractClassHashHistory = Bucket(contractClassHashHistory)
-	// ContractNonceHistory + Contract address + block number -> old nonce.
-	ContractNonceHistory = Bucket(contractNonceHistory)
-	// ContractStorageHistory + Contract address + storage location + block number -> old value.
-	ContractStorageHistory = Bucket(contractStorageHistory)
+	ContractNonceHistory     = Bucket(contractNonceHistory)
+	ContractStorageHistory   = Bucket(contractStorageHistory)
 
 	/****************************************************
 			Mempool
@@ -167,9 +171,9 @@ const (
 	receiptsByBlockNumberAndIndex
 	stateUpdatesByBlockNumber
 	classesTrie
-	contractStorageHistory
-	contractNonceHistory
-	contractClassHashHistory
+	deprecatedContractStorageHistory
+	deprecatedContractNonceHistory
+	deprecatedContractClassHashHistory
 	contractDeploymentHeight
 	l1Height
 	deprecatedSchemaVersion
@@ -196,4 +200,7 @@ const (
 	blockTransactions
 	schemaMetadata
 	schemaIntermediateState
+	contractClassHashHistory
+	contractNonceHistory
+	contractStorageHistory
 )

--- a/db/buckets_enumer.go
+++ b/db/buckets_enumer.go
@@ -7,11 +7,11 @@ import (
 	"strings"
 )
 
-const _innerBucketName = "StateTriePeerContractClassHashContractStorageClassContractNonceChainHeightBlockHeaderNumbersByHashBlockHeadersByNumberTransactionBlockNumbersAndIndicesByHashTransactionsByBlockNumberAndIndexReceiptsByBlockNumberAndIndexStateUpdatesByBlockNumberClassesTrieContractStorageHistoryContractNonceHistoryContractClassHashHistoryContractDeploymentHeightL1HeightDeprecatedSchemaVersionUnusedBlockCommitmentsTemporaryDeprecatedSchemaIntermediateStateL1HandlerTxnHashByMsgHashMempoolHeadMempoolTailMempoolLengthMempoolNodeClassTrieContractTrieContractContractTrieStorageContractStateHashToTrieRootsStateIDPersistedStateIDTrieJournalAggregatedBloomFiltersRunningEventFilterClassCasmHashMetadataBlockTransactionsSchemaMetadataSchemaIntermediateState"
+const _innerBucketName = "StateTriePeerContractClassHashContractStorageClassContractNonceChainHeightBlockHeaderNumbersByHashBlockHeadersByNumberTransactionBlockNumbersAndIndicesByHashTransactionsByBlockNumberAndIndexReceiptsByBlockNumberAndIndexStateUpdatesByBlockNumberClassesTrieDeprecatedContractStorageHistoryDeprecatedContractNonceHistoryDeprecatedContractClassHashHistoryContractDeploymentHeightL1HeightDeprecatedSchemaVersionUnusedBlockCommitmentsTemporaryDeprecatedSchemaIntermediateStateL1HandlerTxnHashByMsgHashMempoolHeadMempoolTailMempoolLengthMempoolNodeClassTrieContractTrieContractContractTrieStorageContractStateHashToTrieRootsStateIDPersistedStateIDTrieJournalAggregatedBloomFiltersRunningEventFilterClassCasmHashMetadataBlockTransactionsSchemaMetadataSchemaIntermediateStateContractClassHashHistoryContractNonceHistoryContractStorageHistory"
 
-var _innerBucketIndex = [...]uint16{0, 9, 13, 30, 45, 50, 63, 74, 98, 118, 157, 190, 219, 244, 255, 277, 297, 321, 345, 353, 376, 382, 398, 407, 440, 465, 476, 487, 500, 511, 520, 540, 559, 567, 587, 594, 610, 621, 643, 661, 682, 699, 713, 736}
+var _innerBucketIndex = [...]uint16{0, 9, 13, 30, 45, 50, 63, 74, 98, 118, 157, 190, 219, 244, 255, 287, 317, 351, 375, 383, 406, 412, 428, 437, 470, 495, 506, 517, 530, 541, 550, 570, 589, 597, 617, 624, 640, 651, 673, 691, 712, 729, 743, 766, 790, 810, 832}
 
-const _innerBucketLowerName = "statetriepeercontractclasshashcontractstorageclasscontractnoncechainheightblockheadernumbersbyhashblockheadersbynumbertransactionblocknumbersandindicesbyhashtransactionsbyblocknumberandindexreceiptsbyblocknumberandindexstateupdatesbyblocknumberclassestriecontractstoragehistorycontractnoncehistorycontractclasshashhistorycontractdeploymentheightl1heightdeprecatedschemaversionunusedblockcommitmentstemporarydeprecatedschemaintermediatestatel1handlertxnhashbymsghashmempoolheadmempooltailmempoollengthmempoolnodeclasstriecontracttriecontractcontracttriestoragecontractstatehashtotrierootsstateidpersistedstateidtriejournalaggregatedbloomfiltersrunningeventfilterclasscasmhashmetadatablocktransactionsschemametadataschemaintermediatestate"
+const _innerBucketLowerName = "statetriepeercontractclasshashcontractstorageclasscontractnoncechainheightblockheadernumbersbyhashblockheadersbynumbertransactionblocknumbersandindicesbyhashtransactionsbyblocknumberandindexreceiptsbyblocknumberandindexstateupdatesbyblocknumberclassestriedeprecatedcontractstoragehistorydeprecatedcontractnoncehistorydeprecatedcontractclasshashhistorycontractdeploymentheightl1heightdeprecatedschemaversionunusedblockcommitmentstemporarydeprecatedschemaintermediatestatel1handlertxnhashbymsghashmempoolheadmempooltailmempoollengthmempoolnodeclasstriecontracttriecontractcontracttriestoragecontractstatehashtotrierootsstateidpersistedstateidtriejournalaggregatedbloomfiltersrunningeventfilterclasscasmhashmetadatablocktransactionsschemametadataschemaintermediatestatecontractclasshashhistorycontractnoncehistorycontractstoragehistory"
 
 func (i innerBucket) String() string {
 	if i >= innerBucket(len(_innerBucketIndex)-1) {
@@ -38,9 +38,9 @@ func _innerBucketNoOp() {
 	_ = x[receiptsByBlockNumberAndIndex-(11)]
 	_ = x[stateUpdatesByBlockNumber-(12)]
 	_ = x[classesTrie-(13)]
-	_ = x[contractStorageHistory-(14)]
-	_ = x[contractNonceHistory-(15)]
-	_ = x[contractClassHashHistory-(16)]
+	_ = x[deprecatedContractStorageHistory-(14)]
+	_ = x[deprecatedContractNonceHistory-(15)]
+	_ = x[deprecatedContractClassHashHistory-(16)]
 	_ = x[contractDeploymentHeight-(17)]
 	_ = x[l1Height-(18)]
 	_ = x[deprecatedSchemaVersion-(19)]
@@ -67,9 +67,12 @@ func _innerBucketNoOp() {
 	_ = x[blockTransactions-(40)]
 	_ = x[schemaMetadata-(41)]
 	_ = x[schemaIntermediateState-(42)]
+	_ = x[contractClassHashHistory-(43)]
+	_ = x[contractNonceHistory-(44)]
+	_ = x[contractStorageHistory-(45)]
 }
 
-var _innerBucketValues = []innerBucket{stateTrie, peer, contractClassHash, contractStorage, class, contractNonce, chainHeight, blockHeaderNumbersByHash, blockHeadersByNumber, transactionBlockNumbersAndIndicesByHash, transactionsByBlockNumberAndIndex, receiptsByBlockNumberAndIndex, stateUpdatesByBlockNumber, classesTrie, contractStorageHistory, contractNonceHistory, contractClassHashHistory, contractDeploymentHeight, l1Height, deprecatedSchemaVersion, unused, blockCommitments, temporary, deprecatedSchemaIntermediateState, l1HandlerTxnHashByMsgHash, mempoolHead, mempoolTail, mempoolLength, mempoolNode, classTrie, contractTrieContract, contractTrieStorage, contract, stateHashToTrieRoots, stateID, persistedStateID, trieJournal, aggregatedBloomFilters, runningEventFilter, classCasmHashMetadata, blockTransactions, schemaMetadata, schemaIntermediateState}
+var _innerBucketValues = []innerBucket{stateTrie, peer, contractClassHash, contractStorage, class, contractNonce, chainHeight, blockHeaderNumbersByHash, blockHeadersByNumber, transactionBlockNumbersAndIndicesByHash, transactionsByBlockNumberAndIndex, receiptsByBlockNumberAndIndex, stateUpdatesByBlockNumber, classesTrie, deprecatedContractStorageHistory, deprecatedContractNonceHistory, deprecatedContractClassHashHistory, contractDeploymentHeight, l1Height, deprecatedSchemaVersion, unused, blockCommitments, temporary, deprecatedSchemaIntermediateState, l1HandlerTxnHashByMsgHash, mempoolHead, mempoolTail, mempoolLength, mempoolNode, classTrie, contractTrieContract, contractTrieStorage, contract, stateHashToTrieRoots, stateID, persistedStateID, trieJournal, aggregatedBloomFilters, runningEventFilter, classCasmHashMetadata, blockTransactions, schemaMetadata, schemaIntermediateState, contractClassHashHistory, contractNonceHistory, contractStorageHistory}
 
 var _innerBucketNameToValueMap = map[string]innerBucket{
 	_innerBucketName[0:9]:          stateTrie,
@@ -100,64 +103,70 @@ var _innerBucketNameToValueMap = map[string]innerBucket{
 	_innerBucketLowerName[219:244]: stateUpdatesByBlockNumber,
 	_innerBucketName[244:255]:      classesTrie,
 	_innerBucketLowerName[244:255]: classesTrie,
-	_innerBucketName[255:277]:      contractStorageHistory,
-	_innerBucketLowerName[255:277]: contractStorageHistory,
-	_innerBucketName[277:297]:      contractNonceHistory,
-	_innerBucketLowerName[277:297]: contractNonceHistory,
-	_innerBucketName[297:321]:      contractClassHashHistory,
-	_innerBucketLowerName[297:321]: contractClassHashHistory,
-	_innerBucketName[321:345]:      contractDeploymentHeight,
-	_innerBucketLowerName[321:345]: contractDeploymentHeight,
-	_innerBucketName[345:353]:      l1Height,
-	_innerBucketLowerName[345:353]: l1Height,
-	_innerBucketName[353:376]:      deprecatedSchemaVersion,
-	_innerBucketLowerName[353:376]: deprecatedSchemaVersion,
-	_innerBucketName[376:382]:      unused,
-	_innerBucketLowerName[376:382]: unused,
-	_innerBucketName[382:398]:      blockCommitments,
-	_innerBucketLowerName[382:398]: blockCommitments,
-	_innerBucketName[398:407]:      temporary,
-	_innerBucketLowerName[398:407]: temporary,
-	_innerBucketName[407:440]:      deprecatedSchemaIntermediateState,
-	_innerBucketLowerName[407:440]: deprecatedSchemaIntermediateState,
-	_innerBucketName[440:465]:      l1HandlerTxnHashByMsgHash,
-	_innerBucketLowerName[440:465]: l1HandlerTxnHashByMsgHash,
-	_innerBucketName[465:476]:      mempoolHead,
-	_innerBucketLowerName[465:476]: mempoolHead,
-	_innerBucketName[476:487]:      mempoolTail,
-	_innerBucketLowerName[476:487]: mempoolTail,
-	_innerBucketName[487:500]:      mempoolLength,
-	_innerBucketLowerName[487:500]: mempoolLength,
-	_innerBucketName[500:511]:      mempoolNode,
-	_innerBucketLowerName[500:511]: mempoolNode,
-	_innerBucketName[511:520]:      classTrie,
-	_innerBucketLowerName[511:520]: classTrie,
-	_innerBucketName[520:540]:      contractTrieContract,
-	_innerBucketLowerName[520:540]: contractTrieContract,
-	_innerBucketName[540:559]:      contractTrieStorage,
-	_innerBucketLowerName[540:559]: contractTrieStorage,
-	_innerBucketName[559:567]:      contract,
-	_innerBucketLowerName[559:567]: contract,
-	_innerBucketName[567:587]:      stateHashToTrieRoots,
-	_innerBucketLowerName[567:587]: stateHashToTrieRoots,
-	_innerBucketName[587:594]:      stateID,
-	_innerBucketLowerName[587:594]: stateID,
-	_innerBucketName[594:610]:      persistedStateID,
-	_innerBucketLowerName[594:610]: persistedStateID,
-	_innerBucketName[610:621]:      trieJournal,
-	_innerBucketLowerName[610:621]: trieJournal,
-	_innerBucketName[621:643]:      aggregatedBloomFilters,
-	_innerBucketLowerName[621:643]: aggregatedBloomFilters,
-	_innerBucketName[643:661]:      runningEventFilter,
-	_innerBucketLowerName[643:661]: runningEventFilter,
-	_innerBucketName[661:682]:      classCasmHashMetadata,
-	_innerBucketLowerName[661:682]: classCasmHashMetadata,
-	_innerBucketName[682:699]:      blockTransactions,
-	_innerBucketLowerName[682:699]: blockTransactions,
-	_innerBucketName[699:713]:      schemaMetadata,
-	_innerBucketLowerName[699:713]: schemaMetadata,
-	_innerBucketName[713:736]:      schemaIntermediateState,
-	_innerBucketLowerName[713:736]: schemaIntermediateState,
+	_innerBucketName[255:287]:      deprecatedContractStorageHistory,
+	_innerBucketLowerName[255:287]: deprecatedContractStorageHistory,
+	_innerBucketName[287:317]:      deprecatedContractNonceHistory,
+	_innerBucketLowerName[287:317]: deprecatedContractNonceHistory,
+	_innerBucketName[317:351]:      deprecatedContractClassHashHistory,
+	_innerBucketLowerName[317:351]: deprecatedContractClassHashHistory,
+	_innerBucketName[351:375]:      contractDeploymentHeight,
+	_innerBucketLowerName[351:375]: contractDeploymentHeight,
+	_innerBucketName[375:383]:      l1Height,
+	_innerBucketLowerName[375:383]: l1Height,
+	_innerBucketName[383:406]:      deprecatedSchemaVersion,
+	_innerBucketLowerName[383:406]: deprecatedSchemaVersion,
+	_innerBucketName[406:412]:      unused,
+	_innerBucketLowerName[406:412]: unused,
+	_innerBucketName[412:428]:      blockCommitments,
+	_innerBucketLowerName[412:428]: blockCommitments,
+	_innerBucketName[428:437]:      temporary,
+	_innerBucketLowerName[428:437]: temporary,
+	_innerBucketName[437:470]:      deprecatedSchemaIntermediateState,
+	_innerBucketLowerName[437:470]: deprecatedSchemaIntermediateState,
+	_innerBucketName[470:495]:      l1HandlerTxnHashByMsgHash,
+	_innerBucketLowerName[470:495]: l1HandlerTxnHashByMsgHash,
+	_innerBucketName[495:506]:      mempoolHead,
+	_innerBucketLowerName[495:506]: mempoolHead,
+	_innerBucketName[506:517]:      mempoolTail,
+	_innerBucketLowerName[506:517]: mempoolTail,
+	_innerBucketName[517:530]:      mempoolLength,
+	_innerBucketLowerName[517:530]: mempoolLength,
+	_innerBucketName[530:541]:      mempoolNode,
+	_innerBucketLowerName[530:541]: mempoolNode,
+	_innerBucketName[541:550]:      classTrie,
+	_innerBucketLowerName[541:550]: classTrie,
+	_innerBucketName[550:570]:      contractTrieContract,
+	_innerBucketLowerName[550:570]: contractTrieContract,
+	_innerBucketName[570:589]:      contractTrieStorage,
+	_innerBucketLowerName[570:589]: contractTrieStorage,
+	_innerBucketName[589:597]:      contract,
+	_innerBucketLowerName[589:597]: contract,
+	_innerBucketName[597:617]:      stateHashToTrieRoots,
+	_innerBucketLowerName[597:617]: stateHashToTrieRoots,
+	_innerBucketName[617:624]:      stateID,
+	_innerBucketLowerName[617:624]: stateID,
+	_innerBucketName[624:640]:      persistedStateID,
+	_innerBucketLowerName[624:640]: persistedStateID,
+	_innerBucketName[640:651]:      trieJournal,
+	_innerBucketLowerName[640:651]: trieJournal,
+	_innerBucketName[651:673]:      aggregatedBloomFilters,
+	_innerBucketLowerName[651:673]: aggregatedBloomFilters,
+	_innerBucketName[673:691]:      runningEventFilter,
+	_innerBucketLowerName[673:691]: runningEventFilter,
+	_innerBucketName[691:712]:      classCasmHashMetadata,
+	_innerBucketLowerName[691:712]: classCasmHashMetadata,
+	_innerBucketName[712:729]:      blockTransactions,
+	_innerBucketLowerName[712:729]: blockTransactions,
+	_innerBucketName[729:743]:      schemaMetadata,
+	_innerBucketLowerName[729:743]: schemaMetadata,
+	_innerBucketName[743:766]:      schemaIntermediateState,
+	_innerBucketLowerName[743:766]: schemaIntermediateState,
+	_innerBucketName[766:790]:      contractClassHashHistory,
+	_innerBucketLowerName[766:790]: contractClassHashHistory,
+	_innerBucketName[790:810]:      contractNonceHistory,
+	_innerBucketLowerName[790:810]: contractNonceHistory,
+	_innerBucketName[810:832]:      contractStorageHistory,
+	_innerBucketLowerName[810:832]: contractStorageHistory,
 }
 
 var _innerBucketNames = []string{
@@ -175,35 +184,38 @@ var _innerBucketNames = []string{
 	_innerBucketName[190:219],
 	_innerBucketName[219:244],
 	_innerBucketName[244:255],
-	_innerBucketName[255:277],
-	_innerBucketName[277:297],
-	_innerBucketName[297:321],
-	_innerBucketName[321:345],
-	_innerBucketName[345:353],
-	_innerBucketName[353:376],
-	_innerBucketName[376:382],
-	_innerBucketName[382:398],
-	_innerBucketName[398:407],
-	_innerBucketName[407:440],
-	_innerBucketName[440:465],
-	_innerBucketName[465:476],
-	_innerBucketName[476:487],
-	_innerBucketName[487:500],
-	_innerBucketName[500:511],
-	_innerBucketName[511:520],
-	_innerBucketName[520:540],
-	_innerBucketName[540:559],
-	_innerBucketName[559:567],
-	_innerBucketName[567:587],
-	_innerBucketName[587:594],
-	_innerBucketName[594:610],
-	_innerBucketName[610:621],
-	_innerBucketName[621:643],
-	_innerBucketName[643:661],
-	_innerBucketName[661:682],
-	_innerBucketName[682:699],
-	_innerBucketName[699:713],
-	_innerBucketName[713:736],
+	_innerBucketName[255:287],
+	_innerBucketName[287:317],
+	_innerBucketName[317:351],
+	_innerBucketName[351:375],
+	_innerBucketName[375:383],
+	_innerBucketName[383:406],
+	_innerBucketName[406:412],
+	_innerBucketName[412:428],
+	_innerBucketName[428:437],
+	_innerBucketName[437:470],
+	_innerBucketName[470:495],
+	_innerBucketName[495:506],
+	_innerBucketName[506:517],
+	_innerBucketName[517:530],
+	_innerBucketName[530:541],
+	_innerBucketName[541:550],
+	_innerBucketName[550:570],
+	_innerBucketName[570:589],
+	_innerBucketName[589:597],
+	_innerBucketName[597:617],
+	_innerBucketName[617:624],
+	_innerBucketName[624:640],
+	_innerBucketName[640:651],
+	_innerBucketName[651:673],
+	_innerBucketName[673:691],
+	_innerBucketName[691:712],
+	_innerBucketName[712:729],
+	_innerBucketName[729:743],
+	_innerBucketName[743:766],
+	_innerBucketName[766:790],
+	_innerBucketName[790:810],
+	_innerBucketName[810:832],
 }
 
 // innerBucketString retrieves an enum value from the enum constants string name.

--- a/db/schema.go
+++ b/db/schema.go
@@ -80,7 +80,7 @@ func DeprecatedContractClassHashHistoryKey(addr *felt.Felt) []byte {
 	return DeprecatedContractClassHashHistory.Key(addr.Marshal())
 }
 
-func ContractStorageHistoryKey(addr *felt.Felt, loc *felt.Felt) []byte {
+func ContractStorageHistoryKey(addr, loc *felt.Felt) []byte {
 	return ContractStorageHistory.Key(addr.Marshal(), loc.Marshal())
 }
 

--- a/db/schema.go
+++ b/db/schema.go
@@ -68,7 +68,19 @@ func StateUpdateByBlockNumKey(num uint64) []byte {
 	return StateUpdatesByBlockNumber.Key(b[:])
 }
 
-func ContractStorageHistoryKey(addr, loc *felt.Felt) []byte {
+func DeprecatedContractStorageHistoryKey(addr, loc *felt.Felt) []byte {
+	return DeprecatedContractStorageHistory.Key(addr.Marshal(), loc.Marshal())
+}
+
+func DeprecatedContractNonceHistoryKey(addr *felt.Felt) []byte {
+	return DeprecatedContractNonceHistory.Key(addr.Marshal())
+}
+
+func DeprecatedContractClassHashHistoryKey(addr *felt.Felt) []byte {
+	return DeprecatedContractClassHashHistory.Key(addr.Marshal())
+}
+
+func ContractStorageHistoryKey(addr *felt.Felt, loc *felt.Felt) []byte {
 	return ContractStorageHistory.Key(addr.Marshal(), loc.Marshal())
 }
 
@@ -101,6 +113,21 @@ func ContractKey(addr *felt.Felt) []byte {
 	return Contract.Key(addr.Marshal())
 }
 
+func DeprecatedContractNonceHistoryAtBlockKey(addr *felt.Felt, blockNum uint64) []byte {
+	b := uint64ToBytes(blockNum)
+	return DeprecatedContractNonceHistory.Key(addr.Marshal(), b[:])
+}
+
+func DeprecatedContractClassHashHistoryAtBlockKey(addr *felt.Felt, blockNum uint64) []byte {
+	b := uint64ToBytes(blockNum)
+	return DeprecatedContractClassHashHistory.Key(addr.Marshal(), b[:])
+}
+
+func DeprecatedContractStorageHistoryAtBlockKey(addr, key *felt.Felt, blockNum uint64) []byte {
+	b := uint64ToBytes(blockNum)
+	return DeprecatedContractStorageHistory.Key(addr.Marshal(), key.Marshal(), b[:])
+}
+
 func ContractNonceHistoryAtBlockKey(addr *felt.Felt, blockNum uint64) []byte {
 	b := uint64ToBytes(blockNum)
 	return ContractNonceHistory.Key(addr.Marshal(), b[:])
@@ -111,7 +138,7 @@ func ContractClassHashHistoryAtBlockKey(addr *felt.Felt, blockNum uint64) []byte
 	return ContractClassHashHistory.Key(addr.Marshal(), b[:])
 }
 
-func ContractStorageHistoryAtBlockKey(addr, key *felt.Felt, blockNum uint64) []byte {
+func ContractStorageHistoryAtBlockKey(addr *felt.Felt, key *felt.Felt, blockNum uint64) []byte {
 	b := uint64ToBytes(blockNum)
 	return ContractStorageHistory.Key(addr.Marshal(), key.Marshal(), b[:])
 }

--- a/db/schema.go
+++ b/db/schema.go
@@ -138,7 +138,7 @@ func ContractClassHashHistoryAtBlockKey(addr *felt.Felt, blockNum uint64) []byte
 	return ContractClassHashHistory.Key(addr.Marshal(), b[:])
 }
 
-func ContractStorageHistoryAtBlockKey(addr *felt.Felt, key *felt.Felt, blockNum uint64) []byte {
+func ContractStorageHistoryAtBlockKey(addr, key *felt.Felt, blockNum uint64) []byte {
 	b := uint64ToBytes(blockNum)
 	return ContractStorageHistory.Key(addr.Marshal(), key.Marshal(), b[:])
 }

--- a/migration/historyprunner/keys.go
+++ b/migration/historyprunner/keys.go
@@ -8,7 +8,7 @@ import (
 // migrationScratchTag is the leading byte of every history-pruner scratch
 // key. We reuse db.Temporary, the canonical scratch bucket also used by
 // deprecated migrations. Production iterators scoped to a single-byte bucket
-// prefix (e.g. NewIterator([]byte{14}, ...) for ContractStorageHistory)
+// prefix (e.g. NewIterator([]byte{14}, ...) for DeprecatedContractStorageHistory)
 // cannot observe scratch keys.
 var migrationScratchTag = byte(db.Temporary)
 
@@ -65,7 +65,7 @@ func fillStorageScratchKey(
 ) []byte {
 	buf = buf[:storageScratchKeyLen]
 	buf[0] = migrationScratchTag
-	buf[1] = byte(db.ContractStorageHistory)
+	buf[1] = byte(db.DeprecatedContractStorageHistory)
 	addrBytes := addr.Bytes()
 	copy(buf[scratchPrefixLen:], addrBytes[:])
 	slotBytes := slot.Bytes()
@@ -82,7 +82,7 @@ func fillNonceScratchKey(
 ) []byte {
 	buf = buf[:nonceScratchKeyLen]
 	buf[0] = migrationScratchTag
-	buf[1] = byte(db.ContractNonceHistory)
+	buf[1] = byte(db.DeprecatedContractNonceHistory)
 	addrBytes := addr.Bytes()
 	copy(buf[scratchPrefixLen:], addrBytes[:])
 	copy(buf[scratchPrefixLen+felt.Bytes:], blockBE[:])
@@ -97,7 +97,7 @@ func fillClassHashScratchKey(
 ) []byte {
 	buf = buf[:classHashScratchKeyLen]
 	buf[0] = migrationScratchTag
-	buf[1] = byte(db.ContractClassHashHistory)
+	buf[1] = byte(db.DeprecatedContractClassHashHistory)
 	addrBytes := addr.Bytes()
 	copy(buf[scratchPrefixLen:], addrBytes[:])
 	copy(buf[scratchPrefixLen+felt.Bytes:], blockBE[:])
@@ -111,7 +111,7 @@ func fillStorageHistoryKey(
 	blockBE [blockNumberSuffixLen]byte,
 ) []byte {
 	buf = buf[:storageHistoryKeyLen]
-	buf[0] = byte(db.ContractStorageHistory)
+	buf[0] = byte(db.DeprecatedContractStorageHistory)
 	addrBytes := addr.Bytes()
 	copy(buf[1:], addrBytes[:])
 	slotBytes := slot.Bytes()
@@ -127,7 +127,7 @@ func fillNonceHistoryKey(
 	blockBE [blockNumberSuffixLen]byte,
 ) []byte {
 	buf = buf[:nonceHistoryKeyLen]
-	buf[0] = byte(db.ContractNonceHistory)
+	buf[0] = byte(db.DeprecatedContractNonceHistory)
 	addrBytes := addr.Bytes()
 	copy(buf[1:], addrBytes[:])
 	copy(buf[1+felt.Bytes:], blockBE[:])
@@ -141,7 +141,7 @@ func fillClassHashHistoryKey(
 	blockBE [blockNumberSuffixLen]byte,
 ) []byte {
 	buf = buf[:classHashHistoryKeyLen]
-	buf[0] = byte(db.ContractClassHashHistory)
+	buf[0] = byte(db.DeprecatedContractClassHashHistory)
 	addrBytes := addr.Bytes()
 	copy(buf[1:], addrBytes[:])
 	copy(buf[1+felt.Bytes:], blockBE[:])

--- a/migration/historyprunner/migrator.go
+++ b/migration/historyprunner/migrator.go
@@ -398,16 +398,16 @@ func wipeReverseLookupBuckets(batch db.Batch) error {
 }
 
 func wipeStorageHistoryBuckets(batch db.Batch) error {
-	if err := wipeBucket(batch, byte(db.ContractStorageHistory)); err != nil {
-		return fmt.Errorf("wiping ContractStorageHistory: %w", err)
+	if err := wipeBucket(batch, byte(db.DeprecatedContractStorageHistory)); err != nil {
+		return fmt.Errorf("wiping DeprecatedContractStorageHistory: %w", err)
 	}
 
-	if err := wipeBucket(batch, byte(db.ContractClassHashHistory)); err != nil {
-		return fmt.Errorf("wiping ContractClassHashHistory: %w", err)
+	if err := wipeBucket(batch, byte(db.DeprecatedContractClassHashHistory)); err != nil {
+		return fmt.Errorf("wiping DeprecatedContractClassHashHistory: %w", err)
 	}
 
-	if err := wipeBucket(batch, byte(db.ContractNonceHistory)); err != nil {
-		return fmt.Errorf("wiping ContractNonceHistory: %w", err)
+	if err := wipeBucket(batch, byte(db.DeprecatedContractNonceHistory)); err != nil {
+		return fmt.Errorf("wiping DeprecatedContractNonceHistory: %w", err)
 	}
 	return nil
 }

--- a/pruner/accessors.go
+++ b/pruner/accessors.go
@@ -277,7 +277,7 @@ func pruneStateHistoryFromUpdate(
 ) error {
 	for addr, storageChanges := range stateUpdate.StateDiff.StorageDiffs {
 		for slot := range storageChanges {
-			err := core.DeleteContractStorageHistory(w, &addr, &slot, blockNumber)
+			err := core.DeleteDeprecatedContractStorageHistory(w, &addr, &slot, blockNumber)
 			if err != nil {
 				return err
 			}
@@ -285,14 +285,14 @@ func pruneStateHistoryFromUpdate(
 	}
 
 	for addr := range stateUpdate.StateDiff.Nonces {
-		err := core.DeleteContractNonceHistory(w, &addr, blockNumber)
+		err := core.DeleteDeprecatedContractNonceHistory(w, &addr, blockNumber)
 		if err != nil {
 			return err
 		}
 	}
 
 	for addr := range stateUpdate.StateDiff.ReplacedClasses {
-		err := core.DeleteContractClassHashHistory(w, &addr, blockNumber)
+		err := core.DeleteDeprecatedContractClassHashHistory(w, &addr, blockNumber)
 		if err != nil {
 			return err
 		}

--- a/pruner/testutils/helpers.go
+++ b/pruner/testutils/helpers.go
@@ -163,15 +163,18 @@ func StoreBlock(t *testing.T, database db.KeyValueStore, blockNum uint64) *Store
 		for slot := range slots {
 			require.NoError(
 				t,
-				core.WriteContractStorageHistory(database, &addr, &slot, oldValue, blockNum),
+				core.WriteDeprecatedContractStorageHistory(database, &addr, &slot, oldValue, blockNum),
 			)
 		}
 	}
 	for addr := range nonces {
-		require.NoError(t, core.WriteContractNonceHistory(database, &addr, oldValue, blockNum))
+		require.NoError(t, core.WriteDeprecatedContractNonceHistory(database, &addr, oldValue, blockNum))
 	}
 	for addr := range replacedClasses {
-		require.NoError(t, core.WriteContractClassHashHistory(database, &addr, oldValue, blockNum))
+		require.NoError(
+			t,
+			core.WriteDeprecatedContractClassHashHistory(database, &addr, oldValue, blockNum),
+		)
 	}
 
 	return &StoredBlock{
@@ -263,16 +266,16 @@ func AssertStateHistoryExists(
 	t.Helper()
 	for addr, slots := range su.StateDiff.StorageDiffs {
 		for slot := range slots {
-			key := db.ContractStorageHistoryAtBlockKey(&addr, &slot, blockNum)
+			key := db.DeprecatedContractStorageHistoryAtBlockKey(&addr, &slot, blockNum)
 			assert.NoError(t, r.Get(key, func([]byte) error { return nil }))
 		}
 	}
 	for addr := range su.StateDiff.Nonces {
-		key := db.ContractNonceHistoryAtBlockKey(&addr, blockNum)
+		key := db.DeprecatedContractNonceHistoryAtBlockKey(&addr, blockNum)
 		assert.NoError(t, r.Get(key, func([]byte) error { return nil }))
 	}
 	for addr := range su.StateDiff.ReplacedClasses {
-		key := db.ContractClassHashHistoryAtBlockKey(&addr, blockNum)
+		key := db.DeprecatedContractClassHashHistoryAtBlockKey(&addr, blockNum)
 		assert.NoError(t, r.Get(key, func([]byte) error { return nil }))
 	}
 }
@@ -287,16 +290,16 @@ func AssertStateHistoryPruned(
 	t.Helper()
 	for addr, slots := range su.StateDiff.StorageDiffs {
 		for slot := range slots {
-			key := db.ContractStorageHistoryAtBlockKey(&addr, &slot, blockNum)
+			key := db.DeprecatedContractStorageHistoryAtBlockKey(&addr, &slot, blockNum)
 			assert.Error(t, r.Get(key, func([]byte) error { return nil }))
 		}
 	}
 	for addr := range su.StateDiff.Nonces {
-		key := db.ContractNonceHistoryAtBlockKey(&addr, blockNum)
+		key := db.DeprecatedContractNonceHistoryAtBlockKey(&addr, blockNum)
 		assert.Error(t, r.Get(key, func([]byte) error { return nil }))
 	}
 	for addr := range su.StateDiff.ReplacedClasses {
-		key := db.ContractClassHashHistoryAtBlockKey(&addr, blockNum)
+		key := db.DeprecatedContractClassHashHistoryAtBlockKey(&addr, blockNum)
 		assert.Error(t, r.Get(key, func([]byte) error { return nil }))
 	}
 }


### PR DESCRIPTION
This makes the new state utilise the new history buckets. This is necessary for the state history migration, as we don't want to overwrite the existing buckets, effectively corrupting them on crash. This PR follows the already existing pattern, where the new state has its own buckets for the trie and contracts.