### PR TITLE
fix(node): avoid duplicate L1 metrics registration in migration

### DIFF
--- a/node/migration.go
+++ b/node/migration.go
@@ -103,7 +103,9 @@ func fetchL1HeadIfMissing(
 	}
 
 	logger.Info("Fetching the L1 head before running the prune migration")
-	client, err := newL1Client(config.EthNode, config.Metrics, chain, logger)
+	// Metrics are registered by the long-lived L1 client built in node.New; reusing
+	// them here would panic via prometheus.MustRegister.
+	client, err := newL1Client(config.EthNode, false, chain, logger)
 	if err != nil {
 		return fmt.Errorf("creating a new L1 client: %w", err)
 	}


### PR DESCRIPTION
###  Summary

When `--metrics` and `--prune` are both enabled, Juno panics on startup with a `prometheus.MustRegister` duplicate-collector error.

`fetchL1HeadIfMissing` (called from the prune migration path in `node/migration.go`) builds a temporary L1 client to fetch the L1 head before pruning runs. It was passing `config.Metrics` through to `newL1Client`, which registers the L1 metric collectors. The long-lived L1 client constructed later in node. New then tries to register the same collectors and panics.
 
The migration-time client is short-lived and only exists to populate the L1 head in the DB, so it doesn't need its own metrics. This change passes `false` for `includeMetrics` at that callsite, leaving registration to the long-lived client in `node.New`.