### PR TITLE
feat(pruner): wallclock min-age retention floor

### DIFF
--- a/cmd/juno/juno.go
+++ b/cmd/juno/juno.go
@@ -109,6 +109,7 @@ const (
 	disableReceivedTxnStreamF           = "disable-received-txn-stream"
 	newStateF                           = "new-state"
 	pruneModeF                          = node.PruneModeFlag
+	pruneMinAgeF                        = node.PruneMinAgeFlag
 
 	defaultConfig                             = ""
 	defaultLogJSON                            = false
@@ -169,6 +170,7 @@ const (
 	defaultMaxConcurrentCompilations          = 8
 	defaultDisableReceivedTxnStream           = false
 	defaultPruneMode                          = uint64(0)
+	defaultPruneMinAge                        = 1 * time.Hour
 
 	configFlagUsage                       = "The YAML configuration file."
 	logLevelFlagUsage                     = "Options: trace, debug, info, warn, error."
@@ -266,6 +268,11 @@ const (
 		"across restarts is safe: the window grows or shrinks accordingly. " +
 		"Growth is gradual — pruning pauses until the pivot advances enough to " +
 		"reach the new floor."
+	pruneMinAgeUsage = "Protect blocks whose on-chain timestamp is " +
+		"younger than this duration from being pruned. Acts as an " +
+		"additional floor on top of --prune-mode: a block is retained " +
+		"if either the block-count window or this minimum-age window " +
+		"covers it. Set 0 to disable. Default 1h. Requires --prune-mode."
 	disableReceivedTxnStreamUsage = "The starknet_subscribeNewTransactions WebSocket API " +
 		"allows users to subscribe to new transactions. By default, it streams " +
 		"transactions that have been accepted on L2. Users can optionally provide " +
@@ -382,6 +389,12 @@ func NewCmd(config *node.Config, run func(*cobra.Command, []string) error) *cobr
 		// its numeric value — --prune-mode=0 is still "on, retain 0".
 		config.Prune = v.IsSet(pruneModeF)
 
+		// --prune-min-age layers on top of --prune-mode; without pruning
+		// enabled there is no floor for it to constrain.
+		if v.IsSet(pruneMinAgeF) && !config.Prune {
+			return fmt.Errorf("--%s requires --%s to be set", pruneMinAgeF, pruneModeF)
+		}
+
 		// Set custom network
 		if v.IsSet(cnNameF) {
 			l1ChainID, ok := new(big.Int).SetString(v.GetString(cnL1ChainIDF), 0)
@@ -484,7 +497,8 @@ func NewCmd(config *node.Config, run func(*cobra.Command, []string) error) *cobr
 	junoCmd.Flags().Uint64(pruneModeF, defaultPruneMode, pruneModeUsage)
 	// NoOptDefVal lets users pass --prune-mode without a value (treated as 0).
 	junoCmd.Flags().Lookup(pruneModeF).NoOptDefVal = "0"
-	setCategory(junoCmd, catPruning, pruneModeF)
+	junoCmd.Flags().Duration(pruneMinAgeF, defaultPruneMinAge, pruneMinAgeUsage)
+	setCategory(junoCmd, catPruning, pruneModeF, pruneMinAgeF)
 
 	// --- Logging ---
 	junoCmd.Flags().String(logLevelF, log.INFO.String(), logLevelFlagUsage)

--- a/cmd/juno/juno_test.go
+++ b/cmd/juno/juno_test.go
@@ -74,6 +74,7 @@ func TestConfigPrecedence(t *testing.T) {
 	defaultRPCRequestTimeout := 1 * time.Minute
 	defaultMaxConcurrentCompilations := uint(8)
 	defaultDisableReceivedTxnStream := false
+	defaultPruneMinAge := time.Hour
 	expectedConfig1 := node.Config{
 		LogLevel:                           "debug",
 		HTTP:                               defaultHTTP,
@@ -116,6 +117,7 @@ func TestConfigPrecedence(t *testing.T) {
 		ReadinessBlockTolerance:            6,
 		RPCRequestTimeout:                  defaultRPCRequestTimeout,
 		MaxConcurrentCompilations:          defaultMaxConcurrentCompilations,
+		PruneMinAge:                        defaultPruneMinAge,
 	}
 
 	expectedConfig2 := node.Config{
@@ -160,6 +162,7 @@ func TestConfigPrecedence(t *testing.T) {
 		ReadinessBlockTolerance:            6,
 		RPCRequestTimeout:                  defaultRPCRequestTimeout,
 		MaxConcurrentCompilations:          defaultMaxConcurrentCompilations,
+		PruneMinAge:                        defaultPruneMinAge,
 	}
 	tests := map[string]struct {
 		cfgFile         bool
@@ -265,6 +268,7 @@ pprof: true
 				ReadinessBlockTolerance:            6,
 				RPCRequestTimeout:                  defaultRPCRequestTimeout,
 				MaxConcurrentCompilations:          defaultMaxConcurrentCompilations,
+				PruneMinAge:                        defaultPruneMinAge,
 			},
 		},
 		"config file with some settings but without any other flags": {
@@ -315,6 +319,7 @@ http-port: 4576
 				ReadinessBlockTolerance:            6,
 				RPCRequestTimeout:                  defaultRPCRequestTimeout,
 				MaxConcurrentCompilations:          defaultMaxConcurrentCompilations,
+				PruneMinAge:                        defaultPruneMinAge,
 			},
 		},
 		"all flags without config file": {
@@ -364,6 +369,7 @@ http-port: 4576
 				ReadinessBlockTolerance:            6,
 				RPCRequestTimeout:                  defaultRPCRequestTimeout,
 				MaxConcurrentCompilations:          defaultMaxConcurrentCompilations,
+				PruneMinAge:                        defaultPruneMinAge,
 			},
 		},
 		"some flags without config file": {
@@ -413,6 +419,7 @@ http-port: 4576
 				ReadinessBlockTolerance:            6,
 				RPCRequestTimeout:                  defaultRPCRequestTimeout,
 				MaxConcurrentCompilations:          defaultMaxConcurrentCompilations,
+				PruneMinAge:                        defaultPruneMinAge,
 			},
 		},
 		"all setting set in both config file and flags": {
@@ -488,6 +495,7 @@ db-cache-size: 1024
 				ReadinessBlockTolerance:            6,
 				RPCRequestTimeout:                  defaultRPCRequestTimeout,
 				MaxConcurrentCompilations:          defaultMaxConcurrentCompilations,
+				PruneMinAge:                        defaultPruneMinAge,
 			},
 		},
 		"some setting set in both config file and flags": {
@@ -540,6 +548,7 @@ network: sepolia
 				ReadinessBlockTolerance:            6,
 				RPCRequestTimeout:                  defaultRPCRequestTimeout,
 				MaxConcurrentCompilations:          defaultMaxConcurrentCompilations,
+				PruneMinAge:                        defaultPruneMinAge,
 			},
 		},
 		"some setting set in default, config file and flags": {
@@ -588,6 +597,7 @@ network: sepolia
 				ReadinessBlockTolerance:            6,
 				RPCRequestTimeout:                  defaultRPCRequestTimeout,
 				MaxConcurrentCompilations:          defaultMaxConcurrentCompilations,
+				PruneMinAge:                        defaultPruneMinAge,
 			},
 		},
 		"only set env variables": {
@@ -634,6 +644,7 @@ network: sepolia
 				ReadinessBlockTolerance:            6,
 				RPCRequestTimeout:                  defaultRPCRequestTimeout,
 				MaxConcurrentCompilations:          defaultMaxConcurrentCompilations,
+				PruneMinAge:                        defaultPruneMinAge,
 			},
 		},
 		"some setting set in both env variables and flags": {
@@ -681,6 +692,7 @@ network: sepolia
 				ReadinessBlockTolerance:            6,
 				RPCRequestTimeout:                  defaultRPCRequestTimeout,
 				MaxConcurrentCompilations:          defaultMaxConcurrentCompilations,
+				PruneMinAge:                        defaultPruneMinAge,
 			},
 		},
 		"log-json flag via CLI": {
@@ -727,6 +739,7 @@ network: sepolia
 				ReadinessBlockTolerance:            6,
 				RPCRequestTimeout:                  defaultRPCRequestTimeout,
 				MaxConcurrentCompilations:          defaultMaxConcurrentCompilations,
+				PruneMinAge:                        defaultPruneMinAge,
 			},
 		},
 		"some setting set in both env variables and config file": {
@@ -775,6 +788,7 @@ network: sepolia
 				ReadinessBlockTolerance:            6,
 				RPCRequestTimeout:                  defaultRPCRequestTimeout,
 				MaxConcurrentCompilations:          defaultMaxConcurrentCompilations,
+				PruneMinAge:                        defaultPruneMinAge,
 			},
 		},
 	}

--- a/node/node.go
+++ b/node/node.go
@@ -58,6 +58,7 @@ const (
 	latestReleaseURL = "https://github.com/NethermindEth/juno/releases/latest"
 	sequencerAddress = 1337
 	PruneModeFlag    = "prune-mode"
+	PruneMinAgeFlag  = "prune-min-age"
 )
 
 // Config is the top-level juno configuration.
@@ -139,7 +140,8 @@ type Config struct {
 	// Prune is true when --prune-mode was provided (any value, including 0
 	// or absent). Set in cmd PreRunE; not bound via mapstructure.
 	Prune          bool
-	RetainedBlocks uint64 `mapstructure:"prune-mode"`
+	RetainedBlocks uint64        `mapstructure:"prune-mode"`
+	PruneMinAge    time.Duration `mapstructure:"prune-min-age"`
 }
 
 type Node struct {
@@ -322,10 +324,12 @@ func New(cfg *Config, version string, logLevel *log.Level) (*Node, error) {
 			WithCallMaxGas(cfg.RPCCallMaxGas)
 		services = append(services, &seq)
 		if cfg.Prune {
-			prunerOpts := make([]pruner.Option, 0, 1)
+			prunerOpts := make([]pruner.Option, 0, 2)
 			if cfg.Metrics {
 				prunerOpts = append(prunerOpts, pruner.WithListener(makePrunerMetrics()))
 			}
+
+			prunerOpts = append(prunerOpts, pruner.WithMinAge(cfg.PruneMinAge))
 			p := pruner.New(
 				database,
 				cfg.RetainedBlocks,
@@ -439,10 +443,12 @@ func New(cfg *Config, version string, logLevel *log.Level) (*Node, error) {
 		if synchronizer != nil {
 			services = append(services, synchronizer)
 			if cfg.Prune {
-				prunerOpts := make([]pruner.Option, 0, 1)
+				prunerOpts := make([]pruner.Option, 0, 2)
 				if cfg.Metrics {
 					prunerOpts = append(prunerOpts, pruner.WithListener(makePrunerMetrics()))
 				}
+
+				prunerOpts = append(prunerOpts, pruner.WithMinAge(cfg.PruneMinAge))
 				p := pruner.New(
 					database,
 					cfg.RetainedBlocks,

--- a/pruner/find_oldest_test.go
+++ b/pruner/find_oldest_test.go
@@ -1,0 +1,103 @@
+package pruner_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/NethermindEth/juno/db"
+	"github.com/NethermindEth/juno/pruner"
+	"github.com/NethermindEth/juno/pruner/testutils"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestFindOldestBlockAtOrAfter exercises the binary-search primitive that
+// powers the min-age floor's seed and per-tick refresh.
+func TestFindOldestBlockAtOrAfter(t *testing.T) {
+	// storeRange writes blocks [from, to) each with the given timestamp.
+	storeRange := func(t *testing.T, database db.KeyValueStore, from, to, timestamp uint64) {
+		t.Helper()
+		for i := from; i < to; i++ {
+			testutils.StoreBlockWithTimestamp(t, database, i, timestamp)
+		}
+	}
+
+	t.Run("lower > upper returns ErrNoBlockInWindow", func(t *testing.T) {
+		database := testutils.NewPebbleTestDB(t)
+		_, err := pruner.FindOldestBlockAtOrAfter(database, 10, 5, time.Unix(100, 0))
+		require.ErrorIs(t, err, pruner.ErrNoBlockInWindow)
+	})
+
+	t.Run("all blocks ancient → returns ErrNoBlockInWindow", func(t *testing.T) {
+		database := testutils.NewPebbleTestDB(t)
+		storeRange(t, database, 0, 20, 1) // all Timestamp=1
+		_, err := pruner.FindOldestBlockAtOrAfter(database, 0, 19, time.Unix(1000, 0))
+		require.ErrorIs(t, err, pruner.ErrNoBlockInWindow,
+			"no block satisfies cutoff → explicit not-found error")
+	})
+
+	t.Run("all blocks fresh → returns lower", func(t *testing.T) {
+		database := testutils.NewPebbleTestDB(t)
+		storeRange(t, database, 0, 20, 5000) // all Timestamp=5000
+		got, err := pruner.FindOldestBlockAtOrAfter(database, 0, 19, time.Unix(1000, 0))
+		require.NoError(t, err)
+		assert.Equal(t, uint64(0), got, "lowest qualifying block is the lower bound")
+	})
+
+	t.Run("boundary in the middle", func(t *testing.T) {
+		database := testutils.NewPebbleTestDB(t)
+		// Blocks 0..9 ancient (Timestamp=1), 10..19 fresh (Timestamp=5000).
+		storeRange(t, database, 0, 10, 1)
+		storeRange(t, database, 10, 20, 5000)
+		got, err := pruner.FindOldestBlockAtOrAfter(database, 0, 19, time.Unix(1000, 0))
+		require.NoError(t, err)
+		assert.Equal(t, uint64(10), got, "first fresh block is the boundary")
+	})
+
+	t.Run("Timestamp equal to cutoff qualifies (>= not >)", func(t *testing.T) {
+		database := testutils.NewPebbleTestDB(t)
+		storeRange(t, database, 0, 5, 1)
+		testutils.StoreBlockWithTimestamp(t, database, 5, 1000) // exactly at cutoff
+		storeRange(t, database, 6, 10, 5000)
+		got, err := pruner.FindOldestBlockAtOrAfter(database, 0, 9, time.Unix(1000, 0))
+		require.NoError(t, err)
+		assert.Equal(t, uint64(5), got, "ts == cutoff must qualify (>=)")
+	})
+
+	t.Run("missing block in range propagates ErrKeyNotFound", func(t *testing.T) {
+		database := testutils.NewPebbleTestDB(t)
+		// Block 5 NOT stored — caller passed a range that crosses a
+		// pruned height; the search hits ErrKeyNotFound and surfaces it.
+		storeRange(t, database, 0, 5, 5000)
+		storeRange(t, database, 6, 10, 5000)
+		_, err := pruner.FindOldestBlockAtOrAfter(database, 5, 9, time.Unix(1000, 0))
+		require.ErrorIs(t, err, db.ErrKeyNotFound,
+			"caller must pass a range of retained blocks; gaps surface as ErrKeyNotFound")
+	})
+
+	t.Run("single-element range [n, n]: block qualifies", func(t *testing.T) {
+		database := testutils.NewPebbleTestDB(t)
+		testutils.StoreBlockWithTimestamp(t, database, 7, 5000)
+		got, err := pruner.FindOldestBlockAtOrAfter(database, 7, 7, time.Unix(1000, 0))
+		require.NoError(t, err)
+		assert.Equal(t, uint64(7), got)
+	})
+
+	t.Run("single-element range [n, n]: block doesn't qualify", func(t *testing.T) {
+		database := testutils.NewPebbleTestDB(t)
+		testutils.StoreBlockWithTimestamp(t, database, 7, 1)
+		_, err := pruner.FindOldestBlockAtOrAfter(database, 7, 7, time.Unix(1000, 0))
+		require.ErrorIs(t, err, pruner.ErrNoBlockInWindow)
+	})
+
+	t.Run("propagates non-ErrKeyNotFound DB errors", func(t *testing.T) {
+		// Use a closed pebble DB to force a real error from GetBlockHeaderByNumber.
+		database := testutils.NewPebbleTestDB(t)
+		storeRange(t, database, 0, 10, 5000)
+		require.NoError(t, database.Close())
+		_, err := pruner.FindOldestBlockAtOrAfter(database, 0, 9, time.Unix(1000, 0))
+		require.Error(t, err, "closed DB must surface as an error")
+		assert.NotErrorIs(t, err, db.ErrKeyNotFound, "should be a real DB error, not ErrKeyNotFound")
+		assert.NotErrorIs(t, err, pruner.ErrNoBlockInWindow, "should not be conflated with not-found")
+	})
+}

--- a/pruner/min_age_test.go
+++ b/pruner/min_age_test.go
@@ -1,0 +1,236 @@
+package pruner_test
+
+import (
+	"testing"
+	"testing/synctest"
+	"time"
+
+	"github.com/NethermindEth/juno/core"
+	"github.com/NethermindEth/juno/pruner"
+	"github.com/NethermindEth/juno/pruner/testutils"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// testMinAge is the minimum-age window used by these tests. Inside a
+// synctest bubble both the pruner's ticker and time.Now() advance only
+// via virtual time.Sleep, so the value doesn't need to be small.
+const testMinAge = 1 * time.Hour
+
+func TestPruner_MinAgeFloor(t *testing.T) {
+	t.Run("tick refreshes floor", testMinAgeFloorTickRefresh)
+	t.Run("init seeds floor to oldest within-window block (restart safety)", testMinAgeFloorInitSeed)
+	t.Run("init: ancient chain seeds to head (deep catch-up)", testMinAgeFloorInitAllAncient)
+	t.Run("L1 path: floor binds when cached sample is below standard floor", testMinAgeFloorL1Binds)
+	t.Run("L1 steady state: floor does not bind when above standard", testMinAgeFloorL1NoBind)
+	t.Run("L2 path: floor binds for near-tip block (fresh timestamp)", testMinAgeFloorL2Binds)
+	t.Run("L2 path: deep catch-up (ancient timestamp) suppresses floor", testMinAgeFloorL2DeepCatchUp)
+}
+
+func testMinAgeFloorTickRefresh(t *testing.T) {
+	const totalBlocks uint64 = 30
+	const retention uint64 = 10
+	// Simulates a node that starts with only ancient blocks (deep
+	// catch-up), then appends fresh-timestamp blocks at the head as
+	// L2 reaches tip. After the next tick, sampleHeight re-runs
+	// and the floor moves from the not-found fallback
+	// (chainHeight) to the lowest fresh block.
+	synctest.Test(t, func(t *testing.T) {
+		database := testutils.NewPebbleTestDB(t)
+		// Start with only 10 ancient blocks. Init seed will fall back
+		// to head (= 9), no time-floor protection.
+		const initialBlocks uint64 = 10
+		for i := range initialBlocks {
+			testutils.StoreBlockWithTimestamp(t, database, i, 1)
+		}
+		require.NoError(t, core.WriteChainHeight(database, 9))
+
+		const tickInterval = 50 * time.Millisecond
+		sp := startPrunerService(t, database, retention,
+			pruner.WithMinAge(testMinAge),
+			pruner.WithFloorTickInterval(tickInterval),
+		)
+		synctest.Wait()
+
+		// Append fresh-timestamp blocks 10..29 (as if L2 had caught
+		// up to tip and is producing real-time blocks now).
+		now := uint64(time.Now().Unix())
+		for i := uint64(10); i < totalBlocks; i++ {
+			testutils.StoreBlockWithTimestamp(t, database, i, now)
+		}
+		require.NoError(t, core.WriteChainHeight(database, totalBlocks-1))
+
+		// Advance past one tick — sampleHeight reruns the binary
+		// search over [previousFloor=9, newHead=29] and finds block
+		// 10 as the lowest fresh block.
+		time.Sleep(tickInterval + time.Millisecond)
+		synctest.Wait()
+
+		// L1=25, retention=10 → standardFloor=15. Floor=10 < 15 → bind at 10.
+		ev := sp.sendL1AndAwait(t, 25)
+		assert.Equal(t, uint64(10), ev.oldest,
+			"tick must bind to the refreshed seed (10)")
+		assert.Equal(t, uint64(10), ev.count)
+	})
+}
+
+func testMinAgeFloorInitSeed(t *testing.T) {
+	const totalBlocks uint64 = 30
+	const retention uint64 = 10
+	// Simulates a restart where the DB already holds a window of
+	// recent blocks. The binary search should find the boundary
+	// where Timestamp first crosses now-minAge and seed both slots
+	// to that height, so the floor protects [boundary, head] from
+	// t=0 — no zero-protection gap after restart.
+	synctest.Test(t, func(t *testing.T) {
+		database := testutils.NewPebbleTestDB(t)
+		now := uint64(time.Now().Unix())
+		fresh := now         // within minAge
+		ancient := uint64(1) // far older than any cutoff
+		// Blocks 0..9 ancient, 10..29 fresh. Binary search should
+		// find block 10 as the lowest still within minAge.
+		for i := range totalBlocks {
+			ts := ancient
+			if i >= 10 {
+				ts = fresh
+			}
+			testutils.StoreBlockWithTimestamp(t, database, i, ts)
+		}
+		require.NoError(t, core.WriteChainHeight(database, totalBlocks-1))
+
+		sp := startPrunerService(t, database, retention, pruner.WithMinAge(testMinAge))
+		synctest.Wait()
+
+		// L1=25, retention=10 → standardFloor=15. Seed floor=10
+		// (lowest fresh block). 10 < 15 → bind at 10.
+		ev := sp.sendL1AndAwait(t, 25)
+		assert.Equal(t, uint64(10), ev.oldest,
+			"floor must bind to the binary-searched seed (10), not to current head")
+		assert.Equal(t, uint64(10), ev.count)
+	})
+}
+
+func testMinAgeFloorInitAllAncient(t *testing.T) {
+	const totalBlocks uint64 = 30
+	const retention uint64 = 10
+	// A node that's been syncing historical chain has every block
+	// timestamped years in the past. Binary search finds nothing
+	// fresh, so it returns current head. The L2-path gate then
+	// suppresses the floor on ancient incoming blocks anyway.
+	synctest.Test(t, func(t *testing.T) {
+		database := testutils.NewPebbleTestDB(t)
+		for i := range totalBlocks {
+			testutils.StoreBlockWithTimestamp(t, database, i, 1) // all ancient
+		}
+		require.NoError(t, core.WriteChainHeight(database, totalBlocks-1))
+
+		sp := startPrunerService(t, database, retention, pruner.WithMinAge(testMinAge))
+		synctest.Wait()
+
+		// L1=25, retention=10 → standardFloor=15. Seed=head=29
+		// (no fresh block). 29 >= 15 → no bind, prune to 15.
+		ev := sp.sendL1AndAwait(t, 25)
+		assert.Equal(t, uint64(15), ev.oldest)
+	})
+}
+
+func testMinAgeFloorL1Binds(t *testing.T) {
+	const totalBlocks uint64 = 30
+	const retention uint64 = 10
+	synctest.Test(t, func(t *testing.T) {
+		database := testutils.NewPebbleTestDB(t)
+		for i := range totalBlocks {
+			testutils.StoreBlock(t, database, i)
+		}
+		// chainHeight=5 at startup → init sample caches 5.
+		require.NoError(t, core.WriteChainHeight(database, 5))
+
+		sp := startPrunerService(t, database, retention, pruner.WithMinAge(testMinAge))
+		synctest.Wait()
+
+		// chainHeight bumped to 30; the ticker hasn't fired yet,
+		// so cached height stays at 5.
+		require.NoError(t, core.WriteChainHeight(database, totalBlocks))
+		ev := sp.sendL1AndAwait(t, 25)
+		// L1=25, retention=10 → standardFloor=15. Cache=5 < 15 → bind at 5.
+		assert.Equal(t, uint64(5), ev.oldest, "floor must clamp to cached height (5)")
+		assert.Equal(t, uint64(5), ev.count)
+	})
+}
+
+func testMinAgeFloorL1NoBind(t *testing.T) {
+	const totalBlocks uint64 = 30
+	const retention uint64 = 10
+	synctest.Test(t, func(t *testing.T) {
+		database := testutils.NewPebbleTestDB(t)
+		for i := range totalBlocks {
+			testutils.StoreBlock(t, database, i)
+		}
+		// chainHeight = highest stored block (= totalBlocks-1). All
+		// blocks have Timestamp=0 so the init search returns
+		// ErrNoBlockInWindow → floor parks at chainHeight.
+		require.NoError(t, core.WriteChainHeight(database, totalBlocks-1))
+
+		sp := startPrunerService(t, database, retention, pruner.WithMinAge(testMinAge))
+		synctest.Wait()
+
+		// L1=25, retention=10 → standardFloor=15. Cache=29 ≥ 15
+		// → no override.
+		ev := sp.sendL1AndAwait(t, 25)
+		assert.Equal(t, uint64(15), ev.oldest,
+			"ev.oldest must equal standardFloor when cached height is above it")
+	})
+}
+
+func testMinAgeFloorL2Binds(t *testing.T) {
+	const totalBlocks uint64 = 30
+	const retention uint64 = 10
+	synctest.Test(t, func(t *testing.T) {
+		database := testutils.NewPebbleTestDB(t)
+		for i := range totalBlocks {
+			testutils.StoreBlock(t, database, i)
+		}
+		require.NoError(t, core.WriteChainHeight(database, 5))
+		require.NoError(t, core.WriteL1Head(database, &core.L1Head{BlockNumber: 25}))
+
+		sp := startPrunerService(t, database, retention,
+			pruner.WithMinAge(testMinAge),
+			pruner.WithL2HeadsPerPrune(1),
+		)
+		synctest.Wait()
+
+		require.NoError(t, core.WriteChainHeight(database, totalBlocks))
+		// L2=20 with fresh timestamp; L1=25 > L2 → L2 path.
+		// standardFloor = 20-10 = 10. Cache=5 < 10 → bind at 5.
+		ev := sp.sendL2WithTimestampAndAwait(t, 20, uint64(time.Now().Unix()))
+		assert.Equal(t, uint64(5), ev.oldest)
+		assert.Equal(t, uint64(5), ev.count)
+	})
+}
+
+func testMinAgeFloorL2DeepCatchUp(t *testing.T) {
+	const totalBlocks uint64 = 30
+	const retention uint64 = 10
+	synctest.Test(t, func(t *testing.T) {
+		database := testutils.NewPebbleTestDB(t)
+		for i := range totalBlocks {
+			testutils.StoreBlock(t, database, i)
+		}
+		require.NoError(t, core.WriteChainHeight(database, 5))
+		require.NoError(t, core.WriteL1Head(database, &core.L1Head{BlockNumber: totalBlocks}))
+
+		sp := startPrunerService(t, database, retention,
+			pruner.WithMinAge(testMinAge),
+			pruner.WithL2HeadsPerPrune(1),
+		)
+		synctest.Wait()
+
+		require.NoError(t, core.WriteChainHeight(database, totalBlocks))
+		const ancientTimestamp uint64 = 1 // before any reasonable cutoff
+		// L2=20, retention=10 → standardFloor=10. Ancient timestamp
+		// suppresses the gate → standardFloor only.
+		ev := sp.sendL2WithTimestampAndAwait(t, 20, ancientTimestamp)
+		assert.Equal(t, uint64(10), ev.oldest, "deep catch-up: standard floor only")
+		assert.Equal(t, uint64(10), ev.count)
+	})
+}

--- a/pruner/pruner.go
+++ b/pruner/pruner.go
@@ -334,8 +334,7 @@ func (p *Pruner) applyTimeFloor(standardFloor uint64) uint64 {
 	if p.minAge == 0 {
 		return standardFloor
 	}
-	tf := p.latestSampledHeight
-	return min(tf, standardFloor)
+	return min(p.latestSampledHeight, standardFloor)
 }
 
 func (p *Pruner) onNewBlock(ctx context.Context, block *core.Block) error {
@@ -367,12 +366,6 @@ func (p *Pruner) onNewBlock(ctx context.Context, block *core.Block) error {
 	}
 
 	return p.pruneUpto(ctx, oldestToKeep)
-}
-
-// withinTimeWindow reports whether the Unix-seconds timestamp ts is no
-// older than window when measured from wallclock now.
-func withinTimeWindow(ts uint64, window time.Duration) bool {
-	return ts >= uint64(time.Now().Add(-window).Unix())
 }
 
 func (p *Pruner) onNewL1Head(ctx context.Context, l1Head *core.L1Head) error {
@@ -416,4 +409,10 @@ func (p *Pruner) pruneUpto(ctx context.Context, oldestBlockToKeep uint64) error 
 		zap.Duration("elapsed", elapsed),
 	)
 	return nil
+}
+
+// withinTimeWindow reports whether the Unix-seconds timestamp ts is no
+// older than window when measured from wallclock now.
+func withinTimeWindow(ts uint64, window time.Duration) bool {
+	return ts >= uint64(time.Now().Add(-window).Unix())
 }

--- a/pruner/pruner.go
+++ b/pruner/pruner.go
@@ -9,6 +9,13 @@
 // The upper bound is the L2 head simply because that is the highest block
 // the node has.
 //
+// In addition to the block-count floor, the pruner enforces an optional
+// wallclock minimum-age floor (see [WithMinAge]): blocks whose on-chain
+// timestamp is younger than minAge are protected from pruning. The
+// combined floor is min(standardFloor, minAgeFloor). The floor is
+// suppressed in the L2 path during deep catch-up sync, where incoming
+// blocks carry historical timestamps.
+//
 // The Pruner runs as a [service.Service]. It listens to two trigger feeds —
 // new L2 heads and new L1 heads — to know when to re-evaluate the floor;
 // the events themselves are only triggers, the retention bound is always
@@ -18,6 +25,7 @@ package pruner
 import (
 	"context"
 	"errors"
+	"fmt"
 	"time"
 
 	"github.com/NethermindEth/juno/core"
@@ -42,6 +50,12 @@ const defaultTargetBatchByteSize = 96 * db.Megabyte
 // covers any leftover coalesced events.
 const defaultL2HeadsPerPrune uint64 = 128
 
+// defaultFloorTickInterval is how often the min-age floor is refreshed
+// in production. Tighter than minAge so the floor's drift between
+// refreshes is bounded by this constant rather than by the (possibly
+// large) minAge window. Overridable via [WithFloorTickInterval]
+const defaultFloorTickInterval = 15 * time.Minute
+
 // Pruner deletes block data older than a retention window in response to
 // new-head events. Construct via [New]; do not zero-value.
 type Pruner struct {
@@ -61,7 +75,16 @@ type Pruner struct {
 	// l2HeadsPerPrune is how many L2 head events the L2 path coalesces
 	// before triggering a prune. See [defaultL2HeadsPerPrune].
 	l2HeadsPerPrune uint64
-	database        db.KeyValueStore
+	// minAge is the wallclock retention window: blocks whose on-chain
+	// timestamp is younger than minAge are protected from pruning.
+	// Zero disables the wallclock floor.
+	minAge time.Duration
+	// floorTickInterval is how often latestSampledHeight is refreshed.
+	floorTickInterval time.Duration
+	// latestSampledHeight is the lowest block with Timestamp >= now-minAge,
+	// re-derived each floorTickInterval tick.
+	latestSampledHeight uint64
+	database            db.KeyValueStore
 	// newHeadSub fires on each new L2 head. During catch-up (L2 < L1) it
 	// drives the floor from this event's block number; otherwise the L1
 	// path drives the floor and this event acts only as a trigger.
@@ -77,6 +100,8 @@ type Pruner struct {
 type options struct {
 	targetBatchByteSize int
 	l2HeadsPerPrune     uint64
+	minAge              time.Duration
+	floorTickInterval   time.Duration
 	listener            EventListener
 }
 
@@ -102,6 +127,25 @@ func WithL2HeadsPerPrune(n uint64) Option {
 	}
 }
 
+// WithMinAge enables the wallclock minimum-age floor: blocks whose
+// on-chain timestamp is younger than duration are protected from pruning,
+// in addition to the standard --prune-mode block-count floor.
+// Zero disables the floor.
+func WithMinAge(duration time.Duration) Option {
+	return func(o *options) {
+		o.minAge = duration
+	}
+}
+
+// WithFloorTickInterval overrides how often the min-age floor is
+// refreshed via binary search. Smaller values tighten the
+// floor's drift bound at the cost of more frequent refreshes.
+func WithFloorTickInterval(duration time.Duration) Option {
+	return func(o *options) {
+		o.floorTickInterval = duration
+	}
+}
+
 // New constructs a Pruner. retainedBlocks is the number of blocks
 // retained below the retention pivot (= min(l1Head, l2Head); the pivot
 // itself is always retained), so the pruner keeps blocks in
@@ -120,6 +164,7 @@ func New(
 	o := options{
 		targetBatchByteSize: defaultTargetBatchByteSize,
 		l2HeadsPerPrune:     defaultL2HeadsPerPrune,
+		floorTickInterval:   defaultFloorTickInterval,
 		listener:            &SelectiveListener{},
 	}
 	for _, opt := range opts {
@@ -129,6 +174,8 @@ func New(
 		numRetainedBlocks:   retainedBlocks,
 		targetBatchByteSize: o.targetBatchByteSize,
 		l2HeadsPerPrune:     o.l2HeadsPerPrune,
+		minAge:              o.minAge,
+		floorTickInterval:   o.floorTickInterval,
 		database:            database,
 		newHeadSub:          newHeadSub,
 		l1HeadSub:           l1HeadSub,
@@ -150,6 +197,18 @@ func (p *Pruner) Run(ctx context.Context) error {
 	const periodicStalenessTick = 1 * time.Hour
 	staleTicker := time.NewTicker(defaultStalenessTick)
 	defer staleTicker.Stop()
+
+	// minAge == 0 disables the wallclock floor; a nil channel never
+	// fires in select, so the ticker case is effectively absent.
+	var sampleTickerC <-chan time.Time
+	if p.minAge > 0 {
+		if err := p.seedFloor(); err != nil {
+			return fmt.Errorf("pruner: seed minimum-age floor: %w", err)
+		}
+		sampleTicker := time.NewTicker(p.floorTickInterval)
+		defer sampleTicker.Stop()
+		sampleTickerC = sampleTicker.C
+	}
 
 	for {
 		select {
@@ -175,6 +234,14 @@ func (p *Pruner) Run(ctx context.Context) error {
 			}
 			staleTicker.Reset(defaultStalenessTick)
 
+		case <-sampleTickerC:
+			if err := p.sampleHeight(); err != nil {
+				// seedFloor above already established a usable baseline;
+				// transient tick failures leave the previous sample in
+				// place and we retry next tick.
+				p.logger.Warn("min-retention height sample failed", zap.Error(err))
+			}
+
 		case <-staleTicker.C:
 			p.listener.OnL1Stale()
 			p.logger.Warn("no L1 head received in more than 24 hours. " +
@@ -183,6 +250,92 @@ func (p *Pruner) Run(ctx context.Context) error {
 			staleTicker.Reset(periodicStalenessTick)
 		}
 	}
+}
+
+// ErrNoBlockInWindow is returned by [FindOldestBlockAtOrAfter] when no
+// block in [lower, upper] has Timestamp >= cutoff.
+var ErrNoBlockInWindow = errors.New("no block in window")
+
+// FindOldestBlockAtOrAfter binary-searches block numbers in [lower, upper]
+// for the smallest one whose Header.Timestamp is at or after cutoff.
+// The caller must pass a range of fully-retained blocks.
+func FindOldestBlockAtOrAfter(
+	database db.KeyValueStore,
+	lower,
+	upper uint64,
+	cutoff time.Time,
+) (uint64, error) {
+	if lower > upper {
+		return 0, ErrNoBlockInWindow
+	}
+	cutoffUnix := uint64(cutoff.Unix())
+	lo, hi := lower, upper+1
+	for lo < hi {
+		mid := lo + (hi-lo)/2
+		hdr, err := core.GetBlockHeaderByNumber(database, mid)
+		if err != nil {
+			return 0, err
+		}
+		if hdr.Timestamp < cutoffUnix {
+			lo = mid + 1
+		} else {
+			hi = mid
+		}
+	}
+	if lo > upper {
+		return 0, ErrNoBlockInWindow
+	}
+	return lo, nil
+}
+
+// sampleHeight (re)computes the wallclock floor
+func (p *Pruner) sampleHeight() error {
+	height, err := core.GetChainHeight(p.database)
+	if err != nil {
+		if errors.Is(err, db.ErrKeyNotFound) {
+			return nil
+		}
+		return err
+	}
+	cutoff := time.Now().Add(-p.minAge)
+	// Reuse the previous floor as the lower bound: the cutoff only
+	// advances, so the new floor can't drop below it.
+	floor, err := FindOldestBlockAtOrAfter(p.database, p.latestSampledHeight, height, cutoff)
+	if err != nil {
+		if errors.Is(err, ErrNoBlockInWindow) {
+			// No block qualifies (deep catch-up or chain younger than minAge).
+			p.latestSampledHeight = height
+			return nil
+		}
+		return err
+	}
+	p.latestSampledHeight = floor
+	return nil
+}
+
+// seedFloor anchors the per-tick search's lower bound to the oldest
+// retained block, then runs the first sampleHeight.
+func (p *Pruner) seedFloor() error {
+	oldest, err := OldestRetainedBlock(p.database)
+	if err != nil {
+		if errors.Is(err, db.ErrKeyNotFound) {
+			// Assumes empty DB
+			return nil
+		}
+		return err
+	}
+	p.latestSampledHeight = oldest
+	return p.sampleHeight()
+}
+
+// applyTimeFloor returns the lower of standardFloor and the wallclock floor,
+// since a smaller oldestBlockToKeep retains more blocks.
+func (p *Pruner) applyTimeFloor(standardFloor uint64) uint64 {
+	if p.minAge == 0 {
+		return standardFloor
+	}
+	tf := p.latestSampledHeight
+	return min(tf, standardFloor)
 }
 
 func (p *Pruner) onNewBlock(ctx context.Context, block *core.Block) error {
@@ -205,9 +358,21 @@ func (p *Pruner) onNewBlock(ctx context.Context, block *core.Block) error {
 	}
 	p.pendingL2Heads = 0
 
-	oldestToKeep := block.Number - p.numRetainedBlocks
+	standardFloor := block.Number - p.numRetainedBlocks
+	// Skip the wallclock floor during deep catch-up: an ancient on-chain
+	// timestamp means our sample reflects sync-recency, not wallclock-recency.
+	oldestToKeep := standardFloor
+	if p.minAge > 0 && withinTimeWindow(block.Timestamp, p.minAge) {
+		oldestToKeep = p.applyTimeFloor(standardFloor)
+	}
 
 	return p.pruneUpto(ctx, oldestToKeep)
+}
+
+// withinTimeWindow reports whether the Unix-seconds timestamp ts is no
+// older than window when measured from wallclock now.
+func withinTimeWindow(ts uint64, window time.Duration) bool {
+	return ts >= uint64(time.Now().Add(-window).Unix())
 }
 
 func (p *Pruner) onNewL1Head(ctx context.Context, l1Head *core.L1Head) error {
@@ -225,7 +390,7 @@ func (p *Pruner) onNewL1Head(ctx context.Context, l1Head *core.L1Head) error {
 	}
 	p.pendingL2Heads = 0
 
-	oldestBlockToKeep := l1Head.BlockNumber - p.numRetainedBlocks
+	oldestBlockToKeep := p.applyTimeFloor(l1Head.BlockNumber - p.numRetainedBlocks)
 
 	return p.pruneUpto(ctx, oldestBlockToKeep)
 }

--- a/pruner/pruner.go
+++ b/pruner/pruner.go
@@ -269,23 +269,23 @@ func FindOldestBlockAtOrAfter(
 		return 0, ErrNoBlockInWindow
 	}
 	cutoffUnix := uint64(cutoff.Unix())
-	lo, hi := lower, upper+1
-	for lo < hi {
-		mid := lo + (hi-lo)/2
-		hdr, err := core.GetBlockHeaderByNumber(database, mid)
+	low, high := lower, upper+1
+	for low < high {
+		mid := low + (high-low)/2
+		header, err := core.GetBlockHeaderByNumber(database, mid)
 		if err != nil {
 			return 0, err
 		}
-		if hdr.Timestamp < cutoffUnix {
-			lo = mid + 1
+		if header.Timestamp < cutoffUnix {
+			low = mid + 1
 		} else {
-			hi = mid
+			high = mid
 		}
 	}
-	if lo > upper {
+	if low > upper {
 		return 0, ErrNoBlockInWindow
 	}
-	return lo, nil
+	return low, nil
 }
 
 // sampleHeight (re)computes the wallclock floor

--- a/pruner/pruner_test.go
+++ b/pruner/pruner_test.go
@@ -99,9 +99,24 @@ func (sp *servicePruner) sendL1AndAwait(t *testing.T, blockNum uint64) pruneEven
 // resulting prune dispatch. Use only when the configured
 // WithL2HeadsPerPrune is 1 (every L2 head triggers OnPrune); higher
 // thresholds coalesce events silently and provide no listener barrier.
+// The block header carries a fresh (wallclock-now) timestamp so the
+// min-age floor's catch-up gate doesn't suppress it; tests exercising
+// the suppression branch should use sendL2WithTimestampAndAwait.
 func (sp *servicePruner) sendL2AndAwait(t *testing.T, blockNum uint64) pruneEvent {
 	t.Helper()
-	sp.l2Feed.Send(&core.Block{Header: &core.Header{Number: blockNum}})
+	return sp.sendL2WithTimestampAndAwait(t, blockNum, uint64(time.Now().Unix()))
+}
+
+// sendL2WithTimestampAndAwait is sendL2AndAwait with an explicit on-chain
+// timestamp on the synthetic block header. Pass an ancient timestamp to
+// simulate a deep-catch-up L2 head event (suppresses the wallclock floor).
+func (sp *servicePruner) sendL2WithTimestampAndAwait(
+	t *testing.T,
+	blockNum,
+	timestamp uint64,
+) pruneEvent {
+	t.Helper()
+	sp.l2Feed.Send(&core.Block{Header: &core.Header{Number: blockNum, Timestamp: timestamp}})
 	select {
 	case ev := <-sp.pruned:
 		return ev

--- a/pruner/testutils/helpers.go
+++ b/pruner/testutils/helpers.go
@@ -61,9 +61,22 @@ var (
 //   - Bucket 16: ContractClassHashHistory
 func StoreBlock(t *testing.T, database db.KeyValueStore, blockNum uint64) *StoredBlock {
 	t.Helper()
+	return StoreBlockWithTimestamp(t, database, blockNum, 0)
+}
+
+// StoreBlockWithTimestamp is StoreBlock but lets the caller set the
+// block header's Timestamp.
+func StoreBlockWithTimestamp(
+	t *testing.T,
+	database db.KeyValueStore,
+	blockNum,
+	timestamp uint64,
+) *StoredBlock {
+	t.Helper()
 
 	header := &core.Header{
 		Number:           blockNum,
+		Timestamp:        timestamp,
 		Hash:             felt.NewRandom[felt.Felt](),
 		ParentHash:       felt.NewRandom[felt.Felt](),
 		GlobalStateRoot:  felt.NewRandom[felt.Felt](),


### PR DESCRIPTION
## Summary
  Adds an optional **wallclock minimum-age retention floor** to the pruner. In addition to `--prune-mode`'s block-count window (keep the last N blocks), a block is now also protected if its on-chain timestamp is younger than `--prune-min-age` — i.e. "keep at least the last 1h of chain history" rather than "keep at least the last N blocks". The effective floor is `min(standardFloor, minAgeFloor)`, so whichever window reaches further back wins.

  - New flag `--prune-min-age` (default `1h`, `0` disables, requires `--prune-mode`).
  - Floor is refreshed every `floorTickInterval` (default `15m`) via binary search for the oldest block with `timestamp >= now - minAge`.
  - Suppressed in the L2 catch-up path when the incoming block's own timestamp is already older than `minAge` — during deep sync the cached sample reflects recently-*synced* blocks, not wallclock-recent ones, and would
  otherwise over-protect.