### PR TITLE
fix(l1): bound startup RPC calls with per-call timeouts

### DIFF
--- a/l1/l1.go
+++ b/l1/l1.go
@@ -2,6 +2,7 @@ package l1
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"math/big"
 	"time"
@@ -131,20 +132,35 @@ func (c *Client) subscribeToUpdates(ctx context.Context, updateChan chan *contra
 	}
 }
 
+// checkChainID checks that the client is connected to the right L1 client
 func (c *Client) checkChainID(ctx context.Context) error {
-	gotChainID, err := c.l1.ChainID(ctx)
+	const chainIDCheckTimeout = 30 * time.Second
+	ctx, cancel := context.WithTimeout(ctx, chainIDCheckTimeout)
+	defer cancel()
+
+	l1ChainID, err := c.l1.ChainID(ctx)
 	if err != nil {
-		return fmt.Errorf("retrieve Ethereum chain ID: %w", err)
+		if errors.Is(err, context.DeadlineExceeded) {
+			return fmt.Errorf(
+				"eth_chainId did not respond within %s; is --eth-node a valid Ethereum L1 RPC URL?",
+				chainIDCheckTimeout,
+			)
+		}
+		return fmt.Errorf("retrieving Ethereum chain ID: %w", err)
 	}
 
-	wantChainID := c.network.L1ChainID
-	if gotChainID.Cmp(wantChainID) == 0 {
+	expectedL1ChainID := c.network.L1ChainID
+	if l1ChainID.Cmp(expectedL1ChainID) == 0 {
 		return nil
 	}
 
 	// NOTE: for now we return an error. If we want to support users who fork
 	// Starknet to create a "custom" Starknet network, we will need to log a warning instead.
-	return fmt.Errorf("mismatched L1 and L2 networks: L2 network %s; is the L1 node on the correct network?", c.network.String())
+	return fmt.Errorf(
+		"mismatched network id between L1 and L2. L2 network is %s; "+
+			"is --eth-node pointing to the right network?",
+		c.network.String(),
+	)
 }
 
 func (c *Client) Run(ctx context.Context) error {
@@ -261,13 +277,36 @@ func (c *Client) applyLogStateUpdate(u *contract.StarknetLogStateUpdate) {
 // caller (Run) treats the error as best-effort and proceeds to the live
 // subscription, so the partial state is an additive head-start, not a leak.
 func (c *Client) catchUpL1HeadUpdates(ctx context.Context) error {
-	latest, err := c.l1.LatestHeight(ctx)
+	const (
+		heightCallTimeout = 30 * time.Second
+		filterCallTimeout = 60 * time.Second
+	)
+
+	latestCtx, cancelLatest := context.WithTimeout(ctx, heightCallTimeout)
+	latest, err := c.l1.LatestHeight(latestCtx)
+	cancelLatest()
 	if err != nil {
-		return fmt.Errorf("L1 catch-up: failed to get latest height: %w", err)
+		if errors.Is(err, context.DeadlineExceeded) {
+			return fmt.Errorf(
+				"eth_blockNumber did not respond within %s; is --eth-node responsive?",
+				heightCallTimeout,
+			)
+		}
+		return fmt.Errorf("failed to get latest height: %w", err)
 	}
-	finalised, err := c.l1.FinalisedHeight(ctx)
+
+	finalisedCtx, cancelFinalised := context.WithTimeout(ctx, heightCallTimeout)
+	finalised, err := c.l1.FinalisedHeight(finalisedCtx)
+	cancelFinalised()
 	if err != nil {
-		return fmt.Errorf("L1 catch-up: failed to get finalised height: %w", err)
+		if errors.Is(err, context.DeadlineExceeded) {
+			return fmt.Errorf(
+				`eth_getBlockByNumber("finalized") did not respond within %s; `+
+					`does --eth-node support the finalized block tag?`,
+				heightCallTimeout,
+			)
+		}
+		return fmt.Errorf("failed to get finalised height: %w", err)
 	}
 
 	c.logger.Info("L1 catch-up starting",
@@ -287,8 +326,16 @@ func (c *Client) catchUpL1HeadUpdates(ctx context.Context) error {
 		if to+1 > c.catchUpChunkSize {
 			from = to + 1 - c.catchUpChunkSize
 		}
-		events, err := c.l1.FilterLogStateUpdate(ctx, from, to)
+		filterCtx, cancelFilter := context.WithTimeout(ctx, filterCallTimeout)
+		events, err := c.l1.FilterLogStateUpdate(filterCtx, from, to)
+		cancelFilter()
 		if err != nil {
+			if errors.Is(err, context.DeadlineExceeded) {
+				return fmt.Errorf(
+					"eth_getLogs did not respond within %s; is --eth-node responsive?",
+					filterCallTimeout,
+				)
+			}
 			return err
 		}
 		chunks++
@@ -315,12 +362,15 @@ func (c *Client) catchUpL1HeadUpdates(ctx context.Context) error {
 }
 
 func (c *Client) finalisedHeight(ctx context.Context) uint64 {
+	const finalisedHeightTimeout = 30 * time.Second
 	for {
 		select {
 		case <-ctx.Done():
 			return 0
 		default:
-			finalisedHeight, err := c.l1.FinalisedHeight(ctx)
+			callCtx, cancel := context.WithTimeout(ctx, finalisedHeightTimeout)
+			finalisedHeight, err := c.l1.FinalisedHeight(callCtx)
+			cancel()
 			if err == nil {
 				return finalisedHeight
 			}

--- a/l1/l1_test.go
+++ b/l1/l1_test.go
@@ -7,6 +7,7 @@ import (
 	"net"
 	"net/http"
 	"testing"
+	"testing/synctest"
 	"time"
 
 	"github.com/NethermindEth/juno/blockchain"
@@ -133,7 +134,259 @@ func TestMismatchedChainID(t *testing.T) {
 	ctx, cancel := context.WithTimeout(t.Context(), time.Second)
 	t.Cleanup(cancel)
 	err := client.Run(ctx)
-	require.ErrorContains(t, err, "mismatched L1 and L2 networks")
+	require.ErrorContains(t, err, "mismatched network id between L1 and L2")
+	require.ErrorContains(t, err, "--eth-node")
+}
+
+// TestChainIDCheckTimeout asserts that the startup eth_chainId probe gives up
+// after chainIDCheckTimeout (30s in production) with a user-actionable error
+// when the L1 endpoint accepts the dial but never responds to eth_chainId
+// (e.g. --eth-node pointing at a Starknet RPC URL). The test runs inside a
+// synctest bubble so the 30s wait advances in virtual time and the test
+// completes in microseconds of wallclock.
+func TestChainIDCheckTimeout(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		network := networks.Mainnet
+		ctrl := gomock.NewController(t)
+		nopLog := log.NewNopZapLogger()
+		chain := blockchain.New(
+			memory.New(),
+			&network,
+			blockchain.WithNewState(statetestutils.UseNewState()),
+		)
+
+		subscriber := mocks.NewMockSubscriber(ctrl)
+		subscriber.EXPECT().Close().Times(1)
+		subscriber.
+			EXPECT().
+			ChainID(gomock.Any()).
+			DoAndReturn(func(ctx context.Context) (*big.Int, error) {
+				<-ctx.Done()
+				return nil, ctx.Err()
+			}).
+			Times(1)
+
+		client := l1.NewClient(subscriber, chain, nopLog)
+
+		err := client.Run(t.Context())
+		require.ErrorContains(t, err, "eth_chainId did not respond within")
+		require.ErrorContains(t, err, "--eth-node")
+	})
+}
+
+func TestChainIDFetchError(t *testing.T) {
+	t.Parallel()
+
+	network := networks.Mainnet
+	ctrl := gomock.NewController(t)
+	nopLog := log.NewNopZapLogger()
+	chain := blockchain.New(
+		memory.New(),
+		&network,
+		blockchain.WithNewState(statetestutils.UseNewState()),
+	)
+
+	subscriber := mocks.NewMockSubscriber(ctrl)
+	subscriber.EXPECT().Close().Times(1)
+	rpcErr := errors.New("boom")
+	subscriber.
+		EXPECT().
+		ChainID(gomock.Any()).
+		Return(nil, rpcErr).
+		Times(1)
+
+	client := l1.NewClient(subscriber, chain, nopLog)
+
+	ctx, cancel := context.WithTimeout(t.Context(), time.Second)
+	t.Cleanup(cancel)
+	err := client.Run(ctx)
+	require.ErrorContains(t, err, "retrieving Ethereum chain ID")
+	require.ErrorIs(t, err, rpcErr)
+}
+
+// TestFinalisedHeightTimeoutDuringCatchUp asserts that the L1 catch-up startup
+// scan gives up on a hung eth_getBlockByNumber("finalized") call with a
+// user-actionable error pointing at --eth-node, instead of stalling forever.
+// Runs inside a synctest bubble so the 30s per-RPC timeout advances in virtual
+// time. CatchUpL1Head (rather than Run) is exercised because Run swallows
+// catch-up errors as best-effort, whereas CatchUpL1Head propagates them.
+func TestFinalisedHeightTimeoutDuringCatchUp(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		network := networks.Mainnet
+		ctrl := gomock.NewController(t)
+		nopLog := log.NewNopZapLogger()
+		chain := blockchain.New(
+			memory.New(),
+			&network,
+			blockchain.WithNewState(statetestutils.UseNewState()),
+		)
+
+		subscriber := mocks.NewMockSubscriber(ctrl)
+		subscriber.EXPECT().Close().Times(1)
+		subscriber.EXPECT().ChainID(gomock.Any()).Return(network.L1ChainID, nil).Times(1)
+		subscriber.EXPECT().LatestHeight(gomock.Any()).Return(uint64(1000), nil).Times(1)
+		subscriber.
+			EXPECT().
+			FinalisedHeight(gomock.Any()).
+			DoAndReturn(func(ctx context.Context) (uint64, error) {
+				<-ctx.Done()
+				return 0, ctx.Err()
+			}).
+			Times(1)
+
+		err := l1.NewClient(subscriber, chain, nopLog).CatchUpL1Head(t.Context())
+		require.ErrorContains(t, err, `eth_getBlockByNumber("finalized")`)
+		require.ErrorContains(t, err, "did not respond within")
+		require.ErrorContains(t, err, "--eth-node")
+	})
+}
+
+// TestLatestHeightTimeoutDuringCatchUp covers the first RPC in the catch-up
+// scan. Same shape as TestFinalisedHeightTimeoutDuringCatchUp but for
+// eth_blockNumber instead of eth_getBlockByNumber("finalized").
+func TestLatestHeightTimeoutDuringCatchUp(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		network := networks.Mainnet
+		ctrl := gomock.NewController(t)
+		nopLog := log.NewNopZapLogger()
+		chain := blockchain.New(
+			memory.New(),
+			&network,
+			blockchain.WithNewState(statetestutils.UseNewState()),
+		)
+
+		subscriber := mocks.NewMockSubscriber(ctrl)
+		subscriber.EXPECT().Close().Times(1)
+		subscriber.EXPECT().ChainID(gomock.Any()).Return(network.L1ChainID, nil).Times(1)
+		subscriber.
+			EXPECT().
+			LatestHeight(gomock.Any()).
+			DoAndReturn(func(ctx context.Context) (uint64, error) {
+				<-ctx.Done()
+				return 0, ctx.Err()
+			}).
+			Times(1)
+
+		err := l1.NewClient(subscriber, chain, nopLog).CatchUpL1Head(t.Context())
+		require.ErrorContains(t, err, "eth_blockNumber did not respond within")
+		require.ErrorContains(t, err, "--eth-node")
+	})
+}
+
+// TestFilterLogStateUpdateTimeoutDuringCatchUp covers the eth_getLogs path. It
+// has a longer (60s) production timeout than the two height calls; the test
+// just relies on synctest to fast-forward whatever the timeout happens to be.
+func TestFilterLogStateUpdateTimeoutDuringCatchUp(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		network := networks.Mainnet
+		ctrl := gomock.NewController(t)
+		nopLog := log.NewNopZapLogger()
+		chain := blockchain.New(
+			memory.New(),
+			&network,
+			blockchain.WithNewState(statetestutils.UseNewState()),
+		)
+
+		subscriber := mocks.NewMockSubscriber(ctrl)
+		subscriber.EXPECT().Close().Times(1)
+		subscriber.EXPECT().ChainID(gomock.Any()).Return(network.L1ChainID, nil).Times(1)
+		subscriber.EXPECT().LatestHeight(gomock.Any()).Return(uint64(1000), nil).Times(1)
+		subscriber.EXPECT().FinalisedHeight(gomock.Any()).Return(uint64(500), nil).Times(1)
+		subscriber.
+			EXPECT().
+			FilterLogStateUpdate(gomock.Any(), gomock.Any(), gomock.Any()).
+			DoAndReturn(func(ctx context.Context, _, _ uint64) ([]*contract.StarknetLogStateUpdate, error) {
+				<-ctx.Done()
+				return nil, ctx.Err()
+			}).
+			Times(1)
+
+		err := l1.NewClient(subscriber, chain, nopLog).CatchUpL1Head(t.Context())
+		require.ErrorContains(t, err, "eth_getLogs did not respond within")
+		require.ErrorContains(t, err, "--eth-node")
+	})
+}
+
+// TestFinalisedHeightRetryLoopProgressesPastHang asserts that the retry loop
+// invoked from setL1Head no longer spins forever when FinalisedHeight hangs:
+// the per-call timeout fires, the loop sleeps for resubscribeDelay, retries,
+// and a subsequent successful response is used to write the L1 head.
+//
+// Drives through the public CatchUpL1Head path. Mocks are sequenced so that
+// the FinalisedHeight call inside the catch-up scan succeeds, then the first
+// call from the retry loop hangs, then the second call from the retry loop
+// succeeds. Asserts via chain.L1Head() that the head was eventually written.
+//
+// Note: without the per-call timeout, this test would deadlock under synctest
+// (no timer to advance), so a passing run is itself proof the timeout is wired.
+func TestFinalisedHeightRetryLoopProgressesPastHang(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		network := networks.Mainnet
+		ctrl := gomock.NewController(t)
+		nopLog := log.NewNopZapLogger()
+		chain := blockchain.New(
+			memory.New(),
+			&network,
+			blockchain.WithNewState(statetestutils.UseNewState()),
+		)
+
+		subscriber := mocks.NewMockSubscriber(ctrl)
+		subscriber.EXPECT().Close().Times(1)
+		subscriber.EXPECT().ChainID(gomock.Any()).Return(network.L1ChainID, nil).Times(1)
+		subscriber.EXPECT().LatestHeight(gomock.Any()).Return(uint64(10), nil).Times(1)
+
+		// FinalisedHeight is called three times in this flow:
+		//   1) inside catchUpL1HeadUpdates — needs a real value so foundFinalised
+		//      becomes true and the scan exits into setL1Head;
+		//   2) first iteration of setL1Head's retry loop — hangs, exercising the
+		//      new per-call timeout;
+		//   3) second iteration — succeeds, the loop returns and the head is set.
+		catchupCall := subscriber.
+			EXPECT().
+			FinalisedHeight(gomock.Any()).
+			Return(uint64(5), nil).
+			Times(1)
+		hungCall := subscriber.
+			EXPECT().
+			FinalisedHeight(gomock.Any()).
+			DoAndReturn(func(ctx context.Context) (uint64, error) {
+				<-ctx.Done()
+				return 0, ctx.Err()
+			}).
+			Times(1).
+			After(catchupCall)
+		subscriber.
+			EXPECT().
+			FinalisedHeight(gomock.Any()).
+			Return(uint64(5), nil).
+			Times(1).
+			After(hungCall)
+
+		// One finalised event at L1=3 (≤ finalised=5) so foundFinalised flips
+		// and the catch-up loop reaches setL1Head with something to commit.
+		event := &contract.StarknetLogStateUpdate{
+			BlockNumber: big.NewInt(7),
+			BlockHash:   big.NewInt(7),
+			GlobalRoot:  big.NewInt(7),
+			Raw:         types.Log{BlockNumber: 3},
+		}
+		subscriber.
+			EXPECT().
+			FilterLogStateUpdate(gomock.Any(), gomock.Any(), gomock.Any()).
+			Return([]*contract.StarknetLogStateUpdate{event}, nil).
+			Times(1)
+
+		client := l1.NewClient(subscriber, chain, nopLog, l1.WithResubscribeDelay(time.Second))
+		require.NoError(t, client.CatchUpL1Head(t.Context()))
+
+		got, err := chain.L1Head()
+		require.NoError(t, err)
+		require.Equal(t, core.L1Head{
+			BlockNumber: 7,
+			BlockHash:   new(felt.Felt).SetUint64(7),
+			StateRoot:   new(felt.Felt).SetUint64(7),
+		}, got)
+	})
 }
 
 func TestEventListener(t *testing.T) {
@@ -346,7 +599,8 @@ func TestCatchUpL1Head_ChainIDMismatch(t *testing.T) {
 	subscriber.EXPECT().Close()
 
 	err := l1.NewClient(subscriber, chain, nopLog).CatchUpL1Head(t.Context())
-	require.ErrorContains(t, err, "mismatched L1 and L2 networks")
+	require.ErrorContains(t, err, "mismatched network id between L1 and L2")
+	require.ErrorContains(t, err, "--eth-node")
 }
 
 func newTestL1Client(service service) *rpc.Server {

--- a/l1/l1_test.go
+++ b/l1/l1_test.go
@@ -141,7 +141,7 @@ func TestMismatchedChainID(t *testing.T) {
 // TestChainIDCheckTimeout asserts that the startup eth_chainId probe gives up
 // after chainIDCheckTimeout (30s in production) with a user-actionable error
 // when the L1 endpoint accepts the dial but never responds to eth_chainId
-// (e.g. --eth-node pointing at a Starknet RPC URL). The test runs inside a
+// (e.g. --eth-node pointing at an incorrect RPC URL). The test runs inside a
 // synctest bubble so the 30s wait advances in virtual time and the test
 // completes in microseconds of wallclock.
 func TestChainIDCheckTimeout(t *testing.T) {

--- a/node/migration.go
+++ b/node/migration.go
@@ -109,8 +109,9 @@ func fetchL1HeadIfMissing(
 	if err != nil {
 		return fmt.Errorf("creating a new L1 client: %w", err)
 	}
+
 	if err := client.CatchUpL1Head(ctx); err != nil {
-		return err
+		return fmt.Errorf("catching up to the latest l1 head: %w", err)
 	}
 
 	if _, err := core.GetL1Head(database); err != nil {

--- a/node/migration.go
+++ b/node/migration.go
@@ -111,7 +111,7 @@ func fetchL1HeadIfMissing(
 	}
 
 	if err := client.CatchUpL1Head(ctx); err != nil {
-		return fmt.Errorf("catching up to the latest l1 head: %w", err)
+		return fmt.Errorf("catching up to the latest L1 head: %w", err)
 	}
 
 	if _, err := core.GetL1Head(database); err != nil {


### PR DESCRIPTION
Adding context deadlines to the interactions with the L1 to avoid node stalling for ever