### PR TITLE
feat(compiler): memory-aware concurrency limit

### DIFF
--- a/cmd/juno/juno.go
+++ b/cmd/juno/juno.go
@@ -484,7 +484,6 @@ func NewCmd(config *node.Config, run func(*cobra.Command, []string) error) *cobr
 	// may mutate their values.
 	defaultNetwork := networks.Mainnet
 	defaultMaxVMs := 3 * runtime.GOMAXPROCS(0)
-	// Empty derives at startup; an explicit 0 disables compilations / the queue.
 	defaultCNUnverifiableRange := []int{} // Uint64Slice is not supported in Flags()
 
 	// --- HTTP RPC ---

--- a/cmd/juno/juno.go
+++ b/cmd/juno/juno.go
@@ -111,6 +111,7 @@ const (
 	maxConcurrentCompilationsF          = "max-concurrent-compilations"
 	maxCompilationQueueF                = "max-compilation-queue"
 	maxCompilationMemoryF               = "max-compilation-memory"
+	nodeMemoryReserveF                  = "node-memory-reserve"
 	maxCompilationCPUTimeF              = "max-compilation-cpu-time"
 	disableReceivedTxnStreamF           = "disable-received-txn-stream"
 	newStateF                           = "new-state"
@@ -175,6 +176,7 @@ const (
 	defaultRPCMaxConcurrentRequests           = 256000
 	defaultRPCMaxQueuedRequests               = 256000
 	defaultMaxCompilationMemory               = 4 * 1024 // MB (4 GB) per compilation process
+	defaultNodeMemoryReserve                  = 4 * 1024 // MB (4 GB) reserved for the rest of the node
 	defaultMaxCompilationCPUTime              = 10       // seconds of CPU time per compilation process
 	defaultDisableReceivedTxnStream           = false
 	defaultPruneMode                          = uint64(0)
@@ -260,11 +262,16 @@ const (
 	rpcMaxConcurrentRequestsUsage = "Maximum concurrent HTTP RPC requests; 0 disables the limit."
 	rpcMaxRequestQueueUsage       = "Maximum number of HTTP RPC requests to queue after " +
 		"reaching rpc-max-concurrent-requests limit."
-	maxConcurrentCompilationsUsage = "Maximum concurrent Sierra compilations."
-	maxCompilationQueueUsage       = "Maximum number of compilation requests to queue after " +
-		"reaching max-concurrent-compilations before starting to reject incoming requests."
+	maxConcurrentCompilationsUsage = "Maximum concurrent Sierra compilations. " +
+		"0 derives a safe value from available memory and CPU count."
+	maxCompilationQueueUsage = "Maximum number of compilation requests to queue after " +
+		"reaching max-concurrent-compilations before starting to reject incoming requests. " +
+		"0 uses twice the concurrency limit."
 	maxCompilationMemoryUsage = "Maximum memory (in MB) each Sierra compilation process may " +
 		"use; a compilation exceeding it is aborted. Enforced on Linux only. 0 disables the limit."
+	nodeMemoryReserveUsage = "Memory (in MB) reserved for the rest of the node and excluded from " +
+		"the compilation memory budget. Used only when max-concurrent-compilations is 0. " +
+		"Container memory limits (cgroups) are respected."
 	maxCompilationCPUTimeUsage = "Maximum CPU time (in seconds) each Sierra compilation process " +
 		"may consume; a compilation exceeding it is aborted. Enforced on Linux only. " +
 		"0 disables the limit."
@@ -477,8 +484,9 @@ func NewCmd(config *node.Config, run func(*cobra.Command, []string) error) *cobr
 	// may mutate their values.
 	defaultNetwork := networks.Mainnet
 	defaultMaxVMs := 3 * runtime.GOMAXPROCS(0)
-	defaultMaxConcurrentCompilations := runtime.GOMAXPROCS(0)
-	defaultCNUnverifiableRange := []int{} // Uint64Slice is not supported in Flags()
+	defaultMaxConcurrentCompilations := uint(0) // 0 = derive at startup (see node.New).
+	defaultMaxCompilationQueue := uint(0)       // 0 = derive at startup (see node.New).
+	defaultCNUnverifiableRange := []int{}       // Uint64Slice is not supported in Flags()
 
 	// --- HTTP RPC ---
 	junoCmd.Flags().Bool(httpF, defaultHTTP, httpUsage)
@@ -606,15 +614,18 @@ func NewCmd(config *node.Config, run func(*cobra.Command, []string) error) *cobr
 	junoCmd.Flags().Uint(maxVMQueueF, 2*uint(defaultMaxVMs), maxVMQueueUsage)
 	junoCmd.Flags().Uint(
 		maxConcurrentCompilationsF,
-		uint(defaultMaxConcurrentCompilations),
+		defaultMaxConcurrentCompilations,
 		maxConcurrentCompilationsUsage,
 	)
 	junoCmd.Flags().Uint(
 		maxCompilationQueueF,
-		2*uint(defaultMaxConcurrentCompilations),
+		defaultMaxCompilationQueue,
 		maxCompilationQueueUsage,
 	)
 	junoCmd.Flags().Uint(maxCompilationMemoryF, defaultMaxCompilationMemory, maxCompilationMemoryUsage)
+	junoCmd.Flags().Uint(
+		nodeMemoryReserveF, defaultNodeMemoryReserve, nodeMemoryReserveUsage,
+	)
 	junoCmd.Flags().Uint(
 		maxCompilationCPUTimeF, defaultMaxCompilationCPUTime, maxCompilationCPUTimeUsage,
 	)
@@ -626,6 +637,7 @@ func NewCmd(config *node.Config, run func(*cobra.Command, []string) error) *cobr
 		maxConcurrentCompilationsF,
 		maxCompilationQueueF,
 		maxCompilationMemoryF,
+		nodeMemoryReserveF,
 		maxCompilationCPUTimeF,
 		versionedConstantsFileF,
 	)

--- a/cmd/juno/juno.go
+++ b/cmd/juno/juno.go
@@ -175,6 +175,8 @@ const (
 	defaultRPCRequestTimeout                  = 1 * time.Minute
 	defaultRPCMaxConcurrentRequests           = 256000
 	defaultRPCMaxQueuedRequests               = 256000
+	defaultMaxConcurrentCompilations          = ""
+	defaultMaxCompilationQueue                = ""
 	defaultMaxCompilationMemory               = 4 * 1024 // MB (4 GB) per compilation process
 	defaultNodeMemoryReserve                  = 4 * 1024 // MB (4 GB) reserved for the rest of the node
 	defaultMaxCompilationCPUTime              = 10       // seconds of CPU time per compilation process
@@ -263,17 +265,16 @@ const (
 	rpcMaxRequestQueueUsage       = "Maximum number of HTTP RPC requests to queue after " +
 		"reaching rpc-max-concurrent-requests limit."
 	maxConcurrentCompilationsUsage = "Maximum concurrent Sierra compilations. " +
-		"Empty derives a safe value from available memory and CPU count; 0 disables compilations."
+		"Default is set based on available hardware resources."
 	maxCompilationQueueUsage = "Maximum number of compilation requests to queue after " +
-		"reaching max-concurrent-compilations before starting to reject incoming requests. " +
-		"Empty uses twice the concurrency limit."
-	maxCompilationMemoryUsage = "Maximum memory (in MB) each Sierra compilation process may " +
+		"reaching max-concurrent-compilations. Default sets the queue to twice the concurrency limit."
+	maxCompilationMemoryUsage = "Maximum virtual memory (in MB) a Sierra compilation process may " +
 		"use; a compilation exceeding it is aborted. Enforced on Linux only. 0 disables the limit."
-	nodeMemoryReserveUsage = "Memory (in MB) reserved for the rest of the node and excluded from " +
-		"the compilation memory budget. Used only when max-concurrent-compilations is empty."
 	maxCompilationCPUTimeUsage = "Maximum CPU time (in seconds) each Sierra compilation process " +
 		"may consume; a compilation exceeding it is aborted. Enforced on Linux only. " +
 		"0 disables the limit."
+	maxCompilationReserveMemory = "Memory (in MB) excluded from the compilations memory budget when " +
+		"calculating the default for `max-concurrent-compilations`"
 	pruneModeUsage = "Enables block-data and state-history pruning. Pruning is " +
 		"disabled by default; passing this flag (with or without a value) turns " +
 		"it on. The value is the size of the retention window in blocks, counted " +
@@ -484,8 +485,6 @@ func NewCmd(config *node.Config, run func(*cobra.Command, []string) error) *cobr
 	defaultNetwork := networks.Mainnet
 	defaultMaxVMs := 3 * runtime.GOMAXPROCS(0)
 	// Empty derives at startup; an explicit 0 disables compilations / the queue.
-	defaultMaxConcurrentCompilations := ""
-	defaultMaxCompilationQueue := ""
 	defaultCNUnverifiableRange := []int{} // Uint64Slice is not supported in Flags()
 
 	// --- HTTP RPC ---
@@ -624,7 +623,7 @@ func NewCmd(config *node.Config, run func(*cobra.Command, []string) error) *cobr
 	)
 	junoCmd.Flags().Uint(maxCompilationMemoryF, defaultMaxCompilationMemory, maxCompilationMemoryUsage)
 	junoCmd.Flags().Uint(
-		nodeMemoryReserveF, defaultNodeMemoryReserve, nodeMemoryReserveUsage,
+		nodeMemoryReserveF, defaultNodeMemoryReserve, maxCompilationReserveMemory,
 	)
 	junoCmd.Flags().Uint(
 		maxCompilationCPUTimeF, defaultMaxCompilationCPUTime, maxCompilationCPUTimeUsage,

--- a/cmd/juno/juno.go
+++ b/cmd/juno/juno.go
@@ -263,15 +263,14 @@ const (
 	rpcMaxRequestQueueUsage       = "Maximum number of HTTP RPC requests to queue after " +
 		"reaching rpc-max-concurrent-requests limit."
 	maxConcurrentCompilationsUsage = "Maximum concurrent Sierra compilations. " +
-		"0 derives a safe value from available memory and CPU count."
+		"Empty derives a safe value from available memory and CPU count; 0 disables compilations."
 	maxCompilationQueueUsage = "Maximum number of compilation requests to queue after " +
 		"reaching max-concurrent-compilations before starting to reject incoming requests. " +
-		"0 uses twice the concurrency limit."
+		"Empty uses twice the concurrency limit."
 	maxCompilationMemoryUsage = "Maximum memory (in MB) each Sierra compilation process may " +
 		"use; a compilation exceeding it is aborted. Enforced on Linux only. 0 disables the limit."
 	nodeMemoryReserveUsage = "Memory (in MB) reserved for the rest of the node and excluded from " +
-		"the compilation memory budget. Used only when max-concurrent-compilations is 0. " +
-		"Container memory limits (cgroups) are respected."
+		"the compilation memory budget. Used only when max-concurrent-compilations is empty."
 	maxCompilationCPUTimeUsage = "Maximum CPU time (in seconds) each Sierra compilation process " +
 		"may consume; a compilation exceeding it is aborted. Enforced on Linux only. " +
 		"0 disables the limit."
@@ -484,9 +483,10 @@ func NewCmd(config *node.Config, run func(*cobra.Command, []string) error) *cobr
 	// may mutate their values.
 	defaultNetwork := networks.Mainnet
 	defaultMaxVMs := 3 * runtime.GOMAXPROCS(0)
-	defaultMaxConcurrentCompilations := uint(0) // 0 = derive at startup (see node.New).
-	defaultMaxCompilationQueue := uint(0)       // 0 = derive at startup (see node.New).
-	defaultCNUnverifiableRange := []int{}       // Uint64Slice is not supported in Flags()
+	// Empty derives at startup; an explicit 0 disables compilations / the queue.
+	defaultMaxConcurrentCompilations := ""
+	defaultMaxCompilationQueue := ""
+	defaultCNUnverifiableRange := []int{} // Uint64Slice is not supported in Flags()
 
 	// --- HTTP RPC ---
 	junoCmd.Flags().Bool(httpF, defaultHTTP, httpUsage)
@@ -612,12 +612,12 @@ func NewCmd(config *node.Config, run func(*cobra.Command, []string) error) *cobr
 	// --- VM & Compilation ---
 	junoCmd.Flags().Uint(maxVMsF, uint(defaultMaxVMs), maxVMsUsage)
 	junoCmd.Flags().Uint(maxVMQueueF, 2*uint(defaultMaxVMs), maxVMQueueUsage)
-	junoCmd.Flags().Uint(
+	junoCmd.Flags().String(
 		maxConcurrentCompilationsF,
 		defaultMaxConcurrentCompilations,
 		maxConcurrentCompilationsUsage,
 	)
-	junoCmd.Flags().Uint(
+	junoCmd.Flags().String(
 		maxCompilationQueueF,
 		defaultMaxCompilationQueue,
 		maxCompilationQueueUsage,

--- a/cmd/juno/juno.go
+++ b/cmd/juno/juno.go
@@ -175,8 +175,8 @@ const (
 	defaultRPCRequestTimeout                  = 1 * time.Minute
 	defaultRPCMaxConcurrentRequests           = 256000
 	defaultRPCMaxQueuedRequests               = 256000
-	defaultMaxConcurrentCompilations          = ""
-	defaultMaxCompilationQueue                = ""
+	defaultMaxConcurrentCompilations          = uint64(0)
+	defaultMaxCompilationQueue                = uint64(0)
 	defaultMaxCompilationMemory               = 4 * 1024 // MB (4 GB) per compilation process
 	defaultNodeMemoryReserve                  = 4 * 1024 // MB (4 GB) reserved for the rest of the node
 	defaultMaxCompilationCPUTime              = 10       // seconds of CPU time per compilation process
@@ -431,6 +431,11 @@ func NewCmd(config *node.Config, run func(*cobra.Command, []string) error) *cobr
 			}
 		}
 
+		// An absent compilation-sizing flag means "derive at startup";
+		// a present one (CLI, env, or YAML) is used as-is, including an explicit 0.
+		config.MaxConcurrentCompilationsExplicit = v.IsSet(maxConcurrentCompilationsF)
+		config.MaxCompilationQueueExplicit = v.IsSet(maxCompilationQueueF)
+
 		// Set custom network
 		if v.IsSet(cnNameF) {
 			l1ChainID, ok := new(big.Int).SetString(v.GetString(cnL1ChainIDF), 0)
@@ -610,12 +615,12 @@ func NewCmd(config *node.Config, run func(*cobra.Command, []string) error) *cobr
 	// --- VM & Compilation ---
 	junoCmd.Flags().Uint(maxVMsF, uint(defaultMaxVMs), maxVMsUsage)
 	junoCmd.Flags().Uint(maxVMQueueF, 2*uint(defaultMaxVMs), maxVMQueueUsage)
-	junoCmd.Flags().String(
+	junoCmd.Flags().Uint64(
 		maxConcurrentCompilationsF,
 		defaultMaxConcurrentCompilations,
 		maxConcurrentCompilationsUsage,
 	)
-	junoCmd.Flags().String(
+	junoCmd.Flags().Uint64(
 		maxCompilationQueueF,
 		defaultMaxCompilationQueue,
 		maxCompilationQueueUsage,

--- a/cmd/juno/juno_test.go
+++ b/cmd/juno/juno_test.go
@@ -81,8 +81,8 @@ func TestConfigPrecedence(t *testing.T) {
 	defaultSubmittedTransactionsCacheSize := uint(10_000)
 	defaultSubmittedTransactionsCacheEntryTTL := 5 * time.Minute
 	defaultRPCRequestTimeout := 1 * time.Minute
-	defaultMaxConcurrentCompilations := uint(0) // 0 = derive from memory and CPUs
-	defaultMaxCompilationQueue := uint(0)       // 0 = derive from concurrency
+	defaultMaxConcurrentCompilations := "" // empty derives from memory and CPUs
+	defaultMaxCompilationQueue := ""       // empty derives from concurrency
 	defaultMaxCompilationMemory := uint(4 * 1024)
 	defaultNodeMemoryReserve := uint(4 * 1024)
 	defaultMaxCompilationCPUTime := uint(10)
@@ -200,6 +200,10 @@ func TestConfigPrecedence(t *testing.T) {
 	expectedExplicitCompilationLimits.MaxCompilationMemory = 2048
 	expectedExplicitCompilationLimits.MaxCompilationCPUTime = 5
 
+	expectedNumericCompilationLimits := expectedConfig2
+	expectedNumericCompilationLimits.MaxConcurrentCompilations = "8"
+	expectedNumericCompilationLimits.MaxCompilationQueue = "32"
+
 	tests := map[string]struct {
 		cfgFile         bool
 		cfgFileContents string
@@ -245,6 +249,13 @@ cn-unverifiable-range: [0,10]
 				"--max-compilation-memory", "2048", "--max-compilation-cpu-time", "5",
 			},
 			expectedConfig: &expectedExplicitCompilationLimits,
+		},
+		"numeric compilation limits in config file": {
+			cfgFile: true,
+			cfgFileContents: `max-concurrent-compilations: 8
+max-compilation-queue: 32
+`,
+			expectedConfig: &expectedNumericCompilationLimits,
 		},
 		"config file path is empty string": {
 			inputArgs:      []string{"--config", ""},

--- a/cmd/juno/juno_test.go
+++ b/cmd/juno/juno_test.go
@@ -81,9 +81,10 @@ func TestConfigPrecedence(t *testing.T) {
 	defaultSubmittedTransactionsCacheSize := uint(10_000)
 	defaultSubmittedTransactionsCacheEntryTTL := 5 * time.Minute
 	defaultRPCRequestTimeout := 1 * time.Minute
-	defaultMaxConcurrentCompilations := uint(runtime.GOMAXPROCS(0))
-	defaultMaxCompilationQueue := 2 * defaultMaxConcurrentCompilations
+	defaultMaxConcurrentCompilations := uint(0) // 0 = derive from memory and CPUs
+	defaultMaxCompilationQueue := uint(0)       // 0 = derive from concurrency
 	defaultMaxCompilationMemory := uint(4 * 1024)
+	defaultNodeMemoryReserve := uint(4 * 1024)
 	defaultMaxCompilationCPUTime := uint(10)
 	if runtime.GOOS != "linux" {
 		// Limits are enforced on Linux only; PreRunE zeroes the unset
@@ -138,6 +139,7 @@ func TestConfigPrecedence(t *testing.T) {
 		MaxConcurrentCompilations:          defaultMaxConcurrentCompilations,
 		MaxCompilationQueue:                defaultMaxCompilationQueue,
 		MaxCompilationMemory:               defaultMaxCompilationMemory,
+		NodeMemoryReserve:                  defaultNodeMemoryReserve,
 		MaxCompilationCPUTime:              defaultMaxCompilationCPUTime,
 		PruneMinAge:                        defaultPruneMinAge,
 	}
@@ -187,6 +189,7 @@ func TestConfigPrecedence(t *testing.T) {
 		MaxConcurrentCompilations:          defaultMaxConcurrentCompilations,
 		MaxCompilationQueue:                defaultMaxCompilationQueue,
 		MaxCompilationMemory:               defaultMaxCompilationMemory,
+		NodeMemoryReserve:                  defaultNodeMemoryReserve,
 		MaxCompilationCPUTime:              defaultMaxCompilationCPUTime,
 		PruneMinAge:                        defaultPruneMinAge,
 	}
@@ -310,6 +313,7 @@ pprof: true
 				MaxConcurrentCompilations:          defaultMaxConcurrentCompilations,
 				MaxCompilationQueue:                defaultMaxCompilationQueue,
 				MaxCompilationMemory:               defaultMaxCompilationMemory,
+				NodeMemoryReserve:                  defaultNodeMemoryReserve,
 				MaxCompilationCPUTime:              defaultMaxCompilationCPUTime,
 				PruneMinAge:                        defaultPruneMinAge,
 			},
@@ -365,6 +369,7 @@ http-port: 4576
 				MaxConcurrentCompilations:          defaultMaxConcurrentCompilations,
 				MaxCompilationQueue:                defaultMaxCompilationQueue,
 				MaxCompilationMemory:               defaultMaxCompilationMemory,
+				NodeMemoryReserve:                  defaultNodeMemoryReserve,
 				MaxCompilationCPUTime:              defaultMaxCompilationCPUTime,
 				PruneMinAge:                        defaultPruneMinAge,
 			},
@@ -419,6 +424,7 @@ http-port: 4576
 				MaxConcurrentCompilations:          defaultMaxConcurrentCompilations,
 				MaxCompilationQueue:                defaultMaxCompilationQueue,
 				MaxCompilationMemory:               defaultMaxCompilationMemory,
+				NodeMemoryReserve:                  defaultNodeMemoryReserve,
 				MaxCompilationCPUTime:              defaultMaxCompilationCPUTime,
 				PruneMinAge:                        defaultPruneMinAge,
 			},
@@ -473,6 +479,7 @@ http-port: 4576
 				MaxConcurrentCompilations:          defaultMaxConcurrentCompilations,
 				MaxCompilationQueue:                defaultMaxCompilationQueue,
 				MaxCompilationMemory:               defaultMaxCompilationMemory,
+				NodeMemoryReserve:                  defaultNodeMemoryReserve,
 				MaxCompilationCPUTime:              defaultMaxCompilationCPUTime,
 				PruneMinAge:                        defaultPruneMinAge,
 			},
@@ -551,6 +558,7 @@ db-cache-size: 1024
 				MaxConcurrentCompilations:          defaultMaxConcurrentCompilations,
 				MaxCompilationQueue:                defaultMaxCompilationQueue,
 				MaxCompilationMemory:               defaultMaxCompilationMemory,
+				NodeMemoryReserve:                  defaultNodeMemoryReserve,
 				MaxCompilationCPUTime:              defaultMaxCompilationCPUTime,
 				PruneMinAge:                        defaultPruneMinAge,
 			},
@@ -608,6 +616,7 @@ network: sepolia
 				MaxConcurrentCompilations:          defaultMaxConcurrentCompilations,
 				MaxCompilationQueue:                defaultMaxCompilationQueue,
 				MaxCompilationMemory:               defaultMaxCompilationMemory,
+				NodeMemoryReserve:                  defaultNodeMemoryReserve,
 				MaxCompilationCPUTime:              defaultMaxCompilationCPUTime,
 				PruneMinAge:                        defaultPruneMinAge,
 			},
@@ -661,6 +670,7 @@ network: sepolia
 				MaxConcurrentCompilations:          defaultMaxConcurrentCompilations,
 				MaxCompilationQueue:                defaultMaxCompilationQueue,
 				MaxCompilationMemory:               defaultMaxCompilationMemory,
+				NodeMemoryReserve:                  defaultNodeMemoryReserve,
 				MaxCompilationCPUTime:              defaultMaxCompilationCPUTime,
 				PruneMinAge:                        defaultPruneMinAge,
 			},
@@ -712,6 +722,7 @@ network: sepolia
 				MaxConcurrentCompilations:          defaultMaxConcurrentCompilations,
 				MaxCompilationQueue:                defaultMaxCompilationQueue,
 				MaxCompilationMemory:               defaultMaxCompilationMemory,
+				NodeMemoryReserve:                  defaultNodeMemoryReserve,
 				MaxCompilationCPUTime:              defaultMaxCompilationCPUTime,
 				PruneMinAge:                        defaultPruneMinAge,
 			},
@@ -764,6 +775,7 @@ network: sepolia
 				MaxConcurrentCompilations:          defaultMaxConcurrentCompilations,
 				MaxCompilationQueue:                defaultMaxCompilationQueue,
 				MaxCompilationMemory:               defaultMaxCompilationMemory,
+				NodeMemoryReserve:                  defaultNodeMemoryReserve,
 				MaxCompilationCPUTime:              defaultMaxCompilationCPUTime,
 				PruneMinAge:                        defaultPruneMinAge,
 			},
@@ -815,6 +827,7 @@ network: sepolia
 				MaxConcurrentCompilations:          defaultMaxConcurrentCompilations,
 				MaxCompilationQueue:                defaultMaxCompilationQueue,
 				MaxCompilationMemory:               defaultMaxCompilationMemory,
+				NodeMemoryReserve:                  defaultNodeMemoryReserve,
 				MaxCompilationCPUTime:              defaultMaxCompilationCPUTime,
 				PruneMinAge:                        defaultPruneMinAge,
 			},
@@ -868,6 +881,7 @@ network: sepolia
 				MaxConcurrentCompilations:          defaultMaxConcurrentCompilations,
 				MaxCompilationQueue:                defaultMaxCompilationQueue,
 				MaxCompilationMemory:               defaultMaxCompilationMemory,
+				NodeMemoryReserve:                  defaultNodeMemoryReserve,
 				MaxCompilationCPUTime:              defaultMaxCompilationCPUTime,
 				PruneMinAge:                        defaultPruneMinAge,
 			},

--- a/cmd/juno/juno_test.go
+++ b/cmd/juno/juno_test.go
@@ -81,8 +81,8 @@ func TestConfigPrecedence(t *testing.T) {
 	defaultSubmittedTransactionsCacheSize := uint(10_000)
 	defaultSubmittedTransactionsCacheEntryTTL := 5 * time.Minute
 	defaultRPCRequestTimeout := 1 * time.Minute
-	defaultMaxConcurrentCompilations := "" // empty derives from memory and CPUs
-	defaultMaxCompilationQueue := ""       // empty derives from concurrency
+	defaultMaxConcurrentCompilations := uint64(0) // unset derives from memory and CPUs
+	defaultMaxCompilationQueue := uint64(0)       // unset derives from concurrency
 	defaultMaxCompilationMemory := uint(4 * 1024)
 	defaultNodeMemoryReserve := uint(4 * 1024)
 	defaultMaxCompilationCPUTime := uint(10)
@@ -201,8 +201,10 @@ func TestConfigPrecedence(t *testing.T) {
 	expectedExplicitCompilationLimits.MaxCompilationCPUTime = 5
 
 	expectedNumericCompilationLimits := expectedConfig2
-	expectedNumericCompilationLimits.MaxConcurrentCompilations = "8"
-	expectedNumericCompilationLimits.MaxCompilationQueue = "32"
+	expectedNumericCompilationLimits.MaxConcurrentCompilations = 8
+	expectedNumericCompilationLimits.MaxConcurrentCompilationsExplicit = true
+	expectedNumericCompilationLimits.MaxCompilationQueue = 32
+	expectedNumericCompilationLimits.MaxCompilationQueueExplicit = true
 
 	tests := map[string]struct {
 		cfgFile         bool
@@ -255,6 +257,12 @@ cn-unverifiable-range: [0,10]
 			cfgFileContents: `max-concurrent-compilations: 8
 max-compilation-queue: 32
 `,
+			expectedConfig: &expectedNumericCompilationLimits,
+		},
+		"numeric compilation limits via CLI": {
+			inputArgs: []string{
+				"--max-concurrent-compilations", "8", "--max-compilation-queue", "32",
+			},
 			expectedConfig: &expectedNumericCompilationLimits,
 		},
 		"config file path is empty string": {
@@ -999,6 +1007,64 @@ func TestCustomNetworkURLValidation(t *testing.T) {
 			require.NoError(t, err)
 			assert.Equal(t, parseURL(t, tc.feeder), config.Network.FeederURL)
 			assert.Equal(t, parseURL(t, tc.gateway), config.Network.GatewayURL)
+		})
+	}
+}
+
+// TestCompilationLimitExplicitDetection guarantees that the *Explicit flags
+// reflect whether each compilation-sizing flag was actually provided: absent
+// means false (derive), present means true (use as-is), independently per flag.
+func TestCompilationLimitExplicitDetection(t *testing.T) {
+	tests := map[string]struct {
+		args                  []string
+		expectedConcExplicit  bool
+		expectedQueueExplicit bool
+	}{
+		"neither provided": {
+			args:                  []string{},
+			expectedConcExplicit:  false,
+			expectedQueueExplicit: false,
+		},
+		"concurrency provided": {
+			args:                  []string{"--max-concurrent-compilations", "4"},
+			expectedConcExplicit:  true,
+			expectedQueueExplicit: false,
+		},
+		"queue provided": {
+			args:                  []string{"--max-compilation-queue", "8"},
+			expectedConcExplicit:  false,
+			expectedQueueExplicit: true,
+		},
+		"both provided": {
+			args: []string{
+				"--max-concurrent-compilations",
+				"4", "--max-compilation-queue",
+				"8",
+			},
+			expectedConcExplicit:  true,
+			expectedQueueExplicit: true,
+		},
+	}
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			config := new(node.Config)
+			cmd := juno.NewCmd(
+				config,
+				func(_ *cobra.Command, _ []string) error { return nil },
+			)
+			cmd.SetArgs(tc.args)
+
+			require.NoError(t, cmd.ExecuteContext(t.Context()))
+			assert.Equal(
+				t,
+				tc.expectedConcExplicit,
+				config.MaxConcurrentCompilationsExplicit,
+			)
+			assert.Equal(
+				t,
+				tc.expectedQueueExplicit,
+				config.MaxCompilationQueueExplicit,
+			)
 		})
 	}
 }

--- a/docs/docs/tuning.md
+++ b/docs/docs/tuning.md
@@ -71,11 +71,15 @@ A larger cache reduces disk reads and improves query performance. On systems wit
 
 ## Sierra Compilation Limits
 
+Juno compiles Sierra classes to CASM in isolated child processes. The flags below cap the resources each compilation uses and how many run at once.
+
+### Per-compilation limits
+
 :::warning
 These limits are enforced by the kernel and only on **Linux**. On other operating systems they have no effect.
 :::
 
-Juno compiles Sierra classes to CASM in isolated child processes. Two flags cap the resources each compilation process may use, protecting the node from pathological or malicious classes that would otherwise consume CPU and memory without bound:
+Two flags cap the resources each compilation process may use, protecting the node from malicious classes that would otherwise consume CPU and memory without bound:
 
 - `--max-compilation-memory` (default: 4096 MB): Maximum memory a single compilation process may use. A compilation exceeding it is aborted.
 - `--max-compilation-cpu-time` (default: 10 seconds): Maximum CPU time a single compilation process may consume. A compilation exceeding it is killed.
@@ -86,4 +90,18 @@ Setting either flag to `0` disables that limit. The defaults are generous for le
 The CPU time limit counts seconds of CPU actually consumed by the compilation process, not elapsed wall-clock time, so it is unaffected by how busy the rest of the machine is.
 :::
 
-Up to `--max-concurrent-compilations` (default: one per available CPU core) processes can run at once, so the worst-case memory that compilations can claim is the product of that flag and `--max-compilation-memory`. Lower either value on memory-constrained machines.
+### Compilation concurrency
+
+`--max-concurrent-compilations` controls how many compilations run at once. At its default of `0`, Juno derives a safe value so concurrent compilations cannot exhaust RAM:
+
+```
+limit = min((available_memory - node_memory_reserve) / max_compilation_memory, cpu_cores)
+```
+
+- `--max-concurrent-compilations` (default: 0): `0` derives the value as above; any other value is used directly.
+- `--max-compilation-queue` (default: 0): How many requests wait once the concurrency limit is reached before new ones are rejected. `0` uses twice the concurrency limit.
+- `--node-memory-reserve` (default: 4096 MB): Memory kept for the rest of the node, excluded from the compilation budget.
+
+The available memory respects container limits (cgroups), so inside a memory-capped container the value reflects the container, not the host. On non-Linux, where the per-compilation memory limit does not apply, the limit is simply the CPU core count.
+
+The limit is always at least 1: on a memory-tight node compilations run one at a time rather than the node refusing to start.

--- a/docs/docs/tuning.md
+++ b/docs/docs/tuning.md
@@ -92,14 +92,14 @@ The CPU time limit counts seconds of CPU actually consumed by the compilation pr
 
 ### Compilation concurrency
 
-`--max-concurrent-compilations` controls how many compilations run at once. At its default of `0`, Juno derives a safe value so concurrent compilations cannot exhaust RAM:
+`--max-concurrent-compilations` controls how many compilations run at once. Left empty (the default), Juno derives a safe value so concurrent compilations cannot exhaust RAM:
 
 ```
 limit = min((available_memory - node_memory_reserve) / max_compilation_memory, cpu_cores)
 ```
 
-- `--max-concurrent-compilations` (default: 0): `0` derives the value as above; any other value is used directly.
-- `--max-compilation-queue` (default: 0): How many requests wait once the concurrency limit is reached before new ones are rejected. `0` uses twice the concurrency limit.
+- `--max-concurrent-compilations` (default: empty): empty derives the value as above; any non-negative integer is used directly (`0` disables compilations).
+- `--max-compilation-queue` (default: empty): How many requests wait once the concurrency limit is reached before new ones are rejected. Empty uses twice the concurrency limit.
 - `--node-memory-reserve` (default: 4096 MB): Memory kept for the rest of the node, excluded from the compilation budget.
 
 The available memory respects container limits (cgroups), so inside a memory-capped container the value reflects the container, not the host. On non-Linux, where the per-compilation memory limit does not apply, the limit is simply the CPU core count.

--- a/docs/docs/tuning.md
+++ b/docs/docs/tuning.md
@@ -92,16 +92,16 @@ The CPU time limit counts seconds of CPU actually consumed by the compilation pr
 
 ### Compilation concurrency
 
-`--max-concurrent-compilations` controls how many compilations run at once. Left empty (the default), Juno derives a safe value so concurrent compilations cannot exhaust RAM:
+- `--max-concurrent-compilations`(default: unset): controls how many compilations run at once. Any non-negative integer is used directly (`0` disables compilations). Left unset (the default), Juno derives a safe value so concurrent compilations cannot exhaust RAM:
 
 ```
-limit = min((available_memory - node_memory_reserve) / max_compilation_memory, cpu_cores)
+limit = min((available_memory - node_memory_reserve) / max_compilation_memory, cpu_cores), at least 1.
 ```
+ 
+- `--max-compilation-queue` (default: unset): How many requests wait once the concurrency limit is reached before new ones are rejected. Unset uses twice the concurrency limit (`0` disables the queue).
 
-- `--max-concurrent-compilations` (default: empty): empty derives the value as above; any non-negative integer is used directly (`0` disables compilations).
-- `--max-compilation-queue` (default: empty): How many requests wait once the concurrency limit is reached before new ones are rejected. Empty uses twice the concurrency limit.
 - `--node-memory-reserve` (default: 4096 MB): Memory kept for the rest of the node, excluded from the compilation budget.
 
 The available memory respects container limits (cgroups), so inside a memory-capped container the value reflects the container, not the host. On non-Linux, where the per-compilation memory limit does not apply, the limit is simply the CPU core count.
 
-The limit is always at least 1: on a memory-tight node compilations run one at a time rather than the node refusing to start.
+The default limit is always at least 1: on a memory-tight node compilations, it runs one at a time rather than the node refusing to start.

--- a/docs/docs/tuning.md
+++ b/docs/docs/tuning.md
@@ -81,7 +81,7 @@ These limits are enforced by the kernel and only on **Linux**. On other operatin
 
 Two flags cap the resources each compilation process may use, protecting the node from malicious classes that would otherwise consume CPU and memory without bound:
 
-- `--max-compilation-memory` (default: 4096 MB): Maximum memory a single compilation process may use. A compilation exceeding it is aborted.
+- `--max-compilation-memory` (default: 4096 MB): Maximum virtual memory (address space) a single compilation process may use. A compilation exceeding it is aborted.
 - `--max-compilation-cpu-time` (default: 10 seconds): Maximum CPU time a single compilation process may consume. A compilation exceeding it is killed.
 
 Setting either flag to `0` disables that limit. The defaults are generous for legitimate classes and only need raising if genuine compilations are being aborted.

--- a/docs/generate-config.js
+++ b/docs/generate-config.js
@@ -106,6 +106,16 @@ const extractConfigs = (codebase) => {
     if (configName === "max-vm-queue") {
       defaultValue = "2 * max-vms";
     }
+    // The registered Cobra default is 0, but an absent flag derives the value at
+    // startup, so show the effective derived default rather than the raw 0.
+    if (configName === "max-concurrent-compilations") {
+      defaultValue = "auto (memory-aware)";
+      description +=
+        ". Derived as `min(cpu_cores, (available_memory - node_memory_reserve) / max_compilation_memory)`, at least 1";
+    }
+    if (configName === "max-compilation-queue") {
+      defaultValue = "2 * max-concurrent-compilations";
+    }
     // The registered Cobra default is 0, but pruning is gated on the flag's
     // presence, not its value — a bare `--prune-mode` enables pruning with the
     // NoOptDefVal of 128. Show 128 as the effective default when enabled.

--- a/docs/generate-config.js
+++ b/docs/generate-config.js
@@ -106,17 +106,11 @@ const extractConfigs = (codebase) => {
     if (configName === "max-vm-queue") {
       defaultValue = "2 * max-vms";
     }
-    if (configName === "max-concurrent-compilations") {
-      defaultValue = "CPU Cores";
-    }
     // The registered Cobra default is 0, but pruning is gated on the flag's
     // presence, not its value — a bare `--prune-mode` enables pruning with the
     // NoOptDefVal of 128. Show 128 as the effective default when enabled.
     if (configName === "prune-mode") {
       defaultValue = 128;
-    }
-    if (configName === "max-compilation-queue") {
-      defaultValue = "2 * max-concurrent-compilations";
     }
     if (configName === "gw-timeouts") {
       defaultValue = "5s";

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/NethermindEth/juno
 go 1.26.0
 
 require (
+	github.com/KimMachineGun/automemlimit v0.7.5
 	github.com/Masterminds/semver/v3 v3.5.0
 	github.com/VictoriaMetrics/fastcache v1.13.3
 	github.com/bits-and-blooms/bitset v1.24.5
@@ -23,6 +24,7 @@ require (
 	github.com/mitchellh/mapstructure v1.5.0
 	github.com/multiformats/go-multiaddr v0.16.1
 	github.com/olekukonko/tablewriter v1.1.4
+	github.com/pbnjay/memory v0.0.0-20210728143218-7b4eea64cf58
 	github.com/prometheus/client_golang v1.23.2
 	github.com/rs/cors v1.11.1
 	github.com/sourcegraph/conc v0.3.1-0.20240121214520-5f936abd7ae8
@@ -138,7 +140,6 @@ require (
 	github.com/olekukonko/cat v0.0.0-20250911104152-50322a0618f6 // indirect
 	github.com/olekukonko/errors v1.2.0 // indirect
 	github.com/olekukonko/ll v0.1.6 // indirect
-	github.com/pbnjay/memory v0.0.0-20210728143218-7b4eea64cf58 // indirect
 	github.com/pelletier/go-toml/v2 v2.2.4 // indirect
 	github.com/pion/datachannel v1.6.0 // indirect
 	github.com/pion/dtls/v3 v3.1.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -45,6 +45,8 @@ github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
 github.com/DataDog/zstd v1.5.7 h1:ybO8RBeh29qrxIhCA9E8gKY6xfONU9T6G6aP9DTKfLE=
 github.com/DataDog/zstd v1.5.7/go.mod h1:g4AWEaM3yOg3HYfnJ3YIawPnVdXJh9QME85blwSAmyw=
+github.com/KimMachineGun/automemlimit v0.7.5 h1:RkbaC0MwhjL1ZuBKunGDjE/ggwAX43DwZrJqVwyveTk=
+github.com/KimMachineGun/automemlimit v0.7.5/go.mod h1:QZxpHaGOQoYvFhv/r4u3U0JTC2ZcOwbSr11UZF46UBM=
 github.com/Masterminds/semver/v3 v3.5.0 h1:kQceYJfbupGfZOKZQg0kou0DgAKhzDg2NZPAwZ/2OOE=
 github.com/Masterminds/semver/v3 v3.5.0/go.mod h1:4V+yj/TJE1HU9XfppCwVMZq3I84lprf4nC11bSS5beM=
 github.com/Microsoft/go-winio v0.6.2 h1:F2VQgta7ecxGYO8k3ZZz3RS8fVIXVxONVUPlNERoyfY=

--- a/node/node.go
+++ b/node/node.go
@@ -10,7 +10,6 @@ import (
 	"reflect"
 	"runtime"
 	"slices"
-	"strconv"
 	"time"
 
 	"github.com/Masterminds/semver/v3"
@@ -149,70 +148,6 @@ type Config struct {
 	Prune          bool
 	RetainedBlocks uint64        `mapstructure:"prune-mode"`
 	PruneMinAge    time.Duration `mapstructure:"prune-min-age"`
-}
-
-// parseCompilationLimit reads a compilation-sizing flag. An empty value derives the
-// value at startup (derive is true); otherwise it must be a non-negative integer.
-func parseCompilationLimit(value string) (limit uint, derive bool, err error) {
-	if value == "" {
-		return 0, true, nil
-	}
-	n, err := strconv.ParseUint(value, 10, strconv.IntSize)
-	if err != nil {
-		return 0, false, fmt.Errorf("%q is not a non-negative integer", value)
-	}
-	return uint(n), false, nil
-}
-
-func newThrottledCompilerFromConfig(
-	cfg *Config, logger *log.ZapLogger,
-) (*ThrottledCompiler, error) {
-	concurrent, concurrentAuto, err := parseCompilationLimit(cfg.MaxConcurrentCompilations)
-	if err != nil {
-		return nil, fmt.Errorf("parsing max-concurrent-compilations: %w", err)
-	}
-	var concurrentCompilations uint
-	if concurrentAuto {
-		availableMemoryMB := compiler.AvailableMemoryMB()
-		concurrentCompilations = max(compiler.ConcurrencyLimit(
-			uint(runtime.GOMAXPROCS(0)),
-			availableMemoryMB,
-			uint64(cfg.NodeMemoryReserve),
-			uint64(cfg.MaxCompilationMemory),
-		), 1)
-		logger.Info("deriving Sierra compilation concurrency",
-			zap.Uint("limit", concurrentCompilations),
-			zap.Uint64("availableMemoryMB", availableMemoryMB),
-			zap.Uint("nodeMemoryReserveMB", cfg.NodeMemoryReserve),
-			zap.Uint("maxMemoryPerCompilationMB", cfg.MaxCompilationMemory),
-		)
-	} else {
-		concurrentCompilations = concurrent
-		logger.Info("using configured Sierra compilation concurrency",
-			zap.Uint("limit", concurrentCompilations))
-	}
-
-	queue, queueAuto, err := parseCompilationLimit(cfg.MaxCompilationQueue)
-	if err != nil {
-		return nil, fmt.Errorf("parsing max-compilation-queue: %w", err)
-	}
-	compilationQueue := queue
-	if queueAuto {
-		compilationQueue = 2 * concurrentCompilations
-	}
-
-	return NewThrottledCompiler(
-		compiler.New(
-			&compiler.Config{
-				MaxMemory:  uint64(cfg.MaxCompilationMemory) * 1024 * 1024,
-				MaxCPUTime: uint64(cfg.MaxCompilationCPUTime),
-			},
-			"",
-			logger,
-		),
-		concurrentCompilations,
-		uint64(compilationQueue),
-	), nil
 }
 
 type Node struct {
@@ -361,7 +296,7 @@ func New(cfg *Config, version string, logLevel *log.Level) (*Node, error) {
 
 	throttledCompiler, err := newThrottledCompilerFromConfig(cfg, logger)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("creating compiler from config: %w", err)
 	}
 
 	if cfg.Sequencer {

--- a/node/node.go
+++ b/node/node.go
@@ -164,6 +164,57 @@ func parseCompilationLimit(value string) (limit uint, derive bool, err error) {
 	return uint(n), false, nil
 }
 
+func newThrottledCompilerFromConfig(
+	cfg *Config, logger *log.ZapLogger,
+) (*ThrottledCompiler, error) {
+	concurrent, concurrentAuto, err := parseCompilationLimit(cfg.MaxConcurrentCompilations)
+	if err != nil {
+		return nil, fmt.Errorf("parsing max-concurrent-compilations: %w", err)
+	}
+	var concurrentCompilations uint
+	if concurrentAuto {
+		availableMemoryMB := compiler.AvailableMemoryMB()
+		concurrentCompilations = max(compiler.ConcurrencyLimit(
+			uint(runtime.GOMAXPROCS(0)),
+			availableMemoryMB,
+			uint64(cfg.NodeMemoryReserve),
+			uint64(cfg.MaxCompilationMemory),
+		), 1)
+		logger.Info("deriving Sierra compilation concurrency",
+			zap.Uint("limit", concurrentCompilations),
+			zap.Uint64("availableMemoryMB", availableMemoryMB),
+			zap.Uint("nodeMemoryReserveMB", cfg.NodeMemoryReserve),
+			zap.Uint("maxMemoryPerCompilationMB", cfg.MaxCompilationMemory),
+		)
+	} else {
+		concurrentCompilations = concurrent
+		logger.Info("using configured Sierra compilation concurrency",
+			zap.Uint("limit", concurrentCompilations))
+	}
+
+	queue, queueAuto, err := parseCompilationLimit(cfg.MaxCompilationQueue)
+	if err != nil {
+		return nil, fmt.Errorf("parsing max-compilation-queue: %w", err)
+	}
+	compilationQueue := queue
+	if queueAuto {
+		compilationQueue = 2 * concurrentCompilations
+	}
+
+	return NewThrottledCompiler(
+		compiler.New(
+			&compiler.Config{
+				MaxMemory:  uint64(cfg.MaxCompilationMemory) * 1024 * 1024,
+				MaxCPUTime: uint64(cfg.MaxCompilationCPUTime),
+			},
+			"",
+			logger,
+		),
+		concurrentCompilations,
+		uint64(compilationQueue),
+	), nil
+}
+
 type Node struct {
 	cfg        *Config
 	db         db.KeyValueStore
@@ -308,51 +359,10 @@ func New(cfg *Config, version string, logLevel *log.Level) (*Node, error) {
 	var nodeVM vm.VM
 	var throttledVM *ThrottledVM
 
-	concurrent, concurrentAuto, err := parseCompilationLimit(cfg.MaxConcurrentCompilations)
+	throttledCompiler, err := newThrottledCompilerFromConfig(cfg, logger)
 	if err != nil {
-		return nil, fmt.Errorf("parsing max-concurrent-compilations: %w", err)
+		return nil, err
 	}
-	var concurrentCompilations uint
-	if concurrentAuto {
-		availableMemoryMB := compiler.AvailableMemoryMB()
-		concurrentCompilations = max(compiler.ConcurrencyLimit(
-			uint(runtime.GOMAXPROCS(0)),
-			availableMemoryMB,
-			uint64(cfg.NodeMemoryReserve),
-			uint64(cfg.MaxCompilationMemory),
-		), 1)
-		logger.Info("deriving Sierra compilation concurrency",
-			zap.Uint("limit", concurrentCompilations),
-			zap.Uint64("availableMemoryMB", availableMemoryMB),
-			zap.Uint("nodeMemoryReserveMB", cfg.NodeMemoryReserve),
-			zap.Uint("maxMemoryPerCompilationMB", cfg.MaxCompilationMemory),
-		)
-	} else {
-		concurrentCompilations = concurrent
-		logger.Info("using configured Sierra compilation concurrency",
-			zap.Uint("limit", concurrentCompilations))
-	}
-
-	queue, queueAuto, err := parseCompilationLimit(cfg.MaxCompilationQueue)
-	if err != nil {
-		return nil, fmt.Errorf("parsing max-compilation-queue: %w", err)
-	}
-	compilationQueue := queue
-	if queueAuto {
-		compilationQueue = 2 * concurrentCompilations
-	}
-	throttledCompiler := NewThrottledCompiler(
-		compiler.New(
-			&compiler.Config{
-				MaxMemory:  uint64(cfg.MaxCompilationMemory) * 1024 * 1024,
-				MaxCPUTime: uint64(cfg.MaxCompilationCPUTime),
-			},
-			"",
-			logger,
-		),
-		concurrentCompilations,
-		uint64(compilationQueue),
-	)
 
 	if cfg.Sequencer {
 		logger.Warn("Sequencer features enabled. Please note the sequencer is in experimental stage")

--- a/node/node.go
+++ b/node/node.go
@@ -135,13 +135,18 @@ type Config struct {
 	RPCRequestTimeout        time.Duration `mapstructure:"rpc-request-timeout"`
 	RPCMaxConcurrentRequests uint          `mapstructure:"rpc-max-concurrent-requests"`
 	RPCMaxRequestQueue       uint          `mapstructure:"rpc-max-request-queue"`
-	// Empty derives the value at startup; an explicit 0 stays valid (no compilations / no queue).
-	MaxConcurrentCompilations string `mapstructure:"max-concurrent-compilations"`
-	MaxCompilationQueue       string `mapstructure:"max-compilation-queue"`
-	MaxCompilationMemory      uint   `mapstructure:"max-compilation-memory"`   // megabytes
-	NodeMemoryReserve         uint   `mapstructure:"node-memory-reserve"`      // megabytes
-	MaxCompilationCPUTime     uint   `mapstructure:"max-compilation-cpu-time"` // CPU seconds
-	NewState                  bool   `mapstructure:"new-state"`
+
+	// If MaxConcurrentCompilations or MaxCompilationQueue are not informed (Explicit is false)
+	// the value is derived at startup. An informed 0 stays valid (no compilations / no queue).
+	MaxConcurrentCompilations         uint64 `mapstructure:"max-concurrent-compilations"`
+	MaxConcurrentCompilationsExplicit bool
+	MaxCompilationQueue               uint64 `mapstructure:"max-compilation-queue"`
+	MaxCompilationQueueExplicit       bool
+
+	MaxCompilationMemory  uint `mapstructure:"max-compilation-memory"`   // megabytes
+	NodeMemoryReserve     uint `mapstructure:"node-memory-reserve"`      // megabytes
+	MaxCompilationCPUTime uint `mapstructure:"max-compilation-cpu-time"` // CPU seconds
+	NewState              bool `mapstructure:"new-state"`
 
 	// Prune is true when --prune-mode was provided (any value, including 0
 	// or absent). Set in cmd PreRunE; not bound via mapstructure.
@@ -294,10 +299,7 @@ func New(cfg *Config, version string, logLevel *log.Level) (*Node, error) {
 	var nodeVM vm.VM
 	var throttledVM *ThrottledVM
 
-	throttledCompiler, err := newThrottledCompilerFromConfig(cfg, logger)
-	if err != nil {
-		return nil, fmt.Errorf("creating compiler from config: %w", err)
-	}
+	throttledCompiler := newThrottledCompilerFromConfig(cfg, logger)
 
 	if cfg.Sequencer {
 		logger.Warn("Sequencer features enabled. Please note the sequencer is in experimental stage")

--- a/node/node.go
+++ b/node/node.go
@@ -138,6 +138,7 @@ type Config struct {
 	MaxConcurrentCompilations uint          `mapstructure:"max-concurrent-compilations"`
 	MaxCompilationQueue       uint          `mapstructure:"max-compilation-queue"`
 	MaxCompilationMemory      uint          `mapstructure:"max-compilation-memory"`   // megabytes
+	NodeMemoryReserve         uint          `mapstructure:"node-memory-reserve"`      // megabytes
 	MaxCompilationCPUTime     uint          `mapstructure:"max-compilation-cpu-time"` // CPU seconds
 	NewState                  bool          `mapstructure:"new-state"`
 
@@ -292,6 +293,30 @@ func New(cfg *Config, version string, logLevel *log.Level) (*Node, error) {
 	var nodeVM vm.VM
 	var throttledVM *ThrottledVM
 
+	concurrentCompilations := cfg.MaxConcurrentCompilations
+	if concurrentCompilations == 0 {
+		availableMemoryMB := compiler.AvailableMemoryMB()
+		concurrentCompilations = max(compiler.ConcurrencyLimit(
+			uint(runtime.GOMAXPROCS(0)),
+			availableMemoryMB,
+			uint64(cfg.NodeMemoryReserve),
+			uint64(cfg.MaxCompilationMemory),
+		), 1)
+		logger.Info("deriving Sierra compilation concurrency",
+			zap.Uint("limit", concurrentCompilations),
+			zap.Uint64("availableMemoryMB", availableMemoryMB),
+			zap.Uint("nodeMemoryReserveMB", cfg.NodeMemoryReserve),
+			zap.Uint("maxMemoryPerCompilationMB", cfg.MaxCompilationMemory),
+		)
+	} else {
+		logger.Info("using configured Sierra compilation concurrency",
+			zap.Uint("limit", concurrentCompilations))
+	}
+
+	compilationQueue := cfg.MaxCompilationQueue
+	if compilationQueue == 0 {
+		compilationQueue = 2 * concurrentCompilations
+	}
 	throttledCompiler := NewThrottledCompiler(
 		compiler.New(
 			&compiler.Config{
@@ -301,8 +326,8 @@ func New(cfg *Config, version string, logLevel *log.Level) (*Node, error) {
 			"",
 			logger,
 		),
-		cfg.MaxConcurrentCompilations,
-		uint64(cfg.MaxCompilationQueue),
+		concurrentCompilations,
+		uint64(compilationQueue),
 	)
 
 	if cfg.Sequencer {

--- a/node/node.go
+++ b/node/node.go
@@ -10,6 +10,7 @@ import (
 	"reflect"
 	"runtime"
 	"slices"
+	"strconv"
 	"time"
 
 	"github.com/Masterminds/semver/v3"
@@ -132,21 +133,35 @@ type Config struct {
 
 	DisableReceivedTxnStream bool `mapstructure:"disable-received-txn-stream"`
 
-	RPCRequestTimeout         time.Duration `mapstructure:"rpc-request-timeout"`
-	RPCMaxConcurrentRequests  uint          `mapstructure:"rpc-max-concurrent-requests"`
-	RPCMaxRequestQueue        uint          `mapstructure:"rpc-max-request-queue"`
-	MaxConcurrentCompilations uint          `mapstructure:"max-concurrent-compilations"`
-	MaxCompilationQueue       uint          `mapstructure:"max-compilation-queue"`
-	MaxCompilationMemory      uint          `mapstructure:"max-compilation-memory"`   // megabytes
-	NodeMemoryReserve         uint          `mapstructure:"node-memory-reserve"`      // megabytes
-	MaxCompilationCPUTime     uint          `mapstructure:"max-compilation-cpu-time"` // CPU seconds
-	NewState                  bool          `mapstructure:"new-state"`
+	RPCRequestTimeout        time.Duration `mapstructure:"rpc-request-timeout"`
+	RPCMaxConcurrentRequests uint          `mapstructure:"rpc-max-concurrent-requests"`
+	RPCMaxRequestQueue       uint          `mapstructure:"rpc-max-request-queue"`
+	// Empty derives the value at startup; an explicit 0 stays valid (no compilations / no queue).
+	MaxConcurrentCompilations string `mapstructure:"max-concurrent-compilations"`
+	MaxCompilationQueue       string `mapstructure:"max-compilation-queue"`
+	MaxCompilationMemory      uint   `mapstructure:"max-compilation-memory"`   // megabytes
+	NodeMemoryReserve         uint   `mapstructure:"node-memory-reserve"`      // megabytes
+	MaxCompilationCPUTime     uint   `mapstructure:"max-compilation-cpu-time"` // CPU seconds
+	NewState                  bool   `mapstructure:"new-state"`
 
 	// Prune is true when --prune-mode was provided (any value, including 0
 	// or absent). Set in cmd PreRunE; not bound via mapstructure.
 	Prune          bool
 	RetainedBlocks uint64        `mapstructure:"prune-mode"`
 	PruneMinAge    time.Duration `mapstructure:"prune-min-age"`
+}
+
+// parseCompilationLimit reads a compilation-sizing flag. An empty value derives the
+// value at startup (derive is true); otherwise it must be a non-negative integer.
+func parseCompilationLimit(value string) (limit uint, derive bool, err error) {
+	if value == "" {
+		return 0, true, nil
+	}
+	n, err := strconv.ParseUint(value, 10, strconv.IntSize)
+	if err != nil {
+		return 0, false, fmt.Errorf("%q is not a non-negative integer", value)
+	}
+	return uint(n), false, nil
 }
 
 type Node struct {
@@ -293,8 +308,12 @@ func New(cfg *Config, version string, logLevel *log.Level) (*Node, error) {
 	var nodeVM vm.VM
 	var throttledVM *ThrottledVM
 
-	concurrentCompilations := cfg.MaxConcurrentCompilations
-	if concurrentCompilations == 0 {
+	concurrent, concurrentAuto, err := parseCompilationLimit(cfg.MaxConcurrentCompilations)
+	if err != nil {
+		return nil, fmt.Errorf("parsing max-concurrent-compilations: %w", err)
+	}
+	var concurrentCompilations uint
+	if concurrentAuto {
 		availableMemoryMB := compiler.AvailableMemoryMB()
 		concurrentCompilations = max(compiler.ConcurrencyLimit(
 			uint(runtime.GOMAXPROCS(0)),
@@ -309,12 +328,17 @@ func New(cfg *Config, version string, logLevel *log.Level) (*Node, error) {
 			zap.Uint("maxMemoryPerCompilationMB", cfg.MaxCompilationMemory),
 		)
 	} else {
+		concurrentCompilations = concurrent
 		logger.Info("using configured Sierra compilation concurrency",
 			zap.Uint("limit", concurrentCompilations))
 	}
 
-	compilationQueue := cfg.MaxCompilationQueue
-	if compilationQueue == 0 {
+	queue, queueAuto, err := parseCompilationLimit(cfg.MaxCompilationQueue)
+	if err != nil {
+		return nil, fmt.Errorf("parsing max-compilation-queue: %w", err)
+	}
+	compilationQueue := queue
+	if queueAuto {
 		compilationQueue = 2 * concurrentCompilations
 	}
 	throttledCompiler := NewThrottledCompiler(

--- a/node/node.go
+++ b/node/node.go
@@ -299,10 +299,21 @@ func New(cfg *Config, version string, logLevel *log.Level) (*Node, error) {
 	var nodeVM vm.VM
 	var throttledVM *ThrottledVM
 
-	throttledCompiler := newThrottledCompilerFromConfig(cfg, logger)
+	maxConcurrentComp, maxQueuedComp := calculateCompilerConcurrencyBudget(cfg, logger)
+	compiler := compiler.New(
+		&compiler.Config{
+			MaxMemory:  uint64(cfg.MaxCompilationMemory) * 1024 * 1024,
+			MaxCPUTime: uint64(cfg.MaxCompilationCPUTime),
+		},
+		"",
+		logger,
+	)
+	throttledCompiler := NewThrottledCompiler(compiler, uint(maxConcurrentComp), maxQueuedComp)
 
 	if cfg.Sequencer {
-		logger.Warn("Sequencer features enabled. Please note the sequencer is in experimental stage")
+		logger.Warn(
+			"Sequencer features enabled. Please note the sequencer is in experimental stage",
+		)
 
 		// Sequencer mode only supports known networks and
 		// uses default fee tokens (custom networks not supported yet)

--- a/node/node_test.go
+++ b/node/node_test.go
@@ -44,7 +44,7 @@ func TestNewNode(t *testing.T) {
 		P2PAddr:                            "",
 		P2PPeers:                           "",
 		SubmittedTransactionsCacheEntryTTL: time.Second,
-		// MaxConcurrentCompilations left empty to exercise the auto-derive path.
+		// MaxConcurrentCompilations left unset (not Explicit) to exercise the auto-derive path.
 	}
 
 	logLevel := log.NewLevel(log.INFO)
@@ -65,7 +65,7 @@ func TestNewNodeRunsOneAtATimeOnLowMemory(t *testing.T) {
 		Network:                            networks.Sepolia,
 		DisableL1Verification:              true,
 		SubmittedTransactionsCacheEntryTTL: time.Second,
-		// MaxConcurrentCompilations left empty: derive, then floor to 1.
+		// MaxConcurrentCompilations left unset: derive, then floor to 1.
 		MaxCompilationMemory: 4096,
 		// Reserve more than the machine has, so nothing fits.
 		NodeMemoryReserve: uint(compiler.AvailableMemoryMB() + 4096),
@@ -84,14 +84,15 @@ func TestNewNodeSkipsDerivedConcurrency(t *testing.T) {
 		Network:                            networks.Sepolia,
 		DisableL1Verification:              true,
 		SubmittedTransactionsCacheEntryTTL: time.Second,
-		MaxConcurrentCompilations:          "2",
+		MaxConcurrentCompilations:          2,
+		MaxConcurrentCompilationsExplicit:  true,
 	}
 
 	_, err := node.New(config, "v0.3", log.NewLevel(log.INFO))
 	require.NoError(t, err)
 }
 
-func TestNewNodeRejectsInvalidConcurrency(t *testing.T) {
+func TestNewNodeSkipsDerivedQueue(t *testing.T) {
 	config := &node.Config{
 		LogLevel:                           "info",
 		HTTP:                               true,
@@ -100,11 +101,12 @@ func TestNewNodeRejectsInvalidConcurrency(t *testing.T) {
 		Network:                            networks.Sepolia,
 		DisableL1Verification:              true,
 		SubmittedTransactionsCacheEntryTTL: time.Second,
-		MaxConcurrentCompilations:          "-1",
+		MaxCompilationQueue:                8,
+		MaxCompilationQueueExplicit:        true,
 	}
 
 	_, err := node.New(config, "v0.3", log.NewLevel(log.INFO))
-	require.ErrorContains(t, err, "max-concurrent-compilations")
+	require.NoError(t, err)
 }
 
 func TestNetworkVerificationOnNonEmptyDB(t *testing.T) {

--- a/node/node_test.go
+++ b/node/node_test.go
@@ -44,7 +44,7 @@ func TestNewNode(t *testing.T) {
 		P2PAddr:                            "",
 		P2PPeers:                           "",
 		SubmittedTransactionsCacheEntryTTL: time.Second,
-		// MaxConcurrentCompilations left 0 to exercise the auto-derive path.
+		// MaxConcurrentCompilations left empty to exercise the auto-derive path.
 	}
 
 	logLevel := log.NewLevel(log.INFO)
@@ -65,7 +65,8 @@ func TestNewNodeRunsOneAtATimeOnLowMemory(t *testing.T) {
 		Network:                            networks.Sepolia,
 		DisableL1Verification:              true,
 		SubmittedTransactionsCacheEntryTTL: time.Second,
-		MaxCompilationMemory:               4096,
+		// MaxConcurrentCompilations left empty: derive, then floor to 1.
+		MaxCompilationMemory: 4096,
 		// Reserve more than the machine has, so nothing fits.
 		NodeMemoryReserve: uint(compiler.AvailableMemoryMB() + 4096),
 	}
@@ -83,7 +84,7 @@ func TestNewNodeSkipsDerivedConcurrency(t *testing.T) {
 		Network:                            networks.Sepolia,
 		DisableL1Verification:              true,
 		SubmittedTransactionsCacheEntryTTL: time.Second,
-		MaxConcurrentCompilations:          2,
+		MaxConcurrentCompilations:          "2",
 	}
 
 	_, err := node.New(config, "v0.3", log.NewLevel(log.INFO))

--- a/node/node_test.go
+++ b/node/node_test.go
@@ -11,6 +11,7 @@ import (
 	statetestutils "github.com/NethermindEth/juno/core/state/testutils"
 	"github.com/NethermindEth/juno/db/pebblev2"
 	"github.com/NethermindEth/juno/node"
+	"github.com/NethermindEth/juno/starknet/compiler"
 	adaptfeeder "github.com/NethermindEth/juno/starknetdata/feeder"
 	"github.com/NethermindEth/juno/sync"
 	"github.com/NethermindEth/juno/utils/log"
@@ -43,6 +44,7 @@ func TestNewNode(t *testing.T) {
 		P2PAddr:                            "",
 		P2PPeers:                           "",
 		SubmittedTransactionsCacheEntryTTL: time.Second,
+		// MaxConcurrentCompilations left 0 to exercise the auto-derive path.
 	}
 
 	logLevel := log.NewLevel(log.INFO)
@@ -52,6 +54,40 @@ func TestNewNode(t *testing.T) {
 	ctx, cancel := context.WithCancel(t.Context())
 	cancel()
 	n.Run(ctx)
+}
+
+func TestNewNodeRunsOneAtATimeOnLowMemory(t *testing.T) {
+	config := &node.Config{
+		LogLevel:                           "info",
+		HTTP:                               true,
+		DatabasePath:                       t.TempDir(),
+		DBCompression:                      "zstd",
+		Network:                            networks.Sepolia,
+		DisableL1Verification:              true,
+		SubmittedTransactionsCacheEntryTTL: time.Second,
+		MaxCompilationMemory:               4096,
+		// Reserve more than the machine has, so nothing fits.
+		NodeMemoryReserve: uint(compiler.AvailableMemoryMB() + 4096),
+	}
+
+	_, err := node.New(config, "v0.3", log.NewLevel(log.INFO))
+	require.NoError(t, err)
+}
+
+func TestNewNodeSkipsDerivedConcurrency(t *testing.T) {
+	config := &node.Config{
+		LogLevel:                           "info",
+		HTTP:                               true,
+		DatabasePath:                       t.TempDir(),
+		DBCompression:                      "zstd",
+		Network:                            networks.Sepolia,
+		DisableL1Verification:              true,
+		SubmittedTransactionsCacheEntryTTL: time.Second,
+		MaxConcurrentCompilations:          2,
+	}
+
+	_, err := node.New(config, "v0.3", log.NewLevel(log.INFO))
+	require.NoError(t, err)
 }
 
 func TestNetworkVerificationOnNonEmptyDB(t *testing.T) {

--- a/node/node_test.go
+++ b/node/node_test.go
@@ -91,6 +91,22 @@ func TestNewNodeSkipsDerivedConcurrency(t *testing.T) {
 	require.NoError(t, err)
 }
 
+func TestNewNodeRejectsInvalidConcurrency(t *testing.T) {
+	config := &node.Config{
+		LogLevel:                           "info",
+		HTTP:                               true,
+		DatabasePath:                       t.TempDir(),
+		DBCompression:                      "zstd",
+		Network:                            networks.Sepolia,
+		DisableL1Verification:              true,
+		SubmittedTransactionsCacheEntryTTL: time.Second,
+		MaxConcurrentCompilations:          "-1",
+	}
+
+	_, err := node.New(config, "v0.3", log.NewLevel(log.INFO))
+	require.ErrorContains(t, err, "max-concurrent-compilations")
+}
+
 func TestNetworkVerificationOnNonEmptyDB(t *testing.T) {
 	network := networks.Sepolia
 	tests := map[string]struct {

--- a/node/throttled_compiler.go
+++ b/node/throttled_compiler.go
@@ -2,16 +2,77 @@ package node
 
 import (
 	"context"
+	"fmt"
+	"runtime"
+	"strconv"
 
 	"github.com/NethermindEth/juno/starknet"
 	"github.com/NethermindEth/juno/starknet/compiler"
+	"github.com/NethermindEth/juno/utils/log"
 	"github.com/NethermindEth/juno/utils/throttler"
+	"go.uber.org/zap"
 )
 
 var _ compiler.Compiler = (*ThrottledCompiler)(nil)
 
 type ThrottledCompiler struct {
 	*throttler.Throttler[compiler.Compiler]
+}
+
+type ThrottledCompilerSettings struct {
+	maxConcurrency uint64
+	queueSize      uint64
+}
+
+// parseCompilerLimit reads a compilation-sizing flag.
+// An empty value derives the value at startup (derived is true).
+func parseCompilerLimit(value string) (limit uint64, derived bool, err error) {
+	if value == "" {
+		return 0, true, nil
+	}
+	valueUint64, err := strconv.ParseUint(value, 10, strconv.IntSize)
+	if err != nil {
+		return 0, false, fmt.Errorf("%q is not an unsigned integer: %w", value, err)
+	}
+	return valueUint64, false, nil
+}
+
+func resolveThrottledCompilerSettings(
+	cfg *Config, logger *log.ZapLogger,
+) (*ThrottledCompilerSettings, error) {
+	maxConcurrency, maxConcurrencyDerived, err := parseCompilerLimit(cfg.MaxConcurrentCompilations)
+	if err != nil {
+		return nil, fmt.Errorf("parsing max-concurrent-compilations: %w", err)
+	}
+
+	if maxConcurrencyDerived {
+		maxConcurrency = compiler.ConcurrencyLimit(
+			uint64(runtime.GOMAXPROCS(0)),
+			compiler.AvailableMemoryMB(),
+			uint64(cfg.NodeMemoryReserve),
+			uint64(cfg.MaxCompilationMemory),
+		)
+	}
+
+	queueSize, queueSizeDerived, err := parseCompilerLimit(cfg.MaxCompilationQueue)
+	if err != nil {
+		return nil, fmt.Errorf("parsing max-compilation-queue: %w", err)
+	}
+
+	if queueSizeDerived {
+		queueSize = 2 * maxConcurrency
+	}
+
+	logger.Info("Sierra compilation limits",
+		zap.Uint64("concurrency", maxConcurrency),
+		zap.Bool("concurrencyDerived", maxConcurrencyDerived),
+		zap.Uint64("queueSize", queueSize),
+		zap.Bool("queueSizeDerived", queueSizeDerived),
+	)
+
+	return &ThrottledCompilerSettings{
+		maxConcurrency, queueSize,
+	}, nil
 }
 
 func NewThrottledCompiler(
@@ -22,6 +83,28 @@ func NewThrottledCompiler(
 			concurrencyBudget, &res, throttler.WithMaxQueueLen(maxQueueLen),
 		),
 	}
+}
+
+func newThrottledCompilerFromConfig(
+	cfg *Config, logger *log.ZapLogger,
+) (*ThrottledCompiler, error) {
+	throttledCompilerSettings, err := resolveThrottledCompilerSettings(cfg, logger)
+	if err != nil {
+		return nil, fmt.Errorf("resolving compiler settings: %w", err)
+	}
+
+	return NewThrottledCompiler(
+		compiler.New(
+			&compiler.Config{
+				MaxMemory:  uint64(cfg.MaxCompilationMemory) * 1024 * 1024,
+				MaxCPUTime: uint64(cfg.MaxCompilationCPUTime),
+			},
+			"",
+			logger,
+		),
+		uint(throttledCompilerSettings.maxConcurrency),
+		throttledCompilerSettings.queueSize,
+	), nil
 }
 
 func (tc *ThrottledCompiler) Compile(

--- a/node/throttled_compiler.go
+++ b/node/throttled_compiler.go
@@ -17,12 +17,31 @@ type ThrottledCompiler struct {
 	*throttler.Throttler[compiler.Compiler]
 }
 
-// resolveThrottledCompilerSettings turns the config's compilation limits into concrete values.
-// An absent flag (not Explicit) is derived from the available hardware.
-// Any explicit value (including 0) is used as-is.
-func resolveThrottledCompilerSettings(
-	cfg *Config, logger *log.ZapLogger,
-) (uint64, uint64) {
+func NewThrottledCompiler(
+	comp compiler.Compiler, concurrencyBudget uint, maxQueueLen uint64,
+) *ThrottledCompiler {
+	return &ThrottledCompiler{
+		Throttler: throttler.NewThrottler(
+			concurrencyBudget, &comp, throttler.WithMaxQueueLen(maxQueueLen),
+		),
+	}
+}
+
+func (tc *ThrottledCompiler) Compile(
+	ctx context.Context, sierra *starknet.SierraClass,
+) (*starknet.CasmClass, error) {
+	var result *starknet.CasmClass
+	err := tc.Do(ctx, func(c *compiler.Compiler) error {
+		var cErr error
+		result, cErr = (*c).Compile(ctx, sierra)
+		return cErr
+	})
+	return result, err
+}
+
+// calculateCompilerConcurrencyBudget determines safe limits for concurrent compilations
+// if this were not explicitly set
+func calculateCompilerConcurrencyBudget(cfg *Config, logger log.StructuredLogger) (uint64, uint64) {
 	maxConcurrency := cfg.MaxConcurrentCompilations
 	availableMemoryMB := compiler.AvailableMemoryMB()
 	if !cfg.MaxConcurrentCompilationsExplicit {
@@ -46,47 +65,5 @@ func resolveThrottledCompilerSettings(
 		zap.Uint("nodeMemoryReserveMB", cfg.NodeMemoryReserve),
 		zap.Uint("maxCompilationMemoryMB", cfg.MaxCompilationMemory),
 	)
-
 	return maxConcurrency, queueSize
-}
-
-func NewThrottledCompiler(
-	res compiler.Compiler, concurrencyBudget uint, maxQueueLen uint64,
-) *ThrottledCompiler {
-	return &ThrottledCompiler{
-		Throttler: throttler.NewThrottler(
-			concurrencyBudget, &res, throttler.WithMaxQueueLen(maxQueueLen),
-		),
-	}
-}
-
-func newThrottledCompilerFromConfig(
-	cfg *Config, logger *log.ZapLogger,
-) *ThrottledCompiler {
-	maxConcurrency, queueSize := resolveThrottledCompilerSettings(cfg, logger)
-
-	return NewThrottledCompiler(
-		compiler.New(
-			&compiler.Config{
-				MaxMemory:  uint64(cfg.MaxCompilationMemory) * 1024 * 1024,
-				MaxCPUTime: uint64(cfg.MaxCompilationCPUTime),
-			},
-			"",
-			logger,
-		),
-		uint(maxConcurrency),
-		queueSize,
-	)
-}
-
-func (tc *ThrottledCompiler) Compile(
-	ctx context.Context, sierra *starknet.SierraClass,
-) (*starknet.CasmClass, error) {
-	var result *starknet.CasmClass
-	err := tc.Do(ctx, func(c *compiler.Compiler) error {
-		var cErr error
-		result, cErr = (*c).Compile(ctx, sierra)
-		return cErr
-	})
-	return result, err
 }

--- a/node/throttled_compiler.go
+++ b/node/throttled_compiler.go
@@ -2,9 +2,7 @@ package node
 
 import (
 	"context"
-	"fmt"
 	"runtime"
-	"strconv"
 
 	"github.com/NethermindEth/juno/starknet"
 	"github.com/NethermindEth/juno/starknet/compiler"
@@ -19,60 +17,37 @@ type ThrottledCompiler struct {
 	*throttler.Throttler[compiler.Compiler]
 }
 
-type ThrottledCompilerSettings struct {
-	maxConcurrency uint64
-	queueSize      uint64
-}
-
-// parseCompilerLimit reads a compilation-sizing flag.
-// An empty value derives the value at startup (derived is true).
-func parseCompilerLimit(value string) (limit uint64, derived bool, err error) {
-	if value == "" {
-		return 0, true, nil
-	}
-	valueUint64, err := strconv.ParseUint(value, 10, strconv.IntSize)
-	if err != nil {
-		return 0, false, fmt.Errorf("%q is not an unsigned integer: %w", value, err)
-	}
-	return valueUint64, false, nil
-}
-
+// resolveThrottledCompilerSettings turns the config's compilation limits into concrete values.
+// An absent flag (not Explicit) is derived from the available hardware.
+// Any explicit value (including 0) is used as-is.
 func resolveThrottledCompilerSettings(
 	cfg *Config, logger *log.ZapLogger,
-) (*ThrottledCompilerSettings, error) {
-	maxConcurrency, maxConcurrencyDerived, err := parseCompilerLimit(cfg.MaxConcurrentCompilations)
-	if err != nil {
-		return nil, fmt.Errorf("parsing max-concurrent-compilations: %w", err)
-	}
-
-	if maxConcurrencyDerived {
+) (uint64, uint64) {
+	maxConcurrency := cfg.MaxConcurrentCompilations
+	availableMemoryMB := compiler.AvailableMemoryMB()
+	if !cfg.MaxConcurrentCompilationsExplicit {
 		maxConcurrency = compiler.ConcurrencyLimit(
 			uint64(runtime.GOMAXPROCS(0)),
-			compiler.AvailableMemoryMB(),
+			availableMemoryMB,
 			uint64(cfg.NodeMemoryReserve),
 			uint64(cfg.MaxCompilationMemory),
 		)
 	}
 
-	queueSize, queueSizeDerived, err := parseCompilerLimit(cfg.MaxCompilationQueue)
-	if err != nil {
-		return nil, fmt.Errorf("parsing max-compilation-queue: %w", err)
-	}
-
-	if queueSizeDerived {
+	queueSize := cfg.MaxCompilationQueue
+	if !cfg.MaxCompilationQueueExplicit {
 		queueSize = 2 * maxConcurrency
 	}
 
 	logger.Info("Sierra compilation limits",
-		zap.Uint64("concurrency", maxConcurrency),
-		zap.Bool("concurrencyDerived", maxConcurrencyDerived),
+		zap.Uint64("maxConcurrency", maxConcurrency),
 		zap.Uint64("queueSize", queueSize),
-		zap.Bool("queueSizeDerived", queueSizeDerived),
+		zap.Uint64("availableMemoryMB", availableMemoryMB),
+		zap.Uint("nodeMemoryReserveMB", cfg.NodeMemoryReserve),
+		zap.Uint("maxCompilationMemoryMB", cfg.MaxCompilationMemory),
 	)
 
-	return &ThrottledCompilerSettings{
-		maxConcurrency, queueSize,
-	}, nil
+	return maxConcurrency, queueSize
 }
 
 func NewThrottledCompiler(
@@ -87,11 +62,8 @@ func NewThrottledCompiler(
 
 func newThrottledCompilerFromConfig(
 	cfg *Config, logger *log.ZapLogger,
-) (*ThrottledCompiler, error) {
-	throttledCompilerSettings, err := resolveThrottledCompilerSettings(cfg, logger)
-	if err != nil {
-		return nil, fmt.Errorf("resolving compiler settings: %w", err)
-	}
+) *ThrottledCompiler {
+	maxConcurrency, queueSize := resolveThrottledCompilerSettings(cfg, logger)
 
 	return NewThrottledCompiler(
 		compiler.New(
@@ -102,9 +74,9 @@ func newThrottledCompilerFromConfig(
 			"",
 			logger,
 		),
-		uint(throttledCompilerSettings.maxConcurrency),
-		throttledCompilerSettings.queueSize,
-	), nil
+		uint(maxConcurrency),
+		queueSize,
+	)
 }
 
 func (tc *ThrottledCompiler) Compile(

--- a/starknet/compiler/compiler.go
+++ b/starknet/compiler/compiler.go
@@ -31,6 +31,10 @@ const (
 	FlagMaxCPUTime = "max-cpu-time" // seconds (RLIMIT_CPU)
 )
 
+// There is no need for more than 2 threads. It runs an FFI, and many threads
+// grow the required virtual address space larger than what is needed.
+const compileChildGOMAXPROCS = "2"
+
 // Config bounds the resources used by compilation child processes.
 type Config struct {
 	// MaxMemory is the address-space limit (RLIMIT_AS) in bytes
@@ -105,6 +109,7 @@ func (c *compiler) Compile(
 
 	//nolint:gosec // binaryPath is the juno binary, not user input
 	cmd := exec.CommandContext(ctx, c.binaryPath, args...)
+	cmd.Env = append(os.Environ(), "GOMAXPROCS="+compileChildGOMAXPROCS)
 	cmd.Stdin = bytes.NewReader(sierraJSON)
 
 	var stdout, stderr bytes.Buffer

--- a/starknet/compiler/concurrency.go
+++ b/starknet/compiler/concurrency.go
@@ -1,0 +1,38 @@
+package compiler
+
+import (
+	"github.com/KimMachineGun/automemlimit/memlimit"
+	"github.com/pbnjay/memory"
+)
+
+const megabyte = 1 << 20
+
+// AvailableMemoryMB returns the RAM this process can use, in MB.
+// Inside a container it uses the cgroup limit, otherwise the host RAM.
+func AvailableMemoryMB() uint64 {
+	hostMemory := memory.TotalMemory()
+	cgroupLimit, err := memlimit.FromCgroup()
+	if err == nil && cgroupLimit > 0 && cgroupLimit < hostMemory {
+		return cgroupLimit / megabyte
+	}
+	return hostMemory / megabyte
+}
+
+// ConcurrencyLimit returns how many compilations fit in memory, capped by maxParallel.
+// Memory is in MB. A zero maxMemoryPerCompilation means no memory limit.
+// Returns 0 when memory fits no compilation.
+func ConcurrencyLimit(
+	maxParallel uint,
+	availableMemory uint64,
+	nodeMemoryReserve uint64,
+	maxMemoryPerCompilation uint64,
+) uint {
+	if maxMemoryPerCompilation == 0 {
+		return maxParallel
+	}
+	if availableMemory <= nodeMemoryReserve {
+		return 0
+	}
+	fitInMemory := uint((availableMemory - nodeMemoryReserve) / maxMemoryPerCompilation)
+	return min(fitInMemory, maxParallel)
+}

--- a/starknet/compiler/concurrency.go
+++ b/starknet/compiler/concurrency.go
@@ -18,21 +18,21 @@ func AvailableMemoryMB() uint64 {
 	return hostMemory / megabyte
 }
 
-// ConcurrencyLimit returns how many compilations fit in memory, capped by maxParallel.
+// ConcurrencyLimit returns how many compilations fit in memory, capped by maxConcurrency.
 // Memory is in MB. A zero maxMemoryPerCompilation means no memory limit.
 // Returns 0 when memory fits no compilation.
 func ConcurrencyLimit(
-	maxParallel uint,
+	maxConcurrency uint64,
 	availableMemory uint64,
 	nodeMemoryReserve uint64,
 	maxMemoryPerCompilation uint64,
-) uint {
+) uint64 {
 	if maxMemoryPerCompilation == 0 {
-		return maxParallel
+		return maxConcurrency
 	}
 	if availableMemory <= nodeMemoryReserve {
 		return 0
 	}
-	fitInMemory := uint((availableMemory - nodeMemoryReserve) / maxMemoryPerCompilation)
-	return min(fitInMemory, maxParallel)
+	fitInMemory := (availableMemory - nodeMemoryReserve) / maxMemoryPerCompilation
+	return min(fitInMemory, maxConcurrency)
 }

--- a/starknet/compiler/concurrency.go
+++ b/starknet/compiler/concurrency.go
@@ -8,7 +8,7 @@ import (
 const megabyte = 1 << 20
 
 // AvailableMemoryMB returns the RAM this process can use, in MB.
-// Inside a container it uses the cgroup limit, otherwise the host RAM.
+// It checks if the memory is limited by the cgroup limit, otherwise it uses the host RAM.
 func AvailableMemoryMB() uint64 {
 	hostMemory := memory.TotalMemory()
 	cgroupLimit, err := memlimit.FromCgroup()
@@ -19,8 +19,8 @@ func AvailableMemoryMB() uint64 {
 }
 
 // ConcurrencyLimit returns how many compilations fit in memory, capped by maxConcurrency.
-// Memory is in MB. A zero maxMemoryPerCompilation means no memory limit.
-// Returns 1 when memory fits no compilation.
+// Memory is in MB. A 0 maxMemoryPerCompilation means no memory limit.
+// Returns 1 when no compilation fits memory.
 func ConcurrencyLimit(
 	maxConcurrency uint64,
 	availableMemory uint64,

--- a/starknet/compiler/concurrency.go
+++ b/starknet/compiler/concurrency.go
@@ -20,7 +20,7 @@ func AvailableMemoryMB() uint64 {
 
 // ConcurrencyLimit returns how many compilations fit in memory, capped by maxConcurrency.
 // Memory is in MB. A zero maxMemoryPerCompilation means no memory limit.
-// Returns 0 when memory fits no compilation.
+// Returns 1 when memory fits no compilation.
 func ConcurrencyLimit(
 	maxConcurrency uint64,
 	availableMemory uint64,
@@ -28,11 +28,17 @@ func ConcurrencyLimit(
 	maxMemoryPerCompilation uint64,
 ) uint64 {
 	if maxMemoryPerCompilation == 0 {
-		return maxConcurrency
+		return max(1, maxConcurrency)
 	}
+
 	if availableMemory <= nodeMemoryReserve {
-		return 0
+		return 1
 	}
+
 	fitInMemory := (availableMemory - nodeMemoryReserve) / maxMemoryPerCompilation
+	if fitInMemory == 0 {
+		return 1
+	}
+
 	return min(fitInMemory, maxConcurrency)
 }

--- a/starknet/compiler/concurrency_test.go
+++ b/starknet/compiler/concurrency_test.go
@@ -1,0 +1,82 @@
+package compiler_test
+
+import (
+	"testing"
+
+	"github.com/NethermindEth/juno/starknet/compiler"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestConcurrencyLimit(t *testing.T) {
+	const gb = 1024 // values are in MB
+	tests := []struct {
+		name                                                        string
+		maxParallel                                                 uint
+		availableMemory, nodeMemoryReserve, maxMemoryPerCompilation uint64
+		want                                                        uint
+	}{
+		{
+			name:                    "memory budget caps below max parallel",
+			maxParallel:             10,
+			availableMemory:         16 * gb,
+			nodeMemoryReserve:       4 * gb,
+			maxMemoryPerCompilation: 4 * gb,
+			want:                    3, // (16-4)/4
+		},
+		{
+			name:                    "max parallel caps below memory budget",
+			maxParallel:             2,
+			availableMemory:         64 * gb,
+			nodeMemoryReserve:       4 * gb,
+			maxMemoryPerCompilation: 4 * gb,
+			want:                    2,
+		},
+		{
+			name:                    "exactly one compilation fits",
+			maxParallel:             10,
+			availableMemory:         8 * gb,
+			nodeMemoryReserve:       4 * gb,
+			maxMemoryPerCompilation: 4 * gb,
+			want:                    1, // (8-4)/4
+		},
+		{
+			name:                    "no room for a single compilation when available equals reserve",
+			maxParallel:             10,
+			availableMemory:         4 * gb,
+			nodeMemoryReserve:       4 * gb,
+			maxMemoryPerCompilation: 4 * gb,
+			want:                    0,
+		},
+		{
+			name:                    "no room when available below reserve plus one compilation",
+			maxParallel:             10,
+			availableMemory:         6 * gb,
+			nodeMemoryReserve:       4 * gb,
+			maxMemoryPerCompilation: 4 * gb,
+			want:                    0, // (6-4)/4
+		},
+		{
+			name:                    "unbounded per-compilation memory ignores budget",
+			maxParallel:             7,
+			availableMemory:         1 * gb,
+			nodeMemoryReserve:       4 * gb,
+			maxMemoryPerCompilation: 0,
+			want:                    7,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := compiler.ConcurrencyLimit(
+				tt.maxParallel,
+				tt.availableMemory,
+				tt.nodeMemoryReserve,
+				tt.maxMemoryPerCompilation,
+			)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestAvailableMemoryMB(t *testing.T) {
+	assert.NotZero(t, compiler.AvailableMemoryMB())
+}

--- a/starknet/compiler/concurrency_test.go
+++ b/starknet/compiler/concurrency_test.go
@@ -13,7 +13,7 @@ func TestConcurrencyLimit(t *testing.T) {
 		name                                                        string
 		maxConcurrency                                              uint64
 		availableMemory, nodeMemoryReserve, maxMemoryPerCompilation uint64
-		want                                                        uint64
+		expected                                                    uint64
 	}{
 		{
 			name:                    "memory budget caps below max parallel",
@@ -21,7 +21,7 @@ func TestConcurrencyLimit(t *testing.T) {
 			availableMemory:         16 * gb,
 			nodeMemoryReserve:       4 * gb,
 			maxMemoryPerCompilation: 4 * gb,
-			want:                    3, // (16-4)/4
+			expected:                3, // (16-4)/4
 		},
 		{
 			name:                    "max parallel caps below memory budget",
@@ -29,7 +29,7 @@ func TestConcurrencyLimit(t *testing.T) {
 			availableMemory:         64 * gb,
 			nodeMemoryReserve:       4 * gb,
 			maxMemoryPerCompilation: 4 * gb,
-			want:                    2,
+			expected:                2,
 		},
 		{
 			name:                    "exactly one compilation fits",
@@ -37,7 +37,7 @@ func TestConcurrencyLimit(t *testing.T) {
 			availableMemory:         8 * gb,
 			nodeMemoryReserve:       4 * gb,
 			maxMemoryPerCompilation: 4 * gb,
-			want:                    1, // (8-4)/4
+			expected:                1, // (8-4)/4
 		},
 		{
 			name:                    "floors to 1 when available equals reserve",
@@ -45,7 +45,7 @@ func TestConcurrencyLimit(t *testing.T) {
 			availableMemory:         4 * gb,
 			nodeMemoryReserve:       4 * gb,
 			maxMemoryPerCompilation: 4 * gb,
-			want:                    1,
+			expected:                1,
 		},
 		{
 			name:                    "floors to 1 when memory fits no compilation",
@@ -53,7 +53,7 @@ func TestConcurrencyLimit(t *testing.T) {
 			availableMemory:         6 * gb,
 			nodeMemoryReserve:       4 * gb,
 			maxMemoryPerCompilation: 4 * gb,
-			want:                    1, // (6-4)/4 = 0, floored to 1
+			expected:                1, // (6-4)/4 = 0, floored to 1
 		},
 		{
 			name:                    "unbounded per-compilation memory ignores budget",
@@ -61,7 +61,7 @@ func TestConcurrencyLimit(t *testing.T) {
 			availableMemory:         1 * gb,
 			nodeMemoryReserve:       4 * gb,
 			maxMemoryPerCompilation: 0,
-			want:                    7,
+			expected:                7,
 		},
 	}
 	for _, tt := range tests {
@@ -72,7 +72,7 @@ func TestConcurrencyLimit(t *testing.T) {
 				tt.nodeMemoryReserve,
 				tt.maxMemoryPerCompilation,
 			)
-			assert.Equal(t, tt.want, got)
+			assert.Equal(t, tt.expected, got)
 		})
 	}
 }

--- a/starknet/compiler/concurrency_test.go
+++ b/starknet/compiler/concurrency_test.go
@@ -40,20 +40,20 @@ func TestConcurrencyLimit(t *testing.T) {
 			want:                    1, // (8-4)/4
 		},
 		{
-			name:                    "no room for a single compilation when available equals reserve",
+			name:                    "floors to 1 when available equals reserve",
 			maxConcurrency:          10,
 			availableMemory:         4 * gb,
 			nodeMemoryReserve:       4 * gb,
 			maxMemoryPerCompilation: 4 * gb,
-			want:                    0,
+			want:                    1,
 		},
 		{
-			name:                    "no room when available below reserve plus one compilation",
+			name:                    "floors to 1 when memory fits no compilation",
 			maxConcurrency:          10,
 			availableMemory:         6 * gb,
 			nodeMemoryReserve:       4 * gb,
 			maxMemoryPerCompilation: 4 * gb,
-			want:                    0, // (6-4)/4
+			want:                    1, // (6-4)/4 = 0, floored to 1
 		},
 		{
 			name:                    "unbounded per-compilation memory ignores budget",

--- a/starknet/compiler/concurrency_test.go
+++ b/starknet/compiler/concurrency_test.go
@@ -11,13 +11,13 @@ func TestConcurrencyLimit(t *testing.T) {
 	const gb = 1024 // values are in MB
 	tests := []struct {
 		name                                                        string
-		maxParallel                                                 uint
+		maxConcurrency                                              uint64
 		availableMemory, nodeMemoryReserve, maxMemoryPerCompilation uint64
-		want                                                        uint
+		want                                                        uint64
 	}{
 		{
 			name:                    "memory budget caps below max parallel",
-			maxParallel:             10,
+			maxConcurrency:          10,
 			availableMemory:         16 * gb,
 			nodeMemoryReserve:       4 * gb,
 			maxMemoryPerCompilation: 4 * gb,
@@ -25,7 +25,7 @@ func TestConcurrencyLimit(t *testing.T) {
 		},
 		{
 			name:                    "max parallel caps below memory budget",
-			maxParallel:             2,
+			maxConcurrency:          2,
 			availableMemory:         64 * gb,
 			nodeMemoryReserve:       4 * gb,
 			maxMemoryPerCompilation: 4 * gb,
@@ -33,7 +33,7 @@ func TestConcurrencyLimit(t *testing.T) {
 		},
 		{
 			name:                    "exactly one compilation fits",
-			maxParallel:             10,
+			maxConcurrency:          10,
 			availableMemory:         8 * gb,
 			nodeMemoryReserve:       4 * gb,
 			maxMemoryPerCompilation: 4 * gb,
@@ -41,7 +41,7 @@ func TestConcurrencyLimit(t *testing.T) {
 		},
 		{
 			name:                    "no room for a single compilation when available equals reserve",
-			maxParallel:             10,
+			maxConcurrency:          10,
 			availableMemory:         4 * gb,
 			nodeMemoryReserve:       4 * gb,
 			maxMemoryPerCompilation: 4 * gb,
@@ -49,7 +49,7 @@ func TestConcurrencyLimit(t *testing.T) {
 		},
 		{
 			name:                    "no room when available below reserve plus one compilation",
-			maxParallel:             10,
+			maxConcurrency:          10,
 			availableMemory:         6 * gb,
 			nodeMemoryReserve:       4 * gb,
 			maxMemoryPerCompilation: 4 * gb,
@@ -57,7 +57,7 @@ func TestConcurrencyLimit(t *testing.T) {
 		},
 		{
 			name:                    "unbounded per-compilation memory ignores budget",
-			maxParallel:             7,
+			maxConcurrency:          7,
 			availableMemory:         1 * gb,
 			nodeMemoryReserve:       4 * gb,
 			maxMemoryPerCompilation: 0,
@@ -67,7 +67,7 @@ func TestConcurrencyLimit(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got := compiler.ConcurrencyLimit(
-				tt.maxParallel,
+				tt.maxConcurrency,
 				tt.availableMemory,
 				tt.nodeMemoryReserve,
 				tt.maxMemoryPerCompilation,


### PR DESCRIPTION
# Auto-size Sierra compilation concurrency from available memory

## What

Today the number of concurrent Sierra→CASM compilations defaults to `GOMAXPROCS`, which ignores memory. A burst of large compilations can exhaust RAM.
This PR derives the limit from **available memory and CPU count**.

Formula (all values in MB):

```
limit = min( (availableMemory - nodeMemoryReserve) / maxMemoryPerCompilation , CPUs )
```

The limit is always at least 1: a memory-tight node compiles one at a time rather than refusing to start.

## Behavior change (heads-up for operators)

The default concurrency is no longer always `GOMAXPROCS`. On a many-core but memory-modest host it drops: e.g. 16 CPU / 16 GB with defaults goes from `16` to `(16-4)/4 = 3`. Intended, but nodes with heavy P2P or `getCompiledCasm` load will see less compile parallelism. Raise `--max-concurrent-compilations` (used as-is) or `--node-memory-reserve` to tune.

## Flags

| Flag | Default | Meaning |
|---|---|---|
| `--max-concurrent-compilations` | `unset` | `unset` (flag not provided) = derive from memory + CPUs. A provided value is used as-is (an explicit `0` disables compilations). |
| `--max-compilation-queue` | `unset` | `unset` = twice the resulting concurrency. A provided value is used as-is. |
| `--node-memory-reserve` | `4096` | RAM (MB) kept for the rest of the node, out of the compilation budget. **New.** |
| `--max-compilation-memory` | `4096` | RAM (MB) one compilation may use. Existing; it is the divisor above. |

Compilation-sizing flags are parsed as unsigned integers by the CLI, so a non-numeric or negative value is rejected at flag-parse time. Whether a flag was provided (across CLI, env, or YAML) is what selects derive-vs-explicit, so an explicit `0` is a valid, distinct value.

## Why these libraries

Two needs: read total RAM, and read the container memory limit. Choice:

| Need | Library | Why |
|---|---|---|
| Host/VM RAM | `pbnjay/memory` | One function, pure Go, no cgo, all OSes. |
| Container limit | `automemlimit` | Purpose-built for `GOMEMLIMIT`, pure Go, reads cgroup v1/v2. |

Both were already indirect dependencies; this only promotes them to direct.
`automemlimit`'s only dependency is `pbnjay/memory`, so the pair adds **no new transitive dependency**.

`gopsutil` was considered and dropped: it does not read the cgroup limit (same blind spot as `pbnjay`), and it would be an extra dependency on top of `pbnjay` (which `automemlimit` pulls anyway).

## Container awareness

A **cgroup** is the Linux kernel feature that caps how much memory a process group may use; it is how Docker and Kubernetes enforce memory limits. A process can sit on a 64 GiB host but be capped to 4 GiB by its cgroup, and the kernel kills it (OOM) if it goes over.

Reading total system memory (`sysinfo` / `/proc/meminfo`) returns the **host** RAM and ignores cgroups, so inside a memory-limited container it over-reports.

`AvailableMemoryMB()` instead returns `min(host RAM, cgroup limit)`, so it respects `docker run --memory=..` and Kubernetes limits.

| Environment | host-only reading | this PR |
|---|---|---|
| Bare metal / no limit | host RAM | host RAM |
| Container with memory limit | host RAM (wrong) | cgroup limit |
| macOS / Windows (no cgroup) | host RAM | host RAM |

## Margin default

`--node-memory-reserve` defaults to **4 GiB**, a conservative reserve for the rest of the node. No deeper analysis; it is configurable. Operators with a large `--db-cache-size` or many VMs can raise it.

## Testing

Verified by running the node and reading the startup log
(`Sierra compilation limits`).

| Environment | Config | `availableMemory` | concurrent compilations | Result |
|---|---|---|---|---|
| macOS native | default | 16384 (host) | 10 (CPUs) | boots |
| macOS native | `--max-compilation-memory 4096` | 16384 | 3 | boots |
| macOS native | `--node-memory-reserve 100000` | 16384 | 1 (floored) | boots |
| Docker `--memory=8g` | default | **8192 (cgroup)** | 1 | boots |
| Docker `--memory=6g` | default | **6144 (cgroup)** | 1 (floored) | boots |

The Docker rows confirm the value follows the cgroup limit, not the 16 GiB host.

When the budget fits no compilation the limit floors to 1, so the node boots and compiles one at a time instead of refusing to start.
