### PR TITLE
feat(sync): request-driven pre_confirmed polling

### DIFF
--- a/cmd/juno/juno.go
+++ b/cmd/juno/juno.go
@@ -199,8 +199,8 @@ const (
 	disableL1VerificationUsage = "Disables L1 verification since an Ethereum node is not provided."
 	preLatestPollIntervalUsage = "Sets polling interval for pre-latest block updates. " +
 		"(0s will disable polling)."
-	preConfirmedPollIntervalUsage = "Sets how frequently pre_confirmed block will be updated" +
-		"(0s will disable fetching of pre_confirmed block)."
+	preConfirmedPollIntervalUsage = "Fallback ticker interval for pre_confirmed polling when no " +
+		"RPC traffic is driving refreshes. (0s disables polling.)"
 	p2pUsage           = "EXPERIMENTAL: Enables p2p server."
 	p2pAddrUsage       = "EXPERIMENTAL: Specify p2p listening source address as multiaddr.  Example: /ip4/0.0.0.0/tcp/7777"
 	p2pPublicAddrUsage = "EXPERIMENTAL: Specify p2p public address as multiaddr.  Example: /ip4/35.243.XXX.XXX/tcp/7777"

--- a/sync/pending_polling.go
+++ b/sync/pending_polling.go
@@ -17,10 +17,15 @@ import (
 
 const (
 	preLatestCacheSize = 10
-	// Per-fetch cap so a hung feeder can't hold the running guard for the
-	// feeder client's full retry budget (~20s). TODO: consider exposing as flag.
-	preConfirmedFetchTimeout = 2 * time.Second
+	// Per-fetch cap scales with poll interval so slower configs get
+	// proportionally longer budgets. Floor avoids pathologically short caps.
+	preConfirmedFetchTimeoutMultiplier = 4
+	preConfirmedFetchTimeoutFloor      = 500 * time.Millisecond
 )
+
+func (s *Synchronizer) preConfirmedFetchTimeout() time.Duration {
+	return max(s.preConfirmedPollInterval*preConfirmedFetchTimeoutMultiplier, preConfirmedFetchTimeoutFloor)
+}
 
 // isGreaterThanTip reports whether the given number is at or beyond the highest known header.
 func (s *Synchronizer) isGreaterThanTip(blockNumber uint64) bool {
@@ -242,9 +247,12 @@ func (s *Synchronizer) pollPreLatest(ctx context.Context, out chan<- *pending.Pr
 	}
 }
 
-// requestPreConfirmedRefresh wakes the polling goroutine. Drops the request
-// if a fetch is already running: that fetch already serves it.
+// requestPreConfirmedRefresh wakes the polling goroutine; no-op if polling
+// is disabled or a fetch is already running (that fetch will serve it).
 func (s *Synchronizer) requestPreConfirmedRefresh() {
+	if s.preConfirmedPollInterval == 0 {
+		return
+	}
 	if s.preConfirmedFetching.Load() {
 		return
 	}
@@ -254,10 +262,9 @@ func (s *Synchronizer) requestPreConfirmedRefresh() {
 	}
 }
 
-// pollPreConfirmed is request-driven: each trigger from requestPreConfirmedRefresh
-// runs one fetch against blockNumberToPoll and forwards the update to out. The
-// ticker is a fallback so passive subscribers still get updates when no RPC
-// traffic drives refreshes.
+// pollPreConfirmed runs one fetch per trigger from requestPreConfirmedRefresh.
+// The ticker is a fallback so passive subscribers still get updates when no
+// RPC traffic drives refreshes.
 func (s *Synchronizer) pollPreConfirmed(
 	ctx context.Context,
 	blockNumberToPoll *atomic.Uint64,
@@ -306,9 +313,10 @@ func (s *Synchronizer) pollPreConfirmed(
 	}
 }
 
-// fetchPreConfirmed runs one fetch under the running guard and the per-fetch
-// timeout. Drains a buffered trigger before releasing the guard so a refresh
-// arriving during this call doesn't fire a back-to-back fetch.
+// fetchPreConfirmed runs one fetch under the running guard. The defer drains
+// a trigger that may have been queued in the window before fetching=true was
+// set; that request is silently swallowed, but the next RPC call or tick
+// re-triggers if needed.
 func (s *Synchronizer) fetchPreConfirmed(
 	ctx context.Context,
 	blockNum uint64,
@@ -324,7 +332,7 @@ func (s *Synchronizer) fetchPreConfirmed(
 		s.preConfirmedFetching.Store(false)
 	}()
 
-	fetchCtx, cancel := context.WithTimeout(ctx, preConfirmedFetchTimeout)
+	fetchCtx, cancel := context.WithTimeout(ctx, s.preConfirmedFetchTimeout())
 	defer cancel()
 
 	return s.dataSource.PreConfirmedBlockByNumber(

--- a/sync/pending_polling.go
+++ b/sync/pending_polling.go
@@ -17,6 +17,9 @@ import (
 
 const (
 	preLatestCacheSize = 10
+	// Per-fetch cap so a hung feeder can't hold the running guard for the
+	// feeder client's full retry budget (~20s). TODO: consider exposing as flag.
+	preConfirmedFetchTimeout = 2 * time.Second
 )
 
 // isGreaterThanTip reports whether the given number is at or beyond the highest known header.
@@ -239,12 +242,22 @@ func (s *Synchronizer) pollPreLatest(ctx context.Context, out chan<- *pending.Pr
 	}
 }
 
-// pollPreConfirmed polls for the current target pre_confirmed number at a fixed interval.
-// The target is read from blockNumberToPoll and only polled while at tip.
-// Each poll echoes the currently stored pre_confirmed's identifier and
-// transaction count so the server can return a no-change marker, a delta of
-// appended transactions, or a fresh full block when the round identifier no
-// longer matches. On success, the resulting update is forwarded to out.
+// requestPreConfirmedRefresh wakes the polling goroutine. Drops the request
+// if a fetch is already running: that fetch already serves it.
+func (s *Synchronizer) requestPreConfirmedRefresh() {
+	if s.preConfirmedFetching.Load() {
+		return
+	}
+	select {
+	case s.preConfirmedTrigger <- struct{}{}:
+	default:
+	}
+}
+
+// pollPreConfirmed is request-driven: each trigger from requestPreConfirmedRefresh
+// runs one fetch against blockNumberToPoll and forwards the update to out. The
+// ticker is a fallback so passive subscribers still get updates when no RPC
+// traffic drives refreshes.
 func (s *Synchronizer) pollPreConfirmed(
 	ctx context.Context,
 	blockNumberToPoll *atomic.Uint64,
@@ -262,41 +275,61 @@ func (s *Synchronizer) pollPreConfirmed(
 		select {
 		case <-ctx.Done():
 			return
-
+		case <-s.preConfirmedTrigger:
 		case <-ticker.C:
-			targetBlockNum := blockNumberToPoll.Load()
-			shouldPoll := targetBlockNum > 0 && s.isGreaterThanTip(targetBlockNum)
-			if !shouldPoll {
-				continue
-			}
+		}
 
-			var (
-				blockIdentifier              = feeder.PreConfirmedBlankIdentifier
-				knownTransactionCount uint64 = 0
-			)
+		// 0 means "no target set yet".
+		targetBlockNum := blockNumberToPoll.Load()
+		if targetBlockNum == 0 || !s.isGreaterThanTip(targetBlockNum) {
+			continue
+		}
 
-			currentPreConf := s.preConfirmed.Load()
-			if currentPreConf != nil {
-				blockIdentifier = currentPreConf.BlockIdentifier
-				knownTransactionCount = uint64(len(currentPreConf.Block.Transactions))
-			}
+		blockIdentifier := feeder.PreConfirmedBlankIdentifier
+		var knownTransactionCount uint64
+		if currentPreConf := s.preConfirmed.Load(); currentPreConf != nil {
+			blockIdentifier = currentPreConf.BlockIdentifier
+			knownTransactionCount = uint64(len(currentPreConf.Block.Transactions))
+		}
 
-			update, err := s.dataSource.PreConfirmedBlockByNumber(
-				ctx, targetBlockNum, blockIdentifier, knownTransactionCount,
-			)
-			if err != nil {
-				s.logger.Debug("Error while trying to poll pre_confirmed block", zap.Error(err))
-				continue
-			}
+		update, err := s.fetchPreConfirmed(ctx, targetBlockNum, blockIdentifier, knownTransactionCount)
+		if err != nil {
+			s.logger.Debug("Error while trying to poll pre_confirmed block", zap.Error(err))
+			continue
+		}
 
-			select {
-			case out <- &update:
-				continue
-			case <-ctx.Done():
-				return
-			}
+		select {
+		case out <- &update:
+		case <-ctx.Done():
+			return
 		}
 	}
+}
+
+// fetchPreConfirmed runs one fetch under the running guard and the per-fetch
+// timeout. Drains a buffered trigger before releasing the guard so a refresh
+// arriving during this call doesn't fire a back-to-back fetch.
+func (s *Synchronizer) fetchPreConfirmed(
+	ctx context.Context,
+	blockNum uint64,
+	blockIdentifier string,
+	knownTransactionCount uint64,
+) (pending.PreConfirmedUpdate, error) {
+	s.preConfirmedFetching.Store(true)
+	defer func() {
+		select {
+		case <-s.preConfirmedTrigger:
+		default:
+		}
+		s.preConfirmedFetching.Store(false)
+	}()
+
+	fetchCtx, cancel := context.WithTimeout(ctx, preConfirmedFetchTimeout)
+	defer cancel()
+
+	return s.dataSource.PreConfirmedBlockByNumber(
+		fetchCtx, blockNum, blockIdentifier, knownTransactionCount,
+	)
 }
 
 // handleHead processes a new head.

--- a/sync/pending_polling_test.go
+++ b/sync/pending_polling_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"slices"
 	stdsync "sync"
 	"sync/atomic"
 	"testing"
@@ -1109,4 +1110,172 @@ func makeEmptyPreLatestForParent(parent *core.Header) pending.PreLatest {
 		NewClasses: make(map[felt.Felt]core.ClassDefinition, 0),
 	}
 	return pending
+}
+
+// TestPreConfirmedUpdateFrequency prints metrics comparing the ticker-only
+// baseline (pre-PR behaviour) with the request-driven path. The baseline
+// subtest never fires triggers; the request-driven subtest fires them at a
+// fixed rate. Run: go test -v -run TestPreConfirmedUpdateFrequency ./sync/
+func TestPreConfirmedUpdateFrequency(t *testing.T) {
+	testDB := memory.New()
+	bc := blockchain.New(testDB, &networks.Sepolia,
+		blockchain.WithNewState(statetestutils.UseNewState()))
+	client := feeder.NewTestClient(t, &networks.Sepolia)
+	gw := adaptfeeder.New(client)
+	dataSource := NewFeederGatewayDataSource(bc, gw)
+
+	head0, err := gw.BlockByNumber(t.Context(), 0)
+	require.NoError(t, err)
+	su0, err := gw.StateUpdate(t.Context(), 0)
+	require.NoError(t, err)
+	require.NoError(t, bc.Store(head0, &core.BlockCommitments{}, su0,
+		map[felt.Felt]core.ClassDefinition{}))
+
+	const (
+		tickerInterval = 500 * time.Millisecond // default --preconfirmed-poll-interval
+		runDuration    = 5 * time.Second
+		triggerRate    = 50 * time.Millisecond // simulated RPC traffic at 20 Hz
+	)
+
+	type scenario struct {
+		name            string
+		triggerInterval time.Duration // 0 means no triggers (ticker-only baseline)
+	}
+	scenarios := []scenario{
+		{"baseline_ticker_only", 0},
+		{"request_driven_20Hz", triggerRate},
+	}
+
+	// Run each scenario across a few realistic feeder latencies.
+	latencies := []time.Duration{
+		50 * time.Millisecond,
+		100 * time.Millisecond,
+		200 * time.Millisecond,
+	}
+
+	for _, fetchLatency := range latencies {
+		for _, sc := range scenarios {
+			name := fmt.Sprintf("%s/fetch=%s", sc.name, fetchLatency)
+			t.Run(name, func(t *testing.T) {
+				synctest.Test(t, func(t *testing.T) {
+					mockDS := &MockDataSource{
+						DataSource: dataSource,
+						PreConfirmedFunc: func(
+							ctx context.Context,
+							number uint64,
+							_ string, _ uint64, _ uint,
+						) (pending.PreConfirmedUpdate, error) {
+							select {
+							case <-time.After(fetchLatency):
+							case <-ctx.Done():
+								return pending.PreConfirmedUpdate{}, ctx.Err()
+							}
+							preConf := makeTestPreConfirmed(number)
+							preConf.BlockIdentifier = "mock"
+							return pending.PreConfirmedUpdate{
+								Mode:            pending.PreConfirmedFull,
+								BlockIdentifier: preConf.BlockIdentifier,
+								FullBlock:       &preConf,
+							}, nil
+						},
+					}
+					syn := New(bc, mockDS, log.NewNopZapLogger(), 0, tickerInterval, false, testDB)
+					syn.highestBlockHeader.Store(head0.Header)
+
+					var target atomic.Uint64
+					target.Store(1)
+					out := make(chan *pending.PreConfirmedUpdate, 1024)
+
+					ctx, cancel := context.WithCancel(t.Context())
+
+					go syn.pollPreConfirmed(ctx, &target, out)
+
+					var emitted atomic.Uint32
+					if sc.triggerInterval > 0 {
+						go func() {
+							ticker := time.NewTicker(sc.triggerInterval)
+							defer ticker.Stop()
+							for {
+								select {
+								case <-ctx.Done():
+									return
+								case <-ticker.C:
+									emitted.Add(1)
+									syn.requestPreConfirmedRefresh()
+								}
+							}
+						}()
+					}
+
+					var intervals []time.Duration
+					var lastUpdate time.Time
+					recorderDone := make(chan struct{})
+					go func() {
+						defer close(recorderDone)
+						for {
+							select {
+							case <-ctx.Done():
+								return
+							case <-out:
+								now := time.Now()
+								if !lastUpdate.IsZero() {
+									intervals = append(intervals, now.Sub(lastUpdate))
+								}
+								lastUpdate = now
+							}
+						}
+					}()
+
+					time.Sleep(runDuration)
+					cancel()
+					<-recorderDone
+
+					fetches := mockDS.numCallsPreConfirmed.Load()
+					trigs := emitted.Load()
+					var dropped uint32
+					if trigs >= fetches {
+						dropped = trigs - fetches
+					}
+					updates := uint32(len(intervals) + 1)
+					if lastUpdate.IsZero() {
+						updates = 0
+					}
+					t.Logf(
+						"%s fetch=%s: updates=%d (%.1f/s) fetches=%d "+
+							"triggers_emitted=%d triggers_dropped=%d "+
+							"mean_interval=%v p99_interval=%v",
+						sc.name, fetchLatency,
+						updates, float64(updates)/runDuration.Seconds(),
+						fetches, trigs, dropped,
+						meanDuration(intervals), p99Duration(intervals),
+					)
+				})
+			})
+		}
+	}
+}
+
+func meanDuration(ds []time.Duration) time.Duration {
+	if len(ds) == 0 {
+		return 0
+	}
+	var sum time.Duration
+	for _, d := range ds {
+		sum += d
+	}
+	return sum / time.Duration(len(ds))
+}
+
+func p99Duration(ds []time.Duration) time.Duration {
+	if len(ds) == 0 {
+		return 0
+	}
+	sorted := make([]time.Duration, len(ds))
+	copy(sorted, ds)
+	slices.Sort(sorted)
+	idx := int(float64(len(sorted)) * 0.99)
+	if idx >= len(sorted) {
+		idx = len(sorted) - 1
+	}
+	return sorted[idx]
 }

--- a/sync/pending_polling_test.go
+++ b/sync/pending_polling_test.go
@@ -1112,14 +1112,12 @@ func makeEmptyPreLatestForParent(parent *core.Header) pending.PreLatest {
 	return pending
 }
 
-// TestPreConfirmedUpdateFrequency prints metrics comparing the ticker-only
-// baseline (pre-PR behaviour) with the request-driven path. The baseline
-// subtest never fires triggers; the request-driven subtest fires them at a
-// fixed rate. Run: go test -v -run TestPreConfirmedUpdateFrequency ./sync/
 // BenchmarkPreConfirmedUpdateFrequency is a diagnostic that measures fetch /
 // update rates under a synthetic RPC trigger load and a ticker-only baseline.
-// Each subtest runs for runDuration in real time and reports rates/intervals
-// via b.Logf; b.N is ignored. Run with: go test -bench=PreConfirmedUpdateFrequency.
+// The baseline subtest never fires triggers; the request-driven subtest fires
+// them at a fixed rate. Each subtest runs for runDuration in real time and
+// reports rates/intervals via b.Logf; b.N is ignored.
+// Run with: go test -bench=PreConfirmedUpdateFrequency ./sync/
 func BenchmarkPreConfirmedUpdateFrequency(b *testing.B) {
 	testDB := memory.New()
 	bc := blockchain.New(testDB, &networks.Sepolia,

--- a/sync/pending_polling_test.go
+++ b/sync/pending_polling_test.go
@@ -1116,19 +1116,23 @@ func makeEmptyPreLatestForParent(parent *core.Header) pending.PreLatest {
 // baseline (pre-PR behaviour) with the request-driven path. The baseline
 // subtest never fires triggers; the request-driven subtest fires them at a
 // fixed rate. Run: go test -v -run TestPreConfirmedUpdateFrequency ./sync/
-func TestPreConfirmedUpdateFrequency(t *testing.T) {
+// BenchmarkPreConfirmedUpdateFrequency is a diagnostic that measures fetch /
+// update rates under a synthetic RPC trigger load and a ticker-only baseline.
+// Each subtest runs for runDuration in real time and reports rates/intervals
+// via b.Logf; b.N is ignored. Run with: go test -bench=PreConfirmedUpdateFrequency.
+func BenchmarkPreConfirmedUpdateFrequency(b *testing.B) {
 	testDB := memory.New()
 	bc := blockchain.New(testDB, &networks.Sepolia,
 		blockchain.WithNewState(statetestutils.UseNewState()))
-	client := feeder.NewTestClient(t, &networks.Sepolia)
+	client := feeder.NewTestClient(b, &networks.Sepolia)
 	gw := adaptfeeder.New(client)
 	dataSource := NewFeederGatewayDataSource(bc, gw)
 
-	head0, err := gw.BlockByNumber(t.Context(), 0)
-	require.NoError(t, err)
-	su0, err := gw.StateUpdate(t.Context(), 0)
-	require.NoError(t, err)
-	require.NoError(t, bc.Store(head0, &core.BlockCommitments{}, su0,
+	head0, err := gw.BlockByNumber(b.Context(), 0)
+	require.NoError(b, err)
+	su0, err := gw.StateUpdate(b.Context(), 0)
+	require.NoError(b, err)
+	require.NoError(b, bc.Store(head0, &core.BlockCommitments{}, su0,
 		map[felt.Felt]core.ClassDefinition{}))
 
 	const (
@@ -1146,7 +1150,6 @@ func TestPreConfirmedUpdateFrequency(t *testing.T) {
 		{"request_driven_20Hz", triggerRate},
 	}
 
-	// Run each scenario across a few realistic feeder latencies.
 	latencies := []time.Duration{
 		50 * time.Millisecond,
 		100 * time.Millisecond,
@@ -1156,100 +1159,98 @@ func TestPreConfirmedUpdateFrequency(t *testing.T) {
 	for _, fetchLatency := range latencies {
 		for _, sc := range scenarios {
 			name := fmt.Sprintf("%s/fetch=%s", sc.name, fetchLatency)
-			t.Run(name, func(t *testing.T) {
-				synctest.Test(t, func(t *testing.T) {
-					mockDS := &MockDataSource{
-						DataSource: dataSource,
-						PreConfirmedFunc: func(
-							ctx context.Context,
-							number uint64,
-							_ string, _ uint64, _ uint,
-						) (pending.PreConfirmedUpdate, error) {
-							select {
-							case <-time.After(fetchLatency):
-							case <-ctx.Done():
-								return pending.PreConfirmedUpdate{}, ctx.Err()
-							}
-							preConf := makeTestPreConfirmed(number)
-							preConf.BlockIdentifier = "mock"
-							return pending.PreConfirmedUpdate{
-								Mode:            pending.PreConfirmedFull,
-								BlockIdentifier: preConf.BlockIdentifier,
-								FullBlock:       &preConf,
-							}, nil
-						},
-					}
-					syn := New(bc, mockDS, log.NewNopZapLogger(), 0, tickerInterval, false, testDB)
-					syn.highestBlockHeader.Store(head0.Header)
+			b.Run(name, func(b *testing.B) {
+				mockDS := &MockDataSource{
+					DataSource: dataSource,
+					PreConfirmedFunc: func(
+						ctx context.Context,
+						number uint64,
+						_ string, _ uint64, _ uint,
+					) (pending.PreConfirmedUpdate, error) {
+						select {
+						case <-time.After(fetchLatency):
+						case <-ctx.Done():
+							return pending.PreConfirmedUpdate{}, ctx.Err()
+						}
+						preConf := makeTestPreConfirmed(number)
+						preConf.BlockIdentifier = "mock"
+						return pending.PreConfirmedUpdate{
+							Mode:            pending.PreConfirmedFull,
+							BlockIdentifier: preConf.BlockIdentifier,
+							FullBlock:       &preConf,
+						}, nil
+					},
+				}
+				syn := New(bc, mockDS, log.NewNopZapLogger(), 0, tickerInterval, false, testDB)
+				syn.highestBlockHeader.Store(head0.Header)
 
-					var target atomic.Uint64
-					target.Store(1)
-					out := make(chan *pending.PreConfirmedUpdate, 1024)
+				var target atomic.Uint64
+				target.Store(1)
+				out := make(chan *pending.PreConfirmedUpdate, 1024)
 
-					ctx, cancel := context.WithCancel(t.Context())
+				ctx, cancel := context.WithCancel(context.Background())
 
-					go syn.pollPreConfirmed(ctx, &target, out)
+				go syn.pollPreConfirmed(ctx, &target, out)
 
-					var emitted atomic.Uint32
-					if sc.triggerInterval > 0 {
-						go func() {
-							ticker := time.NewTicker(sc.triggerInterval)
-							defer ticker.Stop()
-							for {
-								select {
-								case <-ctx.Done():
-									return
-								case <-ticker.C:
-									emitted.Add(1)
-									syn.requestPreConfirmedRefresh()
-								}
-							}
-						}()
-					}
-
-					var intervals []time.Duration
-					var lastUpdate time.Time
-					recorderDone := make(chan struct{})
+				var emitted atomic.Uint32
+				if sc.triggerInterval > 0 {
 					go func() {
-						defer close(recorderDone)
+						ticker := time.NewTicker(sc.triggerInterval)
+						defer ticker.Stop()
 						for {
 							select {
 							case <-ctx.Done():
 								return
-							case <-out:
-								now := time.Now()
-								if !lastUpdate.IsZero() {
-									intervals = append(intervals, now.Sub(lastUpdate))
-								}
-								lastUpdate = now
+							case <-ticker.C:
+								emitted.Add(1)
+								syn.requestPreConfirmedRefresh()
 							}
 						}
 					}()
+				}
 
-					time.Sleep(runDuration)
-					cancel()
-					<-recorderDone
+				var intervals []time.Duration
+				var lastUpdate time.Time
+				recorderDone := make(chan struct{})
+				go func() {
+					defer close(recorderDone)
+					for {
+						select {
+						case <-ctx.Done():
+							return
+						case <-out:
+							now := time.Now()
+							if !lastUpdate.IsZero() {
+								intervals = append(intervals, now.Sub(lastUpdate))
+							}
+							lastUpdate = now
+						}
+					}
+				}()
 
-					fetches := mockDS.numCallsPreConfirmed.Load()
-					trigs := emitted.Load()
-					var dropped uint32
-					if trigs >= fetches {
-						dropped = trigs - fetches
-					}
-					updates := uint32(len(intervals) + 1)
-					if lastUpdate.IsZero() {
-						updates = 0
-					}
-					t.Logf(
-						"%s fetch=%s: updates=%d (%.1f/s) fetches=%d "+
-							"triggers_emitted=%d triggers_dropped=%d "+
-							"mean_interval=%v p99_interval=%v",
-						sc.name, fetchLatency,
-						updates, float64(updates)/runDuration.Seconds(),
-						fetches, trigs, dropped,
-						meanDuration(intervals), p99Duration(intervals),
-					)
-				})
+				time.Sleep(runDuration)
+				cancel()
+				<-recorderDone
+
+				fetches := mockDS.numCallsPreConfirmed.Load()
+				trigs := emitted.Load()
+				var dropped uint32
+				if trigs >= fetches {
+					dropped = trigs - fetches
+				}
+				updates := uint32(len(intervals) + 1)
+				if lastUpdate.IsZero() {
+					updates = 0
+				}
+				b.Logf(
+					"%s fetch=%s: updates=%d (%.1f/s) fetches=%d "+
+						"triggers_emitted=%d triggers_dropped=%d "+
+						"mean_interval=%v p99_interval=%v",
+					sc.name, fetchLatency,
+					updates, float64(updates)/runDuration.Seconds(),
+					fetches, trigs, dropped,
+					meanDuration(intervals), p99Duration(intervals),
+				)
 			})
 		}
 	}

--- a/sync/pending_polling_test.go
+++ b/sync/pending_polling_test.go
@@ -31,8 +31,8 @@ type MockDataSource struct {
 	DataSource
 	pendingErrorThreshold      uint
 	preConfirmedErrorThreshold uint
-	numCallsPreConfirmed       uint
-	numCallsPending            uint
+	numCallsPreConfirmed       atomic.Uint32
+	numCallsPending            atomic.Uint32
 	PendingFunc                func(ctx context.Context) (pending.PreLatest, error)
 	PreConfirmedFunc           func(
 		ctx context.Context,
@@ -45,8 +45,8 @@ type MockDataSource struct {
 
 // Override BlockPreLatest to simulate errors and/or injected responses
 func (m *MockDataSource) BlockPreLatest(ctx context.Context) (pending.PreLatest, error) {
-	m.numCallsPending += 1
-	if m.numCallsPending <= m.pendingErrorThreshold {
+	n := m.numCallsPending.Add(1)
+	if uint(n) <= m.pendingErrorThreshold {
 		return pending.PreLatest{}, errors.New("some error")
 	}
 	// fallback to embedded real method if no override set
@@ -64,8 +64,8 @@ func (m *MockDataSource) PreConfirmedBlockByNumber(
 	blockIdentifier string,
 	knownTransactionCount uint64,
 ) (pending.PreConfirmedUpdate, error) {
-	m.numCallsPreConfirmed += 1
-	if m.numCallsPreConfirmed <= m.preConfirmedErrorThreshold {
+	n := m.numCallsPreConfirmed.Add(1)
+	if uint(n) <= m.preConfirmedErrorThreshold {
 		return pending.PreConfirmedUpdate{}, errors.New("some error")
 	}
 
@@ -76,11 +76,11 @@ func (m *MockDataSource) PreConfirmedBlockByNumber(
 			number,
 			blockIdentifier,
 			knownTransactionCount,
-			m.numCallsPreConfirmed,
+			uint(n),
 		)
 	}
 	preConfirmed := makeTestPreConfirmed(number)
-	preConfirmed.Block.TransactionCount = number%10 + uint64(m.numCallsPreConfirmed)/2
+	preConfirmed.Block.TransactionCount = number%10 + uint64(n)/2
 	preConfirmed.BlockIdentifier = "mock"
 	return pending.PreConfirmedUpdate{
 		Mode:            pending.PreConfirmedFull,
@@ -222,7 +222,8 @@ func TestPollPreLatest(t *testing.T) {
 		select {
 		case got := <-preLatestCh:
 			require.NotNil(t, got)
-			require.GreaterOrEqual(t, mockDS.numCallsPending, uint(3), "expected at least 3 attempts (2 errors + 1 success)")
+			require.GreaterOrEqual(t, mockDS.numCallsPending.Load(), uint32(3),
+				"expected at least 3 attempts (2 errors + 1 success)")
 			require.Equal(t, head.Number+1, got.Block.Number)
 		case <-ctx.Done():
 			t.Fatal("expected pre-latest after retries")
@@ -333,8 +334,8 @@ func TestPollPreConfirmedLoop(t *testing.T) {
 			require.Equal(t, uint64(1), update.FullBlock.Block.Number)
 			require.GreaterOrEqual(
 				t,
-				mockDS.numCallsPreConfirmed,
-				uint(3),
+				mockDS.numCallsPreConfirmed.Load(),
+				uint32(3),
 				"expected at least 3 attempts (2 errors + 1 success)",
 			)
 		case <-ctx.Done():
@@ -362,7 +363,119 @@ func TestPollPreConfirmedLoop(t *testing.T) {
 		})
 		wg.Wait()
 
-		require.GreaterOrEqual(t, mockDS.numCallsPreConfirmed, uint(1), "Should have retried at least once before context cancelled")
+		require.GreaterOrEqual(t, mockDS.numCallsPreConfirmed.Load(), uint32(1),
+			"Should have retried at least once before context cancelled")
+	})
+
+	t.Run("External trigger fires a fetch before the ticker would", func(t *testing.T) {
+		// Ticker interval is set very high so any fetch we observe must have been
+		// driven by the trigger channel rather than by the periodic ticker.
+		mockDS := &MockDataSource{DataSource: dataSource}
+		s := New(bc, mockDS, logger, 0, time.Hour, false, testDB)
+		s.highestBlockHeader.Store(head0.Header)
+
+		var preConfirmedBlockNumberToPoll atomic.Uint64
+		preConfirmedBlockNumberToPoll.Store(1)
+		out := make(chan *pending.PreConfirmedUpdate, 1)
+
+		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+
+		var wg stdsync.WaitGroup
+		wg.Go(func() {
+			s.pollPreConfirmed(ctx, &preConfirmedBlockNumberToPoll, out)
+		})
+		// LIFO: cancel before wg.Wait.
+		defer wg.Wait()
+		defer cancel()
+
+		// Triggering a refresh should produce a fetch well within the ticker window.
+		s.requestPreConfirmedRefresh()
+		select {
+		case update := <-out:
+			require.NotNil(t, update)
+			require.NotNil(t, update.FullBlock)
+			require.Equal(t, uint64(1), update.FullBlock.Block.Number)
+		case <-time.After(500 * time.Millisecond):
+			t.Fatal("trigger did not produce a fetch before the ticker")
+		}
+	})
+
+	t.Run("Trigger storm collapses to one fetch while a fetch is running", func(t *testing.T) {
+		// Block the data source until released so the first fetch stays running
+		// while we dispatch the trigger storm. Any extra fetches would mean the
+		// running guard failed to drop the storm requests.
+		release := make(chan struct{})
+		mockDS := &MockDataSource{
+			DataSource: dataSource,
+			PreConfirmedFunc: func(
+				ctx context.Context,
+				number uint64,
+				_ string,
+				_ uint64,
+				_ uint,
+			) (pending.PreConfirmedUpdate, error) {
+				select {
+				case <-release:
+				case <-ctx.Done():
+					return pending.PreConfirmedUpdate{}, ctx.Err()
+				}
+				preConf := makeTestPreConfirmed(number)
+				preConf.BlockIdentifier = "mock"
+				return pending.PreConfirmedUpdate{
+					Mode:            pending.PreConfirmedFull,
+					BlockIdentifier: preConf.BlockIdentifier,
+					FullBlock:       &preConf,
+				}, nil
+			},
+		}
+		// Ticker interval set very high so the only thing that can drive a fetch
+		// is our explicit trigger calls.
+		s := New(bc, mockDS, logger, 0, time.Hour, false, testDB)
+		s.highestBlockHeader.Store(head0.Header)
+
+		var preConfirmedBlockNumberToPoll atomic.Uint64
+		preConfirmedBlockNumberToPoll.Store(1)
+		out := make(chan *pending.PreConfirmedUpdate, 32)
+
+		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+
+		var wg stdsync.WaitGroup
+		wg.Go(func() {
+			s.pollPreConfirmed(ctx, &preConfirmedBlockNumberToPoll, out)
+		})
+		// LIFO: cancel before wg.Wait so the polling goroutine exits cleanly.
+		defer wg.Wait()
+		defer cancel()
+
+		// Kick off the first fetch and wait until the polling goroutine has
+		// actually entered the data source call. numCallsPreConfirmed is
+		// incremented at the very top of the mock, after the goroutine has
+		// already set preConfirmedFetching=true, so observing the counter is
+		// sufficient to know we're inside the running window.
+		s.requestPreConfirmedRefresh()
+		require.Eventually(t, func() bool {
+			return mockDS.numCallsPreConfirmed.Load() == 1
+		}, time.Second, 5*time.Millisecond, "expected the first fetch to be running")
+
+		// Storm of requests while the fetch is running: all must be dropped
+		// by the running guard.
+		for range 100 {
+			s.requestPreConfirmedRefresh()
+		}
+
+		// Release the first fetch and consume its result.
+		close(release)
+		select {
+		case <-out:
+		case <-time.After(time.Second):
+			t.Fatal("expected the first fetch to deliver a result")
+		}
+
+		// No further fetch should happen: every trigger during the running
+		// window was dropped, and the buffered slot was drained on exit.
+		time.Sleep(50 * time.Millisecond)
+		require.Equal(t, uint32(1), mockDS.numCallsPreConfirmed.Load(),
+			"trigger storm during fetch should not produce additional fetches")
 	})
 }
 

--- a/sync/pending_polling_test.go
+++ b/sync/pending_polling_test.go
@@ -402,81 +402,81 @@ func TestPollPreConfirmedLoop(t *testing.T) {
 	})
 
 	t.Run("Trigger storm collapses to one fetch while a fetch is running", func(t *testing.T) {
-		// Block the data source until released so the first fetch stays running
-		// while we dispatch the trigger storm. Any extra fetches would mean the
-		// running guard failed to drop the storm requests.
-		release := make(chan struct{})
-		mockDS := &MockDataSource{
-			DataSource: dataSource,
-			PreConfirmedFunc: func(
-				ctx context.Context,
-				number uint64,
-				_ string,
-				_ uint64,
-				_ uint,
-			) (pending.PreConfirmedUpdate, error) {
-				select {
-				case <-release:
-				case <-ctx.Done():
-					return pending.PreConfirmedUpdate{}, ctx.Err()
-				}
-				preConf := makeTestPreConfirmed(number)
-				preConf.BlockIdentifier = "mock"
-				return pending.PreConfirmedUpdate{
-					Mode:            pending.PreConfirmedFull,
-					BlockIdentifier: preConf.BlockIdentifier,
-					FullBlock:       &preConf,
-				}, nil
-			},
-		}
-		// Ticker interval set very high so the only thing that can drive a fetch
-		// is our explicit trigger calls.
-		s := New(bc, mockDS, logger, 0, time.Hour, false, testDB)
-		s.highestBlockHeader.Store(head0.Header)
+		synctest.Test(t, func(t *testing.T) {
+			// Block the data source until released so the first fetch stays running
+			// while we dispatch the trigger storm. Any extra fetches would mean the
+			// running guard failed to drop the storm requests.
+			release := make(chan struct{})
+			mockDS := &MockDataSource{
+				DataSource: dataSource,
+				PreConfirmedFunc: func(
+					ctx context.Context,
+					number uint64,
+					_ string,
+					_ uint64,
+					_ uint,
+				) (pending.PreConfirmedUpdate, error) {
+					select {
+					case <-release:
+					case <-ctx.Done():
+						return pending.PreConfirmedUpdate{}, ctx.Err()
+					}
+					preConf := makeTestPreConfirmed(number)
+					preConf.BlockIdentifier = "mock"
+					return pending.PreConfirmedUpdate{
+						Mode:            pending.PreConfirmedFull,
+						BlockIdentifier: preConf.BlockIdentifier,
+						FullBlock:       &preConf,
+					}, nil
+				},
+			}
+			// Ticker interval set very high so the only thing that can drive a
+			// fetch is our explicit trigger calls (synctest can advance virtual
+			// time during Wait, so a small ticker would race with us).
+			s := New(bc, mockDS, logger, 0, time.Hour, false, testDB)
+			s.highestBlockHeader.Store(head0.Header)
 
-		var preConfirmedBlockNumberToPoll atomic.Uint64
-		preConfirmedBlockNumberToPoll.Store(1)
-		out := make(chan *pending.PreConfirmedUpdate, 32)
+			var preConfirmedBlockNumberToPoll atomic.Uint64
+			preConfirmedBlockNumberToPoll.Store(1)
+			out := make(chan *pending.PreConfirmedUpdate, 32)
 
-		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+			ctx, cancel := context.WithCancel(t.Context())
+			var wg stdsync.WaitGroup
+			wg.Go(func() {
+				s.pollPreConfirmed(ctx, &preConfirmedBlockNumberToPoll, out)
+			})
+			defer wg.Wait()
+			defer cancel()
 
-		var wg stdsync.WaitGroup
-		wg.Go(func() {
-			s.pollPreConfirmed(ctx, &preConfirmedBlockNumberToPoll, out)
-		})
-		// LIFO: cancel before wg.Wait so the polling goroutine exits cleanly.
-		defer wg.Wait()
-		defer cancel()
-
-		// Kick off the first fetch and wait until the polling goroutine has
-		// actually entered the data source call. numCallsPreConfirmed is
-		// incremented at the very top of the mock, after the goroutine has
-		// already set preConfirmedFetching=true, so observing the counter is
-		// sufficient to know we're inside the running window.
-		s.requestPreConfirmedRefresh()
-		require.Eventually(t, func() bool {
-			return mockDS.numCallsPreConfirmed.Load() == 1
-		}, time.Second, 5*time.Millisecond, "expected the first fetch to be running")
-
-		// Storm of requests while the fetch is running: all must be dropped
-		// by the running guard.
-		for range 100 {
+			// Kick off the first fetch. synctest.Wait blocks until every other
+			// goroutine in the bubble is durably blocked, which here means the
+			// polling goroutine is parked inside the mock waiting on release.
 			s.requestPreConfirmedRefresh()
-		}
+			synctest.Wait()
+			require.Equal(t, uint32(1), mockDS.numCallsPreConfirmed.Load(),
+				"expected the first fetch to be running")
 
-		// Release the first fetch and consume its result.
-		close(release)
-		select {
-		case <-out:
-		case <-time.After(time.Second):
-			t.Fatal("expected the first fetch to deliver a result")
-		}
+			// Storm of requests while the fetch is running: the running guard
+			// must drop every one of them.
+			for range 100 {
+				s.requestPreConfirmedRefresh()
+			}
+			synctest.Wait()
+			require.Equal(t, uint32(1), mockDS.numCallsPreConfirmed.Load(),
+				"storm requests must be dropped by the running guard")
 
-		// No further fetch should happen: every trigger during the running
-		// window was dropped, and the buffered slot was drained on exit.
-		time.Sleep(50 * time.Millisecond)
-		require.Equal(t, uint32(1), mockDS.numCallsPreConfirmed.Load(),
-			"trigger storm during fetch should not produce additional fetches")
+			// Release the fetch, let the goroutine deliver the update and go
+			// back to waiting, then assert no extra fetch was issued.
+			close(release)
+			synctest.Wait()
+			select {
+			case <-out:
+			default:
+				t.Fatal("expected the first fetch to deliver a result")
+			}
+			require.Equal(t, uint32(1), mockDS.numCallsPreConfirmed.Load(),
+				"trigger storm during fetch should not produce additional fetches")
+		})
 	})
 }
 

--- a/sync/sync.go
+++ b/sync/sync.go
@@ -129,6 +129,13 @@ type Synchronizer struct {
 	preLatestPollInterval    time.Duration
 	preConfirmedPollInterval time.Duration
 
+	// preConfirmedTrigger wakes the polling goroutine. Buffered to one; the
+	// preConfirmedFetching guard drops most requests before they ever hit it.
+	preConfirmedTrigger chan struct{}
+	// preConfirmedFetching is true while a pre_confirmed fetch is running.
+	// See requestPreConfirmedRefresh and fetchPreConfirmed.
+	preConfirmedFetching atomic.Bool
+
 	catchUpMode bool
 	plugin      junoplugin.JunoPlugin
 
@@ -155,6 +162,7 @@ func New(
 		preLatestDataFeed:        feed.New[*pending.PreLatest](),
 		preLatestPollInterval:    preLatestPollInterval,
 		preConfirmedPollInterval: preConfirmedPollInterval,
+		preConfirmedTrigger:      make(chan struct{}, 1),
 		listener:                 &SelectiveListener{},
 		readOnlyBlockchain:       readOnlyBlockchain,
 	}
@@ -600,6 +608,11 @@ func (s *Synchronizer) pollLatest(ctx context.Context) {
 }
 
 func (s *Synchronizer) PreConfirmed() (*pending.PreConfirmed, error) {
+	// Every read is a vote that the cached pre_confirmed should be refreshed.
+	// The polling goroutine picks this up on its next iteration and any subscribers
+	// of preConfirmedDataFeed (e.g. WebSocket clients) benefit from the same fetch.
+	s.requestPreConfirmedRefresh()
+
 	head, err := s.blockchain.HeadsHeader()
 	if err != nil {
 		if !errors.Is(err, db.ErrKeyNotFound) {

--- a/sync/sync.go
+++ b/sync/sync.go
@@ -608,9 +608,8 @@ func (s *Synchronizer) pollLatest(ctx context.Context) {
 }
 
 func (s *Synchronizer) PreConfirmed() (*pending.PreConfirmed, error) {
-	// Every read is a vote that the cached pre_confirmed should be refreshed.
-	// The polling goroutine picks this up on its next iteration and any subscribers
-	// of preConfirmedDataFeed (e.g. WebSocket clients) benefit from the same fetch.
+	// Fire-and-forget: triggers an async refresh whose result is seen by the
+	// next caller and by preConfirmedDataFeed subscribers, not by this call.
 	s.requestPreConfirmedRefresh()
 
 	head, err := s.blockchain.HeadsHeader()


### PR DESCRIPTION
## Summary
- Each call to `PreConfirmed()` now triggers a fresh `pre_confirmed` fetch instead of waiting for the next ticker.
- If a fetch is already running, extra refresh requests are dropped. A burst of RPC calls produces a single fetch, not a storm.
- Each fetch is capped at 2s so a slow or hung feeder cannot block future fetches.
- The `--preconfirmed-poll-interval` ticker is now a fallback when there is no RPC traffic to drive fetches.

## Benchmark
Numbers come from `BenchmarkPreConfirmedUpdateFrequency`: a 5-second simulation where one RPC call hits `PreConfirmed()` every 50ms (mimicking a client, or more than one, dictating a higher request frequency).

Run: `go test -bench=PreConfirmedUpdateFrequency -run=^$ ./sync/`

| feeder latency | baseline (ticker only) | request-driven        | improvement |
|----------------|------------------------|-----------------------|-------------|
| 50ms           | 1.8 upd/s, mean 500ms  | 10.8 upd/s, mean 91ms | 6x          |
| 100ms          | 1.8 upd/s, mean 500ms  | 7.2 upd/s, mean 134ms | 4x          |
| 200ms          | 1.8 upd/s, mean 500ms  | 4.2 upd/s, mean 228ms | 2.3x        |

The running guard caught 44-78% of triggers as duplicates, so it was not a feeder hammer.
