### PR TITLE
feat(utils): Fix throttler behavior when max queue length is zero

### DIFF
--- a/utils/throttler.go
+++ b/utils/throttler.go
@@ -32,6 +32,15 @@ func (t *Throttler[T]) WithMaxQueueLen(maxQueueLen int32) *Throttler[T] {
 
 // Do lets caller acquire the resource within the context of a callback
 func (t *Throttler[T]) Do(doer func(resource *T) error) error {
+	select {
+	case t.sem <- struct{}{}:
+		defer func() {
+			<-t.sem
+		}()
+		return doer(t.resource)
+	default:
+	}
+
 	queueLen := t.queue.Add(1)
 	if queueLen > t.maxQueueLen {
 		t.queue.Add(-1)

--- a/utils/throttler_test.go
+++ b/utils/throttler_test.go
@@ -61,3 +61,35 @@ func TestThrottler(t *testing.T) {
 	wg.Wait()
 	assert.Equal(t, int64(4), runCount)
 }
+
+func TestThrottlerWithZeroMaxQueueLen(t *testing.T) {
+	throttledRes := utils.NewThrottler(1, new(int)).WithMaxQueueLen(0)
+	release := make(chan struct{})
+	started := make(chan struct{})
+	done := make(chan error, 1)
+
+	go func() {
+		done <- throttledRes.Do(func(ptr *int) error {
+			if ptr == nil {
+				return errors.New("nilptr")
+			}
+			close(started)
+			<-release
+			return nil
+		})
+	}()
+
+	select {
+	case <-started:
+	case err := <-done:
+		require.NoError(t, err)
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for throttled job to start")
+	}
+
+	assert.Equal(t, 0, throttledRes.QueueLen())
+	require.ErrorIs(t, throttledRes.Do(func(*int) error { return nil }), utils.ErrResourceBusy)
+
+	close(release)
+	require.NoError(t, <-done)
+}


### PR DESCRIPTION

## Summary

This fixes `utils.Throttler` when `WithMaxQueueLen(0)` is used.

A zero queue length should mean that calls may run immediately when capacity is available, but no additional calls should wait once the resource is saturated. Previously, `Do` checked the queue length before trying to acquire an available slot, so even the first call could return `ErrResourceBusy`.

The updated logic first attempts a non-blocking acquire. Only when the throttler is already at capacity does it increment and check the queue length.

## Testing

- `go test ./utils -run 'TestThrottler' -count=1`
- `go test ./utils -count=1`
- `go test ./l1/eth ./jsonrpc ./utils ./utils/pipeline ./utils/broadcast ./utils/tracker -count=1`