### PR TITLE
fix(preconfirmed): race confiditions

### DIFF
--- a/sync/pending_polling.go
+++ b/sync/pending_polling.go
@@ -3,10 +3,8 @@ package sync
 import (
 	"context"
 	"errors"
-	"sync/atomic"
 	"time"
 
-	"github.com/NethermindEth/juno/clients/feeder"
 	"github.com/NethermindEth/juno/core"
 	"github.com/NethermindEth/juno/core/felt"
 	"github.com/NethermindEth/juno/core/pending"
@@ -176,15 +174,14 @@ type preConfirmedPoll struct {
 	baseTxCount uint64
 }
 
-// pollPreConfirmed polls for the current target pre_confirmed number at a fixed interval.
-// The target is read from blockNumberToPoll and only polled while at tip.
-// Each poll echoes the currently stored pre_confirmed's identifier and
-// transaction count so the server can return a no-change marker, a delta of
-// appended transactions, or a fresh full block when the round identifier no
-// longer matches. On success, the resulting update is forwarded to out.
+// pollPreConfirmed polls the feeder for the current pre_confirmed at a fixed
+// interval. The poll target and the (identifier, txCount) hints are all read
+// from a single atomic load of the stored pre_confirmed, so the three values
+// are necessarily coherent. Polling fires only while at tip (stored number
+// is strictly greater than the highest known header). On success, the
+// resulting update is forwarded to out.
 func (s *Synchronizer) pollPreConfirmed(
 	ctx context.Context,
-	blockNumberToPoll *atomic.Uint64,
 	out chan<- preConfirmedPoll,
 ) {
 	if s.preConfirmedPollInterval == 0 {
@@ -201,25 +198,14 @@ func (s *Synchronizer) pollPreConfirmed(
 			return
 
 		case <-ticker.C:
-			targetBlockNum := blockNumberToPoll.Load()
-			shouldPoll := targetBlockNum > 0 && s.isGreaterThanTip(targetBlockNum)
-			if !shouldPoll {
+			current := s.preConfirmed.ReadUnsafe()
+			if current == nil || !s.isGreaterThanTip(current.Block.Number) {
 				continue
 			}
-
-			var (
-				blockIdentifier              = feeder.PreConfirmedBlankIdentifier
-				knownTransactionCount uint64 = 0
-			)
-
-			currentPreConf := s.preConfirmed.ReadUnsafe()
-			if currentPreConf != nil {
-				blockIdentifier = currentPreConf.BlockIdentifier
-				knownTransactionCount = uint64(len(currentPreConf.Block.Transactions))
-			}
+			txCount := uint64(len(current.Block.Transactions))
 
 			update, err := s.dataSource.PreConfirmedBlockByNumber(
-				ctx, targetBlockNum, blockIdentifier, knownTransactionCount,
+				ctx, current.Block.Number, current.BlockIdentifier, txCount,
 			)
 			if err != nil {
 				s.logger.Debug("Error while trying to poll pre_confirmed block", zap.Error(err))
@@ -229,8 +215,8 @@ func (s *Synchronizer) pollPreConfirmed(
 			select {
 			case out <- preConfirmedPoll{
 				update:      update,
-				blockNumber: targetBlockNum,
-				baseTxCount: knownTransactionCount,
+				blockNumber: current.Block.Number,
+				baseTxCount: txCount,
 			}:
 				continue
 			case <-ctx.Done():
@@ -243,14 +229,18 @@ func (s *Synchronizer) pollPreConfirmed(
 // handleHead processes a new head.
 // It computes nextHeight = head.Number + 1, clears any staged pre_latest if the
 // head catches up to the current target, and stores an empty pre_confirmed when
-// advancing.
+// advancing. The "current target" is implicit in the stored pre_confirmed's
+// block number — the baseline write itself publishes the new target.
 func (s *Synchronizer) handleHead(
 	head *core.Block,
-	targetPreConfirmedNum *atomic.Uint64,
 	stagedPreLatest *pending.PreLatest,
 ) *pending.PreLatest {
 	next := head.Number + 1
-	targetNum := targetPreConfirmedNum.Load()
+	var targetNum uint64
+	if current := s.preConfirmed.ReadUnsafe(); current != nil {
+		targetNum = current.Block.Number
+	}
+
 	if next < targetNum {
 		return stagedPreLatest
 	}
@@ -260,7 +250,6 @@ func (s *Synchronizer) handleHead(
 		return nil
 	}
 
-	targetPreConfirmedNum.Store(next)
 	if err := s.storeEmptyPreConfirmed(head.Header, nil); err != nil {
 		s.logger.Debug("Error storing empty pre_confirmed (from head)", zap.Error(err))
 	}
@@ -272,15 +261,17 @@ func (s *Synchronizer) handleHead(
 // Returns updated staged pre-latest.
 func (s *Synchronizer) handlePreLatest(
 	pl *pending.PreLatest,
-	targetPreConfirmedNum *atomic.Uint64,
 	stagedPreLatest *pending.PreLatest,
 ) *pending.PreLatest {
 	next := pl.Block.Number + 1
-	if next <= targetPreConfirmedNum.Load() {
+	var targetNum uint64
+	if current := s.preConfirmed.ReadUnsafe(); current != nil {
+		targetNum = current.Block.Number
+	}
+	if next <= targetNum {
 		return stagedPreLatest
 	}
 
-	targetPreConfirmedNum.Store(next)
 	if err := s.storeEmptyPreConfirmed(pl.Block.Header, pl); err != nil {
 		s.logger.Debug("Error storing empty pre_confirmed (with pre_latest)", zap.Error(err))
 	}
@@ -334,10 +325,9 @@ func (s *Synchronizer) pollPendingData(ctx context.Context) {
 
 	preLatestCh := make(chan *pending.PreLatest, 1)
 	preConfirmedCh := make(chan preConfirmedPoll, 1)
-	var preConfirmedBlockNumberToPoll atomic.Uint64
 
 	go s.pollPreLatest(ctx, preLatestCh)
-	go s.pollPreConfirmed(ctx, &preConfirmedBlockNumberToPoll, preConfirmedCh)
+	go s.pollPreConfirmed(ctx, preConfirmedCh)
 
 	var stagedPreLatest *pending.PreLatest
 
@@ -351,17 +341,9 @@ func (s *Synchronizer) pollPendingData(ctx context.Context) {
 				return
 			}
 
-			stagedPreLatest = s.handleHead(
-				head,
-				&preConfirmedBlockNumberToPoll,
-				stagedPreLatest,
-			)
+			stagedPreLatest = s.handleHead(head, stagedPreLatest)
 		case pl := <-preLatestCh:
-			stagedPreLatest = s.handlePreLatest(
-				pl,
-				&preConfirmedBlockNumberToPoll,
-				stagedPreLatest,
-			)
+			stagedPreLatest = s.handlePreLatest(pl, stagedPreLatest)
 		case pc := <-preConfirmedCh:
 			s.handlePreConfirmed(pc, stagedPreLatest)
 		}

--- a/sync/pending_polling.go
+++ b/sync/pending_polling.go
@@ -177,9 +177,12 @@ type preConfirmedPoll struct {
 // pollPreConfirmed polls the feeder for the current pre_confirmed at a fixed
 // interval. The poll target and the (identifier, txCount) hints are all read
 // from a single atomic load of the stored pre_confirmed, so the three values
-// are necessarily coherent. Polling fires only while at tip (stored number
-// is strictly greater than the highest known header). On success, the
-// resulting update is forwarded to out.
+// are necessarily coherent. Each poll echoes the stored pre_confirmed's
+// identifier and transaction count so the server can return a no-change
+// marker, a delta of appended transactions, or a fresh full block when the
+// round identifier no longer matches. Polling fires only while at tip
+// (stored number is strictly greater than the highest known header). On
+// success, the resulting update is forwarded to out.
 func (s *Synchronizer) pollPreConfirmed(
 	ctx context.Context,
 	out chan<- preConfirmedPoll,

--- a/sync/pending_polling_test.go
+++ b/sync/pending_polling_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	stdsync "sync"
-	"sync/atomic"
 	"testing"
 	"testing/synctest"
 	"time"
@@ -350,26 +349,26 @@ func TestPollPreConfirmedLoop(t *testing.T) {
 		}
 		s := New(bc, mockDS, logger, 0, 30*time.Millisecond, false, testDB)
 
-		var preConfirmedBlockNumberToPoll atomic.Uint64
 		out := make(chan preConfirmedPoll, 1)
 		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 		defer cancel()
 
 		var wg stdsync.WaitGroup
 		wg.Go(func() {
-			s.pollPreConfirmed(ctx, &preConfirmedBlockNumberToPoll, out)
+			s.pollPreConfirmed(ctx, out)
 		})
 		defer wg.Wait()
 
-		// Initially, no target -> should not emit
+		// Initially, no hints published -> should not emit
 		select {
 		case <-out:
 			t.Fatal("unexpected pre_confirmed with no target set")
 		case <-time.After(100 * time.Millisecond):
 		}
 
-		// Set target but not at tip (highest nil) -> still skip
-		preConfirmedBlockNumberToPoll.Store(uint64(1))
+		// Seed the stored pre_confirmed but stay not-at-tip (highest nil) -> still skip.
+		// The poller derives its target from stored.Block.Number.
+		seedPreConfirmedAtNumber(t, s, 1)
 		select {
 		case <-out:
 			t.Fatal("unexpected pre_confirmed when not at tip")
@@ -402,8 +401,7 @@ func TestPollPreConfirmedLoop(t *testing.T) {
 		}
 		s := New(bc, mockDS, logger, 0, 30*time.Millisecond, false, testDB)
 		s.highestBlockHeader.Store(head0.Header)
-		var preConfirmedBlockNumberToPoll atomic.Uint64
-		preConfirmedBlockNumberToPoll.Store(1)
+		seedPreConfirmedAtNumber(t, s, 1)
 
 		out := make(chan preConfirmedPoll, 1)
 		ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
@@ -411,7 +409,7 @@ func TestPollPreConfirmedLoop(t *testing.T) {
 
 		var wg stdsync.WaitGroup
 		wg.Go(func() {
-			s.pollPreConfirmed(ctx, &preConfirmedBlockNumberToPoll, out)
+			s.pollPreConfirmed(ctx, out)
 		})
 		wg.Wait()
 
@@ -682,4 +680,17 @@ func makeEmptyPreLatestForParent(parent *core.Header) pending.PreLatest {
 		NewClasses: make(map[felt.Felt]core.ClassDefinition, 0),
 	}
 	return pending
+}
+
+// seedPreConfirmedAtNumber installs a minimal blank-identifier pre_confirmed
+// at the given number so the poller derives `number` as its target on the
+// next tick. Mirrors what storeEmptyPreConfirmed would produce.
+func seedPreConfirmedAtNumber(t *testing.T, s *Synchronizer, number uint64) {
+	t.Helper()
+	s.preConfirmed.inner.Store(&pending.PreConfirmed{
+		Block: &core.Block{
+			Header: &core.Header{Number: number},
+		},
+		BlockIdentifier: feeder.PreConfirmedBlankIdentifier,
+	})
 }

--- a/sync/pre_confirmed_storage.go
+++ b/sync/pre_confirmed_storage.go
@@ -14,6 +14,13 @@ import (
 
 // PreConfirmedStorage owns the atomically-stored pre_confirmed block and the
 // rules for evolving it under a wire-side update.
+//
+// The stored block is also the single source of truth for the poll target:
+// pollPreConfirmed reads `inner` once per tick and derives all three poll
+// parameters (number, identifier, txCount) from that single snapshot, so
+// they are necessarily coherent. This means the poll loop only moves to the
+// next height after an empty pre_confirmed is stored for it. If that write
+// is skipped, the poller has no target and stays idle.
 type PreConfirmedStorage struct {
 	inner atomic.Pointer[pending.PreConfirmed]
 }
@@ -126,7 +133,9 @@ func (s *PreConfirmedStorage) ApplyUpdate(
 // Replacement happens when:
 //   - the incoming block is at a higher number than the existing one, or
 //   - same number but a different BlockIdentifier (new round) — replaces even
-//     if the new block has fewer txs, or
+//     if the new block has fewer txs, EXCEPT when the incoming carries the
+//     blank PreConfirmedBlankIdentifier (an internal placeholder), in which
+//     case the existing real round is preserved, or
 //   - same number and identifier but the incoming block is strictly richer
 //     (more transactions).
 //

--- a/sync/pre_confirmed_storage.go
+++ b/sync/pre_confirmed_storage.go
@@ -6,6 +6,7 @@ import (
 	"sync/atomic"
 
 	"github.com/NethermindEth/juno/adapters/sn2core"
+	"github.com/NethermindEth/juno/clients/feeder"
 	"github.com/NethermindEth/juno/core"
 	"github.com/NethermindEth/juno/core/pending"
 	"github.com/NethermindEth/juno/starknet"
@@ -202,7 +203,12 @@ func shouldPreservePreConfirmed(
 	}
 
 	if incomingB.Number == existingB.Number {
-		if incoming.BlockIdentifier != existing.BlockIdentifier {
+		// A different identifier means a new round; replace — except when the
+		// incoming carries PreConfirmedBlankIdentifier, which is an internal
+		// placeholder (the wire never sends it) and must not override a real
+		// round at the same height.
+		if incoming.BlockIdentifier != existing.BlockIdentifier &&
+			incoming.BlockIdentifier != feeder.PreConfirmedBlankIdentifier {
 			return false
 		}
 		if incomingB.TransactionCount > existingB.TransactionCount {

--- a/sync/pre_confirmed_storage_test.go
+++ b/sync/pre_confirmed_storage_test.go
@@ -217,6 +217,45 @@ func TestStorePreConfirmed(t *testing.T) {
 		require.Equal(t, newRound, *ptr)
 	})
 
+	t.Run("blank-identifier baseline does not override a real round", func(t *testing.T) {
+		s.preConfirmed.inner.Store(nil)
+		head, err := bc.HeadsHeader()
+		require.NoError(t, err)
+
+		existing := pending.PreConfirmed{
+			Block: &core.Block{
+				Header: &core.Header{
+					Number:           head.Number + 1,
+					TransactionCount: 5,
+				},
+			},
+			StateUpdate:     &core.StateUpdate{},
+			BlockIdentifier: "round-a",
+		}
+		written, err := s.preConfirmed.StorePreConfirmedForHead(&existing, head)
+		require.NoError(t, err)
+		require.True(t, written)
+
+		// Internal blank-identifier placeholder at the same height must NOT
+		// wipe a real round, regardless of tx count.
+		blank := pending.PreConfirmed{
+			Block: &core.Block{
+				Header: &core.Header{
+					Number:           head.Number + 1,
+					TransactionCount: 0,
+				},
+			},
+			StateUpdate:     &core.StateUpdate{},
+			BlockIdentifier: feeder.PreConfirmedBlankIdentifier,
+		}
+		written, err = s.preConfirmed.StorePreConfirmedForHead(&blank, head)
+		require.NoError(t, err)
+		require.False(t, written, "blank-identifier baseline must not replace a real round")
+		ptr := s.preConfirmed.ReadUnsafe()
+		require.Equal(t, "round-a", ptr.BlockIdentifier)
+		require.Equal(t, uint64(5), ptr.Block.TransactionCount)
+	})
+
 	t.Run("accepts more recent pre_confirmed regardless tx count", func(t *testing.T) {
 		s.preConfirmed.inner.Store(nil)
 		head, err := bc.HeadsHeader()

--- a/sync/sync.go
+++ b/sync/sync.go
@@ -369,10 +369,6 @@ func (s *Synchronizer) storeTask(
 		return
 	}
 
-	if err := s.storeEmptyPreConfirmed(block.Header, nil); err != nil {
-		s.logger.Error("Failed to store empty pre-confirmed data", zap.Error(err))
-	}
-
 	s.listener.OnSyncStepDone(OpStore, block.Number, time.Since(storeTimer))
 
 	highestBlockHeader := s.highestBlockHeader.Load()
@@ -406,8 +402,6 @@ func (s *Synchronizer) storeTask(
 
 func (s *Synchronizer) revertTask(ctx context.Context, lastPossiblyValidHeight uint64, resetStreams context.CancelFunc) {
 	defer resetStreams()
-	var lastHead *core.Header
-
 	shouldContinue := true
 	for shouldContinue {
 		localHeader, err := s.blockchain.HeadsHeader()
@@ -415,7 +409,6 @@ func (s *Synchronizer) revertTask(ctx context.Context, lastPossiblyValidHeight u
 			s.logger.Error("Failed to retrieve the local head header", zap.Error(err))
 			break
 		}
-		lastHead = localHeader
 
 		// Always reorg head newer than lastPossiblyValidHeight. Otherwise, check the hash
 		if localHeader.Number <= lastPossiblyValidHeight {
@@ -440,12 +433,6 @@ func (s *Synchronizer) revertTask(ctx context.Context, lastPossiblyValidHeight u
 			s.handlePluginRevertBlock()
 		}
 		s.revertHead(localHeader)
-	}
-
-	if lastHead != nil {
-		if err := s.storeEmptyPreConfirmed(lastHead, nil); err != nil {
-			s.logger.Error("Failed to store empty pre-confirmed data", zap.Error(err))
-		}
 	}
 }
 


### PR DESCRIPTION
Makes the pending poller the single writer to pre_confirmed storage (drops the eager writes in storeTask/revertTask), adds a guard so a blank-identifier empty can't overwrite a valid round at the same height via identifier drift, and derives poll parameters from a single ReadUnsafe() of storage instead of a separate blockNumberToPoll atomic.