### PR TITLE
perf(state): decode only state root when opening head state

### DIFF
--- a/blockchain/statebackend/statebackend.go
+++ b/blockchain/statebackend/statebackend.go
@@ -19,12 +19,12 @@ func (b *stateBackend) HeadState() (core.StateReader, StateCloser, error) {
 		return nil, nil, err
 	}
 
-	header, err := core.GetBlockHeaderByNumber(b.database, height)
+	stateRoot, err := core.GetGlobalStateRootByBlockNumber(b.database, height)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	st, err := state.NewStateReader(header.GlobalStateRoot, b.stateDB)
+	st, err := state.NewStateReader(stateRoot, b.stateDB)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/core/accessors.go
+++ b/core/accessors.go
@@ -2,6 +2,7 @@ package core
 
 import (
 	"encoding/binary"
+	"errors"
 	"iter"
 
 	"github.com/NethermindEth/juno/core/felt"
@@ -323,6 +324,24 @@ func GetBlockHeaderByNumber(r db.KeyValueReader, blockNum uint64) (*Header, erro
 		return encoder.Unmarshal(data, &header)
 	})
 	return header, err
+}
+
+// Only materialise GlobalStateRoot from the header,
+// callers opening state don't need heavier fields like EventsBloom.
+func GetGlobalStateRootByBlockNumber(r db.KeyValueReader, blockNum uint64) (*felt.Felt, error) {
+	var header struct {
+		GlobalStateRoot *felt.Felt
+	}
+	err := r.Get(db.BlockHeaderByNumberKey(blockNum), func(data []byte) error {
+		return encoder.Unmarshal(data, &header)
+	})
+	if err != nil {
+		return nil, err
+	}
+	if header.GlobalStateRoot == nil {
+		return nil, errors.New("missing GlobalStateRoot in block header")
+	}
+	return header.GlobalStateRoot, nil
 }
 
 func GetBlockHeaderByHash(r db.KeyValueReader, hash *felt.Felt) (*Header, error) {

--- a/core/accessors.go
+++ b/core/accessors.go
@@ -2,7 +2,7 @@ package core
 
 import (
 	"encoding/binary"
-	"errors"
+	"fmt"
 	"iter"
 
 	"github.com/NethermindEth/juno/core/felt"
@@ -326,7 +326,7 @@ func GetBlockHeaderByNumber(r db.KeyValueReader, blockNum uint64) (*Header, erro
 	return header, err
 }
 
-// Only materialise GlobalStateRoot from the header,
+// GetGlobalStateRootByBlockNumber only materialise GlobalStateRoot from the header,
 // callers opening state don't need heavier fields like EventsBloom.
 func GetGlobalStateRootByBlockNumber(r db.KeyValueReader, blockNum uint64) (*felt.Felt, error) {
 	var header struct {
@@ -339,7 +339,7 @@ func GetGlobalStateRootByBlockNumber(r db.KeyValueReader, blockNum uint64) (*fel
 		return nil, err
 	}
 	if header.GlobalStateRoot == nil {
-		return nil, errors.New("missing GlobalStateRoot in block header")
+		return nil, fmt.Errorf("missing GlobalStateRoot in block header %d", blockNum)
 	}
 	return header.GlobalStateRoot, nil
 }

--- a/core/accessors_test.go
+++ b/core/accessors_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/NethermindEth/juno/core/felt"
 	"github.com/NethermindEth/juno/db"
 	"github.com/NethermindEth/juno/db/memory"
+	"github.com/NethermindEth/juno/encoder"
 	adaptfeeder "github.com/NethermindEth/juno/starknetdata/feeder"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -254,5 +255,40 @@ func TestDeleteTransactionsAndReceipts(t *testing.T) {
 		batch := memDB.NewBatch()
 		err := core.DeleteTransactionsAndReceipts(memDB, batch, nonexistentBlockNumber)
 		require.ErrorIs(t, err, db.ErrKeyNotFound)
+	})
+}
+
+func TestGetGlobalStateRootByBlockNumber(t *testing.T) {
+	t.Parallel()
+	memDB, block := setupForTxsAndReceiptsTests(t)
+	require.NoError(t, core.WriteBlockHeaderByNumber(memDB, block.Header))
+
+	t.Run("matches full header decode", func(t *testing.T) {
+		t.Parallel()
+		header, err := core.GetBlockHeaderByNumber(memDB, block.Number)
+		require.NoError(t, err)
+
+		stateRoot, err := core.GetGlobalStateRootByBlockNumber(memDB, block.Number)
+		require.NoError(t, err)
+		assert.Equal(t, header.GlobalStateRoot, stateRoot)
+	})
+
+	t.Run("non-existent block", func(t *testing.T) {
+		t.Parallel()
+		_, err := core.GetGlobalStateRootByBlockNumber(memDB, nonexistentBlockNumber)
+		require.ErrorIs(t, err, db.ErrKeyNotFound)
+	})
+
+	t.Run("missing global state root", func(t *testing.T) {
+		t.Parallel()
+		partialHeaderDB := memory.New()
+		data, err := encoder.Marshal(struct {
+			Number uint64
+		}{Number: block.Number})
+		require.NoError(t, err)
+		require.NoError(t, partialHeaderDB.Put(db.BlockHeaderByNumberKey(block.Number), data))
+
+		_, err = core.GetGlobalStateRootByBlockNumber(partialHeaderDB, block.Number)
+		require.Error(t, err)
 	})
 }


### PR DESCRIPTION
## Summary

Optimizes latest-block state reads by avoiding full block-header decoding when opening head state.

`HeadState()` only needs `Header.GlobalStateRoot` to construct the state reader, but previously called `GetBlockHeaderByNumber`, which materialized the full `Header`, including heavier unused fields such as `EventsBloom`.

This adds `GetGlobalStateRootByBlockNumber`, which decodes only `GlobalStateRoot` from the stored CBOR header map, and uses it in `HeadState()`.

## Benchmarks
I ran local benchmarks that exercise the public RPC handler paths with Pebble DB.

This trades a modest increase in allocation count for a much larger reduction in latency and allocated bytes.

`allocs/op` increases due to extra small map/field bookkeeping during CBOR subset-struct decoding, visible in the allocation profile under `fxamacker/cbor.(*decoder).parseMapToStruct` at 300MB flat / 335.52MB cumulative. `B/op` still drops by about 50% because large unused fields are no longer materialized.


| Path                | Base     | New     | Latency  | B/op                          | allocs/op        |
|---------------------|---------:|--------:|---------:|-------------------------------:|-----------------:|
| `NonceLatest`       | ~12.75µs | ~7.64µs | **−40%** | ~4.0KiB → ~2.0KiB (**−50%**)  | 60 → 72 (**+20%**) |
| `ClassHashAtLatest` | ~12.3µs  | ~6.7µs  | **−46%** | ~4.0KiB → ~2.0KiB (**−50%**)  | 60 → 72 (**+20%**) |
| `StorageAtLatest`   | ~16.5µs  | ~8.9µs  | **−46%** | ~4.2KiB → ~2.0KiB (**−52%**)  | 64 → 76 (**+19%**) |