### PR TITLE
refactor(blockchain): `NewAggregatedBloomCache` returns pointer

### DIFF
--- a/blockchain/aggregated_bloom_filter_cache.go
+++ b/blockchain/aggregated_bloom_filter_cache.go
@@ -33,8 +33,8 @@ type AggregatedBloomFilterCache struct {
 
 // NewAggregatedBloomCache creates a new LRU cache for aggregated bloom filters
 // with the specified maximum size (number of ranges to cache).
-func NewAggregatedBloomCache(size int) AggregatedBloomFilterCache {
-	return AggregatedBloomFilterCache{
+func NewAggregatedBloomCache(size int) *AggregatedBloomFilterCache {
+	return &AggregatedBloomFilterCache{
 		cache: lru.New[
 			EventFiltersCacheKey,
 			*core.AggregatedBloomFilter,

--- a/blockchain/blockchain.go
+++ b/blockchain/blockchain.go
@@ -142,7 +142,7 @@ func New(database db.KeyValueStore, network *networks.Network, opts ...Option) *
 		network:       network,
 		listener:      o.listener,
 		l1HeadFeed:    feed.New[*core.L1Head](),
-		cachedFilters: &cachedFilters,
+		cachedFilters: cachedFilters,
 		runningFilter: runningFilter,
 		stateBackend: statebackend.New(
 			database,


### PR DESCRIPTION
Returning the struct by value let callers hold copies that could drift apart: the LRU stays shared (it's behind a pointer), but each copy has its own `fallbackFunc` slot. Returning a pointer kills the copy path.

Not a live bug today (single production caller), just preventive.

Discussed in #3674.