### PR TITLE
perf(db): make key flattening 2x faster with 1/3 allocs

### DIFF
--- a/db/buckets.go
+++ b/db/buckets.go
@@ -1,7 +1,5 @@
 package db
 
-import "slices"
-
 // Pebble does not support buckets to differentiate between groups of
 // keys like Bolt or MDBX does. We use a global prefix list as a poor
 // man's bucket alternative.
@@ -132,7 +130,18 @@ const (
 
 // Key flattens a prefix and series of byte arrays into a single []byte.
 func (b Bucket) Key(key ...[]byte) []byte {
-	return append([]byte{byte(b)}, slices.Concat(key...)...)
+	size := 1
+	for _, k := range key {
+		size += len(k)
+	}
+
+	buf := make([]byte, size)
+	buf[0] = byte(b)
+	i := 1
+	for _, k := range key {
+		i += copy(buf[i:], k)
+	}
+	return buf
 }
 
 func (b Bucket) String() string {

--- a/db/buckets_bench_test.go
+++ b/db/buckets_bench_test.go
@@ -1,0 +1,48 @@
+package db_test
+
+import (
+	"testing"
+
+	"github.com/NethermindEth/juno/db"
+)
+
+// keySink keeps Key's result escaping so the allocation is measured faithfully.
+// otherwise compiler optimizations will give us better results for the empty
+// key tests
+var keySink []byte
+
+func BenchmarkKey(b *testing.B) {
+	felt := make([]byte, 32)
+	prefix := []byte{0xab}
+
+	manyFelts := func() [][]byte {
+		res := make([][]byte, 1000)
+		for i := range res {
+			res[i] = felt
+		}
+		return res
+	}
+
+	// Cases mirror real call sites: most keys are empty (prefix only) or a
+	// single 32-byte felt; composite keys and wider fan-outs are the stress cases.
+	cases := []struct {
+		name string
+		keys [][]byte
+	}{
+		{"NoKey", nil},
+		{"SingleFelt", [][]byte{felt}},
+		{"PrefixPlusFelt", [][]byte{prefix, felt}},
+		{"TwoFelts", [][]byte{felt, felt}},
+		{"FourFelts", [][]byte{felt, felt, felt, felt}},
+		{"ManyFelts", manyFelts()},
+	}
+
+	for _, c := range cases {
+		b.Run(c.name, func(b *testing.B) {
+			b.ReportAllocs()
+			for b.Loop() {
+				keySink = db.StateTrie.Key(c.keys...)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Reduce unnecessary allocations, I suspect we can go even more to 0 allocations with fixed functions.

Summary: : 3→1 allocs, ~40–50% fewer bytes, and ~55% less time (geomean), strongest on the dominant single-felt call site.

| Case | Time (old → new) | Allocs (old → new) | Bytes (old → new) |
|------|------------------|--------------------|-------------------|
| `NoKey` (prefix only) | 10.1 → 8.0 ns (−21%) | 1 → 1 | 1 → 1 |
| `SingleFelt` | 47.5 → 15.9 ns (−67%) | 3 → 1 (−67%) | 81 → 48 (−41%) |
| `PrefixPlusFelt` | 51.6 → 20.7 ns (−60%) | 3 → 1 (−67%) | 97 → 48 (−51%) |
| `TwoFelts` | 54.7 → 21.2 ns (−61%) | 3 → 1 (−67%) | 145 → 80 (−45%) |
| `FourFelts` | 68.5 → 31.2 ns (−54%) | 3 → 1 (−67%) | 273 → 144 (−47%) |
| `ManyFelts` (1000) | 7.21 → 5.04 µs (−30%) | 3 → 1 (−67%) | 64 → 32 KiB (−50%) |
| **geomean** | **−55%** | **−58%** | **−39%** |