### PR TITLE
fix(sn2core): handle candidate(??) transactions in AdaptPreConfirmedWithDelta

### DIFF
--- a/adapters/sn2core/sn2core.go
+++ b/adapters/sn2core/sn2core.go
@@ -626,6 +626,8 @@ func AdaptPreConfirmedBlock(
 //
 // Returns [ErrPreConfirmedIdentifierMismatch] if current.BlockIdentifier
 // differs from delta.BlockIdentifier.
+//
+//nolint:funlen // Let's simplify it later.
 func AdaptPreConfirmedWithDelta(
 	current *pending.PreConfirmed,
 	delta *starknet.PreConfirmedDeltaUpdate,
@@ -659,10 +661,26 @@ func AdaptPreConfirmedWithDelta(
 	nextStateDiff.Merge(current.StateUpdate.StateDiff)
 
 	addedEventCount := uint64(0)
+	var candidateTxs []core.Transaction
 	for i := range delta.Transactions {
 		tx, err := AdaptTransaction(&delta.Transactions[i])
 		if err != nil {
 			return pending.PreConfirmed{}, err
+		}
+
+		// Bug workaround: the delta endpoint may still return txs that carry a null
+		// state diff / receipt, similar to candidate txs. Store them as candidate txs
+		// instead of dereferencing nil and panicking, and reducing the slice lengths
+		// to match the number of txs that actually have state diff / receipt.
+		// Ref: https://demerzelsolutions.slack.com/archives/C02UDC3AZHQ/p1781793289647619
+		if delta.TransactionStateDiffs[i] == nil || delta.Receipts[i] == nil {
+			candidateTxs = append(candidateTxs, tx)
+			mergedTxs = mergedTxs[:len(mergedTxs)-1]
+			mergedReceipts = mergedReceipts[:len(mergedReceipts)-1]
+			mergedStateDiffs = mergedStateDiffs[:len(mergedStateDiffs)-1]
+			n--
+			addedCount--
+			continue
 		}
 		mergedTxs[n+i] = tx
 
@@ -678,7 +696,7 @@ func AdaptPreConfirmedWithDelta(
 	}
 
 	nextHeader := *current.Block.Header
-	addedBloom := core.EventsBloom(mergedReceipts[n:])
+	addedBloom := core.EventsBloom(mergedReceipts[len(existingTxs):])
 	if err := addedBloom.Merge(current.Block.Header.EventsBloom); err != nil {
 		return pending.PreConfirmed{}, err
 	}
@@ -702,6 +720,7 @@ func AdaptPreConfirmedWithDelta(
 	next.Block = &nextBlock
 	next.StateUpdate = &nextStateUpdate
 	next.TransactionStateDiffs = mergedStateDiffs
+	next.CandidateTxs = candidateTxs
 	return next, nil
 }
 

--- a/adapters/sn2core/sn2core_test.go
+++ b/adapters/sn2core/sn2core_test.go
@@ -957,6 +957,48 @@ func TestAdaptPreConfirmedWithDelta(t *testing.T) {
 		_, err := sn2core.AdaptPreConfirmedWithDelta(current, delta)
 		require.Error(t, err)
 	})
+
+	t.Run("handles tx carrying nil state diff/receipt in delta", func(t *testing.T) {
+		tx := starknet.Transaction{
+			Type: starknet.TxnInvoke, CallData: &[]*felt.Felt{}, Signature: &[]*felt.Felt{},
+		}
+		receipt := starknet.TransactionReceipt{}
+		stateDiff := starknet.StateDiff{}
+
+		// block with 1 "normal" tx
+		current := &pending.PreConfirmed{
+			BlockIdentifier: "round-a",
+			Block: &core.Block{
+				Header: &core.Header{
+					TransactionCount: 1,
+					EventCount:       0,
+					EventsBloom:      core.EventsBloom(nil),
+				},
+				Transactions: []core.Transaction{&core.InvokeTransaction{}},
+				Receipts:     []*core.TransactionReceipt{{}},
+			},
+			StateUpdate:           &core.StateUpdate{StateDiff: &core.StateDiff{}},
+			TransactionStateDiffs: []*core.StateDiff{{}},
+		}
+		// Delta with 2 valid txs and 1 tx without state diff and receipt.
+		// Must not panic; the "buggy" tx should be stored in the CandidateTxs slice,
+		// and the tx count should not include it.
+		delta := &starknet.PreConfirmedDeltaUpdate{
+			BlockIdentifier:       "round-a",
+			Transactions:          []starknet.Transaction{tx, tx, tx},
+			Receipts:              []*starknet.TransactionReceipt{&receipt, nil, &receipt},
+			TransactionStateDiffs: []*starknet.StateDiff{&stateDiff, nil, &stateDiff},
+		}
+
+		next, err := sn2core.AdaptPreConfirmedWithDelta(current, delta)
+		require.NoError(t, err)
+		newLen := len(current.Block.Transactions) + 2 // 2 valid txs
+		assert.Equal(t, newLen, len(next.Block.Transactions))
+		assert.Equal(t, newLen, len(next.Block.Receipts))
+		assert.Equal(t, newLen, len(next.TransactionStateDiffs))
+		assert.Equal(t, uint64(newLen), next.Block.TransactionCount)
+		assert.Equal(t, 1, len(next.CandidateTxs))
+	})
 }
 
 // mustFetchPreConfirmedBlock fetches a real pre_confirmed Full from the test client.


### PR DESCRIPTION
Fix panic in AdaptPreConfirmedWithDelta when the delta endpoint returns txs with nil state diff / receipt. Such txs are now stored as CandidateTxs instead of dereferenced