### PR TITLE
refactor(feeder): return values instead of pointers from client methods

### DIFF
--- a/adapters/sn2core/sn2core_test.go
+++ b/adapters/sn2core/sn2core_test.go
@@ -108,7 +108,7 @@ func TestAdaptBlock(t *testing.T) {
 			if test.sig != nil {
 				sig = test.sig.Signature
 			}
-			block, err := sn2core.AdaptBlock(response, sig)
+			block, err := sn2core.AdaptBlock(&response, sig)
 			require.NoError(t, err)
 
 			expectedEventCount := uint64(0)
@@ -172,7 +172,7 @@ func TestStateUpdate(t *testing.T) {
 		t.Run("number "+strconv.FormatUint(number, 10), func(t *testing.T) {
 			response, err := client.StateUpdate(ctx, strconv.FormatUint(number, 10))
 			require.NoError(t, err)
-			feederUpdate, err := sn2core.AdaptStateUpdate(response)
+			feederUpdate, err := sn2core.AdaptStateUpdate(&response)
 			require.NoError(t, err)
 
 			assert.True(t, response.NewRoot.Equal(feederUpdate.NewRoot))
@@ -219,7 +219,7 @@ func TestStateUpdate(t *testing.T) {
 		t.Run("declared Cairo0 classes", func(t *testing.T) {
 			feederUpdate, err := integClient.StateUpdate(ctx, "283746")
 			require.NoError(t, err)
-			update, err := sn2core.AdaptStateUpdate(feederUpdate)
+			update, err := sn2core.AdaptStateUpdate(&feederUpdate)
 			require.NoError(t, err)
 			assert.NotEmpty(t, update.StateDiff.DeclaredV0Classes)
 			assert.Empty(t, update.StateDiff.DeclaredV1Classes)
@@ -229,7 +229,7 @@ func TestStateUpdate(t *testing.T) {
 		t.Run("declared Cairo1 classes", func(t *testing.T) {
 			feederUpdate, err := integClient.StateUpdate(ctx, "283364")
 			require.NoError(t, err)
-			update, err := sn2core.AdaptStateUpdate(feederUpdate)
+			update, err := sn2core.AdaptStateUpdate(&feederUpdate)
 			require.NoError(t, err)
 			assert.Empty(t, update.StateDiff.DeclaredV0Classes)
 			assert.NotEmpty(t, update.StateDiff.DeclaredV1Classes)
@@ -239,7 +239,7 @@ func TestStateUpdate(t *testing.T) {
 		t.Run("replaced classes", func(t *testing.T) {
 			feederUpdate, err := integClient.StateUpdate(ctx, "283428")
 			require.NoError(t, err)
-			update, err := sn2core.AdaptStateUpdate(feederUpdate)
+			update, err := sn2core.AdaptStateUpdate(&feederUpdate)
 			require.NoError(t, err)
 			assert.Empty(t, update.StateDiff.DeclaredV0Classes)
 			assert.Empty(t, update.StateDiff.DeclaredV1Classes)
@@ -571,7 +571,7 @@ func TestClassV1(t *testing.T) {
 			compiled, err := client.CasmClassDefinition(t.Context(), classHash)
 			require.NoError(t, err)
 
-			v1Class, err := sn2core.AdaptSierraClass(feederClass.Sierra, compiled)
+			v1Class, err := sn2core.AdaptSierraClass(feederClass.Sierra, &compiled)
 			require.NoError(t, err)
 
 			assert.Equal(t, feederClass.Sierra.Abi, v1Class.Abi)

--- a/clients/feeder/feeder.go
+++ b/clients/feeder/feeder.go
@@ -64,7 +64,7 @@ type Reader interface {
 		blockIdentifier string,
 		knownTransactionCount uint64,
 	) (starknet.PreConfirmedUpdate, uint64, error)
-	PublicKey(ctx context.Context) (*felt.Felt, error)
+	PublicKey(ctx context.Context) (felt.Felt, error)
 	Signature(ctx context.Context, blockID string) (starknet.Signature, error)
 	StateUpdate(ctx context.Context, blockID string) (starknet.StateUpdate, error)
 	StateUpdateWithBlockAndSignature(
@@ -277,24 +277,24 @@ func (c *Client) CasmClassDefinition(
 		blockNumberArg: "latest",
 	})
 
-	var class starknet.CasmClass
 	body, err := c.get(ctx, queryURL)
 	if err != nil {
-		return class, err
+		return starknet.CasmClass{}, err
 	}
 	defer body.Close()
 
 	definition, err := io.ReadAll(body)
 	if err != nil {
-		return class, err
+		return starknet.CasmClass{}, err
 	}
 
 	if deprecated, _ := starknet.IsDeprecatedCompiledClassDefinition(definition); deprecated {
-		return class, ErrDeprecatedCompiledClass
+		return starknet.CasmClass{}, ErrDeprecatedCompiledClass
 	}
 
+	var class starknet.CasmClass
 	if err = json.Unmarshal(definition, &class); err != nil {
-		return class, err
+		return starknet.CasmClass{}, err
 	}
 	return class, nil
 }
@@ -316,15 +316,15 @@ func (c *Client) FeeTokenAddresses(ctx context.Context) (starknet.FeeTokenAddres
 	return doRequest[starknet.FeeTokenAddresses](ctx, c, queryURL)
 }
 
-func (c *Client) PublicKey(ctx context.Context) (*felt.Felt, error) {
+func (c *Client) PublicKey(ctx context.Context) (felt.Felt, error) {
 	queryURL := buildQueryString(c.url, "get_public_key", nil)
 
 	// public key is a hex string
 	publicKey, err := doRequest[starknet.PublicKey](ctx, c, queryURL)
 	if err != nil {
-		return nil, err
+		return felt.Felt{}, err
 	}
-	return felt.NewFromString[felt.Felt](string(publicKey))
+	return felt.FromString[felt.Felt](string(publicKey))
 }
 
 func (c *Client) Signature(ctx context.Context, blockID string) (starknet.Signature, error) {

--- a/clients/feeder/feeder.go
+++ b/clients/feeder/feeder.go
@@ -47,11 +47,11 @@ type Client struct {
 //go:generate mockgen -destination=../../mocks/mock_feeder.go -mock_names Reader=MockFeederReader -package=mocks github.com/NethermindEth/juno/clients/feeder Reader
 //nolint:staticcheck // Transaction() returns the deprecated DeprecatedTransactionStatus type.
 type Reader interface {
-	Block(ctx context.Context, blockID string) (*starknet.Block, error)
+	Block(ctx context.Context, blockID string) (starknet.Block, error)
 	BlockHeader(ctx context.Context, blockID string) (starknet.BlockHeader, error)
-	BlockTrace(ctx context.Context, blockHash string) (*starknet.BlockTrace, error)
-	CasmClassDefinition(ctx context.Context, classHash *felt.Felt) (*starknet.CasmClass, error)
-	ClassDefinition(ctx context.Context, classHash *felt.Felt) (*starknet.ClassDefinition, error)
+	BlockTrace(ctx context.Context, blockHash string) (starknet.BlockTrace, error)
+	CasmClassDefinition(ctx context.Context, classHash *felt.Felt) (starknet.CasmClass, error)
+	ClassDefinition(ctx context.Context, classHash *felt.Felt) (starknet.ClassDefinition, error)
 	FeeTokenAddresses(ctx context.Context) (starknet.FeeTokenAddresses, error)
 	PreConfirmedBlockWithIdentifier(
 		ctx context.Context,
@@ -65,21 +65,21 @@ type Reader interface {
 		knownTransactionCount uint64,
 	) (starknet.PreConfirmedUpdate, uint64, error)
 	PublicKey(ctx context.Context) (*felt.Felt, error)
-	Signature(ctx context.Context, blockID string) (*starknet.Signature, error)
-	StateUpdate(ctx context.Context, blockID string) (*starknet.StateUpdate, error)
+	Signature(ctx context.Context, blockID string) (starknet.Signature, error)
+	StateUpdate(ctx context.Context, blockID string) (starknet.StateUpdate, error)
 	StateUpdateWithBlockAndSignature(
 		ctx context.Context,
 		blockID string,
-	) (*starknet.StateUpdateWithBlockAndSignature, error)
+	) (starknet.StateUpdateWithBlockAndSignature, error)
 	// Deprecated: Use TransactionStatus() instead.
 	Transaction(
 		ctx context.Context,
 		transactionHash *felt.Felt,
-	) (*starknet.DeprecatedTransactionStatus, error)
+	) (starknet.DeprecatedTransactionStatus, error)
 	TransactionStatus(
 		ctx context.Context,
 		transactionHash *felt.Felt,
-	) (*starknet.TransactionStatus, error)
+	) (starknet.TransactionStatus, error)
 }
 
 var _ Reader = (*Client)(nil)
@@ -241,7 +241,7 @@ func (c *Client) get(ctx context.Context, queryURL *url.URL) (io.ReadCloser, err
 	return nil, err
 }
 
-func (c *Client) Block(ctx context.Context, blockID string) (*starknet.Block, error) {
+func (c *Client) Block(ctx context.Context, blockID string) (starknet.Block, error) {
 	queryURL := buildQueryString(c.url, "get_block", map[string]string{
 		blockNumberArg: blockID,
 	})
@@ -257,14 +257,10 @@ func (c *Client) BlockHeader(
 		"headerOnly":   trueStr,
 	})
 
-	header, err := doRequest[starknet.BlockHeader](ctx, c, queryURL)
-	if err != nil {
-		return starknet.BlockHeader{}, err
-	}
-	return *header, err
+	return doRequest[starknet.BlockHeader](ctx, c, queryURL)
 }
 
-func (c *Client) BlockTrace(ctx context.Context, blockHash string) (*starknet.BlockTrace, error) {
+func (c *Client) BlockTrace(ctx context.Context, blockHash string) (starknet.BlockTrace, error) {
 	queryURL := buildQueryString(c.url, "get_block_traces", map[string]string{
 		"blockHash": blockHash,
 	})
@@ -275,37 +271,37 @@ func (c *Client) BlockTrace(ctx context.Context, blockHash string) (*starknet.Bl
 func (c *Client) CasmClassDefinition(
 	ctx context.Context,
 	classHash *felt.Felt,
-) (*starknet.CasmClass, error) {
+) (starknet.CasmClass, error) {
 	queryURL := buildQueryString(c.url, "get_compiled_class_by_class_hash", map[string]string{
 		classHashArg:   classHash.String(),
 		blockNumberArg: "latest",
 	})
 
+	var class starknet.CasmClass
 	body, err := c.get(ctx, queryURL)
 	if err != nil {
-		return nil, err
+		return class, err
 	}
 	defer body.Close()
 
 	definition, err := io.ReadAll(body)
 	if err != nil {
-		return nil, err
+		return class, err
 	}
 
 	if deprecated, _ := starknet.IsDeprecatedCompiledClassDefinition(definition); deprecated {
-		return nil, ErrDeprecatedCompiledClass
+		return class, ErrDeprecatedCompiledClass
 	}
 
-	class := new(starknet.CasmClass)
-	if err = json.Unmarshal(definition, class); err != nil {
-		return nil, err
+	if err = json.Unmarshal(definition, &class); err != nil {
+		return class, err
 	}
 	return class, nil
 }
 
 func (c *Client) ClassDefinition(
 	ctx context.Context, classHash *felt.Felt,
-) (*starknet.ClassDefinition, error) {
+) (starknet.ClassDefinition, error) {
 	queryURL := buildQueryString(c.url, "get_class_by_hash", map[string]string{
 		classHashArg:   classHash.String(),
 		blockNumberArg: "latest",
@@ -317,11 +313,7 @@ func (c *Client) ClassDefinition(
 func (c *Client) FeeTokenAddresses(ctx context.Context) (starknet.FeeTokenAddresses, error) {
 	queryURL := buildQueryString(c.url, "get_contract_addresses", nil)
 
-	addresses, err := doRequest[starknet.FeeTokenAddresses](ctx, c, queryURL)
-	if err != nil {
-		return starknet.FeeTokenAddresses{}, err
-	}
-	return *addresses, err
+	return doRequest[starknet.FeeTokenAddresses](ctx, c, queryURL)
 }
 
 func (c *Client) PublicKey(ctx context.Context) (*felt.Felt, error) {
@@ -332,10 +324,10 @@ func (c *Client) PublicKey(ctx context.Context) (*felt.Felt, error) {
 	if err != nil {
 		return nil, err
 	}
-	return felt.NewFromString[felt.Felt](string(*publicKey))
+	return felt.NewFromString[felt.Felt](string(publicKey))
 }
 
-func (c *Client) Signature(ctx context.Context, blockID string) (*starknet.Signature, error) {
+func (c *Client) Signature(ctx context.Context, blockID string) (starknet.Signature, error) {
 	queryURL := buildQueryString(c.url, "get_signature", map[string]string{
 		blockNumberArg: blockID,
 	})
@@ -343,7 +335,7 @@ func (c *Client) Signature(ctx context.Context, blockID string) (*starknet.Signa
 	return doRequest[starknet.Signature](ctx, c, queryURL)
 }
 
-func (c *Client) StateUpdate(ctx context.Context, blockID string) (*starknet.StateUpdate, error) {
+func (c *Client) StateUpdate(ctx context.Context, blockID string) (starknet.StateUpdate, error) {
 	queryURL := buildQueryString(c.url, "get_state_update", map[string]string{
 		blockNumberArg: blockID,
 	})
@@ -354,7 +346,7 @@ func (c *Client) StateUpdate(ctx context.Context, blockID string) (*starknet.Sta
 func (c *Client) StateUpdateWithBlockAndSignature(
 	ctx context.Context,
 	blockID string,
-) (*starknet.StateUpdateWithBlockAndSignature, error) {
+) (starknet.StateUpdateWithBlockAndSignature, error) {
 	queryURL := buildQueryString(c.url, "get_state_update", map[string]string{
 		blockNumberArg:     blockID,
 		"includeBlock":     trueStr,
@@ -460,7 +452,7 @@ func (c *Client) fetchPreConfirmedUpdate(
 // the full transaction body. Use TransactionStatus() instead.
 func (c *Client) Transaction(
 	ctx context.Context, transactionHash *felt.Felt,
-) (*starknet.DeprecatedTransactionStatus, error) {
+) (starknet.DeprecatedTransactionStatus, error) {
 	queryURL := buildQueryString(c.url, "get_transaction", map[string]string{
 		"transactionHash": transactionHash.String(),
 	})
@@ -473,7 +465,7 @@ func (c *Client) Transaction(
 func (c *Client) TransactionStatus(
 	ctx context.Context,
 	transactionHash *felt.Felt,
-) (*starknet.TransactionStatus, error) {
+) (starknet.TransactionStatus, error) {
 	queryURL := buildQueryString(c.url, "get_transaction_status", map[string]string{
 		"transactionHash": transactionHash.String(),
 	})

--- a/clients/feeder/feeder_test.go
+++ b/clients/feeder/feeder_test.go
@@ -752,7 +752,7 @@ func TestStateUpdate(t *testing.T) {
 	})
 	t.Run("Test block number out of boundary", func(t *testing.T) {
 		stateUpdate, err := client.StateUpdate(t.Context(), "1000000")
-		assert.Nil(t, stateUpdate)
+		assert.Zero(t, stateUpdate)
 		assert.Error(t, err)
 	})
 
@@ -788,7 +788,7 @@ func TestTransaction(t *testing.T) {
 		)
 		actualStatus, err := client.TransactionStatus(t.Context(), transactionHash)
 		require.NoError(t, err)
-		assert.NotNil(t, actualStatus)
+		assert.NotZero(t, actualStatus)
 	})
 	t.Run("Test case when transaction_hash does not exist", func(t *testing.T) {
 		transactionHash := felt.NewUnsafeFromString[felt.Felt]("0xffff")
@@ -804,17 +804,17 @@ func TestBlock(t *testing.T) {
 	t.Run("Test normal case", func(t *testing.T) {
 		actualBlock, err := client.Block(t.Context(), strconv.Itoa(11817))
 		assert.Equal(t, nil, err, "Unexpected error")
-		assert.NotNil(t, actualBlock)
+		assert.NotZero(t, actualBlock)
 	})
 	t.Run("Test block number out of boundary", func(t *testing.T) {
 		actualBlock, err := client.Block(t.Context(), strconv.Itoa(1000000))
-		assert.Nil(t, actualBlock)
+		assert.Zero(t, actualBlock)
 		assert.Error(t, err)
 	})
 	t.Run("Test latest block", func(t *testing.T) {
 		actualBlock, err := client.Block(t.Context(), "latest")
 		assert.Equal(t, nil, err, "Unexpected error")
-		assert.NotNil(t, actualBlock)
+		assert.NotZero(t, actualBlock)
 	})
 }
 
@@ -828,12 +828,12 @@ func TestClassDefinition(t *testing.T) {
 
 		actualClass, err := client.ClassDefinition(t.Context(), classHash)
 		assert.Equal(t, nil, err, "Unexpected error")
-		assert.NotNil(t, actualClass)
+		assert.NotZero(t, actualClass)
 	})
 	t.Run("Test classHash not find", func(t *testing.T) {
 		classHash := felt.NewUnsafeFromString[felt.Felt]("0x000")
 		actualClass, err := client.ClassDefinition(t.Context(), classHash)
-		assert.Nil(t, actualClass)
+		assert.Zero(t, actualClass)
 		assert.Error(t, err)
 	})
 }
@@ -992,12 +992,12 @@ func TestSignature(t *testing.T) {
 	t.Run("Test on unexisting block", func(t *testing.T) {
 		actualSignature, err := client.Signature(t.Context(), strconv.Itoa(10000000000))
 		assert.Error(t, err)
-		assert.Nil(t, actualSignature)
+		assert.Zero(t, actualSignature)
 	})
 	t.Run("Test on latest block", func(t *testing.T) {
 		actualSignature, err := client.Signature(t.Context(), "latest")
 		assert.NoError(t, err)
-		assert.NotNil(t, actualSignature)
+		assert.NotZero(t, actualSignature)
 	})
 }
 
@@ -1065,12 +1065,12 @@ func TestStateUpdateWithBlockAndSignature(t *testing.T) {
 			strconv.Itoa(10000000000),
 		)
 		assert.Error(t, err)
-		assert.Nil(t, actualStateUpdate)
+		assert.Zero(t, actualStateUpdate)
 	})
 	t.Run("Test on latest block", func(t *testing.T) {
 		actualStateUpdate, err := client.StateUpdateWithBlockAndSignature(t.Context(), "latest")
 		assert.NoError(t, err)
-		assert.NotNil(t, actualStateUpdate)
+		assert.NotZero(t, actualStateUpdate)
 	})
 }
 
@@ -1146,7 +1146,7 @@ func TestClientRetryBehavior(t *testing.T) {
 
 		block, err := client.Block(t.Context(), "1")
 		require.NoError(t, err)
-		require.NotNil(t, block)
+		require.NotZero(t, block)
 		require.Equal(t, 3, requestCount)
 	})
 
@@ -1196,7 +1196,7 @@ func TestClientRetryBehavior(t *testing.T) {
 
 		block, err := client.Block(t.Context(), "1")
 		require.NoError(t, err)
-		require.NotNil(t, block)
+		require.NotZero(t, block)
 		require.Equal(t, 2, requestCount)
 	})
 }

--- a/clients/feeder/request.go
+++ b/clients/feeder/request.go
@@ -32,12 +32,13 @@ func doRequest[T any, V Validatable[T]](
 	defer body.Close()
 
 	if err = json.NewDecoder(body).Decode(&result); err != nil {
-		return result, err
+		var zero T
+		return zero, err
 	}
 
-	err = V(&result).Validate()
-	if err != nil {
-		return result, errors.Join(
+	if err = V(&result).Validate(); err != nil {
+		var zero T
+		return zero, errors.Join(
 			ErrInvalidFeederResponse,
 			fmt.Errorf("querying %s: %w", fullURL, err),
 		)

--- a/clients/feeder/request.go
+++ b/clients/feeder/request.go
@@ -23,27 +23,27 @@ func doRequest[T any, V Validatable[T]](
 	ctx context.Context,
 	client *Client,
 	fullURL *url.URL,
-) (*T, error) {
+) (T, error) {
 	var result T
 	body, err := client.get(ctx, fullURL)
 	if err != nil {
-		return nil, err
+		return result, err
 	}
 	defer body.Close()
 
 	if err = json.NewDecoder(body).Decode(&result); err != nil {
-		return nil, err
+		return result, err
 	}
 
 	err = V(&result).Validate()
 	if err != nil {
-		return nil, errors.Join(
+		return result, errors.Join(
 			ErrInvalidFeederResponse,
 			fmt.Errorf("querying %s: %w", fullURL, err),
 		)
 	}
 
-	return &result, nil
+	return result, nil
 }
 
 // buildQueryString builds the full URL with encoded parameters

--- a/consensus/p2p/validator/fixtures_test.go
+++ b/consensus/p2p/validator/fixtures_test.go
@@ -102,15 +102,19 @@ func BuildTestFixture(
 
 	proposer := &common.Address{Elements: ToBytes(*block.Header.SequencerAddress)}
 	concatCounts := calculateConcatCounts(block, stateUpdate)
-	totalGasConsumed := calculateTotalGasConsumed(rawStateUpdate)
+	totalGasConsumed := calculateTotalGasConsumed(&rawStateUpdate)
 
 	proposalInit := buildProposalInit(testCase, proposer)
 	blockInfo := buildBlockInfo(testCase.Height, proposer, block)
 	transactions := buildTransactions(t, gw, block, testCase.TxBatchCount)
-	proposalCommitment := buildProposalCommitment(rawStateUpdate, block, headBlock, proposer, concatCounts, totalGasConsumed)
+	proposalCommitment := buildProposalCommitment(
+		&rawStateUpdate, block, headBlock, proposer, concatCounts, totalGasConsumed,
+	)
 	proposalFin := buildProposalFin(block)
 
-	buildResult := buildBuildResult(t, gw, block, stateUpdate, rawStateUpdate, concatCounts, totalGasConsumed)
+	buildResult := buildBuildResult(
+		t, gw, block, stateUpdate, &rawStateUpdate, concatCounts, totalGasConsumed,
+	)
 
 	proposal := buildProposal(testCase.Round, testCase.ValidRound, block)
 

--- a/mocks/mock_feeder.go
+++ b/mocks/mock_feeder.go
@@ -164,10 +164,10 @@ func (mr *MockFeederReaderMockRecorder) PreConfirmedBlockWithIdentifier(ctx, blo
 }
 
 // PublicKey mocks base method.
-func (m *MockFeederReader) PublicKey(ctx context.Context) (*felt.Felt, error) {
+func (m *MockFeederReader) PublicKey(ctx context.Context) (felt.Felt, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "PublicKey", ctx)
-	ret0, _ := ret[0].(*felt.Felt)
+	ret0, _ := ret[0].(felt.Felt)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }

--- a/mocks/mock_feeder.go
+++ b/mocks/mock_feeder.go
@@ -43,10 +43,10 @@ func (m *MockFeederReader) EXPECT() *MockFeederReaderMockRecorder {
 }
 
 // Block mocks base method.
-func (m *MockFeederReader) Block(ctx context.Context, blockID string) (*starknet.Block, error) {
+func (m *MockFeederReader) Block(ctx context.Context, blockID string) (starknet.Block, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Block", ctx, blockID)
-	ret0, _ := ret[0].(*starknet.Block)
+	ret0, _ := ret[0].(starknet.Block)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -73,10 +73,10 @@ func (mr *MockFeederReaderMockRecorder) BlockHeader(ctx, blockID any) *gomock.Ca
 }
 
 // BlockTrace mocks base method.
-func (m *MockFeederReader) BlockTrace(ctx context.Context, blockHash string) (*starknet.BlockTrace, error) {
+func (m *MockFeederReader) BlockTrace(ctx context.Context, blockHash string) (starknet.BlockTrace, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "BlockTrace", ctx, blockHash)
-	ret0, _ := ret[0].(*starknet.BlockTrace)
+	ret0, _ := ret[0].(starknet.BlockTrace)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -88,10 +88,10 @@ func (mr *MockFeederReaderMockRecorder) BlockTrace(ctx, blockHash any) *gomock.C
 }
 
 // CasmClassDefinition mocks base method.
-func (m *MockFeederReader) CasmClassDefinition(ctx context.Context, classHash *felt.Felt) (*starknet.CasmClass, error) {
+func (m *MockFeederReader) CasmClassDefinition(ctx context.Context, classHash *felt.Felt) (starknet.CasmClass, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CasmClassDefinition", ctx, classHash)
-	ret0, _ := ret[0].(*starknet.CasmClass)
+	ret0, _ := ret[0].(starknet.CasmClass)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -103,10 +103,10 @@ func (mr *MockFeederReaderMockRecorder) CasmClassDefinition(ctx, classHash any) 
 }
 
 // ClassDefinition mocks base method.
-func (m *MockFeederReader) ClassDefinition(ctx context.Context, classHash *felt.Felt) (*starknet.ClassDefinition, error) {
+func (m *MockFeederReader) ClassDefinition(ctx context.Context, classHash *felt.Felt) (starknet.ClassDefinition, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ClassDefinition", ctx, classHash)
-	ret0, _ := ret[0].(*starknet.ClassDefinition)
+	ret0, _ := ret[0].(starknet.ClassDefinition)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -179,10 +179,10 @@ func (mr *MockFeederReaderMockRecorder) PublicKey(ctx any) *gomock.Call {
 }
 
 // Signature mocks base method.
-func (m *MockFeederReader) Signature(ctx context.Context, blockID string) (*starknet.Signature, error) {
+func (m *MockFeederReader) Signature(ctx context.Context, blockID string) (starknet.Signature, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Signature", ctx, blockID)
-	ret0, _ := ret[0].(*starknet.Signature)
+	ret0, _ := ret[0].(starknet.Signature)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -194,10 +194,10 @@ func (mr *MockFeederReaderMockRecorder) Signature(ctx, blockID any) *gomock.Call
 }
 
 // StateUpdate mocks base method.
-func (m *MockFeederReader) StateUpdate(ctx context.Context, blockID string) (*starknet.StateUpdate, error) {
+func (m *MockFeederReader) StateUpdate(ctx context.Context, blockID string) (starknet.StateUpdate, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "StateUpdate", ctx, blockID)
-	ret0, _ := ret[0].(*starknet.StateUpdate)
+	ret0, _ := ret[0].(starknet.StateUpdate)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -209,10 +209,10 @@ func (mr *MockFeederReaderMockRecorder) StateUpdate(ctx, blockID any) *gomock.Ca
 }
 
 // StateUpdateWithBlockAndSignature mocks base method.
-func (m *MockFeederReader) StateUpdateWithBlockAndSignature(ctx context.Context, blockID string) (*starknet.StateUpdateWithBlockAndSignature, error) {
+func (m *MockFeederReader) StateUpdateWithBlockAndSignature(ctx context.Context, blockID string) (starknet.StateUpdateWithBlockAndSignature, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "StateUpdateWithBlockAndSignature", ctx, blockID)
-	ret0, _ := ret[0].(*starknet.StateUpdateWithBlockAndSignature)
+	ret0, _ := ret[0].(starknet.StateUpdateWithBlockAndSignature)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -224,10 +224,10 @@ func (mr *MockFeederReaderMockRecorder) StateUpdateWithBlockAndSignature(ctx, bl
 }
 
 // Transaction mocks base method.
-func (m *MockFeederReader) Transaction(ctx context.Context, transactionHash *felt.Felt) (*starknet.DeprecatedTransactionStatus, error) {
+func (m *MockFeederReader) Transaction(ctx context.Context, transactionHash *felt.Felt) (starknet.DeprecatedTransactionStatus, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Transaction", ctx, transactionHash)
-	ret0, _ := ret[0].(*starknet.DeprecatedTransactionStatus)
+	ret0, _ := ret[0].(starknet.DeprecatedTransactionStatus)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -239,10 +239,10 @@ func (mr *MockFeederReaderMockRecorder) Transaction(ctx, transactionHash any) *g
 }
 
 // TransactionStatus mocks base method.
-func (m *MockFeederReader) TransactionStatus(ctx context.Context, transactionHash *felt.Felt) (*starknet.TransactionStatus, error) {
+func (m *MockFeederReader) TransactionStatus(ctx context.Context, transactionHash *felt.Felt) (starknet.TransactionStatus, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "TransactionStatus", ctx, transactionHash)
-	ret0, _ := ret[0].(*starknet.TransactionStatus)
+	ret0, _ := ret[0].(starknet.TransactionStatus)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }

--- a/rpc/v10/trace.go
+++ b/rpc/v10/trace.go
@@ -472,7 +472,7 @@ func (h *Handler) fetchTracesFromFeederGateway(
 		return nil, rpccore.ErrUnexpectedError.CloneWithData(err.Error())
 	}
 
-	traces, err := AdaptFeederBlockTrace(block, blockTrace)
+	traces, err := AdaptFeederBlockTrace(block, &blockTrace)
 	if err != nil {
 		return nil, rpccore.ErrUnexpectedError.CloneWithData(err.Error())
 	}

--- a/rpc/v10/transaction.go
+++ b/rpc/v10/transaction.go
@@ -302,7 +302,7 @@ func (h *Handler) TransactionStatus(
 			}
 		}
 
-		status, err := AdaptTransactionStatus(txStatus)
+		status, err := AdaptTransactionStatus(&txStatus)
 		if err != nil {
 			if !errors.Is(err, ErrTransactionNotFound) {
 				h.logger.Error("Failed to adapt transaction status", zap.Error(err))

--- a/rpc/v8/trace.go
+++ b/rpc/v8/trace.go
@@ -294,7 +294,7 @@ func (h *Handler) fetchTracesFromFeederGateway(
 		return nil, rpccore.ErrUnexpectedError.CloneWithData(err.Error())
 	}
 
-	traces, err := AdaptFeederBlockTrace(rpcBlock, blockTrace)
+	traces, err := AdaptFeederBlockTrace(rpcBlock, &blockTrace)
 	if err != nil {
 		return nil, rpccore.ErrUnexpectedError.CloneWithData(err.Error())
 	}

--- a/rpc/v8/transaction.go
+++ b/rpc/v8/transaction.go
@@ -790,7 +790,7 @@ func (h *Handler) TransactionStatus(ctx context.Context, hash felt.Felt) (*Trans
 			}
 		}
 
-		status, err := adaptTransactionStatus(txStatus)
+		status, err := adaptTransactionStatus(&txStatus)
 		if err != nil {
 			if !errors.Is(err, errTransactionNotFound) {
 				h.logger.Error("Failed to adapt transaction status", zap.Error(err))

--- a/rpc/v9/trace.go
+++ b/rpc/v9/trace.go
@@ -463,7 +463,7 @@ func (h *Handler) fetchTracesFromFeederGateway(
 		return nil, rpccore.ErrUnexpectedError.CloneWithData(err.Error())
 	}
 
-	traces, err := AdaptFeederBlockTrace(rpcBlock, blockTrace)
+	traces, err := AdaptFeederBlockTrace(rpcBlock, &blockTrace)
 	if err != nil {
 		return nil, rpccore.ErrUnexpectedError.CloneWithData(err.Error())
 	}

--- a/rpc/v9/transaction.go
+++ b/rpc/v9/transaction.go
@@ -866,7 +866,7 @@ func (h *Handler) TransactionStatus(
 			}
 		}
 
-		status, err := AdaptTransactionStatus(txStatus)
+		status, err := AdaptTransactionStatus(&txStatus)
 		if err != nil {
 			if !errors.Is(err, ErrTransactionNotFound) {
 				h.logger.Error("Failed to adapt transaction status", zap.Error(err))

--- a/starknet/compiler/compiler_test.go
+++ b/starknet/compiler/compiler_test.go
@@ -39,7 +39,7 @@ func TestCompileFFI(t *testing.T) {
 		compiledDef, err := cl.CasmClassDefinition(t.Context(), classHash)
 		require.NoError(t, err)
 
-		expectedCompiled, err := sn2core.AdaptCompiledClass(compiledDef)
+		expectedCompiled, err := sn2core.AdaptCompiledClass(&compiledDef)
 		require.NoError(t, err)
 
 		res, err := compiler.CompileFFI(classDef.Sierra)

--- a/starknetdata/feeder/feeder.go
+++ b/starknetdata/feeder/feeder.go
@@ -64,7 +64,7 @@ func (f *Feeder) block(ctx context.Context, blockID string) (*core.Block, error)
 		return nil, fmt.Errorf("get signature for block %q: %v", blockID, err)
 	}
 
-	return sn2core.AdaptBlock(response, sig.Signature)
+	return sn2core.AdaptBlock(&response, sig.Signature)
 }
 
 // Deprecated: Transaction gets the transaction for a given transaction hash from the feeder,
@@ -98,7 +98,14 @@ func (f *Feeder) Class(ctx context.Context, classHash *felt.Felt) (core.ClassDef
 			return nil, cErr
 		}
 
-		return sn2core.AdaptSierraClass(response.Sierra, casmClass)
+		// A deprecated compiled class yields no CASM; pass nil so the adapter
+		// treats the Sierra class as having no compiled counterpart.
+		var compiledClass *starknet.CasmClass
+		if cErr == nil {
+			compiledClass = &casmClass
+		}
+
+		return sn2core.AdaptSierraClass(response.Sierra, compiledClass)
 	case response.DeprecatedCairo != nil:
 		return sn2core.AdaptDeprecatedCairoClass(response.DeprecatedCairo)
 	default:
@@ -112,7 +119,7 @@ func (f *Feeder) stateUpdate(ctx context.Context, blockID string) (*core.StateUp
 		return nil, err
 	}
 
-	return sn2core.AdaptStateUpdate(response)
+	return sn2core.AdaptStateUpdate(&response)
 }
 
 // StateUpdate gets the state update for a given block number from the feeder,

--- a/starknetdata/feeder/feeder_test.go
+++ b/starknetdata/feeder/feeder_test.go
@@ -34,7 +34,7 @@ func TestBlockByNumber(t *testing.T) {
 			require.NoError(t, err)
 			block, err := adapter.BlockByNumber(ctx, number)
 			require.NoError(t, err)
-			adaptedResponse, err := sn2core.AdaptBlock(response, sig.Signature)
+			adaptedResponse, err := sn2core.AdaptBlock(&response, sig.Signature)
 			require.NoError(t, err)
 			assert.Equal(t, adaptedResponse, block)
 		})
@@ -52,7 +52,7 @@ func TestBlockLatest(t *testing.T) {
 	require.NoError(t, err)
 	block, err := adapter.BlockLatest(ctx)
 	require.NoError(t, err)
-	adaptedResponse, err := sn2core.AdaptBlock(response, sig.Signature)
+	adaptedResponse, err := sn2core.AdaptBlock(&response, sig.Signature)
 	require.NoError(t, err)
 	assert.Equal(t, adaptedResponse, block)
 }
@@ -87,7 +87,7 @@ func TestStateUpdate(t *testing.T) {
 			feederUpdate, err := adapter.StateUpdate(ctx, number)
 			require.NoError(t, err)
 
-			adaptedResponse, err := sn2core.AdaptStateUpdate(response)
+			adaptedResponse, err := sn2core.AdaptStateUpdate(&response)
 			require.NoError(t, err)
 			assert.Equal(t, adaptedResponse, feederUpdate)
 		})
@@ -221,13 +221,15 @@ func TestClassV1(t *testing.T) {
 		feederClass, err := client.ClassDefinition(t.Context(), test.classHash)
 		require.NoError(t, err)
 		casmClass, err := client.CasmClassDefinition(t.Context(), test.classHash)
+		var compiledClass *starknet.CasmClass
 		if test.hasCompiledClass {
 			require.NoError(t, err)
+			compiledClass = &casmClass
 		} else {
 			require.EqualError(t, err, "deprecated compiled class")
 		}
 
-		adaptedResponse, err := sn2core.AdaptSierraClass(feederClass.Sierra, casmClass)
+		adaptedResponse, err := sn2core.AdaptSierraClass(feederClass.Sierra, compiledClass)
 		require.NoError(t, err)
 		assert.Equal(t, adaptedResponse, class)
 


### PR DESCRIPTION
## Description

Closes #3686.

Makes the `clients/feeder` `Client` methods (and the shared `doRequest` helper) return values instead of pointers, and updates the `Reader` interface and all call sites accordingly.

### What changed
- `doRequest[T, V]` now returns `(T, error)` instead of `(*T, error)`.
- All `Client` methods that previously returned `*starknet.X` now return `starknet.X`; the `Reader` interface signatures match.
- `BlockHeader` and `FeeTokenAddresses`, which previously dereferenced the pointer, are simplified to return the `doRequest` result directly.
- `CasmClassDefinition` keeps its deprecated-class semantics: it still signals "no compiled class" via `ErrDeprecatedCompiledClass`, and consumers pass `nil` to the adapter on that path instead of relying on a nil pointer return.
- Consumers updated to take the address locally where a pointer is still required: the `starknetdata/feeder` adapter, the `rpc/v8|v9|v10` trace/transaction handlers, and the affected tests.
- `mocks/mock_feeder.go` regenerated.

### Notes
- `PublicKey` now also returns `felt.Felt` by value (changed during review — it originally kept the pointer return, but there was no reason for the exception). `PreConfirmedBlockWithIdentifier` still returns the `starknet.PreConfirmedUpdate` interface, which is unchanged.

### Testing
- `golangci-lint` (diff + full): clean
- `make lint`: pass
- `go test ./...`: pass
