### PR TITLE
perf(hash): alloc-free hashes and empty-data cache

### DIFF
--- a/core/class.go
+++ b/core/class.go
@@ -274,10 +274,10 @@ func SegmentedBytecodeHash(
 // Order matters (selector then index): it influences the class hash.
 func sierraEntryPointsHash(entryPoints []SierraEntryPoint) felt.Felt {
 	var digest crypto.PoseidonDigest
-	var index felt.Felt
-	for i := range entryPoints {
-		index.SetUint64(entryPoints[i].Index)
-		digest.Update(entryPoints[i].Selector, &index)
+	for _, ep := range entryPoints {
+		var index felt.Felt
+		index.SetUint64(ep.Index)
+		digest.Update(ep.Selector, &index)
 	}
 	return digest.Finish()
 }
@@ -285,11 +285,14 @@ func sierraEntryPointsHash(entryPoints []SierraEntryPoint) felt.Felt {
 // Order matters (selector, offset, builtins hash): it influences the class hash.
 func compiledEntryPointsHash(entryPoints []CasmEntryPoint, h Hasher) felt.Felt {
 	digest := h.NewDigest()
+	// Passing &offset and &builtinsHash to digest.Update (an interface call)
+	// makes the compiler heap-allocate them. Declaring them once and reusing
+	// them keeps that to a single allocation instead of one per entry point.
 	var offset, builtinsHash felt.Felt
-	for i := range entryPoints {
-		offset.SetUint64(entryPoints[i].Offset)
-		builtinsHash = compiledBuiltinsHash(entryPoints[i].Builtins, h)
-		digest.Update(entryPoints[i].Selector, &offset, &builtinsHash)
+	for _, ep := range entryPoints {
+		offset.SetUint64(ep.Offset)
+		builtinsHash = compiledBuiltinsHash(ep.Builtins, h)
+		digest.Update(ep.Selector, &offset, &builtinsHash)
 	}
 	return digest.Finish()
 }

--- a/core/class.go
+++ b/core/class.go
@@ -118,15 +118,9 @@ func (c *SierraClass) Version() uint64 {
 }
 
 func (c *SierraClass) Hash() (felt.Felt, error) {
-	externalEntryPointsHash := crypto.PoseidonArray(
-		flattenSierraEntryPoints(c.EntryPoints.External)...,
-	)
-	l1HandlerEntryPointsHash := crypto.PoseidonArray(
-		flattenSierraEntryPoints(c.EntryPoints.L1Handler)...,
-	)
-	constructorHash := crypto.PoseidonArray(
-		flattenSierraEntryPoints(c.EntryPoints.Constructor)...,
-	)
+	externalEntryPointsHash := sierraEntryPointsHash(c.EntryPoints.External)
+	l1HandlerEntryPointsHash := sierraEntryPointsHash(c.EntryPoints.L1Handler)
+	constructorHash := sierraEntryPointsHash(c.EntryPoints.Constructor)
 	return crypto.PoseidonArray(
 		felt.NewFromBytes[felt.Felt]([]byte("CONTRACT_CLASS_V"+c.SemanticVersion)),
 		&externalEntryPointsHash,
@@ -225,9 +219,9 @@ func (c *CasmClass) Hash(version CasmHashVersion) felt.Felt {
 		bytecodeHash = SegmentedBytecodeHash(c.Bytecode, c.BytecodeSegmentLengths.Children, h)
 	}
 
-	externalEntryPointsHash := h.HashArray(flattenCompiledEntryPoints(c.External, h)...)
-	l1HandlerEntryPointsHash := h.HashArray(flattenCompiledEntryPoints(c.L1Handler, h)...)
-	constructorHash := h.HashArray(flattenCompiledEntryPoints(c.Constructor, h)...)
+	externalEntryPointsHash := compiledEntryPointsHash(c.External, h)
+	l1HandlerEntryPointsHash := compiledEntryPointsHash(c.L1Handler, h)
+	constructorHash := compiledEntryPointsHash(c.Constructor, h)
 
 	return h.HashArray(
 		compiledClassV1Prefix,
@@ -277,33 +271,37 @@ func SegmentedBytecodeHash(
 	return hash
 }
 
-func flattenSierraEntryPoints(entryPoints []SierraEntryPoint) []*felt.Felt {
-	result := make([]*felt.Felt, len(entryPoints)*2)
-	for i, entryPoint := range entryPoints {
-		// It is important that Selector is first because the order
-		// influences the class hash.
-		result[2*i] = entryPoint.Selector
-		result[2*i+1] = felt.NewFromUint64[felt.Felt](entryPoint.Index)
+// Order matters (selector then index): it influences the class hash.
+func sierraEntryPointsHash(entryPoints []SierraEntryPoint) felt.Felt {
+	var digest crypto.PoseidonDigest
+	var index felt.Felt
+	for i := range entryPoints {
+		index.SetUint64(entryPoints[i].Index)
+		digest.Update(entryPoints[i].Selector, &index)
 	}
-	return result
+	return digest.Finish()
 }
 
-func flattenCompiledEntryPoints(entryPoints []CasmEntryPoint, h Hasher) []*felt.Felt {
-	result := make([]*felt.Felt, len(entryPoints)*3)
-	for i, entryPoint := range entryPoints {
-		// It is important that Selector is first, then Offset is second because the order
-		// influences the class hash.
-		result[3*i] = entryPoint.Selector
-		result[3*i+1] = felt.NewFromUint64[felt.Felt](entryPoint.Offset)
-		builtins := make([]*felt.Felt, len(entryPoint.Builtins))
-		for idx, buil := range entryPoint.Builtins {
-			builtins[idx] = felt.NewFromBytes[felt.Felt]([]byte(buil))
-		}
-		builtinsHash := h.HashArray(builtins...)
-		result[3*i+2] = &builtinsHash
+// Order matters (selector, offset, builtins hash): it influences the class hash.
+func compiledEntryPointsHash(entryPoints []CasmEntryPoint, h Hasher) felt.Felt {
+	digest := h.NewDigest()
+	var offset, builtinsHash felt.Felt
+	for i := range entryPoints {
+		offset.SetUint64(entryPoints[i].Offset)
+		builtinsHash = compiledBuiltinsHash(entryPoints[i].Builtins, h)
+		digest.Update(entryPoints[i].Selector, &offset, &builtinsHash)
 	}
+	return digest.Finish()
+}
 
-	return result
+func compiledBuiltinsHash(builtins []string, h Hasher) felt.Felt {
+	digest := h.NewDigest()
+	var b felt.Felt
+	for i := range builtins {
+		b.SetBytes([]byte(builtins[i]))
+		digest.Update(&b)
+	}
+	return digest.Finish()
 }
 
 func VerifyClassHashes(classes map[felt.Felt]ClassDefinition) error {

--- a/core/class.go
+++ b/core/class.go
@@ -210,20 +210,20 @@ var compiledClassV1Prefix = felt.NewFromBytes[felt.Felt]([]byte("COMPILED_CLASS_
 
 // Hash computes the class hash using the specified hash version
 func (c *CasmClass) Hash(version CasmHashVersion) felt.Felt {
-	h := NewCasmHasher(version)
+	hasher := NewCasmHasher(version)
 
 	var bytecodeHash felt.Felt
 	if len(c.BytecodeSegmentLengths.Children) == 0 {
-		bytecodeHash = h.HashArray(c.Bytecode...)
+		bytecodeHash = hasher.HashArray(c.Bytecode...)
 	} else {
-		bytecodeHash = SegmentedBytecodeHash(c.Bytecode, c.BytecodeSegmentLengths.Children, h)
+		bytecodeHash = SegmentedBytecodeHash(c.Bytecode, c.BytecodeSegmentLengths.Children, hasher)
 	}
 
-	externalEntryPointsHash := compiledEntryPointsHash(c.External, h)
-	l1HandlerEntryPointsHash := compiledEntryPointsHash(c.L1Handler, h)
-	constructorHash := compiledEntryPointsHash(c.Constructor, h)
+	externalEntryPointsHash := compiledEntryPointsHash(c.External, hasher)
+	l1HandlerEntryPointsHash := compiledEntryPointsHash(c.L1Handler, hasher)
+	constructorHash := compiledEntryPointsHash(c.Constructor, hasher)
 
-	return h.HashArray(
+	return hasher.HashArray(
 		compiledClassV1Prefix,
 		&externalEntryPointsHash,
 		&l1HandlerEntryPointsHash,
@@ -235,13 +235,13 @@ func (c *CasmClass) Hash(version CasmHashVersion) felt.Felt {
 func SegmentedBytecodeHash(
 	bytecode []*felt.Felt,
 	segmentLengths []SegmentLengths,
-	h Hasher,
+	hasher Hasher,
 ) felt.Felt {
 	var startingOffset uint64
 	var digestSegment func(segments []SegmentLengths) (uint64, felt.Felt)
 	digestSegment = func(segments []SegmentLengths) (uint64, felt.Felt) {
 		var totalLength uint64
-		digest := h.NewDigest()
+		digest := hasher.NewDigest()
 
 		for _, segment := range segments {
 			var curSegmentLength uint64
@@ -250,7 +250,7 @@ func SegmentedBytecodeHash(
 			if len(segment.Children) == 0 {
 				curSegmentLength = segment.Length
 				segmentBytecode := bytecode[startingOffset : startingOffset+segment.Length]
-				curSegmentHash = h.HashArray(segmentBytecode...)
+				curSegmentHash = hasher.HashArray(segmentBytecode...)
 			} else {
 				curSegmentLength, curSegmentHash = digestSegment(segment.Children)
 			}
@@ -283,22 +283,22 @@ func sierraEntryPointsHash(entryPoints []SierraEntryPoint) felt.Felt {
 }
 
 // Order matters (selector, offset, builtins hash): it influences the class hash.
-func compiledEntryPointsHash(entryPoints []CasmEntryPoint, h Hasher) felt.Felt {
-	digest := h.NewDigest()
+func compiledEntryPointsHash(entryPoints []CasmEntryPoint, hasher Hasher) felt.Felt {
+	digest := hasher.NewDigest()
 	// Passing &offset and &builtinsHash to digest.Update (an interface call)
 	// makes the compiler heap-allocate them. Declaring them once and reusing
 	// them keeps that to a single allocation instead of one per entry point.
 	var offset, builtinsHash felt.Felt
 	for _, ep := range entryPoints {
 		offset.SetUint64(ep.Offset)
-		builtinsHash = compiledBuiltinsHash(ep.Builtins, h)
+		builtinsHash = compiledBuiltinsHash(ep.Builtins, hasher)
 		digest.Update(ep.Selector, &offset, &builtinsHash)
 	}
 	return digest.Finish()
 }
 
-func compiledBuiltinsHash(builtins []string, h Hasher) felt.Felt {
-	digest := h.NewDigest()
+func compiledBuiltinsHash(builtins []string, hasher Hasher) felt.Felt {
+	digest := hasher.NewDigest()
 	var b felt.Felt
 	for i := range builtins {
 		b.SetBytes([]byte(builtins[i]))

--- a/core/crypto/poseidon_hash.go
+++ b/core/crypto/poseidon_hash.go
@@ -12,7 +12,8 @@ const (
 	totalRounds   = fullRounds + partialRounds
 )
 
-// Caches the {0, 1, 0} input (empty data); emptyDataOutput is computed in initializePoseidon.
+// Caches the {0, 1, 0} input (state for hashing a single zero felt).
+// emptyDataOutput is computed in initializePoseidon.
 var (
 	emptyDataInput  = [3]felt.Felt{{}, felt.One, {}}
 	emptyDataOutput [3]felt.Felt

--- a/core/crypto/poseidon_hash.go
+++ b/core/crypto/poseidon_hash.go
@@ -12,11 +12,26 @@ const (
 	totalRounds   = fullRounds + partialRounds
 )
 
-// HadesPermutation applies the Hades permutation to state in place.
-// The hashing steps are intentionally inlined for performance reasons.
-func HadesPermutation(state *[3]felt.Felt) {
-	initialiseRoundKeys.Do(setRoundKeys)
+// Caches the {0, 1, 0} input (empty data); emptyDataOutput is computed in initializePoseidon.
+var (
+	emptyDataInput  = [3]felt.Felt{{}, felt.One, {}}
+	emptyDataOutput [3]felt.Felt
+)
 
+// HadesPermutation applies the Hades permutation to state in place.
+func HadesPermutation(state *[3]felt.Felt) {
+	poseidonInit.Do(initializePoseidon)
+	if *state == emptyDataInput {
+		*state = emptyDataOutput
+		return
+	}
+	hadesPermutationRounds(state)
+}
+
+// hadesPermutationRounds runs the Hades rounds in place.
+// The hashing steps are intentionally inlined for performance reasons.
+// The sparse-MDS optimization was measured ~53% slower here (our MDS is mul-free), don't try it.
+func hadesPermutationRounds(state *[3]felt.Felt) {
 	var squared, stateSum, triple felt.Felt
 	for i := range totalRounds {
 		full := (i < fullRounds/2) || (totalRounds-i <= fullRounds/2)
@@ -80,9 +95,16 @@ func PoseidonArray(elems ...*felt.Felt) felt.Felt {
 }
 
 var (
-	initialiseRoundKeys sync.Once
-	roundKeys           [totalRounds][3]felt.Felt
+	poseidonInit sync.Once
+	roundKeys    [totalRounds][3]felt.Felt
 )
+
+// initializePoseidon loads the round keys and precomputes the empty-data output.
+func initializePoseidon() {
+	setRoundKeys()
+	emptyDataOutput = emptyDataInput
+	hadesPermutationRounds(&emptyDataOutput)
+}
 
 func setRoundKeys() {
 	var err error
@@ -103,28 +125,30 @@ var _ Digest = (*PoseidonDigest)(nil)
 
 type PoseidonDigest struct {
 	state    [3]felt.Felt
-	lastElem *felt.Felt
+	lastElem felt.Felt
+	hasLast  bool
 }
 
 func (d *PoseidonDigest) Update(elems ...*felt.Felt) Digest {
 	for idx := range elems {
-		if d.lastElem == nil {
-			d.lastElem = new(felt.Felt).Set(elems[idx])
+		if !d.hasLast {
+			d.lastElem = *elems[idx]
+			d.hasLast = true
 		} else {
-			d.state[0].Add(&d.state[0], d.lastElem)
+			d.state[0].Add(&d.state[0], &d.lastElem)
 			d.state[1].Add(&d.state[1], elems[idx])
 			HadesPermutation(&d.state)
-			d.lastElem = nil
+			d.hasLast = false
 		}
 	}
 	return d
 }
 
 func (d *PoseidonDigest) Finish() felt.Felt {
-	if d.lastElem == nil {
+	if !d.hasLast {
 		d.state[0].Add(&d.state[0], &felt.One)
 	} else {
-		d.state[0].Add(&d.state[0], d.lastElem)
+		d.state[0].Add(&d.state[0], &d.lastElem)
 		d.state[1].Add(&d.state[1], &felt.One)
 	}
 	HadesPermutation(&d.state)

--- a/core/crypto/poseidon_hash.go
+++ b/core/crypto/poseidon_hash.go
@@ -32,6 +32,9 @@ func HadesPermutation(state *[3]felt.Felt) {
 // hadesPermutationRounds runs the Hades rounds in place.
 // The hashing steps are intentionally inlined for performance reasons.
 // The sparse-MDS optimization was measured ~53% slower here (our MDS is mul-free), don't try it.
+//
+// The only remaining way to speed up Poseidon is FFI, see the discussion:
+// https://github.com/NethermindEth/juno/pull/3731
 func hadesPermutationRounds(state *[3]felt.Felt) {
 	var squared, stateSum, triple felt.Felt
 	for i := range totalRounds {

--- a/core/crypto/poseidon_hash_test.go
+++ b/core/crypto/poseidon_hash_test.go
@@ -85,3 +85,19 @@ func BenchmarkPoseidon(b *testing.B) {
 	}
 	benchHashR = f
 }
+
+// BenchmarkPoseidonDigest locks in the allocation count of the streaming
+// digest path (Update + Finish), which struct/array hashing relies on.
+// 40 felts exercises ~20 Hades permutations.
+func BenchmarkPoseidonDigest(b *testing.B) {
+	elems := genRandomFelts(b, 40)
+
+	var f felt.Felt
+	b.ReportAllocs()
+	for b.Loop() {
+		var digest crypto.PoseidonDigest
+		digest.Update(elems...)
+		f = digest.Finish()
+	}
+	benchHashR = f
+}

--- a/core/receipt.go
+++ b/core/receipt.go
@@ -54,17 +54,18 @@ func (r *TransactionReceipt) hash() felt.Felt {
 }
 
 func messagesSentHash(messages []*L2ToL1Message) felt.Felt {
-	chain := []*felt.Felt{
-		felt.NewFromUint64[felt.Felt](uint64(len(messages))),
-	}
+	var digest crypto.PoseidonDigest
+	var count, msgTo, payloadSize felt.Felt
+	count.SetUint64(uint64(len(messages)))
+	digest.Update(&count)
 	for _, msg := range messages {
-		msgTo := felt.FromBytes[felt.Felt](msg.To.Bytes())
-		payloadSize := felt.FromUint64[felt.Felt](uint64(len(msg.Payload)))
-		chain = append(chain, msg.From, &msgTo, &payloadSize)
-		chain = append(chain, msg.Payload...)
+		msgTo.SetBytes(msg.To.Bytes())
+		payloadSize.SetUint64(uint64(len(msg.Payload)))
+		digest.Update(msg.From, &msgTo, &payloadSize)
+		digest.Update(msg.Payload...)
 	}
 
-	return crypto.PoseidonArray(chain...)
+	return digest.Finish()
 }
 
 func receiptCommitment(receipts []*TransactionReceipt, backend TempTrieBackend) (felt.Felt, error) {

--- a/core/transaction.go
+++ b/core/transaction.go
@@ -480,7 +480,8 @@ func invokeTransactionHash(i *InvokeTransaction, n *networks.Network) (felt.Felt
 		calldataHash := crypto.PoseidonArray(i.CallData...)
 		daMode := felt.FromUint64[felt.Felt](dataAvailabilityMode(i.FeeDAMode, i.NonceDAMode))
 
-		hashElems := []*felt.Felt{
+		var digest crypto.PoseidonDigest
+		digest.Update(
 			invokeFelt,
 			i.Version.AsFelt(),
 			i.SenderAddress,
@@ -491,19 +492,18 @@ func invokeTransactionHash(i *InvokeTransaction, n *networks.Network) (felt.Felt
 			&daMode,
 			&accountDeploymentDataHash,
 			&calldataHash,
-		}
+		)
 
 		if len(i.ProofFacts) > 0 {
-			proofFacts := make([]*felt.Felt, len(i.ProofFacts))
-			for i, proofFact := range i.ProofFacts {
-				proofFacts[i] = &proofFact
+			var proofFactsDigest crypto.PoseidonDigest
+			for j := range i.ProofFacts {
+				proofFactsDigest.Update(&i.ProofFacts[j])
 			}
-
-			proofFactsHash := crypto.PoseidonArray(proofFacts...)
-			hashElems = append(hashElems, &proofFactsHash)
+			proofFactsHash := proofFactsDigest.Finish()
+			digest.Update(&proofFactsHash)
 		}
 
-		return crypto.PoseidonArray(hashElems...), nil
+		return digest.Finish(), nil
 	default:
 		return felt.Felt{}, errInvalidTransactionVersion(i, i.Version)
 	}
@@ -513,19 +513,17 @@ func tipAndResourcesHash(tip uint64, resourceBounds map[Resource]ResourceBounds)
 	l1Bounds := felt.FromBytes[felt.Felt](resourceBounds[ResourceL1Gas].Bytes(ResourceL1Gas))
 	l2Bounds := felt.FromBytes[felt.Felt](resourceBounds[ResourceL2Gas].Bytes(ResourceL2Gas))
 	tipFelt := felt.FromUint64[felt.Felt](tip)
-	elems := []*felt.Felt{
-		&tipFelt,
-		&l1Bounds,
-		&l2Bounds,
-	}
+
+	var digest crypto.PoseidonDigest
+	digest.Update(&tipFelt, &l1Bounds, &l2Bounds)
 
 	// l1_data_gas resource bounds were added in 0.13.4
 	if bounds, ok := resourceBounds[ResourceL1DataGas]; ok && bounds.MaxPricePerUnit != nil {
 		l1DataBounds := felt.FromBytes[felt.Felt](bounds.Bytes(ResourceL1DataGas))
-		elems = append(elems, &l1DataBounds)
+		digest.Update(&l1DataBounds)
 	}
 
-	return crypto.PoseidonArray(elems...)
+	return digest.Finish()
 }
 
 func dataAvailabilityMode(feeDAMode, nonceDAMode DataAvailabilityMode) uint64 {


### PR DESCRIPTION
## What
1. **Alloc-free `PoseidonDigest`** — the streaming digest no longer allocates.
2. **Short-circuit the most common Hades input `{0,1,0}`** (hashing a single zero felt): precomputed once at init and returned directly, skipping a full permutation.

## Allocs/op (backed by committed benchmarks, `b.ReportAllocs()`)
| benchmark | before | after |
|---|---|---|
| `BenchmarkSierraClassHash` | 15 | 1 |
| `BenchmarkTransactionV3Hash` | 14 | 3 |
| `BenchmarkPoseidonDigest` (40 felts) | 20 | 0 |

"before" = `origin/main`; "after" = this branch.

## Notes
~4% of Hades permutations on `SepoliaIntegration` blocks are exactly the empty-data input, now short-circuited. (~14% of permutations had repeated inputs overall. A broader memoization is a follow-up PR.)
