### PR TITLE
chore(ci): Request specific rust version

### DIFF
--- a/.github/workflows/build-binaries.yml
+++ b/.github/workflows/build-binaries.yml
@@ -37,7 +37,10 @@ jobs:
 
       - name: Set up Rust
         uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
-      
+        with:
+          toolchain: "1.88.0"
+
+
       - name: Cache Rust dependencies
         uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2.8.1
         with:

--- a/.github/workflows/juno-test.yml
+++ b/.github/workflows/juno-test.yml
@@ -28,7 +28,9 @@ jobs:
         with:
           go-version-file: go.mod
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
-  
+        with:
+          toolchain: "1.88.0"
+
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2.8.1
         with:
           key: rust-toolchain-${{ matrix.os }}


### PR DESCRIPTION
There were some CI failures where the worker failed to use the correct rust version. It was a fluke, potentially related to stale machine state or our CI cache. This PR attempts to fix the symptom, rather than the actual issue, as it remains obscure atm. 