### PR TITLE
perf(hash): speed up Poseidon hash by ~6%

### DIFF
--- a/core/class_test.go
+++ b/core/class_test.go
@@ -771,3 +771,23 @@ func BenchmarkClassV0Hash(b *testing.B) {
 		})
 	}
 }
+
+// BenchmarkSierraClassHash measures the Poseidon-based Sierra (Cairo 1) class hash.
+func BenchmarkSierraClassHash(b *testing.B) {
+	client := feeder.NewTestClient(b, &networks.Integration)
+	gw := adaptfeeder.New(client)
+
+	key := "0x6d8ede036bb4720e6f348643221d8672bf4f0895622c32c11e57460b3b7dffc"
+	hash := felt.UnsafeFromString[felt.Felt](key)
+	class, err := gw.Class(b.Context(), &hash)
+	require.NoError(b, err)
+	sierra, ok := class.(*core.SierraClass)
+	require.True(b, ok)
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for range b.N {
+		_, err := sierra.Hash()
+		require.NoError(b, err)
+	}
+}

--- a/core/crypto/poseidon_hash.go
+++ b/core/crypto/poseidon_hash.go
@@ -14,9 +14,8 @@ const (
 
 // HadesPermutation applies the Hades permutation to state in place.
 // The hashing steps are intentionally inlined for performance reasons.
-func HadesPermutation(stateSlice []felt.Felt) {
+func HadesPermutation(state *[3]felt.Felt) {
 	initialiseRoundKeys.Do(setRoundKeys)
-	state := (*[3]felt.Felt)(stateSlice)
 
 	var squared, stateSum, triple felt.Felt
 	for i := range totalRounds {
@@ -49,8 +48,8 @@ var two = felt.FromUint64[felt.Felt](2)
 //
 // [Poseidon hash]: https://docs.starknet.io/learn/protocol/cryptography#poseidon-hash
 func Poseidon(x, y *felt.Felt) felt.Felt {
-	state := []felt.Felt{*x, *y, two}
-	HadesPermutation(state)
+	state := [3]felt.Felt{*x, *y, two}
+	HadesPermutation(&state)
 	return state[0]
 }
 
@@ -62,12 +61,12 @@ func Poseidon(x, y *felt.Felt) felt.Felt {
 //
 // [Poseidon array hashing]: https://docs.starknet.io/learn/protocol/cryptography#array-hashing
 func PoseidonArray(elems ...*felt.Felt) felt.Felt {
-	state := []felt.Felt{{}, {}, {}}
+	state := [3]felt.Felt{}
 
 	for i := range len(elems) / 2 {
 		state[0].Add(&state[0], elems[2*i])
 		state[1].Add(&state[1], elems[2*i+1])
-		HadesPermutation(state)
+		HadesPermutation(&state)
 	}
 
 	rem := len(elems) % 2
@@ -75,7 +74,7 @@ func PoseidonArray(elems ...*felt.Felt) felt.Felt {
 		state[0].Add(&state[0], elems[len(elems)-1])
 	}
 	state[rem].Add(&state[rem], &felt.One)
-	HadesPermutation(state)
+	HadesPermutation(&state)
 
 	return state[0]
 }
@@ -114,7 +113,7 @@ func (d *PoseidonDigest) Update(elems ...*felt.Felt) Digest {
 		} else {
 			d.state[0].Add(&d.state[0], d.lastElem)
 			d.state[1].Add(&d.state[1], elems[idx])
-			HadesPermutation(d.state[:])
+			HadesPermutation(&d.state)
 			d.lastElem = nil
 		}
 	}
@@ -128,7 +127,7 @@ func (d *PoseidonDigest) Finish() felt.Felt {
 		d.state[0].Add(&d.state[0], d.lastElem)
 		d.state[1].Add(&d.state[1], &felt.One)
 	}
-	HadesPermutation(d.state[:])
+	HadesPermutation(&d.state)
 	return d.state[0]
 }
 

--- a/core/crypto/poseidon_hash.go
+++ b/core/crypto/poseidon_hash.go
@@ -9,45 +9,37 @@ import (
 const (
 	fullRounds    = 8
 	partialRounds = 83
+	totalRounds   = fullRounds + partialRounds
 )
 
-func addRoundKeys(state []felt.Felt, round int) {
-	state[0].Add(&state[0], &roundKeys[round][0])
-	state[1].Add(&state[1], &roundKeys[round][1])
-	state[2].Add(&state[2], &roundKeys[round][2])
-}
-
-func subWords(state []felt.Felt, full bool) {
-	squared := felt.Felt{}
-	state[2].Mul(&state[2], squared.Mul(&state[2], &state[2]))
-	if full {
-		state[0].Mul(&state[0], squared.Mul(&state[0], &state[0]))
-		state[1].Mul(&state[1], squared.Mul(&state[1], &state[1]))
-	}
-}
-
-// M = ((3,1,1), (1,-1,1), (1,1,-2))
-// state = M * state
-func mixLayer(state []felt.Felt) {
-	stateSum := new(felt.Felt).Add(&state[0], &state[1])
-	stateSum.Add(stateSum, &state[2])
-	state[0].Double(&state[0]).Add(&state[0], stateSum)                               // stateSum + state[0] * 2
-	state[1].Sub(stateSum, state[1].Double(&state[1]))                                // stateSum - state[1] * 2
-	state[2].Sub(stateSum, state[2].Add(&state[2], new(felt.Felt).Double(&state[2]))) // stateSum - state[2] * 3
-}
-
-func round(state []felt.Felt, full bool, index int) {
-	addRoundKeys(state, index)
-	subWords(state, full)
-	mixLayer(state)
-}
-
-func HadesPermutation(state []felt.Felt) {
+// HadesPermutation applies the Hades permutation to state in place.
+// The hashing steps are intentionally inlined for performance reasons.
+func HadesPermutation(stateSlice []felt.Felt) {
 	initialiseRoundKeys.Do(setRoundKeys)
-	totalRounds := fullRounds + partialRounds
+	state := (*[3]felt.Felt)(stateSlice)
+
+	var squared, stateSum, triple felt.Felt
 	for i := range totalRounds {
 		full := (i < fullRounds/2) || (totalRounds-i <= fullRounds/2)
-		round(state, full, i)
+
+		// add round keys
+		state[0].Add(&state[0], &roundKeys[i][0])
+		state[1].Add(&state[1], &roundKeys[i][1])
+		state[2].Add(&state[2], &roundKeys[i][2])
+
+		// S-box: cube state[2] every round, state[0] and state[1] only in full rounds
+		state[2].Mul(&state[2], squared.Mul(&state[2], &state[2]))
+		if full {
+			state[0].Mul(&state[0], squared.Mul(&state[0], &state[0]))
+			state[1].Mul(&state[1], squared.Mul(&state[1], &state[1]))
+		}
+
+		// mix layer: state = M * state
+		stateSum.Add(&state[0], &state[1])
+		stateSum.Add(&stateSum, &state[2])
+		state[0].Double(&state[0]).Add(&state[0], &stateSum)
+		state[1].Sub(&stateSum, state[1].Double(&state[1]))
+		state[2].Sub(&stateSum, triple.Double(&state[2]).Add(&triple, &state[2]))
 	}
 }
 
@@ -90,23 +82,21 @@ func PoseidonArray(elems ...*felt.Felt) felt.Felt {
 
 var (
 	initialiseRoundKeys sync.Once
-	roundKeys           = [][]felt.Felt{}
+	roundKeys           [totalRounds][3]felt.Felt
 )
 
 func setRoundKeys() {
 	var err error
-	for _, keysStr := range roundKeysSpec {
-		curRound := make([]felt.Felt, len(keysStr))
+	for round, keysStr := range roundKeysSpec {
 		for i, keyStr := range keysStr {
-			curRound[i], err = felt.FromString[felt.Felt](keyStr)
+			roundKeys[round][i], err = felt.FromString[felt.Felt](keyStr)
 			if err != nil {
 				panic(err)
 			}
-			if keyStr != curRound[i].Text(felt.Base10) {
+			if keyStr != roundKeys[round][i].Text(felt.Base10) {
 				panic("round key not in stark field " + keyStr)
 			}
 		}
-		roundKeys = append(roundKeys, curRound)
 	}
 }
 

--- a/core/crypto/poseidon_hash_pkg_test.go
+++ b/core/crypto/poseidon_hash_pkg_test.go
@@ -9,8 +9,8 @@ import (
 
 // Test vector from https://github.com/starkware-industries/poseidon
 func TestPermutate(t *testing.T) {
-	state := []felt.Felt{{}, {}, {}}
-	HadesPermutation(state)
+	state := [3]felt.Felt{}
+	HadesPermutation(&state)
 	assert.Equal(t, "3446325744004048536138401612021367625846492093718951375866996507163446763827", state[0].Text(10))
 	assert.Equal(t, "1590252087433376791875644726012779423683501236913937337746052470473806035332", state[1].Text(10))
 	assert.Equal(t, "867921192302518434283879514999422690776342565400001269945778456016268852423", state[2].Text(10))

--- a/core/crypto/poseidon_hash_test.go
+++ b/core/crypto/poseidon_hash_test.go
@@ -61,17 +61,15 @@ func TestPoseidonArray(t *testing.T) {
 	}
 }
 
-// go test -bench=. -run=^# -cpu=1,2,4,8,16
 func BenchmarkPoseidonArray(b *testing.B) {
 	numOfElems := []int{3, 5, 10, 15, 20, 25, 30, 35, 40}
 
-	for _, i := range numOfElems {
-		b.Run(fmt.Sprintf("Number of felts: %d", i), func(b *testing.B) {
-			randomFeltSls := genRandomFeltSls(b, i)
+	for _, n := range numOfElems {
+		b.Run(fmt.Sprintf("Number of felts: %d", n), func(b *testing.B) {
+			elems := genRandomFelts(b, n)
 			var f felt.Felt
-			b.ResetTimer()
-			for n := range b.N {
-				f = crypto.PoseidonArray(randomFeltSls[n]...)
+			for b.Loop() {
+				f = crypto.PoseidonArray(elems...)
 			}
 			benchHashR = f
 		})
@@ -79,12 +77,11 @@ func BenchmarkPoseidonArray(b *testing.B) {
 }
 
 func BenchmarkPoseidon(b *testing.B) {
-	randFelts := genRandomFeltPairs(b)
+	in := genRandomFelts(b, 2)
 
 	var f felt.Felt
-	b.ResetTimer()
-	for n := range b.N {
-		f = crypto.Poseidon(randFelts[n][0], randFelts[n][1])
+	for b.Loop() {
+		f = crypto.Poseidon(in[0], in[1])
 	}
 	benchHashR = f
 }

--- a/core/transaction_test.go
+++ b/core/transaction_test.go
@@ -279,6 +279,28 @@ func TestTransactionV3Hash(t *testing.T) {
 	}
 }
 
+// BenchmarkTransactionV3Hash measures the Poseidon-based v3 invoke transaction hash.
+func BenchmarkTransactionV3Hash(b *testing.B) {
+	network := networks.Sepolia
+	gw := adaptfeeder.New(feeder.NewTestClient(b, &network))
+
+	key := "0x76b52e17bc09064bd986ead34263e6305ef3cecfb3ae9e19b86bf4f1a1a20ea"
+	hash := felt.UnsafeFromString[felt.Felt](key)
+	//nolint:staticcheck // need the full transaction to hash it; the status endpoint won't do
+	tx, err := gw.Transaction(b.Context(), &hash)
+	require.NoError(b, err)
+	invoke, ok := tx.(*core.InvokeTransaction)
+	require.True(b, ok)
+	invoke.TransactionHash = nil
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for range b.N {
+		_, err := core.TransactionHash(invoke, &network)
+		require.NoError(b, err)
+	}
+}
+
 func TestTransactionVersion(t *testing.T) {
 	f := felt.NewUnsafeFromString[felt.Felt]("0x100000000000000000000000000000002")
 	v := (*core.TransactionVersion)(f)


### PR DESCRIPTION
Small "implementation" Optimizations.
No behavior change, no signature change, same hashes, same test vectors.

I'm delivering this because it is a low hanging fruit. 
Further optimizations ("implementation" and  "algorithmic" wise) need to be explored.

### Changes
- `roundKeys`: slice-of-slices → fixed `[91][3]felt.Felt`, contiguous, one less pointer indirection per round
- state accessed as `*[3]felt.Felt` so the compiler drops bounds checks
- inlined the hash steps into the `HadesPermutation` loop to avoid per-round call indirections. 


### Benchmarks (benchstat, n=10, Apple M4)

Real-world:
| benchmark | base | new | Δ |
|---|---|---|---|
| SierraClassHash | 159.5µs | 150.2µs | -5.79% |
| TransactionV3Hash | 116.3µs | 109.7µs | -5.71% |

Micro (`core/crypto`):
| benchmark | Δ |
|---|---|
| Poseidon | -5.04% |
| PoseidonArray (3..40 felts) | -4.9% to -8.4% |
| geomean | -6.44% |

All `p=0.000`, allocations unchanged.