### PR TITLE
perf(state): avoid full header decode in deprecated state backend

### DIFF
--- a/blockchain/statebackend/deprecated.go
+++ b/blockchain/statebackend/deprecated.go
@@ -17,14 +17,9 @@ func (b *deprecatedStateBackend) HeadState() (core.StateReader, StateCloser, err
 	//nolint:staticcheck,nolintlint // used by old state
 	txn := b.database.NewIndexedBatch()
 
-	height, err := core.GetChainHeight(txn)
-	if err != nil {
-		return nil, nil, err
-	}
-
-	// Note(Ege): Why do we fetch header here?
-	_, err = core.GetBlockHeaderByNumber(txn, height)
-	if err != nil {
+	// Fail early if no block has been committed (no head state to open)
+	// only the key's existence matters, not the height itself.
+	if _, err := core.GetChainHeight(txn); err != nil {
 		return nil, nil, err
 	}
 
@@ -34,8 +29,7 @@ func (b *deprecatedStateBackend) HeadState() (core.StateReader, StateCloser, err
 func (b *deprecatedStateBackend) StateAtBlockNumber(
 	blockNumber uint64,
 ) (core.StateReader, StateCloser, error) {
-	_, err := pruner.HeaderByNumberIfStateRetained(b.database, blockNumber)
-	if err != nil {
+	if err := pruner.RequireStateRetainedByBlockNumber(b.database, blockNumber); err != nil {
 		return nil, nil, err
 	}
 	//nolint:staticcheck,nolintlint // used by old state
@@ -56,7 +50,7 @@ func (b *deprecatedStateBackend) StateAtBlockHash(
 		return deprecatedstate.New(txn), NoopStateCloser, nil
 	}
 
-	header, err := pruner.HeaderByHashIfStateRetained(b.database, blockHash)
+	blockNumber, err := pruner.BlockNumberByHashIfStateRetained(b.database, blockHash)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -64,7 +58,7 @@ func (b *deprecatedStateBackend) StateAtBlockHash(
 	txn := b.database.NewIndexedBatch() //nolint:staticcheck // indexedBatch used by old state
 	return deprecatedstate.NewHistory(
 		deprecatedstate.New(txn),
-		header.Number,
+		blockNumber,
 	), NoopStateCloser, nil
 }
 

--- a/core/accessors.go
+++ b/core/accessors.go
@@ -344,6 +344,24 @@ func GetGlobalStateRootByBlockNumber(r db.KeyValueReader, blockNum uint64) (*fel
 	return header.GlobalStateRoot, nil
 }
 
+// GetBlockHeaderHashByNumber only materialises Hash from the header,
+// skipping heavier unused fields.
+func GetBlockHeaderHashByNumber(r db.KeyValueReader, blockNum uint64) (*felt.Felt, error) {
+	var header struct {
+		Hash *felt.Felt
+	}
+	err := r.Get(db.BlockHeaderByNumberKey(blockNum), func(data []byte) error {
+		return encoder.Unmarshal(data, &header)
+	})
+	if err != nil {
+		return nil, err
+	}
+	if header.Hash == nil {
+		return nil, fmt.Errorf("missing Hash in block header %d", blockNum)
+	}
+	return header.Hash, nil
+}
+
 func GetBlockHeaderByHash(r db.KeyValueReader, hash *felt.Felt) (*Header, error) {
 	var blockNum uint64
 	err := r.Get(db.BlockHeaderNumbersByHashKey(hash), func(data []byte) error {

--- a/core/accessors_test.go
+++ b/core/accessors_test.go
@@ -10,7 +10,6 @@ import (
 	"github.com/NethermindEth/juno/core/felt"
 	"github.com/NethermindEth/juno/db"
 	"github.com/NethermindEth/juno/db/memory"
-	"github.com/NethermindEth/juno/encoder"
 	adaptfeeder "github.com/NethermindEth/juno/starknetdata/feeder"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -258,37 +257,50 @@ func TestDeleteTransactionsAndReceipts(t *testing.T) {
 	})
 }
 
-func TestGetGlobalStateRootByBlockNumber(t *testing.T) {
+func TestPartialBlockHeaderAccessorsByNumber(t *testing.T) {
 	t.Parallel()
 	memDB, block := setupForTxsAndReceiptsTests(t)
 	require.NoError(t, core.WriteBlockHeaderByNumber(memDB, block.Header))
 
-	t.Run("matches full header decode", func(t *testing.T) {
-		t.Parallel()
-		header, err := core.GetBlockHeaderByNumber(memDB, block.Number)
-		require.NoError(t, err)
+	tests := []struct {
+		name        string
+		readPartial func(db.KeyValueReader, uint64) (*felt.Felt, error)
+		getExpected func(*core.Header) *felt.Felt
+	}{
+		{
+			name:        "global state root",
+			readPartial: core.GetGlobalStateRootByBlockNumber,
+			getExpected: func(header *core.Header) *felt.Felt {
+				return header.GlobalStateRoot
+			},
+		},
+		{
+			name:        "block hash",
+			readPartial: core.GetBlockHeaderHashByNumber,
+			getExpected: func(header *core.Header) *felt.Felt {
+				return header.Hash
+			},
+		},
+	}
 
-		stateRoot, err := core.GetGlobalStateRootByBlockNumber(memDB, block.Number)
-		require.NoError(t, err)
-		assert.Equal(t, header.GlobalStateRoot, stateRoot)
-	})
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 
-	t.Run("non-existent block", func(t *testing.T) {
-		t.Parallel()
-		_, err := core.GetGlobalStateRootByBlockNumber(memDB, nonexistentBlockNumber)
-		require.ErrorIs(t, err, db.ErrKeyNotFound)
-	})
+			t.Run("matches full header decode", func(t *testing.T) {
+				t.Parallel()
+				header, err := core.GetBlockHeaderByNumber(memDB, block.Number)
+				require.NoError(t, err)
+				got, err := tt.readPartial(memDB, block.Number)
+				require.NoError(t, err)
+				assert.Equal(t, tt.getExpected(header), got)
+			})
 
-	t.Run("missing global state root", func(t *testing.T) {
-		t.Parallel()
-		partialHeaderDB := memory.New()
-		data, err := encoder.Marshal(struct {
-			Number uint64
-		}{Number: block.Number})
-		require.NoError(t, err)
-		require.NoError(t, partialHeaderDB.Put(db.BlockHeaderByNumberKey(block.Number), data))
-
-		_, err = core.GetGlobalStateRootByBlockNumber(partialHeaderDB, block.Number)
-		require.Error(t, err)
-	})
+			t.Run("missing block returns ErrKeyNotFound", func(t *testing.T) {
+				t.Parallel()
+				_, err := tt.readPartial(memDB, nonexistentBlockNumber)
+				require.ErrorIs(t, err, db.ErrKeyNotFound)
+			})
+		})
+	}
 }

--- a/core/accessors_test.go
+++ b/core/accessors_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/NethermindEth/juno/core/felt"
 	"github.com/NethermindEth/juno/db"
 	"github.com/NethermindEth/juno/db/memory"
+	"github.com/NethermindEth/juno/encoder"
 	adaptfeeder "github.com/NethermindEth/juno/starknetdata/feeder"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -263,9 +264,10 @@ func TestPartialBlockHeaderAccessorsByNumber(t *testing.T) {
 	require.NoError(t, core.WriteBlockHeaderByNumber(memDB, block.Header))
 
 	tests := []struct {
-		name        string
-		readPartial func(db.KeyValueReader, uint64) (*felt.Felt, error)
-		getExpected func(*core.Header) *felt.Felt
+		name               string
+		readPartial        func(db.KeyValueReader, uint64) (*felt.Felt, error)
+		getExpected        func(*core.Header) *felt.Felt
+		headerWithoutField any
 	}{
 		{
 			name:        "global state root",
@@ -273,6 +275,9 @@ func TestPartialBlockHeaderAccessorsByNumber(t *testing.T) {
 			getExpected: func(header *core.Header) *felt.Felt {
 				return header.GlobalStateRoot
 			},
+			headerWithoutField: struct {
+				Hash *felt.Felt
+			}{Hash: block.Hash},
 		},
 		{
 			name:        "block hash",
@@ -280,6 +285,9 @@ func TestPartialBlockHeaderAccessorsByNumber(t *testing.T) {
 			getExpected: func(header *core.Header) *felt.Felt {
 				return header.Hash
 			},
+			headerWithoutField: struct {
+				GlobalStateRoot *felt.Felt
+			}{GlobalStateRoot: block.GlobalStateRoot},
 		},
 	}
 
@@ -300,6 +308,17 @@ func TestPartialBlockHeaderAccessorsByNumber(t *testing.T) {
 				t.Parallel()
 				_, err := tt.readPartial(memDB, nonexistentBlockNumber)
 				require.ErrorIs(t, err, db.ErrKeyNotFound)
+			})
+
+			t.Run("missing field returns error", func(t *testing.T) {
+				t.Parallel()
+				partialHeaderDB := memory.New()
+				data, err := encoder.Marshal(tt.headerWithoutField)
+				require.NoError(t, err)
+				require.NoError(t, partialHeaderDB.Put(db.BlockHeaderByNumberKey(block.Number), data))
+
+				_, err = tt.readPartial(partialHeaderDB, block.Number)
+				require.Error(t, err)
 			})
 		})
 	}

--- a/pruner/retention.go
+++ b/pruner/retention.go
@@ -72,6 +72,17 @@ func HeaderByNumberIfStateRetained(r db.KeyValueReader, blockNumber uint64) (*co
 	return header, nil
 }
 
+// Checks state retention by number, avoiding the full
+// header decode (and its heavy fields like EventsBloom) when only the hash is needed.
+func RequireStateRetainedByBlockNumber(r db.KeyValueReader, blockNumber uint64) error {
+	hash, err := core.GetBlockHeaderHashByNumber(r, blockNumber)
+	if err != nil {
+		return err
+	}
+	_, err = core.GetBlockHeaderNumberByHash(r, hash)
+	return err
+}
+
 // HeaderByHashIfStateRetained returns the header for blockHash only if
 // state at that block is queryable. Use this for state access only; for
 // block-level data use [RequireRetained] + the plain core accessors instead.
@@ -79,6 +90,12 @@ func HeaderByNumberIfStateRetained(r db.KeyValueReader, blockNumber uint64) (*co
 // when state at blockHash is not available.
 func HeaderByHashIfStateRetained(r db.KeyValueReader, blockHash *felt.Felt) (*core.Header, error) {
 	return core.GetBlockHeaderByHash(r, blockHash)
+}
+
+// Resolves blockHash to its number, avoiding the full
+// header decode (and its heavy fields like EventsBloom) when only the number is needed.
+func BlockNumberByHashIfStateRetained(r db.KeyValueReader, blockHash *felt.Felt) (uint64, error) {
+	return core.GetBlockHeaderNumberByHash(r, blockHash)
 }
 
 // OldestRetainedBlock returns the lowest block number still fully retained,

--- a/pruner/retention.go
+++ b/pruner/retention.go
@@ -72,7 +72,7 @@ func HeaderByNumberIfStateRetained(r db.KeyValueReader, blockNumber uint64) (*co
 	return header, nil
 }
 
-// Checks state retention by number, avoiding the full
+// RequireStateRetainedByBlockNumber checks state retention by number, avoiding the full
 // header decode (and its heavy fields like EventsBloom) when only the hash is needed.
 func RequireStateRetainedByBlockNumber(r db.KeyValueReader, blockNumber uint64) error {
 	hash, err := core.GetBlockHeaderHashByNumber(r, blockNumber)
@@ -92,7 +92,7 @@ func HeaderByHashIfStateRetained(r db.KeyValueReader, blockHash *felt.Felt) (*co
 	return core.GetBlockHeaderByHash(r, blockHash)
 }
 
-// Resolves blockHash to its number, avoiding the full
+// BlockNumberByHashIfStateRetained resolves blockHash to its number, avoiding the full
 // header decode (and its heavy fields like EventsBloom) when only the number is needed.
 func BlockNumberByHashIfStateRetained(r db.KeyValueReader, blockHash *felt.Felt) (uint64, error) {
 	return core.GetBlockHeaderNumberByHash(r, blockHash)

--- a/pruner/retention_test.go
+++ b/pruner/retention_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/NethermindEth/juno/core/felt"
 	"github.com/NethermindEth/juno/db"
+	"github.com/NethermindEth/juno/db/memory"
 	_ "github.com/NethermindEth/juno/encoder/registry"
 	"github.com/NethermindEth/juno/pruner"
 	"github.com/NethermindEth/juno/pruner/testutils"
@@ -115,6 +116,33 @@ func TestHeaderByNumberIfStateRetained(t *testing.T) {
 	t.Run("missing block returns ErrKeyNotFound", func(t *testing.T) {
 		database := testutils.NewPebbleTestDB(t)
 		_, err := pruner.HeaderByNumberIfStateRetained(database, 0)
+		require.ErrorIs(t, err, db.ErrKeyNotFound)
+	})
+}
+
+func TestRequireStateRetainedByBlockNumber(t *testing.T) {
+	t.Run("allows retained state", func(t *testing.T) {
+		const blockNumber = uint64(3)
+
+		database := memory.New()
+		for i := range uint64(5) {
+			testutils.StoreBlock(t, database, i)
+		}
+		require.NoError(t, pruner.RequireStateRetainedByBlockNumber(database, blockNumber))
+	})
+
+	t.Run("rejects pruned state when header remains", func(t *testing.T) {
+		const blockNumber = uint64(1)
+
+		database := memory.New()
+		blocks := make([]*testutils.StoredBlock, 5)
+		for i := range uint64(5) {
+			blocks[i] = testutils.StoreBlock(t, database, i)
+		}
+		prunedHash := blocks[blockNumber].Header.Hash
+		require.NoError(t, database.Delete(db.BlockHeaderNumbersByHashKey(prunedHash)))
+
+		err := pruner.RequireStateRetainedByBlockNumber(database, blockNumber)
 		require.ErrorIs(t, err, db.ErrKeyNotFound)
 	})
 }


### PR DESCRIPTION
Extends the partial-header-decode optimization from #3782 to the
production-default `deprecatedStateBackend`, avoiding full header decodes
(including `EventsBloom`) when only one field or an existence check is needed.

- **`HeadState`**: dropped the discarded `GetBlockHeaderByNumber` fetch;
  `GetChainHeight` is now only used as the head-exists guard.
- **`StateAtBlockNumber`**: gated on `RequireStateRetainedByBlockNumber`,
  which reads only the block hash + hash→number index.
- **`StateAtBlockHash`**: resolves the block number via the hash→number
  index without decoding the header.

## Why

These paths back latest/head and historical-block state RPCs (`getNonce`,
`getStorageAt`, `getClass*`, `call`, `estimateFee`, tracing, etc.). The full
header decode was pure overhead on the hot read path.

## Behavior note

`HeadState` and `StateAtBlockHash` no longer perform a full header decode
as an incidental DB-corruption/header-existence guard. The `GetChainHeight`
check and the hash→number index lookup remain as guards, which is correct
for a consistent DB.

## Benchmark

Note: I could not use the recent mainnet data sampled earlier because these state-read benchmarks require contiguous chain data with matching parent hashes. The available fixture-sync path only provides a contiguous mainnet chain through block 2, so this uses shallow fixture data instead.

| Path / op | sec/op base | sec/op new | sec/op Δ | B/op base | B/op new | B/op Δ | allocs/op base | allocs/op new | allocs/op Δ |
|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|
| Latest/Nonce | 68.14µ | 11.41µ | **−83.3%** (p=0.002) | 4.558Ki | 1.784Ki | **−60.9%** | 39 | 15 | **−61.5%** |
| Latest/ClassHashAt | 70.30µ | 10.56µ | **−85.0%** (p=0.002) | 4.558Ki | 1.784Ki | **−60.9%** | 39 | 15 | **−61.5%** |
| Latest/StorageAt | 95.23µ | 17.42µ | **−81.7%** (p=0.015) | 5.066Ki | 2.285Ki | **−54.9%** | 51 | 27 | **−47.1%** |
| ByNumber/Nonce | 67.57µ | 50.79µ | **−24.8%** (p=0.009) | 4.766Ki | 2.684Ki | **−43.7%** | 48 | 60 | **+25.0%** |
| ByNumber/ClassHashAt | 68.38µ | 52.83µ | ~ (p=0.065) | 4.766Ki | 2.680Ki | **−43.8%** | 48 | 60 | **+25.0%** |
| ByNumber/StorageAt | 76.44µ | 68.49µ | ~ (p=0.132) | 5.471Ki | 3.393Ki | **−38.0%** | 61 | 73 | **+19.7%** |
| ByHash/Nonce | 73.20µ | 34.53µ | **−52.8%** (p=0.002) | 4.770Ki | 2.172Ki | **−54.5%** | 48 | 26 | **−45.8%** |
| ByHash/ClassHashAt | 65.38µ | 34.79µ | **−46.8%** (p=0.002) | 4.766Ki | 2.172Ki | **−54.4%** | 48 | 26 | **−45.8%** |
| ByHash/StorageAt | 77.86µ | 48.41µ | **−37.8%** (p=0.002) | 5.473Ki | 2.877Ki | **−47.4%** | 61 | 39 | **−36.1%** |

All `B/op` deltas have `p=0.002`.

## Tests

- Added focused tests for the new partial accessor and retention guard.