### PR TITLE
refactor: use l1/eth types in non-L1 callers

### DIFF
--- a/adapters/p2p2core/felt.go
+++ b/adapters/p2p2core/felt.go
@@ -4,8 +4,8 @@ import (
 	"encoding/binary"
 
 	"github.com/NethermindEth/juno/core/felt"
+	"github.com/NethermindEth/juno/l1/eth"
 	"github.com/NethermindEth/juno/utils"
-	ethcommon "github.com/ethereum/go-ethereum/common"
 	"github.com/starknet-io/starknet-p2p-specs/p2p/proto/common"
 	"github.com/starknet-io/starknet-p2p-specs/p2p/proto/sync/receipt"
 )
@@ -18,8 +18,8 @@ func AdaptAddress(h *common.Address) *felt.Felt {
 	return adapt(h)
 }
 
-func AdaptEthAddress(h *receipt.EthereumAddress) ethcommon.Address {
-	return ethcommon.BytesToAddress(h.Elements)
+func AdaptEthAddress(h *receipt.EthereumAddress) eth.Address {
+	return eth.AddressFromBytes(h.Elements)
 }
 
 func AdaptFelt(f *common.Felt252) *felt.Felt {

--- a/adapters/sn2core/sn2core.go
+++ b/adapters/sn2core/sn2core.go
@@ -9,9 +9,9 @@ import (
 	"github.com/NethermindEth/juno/core/crypto"
 	"github.com/NethermindEth/juno/core/felt"
 	"github.com/NethermindEth/juno/core/pending"
+	"github.com/NethermindEth/juno/l1/eth"
 	"github.com/NethermindEth/juno/starknet"
 	"github.com/NethermindEth/juno/utils"
-	"github.com/ethereum/go-ethereum/common"
 )
 
 // ErrPreConfirmedIdentifierMismatch is returned by AdaptPreConfirmedWithDelta
@@ -154,7 +154,7 @@ func AdaptL1ToL2Message(response *starknet.L1ToL2Message) *core.L1ToL2Message {
 	}
 
 	return &core.L1ToL2Message{
-		From:     common.HexToAddress(response.From),
+		From:     eth.AddressFromString(response.From),
 		Nonce:    response.Nonce,
 		Payload:  response.Payload,
 		Selector: response.Selector,
@@ -170,7 +170,7 @@ func AdaptL2ToL1Message(response *starknet.L2ToL1Message) *core.L2ToL1Message {
 	return &core.L2ToL1Message{
 		From:    response.From,
 		Payload: response.Payload,
-		To:      common.HexToAddress(response.To),
+		To:      eth.AddressFromString(response.To),
 	}
 }
 

--- a/adapters/testutils/core_test_utils.go
+++ b/adapters/testutils/core_test_utils.go
@@ -9,7 +9,7 @@ import (
 	"github.com/NethermindEth/juno/blockchain/networks"
 	"github.com/NethermindEth/juno/core"
 	"github.com/NethermindEth/juno/core/felt"
-	"github.com/ethereum/go-ethereum/common"
+	"github.com/NethermindEth/juno/l1/eth"
 	"github.com/stretchr/testify/require"
 )
 
@@ -36,9 +36,9 @@ func randomSliceT[T any](t *testing.T, size int, generator func(t *testing.T) T)
 	return items
 }
 
-func randomL1Address(t *testing.T) common.Address {
+func randomL1Address(t *testing.T) eth.Address {
 	t.Helper()
-	var l1Address common.Address
+	var l1Address eth.Address
 	read, err := cryptorand.Read(l1Address[:])
 	require.Equal(t, len(l1Address), read)
 	require.NoError(t, err)

--- a/adapters/vm2core/vm2core.go
+++ b/adapters/vm2core/vm2core.go
@@ -6,9 +6,9 @@ import (
 
 	"github.com/NethermindEth/juno/core"
 	"github.com/NethermindEth/juno/core/felt"
+	"github.com/NethermindEth/juno/l1/eth"
 	"github.com/NethermindEth/juno/utils"
 	"github.com/NethermindEth/juno/vm"
-	"github.com/ethereum/go-ethereum/common"
 )
 
 func AdaptOrderedEvent(event vm.OrderedEvent) *core.Event {
@@ -29,7 +29,7 @@ func AdaptOrderedMessageToL1(message *vm.OrderedL2toL1Message) core.L2ToL1Messag
 		// todo(rdr): this is not correct because it implies the L1 is always Ethereum
 		// 			  and from Starknet 0.14.1 that is no longer a strong assumption.
 		//            we should have a `felt.L1Address` (or similar)
-		To: common.HexToAddress(message.To.String()),
+		To: eth.AddressFromString(message.To.String()),
 	}
 }
 

--- a/adapters/vm2core/vm2core_test.go
+++ b/adapters/vm2core/vm2core_test.go
@@ -6,8 +6,8 @@ import (
 	"github.com/NethermindEth/juno/adapters/vm2core"
 	"github.com/NethermindEth/juno/core"
 	"github.com/NethermindEth/juno/core/felt"
+	"github.com/NethermindEth/juno/l1/eth"
 	"github.com/NethermindEth/juno/vm"
-	"github.com/ethereum/go-ethereum/common"
 	"github.com/stretchr/testify/require"
 )
 
@@ -42,7 +42,7 @@ func TestAdaptOrderedEvents(t *testing.T) {
 func TestAdaptOrderedMessageToL1(t *testing.T) {
 	require.Equal(t, core.L2ToL1Message{
 		From:    felt.NewFromUint64[felt.Felt](2),
-		To:      common.HexToAddress("0x3"),
+		To:      eth.AddressFromString("0x3"),
 		Payload: []*felt.Felt{new(felt.Felt).SetUint64(4)},
 	}, vm2core.AdaptOrderedMessageToL1(&vm.OrderedL2toL1Message{
 		Order:   1,

--- a/blockchain/networks/network.go
+++ b/blockchain/networks/network.go
@@ -7,8 +7,8 @@ import (
 	"strings"
 
 	"github.com/NethermindEth/juno/core/felt"
+	"github.com/NethermindEth/juno/l1/eth"
 	"github.com/NethermindEth/juno/starknet"
-	"github.com/ethereum/go-ethereum/common"
 	"github.com/spf13/pflag"
 )
 
@@ -50,7 +50,7 @@ type Network struct {
 	GatewayURL          string             `json:"gateway_url" validate:"required"`
 	L1ChainID           *big.Int           `json:"l1_chain_id" validate:"required"`
 	L2ChainID           string             `json:"l2_chain_id" validate:"required"`
-	CoreContractAddress common.Address     `json:"core_contract_address" validate:"required"`
+	CoreContractAddress eth.Address        `json:"core_contract_address" validate:"required"`
 	BlockHashMetaInfo   *BlockHashMetaInfo `json:"block_hash_meta_info"`
 }
 
@@ -77,7 +77,7 @@ var (
 		GatewayURL:          "https://alpha-mainnet.starknet.io/gateway/",
 		L2ChainID:           "SN_MAIN",
 		L1ChainID:           big.NewInt(1),
-		CoreContractAddress: common.HexToAddress("0xc662c410C0ECf747543f5bA90660f6ABeBD9C8c4"),
+		CoreContractAddress: eth.AddressFromString("0xc662c410C0ECf747543f5bA90660f6ABeBD9C8c4"),
 		BlockHashMetaInfo: &BlockHashMetaInfo{
 			First07Block:             833,
 			FallBackSequencerAddress: fallBackSequencerAddressMainnet,
@@ -90,7 +90,7 @@ var (
 		L2ChainID:  "SN_GOERLI",
 		//nolint:mnd
 		L1ChainID:           big.NewInt(5),
-		CoreContractAddress: common.HexToAddress("0xde29d060D45901Fb19ED6C6e959EB22d8626708e"),
+		CoreContractAddress: eth.AddressFromString("0xde29d060D45901Fb19ED6C6e959EB22d8626708e"),
 		BlockHashMetaInfo: &BlockHashMetaInfo{
 			First07Block:             47028,
 			UnverifiableRange:        []uint64{119802, 148428},
@@ -104,7 +104,7 @@ var (
 		L2ChainID:  "SN_GOERLI2",
 		//nolint:mnd
 		L1ChainID:           big.NewInt(5),
-		CoreContractAddress: common.HexToAddress("0xa4eD3aD27c294565cB0DCc993BDdCC75432D498c"),
+		CoreContractAddress: eth.AddressFromString("0xa4eD3aD27c294565cB0DCc993BDdCC75432D498c"),
 		BlockHashMetaInfo: &BlockHashMetaInfo{
 			First07Block:             0,
 			FallBackSequencerAddress: fallBackSequencerAddress,
@@ -117,7 +117,7 @@ var (
 		L2ChainID:  "SN_GOERLI",
 		//nolint:mnd
 		L1ChainID:           big.NewInt(5),
-		CoreContractAddress: common.HexToAddress("0xd5c325D183C592C94998000C5e0EED9e6655c020"),
+		CoreContractAddress: eth.AddressFromString("0xd5c325D183C592C94998000C5e0EED9e6655c020"),
 		BlockHashMetaInfo: &BlockHashMetaInfo{
 			First07Block:             110511,
 			UnverifiableRange:        []uint64{0, 110511},
@@ -131,7 +131,7 @@ var (
 		L2ChainID:  "SN_SEPOLIA",
 		//nolint:mnd
 		L1ChainID:           big.NewInt(11155111),
-		CoreContractAddress: common.HexToAddress("0xE2Bb56ee936fd6433DC0F6e7e3b8365C906AA057"),
+		CoreContractAddress: eth.AddressFromString("0xE2Bb56ee936fd6433DC0F6e7e3b8365C906AA057"),
 		BlockHashMetaInfo: &BlockHashMetaInfo{
 			First07Block:             0,
 			FallBackSequencerAddress: fallBackSequencerAddress,
@@ -144,7 +144,7 @@ var (
 		L2ChainID:  "SN_INTEGRATION_SEPOLIA",
 		//nolint:mnd
 		L1ChainID:           big.NewInt(11155111),
-		CoreContractAddress: common.HexToAddress("0x4737c0c1B4D5b1A687B42610DdabEE781152359c"),
+		CoreContractAddress: eth.AddressFromString("0x4737c0c1B4D5b1A687B42610DdabEE781152359c"),
 		BlockHashMetaInfo: &BlockHashMetaInfo{
 			First07Block:             0,
 			FallBackSequencerAddress: fallBackSequencerAddress,

--- a/blockchain/networks/network_test.go
+++ b/blockchain/networks/network_test.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/NethermindEth/juno/blockchain/networks"
 	"github.com/NethermindEth/juno/core/felt"
-	"github.com/ethereum/go-ethereum/common"
+	"github.com/NethermindEth/juno/l1/eth"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -141,13 +141,13 @@ func TestNetworkType(t *testing.T) {
 }
 
 func TestCoreContractAddress(t *testing.T) {
-	addresses := map[networks.Network]common.Address{
-		networks.Mainnet:            common.HexToAddress("0xc662c410C0ECf747543f5bA90660f6ABeBD9C8c4"),
-		networks.Goerli:             common.HexToAddress("0xde29d060D45901Fb19ED6C6e959EB22d8626708e"),
-		networks.Goerli2:            common.HexToAddress("0xa4eD3aD27c294565cB0DCc993BDdCC75432D498c"),
-		networks.Integration:        common.HexToAddress("0xd5c325D183C592C94998000C5e0EED9e6655c020"),
-		networks.Sepolia:            common.HexToAddress("0xE2Bb56ee936fd6433DC0F6e7e3b8365C906AA057"),
-		networks.SepoliaIntegration: common.HexToAddress("0x4737c0c1B4D5b1A687B42610DdabEE781152359c"),
+	addresses := map[networks.Network]eth.Address{
+		networks.Mainnet:            eth.AddressFromString("0xc662c410C0ECf747543f5bA90660f6ABeBD9C8c4"),
+		networks.Goerli:             eth.AddressFromString("0xde29d060D45901Fb19ED6C6e959EB22d8626708e"),
+		networks.Goerli2:            eth.AddressFromString("0xa4eD3aD27c294565cB0DCc993BDdCC75432D498c"),
+		networks.Integration:        eth.AddressFromString("0xd5c325D183C592C94998000C5e0EED9e6655c020"),
+		networks.Sepolia:            eth.AddressFromString("0xE2Bb56ee936fd6433DC0F6e7e3b8365C906AA057"),
+		networks.SepoliaIntegration: eth.AddressFromString("0x4737c0c1B4D5b1A687B42610DdabEE781152359c"),
 	}
 
 	for n := range networkStrings {

--- a/cmd/juno/juno.go
+++ b/cmd/juno/juno.go
@@ -16,10 +16,10 @@ import (
 	"github.com/NethermindEth/juno/blockchain/networks"
 	_ "github.com/NethermindEth/juno/encoder/registry"
 	_ "github.com/NethermindEth/juno/jemalloc"
+	"github.com/NethermindEth/juno/l1/eth"
 	"github.com/NethermindEth/juno/node"
 	"github.com/NethermindEth/juno/utils/log"
 	"github.com/NethermindEth/juno/vm"
-	"github.com/ethereum/go-ethereum/common"
 	"github.com/mitchellh/mapstructure"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
@@ -412,7 +412,7 @@ func NewCmd(config *node.Config, run func(*cobra.Command, []string) error) *cobr
 				GatewayURL:          v.GetString(cnGatewayURLF),
 				L1ChainID:           l1ChainID,
 				L2ChainID:           v.GetString(cnL2ChainIDF),
-				CoreContractAddress: common.HexToAddress(v.GetString(cnCoreContractAddressF)),
+				CoreContractAddress: eth.AddressFromString(v.GetString(cnCoreContractAddressF)),
 				BlockHashMetaInfo: &networks.BlockHashMetaInfo{
 					First07Block:      0,
 					UnverifiableRange: []uint64{uint64(unverifRange[0]), uint64(unverifRange[1])},

--- a/cmd/juno/juno_test.go
+++ b/cmd/juno/juno_test.go
@@ -12,8 +12,8 @@ import (
 
 	"github.com/NethermindEth/juno/blockchain/networks"
 	juno "github.com/NethermindEth/juno/cmd/juno"
+	"github.com/NethermindEth/juno/l1/eth"
 	"github.com/NethermindEth/juno/node"
-	"github.com/ethereum/go-ethereum/common"
 	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -35,7 +35,7 @@ func TestConfigPrecedence(t *testing.T) {
 	defaultWS := false
 	defaultWSPort := uint16(6061)
 	defaultDBPath := filepath.Join(pwd, "juno")
-	defaultCoreContractAddress := common.HexToAddress("0xc662c410C0ECf747543f5bA90660f6ABeBD9C8c4")
+	defaultCoreContractAddress := eth.AddressFromString("0xc662c410C0ECf747543f5bA90660f6ABeBD9C8c4")
 	defaultNetwork := networks.Mainnet
 	defaultCustomNetwork := networks.Network{
 		Name:                "custom",

--- a/core/transaction.go
+++ b/core/transaction.go
@@ -11,8 +11,8 @@ import (
 	"github.com/NethermindEth/juno/blockchain/networks"
 	"github.com/NethermindEth/juno/core/crypto"
 	"github.com/NethermindEth/juno/core/felt"
+	"github.com/NethermindEth/juno/l1/eth"
 	"github.com/bits-and-blooms/bloom/v3"
-	"github.com/ethereum/go-ethereum/common"
 	"github.com/fxamacker/cbor/v2"
 	"golang.org/x/crypto/sha3"
 )
@@ -89,7 +89,7 @@ type Event struct {
 type L1ToL2Message struct {
 	// todo(rdr): Starknet from 0.14.1 has dropped the assumption that we use an EthAddress
 	//            here. We should change this to felt.Address
-	From     common.Address
+	From     eth.Address
 	Nonce    *felt.Felt
 	Payload  []*felt.Felt
 	Selector *felt.Felt
@@ -101,7 +101,7 @@ type L2ToL1Message struct {
 	Payload []*felt.Felt
 	// todo(rdr): Starknet from 0.14.1 has dropped the assumption that we use an EthAddress
 	//            here. We should change this to felt.Address
-	To common.Address
+	To eth.Address
 }
 
 type ExecutionResources struct {

--- a/l1/eth_subscriber.go
+++ b/l1/eth_subscriber.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/NethermindEth/juno/l1/contract"
+	"github.com/NethermindEth/juno/l1/eth"
 	"github.com/ethereum/go-ethereum"
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/common"
@@ -28,7 +29,10 @@ type EthSubscriber struct {
 
 var _ Subscriber = (*EthSubscriber)(nil)
 
-func NewEthSubscriber(ethClientAddress string, coreContractAddress common.Address) (*EthSubscriber, error) {
+func NewEthSubscriber(
+	ethClientAddress string,
+	coreContractAddress eth.Address,
+) (*EthSubscriber, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
 	defer cancel()
 
@@ -37,7 +41,7 @@ func NewEthSubscriber(ethClientAddress string, coreContractAddress common.Addres
 		return nil, err
 	}
 	ethClient := ethclient.NewClient(client)
-	filterer, err := contract.NewStarknetFilterer(coreContractAddress, ethClient)
+	filterer, err := contract.NewStarknetFilterer(common.Address(coreContractAddress), ethClient)
 	if err != nil {
 		return nil, err
 	}

--- a/l1/l1_test.go
+++ b/l1/l1_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/NethermindEth/juno/db/memory"
 	"github.com/NethermindEth/juno/l1"
 	"github.com/NethermindEth/juno/l1/contract"
+	"github.com/NethermindEth/juno/l1/eth"
 	"github.com/NethermindEth/juno/mocks"
 	"github.com/NethermindEth/juno/utils/log"
 	"github.com/ethereum/go-ethereum/common"
@@ -729,7 +730,7 @@ func testEthSubscriberHeight(t *testing.T, tests map[string]struct {
 			server, listener := startServer("127.0.0.1:0", test.service)
 			defer server.Stop()
 
-			subscriber, err := l1.NewEthSubscriber("ws://"+listener.Addr().String(), common.Address{})
+			subscriber, err := l1.NewEthSubscriber("ws://"+listener.Addr().String(), eth.Address{})
 			require.NoError(t, err)
 			defer subscriber.Close()
 

--- a/migration/deprecated/migration_pkg_test.go
+++ b/migration/deprecated/migration_pkg_test.go
@@ -19,10 +19,10 @@ import (
 	"github.com/NethermindEth/juno/db"
 	"github.com/NethermindEth/juno/db/memory"
 	"github.com/NethermindEth/juno/encoder"
+	"github.com/NethermindEth/juno/l1/eth"
 	adaptfeeder "github.com/NethermindEth/juno/starknetdata/feeder"
 	"github.com/NethermindEth/juno/utils/log"
 	"github.com/bits-and-blooms/bitset"
-	"github.com/ethereum/go-ethereum/common"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -238,7 +238,7 @@ func TestL1HandlerTxns(t *testing.T) {
 		require.NoError(t, state.Store(b, &core.BlockCommitments{}, su, nil))
 	}
 
-	msgHash := common.HexToHash("0x42e76df4e3d5255262929c27132bd0d295a8d3db2cfe63d2fcd061c7a7a7ab34")
+	msgHash := eth.HashFromString("0x42e76df4e3d5255262929c27132bd0d295a8d3db2cfe63d2fcd061c7a7a7ab34")
 
 	// Delete the L1 handler txn hash from the database
 	require.NoError(t, testdb.Update(func(txn db.IndexedBatch) error {
@@ -254,7 +254,7 @@ func TestL1HandlerTxns(t *testing.T) {
 		return calculateL1MsgHashes2(txn, &networks.Sepolia)
 	}))
 
-	msgHash = common.HexToHash("0x42e76df4e3d5255262929c27132bd0d295a8d3db2cfe63d2fcd061c7a7a7ab34")
+	msgHash = eth.HashFromString("0x42e76df4e3d5255262929c27132bd0d295a8d3db2cfe63d2fcd061c7a7a7ab34")
 	l1HandlerTxnHash, err := core.GetL1HandlerTxnHashByMsgHash(testdb, msgHash.Bytes())
 	require.NoError(t, err)
 	assert.Equal(t, l1HandlerTxnHash.String(), "0x785c2ada3f53fbc66078d47715c27718f92e6e48b96372b36e5197de69b82b5")

--- a/rpc/v10/estimate_fee.go
+++ b/rpc/v10/estimate_fee.go
@@ -6,14 +6,14 @@ import (
 
 	"github.com/NethermindEth/juno/core/felt"
 	"github.com/NethermindEth/juno/jsonrpc"
+	"github.com/NethermindEth/juno/l1/eth"
 	"github.com/NethermindEth/juno/rpc/rpccore"
-	"github.com/ethereum/go-ethereum/common"
 )
 
 // MsgFromL1 represents a message sent from L1 to L2.
 type MsgFromL1 struct {
 	// The address of the L1 contract sending the message.
-	From common.Address `json:"from_address" validate:"required"`
+	From eth.Address `json:"from_address" validate:"required"`
 	// The address of the L2 contract receiving the message.
 	To felt.Felt `json:"to_address" validate:"required"`
 	// The payload of the message.

--- a/rpc/v10/transaction_types.go
+++ b/rpc/v10/transaction_types.go
@@ -9,9 +9,9 @@ import (
 	"github.com/NethermindEth/juno/core"
 	"github.com/NethermindEth/juno/core/felt"
 	"github.com/NethermindEth/juno/jsonrpc"
+	"github.com/NethermindEth/juno/l1/eth"
 	"github.com/NethermindEth/juno/rpc/rpccore"
 	"github.com/NethermindEth/juno/vm"
-	"github.com/ethereum/go-ethereum/common"
 )
 
 type TransactionType uint8
@@ -264,9 +264,9 @@ type FeePayment struct {
 }
 
 type MsgToL1 struct {
-	From    *felt.Felt     `json:"from_address,omitempty"`
-	To      common.Address `json:"to_address"`
-	Payload []*felt.Felt   `json:"payload"`
+	From    *felt.Felt   `json:"from_address,omitempty"`
+	To      eth.Address  `json:"to_address"`
+	Payload []*felt.Felt `json:"payload"`
 }
 
 type ComputationResources struct {

--- a/rpc/v10/wire_parity_test.go
+++ b/rpc/v10/wire_parity_test.go
@@ -10,7 +10,12 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// See rpc/v8/wire_parity_test.go for rationale. Same JSON shape as v8/v9.
+// These tests pin the JSON-RPC wire shape of MsgToL1 and MsgFromL1 after
+// migrating their address fields from go-ethereum's common.Address to
+// l1/eth.Address. The expected byte sequences match exactly what geth's
+// common.Address.MarshalJSON would have produced (lowercase 0x-prefixed
+// 40-char hex, no EIP-55 checksum) — proven byte-for-byte in
+// l1/eth/address_test.go.
 
 func TestMsgToL1_JSONShape_Stable_v10(t *testing.T) {
 	in := MsgToL1{

--- a/rpc/v10/wire_parity_test.go
+++ b/rpc/v10/wire_parity_test.go
@@ -1,0 +1,73 @@
+package rpcv10
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/NethermindEth/juno/core/felt"
+	"github.com/NethermindEth/juno/l1/eth"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// See rpc/v8/wire_parity_test.go for rationale. Same JSON shape as v8/v9.
+
+func TestMsgToL1_JSONShape_Stable_v10(t *testing.T) {
+	in := MsgToL1{
+		From:    felt.NewFromUint64[felt.Felt](0xabc),
+		To:      eth.AddressFromString("0xc662c410C0ECf747543f5bA90660f6ABeBD9C8c4"),
+		Payload: []*felt.Felt{felt.NewFromUint64[felt.Felt](1), felt.NewFromUint64[felt.Felt](2)},
+	}
+
+	raw, err := json.Marshal(in)
+	require.NoError(t, err)
+
+	const want = `{` +
+		`"from_address":"0xabc",` +
+		`"to_address":"0xc662c410c0ecf747543f5ba90660f6abebd9c8c4",` +
+		`"payload":["0x1","0x2"]` +
+		`}`
+	assert.JSONEq(t, want, string(raw))
+
+	var out MsgToL1
+	require.NoError(t, json.Unmarshal(raw, &out))
+	assert.Equal(t, in.To, out.To)
+}
+
+func TestMsgToL1_JSONShape_OmitsFromWhenNil_v10(t *testing.T) {
+	in := MsgToL1{
+		To:      eth.AddressFromString("0x0000000000000000000000000000000000000001"),
+		Payload: []*felt.Felt{},
+	}
+	raw, err := json.Marshal(in)
+	require.NoError(t, err)
+
+	const want = `{"to_address":"0x0000000000000000000000000000000000000001","payload":[]}`
+	assert.JSONEq(t, want, string(raw))
+}
+
+func TestMsgFromL1_JSONShape_Stable_v10(t *testing.T) {
+	one := felt.NewFromUint64[felt.Felt](1)
+	two := felt.NewFromUint64[felt.Felt](2)
+	in := MsgFromL1{
+		From:     eth.AddressFromString("0xc662c410C0ECf747543f5bA90660f6ABeBD9C8c4"),
+		To:       *felt.NewFromUint64[felt.Felt](0xdef),
+		Payload:  []felt.Felt{*one, *two},
+		Selector: *felt.NewFromUint64[felt.Felt](0x3),
+	}
+
+	raw, err := json.Marshal(in)
+	require.NoError(t, err)
+
+	const want = `{` +
+		`"from_address":"0xc662c410c0ecf747543f5ba90660f6abebd9c8c4",` +
+		`"to_address":"0xdef",` +
+		`"payload":["0x1","0x2"],` +
+		`"entry_point_selector":"0x3"` +
+		`}`
+	assert.JSONEq(t, want, string(raw))
+
+	var out MsgFromL1
+	require.NoError(t, json.Unmarshal(raw, &out))
+	assert.Equal(t, in.From, out.From)
+}

--- a/rpc/v10/wire_parity_test.go
+++ b/rpc/v10/wire_parity_test.go
@@ -1,4 +1,4 @@
-package rpcv10
+package rpcv10_test
 
 import (
 	"encoding/json"
@@ -6,6 +6,7 @@ import (
 
 	"github.com/NethermindEth/juno/core/felt"
 	"github.com/NethermindEth/juno/l1/eth"
+	rpc "github.com/NethermindEth/juno/rpc/v10"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -18,7 +19,7 @@ import (
 // l1/eth/address_test.go.
 
 func TestMsgToL1_JSONShape_Stable_v10(t *testing.T) {
-	in := MsgToL1{
+	in := rpc.MsgToL1{
 		From:    felt.NewFromUint64[felt.Felt](0xabc),
 		To:      eth.AddressFromString("0xc662c410C0ECf747543f5bA90660f6ABeBD9C8c4"),
 		Payload: []*felt.Felt{felt.NewFromUint64[felt.Felt](1), felt.NewFromUint64[felt.Felt](2)},
@@ -34,13 +35,13 @@ func TestMsgToL1_JSONShape_Stable_v10(t *testing.T) {
 		`}`
 	assert.JSONEq(t, want, string(raw))
 
-	var out MsgToL1
+	var out rpc.MsgToL1
 	require.NoError(t, json.Unmarshal(raw, &out))
 	assert.Equal(t, in.To, out.To)
 }
 
 func TestMsgToL1_JSONShape_OmitsFromWhenNil_v10(t *testing.T) {
-	in := MsgToL1{
+	in := rpc.MsgToL1{
 		To:      eth.AddressFromString("0x0000000000000000000000000000000000000001"),
 		Payload: []*felt.Felt{},
 	}
@@ -54,7 +55,7 @@ func TestMsgToL1_JSONShape_OmitsFromWhenNil_v10(t *testing.T) {
 func TestMsgFromL1_JSONShape_Stable_v10(t *testing.T) {
 	one := felt.NewFromUint64[felt.Felt](1)
 	two := felt.NewFromUint64[felt.Felt](2)
-	in := MsgFromL1{
+	in := rpc.MsgFromL1{
 		From:     eth.AddressFromString("0xc662c410C0ECf747543f5bA90660f6ABeBD9C8c4"),
 		To:       *felt.NewFromUint64[felt.Felt](0xdef),
 		Payload:  []felt.Felt{*one, *two},
@@ -72,7 +73,7 @@ func TestMsgFromL1_JSONShape_Stable_v10(t *testing.T) {
 		`}`
 	assert.JSONEq(t, want, string(raw))
 
-	var out MsgFromL1
+	var out rpc.MsgFromL1
 	require.NoError(t, json.Unmarshal(raw, &out))
 	assert.Equal(t, in.From, out.From)
 }

--- a/rpc/v8/estimate_fee.go
+++ b/rpc/v8/estimate_fee.go
@@ -8,8 +8,8 @@ import (
 
 	"github.com/NethermindEth/juno/core/felt"
 	"github.com/NethermindEth/juno/jsonrpc"
+	"github.com/NethermindEth/juno/l1/eth"
 	"github.com/NethermindEth/juno/rpc/rpccore"
-	"github.com/ethereum/go-ethereum/common"
 )
 
 type FeeUnit byte
@@ -43,7 +43,7 @@ type FeeEstimate struct {
 
 type MsgFromL1 struct {
 	// The address of the L1 contract sending the message.
-	From common.Address `json:"from_address" validate:"required"`
+	From eth.Address `json:"from_address" validate:"required"`
 	// The address of the L2 contract receiving the message.
 	To felt.Felt `json:"to_address" validate:"required"`
 	// The payload of the message.

--- a/rpc/v8/transaction.go
+++ b/rpc/v8/transaction.go
@@ -15,12 +15,12 @@ import (
 	"github.com/NethermindEth/juno/core/felt"
 	"github.com/NethermindEth/juno/db"
 	"github.com/NethermindEth/juno/jsonrpc"
+	"github.com/NethermindEth/juno/l1/eth"
 	"github.com/NethermindEth/juno/mempool"
 	"github.com/NethermindEth/juno/rpc/rpccore"
 	"github.com/NethermindEth/juno/starknet"
 	"github.com/NethermindEth/juno/starknet/compiler"
 	"github.com/NethermindEth/juno/utils"
-	"github.com/ethereum/go-ethereum/common"
 	"go.uber.org/zap"
 )
 
@@ -272,9 +272,9 @@ type TransactionStatus struct {
 }
 
 type MsgToL1 struct {
-	From    *felt.Felt     `json:"from_address,omitempty"`
-	To      common.Address `json:"to_address"`
-	Payload []*felt.Felt   `json:"payload"`
+	From    *felt.Felt   `json:"from_address,omitempty"`
+	To      eth.Address  `json:"to_address"`
+	Payload []*felt.Felt `json:"payload"`
 }
 
 type ComputationResources struct {

--- a/rpc/v8/wire_parity_test.go
+++ b/rpc/v8/wire_parity_test.go
@@ -1,0 +1,79 @@
+package rpcv8
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/NethermindEth/juno/core/felt"
+	"github.com/NethermindEth/juno/l1/eth"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// These tests pin the JSON-RPC wire shape of MsgToL1 and MsgFromL1 after
+// migrating their address fields from go-ethereum's common.Address to
+// l1/eth.Address. The expected byte sequences match exactly what geth's
+// common.Address.MarshalJSON would have produced (lowercase 0x-prefixed
+// 40-char hex, no EIP-55 checksum) — proven byte-for-byte in
+// l1/eth/address_test.go.
+
+func TestMsgToL1_JSONShape_Stable_v8(t *testing.T) {
+	in := MsgToL1{
+		From:    felt.NewFromUint64[felt.Felt](0xabc),
+		To:      eth.AddressFromString("0xc662c410C0ECf747543f5bA90660f6ABeBD9C8c4"),
+		Payload: []*felt.Felt{felt.NewFromUint64[felt.Felt](1), felt.NewFromUint64[felt.Felt](2)},
+	}
+
+	raw, err := json.Marshal(in)
+	require.NoError(t, err)
+
+	const want = `{` +
+		`"from_address":"0xabc",` +
+		`"to_address":"0xc662c410c0ecf747543f5ba90660f6abebd9c8c4",` +
+		`"payload":["0x1","0x2"]` +
+		`}`
+	assert.JSONEq(t, want, string(raw))
+
+	var out MsgToL1
+	require.NoError(t, json.Unmarshal(raw, &out))
+	assert.Equal(t, in.To, out.To)
+}
+
+func TestMsgToL1_JSONShape_OmitsFromWhenNil_v8(t *testing.T) {
+	// MsgToL1.From has omitempty; a nil pointer must not emit the key.
+	in := MsgToL1{
+		To:      eth.AddressFromString("0x0000000000000000000000000000000000000001"),
+		Payload: []*felt.Felt{},
+	}
+	raw, err := json.Marshal(in)
+	require.NoError(t, err)
+
+	const want = `{"to_address":"0x0000000000000000000000000000000000000001","payload":[]}`
+	assert.JSONEq(t, want, string(raw))
+}
+
+func TestMsgFromL1_JSONShape_Stable_v8(t *testing.T) {
+	one := felt.NewFromUint64[felt.Felt](1)
+	two := felt.NewFromUint64[felt.Felt](2)
+	in := MsgFromL1{
+		From:     eth.AddressFromString("0xc662c410C0ECf747543f5bA90660f6ABeBD9C8c4"),
+		To:       *felt.NewFromUint64[felt.Felt](0xdef),
+		Payload:  []felt.Felt{*one, *two},
+		Selector: *felt.NewFromUint64[felt.Felt](0x3),
+	}
+
+	raw, err := json.Marshal(in)
+	require.NoError(t, err)
+
+	const want = `{` +
+		`"from_address":"0xc662c410c0ecf747543f5ba90660f6abebd9c8c4",` +
+		`"to_address":"0xdef",` +
+		`"payload":["0x1","0x2"],` +
+		`"entry_point_selector":"0x3"` +
+		`}`
+	assert.JSONEq(t, want, string(raw))
+
+	var out MsgFromL1
+	require.NoError(t, json.Unmarshal(raw, &out))
+	assert.Equal(t, in.From, out.From)
+}

--- a/rpc/v8/wire_parity_test.go
+++ b/rpc/v8/wire_parity_test.go
@@ -10,12 +10,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// These tests pin the JSON-RPC wire shape of MsgToL1 and MsgFromL1 after
-// migrating their address fields from go-ethereum's common.Address to
-// l1/eth.Address. The expected byte sequences match exactly what geth's
-// common.Address.MarshalJSON would have produced (lowercase 0x-prefixed
-// 40-char hex, no EIP-55 checksum) — proven byte-for-byte in
-// l1/eth/address_test.go.
+// See rpc/v10/wire_parity_test.go for rationale. Same JSON shape as v10/v9.
 
 func TestMsgToL1_JSONShape_Stable_v8(t *testing.T) {
 	in := MsgToL1{

--- a/rpc/v8/wire_parity_test.go
+++ b/rpc/v8/wire_parity_test.go
@@ -1,4 +1,4 @@
-package rpcv8
+package rpcv8_test
 
 import (
 	"encoding/json"
@@ -6,6 +6,7 @@ import (
 
 	"github.com/NethermindEth/juno/core/felt"
 	"github.com/NethermindEth/juno/l1/eth"
+	rpc "github.com/NethermindEth/juno/rpc/v8"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -13,7 +14,7 @@ import (
 // See rpc/v10/wire_parity_test.go for rationale. Same JSON shape as v10/v9.
 
 func TestMsgToL1_JSONShape_Stable_v8(t *testing.T) {
-	in := MsgToL1{
+	in := rpc.MsgToL1{
 		From:    felt.NewFromUint64[felt.Felt](0xabc),
 		To:      eth.AddressFromString("0xc662c410C0ECf747543f5bA90660f6ABeBD9C8c4"),
 		Payload: []*felt.Felt{felt.NewFromUint64[felt.Felt](1), felt.NewFromUint64[felt.Felt](2)},
@@ -29,14 +30,14 @@ func TestMsgToL1_JSONShape_Stable_v8(t *testing.T) {
 		`}`
 	assert.JSONEq(t, want, string(raw))
 
-	var out MsgToL1
+	var out rpc.MsgToL1
 	require.NoError(t, json.Unmarshal(raw, &out))
 	assert.Equal(t, in.To, out.To)
 }
 
 func TestMsgToL1_JSONShape_OmitsFromWhenNil_v8(t *testing.T) {
 	// MsgToL1.From has omitempty; a nil pointer must not emit the key.
-	in := MsgToL1{
+	in := rpc.MsgToL1{
 		To:      eth.AddressFromString("0x0000000000000000000000000000000000000001"),
 		Payload: []*felt.Felt{},
 	}
@@ -50,7 +51,7 @@ func TestMsgToL1_JSONShape_OmitsFromWhenNil_v8(t *testing.T) {
 func TestMsgFromL1_JSONShape_Stable_v8(t *testing.T) {
 	one := felt.NewFromUint64[felt.Felt](1)
 	two := felt.NewFromUint64[felt.Felt](2)
-	in := MsgFromL1{
+	in := rpc.MsgFromL1{
 		From:     eth.AddressFromString("0xc662c410C0ECf747543f5bA90660f6ABeBD9C8c4"),
 		To:       *felt.NewFromUint64[felt.Felt](0xdef),
 		Payload:  []felt.Felt{*one, *two},
@@ -68,7 +69,7 @@ func TestMsgFromL1_JSONShape_Stable_v8(t *testing.T) {
 		`}`
 	assert.JSONEq(t, want, string(raw))
 
-	var out MsgFromL1
+	var out rpc.MsgFromL1
 	require.NoError(t, json.Unmarshal(raw, &out))
 	assert.Equal(t, in.From, out.From)
 }

--- a/rpc/v9/estimate_fee.go
+++ b/rpc/v9/estimate_fee.go
@@ -8,8 +8,8 @@ import (
 
 	"github.com/NethermindEth/juno/core/felt"
 	"github.com/NethermindEth/juno/jsonrpc"
+	"github.com/NethermindEth/juno/l1/eth"
 	"github.com/NethermindEth/juno/rpc/rpccore"
-	"github.com/ethereum/go-ethereum/common"
 )
 
 type FeeUnit byte
@@ -299,7 +299,7 @@ func (h *Handler) EstimateFee(
 
 type MsgFromL1 struct {
 	// The address of the L1 contract sending the message.
-	From common.Address `json:"from_address" validate:"required"`
+	From eth.Address `json:"from_address" validate:"required"`
 	// The address of the L2 contract receiving the message.
 	To felt.Felt `json:"to_address" validate:"required"`
 	// The payload of the message.

--- a/rpc/v9/transaction.go
+++ b/rpc/v9/transaction.go
@@ -15,12 +15,12 @@ import (
 	"github.com/NethermindEth/juno/core/felt"
 	"github.com/NethermindEth/juno/db"
 	"github.com/NethermindEth/juno/jsonrpc"
+	"github.com/NethermindEth/juno/l1/eth"
 	"github.com/NethermindEth/juno/mempool"
 	"github.com/NethermindEth/juno/rpc/rpccore"
 	"github.com/NethermindEth/juno/starknet"
 	"github.com/NethermindEth/juno/starknet/compiler"
 	"github.com/NethermindEth/juno/utils"
-	"github.com/ethereum/go-ethereum/common"
 	"go.uber.org/zap"
 )
 
@@ -301,9 +301,9 @@ type TransactionStatus struct {
 }
 
 type MsgToL1 struct {
-	From    *felt.Felt     `json:"from_address,omitempty"`
-	To      common.Address `json:"to_address"`
-	Payload []*felt.Felt   `json:"payload"`
+	From    *felt.Felt   `json:"from_address,omitempty"`
+	To      eth.Address  `json:"to_address"`
+	Payload []*felt.Felt `json:"payload"`
 }
 
 type ComputationResources struct {

--- a/rpc/v9/wire_parity_test.go
+++ b/rpc/v9/wire_parity_test.go
@@ -1,0 +1,73 @@
+package rpcv9
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/NethermindEth/juno/core/felt"
+	"github.com/NethermindEth/juno/l1/eth"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// See rpc/v8/wire_parity_test.go for rationale. Same JSON shape as v8.
+
+func TestMsgToL1_JSONShape_Stable_v9(t *testing.T) {
+	in := MsgToL1{
+		From:    felt.NewFromUint64[felt.Felt](0xabc),
+		To:      eth.AddressFromString("0xc662c410C0ECf747543f5bA90660f6ABeBD9C8c4"),
+		Payload: []*felt.Felt{felt.NewFromUint64[felt.Felt](1), felt.NewFromUint64[felt.Felt](2)},
+	}
+
+	raw, err := json.Marshal(in)
+	require.NoError(t, err)
+
+	const want = `{` +
+		`"from_address":"0xabc",` +
+		`"to_address":"0xc662c410c0ecf747543f5ba90660f6abebd9c8c4",` +
+		`"payload":["0x1","0x2"]` +
+		`}`
+	assert.JSONEq(t, want, string(raw))
+
+	var out MsgToL1
+	require.NoError(t, json.Unmarshal(raw, &out))
+	assert.Equal(t, in.To, out.To)
+}
+
+func TestMsgToL1_JSONShape_OmitsFromWhenNil_v9(t *testing.T) {
+	in := MsgToL1{
+		To:      eth.AddressFromString("0x0000000000000000000000000000000000000001"),
+		Payload: []*felt.Felt{},
+	}
+	raw, err := json.Marshal(in)
+	require.NoError(t, err)
+
+	const want = `{"to_address":"0x0000000000000000000000000000000000000001","payload":[]}`
+	assert.JSONEq(t, want, string(raw))
+}
+
+func TestMsgFromL1_JSONShape_Stable_v9(t *testing.T) {
+	one := felt.NewFromUint64[felt.Felt](1)
+	two := felt.NewFromUint64[felt.Felt](2)
+	in := MsgFromL1{
+		From:     eth.AddressFromString("0xc662c410C0ECf747543f5bA90660f6ABeBD9C8c4"),
+		To:       *felt.NewFromUint64[felt.Felt](0xdef),
+		Payload:  []felt.Felt{*one, *two},
+		Selector: *felt.NewFromUint64[felt.Felt](0x3),
+	}
+
+	raw, err := json.Marshal(in)
+	require.NoError(t, err)
+
+	const want = `{` +
+		`"from_address":"0xc662c410c0ecf747543f5ba90660f6abebd9c8c4",` +
+		`"to_address":"0xdef",` +
+		`"payload":["0x1","0x2"],` +
+		`"entry_point_selector":"0x3"` +
+		`}`
+	assert.JSONEq(t, want, string(raw))
+
+	var out MsgFromL1
+	require.NoError(t, json.Unmarshal(raw, &out))
+	assert.Equal(t, in.From, out.From)
+}

--- a/rpc/v9/wire_parity_test.go
+++ b/rpc/v9/wire_parity_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// See rpc/v8/wire_parity_test.go for rationale. Same JSON shape as v8.
+// See rpc/v10/wire_parity_test.go for rationale. Same JSON shape as v10/v9.
 
 func TestMsgToL1_JSONShape_Stable_v9(t *testing.T) {
 	in := MsgToL1{

--- a/rpc/v9/wire_parity_test.go
+++ b/rpc/v9/wire_parity_test.go
@@ -1,4 +1,4 @@
-package rpcv9
+package rpcv9_test
 
 import (
 	"encoding/json"
@@ -6,6 +6,7 @@ import (
 
 	"github.com/NethermindEth/juno/core/felt"
 	"github.com/NethermindEth/juno/l1/eth"
+	rpc "github.com/NethermindEth/juno/rpc/v9"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -13,7 +14,7 @@ import (
 // See rpc/v10/wire_parity_test.go for rationale. Same JSON shape as v10/v9.
 
 func TestMsgToL1_JSONShape_Stable_v9(t *testing.T) {
-	in := MsgToL1{
+	in := rpc.MsgToL1{
 		From:    felt.NewFromUint64[felt.Felt](0xabc),
 		To:      eth.AddressFromString("0xc662c410C0ECf747543f5bA90660f6ABeBD9C8c4"),
 		Payload: []*felt.Felt{felt.NewFromUint64[felt.Felt](1), felt.NewFromUint64[felt.Felt](2)},
@@ -29,13 +30,13 @@ func TestMsgToL1_JSONShape_Stable_v9(t *testing.T) {
 		`}`
 	assert.JSONEq(t, want, string(raw))
 
-	var out MsgToL1
+	var out rpc.MsgToL1
 	require.NoError(t, json.Unmarshal(raw, &out))
 	assert.Equal(t, in.To, out.To)
 }
 
 func TestMsgToL1_JSONShape_OmitsFromWhenNil_v9(t *testing.T) {
-	in := MsgToL1{
+	in := rpc.MsgToL1{
 		To:      eth.AddressFromString("0x0000000000000000000000000000000000000001"),
 		Payload: []*felt.Felt{},
 	}
@@ -49,7 +50,7 @@ func TestMsgToL1_JSONShape_OmitsFromWhenNil_v9(t *testing.T) {
 func TestMsgFromL1_JSONShape_Stable_v9(t *testing.T) {
 	one := felt.NewFromUint64[felt.Felt](1)
 	two := felt.NewFromUint64[felt.Felt](2)
-	in := MsgFromL1{
+	in := rpc.MsgFromL1{
 		From:     eth.AddressFromString("0xc662c410C0ECf747543f5bA90660f6ABeBD9C8c4"),
 		To:       *felt.NewFromUint64[felt.Felt](0xdef),
 		Payload:  []felt.Felt{*one, *two},
@@ -67,7 +68,7 @@ func TestMsgFromL1_JSONShape_Stable_v9(t *testing.T) {
 		`}`
 	assert.JSONEq(t, want, string(raw))
 
-	var out MsgFromL1
+	var out rpc.MsgFromL1
 	require.NoError(t, json.Unmarshal(raw, &out))
 	assert.Equal(t, in.From, out.From)
 }


### PR DESCRIPTION
Switches the eth types usage from geth to our own defined types on non-l1 callers. 