### PR TITLE
chore: migrate Starknet docs URLs

### DIFF
--- a/blockchain/networks/network.go
+++ b/blockchain/networks/network.go
@@ -70,7 +70,7 @@ var (
 	_ pflag.Value              = (*Network)(nil)
 	_ encoding.TextUnmarshaler = (*Network)(nil)
 
-	// The docs states the addresses for each network: https://docs.starknet.io/tools/important-addresses/
+	// The docs states the addresses for each network: https://docs.starknet.io/learn/cheatsheets/chain-info#important-addresses
 	Mainnet = Network{
 		Name:                "mainnet",
 		FeederURL:           "https://feeder.alpha-mainnet.starknet.io/feeder_gateway/",

--- a/core/crypto/keccak.go
+++ b/core/crypto/keccak.go
@@ -24,7 +24,7 @@ func StarknetKeccakSum(h hash.Hash) felt.Felt {
 
 // StarknetKeccak implements [Starknet keccak]
 //
-// [Starknet keccak]: https://docs.starknet.io/architecture-and-concepts/cryptography/hash-functions/#starknet_keccak
+// [Starknet keccak]: https://docs.starknet.io/learn/protocol/cryptography#starknet-keccak
 func StarknetKeccak(b []byte) felt.Felt {
 	h := NewStarknetKeccakState()
 	if _, err := h.Write(b); err != nil {

--- a/core/crypto/pedersen_hash.go
+++ b/core/crypto/pedersen_hash.go
@@ -131,7 +131,7 @@ func mulBy256(point *starkcurve.G1Jac) {
 
 // PedersenArray implements [Pedersen array hashing].
 //
-// [Pedersen array hashing]: https://docs.starknet.io/architecture-and-concepts/cryptography/hash-functions/#array_hashing
+// [Pedersen array hashing]: https://docs.starknet.io/learn/protocol/cryptography#array-hashing
 func PedersenArray(elems ...*felt.Felt) felt.Felt {
 	var digest PedersenDigest
 	return digest.Update(elems...).Finish()
@@ -139,7 +139,7 @@ func PedersenArray(elems ...*felt.Felt) felt.Felt {
 
 // Pedersen implements the [Pedersen hash].
 //
-// [Pedersen hash]: https://docs.starknet.io/architecture-and-concepts/cryptography/hash-functions/#pedersen_hash
+// [Pedersen hash]: https://docs.starknet.io/learn/protocol/cryptography#pedersen-hash
 func Pedersen(a, b *felt.Felt) felt.Felt {
 	return felt.Felt(pedersen(a.Impl(), b.Impl()))
 }

--- a/core/crypto/pedersen_hash_test.go
+++ b/core/crypto/pedersen_hash_test.go
@@ -47,7 +47,7 @@ func TestPedersenArray(t *testing.T) {
 		// Contract address calculation. See the following links for how the
 		// calculation is carried out and the result referenced.
 		//
-		// https://docs.starknet.io/learn/cheatsheets/transactions-reference#deploy-account-v3
+		// https://www.starknet.io/cairo-book/ch100-01-contracts-classes-and-instances.html
 		{
 			input: []string{
 				// Hex representation of []byte("STARKNET_CONTRACT_ADDRESS").

--- a/core/crypto/pedersen_hash_test.go
+++ b/core/crypto/pedersen_hash_test.go
@@ -47,7 +47,7 @@ func TestPedersenArray(t *testing.T) {
 		// Contract address calculation. See the following links for how the
 		// calculation is carried out and the result referenced.
 		//
-		// https://docs.starknet.io/architecture-and-concepts/smart-contracts/contract-address/
+		// https://docs.starknet.io/learn/cheatsheets/transactions-reference#deploy-account-v3
 		{
 			input: []string{
 				// Hex representation of []byte("STARKNET_CONTRACT_ADDRESS").

--- a/core/crypto/poseidon_hash.go
+++ b/core/crypto/poseidon_hash.go
@@ -55,7 +55,7 @@ var two = felt.FromUint64[felt.Felt](2)
 
 // Poseidon implements the [Poseidon hash].
 //
-// [Poseidon hash]: https://docs.starknet.io/architecture-and-concepts/cryptography/hash-functions/#poseidon_hash
+// [Poseidon hash]: https://docs.starknet.io/learn/protocol/cryptography#poseidon-hash
 func Poseidon(x, y *felt.Felt) felt.Felt {
 	state := []felt.Felt{*x, *y, two}
 	HadesPermutation(state)
@@ -68,7 +68,7 @@ func Poseidon(x, y *felt.Felt) felt.Felt {
 //
 // PoseidonArray implements [Poseidon array hashing].
 //
-// [Poseidon array hashing]: https://docs.starknet.io/architecture-and-concepts/cryptography/hash-functions/#poseidon_array_hash
+// [Poseidon array hashing]: https://docs.starknet.io/learn/protocol/cryptography#array-hashing
 func PoseidonArray(elems ...*felt.Felt) felt.Felt {
 	state := []felt.Felt{{}, {}, {}}
 

--- a/core/transaction.go
+++ b/core/transaction.go
@@ -873,7 +873,7 @@ func ContractAddress(
 	prefix := felt.FromBytes[felt.Felt]([]byte("STARKNET_CONTRACT_ADDRESS"))
 	callDataHash := crypto.PedersenArray(constructorCallData...)
 
-	// https://docs.starknet.io/architecture-and-concepts/smart-contracts/contract-address/
+	// https://docs.starknet.io/learn/cheatsheets/transactions-reference#deploy-account-v3
 	return crypto.PedersenArray(
 		&prefix,
 		callerAddress,

--- a/core/transaction.go
+++ b/core/transaction.go
@@ -873,7 +873,7 @@ func ContractAddress(
 	prefix := felt.FromBytes[felt.Felt]([]byte("STARKNET_CONTRACT_ADDRESS"))
 	callDataHash := crypto.PedersenArray(constructorCallData...)
 
-	// https://docs.starknet.io/learn/cheatsheets/transactions-reference#deploy-account-v3
+	// https://www.starknet.io/cairo-book/ch100-01-contracts-classes-and-instances.html
 	return crypto.PedersenArray(
 		&prefix,
 		callerAddress,

--- a/core/trie/node.go
+++ b/core/trie/node.go
@@ -10,7 +10,7 @@ import (
 )
 
 // A Node represents a node in the [Trie]
-// https://docs.starknet.io/architecture-and-concepts/network-architecture/starknet-state/#trie_construction
+// https://docs.starknet.io/learn/protocol/state#trie-construction
 type Node struct {
 	Value     *felt.Felt
 	Left      *BitArray

--- a/core/trie/trie.go
+++ b/core/trie/trie.go
@@ -93,7 +93,7 @@ func newTrieReader(
 //   - key: represents the storage key for trie [Node]s. It is the full path to the node from the
 //     root.
 //
-// [specification]: https://docs.starknet.io/architecture-and-concepts/network-architecture/starknet-state/#merkle_patricia_trie
+// [specification]: https://docs.starknet.io/learn/protocol/state#merkle-patricia-trie
 type Trie struct {
 	TrieReader
 	storage        *Storage

--- a/starknet-p2p-specs/p2p/proto/sync/header/header.pb.go
+++ b/starknet-p2p-specs/p2p/proto/sync/header/header.pb.go
@@ -27,7 +27,7 @@ const (
 // hash of block header sent to L1
 type SignedBlockHeader struct {
 	state               protoimpl.MessageState       `protogen:"open.v1"`
-	BlockHash           *common.Hash                 `protobuf:"bytes,1,opt,name=block_hash,json=blockHash,proto3" json:"block_hash,omitempty"` //  For the structure of the block hash, see https://docs.starknet.io/documentation/architecture_and_concepts/Network_Architecture/header/#block_hash
+	BlockHash           *common.Hash                 `protobuf:"bytes,1,opt,name=block_hash,json=blockHash,proto3" json:"block_hash,omitempty"` //  For the structure of the block hash, see https://docs.starknet.io/learn/protocol/blocks#block-hash
 	ParentHash          *common.Hash                 `protobuf:"bytes,2,opt,name=parent_hash,json=parentHash,proto3" json:"parent_hash,omitempty"`
 	Number              uint64                       `protobuf:"varint,3,opt,name=number,proto3" json:"number,omitempty"` // This can be deduced from context. We can consider removing this field.
 	Time                uint64                       `protobuf:"varint,4,opt,name=time,proto3" json:"time,omitempty"`     // Encoded in Unix time.


### PR DESCRIPTION
Updates docs.starknet.io links to new paths/anchors per migration map.