### PR TITLE
refactor(v10): check storage existence only for zeros

### DIFF
--- a/core/deprecatedstate/contract.go
+++ b/core/deprecatedstate/contract.go
@@ -148,11 +148,9 @@ func (c *ContractUpdater) UpdateStorage(diff map[felt.Felt]*felt.Felt, cb OnValu
 
 //nolint:staticcheck // Necessary for old state
 func ContractStorage(addr, key *felt.Felt, txn db.IndexedBatch) (felt.Felt, error) {
-	cStorage, err := storage(addr, txn)
-	if err != nil {
-		return felt.Felt{}, err
-	}
-	return cStorage.Get(key)
+	return trie.GetLeafPedersen(
+		txn, db.ContractStorage.Key(addr.Marshal()), ContractStorageTrieHeight, key,
+	)
 }
 
 //nolint:staticcheck // Necessary for old state

--- a/core/deprecatedstate/contract_test.go
+++ b/core/deprecatedstate/contract_test.go
@@ -121,9 +121,10 @@ func TestContractStorage(t *testing.T) {
 	require.NoError(t, err)
 	require.NoError(t, txn2.Write())
 
-	t.Run("returns error when Get() fails on corrupted trie data", func(t *testing.T) {
+	t.Run("corrupted root key does not affect a direct leaf read", func(t *testing.T) {
 		txn3 := testDB.NewIndexedBatch()
-		_, err := ContractStorage(addr, key, txn3)
-		require.Error(t, err, "should fail on corrupted trie data")
+		value, err := ContractStorage(addr, key, txn3)
+		require.NoError(t, err)
+		require.Equal(t, expectedValue, &value)
 	})
 }

--- a/core/trie/trie.go
+++ b/core/trie/trie.go
@@ -47,14 +47,14 @@ func NewTrieReaderPoseidon(
 }
 
 // maxKeyByHeight[h] is 2^h - 1, the largest key a trie of height h can hold.
-var maxKeyByHeight = func() [256]*felt.Felt {
-	var table [256]*felt.Felt
+var maxKeyByHeight = func() [felt.Bits + 1]felt.Felt {
+	var table [felt.Bits + 1]felt.Felt
 	for h := range table {
 		x := felt.NewFromUint64[felt.Felt](2)
 		y := new(big.Int).SetUint64(uint64(h))
 		maxKey := x.Exp(x, y)
 		maxKey.Sub(maxKey, &felt.One)
-		table[h] = maxKey
+		table[h] = *maxKey
 	}
 	return table
 }()
@@ -66,29 +66,17 @@ func GetLeafPedersen(
 	height uint8,
 	key *felt.Felt,
 ) (felt.Felt, error) {
-	reader, err := newLeafReaderPedersen(r, prefix, height)
-	if err != nil {
-		return felt.Felt{}, err
-	}
-	return reader.Get(key)
-}
-
-// newLeafReaderPedersen builds a read-only reader that skips loading the root
-// key. Only Get is valid on it
-func newLeafReaderPedersen(
-	r db.KeyValueReader,
-	prefix []byte,
-	height uint8,
-) (TrieReader, error) {
 	if height > felt.Bits {
-		return TrieReader{}, fmt.Errorf("max trie height is %d, got: %d", felt.Bits, height)
+		return felt.Felt{}, fmt.Errorf("max trie height is %d, got: %d", felt.Bits, height)
 	}
-	return TrieReader{
+	reader := TrieReader{
 		readStorage: NewReadStorage(r, prefix),
 		height:      height,
-		maxKey:      maxKeyByHeight[height],
+		maxKey:      &maxKeyByHeight[height],
 		hash:        crypto.Pedersen,
-	}, nil
+	}
+
+	return reader.Get(key)
 }
 
 func newTrieReader(
@@ -107,12 +95,11 @@ func newTrieReader(
 		return TrieReader{}, err
 	}
 
-	maxKey := maxKeyByHeight[height]
 	return TrieReader{
 		readStorage: readStorage,
 		height:      height,
 		rootKey:     rootKey,
-		maxKey:      maxKey,
+		maxKey:      &maxKeyByHeight[height],
 		hash:        hash,
 	}, nil
 }

--- a/core/trie/trie.go
+++ b/core/trie/trie.go
@@ -46,6 +46,51 @@ func NewTrieReaderPoseidon(
 	return newTrieReader(r, prefix, height, crypto.Poseidon)
 }
 
+// maxKeyByHeight[h] is 2^h - 1, the largest key a trie of height h can hold.
+var maxKeyByHeight = func() [256]*felt.Felt {
+	var table [256]*felt.Felt
+	for h := range table {
+		x := felt.NewFromUint64[felt.Felt](2)
+		y := new(big.Int).SetUint64(uint64(h))
+		maxKey := x.Exp(x, y)
+		maxKey.Sub(maxKey, &felt.One)
+		table[h] = maxKey
+	}
+	return table
+}()
+
+// GetLeafPedersen reads a single leaf value by key from the flat Pedersen trie at prefix
+func GetLeafPedersen(
+	r db.KeyValueReader,
+	prefix []byte,
+	height uint8,
+	key *felt.Felt,
+) (felt.Felt, error) {
+	reader, err := newLeafReaderPedersen(r, prefix, height)
+	if err != nil {
+		return felt.Felt{}, err
+	}
+	return reader.Get(key)
+}
+
+// newLeafReaderPedersen builds a read-only reader that skips loading the root
+// key. Only Get is valid on it
+func newLeafReaderPedersen(
+	r db.KeyValueReader,
+	prefix []byte,
+	height uint8,
+) (TrieReader, error) {
+	if height > felt.Bits {
+		return TrieReader{}, fmt.Errorf("max trie height is %d, got: %d", felt.Bits, height)
+	}
+	return TrieReader{
+		readStorage: NewReadStorage(r, prefix),
+		height:      height,
+		maxKey:      maxKeyByHeight[height],
+		hash:        crypto.Pedersen,
+	}, nil
+}
+
 func newTrieReader(
 	r db.KeyValueReader,
 	prefix []byte,
@@ -56,18 +101,13 @@ func newTrieReader(
 		return TrieReader{}, fmt.Errorf("max trie height is %d, got: %d", felt.Bits, height)
 	}
 
-	// maxKey is 2^height - 1
-	x := felt.NewFromUint64[felt.Felt](2)
-	y := new(big.Int).SetUint64(uint64(height))
-	maxKey := x.Exp(x, y)
-	maxKey.Sub(maxKey, &felt.One)
-
 	readStorage := NewReadStorage(r, prefix)
 	rootKey, err := readStorage.RootKey()
 	if err != nil && !errors.Is(err, db.ErrKeyNotFound) {
 		return TrieReader{}, err
 	}
 
+	maxKey := maxKeyByHeight[height]
 	return TrieReader{
 		readStorage: readStorage,
 		height:      height,
@@ -458,7 +498,7 @@ func (t *Trie) insertOrUpdateValue(
 		}
 
 		if len(nodes) > 1 { // sibling has a parent
-			siblingParent := (nodes)[len(nodes)-2]
+			siblingParent := nodes[len(nodes)-2]
 
 			t.replaceLinkWithNewParent(sibling.key, commonKey, siblingParent)
 			if err := t.storage.Put(siblingParent.key, siblingParent.node); err != nil {
@@ -865,7 +905,8 @@ func (t *TrieReader) dump(level int, parentP *BitArray) {
 		rightHash = root.RightHash.String()
 	}
 
-	fmt.Printf("%skey : \"%s\" path: \"%s\" left: \"%s\" right: \"%s\" LH: \"%s\" RH: \"%s\" value: \"%s\" \n",
+	fmt.Printf(
+		"%skey : \"%s\" path: \"%s\" left: \"%s\" right: \"%s\" LH: \"%s\" RH: \"%s\" value: \"%s\" \n",
 		strings.Repeat("\t", level),
 		t.rootKey.String(),
 		path.String(),

--- a/rpc/v10/storage.go
+++ b/rpc/v10/storage.go
@@ -110,13 +110,13 @@ func (h *Handler) StorageAt(
 		if errors.Is(err, db.ErrKeyNotFound) {
 			return nil, rpccore.ErrContractNotFound
 		}
+		h.logger.Error("Failed to get contract storage", zap.Error(err))
 		return nil, rpccore.ErrInternal.CloneWithData(err)
 	}
 
-	// A zero value is ambiguous: an unset slot reads as zero, but so does a
-	// missing contract on the head reader (which returns zero without erroring).
-	// A non-zero value already proves the contract exists, so probe only here.
-	if value.IsZero() {
+	// Only head readers return zero (not ErrKeyNotFound) for a missing contract,
+	// so a zero value needs an existence probe there; historical readers don't.
+	if value.IsZero() && (id.IsLatest() || id.IsPreConfirmed()) {
 		if _, err := stateReader.ContractClassHash(addressFelt); err != nil {
 			if errors.Is(err, db.ErrKeyNotFound) {
 				return nil, rpccore.ErrContractNotFound

--- a/rpc/v10/storage.go
+++ b/rpc/v10/storage.go
@@ -114,9 +114,9 @@ func (h *Handler) StorageAt(
 		return nil, rpccore.ErrInternal.CloneWithData(err)
 	}
 
-	// Only the head (latest) reader returns zero for a missing contract, so probe
-	// the class hash to distinguish "contract absent" from "slot is zero".
-	// Historical and pre_confirmed readers surface it as ErrKeyNotFound above.
+	// Head readers return zero for a missing contract, so probe the class hash to
+	// tell it apart from an unset slot. Other readers already return ErrKeyNotFound.
+	// Genesis pre_confirmed case is ignored deliberately
 	if value.IsZero() && id.IsLatest() {
 		if _, err := stateReader.ContractClassHash(addressFelt); err != nil {
 			if errors.Is(err, db.ErrKeyNotFound) {

--- a/rpc/v10/storage.go
+++ b/rpc/v10/storage.go
@@ -105,21 +105,28 @@ func (h *Handler) StorageAt(
 	}
 	defer h.callAndLogErr(stateCloser, "Error closing state reader in getStorageAt")
 
-	// This checks if the contract exists because if a key doesn't exist in contract storage,
-	// the returned value is always zero and error is nil.
-	_, err := stateReader.ContractClassHash(addressFelt)
+	value, err := stateReader.ContractStorage(addressFelt, key)
 	if err != nil {
 		if errors.Is(err, db.ErrKeyNotFound) {
 			return nil, rpccore.ErrContractNotFound
 		}
-		h.logger.Error("Failed to get contract class hash", zap.Error(err))
 		return nil, rpccore.ErrInternal.CloneWithData(err)
 	}
 
-	result.Value, err = stateReader.ContractStorage(addressFelt, key)
-	if err != nil {
-		return nil, rpccore.ErrInternal.CloneWithData(err)
+	// A zero value is ambiguous: an unset slot reads as zero, but so does a
+	// missing contract on the head reader (which returns zero without erroring).
+	// A non-zero value already proves the contract exists, so probe only here.
+	if value.IsZero() {
+		if _, err := stateReader.ContractClassHash(addressFelt); err != nil {
+			if errors.Is(err, db.ErrKeyNotFound) {
+				return nil, rpccore.ErrContractNotFound
+			}
+			h.logger.Error("Failed to get contract class hash", zap.Error(err))
+			return nil, rpccore.ErrInternal.CloneWithData(err)
+		}
 	}
+
+	result.Value = value
 
 	if !flags.IncludeLastUpdateBlock {
 		return &result, nil

--- a/rpc/v10/storage.go
+++ b/rpc/v10/storage.go
@@ -114,8 +114,9 @@ func (h *Handler) StorageAt(
 		return nil, rpccore.ErrInternal.CloneWithData(err)
 	}
 
-	// Only the latest (head) reader returns zero for a missing contract; historical
-	// and pre_confirmed readers already surface it as ErrKeyNotFound.
+	// Only the head (latest) reader returns zero for a missing contract, so probe
+	// the class hash to distinguish "contract absent" from "slot is zero".
+	// Historical and pre_confirmed readers surface it as ErrKeyNotFound above.
 	if value.IsZero() && id.IsLatest() {
 		if _, err := stateReader.ContractClassHash(addressFelt); err != nil {
 			if errors.Is(err, db.ErrKeyNotFound) {

--- a/rpc/v10/storage.go
+++ b/rpc/v10/storage.go
@@ -114,9 +114,9 @@ func (h *Handler) StorageAt(
 		return nil, rpccore.ErrInternal.CloneWithData(err)
 	}
 
-	// Only head readers return zero (not ErrKeyNotFound) for a missing contract,
-	// so a zero value needs an existence probe there; historical readers don't.
-	if value.IsZero() && (id.IsLatest() || id.IsPreConfirmed()) {
+	// Only the latest (head) reader returns zero for a missing contract; historical
+	// and pre_confirmed readers already surface it as ErrKeyNotFound.
+	if value.IsZero() && id.IsLatest() {
 		if _, err := stateReader.ContractClassHash(addressFelt); err != nil {
 			if errors.Is(err, db.ErrKeyNotFound) {
 				return nil, rpccore.ErrContractNotFound

--- a/rpc/v10/storage_test.go
+++ b/rpc/v10/storage_test.go
@@ -180,6 +180,16 @@ func TestStorageAt(t *testing.T) {
 			assert.Equal(t, expectedStorage, result.Value)
 		})
 
+		t.Run("zero value on historical reader skips the existence probe", func(t *testing.T) {
+			mockReader.EXPECT().StateAtBlockNumber(uint64(8)).Return(mockState, nopCloser, nil)
+			mockState.EXPECT().ContractStorage(&targetAddressFelt, &targetSlot).Return(felt.Zero, nil)
+
+			blockID := rpc.BlockIDFromNumber(8)
+			result, rpcErr := handler.StorageAt(&targetAddress, &targetSlot, &blockID, noFlags)
+			require.Nil(t, rpcErr)
+			assert.Equal(t, felt.Zero, result.Value)
+		})
+
 		t.Run("internal error while retrieving key", func(t *testing.T) {
 			internalErr := errors.New("some internal error")
 			mockReader.EXPECT().HeadState().Return(mockState, nopCloser, nil)

--- a/rpc/v10/storage_test.go
+++ b/rpc/v10/storage_test.go
@@ -141,6 +141,7 @@ func TestStorageAt(t *testing.T) {
 
 		t.Run("non-existent contract", func(t *testing.T) {
 			mockReader.EXPECT().HeadState().Return(mockState, nopCloser, nil)
+			mockState.EXPECT().ContractStorage(&targetAddressFelt, &targetSlot).Return(felt.Zero, nil)
 			mockState.EXPECT().ContractClassHash(&targetAddressFelt).Return(felt.Felt{}, db.ErrKeyNotFound)
 
 			blockID := rpc.BlockIDLatest()
@@ -169,10 +170,19 @@ func TestStorageAt(t *testing.T) {
 			validateStorageAtJSON(t, result, noFlags.IncludeLastUpdateBlock)
 		})
 
+		t.Run("non-zero value skips the existence probe", func(t *testing.T) {
+			mockReader.EXPECT().StateAtBlockNumber(uint64(7)).Return(mockState, nopCloser, nil)
+			mockState.EXPECT().ContractStorage(&targetAddressFelt, &targetSlot).Return(expectedStorage, nil)
+
+			blockID := rpc.BlockIDFromNumber(7)
+			result, rpcErr := handler.StorageAt(&targetAddress, &targetSlot, &blockID, noFlags)
+			require.Nil(t, rpcErr)
+			assert.Equal(t, expectedStorage, result.Value)
+		})
+
 		t.Run("internal error while retrieving key", func(t *testing.T) {
 			internalErr := errors.New("some internal error")
 			mockReader.EXPECT().HeadState().Return(mockState, nopCloser, nil)
-			mockState.EXPECT().ContractClassHash(&targetAddressFelt).Return(felt.Felt{}, nil)
 			mockState.EXPECT().ContractStorage(&targetAddressFelt, &targetSlot).
 				Return(felt.Felt{}, internalErr)
 
@@ -188,7 +198,6 @@ func TestStorageAt(t *testing.T) {
 
 		t.Run("blockID - latest", func(t *testing.T) {
 			mockReader.EXPECT().HeadState().Return(mockState, nopCloser, nil)
-			mockState.EXPECT().ContractClassHash(&targetAddressFelt).Return(felt.Felt{}, nil)
 			mockState.EXPECT().ContractStorage(&targetAddressFelt, &targetSlot).Return(expectedStorage, nil)
 
 			blockID := rpc.BlockIDLatest()
@@ -204,7 +213,6 @@ func TestStorageAt(t *testing.T) {
 
 		t.Run("blockID - hash", func(t *testing.T) {
 			mockReader.EXPECT().StateAtBlockHash(&felt.Zero).Return(mockState, nopCloser, nil)
-			mockState.EXPECT().ContractClassHash(&targetAddressFelt).Return(felt.Felt{}, nil)
 			mockState.EXPECT().ContractStorage(&targetAddressFelt, &targetSlot).Return(expectedStorage, nil)
 
 			blockID := rpc.BlockIDFromHash(&felt.Zero)
@@ -220,7 +228,6 @@ func TestStorageAt(t *testing.T) {
 
 		t.Run("blockID - number", func(t *testing.T) {
 			mockReader.EXPECT().StateAtBlockNumber(uint64(0)).Return(mockState, nopCloser, nil)
-			mockState.EXPECT().ContractClassHash(&targetAddressFelt).Return(felt.Felt{}, nil)
 			mockState.EXPECT().ContractStorage(&targetAddressFelt, &targetSlot).Return(expectedStorage, nil)
 
 			blockID := rpc.BlockIDFromNumber(0)
@@ -302,7 +309,6 @@ func TestStorageAt(t *testing.T) {
 			)
 			mockReader.EXPECT().Height().Return(l1HeadBlockNumber, nil)
 			mockReader.EXPECT().StateAtBlockNumber(l1HeadBlockNumber).Return(mockState, nopCloser, nil)
-			mockState.EXPECT().ContractClassHash(&felt.Zero).Return(felt.Zero, nil)
 			mockState.EXPECT().ContractStorage(gomock.Any(), gomock.Any()).Return(expectedStorage, nil)
 
 			blockID := rpc.BlockIDL1Accepted()
@@ -320,7 +326,6 @@ func TestStorageAt(t *testing.T) {
 			)
 			mockReader.EXPECT().Height().Return(chainHeight, nil)
 			mockReader.EXPECT().StateAtBlockNumber(chainHeight).Return(mockState, nopCloser, nil)
-			mockState.EXPECT().ContractClassHash(&felt.Zero).Return(felt.Zero, nil)
 			mockState.EXPECT().ContractStorage(gomock.Any(), gomock.Any()).Return(expectedStorage, nil)
 
 			blockID := rpc.BlockIDL1Accepted()
@@ -338,7 +343,6 @@ func TestStorageAt(t *testing.T) {
 			lastUpdateBlockNum := uint64(3)
 
 			mockReader.EXPECT().StateAtBlockNumber(blockNumber).Return(mockState, nopCloser, nil)
-			mockState.EXPECT().ContractClassHash(&targetAddressFelt).Return(felt.Felt{}, nil)
 			mockState.EXPECT().ContractStorage(&targetAddressFelt, &targetSlot).Return(expectedStorage, nil)
 			mockState.EXPECT().ContractStorageLastUpdatedBlock(&targetAddress, &targetSlot).
 				Return(lastUpdateBlockNum, nil)
@@ -353,7 +357,6 @@ func TestStorageAt(t *testing.T) {
 			lastUpdateBlockNum := uint64(2)
 
 			mockReader.EXPECT().HeadState().Return(mockState, nopCloser, nil)
-			mockState.EXPECT().ContractClassHash(&targetAddressFelt).Return(felt.Felt{}, nil)
 			mockState.EXPECT().ContractStorage(&targetAddressFelt, &targetSlot).Return(expectedStorage, nil)
 			mockState.EXPECT().ContractStorageLastUpdatedBlock(&targetAddress, &targetSlot).
 				Return(lastUpdateBlockNum, nil)
@@ -369,7 +372,6 @@ func TestStorageAt(t *testing.T) {
 			lastUpdateBlockNum := uint64(1)
 
 			mockReader.EXPECT().StateAtBlockHash(&blockHash).Return(mockState, nopCloser, nil)
-			mockState.EXPECT().ContractClassHash(&targetAddressFelt).Return(felt.Felt{}, nil)
 			mockState.EXPECT().ContractStorage(&targetAddressFelt, &targetSlot).Return(expectedStorage, nil)
 			mockState.EXPECT().ContractStorageLastUpdatedBlock(&targetAddress, &targetSlot).
 				Return(lastUpdateBlockNum, nil)
@@ -394,7 +396,6 @@ func TestStorageAt(t *testing.T) {
 			)
 			mockReader.EXPECT().Height().Return(l1HeadBlockNumber, nil)
 			mockReader.EXPECT().StateAtBlockNumber(l1HeadBlockNumber).Return(mockState, nopCloser, nil)
-			mockState.EXPECT().ContractClassHash(&targetAddressFelt).Return(felt.Felt{}, nil)
 			mockState.EXPECT().ContractStorage(&targetAddressFelt, &targetSlot).Return(expectedStorage, nil)
 			mockState.EXPECT().ContractStorageLastUpdatedBlock(&targetAddress, &targetSlot).
 				Return(lastUpdateBlockNum, nil)
@@ -427,7 +428,6 @@ func TestStorageAt(t *testing.T) {
 					mockSyncReader.EXPECT().PreConfirmedChain().Return(mustNewChain(t, &preConfirmed), nil)
 					mockReader.EXPECT().StateAtBlockNumber(preConfirmedBlockNumber-1).
 						Return(mockState, nopCloser, nil)
-					mockState.EXPECT().ContractClassHash(&targetAddressFelt).Return(felt.Felt{}, nil)
 					mockState.EXPECT().ContractStorage(&targetAddressFelt, &targetSlot).
 						Return(expectedStorage, nil)
 					mockState.EXPECT().ContractStorageLastUpdatedBlock(&targetAddress, &targetSlot).
@@ -439,7 +439,8 @@ func TestStorageAt(t *testing.T) {
 					assert.Equal(t, expectedStorage, result.Value)
 					assert.Equal(t, lastUpdateBlockNum, result.LastUpdateBlock)
 					validateStorageAtJSON(t, result, flags.IncludeLastUpdateBlock)
-				})
+				},
+			)
 
 			t.Run(
 				"with storage update for the target key - returns pre_confirmed block number",
@@ -452,7 +453,6 @@ func TestStorageAt(t *testing.T) {
 					mockSyncReader.EXPECT().PreConfirmedChain().Return(mustNewChain(t, &preConfirmed), nil)
 					mockReader.EXPECT().StateAtBlockNumber(preConfirmedBlockNumber-1).
 						Return(mockState, nopCloser, nil)
-					mockState.EXPECT().ContractClassHash(&targetAddressFelt).Return(felt.Felt{}, nil)
 
 					preConfirmedID := rpc.BlockIDPreConfirmed()
 					result, rpcErr := handler.StorageAt(&targetAddress, &targetSlot, &preConfirmedID, flags)
@@ -460,7 +460,8 @@ func TestStorageAt(t *testing.T) {
 					assert.Equal(t, expectedStorage, result.Value)
 					assert.Equal(t, preConfirmedBlockNumber, result.LastUpdateBlock)
 					validateStorageAtJSON(t, result, flags.IncludeLastUpdateBlock)
-				})
+				},
+			)
 
 			t.Run(
 				"new deployed contract with storage update - returns pre_confirmed block number",
@@ -488,7 +489,8 @@ func TestStorageAt(t *testing.T) {
 					assert.Equal(t, expectedStorage, result.Value)
 					assert.Equal(t, preConfirmedBlockNumber, result.LastUpdateBlock)
 					validateStorageAtJSON(t, result, flags.IncludeLastUpdateBlock)
-				})
+				},
+			)
 
 			t.Run(
 				"new deployed contract with NO storage diffs - returns 0 block number",
@@ -515,14 +517,14 @@ func TestStorageAt(t *testing.T) {
 					assert.Equal(t, felt.Zero, result.Value)
 					assert.Equal(t, uint64(0), result.LastUpdateBlock)
 					validateStorageAtJSON(t, result, flags.IncludeLastUpdateBlock)
-				})
+				},
+			)
 		})
 
 		t.Run("no history entry (storage never updated)", func(t *testing.T) {
 			blockNumber := uint64(4)
 
 			mockReader.EXPECT().StateAtBlockNumber(blockNumber).Return(mockState, nopCloser, nil)
-			mockState.EXPECT().ContractClassHash(&targetAddressFelt).Return(felt.Felt{}, nil)
 			mockState.EXPECT().ContractStorage(&targetAddressFelt, &targetSlot).Return(expectedStorage, nil)
 			mockState.EXPECT().ContractStorageLastUpdatedBlock(&targetAddress, &targetSlot).
 				Return(uint64(0), nil)
@@ -539,7 +541,7 @@ func TestStorageAt(t *testing.T) {
 		dbErr := errors.New("db error")
 
 		mockReader.EXPECT().StateAtBlockNumber(blockNumber).Return(mockState, nopCloser, nil)
-		mockState.EXPECT().ContractClassHash(&targetAddressFelt).Return(felt.Felt{}, dbErr)
+		mockState.EXPECT().ContractStorage(&targetAddressFelt, &targetSlot).Return(felt.Felt{}, dbErr)
 
 		blockID := rpc.BlockIDFromNumber(blockNumber)
 		_, rpcErr := handler.StorageAt(
@@ -563,8 +565,10 @@ func TestStorageAt(t *testing.T) {
 	t.Run("error: contract not found", func(t *testing.T) {
 		blockNumber := uint64(99)
 
+		// Historical reader surfaces a missing contract directly from ContractStorage.
 		mockReader.EXPECT().StateAtBlockNumber(blockNumber).Return(mockState, nopCloser, nil)
-		mockState.EXPECT().ContractClassHash(&targetAddressFelt).Return(felt.Felt{}, db.ErrKeyNotFound)
+		mockState.EXPECT().ContractStorage(&targetAddressFelt, &targetSlot).
+			Return(felt.Felt{}, db.ErrKeyNotFound)
 
 		blockID := rpc.BlockIDFromNumber(blockNumber)
 		_, rpcErr := handler.StorageAt(
@@ -938,7 +942,8 @@ func TestStorageProof(t *testing.T) {
 			require.Equal(t, classHash, ld.ClassHash)
 			require.Equal(t, &expectedStorageRoot, ld.StorageRoot,
 				"StorageRoot should be the contract's storage trie root, not the global contracts trie root")
-		})
+		},
+	)
 	t.Run("contract storage trie address does not exist in a trie", func(t *testing.T) {
 		mockReader.EXPECT().BlockHeaderByNumber(blockNumber).
 			Return(headBlock.Header, nil)
@@ -1488,7 +1493,8 @@ func TestStorageProof_StorageRoots(t *testing.T) {
 		handler := rpc.New(bc, nil, nil, logger)
 		blockID := rpc.BlockIDLatest()
 		result, rpcErr := handler.StorageProof(
-			&blockID, nil, []felt.Felt{*expectedContractAddress}, nil)
+			&blockID, nil, []felt.Felt{*expectedContractAddress}, nil,
+		)
 		require.Nil(t, rpcErr)
 
 		expectedResult := rpc.StorageProofResult{

--- a/sync/preconfirmed/chain_storage_test.go
+++ b/sync/preconfirmed/chain_storage_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/NethermindEth/juno/core"
 	"github.com/NethermindEth/juno/core/felt"
 	"github.com/NethermindEth/juno/core/pending"
+	"github.com/NethermindEth/juno/db"
 	"github.com/NethermindEth/juno/mocks"
 	"github.com/NethermindEth/juno/starknet"
 	"github.com/NethermindEth/juno/sync/preconfirmed"
@@ -634,6 +635,8 @@ func TestChainReader(t *testing.T) {
 		testChainReaderPreConfirmedStateAtBaseAlignsWithOldestPreConf)
 	t.Run("PreConfirmedStateAt at genesis underflows",
 		testChainReaderPreConfirmedStateAtBaseAtGenesis)
+	t.Run("PreConfirmedStateAt at genesis reports missing contract as not found",
+		testChainReaderPreConfirmedStateAtGenesisMissingContract)
 	t.Run("PreConfirmedStateAt surfaces bcReader error from base lookup",
 		testChainReaderPreConfirmedStateAtBaseError)
 	t.Run("TransactionByHash finds tx in any chain entry",
@@ -1060,6 +1063,26 @@ func testChainReaderPreConfirmedStateAtBaseAtGenesis(t *testing.T) {
 
 	_, _, err := view.PreConfirmedStateAt(0, bc)
 	require.ErrorContains(t, err, "some kind of underflow")
+}
+
+func testChainReaderPreConfirmedStateAtGenesisMissingContract(t *testing.T) {
+	s := preconfirmed.NewChainStorage()
+	applyBlock(t, s, roundID(0), 0, 0, nil)
+	view := s.SnapshotForHead(nil)
+
+	ctrl := gomock.NewController(t)
+	base := mocks.NewMockStateReader(ctrl)
+	bc := mocks.NewMockReader(ctrl)
+	bc.EXPECT().StateAtBlockHash(&felt.Zero).Return(base, func() error { return nil }, nil)
+
+	state, closer, err := view.PreConfirmedStateAt(0, bc)
+	require.NoError(t, err)
+
+	addr := felt.FromUint64[felt.Felt](0x1234)
+	key := felt.FromUint64[felt.Felt](0x5678)
+	_, err = state.ContractStorage(&addr, &key)
+	require.ErrorIs(t, err, db.ErrKeyNotFound)
+	require.NoError(t, closer())
 }
 
 // testChainReaderPreConfirmedStateAtBaseError verifies that a bcReader failure

--- a/sync/preconfirmed/chain_storage_test.go
+++ b/sync/preconfirmed/chain_storage_test.go
@@ -10,7 +10,6 @@ import (
 	"github.com/NethermindEth/juno/core"
 	"github.com/NethermindEth/juno/core/felt"
 	"github.com/NethermindEth/juno/core/pending"
-	"github.com/NethermindEth/juno/db"
 	"github.com/NethermindEth/juno/mocks"
 	"github.com/NethermindEth/juno/starknet"
 	"github.com/NethermindEth/juno/sync/preconfirmed"
@@ -1070,18 +1069,21 @@ func testChainReaderPreConfirmedStateAtGenesisMissingContract(t *testing.T) {
 	applyBlock(t, s, roundID(0), 0, 0, nil)
 	view := s.SnapshotForHead(nil)
 
+	addr := felt.FromUint64[felt.Felt](0x1234)
+	key := felt.FromUint64[felt.Felt](0x5678)
+
 	ctrl := gomock.NewController(t)
 	base := mocks.NewMockStateReader(ctrl)
+	base.EXPECT().ContractStorage(&addr, &key).Return(felt.Zero, nil)
 	bc := mocks.NewMockReader(ctrl)
 	bc.EXPECT().StateAtBlockHash(&felt.Zero).Return(base, func() error { return nil }, nil)
 
 	state, closer, err := view.PreConfirmedStateAt(0, bc)
 	require.NoError(t, err)
 
-	addr := felt.FromUint64[felt.Felt](0x1234)
-	key := felt.FromUint64[felt.Felt](0x5678)
-	_, err = state.ContractStorage(&addr, &key)
-	require.ErrorIs(t, err, db.ErrKeyNotFound)
+	value, err := state.ContractStorage(&addr, &key)
+	require.NoError(t, err)
+	require.True(t, value.IsZero())
 	require.NoError(t, closer())
 }
 

--- a/sync/preconfirmed/chain_storage_test.go
+++ b/sync/preconfirmed/chain_storage_test.go
@@ -634,8 +634,6 @@ func TestChainReader(t *testing.T) {
 		testChainReaderPreConfirmedStateAtBaseAlignsWithOldestPreConf)
 	t.Run("PreConfirmedStateAt at genesis underflows",
 		testChainReaderPreConfirmedStateAtBaseAtGenesis)
-	t.Run("PreConfirmedStateAt at genesis reports missing contract as not found",
-		testChainReaderPreConfirmedStateAtGenesisMissingContract)
 	t.Run("PreConfirmedStateAt surfaces bcReader error from base lookup",
 		testChainReaderPreConfirmedStateAtBaseError)
 	t.Run("TransactionByHash finds tx in any chain entry",
@@ -1062,29 +1060,6 @@ func testChainReaderPreConfirmedStateAtBaseAtGenesis(t *testing.T) {
 
 	_, _, err := view.PreConfirmedStateAt(0, bc)
 	require.ErrorContains(t, err, "some kind of underflow")
-}
-
-func testChainReaderPreConfirmedStateAtGenesisMissingContract(t *testing.T) {
-	s := preconfirmed.NewChainStorage()
-	applyBlock(t, s, roundID(0), 0, 0, nil)
-	view := s.SnapshotForHead(nil)
-
-	addr := felt.FromUint64[felt.Felt](0x1234)
-	key := felt.FromUint64[felt.Felt](0x5678)
-
-	ctrl := gomock.NewController(t)
-	base := mocks.NewMockStateReader(ctrl)
-	base.EXPECT().ContractStorage(&addr, &key).Return(felt.Zero, nil)
-	bc := mocks.NewMockReader(ctrl)
-	bc.EXPECT().StateAtBlockHash(&felt.Zero).Return(base, func() error { return nil }, nil)
-
-	state, closer, err := view.PreConfirmedStateAt(0, bc)
-	require.NoError(t, err)
-
-	value, err := state.ContractStorage(&addr, &key)
-	require.NoError(t, err)
-	require.True(t, value.IsZero())
-	require.NoError(t, closer())
 }
 
 // testChainReaderPreConfirmedStateAtBaseError verifies that a bcReader failure


### PR DESCRIPTION
Bench results:
(Generated using sepolia snapshot, 1 block temp db wasn't representative, as the data was hot, and results were marginal)

Note that only for the missing contract on the latest block we would face degradation. 

| Reader | Scenario | main sec/op | branch sec/op | delta time | main allocs | branch allocs | Δ allocs |
|---|---|---|---|---|---|---|---|
| latest | non_zero | 38.45µs | 24.74µs | -35.7%  | 81 | 70 | -13.6% |
| latest | zero_exists | 58.16µs | 57.08µs | ~  | 86 | 86 | ~ |
| latest | missing_contract | 21.71µs | 49.65µs | +128.7%  | 58 | 88 | +51.7% |
| historical | non_zero | 112.0µs | 59.85µs | -46.6% | 120 | 88 | -26.7% |
| historical | zero_exists | 129.5µs | 81.69µs | -36.9% | 124 | 93 | -25.0% |
| historical | missing_contract | 20.78µs | 21.96µs | ~  | 55 | 55 | ~ |

[Updated benchmark results](https://github.com/NethermindEth/juno/pull/3790#issuecomment-4982068896)