### PR TITLE
refactor(starknet): replace BlockStatus string with typed enum

### DIFF
--- a/clients/feeder/feeder_test.go
+++ b/clients/feeder/feeder_test.go
@@ -480,7 +480,7 @@ func TestBlockWithoutSequencerAddressUnmarshal(t *testing.T) {
 		"0x3df24be7b5fed6b41de08d38686b6142944119ca2a345c38793590d6804bba4",
 		block.StateRoot.String(),
 	)
-	assert.Equal(t, "ACCEPTED_ON_L2", block.Status)
+	assert.Equal(t, starknet.BlockAcceptedOnL2, block.Status)
 	assert.Equal(t, "0x27ad16775", block.L1GasPriceETH().String())
 	assert.Equal(t, 52, len(block.Transactions))
 	assert.Equal(t, 52, len(block.Receipts))
@@ -510,7 +510,7 @@ func TestBlockWithSequencerAddressUnmarshal(t *testing.T) {
 		"0x541b796ea02703d02ff31459815f65f410ceefe80a4e3499f7ef9ccc36d26ee",
 		block.StateRoot.String(),
 	)
-	assert.Equal(t, "ACCEPTED_ON_L2", block.Status)
+	assert.Equal(t, starknet.BlockAcceptedOnL2, block.Status)
 	assert.Equal(t, "0x31c4e2d75", block.L1GasPriceETH().String())
 	assert.Equal(t, 324, len(block.Transactions))
 	assert.Equal(t, 324, len(block.Receipts))
@@ -548,7 +548,7 @@ func TestBlockHeaderV013Unmarshal(t *testing.T) {
 			"0x2a6b9a8b60e1de80dc50e6b704b415a38e8fd03d82244cec92cbff0821a8975"),
 		block.StateRoot,
 	)
-	require.Equal(t, "ACCEPTED_ON_L2", block.Status)
+	require.Equal(t, starknet.BlockAcceptedOnL2, block.Status)
 	require.Equal(t, felt.NewUnsafeFromString[felt.Felt]("0x3b9aca08"), block.L1GasPriceETH())
 	require.Equal(t, felt.NewUnsafeFromString[felt.Felt]("0x2540be400"), block.L1GasPriceSTRK())
 	require.Equal(t, uint64(1700075354), block.Timestamp)
@@ -1287,7 +1287,7 @@ func TestPreConfirmedBlockLatest(t *testing.T) {
 		full, ok := update.(starknet.PreConfirmedBlock)
 		require.True(t, ok, "expected PreConfirmedBlock, got %T", update)
 		assert.Equal(t, "0x1cbe25d9", full.BlockIdentifier)
-		assert.Equal(t, "PRE_CONFIRMED", full.Status)
+		assert.Equal(t, starknet.BlockPreConfirmed, full.Status)
 		assert.Equal(t, "0.14.2", full.Version)
 		assert.Len(t, full.Transactions, 3)
 	})

--- a/rpc/v10/transaction_test.go
+++ b/rpc/v10/transaction_test.go
@@ -643,7 +643,7 @@ func TestTransactionByHash_MultiplePreConfirmed(t *testing.T) {
 		emptySlice := []*felt.Felt{}
 		block := starknet.PreConfirmedBlock{
 			BlockIdentifier:  fmt.Sprintf("round-%d", blockNumber),
-			Status:           "PRE_CONFIRMED",
+			Status:           starknet.BlockPreConfirmed,
 			Timestamp:        1,
 			Version:          core.Ver0_14_0.String(),
 			SequencerAddress: &felt.One,

--- a/rpc/v9/transaction_test.go
+++ b/rpc/v9/transaction_test.go
@@ -517,7 +517,7 @@ func TestTransactionByHash_MultiplePreConfirmed(t *testing.T) {
 		emptySlice := []*felt.Felt{}
 		block := starknet.PreConfirmedBlock{
 			BlockIdentifier:  fmt.Sprintf("round-%d", blockNumber),
-			Status:           "PRE_CONFIRMED",
+			Status:           starknet.BlockPreConfirmed,
 			Timestamp:        1,
 			Version:          core.Ver0_14_0.String(),
 			SequencerAddress: &felt.One,

--- a/starknet/block.go
+++ b/starknet/block.go
@@ -2,6 +2,7 @@ package starknet
 
 import (
 	"errors"
+	"fmt"
 
 	"github.com/NethermindEth/juno/core/felt"
 )
@@ -12,6 +13,33 @@ import (
 type BlockHeader struct {
 	Hash   *felt.Felt `json:"block_hash"`
 	Number uint64     `json:"block_number"`
+}
+type BlockStatus uint8
+
+const (
+	BlockPending BlockStatus = iota + 1
+	BlockAcceptedOnL1
+	BlockAcceptedOnL2
+	BlockRejected
+	BlockPreConfirmed
+)
+
+func (bs *BlockStatus) UnmarshalText(data []byte) error {
+	switch str := string(data); str {
+	case "ACCEPTED_ON_L2":
+		*bs = BlockAcceptedOnL2
+	case "ACCEPTED_ON_L1":
+		*bs = BlockAcceptedOnL1
+	case "REJECTED":
+		*bs = BlockRejected
+	case "PENDING":
+		*bs = BlockPending
+	case "PRE_CONFIRMED":
+		*bs = BlockPreConfirmed
+	default:
+		return fmt.Errorf("unknown BlockStatus %q", str)
+	}
+	return nil
 }
 
 // TODO: placeholder for now to avoid compiler errors. A proper validation
@@ -31,7 +59,7 @@ type Block struct {
 	ReceiptCommitment     *felt.Felt            `json:"receipt_commitment"`
 	StateDiffCommitment   *felt.Felt            `json:"state_diff_commitment"`
 	StateDiffLength       uint64                `json:"state_diff_length"`
-	Status                string                `json:"status"`
+	Status                BlockStatus           `json:"status"`
 	Transactions          []*Transaction        `json:"transactions"`
 	Timestamp             uint64                `json:"timestamp"`
 	Version               string                `json:"starknet_version"`

--- a/starknet/pre_confirmed_update.go
+++ b/starknet/pre_confirmed_update.go
@@ -53,7 +53,7 @@ type PreConfirmedBlock struct {
 	Transactions          []Transaction         `json:"transactions"`
 	Receipts              []*TransactionReceipt `json:"transaction_receipts"`
 	TransactionStateDiffs []*StateDiff          `json:"transaction_state_diffs"`
-	Status                string                `json:"status"`
+	Status                BlockStatus           `json:"status"`
 	Timestamp             uint64                `json:"timestamp"`
 	Version               string                `json:"starknet_version"`
 	SequencerAddress      *felt.Felt            `json:"sequencer_address"`
@@ -69,8 +69,8 @@ func (pb *PreConfirmedBlock) validate() error {
 	if pb.BlockIdentifier == "" {
 		return errors.New("block_identifier is required")
 	}
-	if pb.Status != "PRE_CONFIRMED" {
-		return fmt.Errorf("invalid status: %s", pb.Status)
+	if pb.Status != BlockPreConfirmed {
+		return fmt.Errorf("invalid status: %d", pb.Status)
 	}
 	if pb.Version == "" {
 		return errors.New("version is required")

--- a/starknet/pre_confirmed_update_test.go
+++ b/starknet/pre_confirmed_update_test.go
@@ -36,7 +36,7 @@ func TestDecodePreConfirmedUpdate(t *testing.T) {
 			full, ok := env.Update.(starknet.PreConfirmedBlock)
 			require.True(t, ok, "expected PreConfirmedBlock, got %T", env.Update)
 			assert.Equal(t, "0x1cbe25d9", full.BlockIdentifier)
-			assert.Equal(t, "PRE_CONFIRMED", full.Status)
+			assert.Equal(t, starknet.BlockPreConfirmed, full.Status)
 			assert.Equal(t, "0.14.2", full.Version)
 			assert.NotZero(t, full.Timestamp)
 			assert.NotNil(t, full.SequencerAddress)
@@ -89,7 +89,7 @@ func TestDecodePreConfirmedUpdate(t *testing.T) {
 			full, ok := env.Update.(starknet.PreConfirmedBlock)
 			require.True(t, ok, "expected PreConfirmedBlock, got %T", env.Update)
 			assert.Equal(t, "0x1857317c", full.BlockIdentifier)
-			assert.Equal(t, "PRE_CONFIRMED", full.Status)
+			assert.Equal(t, starknet.BlockPreConfirmed, full.Status)
 			assert.Equal(t, "0.14.2", full.Version)
 			assert.NotZero(t, full.Timestamp)
 			assert.NotNil(t, full.SequencerAddress)
@@ -178,7 +178,7 @@ func validBlock() starknet.PreConfirmedBlock {
 		Transactions:          []starknet.Transaction{nonEmptyTx()},
 		Receipts:              []*starknet.TransactionReceipt{{}},
 		TransactionStateDiffs: []*starknet.StateDiff{{}},
-		Status:                "PRE_CONFIRMED",
+		Status:                starknet.BlockPreConfirmed,
 		Version:               "0.14.0",
 		SequencerAddress:      felt.NewFromUint64[felt.Felt](0xaa),
 		L1GasPrice:            &starknet.GasPrice{},
@@ -218,7 +218,7 @@ func TestPreConfirmedUpdateEnvelope_Validate(t *testing.T) {
 
 	t.Run("invalid Block propagates validate error", func(t *testing.T) {
 		b := validBlock()
-		b.Status = "ACCEPTED_ON_L2"
+		b.Status = starknet.BlockAcceptedOnL2
 		env := &starknet.PreConfirmedUpdateEnvelope{Update: b}
 		err := env.Validate()
 		require.Error(t, err)
@@ -258,7 +258,7 @@ func TestPreConfirmedBlock_validate(t *testing.T) {
 		},
 		{
 			name:    "wrong status",
-			mutate:  func(b *starknet.PreConfirmedBlock) { b.Status = "ACCEPTED_ON_L2" },
+			mutate:  func(b *starknet.PreConfirmedBlock) { b.Status = starknet.BlockAcceptedOnL2 },
 			wantErr: true,
 		},
 		{

--- a/sync/preconfirmed/chain_storage_test.go
+++ b/sync/preconfirmed/chain_storage_test.go
@@ -773,7 +773,7 @@ func applyBlockWithStorageWrites(
 		Transactions:          txs,
 		Receipts:              receipts,
 		TransactionStateDiffs: stateDiffs,
-		Status:                "PRE_CONFIRMED",
+		Status:                starknet.BlockPreConfirmed,
 		Timestamp:             uint64(time.Now().Unix()),
 		Version:               core.Ver0_14_0.String(),
 		SequencerAddress:      feltOne,

--- a/sync/preconfirmed/poller_test.go
+++ b/sync/preconfirmed/poller_test.go
@@ -63,7 +63,7 @@ func makeTestPreConfirmedBlock(identifier string, txCount int) starknet.PreConfi
 		Transactions:          txs,
 		Receipts:              receipts,
 		TransactionStateDiffs: stateDiffs,
-		Status:                "PRE_CONFIRMED",
+		Status:                starknet.BlockPreConfirmed,
 		Timestamp:             uint64(time.Now().Unix()),
 		Version:               core.Ver0_14_0.String(),
 		SequencerAddress:      feltOne,


### PR DESCRIPTION
- Introduces BlockStatus as a typed uint8 enum in starknet/block.go with constants BlockPending, BlockAcceptedOnL1, BlockAcceptedOnL2, BlockRejected, and BlockPreConfirmed
- Adds UnmarshalText so the feeder JSON response deserialises directly into the enum and invalid status strings now return an error 
- Updates all comparison sites and test assertions to use the typed constants