### PR TITLE
Perf/lazy state reader tries

### DIFF
--- a/core/state/state_reader.go
+++ b/core/state/state_reader.go
@@ -24,21 +24,9 @@ type StateReader struct {
 // NewStateReader creates a read-only view of the state at the given root.
 // Should be used for read operations that don't require state mutations.
 func NewStateReader(stateRoot *felt.Felt, db *StateDB) (*StateReader, error) {
-	contractTrie, err := db.ContractTrie(stateRoot)
-	if err != nil {
-		return nil, err
-	}
-
-	classTrie, err := db.ClassTrie(stateRoot)
-	if err != nil {
-		return nil, err
-	}
-
 	return &StateReader{
-		initRoot:     *stateRoot,
-		db:           db,
-		contractTrie: contractTrie,
-		classTrie:    classTrie,
+		initRoot: *stateRoot,
+		db:       db,
 	}, nil
 }
 
@@ -106,10 +94,24 @@ func (s *StateReader) Class(classHash *felt.Felt) (*core.DeclaredClassDefinition
 }
 
 func (s *StateReader) ClassTrie() (core.TrieReader, error) {
+	if s.classTrie == nil {
+		classTrie, err := s.db.ClassTrie(&s.initRoot)
+		if err != nil {
+			return nil, err
+		}
+		s.classTrie = classTrie
+	}
 	return s.classTrie, nil
 }
 
 func (s *StateReader) ContractTrie() (core.TrieReader, error) {
+	if s.contractTrie == nil {
+		contractTrie, err := s.db.ContractTrie(&s.initRoot)
+		if err != nil {
+			return nil, err
+		}
+		s.contractTrie = contractTrie
+	}
 	return s.contractTrie, nil
 }
 
@@ -138,11 +140,20 @@ func (s *StateReader) CompiledClassHashV2(
 }
 
 func (s *StateReader) Commitment(protocolVersion string) (felt.Felt, error) {
-	contractRoot, err := s.contractTrie.Hash()
+	contractTrie, err := s.ContractTrie()
 	if err != nil {
 		return felt.Felt{}, err
 	}
-	classRoot, err := s.classTrie.Hash()
+	classTrie, err := s.ClassTrie()
+	if err != nil {
+		return felt.Felt{}, err
+	}
+
+	contractRoot, err := contractTrie.Hash()
+	if err != nil {
+		return felt.Felt{}, err
+	}
+	classRoot, err := classTrie.Hash()
 	if err != nil {
 		return felt.Felt{}, err
 	}

--- a/core/state/state_reader.go
+++ b/core/state/state_reader.go
@@ -24,9 +24,13 @@ type StateReader struct {
 // NewStateReader creates a read-only view of the state at the given root.
 // Should be used for read operations that don't require state mutations.
 func NewStateReader(stateRoot *felt.Felt, db *StateDB) (*StateReader, error) {
+	// todo(rdr): change this function to not return an error
 	return &StateReader{
 		initRoot: *stateRoot,
 		db:       db,
+		// Initialized lazily on demand
+		contractTrie: nil,
+		classTrie:    nil,
 	}, nil
 }
 


### PR DESCRIPTION
## Summary

- Lazily construct `StateReader` contract and class tries instead of opening both in `NewStateReader`.
- Keep trie construction on demand for paths that need it, such as storage proofs and state commitment.
- Avoid two unnecessary trie opens for common state-read RPC paths that never access those tries.

## Why

`NewStateReader` previously opened both the contract trie and class trie for every state reader.

RPC methods such as `getStorageAt`, `getClassHashAt`, `getNonce`, and `getClass` read directly from contract, class, or storage accessors. They do not use `ClassTrie()` or `ContractTrie()`.

As a result, every state-read request paid for two unused trie root-node reads/resolves.

## Benchmarks

I ran local benchmarks that exercise the public RPC handler paths with Pebble DB.

| Benchmark         | latency             | latency Δ   | B/op              | B/op Δ  | allocs/op | allocs/op Δ |
|-------------------|--------------------:|------------:|------------------:|--------:|----------:|------------:|
| NonceLatest       | 14.05µs → 9.26µs    | **-34.12%** | 4.008Ki → 2.945Ki | -26.51% | 60 → 34   | -43.33%     |
| ClassHashAtLatest | 14.86µs → 9.23µs    | **-37.87%** | 4.008Ki → 2.945Ki | -26.51% | 60 → 34   | -43.33%     |
| StorageAtLatest   | 14.93µs → 10.06µs   | **-32.63%** | 4.173Ki → 3.109Ki | -25.49% | 64 → 38   | -40.62%     |
| NonceNumber       | 19.89µs → 11.11µs   | **-44.14%** | 4.271Ki → 3.198Ki | -25.11% | 69 → 43   | -37.68%     |
| NonceHash         | 17.19µs → 11.03µs   | **-35.86%** | 4.271Ki → 3.206Ki | -24.93% | 69 → 43   | -37.68%     |