### PR TITLE
refactor(networks): store feeder and gateway URLs as *url.URL

### DIFF
--- a/blockchain/networks/network.go
+++ b/blockchain/networks/network.go
@@ -198,11 +198,13 @@ func (n *Network) L2ChainIDFelt() *felt.Felt {
 }
 
 // mustParseURL parses a raw URL and panics on error. It is only used for the
-// hardcoded predefined network URLs, which are always valid.
+// hardcoded predefined network URLs, which are always valid. ParseRequestURI
+// (unlike Parse) rejects relative/scheme-less strings, so a malformed constant
+// fails fast and diagnostically at startup.
 func mustParseURL(rawURL string) *url.URL {
-	u, err := url.Parse(rawURL)
+	u, err := url.ParseRequestURI(rawURL)
 	if err != nil {
-		panic(err)
+		panic(fmt.Sprintf("invalid network URL %q: %v", rawURL, err))
 	}
 	return u
 }

--- a/blockchain/networks/network.go
+++ b/blockchain/networks/network.go
@@ -4,6 +4,7 @@ import (
 	"encoding"
 	"fmt"
 	"math/big"
+	"net/url"
 	"strings"
 
 	"github.com/NethermindEth/juno/core/felt"
@@ -46,8 +47,8 @@ var errUnknownNetwork = fmt.Errorf("unknown network (known: %s)",
 
 type Network struct {
 	Name                string             `json:"name" validate:"required"`
-	FeederURL           string             `json:"feeder_url" validate:"required"`
-	GatewayURL          string             `json:"gateway_url" validate:"required"`
+	FeederURL           *url.URL           `json:"feeder_url" validate:"required"`
+	GatewayURL          *url.URL           `json:"gateway_url" validate:"required"`
 	L1ChainID           *big.Int           `json:"l1_chain_id" validate:"required"`
 	L2ChainID           string             `json:"l2_chain_id" validate:"required"`
 	CoreContractAddress eth.Address        `json:"core_contract_address" validate:"required"`
@@ -73,8 +74,8 @@ var (
 	// The docs states the addresses for each network: https://docs.starknet.io/learn/cheatsheets/chain-info#important-addresses
 	Mainnet = Network{
 		Name:                "mainnet",
-		FeederURL:           "https://feeder.alpha-mainnet.starknet.io/feeder_gateway/",
-		GatewayURL:          "https://alpha-mainnet.starknet.io/gateway/",
+		FeederURL:           mustParseURL("https://feeder.alpha-mainnet.starknet.io/feeder_gateway/"),
+		GatewayURL:          mustParseURL("https://alpha-mainnet.starknet.io/gateway/"),
 		L2ChainID:           "SN_MAIN",
 		L1ChainID:           big.NewInt(1),
 		CoreContractAddress: eth.AddressFromString("0xc662c410C0ECf747543f5bA90660f6ABeBD9C8c4"),
@@ -85,8 +86,8 @@ var (
 	}
 	Goerli = Network{
 		Name:       "goerli",
-		FeederURL:  "https://alpha4.starknet.io/feeder_gateway/",
-		GatewayURL: "https://alpha4.starknet.io/gateway/",
+		FeederURL:  mustParseURL("https://alpha4.starknet.io/feeder_gateway/"),
+		GatewayURL: mustParseURL("https://alpha4.starknet.io/gateway/"),
 		L2ChainID:  "SN_GOERLI",
 		//nolint:mnd
 		L1ChainID:           big.NewInt(5),
@@ -99,8 +100,8 @@ var (
 	}
 	Goerli2 = Network{
 		Name:       "goerli2",
-		FeederURL:  "https://alpha4-2.starknet.io/feeder_gateway/",
-		GatewayURL: "https://alpha4-2.starknet.io/gateway/",
+		FeederURL:  mustParseURL("https://alpha4-2.starknet.io/feeder_gateway/"),
+		GatewayURL: mustParseURL("https://alpha4-2.starknet.io/gateway/"),
 		L2ChainID:  "SN_GOERLI2",
 		//nolint:mnd
 		L1ChainID:           big.NewInt(5),
@@ -112,8 +113,8 @@ var (
 	}
 	Integration = Network{
 		Name:       "integration",
-		FeederURL:  "https://external.integration.starknet.io/feeder_gateway/",
-		GatewayURL: "https://external.integration.starknet.io/gateway/",
+		FeederURL:  mustParseURL("https://external.integration.starknet.io/feeder_gateway/"),
+		GatewayURL: mustParseURL("https://external.integration.starknet.io/gateway/"),
 		L2ChainID:  "SN_GOERLI",
 		//nolint:mnd
 		L1ChainID:           big.NewInt(5),
@@ -126,8 +127,8 @@ var (
 	}
 	Sepolia = Network{
 		Name:       "sepolia",
-		FeederURL:  "https://feeder.alpha-sepolia.starknet.io/feeder_gateway/",
-		GatewayURL: "https://alpha-sepolia.starknet.io/gateway/",
+		FeederURL:  mustParseURL("https://feeder.alpha-sepolia.starknet.io/feeder_gateway/"),
+		GatewayURL: mustParseURL("https://alpha-sepolia.starknet.io/gateway/"),
 		L2ChainID:  "SN_SEPOLIA",
 		//nolint:mnd
 		L1ChainID:           big.NewInt(11155111),
@@ -139,8 +140,8 @@ var (
 	}
 	SepoliaIntegration = Network{
 		Name:       "sepolia-integration",
-		FeederURL:  "https://feeder.integration-sepolia.starknet.io/feeder_gateway/",
-		GatewayURL: "https://integration-sepolia.starknet.io/gateway/",
+		FeederURL:  mustParseURL("https://feeder.integration-sepolia.starknet.io/feeder_gateway/"),
+		GatewayURL: mustParseURL("https://integration-sepolia.starknet.io/gateway/"),
 		L2ChainID:  "SN_INTEGRATION_SEPOLIA",
 		//nolint:mnd
 		L1ChainID:           big.NewInt(11155111),
@@ -194,4 +195,14 @@ func (n *Network) UnmarshalText(text []byte) error {
 
 func (n *Network) L2ChainIDFelt() *felt.Felt {
 	return new(felt.Felt).SetBytes([]byte(n.L2ChainID))
+}
+
+// mustParseURL parses a raw URL and panics on error. It is only used for the
+// hardcoded predefined network URLs, which are always valid.
+func mustParseURL(rawURL string) *url.URL {
+	u, err := url.Parse(rawURL)
+	if err != nil {
+		panic(err)
+	}
+	return u
 }

--- a/blockchain/networks/network.go
+++ b/blockchain/networks/network.go
@@ -197,10 +197,7 @@ func (n *Network) L2ChainIDFelt() *felt.Felt {
 	return new(felt.Felt).SetBytes([]byte(n.L2ChainID))
 }
 
-// mustParseURL parses a raw URL and panics on error. It is only used for the
-// hardcoded predefined network URLs, which are always valid. It enforces the
-// same constraints as custom-network URLs (http/https scheme, non-empty host)
-// so a malformed constant fails fast and diagnostically at startup.
+// mustParseURL parses a raw URL and panics on error.
 func mustParseURL(rawURL string) *url.URL {
 	// ParseRequestURI (unlike Parse) rejects relative/scheme-less strings.
 	u, err := url.ParseRequestURI(rawURL)

--- a/blockchain/networks/network.go
+++ b/blockchain/networks/network.go
@@ -198,13 +198,21 @@ func (n *Network) L2ChainIDFelt() *felt.Felt {
 }
 
 // mustParseURL parses a raw URL and panics on error. It is only used for the
-// hardcoded predefined network URLs, which are always valid. ParseRequestURI
-// (unlike Parse) rejects relative/scheme-less strings, so a malformed constant
-// fails fast and diagnostically at startup.
+// hardcoded predefined network URLs, which are always valid. It enforces the
+// same constraints as custom-network URLs (http/https scheme, non-empty host)
+// so a malformed constant fails fast and diagnostically at startup.
 func mustParseURL(rawURL string) *url.URL {
+	// ParseRequestURI (unlike Parse) rejects relative/scheme-less strings.
 	u, err := url.ParseRequestURI(rawURL)
 	if err != nil {
 		panic(fmt.Sprintf("invalid network URL %q: %v", rawURL, err))
+	}
+	if u.Scheme != "http" && u.Scheme != "https" {
+		panic(fmt.Sprintf("invalid network URL %q: must use http or https scheme, got %s",
+			rawURL, u.Scheme))
+	}
+	if u.Host == "" {
+		panic(fmt.Sprintf("invalid network URL %q: must have a host", rawURL))
 	}
 	return u
 }

--- a/blockchain/networks/network_test.go
+++ b/blockchain/networks/network_test.go
@@ -42,8 +42,8 @@ func TestNetwork(t *testing.T) {
 
 		for _, tc := range testCases {
 			t.Run(fmt.Sprintf("Network %v", tc.network), func(t *testing.T) {
-				assert.Equal(t, tc.feederURL, tc.network.FeederURL)
-				assert.Equal(t, tc.gatewayURL, tc.network.GatewayURL)
+				assert.Equal(t, tc.feederURL, tc.network.FeederURL.String())
+				assert.Equal(t, tc.gatewayURL, tc.network.GatewayURL.String())
 			})
 		}
 	})

--- a/blockchain/networks/network_test.go
+++ b/blockchain/networks/network_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"math/big"
+	"net/url"
 	"strings"
 	"testing"
 
@@ -20,6 +21,13 @@ var networkStrings = map[networks.Network]string{
 	networks.SepoliaIntegration: "sepolia-integration",
 }
 
+func parseURL(t *testing.T, rawURL string) *url.URL {
+	t.Helper()
+	u, err := url.ParseRequestURI(rawURL)
+	require.NoError(t, err)
+	return u
+}
+
 func TestNetwork(t *testing.T) {
 	t.Run("string", func(t *testing.T) {
 		for network, str := range networkStrings {
@@ -29,21 +37,21 @@ func TestNetwork(t *testing.T) {
 	t.Run("feeder and gateway url", func(t *testing.T) {
 		testCases := []struct {
 			network    networks.Network
-			feederURL  string
-			gatewayURL string
+			feederURL  *url.URL
+			gatewayURL *url.URL
 		}{
-			{networks.Mainnet, "https://feeder.alpha-mainnet.starknet.io/feeder_gateway/", "https://alpha-mainnet.starknet.io/gateway/"},
-			{networks.Goerli, "https://alpha4.starknet.io/feeder_gateway/", "https://alpha4.starknet.io/gateway/"},
-			{networks.Goerli2, "https://alpha4-2.starknet.io/feeder_gateway/", "https://alpha4-2.starknet.io/gateway/"},
-			{networks.Integration, "https://external.integration.starknet.io/feeder_gateway/", "https://external.integration.starknet.io/gateway/"},
-			{networks.Sepolia, "https://feeder.alpha-sepolia.starknet.io/feeder_gateway/", "https://alpha-sepolia.starknet.io/gateway/"},
-			{networks.SepoliaIntegration, "https://feeder.integration-sepolia.starknet.io/feeder_gateway/", "https://integration-sepolia.starknet.io/gateway/"},
+			{networks.Mainnet, parseURL(t, "https://feeder.alpha-mainnet.starknet.io/feeder_gateway/"), parseURL(t, "https://alpha-mainnet.starknet.io/gateway/")},
+			{networks.Goerli, parseURL(t, "https://alpha4.starknet.io/feeder_gateway/"), parseURL(t, "https://alpha4.starknet.io/gateway/")},
+			{networks.Goerli2, parseURL(t, "https://alpha4-2.starknet.io/feeder_gateway/"), parseURL(t, "https://alpha4-2.starknet.io/gateway/")},
+			{networks.Integration, parseURL(t, "https://external.integration.starknet.io/feeder_gateway/"), parseURL(t, "https://external.integration.starknet.io/gateway/")},
+			{networks.Sepolia, parseURL(t, "https://feeder.alpha-sepolia.starknet.io/feeder_gateway/"), parseURL(t, "https://alpha-sepolia.starknet.io/gateway/")},
+			{networks.SepoliaIntegration, parseURL(t, "https://feeder.integration-sepolia.starknet.io/feeder_gateway/"), parseURL(t, "https://integration-sepolia.starknet.io/gateway/")},
 		}
 
 		for _, tc := range testCases {
 			t.Run(fmt.Sprintf("Network %v", tc.network), func(t *testing.T) {
-				assert.Equal(t, tc.feederURL, tc.network.FeederURL.String())
-				assert.Equal(t, tc.gatewayURL, tc.network.GatewayURL.String())
+				assert.Equal(t, tc.feederURL, tc.network.FeederURL)
+				assert.Equal(t, tc.gatewayURL, tc.network.GatewayURL)
 			})
 		}
 	})

--- a/clients/gateway/gateway.go
+++ b/clients/gateway/gateway.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
 	"strings"
 	"time"
 
@@ -63,10 +64,9 @@ func (c *Client) WithListener(l EventListener) *Client {
 	return c
 }
 
-func NewClient(gatewayURL string, logger log.StructuredLogger) *Client {
-	gatewayURL = strings.TrimSuffix(gatewayURL, "/")
+func NewClient(gatewayURL *url.URL, logger log.StructuredLogger) *Client {
 	return &Client{
-		url: gatewayURL,
+		url: strings.TrimSuffix(gatewayURL.String(), "/"),
 		client: &http.Client{
 			Timeout: time.Minute,
 		},

--- a/clients/gateway/gateway.go
+++ b/clients/gateway/gateway.go
@@ -10,7 +10,6 @@ import (
 	"io"
 	"net/http"
 	"net/url"
-	"strings"
 	"time"
 
 	"github.com/NethermindEth/juno/utils/log"
@@ -41,7 +40,7 @@ var (
 const gzipMinSize = 1024
 
 type Client struct {
-	url       string
+	url       *url.URL
 	client    *http.Client
 	listener  EventListener
 	logger    log.StructuredLogger
@@ -66,7 +65,7 @@ func (c *Client) WithListener(l EventListener) *Client {
 
 func NewClient(gatewayURL *url.URL, logger log.StructuredLogger) *Client {
 	return &Client{
-		url: strings.TrimSuffix(gatewayURL.String(), "/"),
+		url: gatewayURL,
 		client: &http.Client{
 			Timeout: time.Minute,
 		},
@@ -76,7 +75,7 @@ func NewClient(gatewayURL *url.URL, logger log.StructuredLogger) *Client {
 }
 
 func (c *Client) AddTransaction(ctx context.Context, txn json.RawMessage) (json.RawMessage, error) {
-	return c.post(ctx, c.url+"/add_transaction", txn)
+	return c.post(ctx, c.url.JoinPath("add_transaction").String(), txn)
 }
 
 // post performs additional utility function over doPost method

--- a/clients/gateway/test_gateway.go
+++ b/clients/gateway/test_gateway.go
@@ -6,11 +6,13 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"testing"
 
 	"github.com/NethermindEth/juno/core/felt"
 	"github.com/NethermindEth/juno/utils/log"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 // NewTestClient returns a client and a function to close a test server.
@@ -20,7 +22,10 @@ func NewTestClient(t *testing.T) *Client {
 	apiKey := "API_KEY"
 	t.Cleanup(srv.Close)
 
-	return NewClient(srv.URL, log.NewNopZapLogger()).WithUserAgent(ua).WithAPIKey(apiKey)
+	gatewayURL, err := url.Parse(srv.URL)
+	require.NoError(t, err)
+
+	return NewClient(gatewayURL, log.NewNopZapLogger()).WithUserAgent(ua).WithAPIKey(apiKey)
 }
 
 func newTestServer(t *testing.T) *httptest.Server {

--- a/cmd/juno/juno.go
+++ b/cmd/juno/juno.go
@@ -439,14 +439,16 @@ func NewCmd(config *node.Config, run func(*cobra.Command, []string) error) *cobr
 				return fmt.Errorf("invalid %s:%v, must be uint array of length 2 (e.g. `0,100`)", cnUnverifiableRangeF, unverifRange)
 			}
 
-			feederURL := v.GetString(cnFeederURLF)
-			gatewayURL := v.GetString(cnGatewayURLF)
+			rawFeederURL := v.GetString(cnFeederURLF)
+			rawGatewayURL := v.GetString(cnGatewayURLF)
 
-			if err := validateHTTPURL(feederURL); err != nil {
-				return fmt.Errorf("invalid feeder URL %s: %w", feederURL, err)
+			feederURL, err := parseHTTPURL(rawFeederURL)
+			if err != nil {
+				return fmt.Errorf("invalid feeder URL %s: %w", rawFeederURL, err)
 			}
-			if err := validateHTTPURL(gatewayURL); err != nil {
-				return fmt.Errorf("invalid gateway URL %s: %w", gatewayURL, err)
+			gatewayURL, err := parseHTTPURL(rawGatewayURL)
+			if err != nil {
+				return fmt.Errorf("invalid gateway URL %s: %w", rawGatewayURL, err)
 			}
 
 			config.Network = networks.Network{
@@ -703,17 +705,17 @@ func NewCmd(config *node.Config, run func(*cobra.Command, []string) error) *cobr
 	return junoCmd
 }
 
-func validateHTTPURL(rawURL string) error {
+func parseHTTPURL(rawURL string) (*url.URL, error) {
 	// rejects relative / scheme-less strings
 	u, err := url.ParseRequestURI(rawURL)
 	if err != nil {
-		return err
+		return nil, err
 	}
 	if u.Scheme != "http" && u.Scheme != "https" {
-		return fmt.Errorf("URL must use http or https scheme, got %s", u.Scheme)
+		return nil, fmt.Errorf("URL must use http or https scheme, got %s", u.Scheme)
 	}
 	if u.Host == "" {
-		return errors.New("URL must have a host")
+		return nil, errors.New("URL must have a host")
 	}
-	return nil
+	return u, nil
 }

--- a/cmd/juno/juno_test.go
+++ b/cmd/juno/juno_test.go
@@ -20,6 +20,13 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func parseURL(t *testing.T, rawURL string) *url.URL {
+	t.Helper()
+	u, err := url.ParseRequestURI(rawURL)
+	require.NoError(t, err)
+	return u
+}
+
 func TestConfigPrecedence(t *testing.T) {
 	pwd, err := os.Getwd()
 	require.NoError(t, err)
@@ -38,14 +45,10 @@ func TestConfigPrecedence(t *testing.T) {
 	defaultDBPath := filepath.Join(pwd, "juno")
 	defaultCoreContractAddress := eth.AddressFromString("0xc662c410C0ECf747543f5bA90660f6ABeBD9C8c4")
 	defaultNetwork := networks.Mainnet
-	customFeederURL, err := url.Parse("http://awesome.feeder")
-	require.NoError(t, err)
-	customGatewayURL, err := url.Parse("http://awesome.gateway")
-	require.NoError(t, err)
 	defaultCustomNetwork := networks.Network{
 		Name:                "custom",
-		FeederURL:           customFeederURL,
-		GatewayURL:          customGatewayURL,
+		FeederURL:           parseURL(t, "http://awesome.feeder"),
+		GatewayURL:          parseURL(t, "http://awesome.gateway"),
 		L2ChainID:           "SN_AWESOME",
 		L1ChainID:           new(big.Int).SetUint64(1),
 		CoreContractAddress: defaultCoreContractAddress,
@@ -985,8 +988,8 @@ func TestCustomNetworkURLValidation(t *testing.T) {
 				return
 			}
 			require.NoError(t, err)
-			assert.Equal(t, tc.feeder, config.Network.FeederURL.String())
-			assert.Equal(t, tc.gateway, config.Network.GatewayURL.String())
+			assert.Equal(t, parseURL(t, tc.feeder), config.Network.FeederURL)
+			assert.Equal(t, parseURL(t, tc.gateway), config.Network.GatewayURL)
 		})
 	}
 }

--- a/cmd/juno/juno_test.go
+++ b/cmd/juno/juno_test.go
@@ -3,6 +3,7 @@ package main_test
 import (
 	"math"
 	"math/big"
+	"net/url"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -37,10 +38,14 @@ func TestConfigPrecedence(t *testing.T) {
 	defaultDBPath := filepath.Join(pwd, "juno")
 	defaultCoreContractAddress := eth.AddressFromString("0xc662c410C0ECf747543f5bA90660f6ABeBD9C8c4")
 	defaultNetwork := networks.Mainnet
+	customFeederURL, err := url.Parse("http://awesome.feeder")
+	require.NoError(t, err)
+	customGatewayURL, err := url.Parse("http://awesome.gateway")
+	require.NoError(t, err)
 	defaultCustomNetwork := networks.Network{
 		Name:                "custom",
-		FeederURL:           "http://awesome.feeder",
-		GatewayURL:          "http://awesome.gateway",
+		FeederURL:           customFeederURL,
+		GatewayURL:          customGatewayURL,
 		L2ChainID:           "SN_AWESOME",
 		L1ChainID:           new(big.Int).SetUint64(1),
 		CoreContractAddress: defaultCoreContractAddress,
@@ -980,8 +985,8 @@ func TestCustomNetworkURLValidation(t *testing.T) {
 				return
 			}
 			require.NoError(t, err)
-			assert.Equal(t, tc.feeder, config.Network.FeederURL)
-			assert.Equal(t, tc.gateway, config.Network.GatewayURL)
+			assert.Equal(t, tc.feeder, config.Network.FeederURL.String())
+			assert.Equal(t, tc.gateway, config.Network.GatewayURL.String())
 		})
 	}
 }

--- a/node/node.go
+++ b/node/node.go
@@ -361,6 +361,10 @@ func New(cfg *Config, version string, logLevel *log.Level) (*Node, error) {
 			return nil, fmt.Errorf("invalid gateway timeouts: %w", err)
 		}
 
+		if cfg.Network.FeederURL == nil || cfg.Network.GatewayURL == nil {
+			return nil, fmt.Errorf("network %q has no feeder or gateway URL configured", cfg.Network.Name)
+		}
+
 		client = feeder.NewClient(cfg.Network.FeederURL).
 			WithUserAgent(ua).
 			WithLogger(logger).
@@ -397,7 +401,7 @@ func New(cfg *Config, version string, logLevel *log.Level) (*Node, error) {
 		)
 		synchronizer.WithPlugin(junoPlugin)
 
-		gatewayClient = gateway.NewClient(cfg.Network.GatewayURL.String(), logger).
+		gatewayClient = gateway.NewClient(cfg.Network.GatewayURL, logger).
 			WithUserAgent(ua).
 			WithAPIKey(cfg.GatewayAPIKey)
 

--- a/node/node.go
+++ b/node/node.go
@@ -361,11 +361,7 @@ func New(cfg *Config, version string, logLevel *log.Level) (*Node, error) {
 			return nil, fmt.Errorf("invalid gateway timeouts: %w", err)
 		}
 
-		feederURL, err := url.Parse(cfg.Network.FeederURL)
-		if err != nil {
-			return nil, fmt.Errorf("invalid feeder URL %s: %w", cfg.Network.FeederURL, err)
-		}
-		client = feeder.NewClient(feederURL).
+		client = feeder.NewClient(cfg.Network.FeederURL).
 			WithUserAgent(ua).
 			WithLogger(logger).
 			WithTimeouts(timeouts, fixed).
@@ -401,7 +397,7 @@ func New(cfg *Config, version string, logLevel *log.Level) (*Node, error) {
 		)
 		synchronizer.WithPlugin(junoPlugin)
 
-		gatewayClient = gateway.NewClient(cfg.Network.GatewayURL, logger).
+		gatewayClient = gateway.NewClient(cfg.Network.GatewayURL.String(), logger).
 			WithUserAgent(ua).
 			WithAPIKey(cfg.GatewayAPIKey)
 

--- a/node/node.go
+++ b/node/node.go
@@ -361,8 +361,11 @@ func New(cfg *Config, version string, logLevel *log.Level) (*Node, error) {
 			return nil, fmt.Errorf("invalid gateway timeouts: %w", err)
 		}
 
-		if cfg.Network.FeederURL == nil || cfg.Network.GatewayURL == nil {
-			return nil, fmt.Errorf("network %q has no feeder or gateway URL configured", cfg.Network.Name)
+		if cfg.Network.FeederURL == nil {
+			return nil, fmt.Errorf("network %q has no feeder URL configured", cfg.Network.Name)
+		}
+		if cfg.Network.GatewayURL == nil {
+			return nil, fmt.Errorf("network %q has no gateway URL configured", cfg.Network.Name)
 		}
 
 		client = feeder.NewClient(cfg.Network.FeederURL).


### PR DESCRIPTION
## What

The `Network` type stored its feeder and gateway URLs as plain `string`s. Every consumer that needed an actual URL had to re-parse them, and since #3749 the feeder client takes a `*url.URL`, node startup parsed the string only to hand it straight back.

This changes `Network.FeederURL` and `Network.GatewayURL` to `*url.URL` and drops the redundant conversions:

- Predefined networks build their URLs up front (via a small `mustParseURL` helper).
- Custom-network URLs are parsed and validated once during config load (`validateHTTPURL` -> `parseHTTPURL`, returning the parsed URL).
- `node` no longer re-parses the feeder URL before constructing the client.

No behavioural change.

## Testing

- `go build ./cmd/juno/`
- `go test ./blockchain/networks/... ./cmd/juno/... ./node/... ./clients/...`

Closes #3761