### PR TITLE
feat(compiler): Compilation memory ceiling

### DIFF
--- a/cmd/juno/juno.go
+++ b/cmd/juno/juno.go
@@ -267,15 +267,14 @@ const (
 	rpcMaxRequestQueueUsage       = "Maximum number of HTTP RPC requests to queue after " +
 		"reaching rpc-max-concurrent-requests limit."
 	maxConcurrentCompilationsUsage = "Maximum concurrent Sierra compilations. " +
-		"0 derives a safe value from available memory and CPU count."
+		"Empty derives a safe value from available memory and CPU count; 0 disables compilations."
 	maxCompilationQueueUsage = "Maximum number of compilation requests to queue after " +
 		"reaching max-concurrent-compilations before starting to reject incoming requests. " +
-		"0 uses twice the concurrency limit."
+		"Empty uses twice the concurrency limit."
 	maxCompilationMemoryUsage = "Maximum memory (in MB) each Sierra compilation process may " +
 		"use; a compilation exceeding it is aborted. Enforced on Linux only. 0 disables the limit."
 	nodeMemoryReserveUsage = "Memory (in MB) reserved for the rest of the node and excluded from " +
-		"the compilation memory budget. Used only when max-concurrent-compilations is 0. " +
-		"Container memory limits (cgroups) are respected."
+		"the compilation memory budget. Used only when max-concurrent-compilations is empty."
 	maxCompilationCPUTimeUsage = "Maximum CPU time (in seconds) each Sierra compilation process " +
 		"may consume; a compilation exceeding it is aborted. Enforced on Linux only. " +
 		"0 disables the limit."
@@ -488,9 +487,10 @@ func NewCmd(config *node.Config, run func(*cobra.Command, []string) error) *cobr
 	// may mutate their values.
 	defaultNetwork := networks.Mainnet
 	defaultMaxVMs := 3 * runtime.GOMAXPROCS(0)
-	defaultMaxConcurrentCompilations := uint(0) // 0 = derive at startup (see node.New).
-	defaultMaxCompilationQueue := uint(0)       // 0 = derive at startup (see node.New).
-	defaultCNUnverifiableRange := []int{}       // Uint64Slice is not supported in Flags()
+	// Empty derives at startup; an explicit 0 disables compilations / the queue.
+	defaultMaxConcurrentCompilations := ""
+	defaultMaxCompilationQueue := ""
+	defaultCNUnverifiableRange := []int{} // Uint64Slice is not supported in Flags()
 
 	// --- HTTP RPC ---
 	junoCmd.Flags().Bool(httpF, defaultHTTP, httpUsage)
@@ -620,12 +620,12 @@ func NewCmd(config *node.Config, run func(*cobra.Command, []string) error) *cobr
 	// --- VM & Compilation ---
 	junoCmd.Flags().Uint(maxVMsF, uint(defaultMaxVMs), maxVMsUsage)
 	junoCmd.Flags().Uint(maxVMQueueF, 2*uint(defaultMaxVMs), maxVMQueueUsage)
-	junoCmd.Flags().Uint(
+	junoCmd.Flags().String(
 		maxConcurrentCompilationsF,
 		defaultMaxConcurrentCompilations,
 		maxConcurrentCompilationsUsage,
 	)
-	junoCmd.Flags().Uint(
+	junoCmd.Flags().String(
 		maxCompilationQueueF,
 		defaultMaxCompilationQueue,
 		maxCompilationQueueUsage,

--- a/cmd/juno/juno.go
+++ b/cmd/juno/juno.go
@@ -112,6 +112,7 @@ const (
 	maxConcurrentCompilationsF          = "max-concurrent-compilations"
 	maxCompilationQueueF                = "max-compilation-queue"
 	maxCompilationMemoryF               = "max-compilation-memory"
+	nodeMemoryReserveF                  = "node-memory-reserve"
 	maxCompilationCPUTimeF              = "max-compilation-cpu-time"
 	disableReceivedTxnStreamF           = "disable-received-txn-stream"
 	newStateF                           = "new-state"
@@ -177,6 +178,7 @@ const (
 	defaultRPCMaxConcurrentRequests           = 256000
 	defaultRPCMaxQueuedRequests               = 256000
 	defaultMaxCompilationMemory               = 4 * 1024 // MB (4 GB) per compilation process
+	defaultNodeMemoryReserve                  = 4 * 1024 // MB (4 GB) reserved for the rest of the node
 	defaultMaxCompilationCPUTime              = 10       // seconds of CPU time per compilation process
 	defaultDisableReceivedTxnStream           = false
 	defaultPruneMode                          = uint64(0)
@@ -264,11 +266,16 @@ const (
 	rpcMaxConcurrentRequestsUsage = "Maximum concurrent HTTP RPC requests; 0 disables the limit."
 	rpcMaxRequestQueueUsage       = "Maximum number of HTTP RPC requests to queue after " +
 		"reaching rpc-max-concurrent-requests limit."
-	maxConcurrentCompilationsUsage = "Maximum concurrent Sierra compilations."
-	maxCompilationQueueUsage       = "Maximum number of compilation requests to queue after " +
-		"reaching max-concurrent-compilations before starting to reject incoming requests."
+	maxConcurrentCompilationsUsage = "Maximum concurrent Sierra compilations. " +
+		"0 derives a safe value from available memory and CPU count."
+	maxCompilationQueueUsage = "Maximum number of compilation requests to queue after " +
+		"reaching max-concurrent-compilations before starting to reject incoming requests. " +
+		"0 uses twice the concurrency limit."
 	maxCompilationMemoryUsage = "Maximum memory (in MB) each Sierra compilation process may " +
 		"use; a compilation exceeding it is aborted. Enforced on Linux only. 0 disables the limit."
+	nodeMemoryReserveUsage = "Memory (in MB) reserved for the rest of the node and excluded from " +
+		"the compilation memory budget. Used only when max-concurrent-compilations is 0. " +
+		"Container memory limits (cgroups) are respected."
 	maxCompilationCPUTimeUsage = "Maximum CPU time (in seconds) each Sierra compilation process " +
 		"may consume; a compilation exceeding it is aborted. Enforced on Linux only. " +
 		"0 disables the limit."
@@ -481,8 +488,9 @@ func NewCmd(config *node.Config, run func(*cobra.Command, []string) error) *cobr
 	// may mutate their values.
 	defaultNetwork := networks.Mainnet
 	defaultMaxVMs := 3 * runtime.GOMAXPROCS(0)
-	defaultMaxConcurrentCompilations := runtime.GOMAXPROCS(0)
-	defaultCNUnverifiableRange := []int{} // Uint64Slice is not supported in Flags()
+	defaultMaxConcurrentCompilations := uint(0) // 0 = derive at startup (see node.New).
+	defaultMaxCompilationQueue := uint(0)       // 0 = derive at startup (see node.New).
+	defaultCNUnverifiableRange := []int{}       // Uint64Slice is not supported in Flags()
 
 	// --- HTTP RPC ---
 	junoCmd.Flags().Bool(httpF, defaultHTTP, httpUsage)
@@ -614,15 +622,18 @@ func NewCmd(config *node.Config, run func(*cobra.Command, []string) error) *cobr
 	junoCmd.Flags().Uint(maxVMQueueF, 2*uint(defaultMaxVMs), maxVMQueueUsage)
 	junoCmd.Flags().Uint(
 		maxConcurrentCompilationsF,
-		uint(defaultMaxConcurrentCompilations),
+		defaultMaxConcurrentCompilations,
 		maxConcurrentCompilationsUsage,
 	)
 	junoCmd.Flags().Uint(
 		maxCompilationQueueF,
-		2*uint(defaultMaxConcurrentCompilations),
+		defaultMaxCompilationQueue,
 		maxCompilationQueueUsage,
 	)
 	junoCmd.Flags().Uint(maxCompilationMemoryF, defaultMaxCompilationMemory, maxCompilationMemoryUsage)
+	junoCmd.Flags().Uint(
+		nodeMemoryReserveF, defaultNodeMemoryReserve, nodeMemoryReserveUsage,
+	)
 	junoCmd.Flags().Uint(
 		maxCompilationCPUTimeF, defaultMaxCompilationCPUTime, maxCompilationCPUTimeUsage,
 	)
@@ -634,6 +645,7 @@ func NewCmd(config *node.Config, run func(*cobra.Command, []string) error) *cobr
 		maxConcurrentCompilationsF,
 		maxCompilationQueueF,
 		maxCompilationMemoryF,
+		nodeMemoryReserveF,
 		maxCompilationCPUTimeF,
 		versionedConstantsFileF,
 	)

--- a/cmd/juno/juno.go
+++ b/cmd/juno/juno.go
@@ -177,7 +177,7 @@ const (
 	defaultRPCRequestTimeout                  = 1 * time.Minute
 	defaultRPCMaxConcurrentRequests           = 256000
 	defaultRPCMaxQueuedRequests               = 256000
-	defaultMaxCompilationMemory               = 4 * 1024 // MB (4 GB) per compilation process
+	defaultMaxCompilationMemory               = 2 * 1024 // MB (2 GB) per compilation process
 	defaultNodeMemoryReserve                  = 4 * 1024 // MB (4 GB) reserved for the rest of the node
 	defaultMaxCompilationCPUTime              = 10       // seconds of CPU time per compilation process
 	defaultDisableReceivedTxnStream           = false

--- a/cmd/juno/juno_test.go
+++ b/cmd/juno/juno_test.go
@@ -82,8 +82,8 @@ func TestConfigPrecedence(t *testing.T) {
 	defaultSubmittedTransactionsCacheSize := uint(10_000)
 	defaultSubmittedTransactionsCacheEntryTTL := 5 * time.Minute
 	defaultRPCRequestTimeout := 1 * time.Minute
-	defaultMaxConcurrentCompilations := uint(0) // 0 = derive from memory and CPUs
-	defaultMaxCompilationQueue := uint(0)       // 0 = derive from concurrency
+	defaultMaxConcurrentCompilations := "" // empty derives from memory and CPUs
+	defaultMaxCompilationQueue := ""       // empty derives from concurrency
 	defaultMaxCompilationMemory := uint(4 * 1024)
 	defaultNodeMemoryReserve := uint(4 * 1024)
 	defaultMaxCompilationCPUTime := uint(10)
@@ -203,6 +203,10 @@ func TestConfigPrecedence(t *testing.T) {
 	expectedExplicitCompilationLimits.MaxCompilationMemory = 2048
 	expectedExplicitCompilationLimits.MaxCompilationCPUTime = 5
 
+	expectedNumericCompilationLimits := expectedConfig2
+	expectedNumericCompilationLimits.MaxConcurrentCompilations = "8"
+	expectedNumericCompilationLimits.MaxCompilationQueue = "32"
+
 	tests := map[string]struct {
 		cfgFile         bool
 		cfgFileContents string
@@ -248,6 +252,13 @@ cn-unverifiable-range: [0,10]
 				"--max-compilation-memory", "2048", "--max-compilation-cpu-time", "5",
 			},
 			expectedConfig: &expectedExplicitCompilationLimits,
+		},
+		"numeric compilation limits in config file": {
+			cfgFile: true,
+			cfgFileContents: `max-concurrent-compilations: 8
+max-compilation-queue: 32
+`,
+			expectedConfig: &expectedNumericCompilationLimits,
 		},
 		"config file path is empty string": {
 			inputArgs:      []string{"--config", ""},

--- a/cmd/juno/juno_test.go
+++ b/cmd/juno/juno_test.go
@@ -82,9 +82,10 @@ func TestConfigPrecedence(t *testing.T) {
 	defaultSubmittedTransactionsCacheSize := uint(10_000)
 	defaultSubmittedTransactionsCacheEntryTTL := 5 * time.Minute
 	defaultRPCRequestTimeout := 1 * time.Minute
-	defaultMaxConcurrentCompilations := uint(runtime.GOMAXPROCS(0))
-	defaultMaxCompilationQueue := 2 * defaultMaxConcurrentCompilations
+	defaultMaxConcurrentCompilations := uint(0) // 0 = derive from memory and CPUs
+	defaultMaxCompilationQueue := uint(0)       // 0 = derive from concurrency
 	defaultMaxCompilationMemory := uint(4 * 1024)
+	defaultNodeMemoryReserve := uint(4 * 1024)
 	defaultMaxCompilationCPUTime := uint(10)
 	if runtime.GOOS != "linux" {
 		// Limits are enforced on Linux only; PreRunE zeroes the unset
@@ -140,6 +141,7 @@ func TestConfigPrecedence(t *testing.T) {
 		MaxConcurrentCompilations:          defaultMaxConcurrentCompilations,
 		MaxCompilationQueue:                defaultMaxCompilationQueue,
 		MaxCompilationMemory:               defaultMaxCompilationMemory,
+		NodeMemoryReserve:                  defaultNodeMemoryReserve,
 		MaxCompilationCPUTime:              defaultMaxCompilationCPUTime,
 		PruneMinAge:                        defaultPruneMinAge,
 	}
@@ -190,6 +192,7 @@ func TestConfigPrecedence(t *testing.T) {
 		MaxConcurrentCompilations:          defaultMaxConcurrentCompilations,
 		MaxCompilationQueue:                defaultMaxCompilationQueue,
 		MaxCompilationMemory:               defaultMaxCompilationMemory,
+		NodeMemoryReserve:                  defaultNodeMemoryReserve,
 		MaxCompilationCPUTime:              defaultMaxCompilationCPUTime,
 		PruneMinAge:                        defaultPruneMinAge,
 	}
@@ -314,6 +317,7 @@ pprof: true
 				MaxConcurrentCompilations:          defaultMaxConcurrentCompilations,
 				MaxCompilationQueue:                defaultMaxCompilationQueue,
 				MaxCompilationMemory:               defaultMaxCompilationMemory,
+				NodeMemoryReserve:                  defaultNodeMemoryReserve,
 				MaxCompilationCPUTime:              defaultMaxCompilationCPUTime,
 				PruneMinAge:                        defaultPruneMinAge,
 			},
@@ -370,6 +374,7 @@ http-port: 4576
 				MaxConcurrentCompilations:          defaultMaxConcurrentCompilations,
 				MaxCompilationQueue:                defaultMaxCompilationQueue,
 				MaxCompilationMemory:               defaultMaxCompilationMemory,
+				NodeMemoryReserve:                  defaultNodeMemoryReserve,
 				MaxCompilationCPUTime:              defaultMaxCompilationCPUTime,
 				PruneMinAge:                        defaultPruneMinAge,
 			},
@@ -425,6 +430,7 @@ http-port: 4576
 				MaxConcurrentCompilations:          defaultMaxConcurrentCompilations,
 				MaxCompilationQueue:                defaultMaxCompilationQueue,
 				MaxCompilationMemory:               defaultMaxCompilationMemory,
+				NodeMemoryReserve:                  defaultNodeMemoryReserve,
 				MaxCompilationCPUTime:              defaultMaxCompilationCPUTime,
 				PruneMinAge:                        defaultPruneMinAge,
 			},
@@ -480,6 +486,7 @@ http-port: 4576
 				MaxConcurrentCompilations:          defaultMaxConcurrentCompilations,
 				MaxCompilationQueue:                defaultMaxCompilationQueue,
 				MaxCompilationMemory:               defaultMaxCompilationMemory,
+				NodeMemoryReserve:                  defaultNodeMemoryReserve,
 				MaxCompilationCPUTime:              defaultMaxCompilationCPUTime,
 				PruneMinAge:                        defaultPruneMinAge,
 			},
@@ -561,6 +568,7 @@ db-cache-size: 1024
 				MaxConcurrentCompilations:          defaultMaxConcurrentCompilations,
 				MaxCompilationQueue:                defaultMaxCompilationQueue,
 				MaxCompilationMemory:               defaultMaxCompilationMemory,
+				NodeMemoryReserve:                  defaultNodeMemoryReserve,
 				MaxCompilationCPUTime:              defaultMaxCompilationCPUTime,
 				PruneMinAge:                        defaultPruneMinAge,
 			},
@@ -619,6 +627,7 @@ network: sepolia
 				MaxConcurrentCompilations:          defaultMaxConcurrentCompilations,
 				MaxCompilationQueue:                defaultMaxCompilationQueue,
 				MaxCompilationMemory:               defaultMaxCompilationMemory,
+				NodeMemoryReserve:                  defaultNodeMemoryReserve,
 				MaxCompilationCPUTime:              defaultMaxCompilationCPUTime,
 				PruneMinAge:                        defaultPruneMinAge,
 			},
@@ -673,6 +682,7 @@ network: sepolia
 				MaxConcurrentCompilations:          defaultMaxConcurrentCompilations,
 				MaxCompilationQueue:                defaultMaxCompilationQueue,
 				MaxCompilationMemory:               defaultMaxCompilationMemory,
+				NodeMemoryReserve:                  defaultNodeMemoryReserve,
 				MaxCompilationCPUTime:              defaultMaxCompilationCPUTime,
 				PruneMinAge:                        defaultPruneMinAge,
 			},
@@ -725,6 +735,7 @@ network: sepolia
 				MaxConcurrentCompilations:          defaultMaxConcurrentCompilations,
 				MaxCompilationQueue:                defaultMaxCompilationQueue,
 				MaxCompilationMemory:               defaultMaxCompilationMemory,
+				NodeMemoryReserve:                  defaultNodeMemoryReserve,
 				MaxCompilationCPUTime:              defaultMaxCompilationCPUTime,
 				PruneMinAge:                        defaultPruneMinAge,
 			},
@@ -778,6 +789,7 @@ network: sepolia
 				MaxConcurrentCompilations:          defaultMaxConcurrentCompilations,
 				MaxCompilationQueue:                defaultMaxCompilationQueue,
 				MaxCompilationMemory:               defaultMaxCompilationMemory,
+				NodeMemoryReserve:                  defaultNodeMemoryReserve,
 				MaxCompilationCPUTime:              defaultMaxCompilationCPUTime,
 				PruneMinAge:                        defaultPruneMinAge,
 			},
@@ -830,6 +842,7 @@ network: sepolia
 				MaxConcurrentCompilations:          defaultMaxConcurrentCompilations,
 				MaxCompilationQueue:                defaultMaxCompilationQueue,
 				MaxCompilationMemory:               defaultMaxCompilationMemory,
+				NodeMemoryReserve:                  defaultNodeMemoryReserve,
 				MaxCompilationCPUTime:              defaultMaxCompilationCPUTime,
 				PruneMinAge:                        defaultPruneMinAge,
 			},
@@ -884,6 +897,7 @@ network: sepolia
 				MaxConcurrentCompilations:          defaultMaxConcurrentCompilations,
 				MaxCompilationQueue:                defaultMaxCompilationQueue,
 				MaxCompilationMemory:               defaultMaxCompilationMemory,
+				NodeMemoryReserve:                  defaultNodeMemoryReserve,
 				MaxCompilationCPUTime:              defaultMaxCompilationCPUTime,
 				PruneMinAge:                        defaultPruneMinAge,
 			},

--- a/cmd/juno/juno_test.go
+++ b/cmd/juno/juno_test.go
@@ -84,7 +84,7 @@ func TestConfigPrecedence(t *testing.T) {
 	defaultRPCRequestTimeout := 1 * time.Minute
 	defaultMaxConcurrentCompilations := "" // empty derives from memory and CPUs
 	defaultMaxCompilationQueue := ""       // empty derives from concurrency
-	defaultMaxCompilationMemory := uint(4 * 1024)
+	defaultMaxCompilationMemory := uint(2 * 1024)
 	defaultNodeMemoryReserve := uint(4 * 1024)
 	defaultMaxCompilationCPUTime := uint(10)
 	if runtime.GOOS != "linux" {

--- a/docs/docs/tuning.md
+++ b/docs/docs/tuning.md
@@ -71,11 +71,15 @@ A larger cache reduces disk reads and improves query performance. On systems wit
 
 ## Sierra Compilation Limits
 
+Juno compiles Sierra classes to CASM in isolated child processes. The flags below cap the resources each compilation uses and how many run at once.
+
+### Per-compilation limits
+
 :::warning
 These limits are enforced by the kernel and only on **Linux**. On other operating systems they have no effect.
 :::
 
-Juno compiles Sierra classes to CASM in isolated child processes. Two flags cap the resources each compilation process may use, protecting the node from pathological or malicious classes that would otherwise consume CPU and memory without bound:
+Two flags cap the resources each compilation process may use, protecting the node from malicious classes that would otherwise consume CPU and memory without bound:
 
 - `--max-compilation-memory` (default: 4096 MB): Maximum memory a single compilation process may use. A compilation exceeding it is aborted.
 - `--max-compilation-cpu-time` (default: 10 seconds): Maximum CPU time a single compilation process may consume. A compilation exceeding it is killed.
@@ -86,4 +90,18 @@ Setting either flag to `0` disables that limit. The defaults are generous for le
 The CPU time limit counts seconds of CPU actually consumed by the compilation process, not elapsed wall-clock time, so it is unaffected by how busy the rest of the machine is.
 :::
 
-Up to `--max-concurrent-compilations` (default: one per available CPU core) processes can run at once, so the worst-case memory that compilations can claim is the product of that flag and `--max-compilation-memory`. Lower either value on memory-constrained machines.
+### Compilation concurrency
+
+`--max-concurrent-compilations` controls how many compilations run at once. At its default of `0`, Juno derives a safe value so concurrent compilations cannot exhaust RAM:
+
+```
+limit = min((available_memory - node_memory_reserve) / max_compilation_memory, cpu_cores)
+```
+
+- `--max-concurrent-compilations` (default: 0): `0` derives the value as above; any other value is used directly.
+- `--max-compilation-queue` (default: 0): How many requests wait once the concurrency limit is reached before new ones are rejected. `0` uses twice the concurrency limit.
+- `--node-memory-reserve` (default: 4096 MB): Memory kept for the rest of the node, excluded from the compilation budget.
+
+The available memory respects container limits (cgroups), so inside a memory-capped container the value reflects the container, not the host. On non-Linux, where the per-compilation memory limit does not apply, the limit is simply the CPU core count.
+
+The limit is always at least 1: on a memory-tight node compilations run one at a time rather than the node refusing to start.

--- a/docs/docs/tuning.md
+++ b/docs/docs/tuning.md
@@ -92,14 +92,14 @@ The CPU time limit counts seconds of CPU actually consumed by the compilation pr
 
 ### Compilation concurrency
 
-`--max-concurrent-compilations` controls how many compilations run at once. At its default of `0`, Juno derives a safe value so concurrent compilations cannot exhaust RAM:
+`--max-concurrent-compilations` controls how many compilations run at once. Left empty (the default), Juno derives a safe value so concurrent compilations cannot exhaust RAM:
 
 ```
 limit = min((available_memory - node_memory_reserve) / max_compilation_memory, cpu_cores)
 ```
 
-- `--max-concurrent-compilations` (default: 0): `0` derives the value as above; any other value is used directly.
-- `--max-compilation-queue` (default: 0): How many requests wait once the concurrency limit is reached before new ones are rejected. `0` uses twice the concurrency limit.
+- `--max-concurrent-compilations` (default: empty): empty derives the value as above; any non-negative integer is used directly (`0` disables compilations).
+- `--max-compilation-queue` (default: empty): How many requests wait once the concurrency limit is reached before new ones are rejected. Empty uses twice the concurrency limit.
 - `--node-memory-reserve` (default: 4096 MB): Memory kept for the rest of the node, excluded from the compilation budget.
 
 The available memory respects container limits (cgroups), so inside a memory-capped container the value reflects the container, not the host. On non-Linux, where the per-compilation memory limit does not apply, the limit is simply the CPU core count.

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/NethermindEth/juno
 go 1.26.0
 
 require (
+	github.com/KimMachineGun/automemlimit v0.7.5
 	github.com/Masterminds/semver/v3 v3.5.0
 	github.com/VictoriaMetrics/fastcache v1.13.3
 	github.com/bits-and-blooms/bitset v1.24.5
@@ -23,6 +24,7 @@ require (
 	github.com/mitchellh/mapstructure v1.5.0
 	github.com/multiformats/go-multiaddr v0.16.1
 	github.com/olekukonko/tablewriter v1.1.4
+	github.com/pbnjay/memory v0.0.0-20210728143218-7b4eea64cf58
 	github.com/prometheus/client_golang v1.23.2
 	github.com/rs/cors v1.11.1
 	github.com/sourcegraph/conc v0.3.1-0.20240121214520-5f936abd7ae8
@@ -137,7 +139,6 @@ require (
 	github.com/olekukonko/cat v0.0.0-20250911104152-50322a0618f6 // indirect
 	github.com/olekukonko/errors v1.2.0 // indirect
 	github.com/olekukonko/ll v0.1.6 // indirect
-	github.com/pbnjay/memory v0.0.0-20210728143218-7b4eea64cf58 // indirect
 	github.com/pelletier/go-toml/v2 v2.2.4 // indirect
 	github.com/pion/datachannel v1.6.0 // indirect
 	github.com/pion/dtls/v3 v3.1.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -45,6 +45,8 @@ github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
 github.com/DataDog/zstd v1.5.7 h1:ybO8RBeh29qrxIhCA9E8gKY6xfONU9T6G6aP9DTKfLE=
 github.com/DataDog/zstd v1.5.7/go.mod h1:g4AWEaM3yOg3HYfnJ3YIawPnVdXJh9QME85blwSAmyw=
+github.com/KimMachineGun/automemlimit v0.7.5 h1:RkbaC0MwhjL1ZuBKunGDjE/ggwAX43DwZrJqVwyveTk=
+github.com/KimMachineGun/automemlimit v0.7.5/go.mod h1:QZxpHaGOQoYvFhv/r4u3U0JTC2ZcOwbSr11UZF46UBM=
 github.com/Masterminds/semver/v3 v3.5.0 h1:kQceYJfbupGfZOKZQg0kou0DgAKhzDg2NZPAwZ/2OOE=
 github.com/Masterminds/semver/v3 v3.5.0/go.mod h1:4V+yj/TJE1HU9XfppCwVMZq3I84lprf4nC11bSS5beM=
 github.com/Microsoft/go-winio v0.6.2 h1:F2VQgta7ecxGYO8k3ZZz3RS8fVIXVxONVUPlNERoyfY=

--- a/node/node.go
+++ b/node/node.go
@@ -10,6 +10,7 @@ import (
 	"reflect"
 	"runtime"
 	"slices"
+	"strconv"
 	"time"
 
 	"github.com/Masterminds/semver/v3"
@@ -133,21 +134,35 @@ type Config struct {
 
 	DisableReceivedTxnStream bool `mapstructure:"disable-received-txn-stream"`
 
-	RPCRequestTimeout         time.Duration `mapstructure:"rpc-request-timeout"`
-	RPCMaxConcurrentRequests  uint          `mapstructure:"rpc-max-concurrent-requests"`
-	RPCMaxRequestQueue        uint          `mapstructure:"rpc-max-request-queue"`
-	MaxConcurrentCompilations uint          `mapstructure:"max-concurrent-compilations"`
-	MaxCompilationQueue       uint          `mapstructure:"max-compilation-queue"`
-	MaxCompilationMemory      uint          `mapstructure:"max-compilation-memory"`   // megabytes
-	NodeMemoryReserve         uint          `mapstructure:"node-memory-reserve"`      // megabytes
-	MaxCompilationCPUTime     uint          `mapstructure:"max-compilation-cpu-time"` // CPU seconds
-	NewState                  bool          `mapstructure:"new-state"`
+	RPCRequestTimeout        time.Duration `mapstructure:"rpc-request-timeout"`
+	RPCMaxConcurrentRequests uint          `mapstructure:"rpc-max-concurrent-requests"`
+	RPCMaxRequestQueue       uint          `mapstructure:"rpc-max-request-queue"`
+	// Empty derives the value at startup; an explicit 0 stays valid (no compilations / no queue).
+	MaxConcurrentCompilations string `mapstructure:"max-concurrent-compilations"`
+	MaxCompilationQueue       string `mapstructure:"max-compilation-queue"`
+	MaxCompilationMemory      uint   `mapstructure:"max-compilation-memory"`   // megabytes
+	NodeMemoryReserve         uint   `mapstructure:"node-memory-reserve"`      // megabytes
+	MaxCompilationCPUTime     uint   `mapstructure:"max-compilation-cpu-time"` // CPU seconds
+	NewState                  bool   `mapstructure:"new-state"`
 
 	// Prune is true when --prune-mode was provided (any value, including 0
 	// or absent). Set in cmd PreRunE; not bound via mapstructure.
 	Prune          bool
 	RetainedBlocks uint64        `mapstructure:"prune-mode"`
 	PruneMinAge    time.Duration `mapstructure:"prune-min-age"`
+}
+
+// parseCompilationLimit reads a compilation-sizing flag. An empty value derives the
+// value at startup (derive is true); otherwise it must be a non-negative integer.
+func parseCompilationLimit(value string) (limit uint, derive bool, err error) {
+	if value == "" {
+		return 0, true, nil
+	}
+	n, err := strconv.ParseUint(value, 10, strconv.IntSize)
+	if err != nil {
+		return 0, false, fmt.Errorf("%q is not a non-negative integer", value)
+	}
+	return uint(n), false, nil
 }
 
 type Node struct {
@@ -294,8 +309,12 @@ func New(cfg *Config, version string, logLevel *log.Level) (*Node, error) {
 	var nodeVM vm.VM
 	var throttledVM *ThrottledVM
 
-	concurrentCompilations := cfg.MaxConcurrentCompilations
-	if concurrentCompilations == 0 {
+	concurrent, concurrentAuto, err := parseCompilationLimit(cfg.MaxConcurrentCompilations)
+	if err != nil {
+		return nil, fmt.Errorf("parsing max-concurrent-compilations: %w", err)
+	}
+	var concurrentCompilations uint
+	if concurrentAuto {
 		availableMemoryMB := compiler.AvailableMemoryMB()
 		concurrentCompilations = max(compiler.ConcurrencyLimit(
 			uint(runtime.GOMAXPROCS(0)),
@@ -310,12 +329,17 @@ func New(cfg *Config, version string, logLevel *log.Level) (*Node, error) {
 			zap.Uint("maxMemoryPerCompilationMB", cfg.MaxCompilationMemory),
 		)
 	} else {
+		concurrentCompilations = concurrent
 		logger.Info("using configured Sierra compilation concurrency",
 			zap.Uint("limit", concurrentCompilations))
 	}
 
-	compilationQueue := cfg.MaxCompilationQueue
-	if compilationQueue == 0 {
+	queue, queueAuto, err := parseCompilationLimit(cfg.MaxCompilationQueue)
+	if err != nil {
+		return nil, fmt.Errorf("parsing max-compilation-queue: %w", err)
+	}
+	compilationQueue := queue
+	if queueAuto {
 		compilationQueue = 2 * concurrentCompilations
 	}
 	throttledCompiler := NewThrottledCompiler(

--- a/node/node.go
+++ b/node/node.go
@@ -139,6 +139,7 @@ type Config struct {
 	MaxConcurrentCompilations uint          `mapstructure:"max-concurrent-compilations"`
 	MaxCompilationQueue       uint          `mapstructure:"max-compilation-queue"`
 	MaxCompilationMemory      uint          `mapstructure:"max-compilation-memory"`   // megabytes
+	NodeMemoryReserve         uint          `mapstructure:"node-memory-reserve"`      // megabytes
 	MaxCompilationCPUTime     uint          `mapstructure:"max-compilation-cpu-time"` // CPU seconds
 	NewState                  bool          `mapstructure:"new-state"`
 
@@ -293,6 +294,30 @@ func New(cfg *Config, version string, logLevel *log.Level) (*Node, error) {
 	var nodeVM vm.VM
 	var throttledVM *ThrottledVM
 
+	concurrentCompilations := cfg.MaxConcurrentCompilations
+	if concurrentCompilations == 0 {
+		availableMemoryMB := compiler.AvailableMemoryMB()
+		concurrentCompilations = max(compiler.ConcurrencyLimit(
+			uint(runtime.GOMAXPROCS(0)),
+			availableMemoryMB,
+			uint64(cfg.NodeMemoryReserve),
+			uint64(cfg.MaxCompilationMemory),
+		), 1)
+		logger.Info("deriving Sierra compilation concurrency",
+			zap.Uint("limit", concurrentCompilations),
+			zap.Uint64("availableMemoryMB", availableMemoryMB),
+			zap.Uint("nodeMemoryReserveMB", cfg.NodeMemoryReserve),
+			zap.Uint("maxMemoryPerCompilationMB", cfg.MaxCompilationMemory),
+		)
+	} else {
+		logger.Info("using configured Sierra compilation concurrency",
+			zap.Uint("limit", concurrentCompilations))
+	}
+
+	compilationQueue := cfg.MaxCompilationQueue
+	if compilationQueue == 0 {
+		compilationQueue = 2 * concurrentCompilations
+	}
 	throttledCompiler := NewThrottledCompiler(
 		compiler.New(
 			&compiler.Config{
@@ -302,8 +327,8 @@ func New(cfg *Config, version string, logLevel *log.Level) (*Node, error) {
 			"",
 			logger,
 		),
-		cfg.MaxConcurrentCompilations,
-		uint64(cfg.MaxCompilationQueue),
+		concurrentCompilations,
+		uint64(compilationQueue),
 	)
 
 	if cfg.Sequencer {

--- a/node/node_test.go
+++ b/node/node_test.go
@@ -11,6 +11,7 @@ import (
 	statetestutils "github.com/NethermindEth/juno/core/state/testutils"
 	"github.com/NethermindEth/juno/db/pebblev2"
 	"github.com/NethermindEth/juno/node"
+	"github.com/NethermindEth/juno/starknet/compiler"
 	adaptfeeder "github.com/NethermindEth/juno/starknetdata/feeder"
 	"github.com/NethermindEth/juno/sync"
 	"github.com/NethermindEth/juno/utils/log"
@@ -44,6 +45,7 @@ func TestNewNode(t *testing.T) {
 		P2PAddr:                            "",
 		P2PPeers:                           "",
 		SubmittedTransactionsCacheEntryTTL: time.Second,
+		// MaxConcurrentCompilations left 0 to exercise the auto-derive path.
 	}
 
 	logLevel := log.NewLevel(log.INFO)
@@ -53,6 +55,40 @@ func TestNewNode(t *testing.T) {
 	ctx, cancel := context.WithCancel(t.Context())
 	cancel()
 	n.Run(ctx)
+}
+
+func TestNewNodeRunsOneAtATimeOnLowMemory(t *testing.T) {
+	config := &node.Config{
+		LogLevel:                           "info",
+		HTTP:                               true,
+		DatabasePath:                       t.TempDir(),
+		DBCompression:                      "zstd",
+		Network:                            networks.Sepolia,
+		DisableL1Verification:              true,
+		SubmittedTransactionsCacheEntryTTL: time.Second,
+		MaxCompilationMemory:               4096,
+		// Reserve more than the machine has, so nothing fits.
+		NodeMemoryReserve: uint(compiler.AvailableMemoryMB() + 4096),
+	}
+
+	_, err := node.New(config, "v0.3", log.NewLevel(log.INFO))
+	require.NoError(t, err)
+}
+
+func TestNewNodeSkipsDerivedConcurrency(t *testing.T) {
+	config := &node.Config{
+		LogLevel:                           "info",
+		HTTP:                               true,
+		DatabasePath:                       t.TempDir(),
+		DBCompression:                      "zstd",
+		Network:                            networks.Sepolia,
+		DisableL1Verification:              true,
+		SubmittedTransactionsCacheEntryTTL: time.Second,
+		MaxConcurrentCompilations:          2,
+	}
+
+	_, err := node.New(config, "v0.3", log.NewLevel(log.INFO))
+	require.NoError(t, err)
 }
 
 func TestNetworkVerificationOnNonEmptyDB(t *testing.T) {

--- a/node/node_test.go
+++ b/node/node_test.go
@@ -45,7 +45,7 @@ func TestNewNode(t *testing.T) {
 		P2PAddr:                            "",
 		P2PPeers:                           "",
 		SubmittedTransactionsCacheEntryTTL: time.Second,
-		// MaxConcurrentCompilations left 0 to exercise the auto-derive path.
+		// MaxConcurrentCompilations left empty to exercise the auto-derive path.
 	}
 
 	logLevel := log.NewLevel(log.INFO)
@@ -66,7 +66,8 @@ func TestNewNodeRunsOneAtATimeOnLowMemory(t *testing.T) {
 		Network:                            networks.Sepolia,
 		DisableL1Verification:              true,
 		SubmittedTransactionsCacheEntryTTL: time.Second,
-		MaxCompilationMemory:               4096,
+		// MaxConcurrentCompilations left empty: derive, then floor to 1.
+		MaxCompilationMemory: 4096,
 		// Reserve more than the machine has, so nothing fits.
 		NodeMemoryReserve: uint(compiler.AvailableMemoryMB() + 4096),
 	}
@@ -84,7 +85,7 @@ func TestNewNodeSkipsDerivedConcurrency(t *testing.T) {
 		Network:                            networks.Sepolia,
 		DisableL1Verification:              true,
 		SubmittedTransactionsCacheEntryTTL: time.Second,
-		MaxConcurrentCompilations:          2,
+		MaxConcurrentCompilations:          "2",
 	}
 
 	_, err := node.New(config, "v0.3", log.NewLevel(log.INFO))

--- a/starknet/compiler/compiler.go
+++ b/starknet/compiler/compiler.go
@@ -31,6 +31,11 @@ const (
 	FlagMaxCPUTime = "max-cpu-time" // seconds (RLIMIT_CPU)
 )
 
+// Pin the compile child to a small GOMAXPROCS. A compilation is one Rust FFI call,
+// so extra Go threads don't speed it up; they only add per-thread stacks that grow
+// the child's address space toward the RLIMIT_AS limit on many-core hosts.
+const compileChildGOMAXPROCS = "2"
+
 // Config bounds the resources used by compilation child processes.
 type Config struct {
 	// MaxMemory is the address-space limit (RLIMIT_AS) in bytes
@@ -105,6 +110,7 @@ func (c *compiler) Compile(
 
 	//nolint:gosec // binaryPath is the juno binary, not user input
 	cmd := exec.CommandContext(ctx, c.binaryPath, args...)
+	cmd.Env = append(os.Environ(), "GOMAXPROCS="+compileChildGOMAXPROCS)
 	cmd.Stdin = bytes.NewReader(sierraJSON)
 
 	var stdout, stderr bytes.Buffer

--- a/starknet/compiler/concurrency.go
+++ b/starknet/compiler/concurrency.go
@@ -1,0 +1,38 @@
+package compiler
+
+import (
+	"github.com/KimMachineGun/automemlimit/memlimit"
+	"github.com/pbnjay/memory"
+)
+
+const megabyte = 1 << 20
+
+// AvailableMemoryMB returns the RAM this process can use, in MB.
+// Inside a container it uses the cgroup limit, otherwise the host RAM.
+func AvailableMemoryMB() uint64 {
+	hostMemory := memory.TotalMemory()
+	cgroupLimit, err := memlimit.FromCgroup()
+	if err == nil && cgroupLimit > 0 && cgroupLimit < hostMemory {
+		return cgroupLimit / megabyte
+	}
+	return hostMemory / megabyte
+}
+
+// ConcurrencyLimit returns how many compilations fit in memory, capped by maxParallel.
+// Memory is in MB. A zero maxMemoryPerCompilation means no memory limit.
+// Returns 0 when memory fits no compilation.
+func ConcurrencyLimit(
+	maxParallel uint,
+	availableMemory uint64,
+	nodeMemoryReserve uint64,
+	maxMemoryPerCompilation uint64,
+) uint {
+	if maxMemoryPerCompilation == 0 {
+		return maxParallel
+	}
+	if availableMemory <= nodeMemoryReserve {
+		return 0
+	}
+	fitInMemory := uint((availableMemory - nodeMemoryReserve) / maxMemoryPerCompilation)
+	return min(fitInMemory, maxParallel)
+}

--- a/starknet/compiler/concurrency_test.go
+++ b/starknet/compiler/concurrency_test.go
@@ -1,0 +1,82 @@
+package compiler_test
+
+import (
+	"testing"
+
+	"github.com/NethermindEth/juno/starknet/compiler"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestConcurrencyLimit(t *testing.T) {
+	const gb = 1024 // values are in MB
+	tests := []struct {
+		name                                                        string
+		maxParallel                                                 uint
+		availableMemory, nodeMemoryReserve, maxMemoryPerCompilation uint64
+		want                                                        uint
+	}{
+		{
+			name:                    "memory budget caps below max parallel",
+			maxParallel:             10,
+			availableMemory:         16 * gb,
+			nodeMemoryReserve:       4 * gb,
+			maxMemoryPerCompilation: 4 * gb,
+			want:                    3, // (16-4)/4
+		},
+		{
+			name:                    "max parallel caps below memory budget",
+			maxParallel:             2,
+			availableMemory:         64 * gb,
+			nodeMemoryReserve:       4 * gb,
+			maxMemoryPerCompilation: 4 * gb,
+			want:                    2,
+		},
+		{
+			name:                    "exactly one compilation fits",
+			maxParallel:             10,
+			availableMemory:         8 * gb,
+			nodeMemoryReserve:       4 * gb,
+			maxMemoryPerCompilation: 4 * gb,
+			want:                    1, // (8-4)/4
+		},
+		{
+			name:                    "no room for a single compilation when available equals reserve",
+			maxParallel:             10,
+			availableMemory:         4 * gb,
+			nodeMemoryReserve:       4 * gb,
+			maxMemoryPerCompilation: 4 * gb,
+			want:                    0,
+		},
+		{
+			name:                    "no room when available below reserve plus one compilation",
+			maxParallel:             10,
+			availableMemory:         6 * gb,
+			nodeMemoryReserve:       4 * gb,
+			maxMemoryPerCompilation: 4 * gb,
+			want:                    0, // (6-4)/4
+		},
+		{
+			name:                    "unbounded per-compilation memory ignores budget",
+			maxParallel:             7,
+			availableMemory:         1 * gb,
+			nodeMemoryReserve:       4 * gb,
+			maxMemoryPerCompilation: 0,
+			want:                    7,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := compiler.ConcurrencyLimit(
+				tt.maxParallel,
+				tt.availableMemory,
+				tt.nodeMemoryReserve,
+				tt.maxMemoryPerCompilation,
+			)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestAvailableMemoryMB(t *testing.T) {
+	assert.NotZero(t, compiler.AvailableMemoryMB())
+}


### PR DESCRIPTION
Sets two memory defaults for Sierra compilation, from measurements.

## What changes

| flag | old | new | role |
|---|---|---|---|
| `--max-compilation-memory` | 4 GB | **2 GB** | per-compile address-space ceiling; also sets how many run at once |
| `--node-memory-reserve` | 4 GB | 4 GB (unchanged) | memory held back for the rest of the node |

Plus: the compile child process is pinned to `GOMAXPROCS=2`.

## Real vs virtual memory

Each compilation runs in its own child process, with two very different memory numbers:

| | a compilation | what it means |
|---|---|---|
| Real memory (RSS) | ~150-200 MB | what it actually occupies in RAM |
| Virtual memory (address space) | ~1.5-1.8 GB | what it maps, used or not |

They differ this much because **Go reserves far more virtual memory than it uses**.

## Compilation memory ceiling (2 GB)

`--max-compilation-memory` is an `RLIMIT_AS` limit, so it caps **virtual** memory. A compile maps ~1.6 GB of it, so the limit has to be around that, not the ~200 MB of real usage. Capping real memory is not reliable, only trhorugh `cgroup`, which needs special permision in containers.

Measured peak virtual memory of the heaviest honest mainnet contract:

| arch / cores | VmPeak |
|---|---|
| arm64 | ~1.6 GB |
| amd64, 16 cores | 1.77 GB |
| amd64, 128 cores (unpinned) | 1.93 GB |
| any, pinned to GOMAXPROCS=2 | ~1.58 GB |

2 GB sits just above that peak. This flag also caps how many compile at once, so lowering it from 4 GB doubles concurrency (a 16 GB node goes from 3 to 6 slots) and halves the worst-case ceiling per compile.

## Pinning the compile child to GOMAXPROCS=2

A compilation is one Rust FFI call, so extra Go threads do not make it faster; they only add per-thread stacks that grow the virtual memory peak. Inheriting a large host GOMAXPROCS pushes the memory peak up (1.93 GB at 128 cores, near the limit). Pinning keeps it host-independent (~1.58 GB) at no time cost.

## Node memory reserve (4 GB)

Measured on a real synced mainnet node via `process_resident_memory_bytes`, which counts the node's whole footprint together: Go heap, pebble (DB) cache, state, contract execution and RPC.

| | RSS |
|---|---|
| steady state | ~1.5 GB |
| peak over 24h | ~2.25 GB |
| worst over 7d | ~2.86 GB |

4 GB covers the peak with headroom.

## Validation

Checked derivation, fallback and virtual peak across Docker (arm64), native macOS (arm64) and a native amd64 host, from 1 to 128 cores. Build, tests and lint green.
