### PR TITLE
perf(rpc): update resolveBlockRange to use block numbers instead of headers

### DIFF
--- a/rpc/v10/subscription_events.go
+++ b/rpc/v10/subscription_events.go
@@ -77,7 +77,7 @@ func newEventSubscriber(
 		}
 	}
 
-	requestedHeader, headHeader, rpcErr := handler.resolveBlockRange(blockID)
+	startBlock, latestBlock, rpcErr := handler.resolveBlockRange(blockID)
 	if rpcErr != nil {
 		return subscriber{}, rpcErr
 	}
@@ -103,14 +103,14 @@ func newEventSubscriber(
 			return state.processHistoricalEvents(
 				ctx,
 				id,
-				requestedHeader.Number,
-				headHeader.Number,
+				startBlock,
+				latestBlock,
 				fromAddrs,
 				keys,
 			)
 		},
-		onReorg:   state.onReorg,
 		onNewHead: state.onNewHead,
+		onReorg:   state.onReorg,
 	}
 	if finalityStatus != nil && *finalityStatus == TxnFinalityStatusWithoutL1(TxnPreConfirmed) {
 		s.onPreConfirmed = state.onPreConfirmed

--- a/rpc/v10/subscription_heads.go
+++ b/rpc/v10/subscription_heads.go
@@ -24,12 +24,12 @@ func (h *Handler) SubscribeNewHeads(
 		return "", jsonrpc.Err(jsonrpc.MethodNotFound, nil)
 	}
 
-	startHeader, latestHeader, rpcErr := h.resolveBlockRange(blockID)
+	startBlock, latestBlock, rpcErr := h.resolveBlockRange(blockID)
 	if rpcErr != nil {
 		return "", rpcErr
 	}
 
-	return h.subscribe(ctx, w, newHeadsSubscriber(h, w, startHeader, latestHeader))
+	return h.subscribe(ctx, w, newHeadsSubscriber(h, w, startBlock, latestBlock))
 }
 
 type headsSubscriberState struct {
@@ -40,13 +40,14 @@ type headsSubscriberState struct {
 func newHeadsSubscriber(
 	h *Handler,
 	conn jsonrpc.Conn,
-	startHeader, latestHeader *core.Header,
+	startBlock,
+	latestBlock uint64,
 ) subscriber {
 	state := &headsSubscriberState{handler: h, conn: conn}
 
 	return subscriber{
 		onStart: func(ctx context.Context, id string, _ *subscription, _ any) error {
-			return state.sendHistoricalHeaders(ctx, id, startHeader, latestHeader)
+			return state.sendHistoricalHeaders(ctx, id, startBlock, latestBlock)
 		},
 		onReorg:   state.onReorg,
 		onNewHead: state.onNewHead,
@@ -80,35 +81,32 @@ func (s *headsSubscriberState) onNewHead(
 func (s *headsSubscriberState) sendHistoricalHeaders(
 	ctx context.Context,
 	id string,
-	startHeader,
-	latestHeader *core.Header,
+	startBlock,
+	latestBlock uint64,
 ) error {
-	curHeader := startHeader
-	for {
+	for currentBlock := startBlock; currentBlock <= latestBlock; currentBlock++ {
 		select {
 		case <-ctx.Done():
 			return ctx.Err()
 		default:
-			commitments, stateDiff, err := s.handler.getCommitmentsAndStateDiff(curHeader.Number)
-			if err != nil {
-				return err
-			}
+		}
 
-			adaptedHeader := AdaptBlockHeader(curHeader, commitments, stateDiff)
-			if err = sendHeader(s.conn, &adaptedHeader, id); err != nil {
-				return err
-			}
+		commitments, stateDiff, err := s.handler.getCommitmentsAndStateDiff(currentBlock)
+		if err != nil {
+			return err
+		}
 
-			if curHeader.Number == latestHeader.Number {
-				return nil
-			}
+		currentHeader, err := s.handler.bcReader.BlockHeaderByNumber(currentBlock)
+		if err != nil {
+			return err
+		}
 
-			curHeader, err = s.handler.bcReader.BlockHeaderByNumber(curHeader.Number + 1)
-			if err != nil {
-				return err
-			}
+		adaptedHeader := AdaptBlockHeader(currentHeader, commitments, stateDiff)
+		if err = sendHeader(s.conn, &adaptedHeader, id); err != nil {
+			return err
 		}
 	}
+	return nil
 }
 
 func sendHeader(w jsonrpc.Conn, header *BlockHeader, id string) error {

--- a/rpc/v10/subscriptions.go
+++ b/rpc/v10/subscriptions.go
@@ -3,10 +3,12 @@ package rpcv10
 import (
 	"context"
 	"encoding/json"
+	"errors"
 
 	"github.com/NethermindEth/juno/core"
 	"github.com/NethermindEth/juno/core/felt"
 	"github.com/NethermindEth/juno/core/pending"
+	"github.com/NethermindEth/juno/db"
 	"github.com/NethermindEth/juno/feed"
 	"github.com/NethermindEth/juno/jsonrpc"
 	"github.com/NethermindEth/juno/rpc/rpccore"
@@ -166,31 +168,42 @@ func filterTxBySender(txn core.Transaction, senderAddr []felt.Address) bool {
 	return false
 }
 
-// resolveBlockRange returns the start and latest headers based on the blockID.
+// resolveBlockRange returns the start and latest block numbers based on the blockID.
 func (h *Handler) resolveBlockRange(
 	blockID *SubscriptionBlockID,
-) (*core.Header, *core.Header, *jsonrpc.Error) {
-	latestHeader, err := h.bcReader.HeadsHeader()
+) (uint64, uint64, *jsonrpc.Error) {
+	latestBlock, err := h.bcReader.Height()
 	if err != nil {
-		return nil, nil, rpccore.ErrInternal.CloneWithData(err.Error())
+		return 0, 0, rpccore.ErrInternal.CloneWithData(err.Error())
 	}
 
 	if blockID == nil || blockID.IsLatest() {
-		return latestHeader, latestHeader, nil
+		return latestBlock, latestBlock, nil
 	}
 
-	startHeader, rpcErr := h.blockHeaderByID((*BlockID)(blockID))
-	if rpcErr != nil {
-		return nil, nil, rpcErr
+	var startBlock uint64
+	if blockID.IsHash() {
+		startBlock, err = h.bcReader.BlockNumberByHash(blockID.Hash())
+		if err != nil {
+			if errors.Is(err, db.ErrKeyNotFound) {
+				return 0, 0, rpccore.ErrBlockNotFound
+			}
+			return 0, 0, rpccore.ErrInternal.CloneWithData(err.Error())
+		}
+	} else {
+		startBlock = blockID.Number()
+		if startBlock > latestBlock {
+			return 0, 0, rpccore.ErrBlockNotFound
+		}
 	}
 
-	tooManyBlocks := latestHeader.Number >= rpccore.MaxBlocksBack &&
-		startHeader.Number <= latestHeader.Number-rpccore.MaxBlocksBack
+	tooManyBlocks := latestBlock >= rpccore.MaxBlocksBack &&
+		startBlock <= latestBlock-rpccore.MaxBlocksBack
 	if tooManyBlocks {
-		return nil, nil, rpccore.ErrTooManyBlocksBack
+		return 0, 0, rpccore.ErrTooManyBlocksBack
 	}
 
-	return startHeader, latestHeader, nil
+	return startBlock, latestBlock, nil
 }
 
 func (h *Handler) Unsubscribe(ctx context.Context, id string) (bool, *jsonrpc.Error) {

--- a/rpc/v10/subscriptions_test.go
+++ b/rpc/v10/subscriptions_test.go
@@ -3,6 +3,7 @@ package rpcv10
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net"
@@ -1124,6 +1125,44 @@ func TestSubscribeNewHeadsErrorCases(t *testing.T) {
 			assert.Equal(t, rpccore.ErrTooManyBlocksBack, rpcErr)
 		})
 	})
+
+	t.Run("BlockID - Hash", func(t *testing.T) {
+		mockCtrl := gomock.NewController(t)
+		t.Cleanup(mockCtrl.Finish)
+
+		mockChain := mocks.NewMockReader(mockCtrl)
+		mockSyncer := mocks.NewMockSyncReader(mockCtrl)
+		handler := New(mockChain, mockSyncer, nil, logger)
+
+		blockHash := felt.NewFromUint64[felt.Felt](1)
+		blockID := SubscriptionBlockID(BlockIDFromHash(blockHash))
+
+		serverConn, _ := net.Pipe()
+		t.Cleanup(func() {
+			require.NoError(t, serverConn.Close())
+		})
+
+		subCtx := context.WithValue(t.Context(), jsonrpc.ConnKey{}, &fakeConn{w: serverConn})
+
+		t.Run("block not found", func(t *testing.T) {
+			mockChain.EXPECT().Height().Return(uint64(2), nil)
+			mockChain.EXPECT().BlockNumberByHash(blockHash).Return(uint64(0), db.ErrKeyNotFound)
+
+			id, rpcErr := handler.SubscribeNewHeads(subCtx, &blockID)
+			assert.Zero(t, id)
+			assert.Equal(t, rpccore.ErrBlockNotFound, rpcErr)
+		})
+
+		t.Run("internal error", func(t *testing.T) {
+			internalErr := errors.New("some internal error")
+			mockChain.EXPECT().Height().Return(uint64(2), nil)
+			mockChain.EXPECT().BlockNumberByHash(blockHash).Return(uint64(0), internalErr)
+
+			id, rpcErr := handler.SubscribeNewHeads(subCtx, &blockID)
+			assert.Zero(t, id)
+			assert.Equal(t, rpccore.ErrInternal.CloneWithData(internalErr.Error()), rpcErr)
+		})
+	})
 }
 
 func TestSubscribeNewHeads(t *testing.T) {
@@ -1219,6 +1258,46 @@ func TestSubscribeNewHeadsHistorical(t *testing.T) {
 	handler.newHeads.Send(block3)
 	adaptedHeader3 := AdaptBlockHeader(block3.Header, commitments3, stateUpdate3.StateDiff)
 	assertNextHead(t, conn, subID, &adaptedHeader3)
+}
+
+func TestSubscribeNewHeadsHistoricalByHash(t *testing.T) {
+	logger := log.NewNopZapLogger()
+	client := feeder.NewTestClient(t, &networks.Sepolia)
+	blockNumber1 := uint64(56377)
+	blockNumber2 := uint64(56378)
+	block1, commitments1, stateUpdate1 := GetTestBlockWithCommitments(t, client, blockNumber1)
+	block2, commitments2, stateUpdate2 := GetTestBlockWithCommitments(t, client, blockNumber2)
+
+	mockCtrl := gomock.NewController(t)
+	t.Cleanup(mockCtrl.Finish)
+
+	mockChain := mocks.NewMockReader(mockCtrl)
+	handler := New(mockChain, nil, nil, logger)
+
+	mockChain.EXPECT().Height().Return(block2.Number, nil)
+	mockChain.EXPECT().BlockNumberByHash(block1.Hash).Return(block1.Number, nil)
+	mockChain.EXPECT().BlockHeaderByNumber(block1.Number).Return(block1.Header, nil)
+	mockChain.EXPECT().BlockHeaderByNumber(block2.Number).Return(block2.Header, nil)
+
+	mockChain.EXPECT().BlockCommitmentsByNumber(block1.Number).Return(commitments1, nil)
+	mockChain.EXPECT().StateUpdateByNumber(block1.Number).Return(stateUpdate1, nil)
+	mockChain.EXPECT().BlockCommitmentsByNumber(block2.Number).Return(commitments2, nil)
+	mockChain.EXPECT().StateUpdateByNumber(block2.Number).Return(stateUpdate2, nil)
+
+	blockID := BlockIDFromHash(block1.Hash)
+	subID, conn := createTestNewHeadsWebsocket(
+		t,
+		handler,
+		(*SubscriptionBlockID)(&blockID),
+	)
+
+	// The hash resolves to block1's number, so the replay starts there and
+	// covers the range up to the latest block.
+	adaptedHeader := AdaptBlockHeader(block1.Header, commitments1, stateUpdate1.StateDiff)
+	assertNextHead(t, conn, subID, &adaptedHeader)
+
+	adaptedHeader2 := AdaptBlockHeader(block2.Header, commitments2, stateUpdate2.StateDiff)
+	assertNextHead(t, conn, subID, &adaptedHeader2)
 }
 
 func TestSubscribeNewHeadsReturnsReorgNotification(t *testing.T) {

--- a/rpc/v10/subscriptions_test.go
+++ b/rpc/v10/subscriptions_test.go
@@ -105,7 +105,7 @@ func setupMockEventFilterer(
 	l1HeadNumber uint64,
 	filteredEvents []blockchain.FilteredEvent,
 ) {
-	mockChain.EXPECT().HeadsHeader().Return(header, nil)
+	mockChain.EXPECT().Height().Return(header.Number, nil)
 	mockChain.EXPECT().L1Head().Return(
 		core.L1Head{BlockNumber: l1HeadNumber},
 		nil,
@@ -122,7 +122,7 @@ func setupMockEventFiltererWithMultiple(
 	l1HeadNumber uint64,
 	filteredEvents ...[]blockchain.FilteredEvent,
 ) {
-	mockChain.EXPECT().HeadsHeader().Return(header, nil)
+	mockChain.EXPECT().Height().Return(header.Number, nil)
 	mockChain.EXPECT().L1Head().Return(
 		core.L1Head{BlockNumber: l1HeadNumber},
 		nil,
@@ -191,9 +191,7 @@ func TestSubscribeEventsInvalidInputs(t *testing.T) {
 		// is more than the head, a block not found error will be returned. This behaviour has been
 		// tested in various other tests, and we don't need to test it here again.
 		t.Run("head is 1024", func(t *testing.T) {
-			mockChain.EXPECT().HeadsHeader().Return(&core.Header{Number: 1024}, nil)
-			mockChain.EXPECT().BlockHeaderByNumber(blockID.Number()).
-				Return(&core.Header{Number: 0}, nil)
+			mockChain.EXPECT().Height().Return(uint64(1024), nil)
 
 			id, rpcErr := handler.SubscribeEvents(subCtx, []felt.Address{fromAddr}, keys, &blockID, nil)
 			assert.Zero(t, id)
@@ -201,9 +199,7 @@ func TestSubscribeEventsInvalidInputs(t *testing.T) {
 		})
 
 		t.Run("head is more than 1024", func(t *testing.T) {
-			mockChain.EXPECT().HeadsHeader().Return(&core.Header{Number: 2024}, nil)
-			mockChain.EXPECT().BlockHeaderByNumber(blockID.Number()).
-				Return(&core.Header{Number: 0}, nil)
+			mockChain.EXPECT().Height().Return(uint64(2024), nil)
 
 			id, rpcErr := handler.SubscribeEvents(subCtx, []felt.Address{fromAddr}, keys, &blockID, nil)
 			assert.Zero(t, id)
@@ -476,7 +472,6 @@ func TestSubscribeEvents(t *testing.T) {
 				b1Filtered,
 				b2Filtered,
 			)
-			mockChain.EXPECT().BlockHeaderByNumber(b1.Number).Return(b1.Header, nil)
 		},
 		steps: []stepInfo{
 			{
@@ -496,8 +491,7 @@ func TestSubscribeEvents(t *testing.T) {
 		keys:        nil,
 		fromAddrs:   nil,
 		setupMocks: func() {
-			mockChain.EXPECT().HeadsHeader().Return(b2.Header, nil)
-			mockChain.EXPECT().BlockHeaderByNumber(b1.Number).Return(b1.Header, nil)
+			mockChain.EXPECT().Height().Return(b2.Number, nil)
 			mockChain.EXPECT().L1Head().Return(
 				core.L1Head{BlockNumber: uint64(max(0, int(b1.Header.Number)-1))},
 				nil,
@@ -1115,9 +1109,7 @@ func TestSubscribeNewHeadsErrorCases(t *testing.T) {
 		subCtx := context.WithValue(t.Context(), jsonrpc.ConnKey{}, &fakeConn{w: serverConn})
 
 		t.Run("BlockID head is 1024", func(t *testing.T) {
-			mockChain.EXPECT().HeadsHeader().Return(&core.Header{Number: 1024}, nil)
-			mockChain.EXPECT().BlockHeaderByNumber(blockID.Number()).
-				Return(&core.Header{Number: 0}, nil)
+			mockChain.EXPECT().Height().Return(uint64(1024), nil)
 
 			id, rpcErr := handler.SubscribeNewHeads(subCtx, &blockID)
 			assert.Zero(t, id)
@@ -1125,9 +1117,7 @@ func TestSubscribeNewHeadsErrorCases(t *testing.T) {
 		})
 
 		t.Run("head is more than 1024", func(t *testing.T) {
-			mockChain.EXPECT().HeadsHeader().Return(&core.Header{Number: 2024}, nil)
-			mockChain.EXPECT().BlockHeaderByNumber(blockID.Number()).
-				Return(&core.Header{Number: 0}, nil)
+			mockChain.EXPECT().Height().Return(uint64(2024), nil)
 
 			id, rpcErr := handler.SubscribeNewHeads(subCtx, &blockID)
 			assert.Zero(t, id)
@@ -1152,8 +1142,9 @@ func TestSubscribeNewHeads(t *testing.T) {
 	mockChain := mocks.NewMockReader(mockCtrl)
 	handler := New(mockChain, nil, nil, logger)
 
-	mockChain.EXPECT().HeadsHeader().Return(block1.Header, nil)
+	mockChain.EXPECT().Height().Return(block1.Number, nil)
 
+	mockChain.EXPECT().BlockHeaderByNumber(block1.Number).Return(block1.Header, nil)
 	mockChain.EXPECT().BlockCommitmentsByNumber(block1.Number).Return(commitments1, nil)
 	mockChain.EXPECT().StateUpdateByNumber(block1.Number).Return(stateUpdate1, nil)
 	blockIDLatest := BlockIDLatest()
@@ -1198,7 +1189,7 @@ func TestSubscribeNewHeadsHistorical(t *testing.T) {
 	mockChain := mocks.NewMockReader(mockCtrl)
 	handler := New(mockChain, nil, nil, logger)
 
-	mockChain.EXPECT().HeadsHeader().Return(block2.Header, nil)
+	mockChain.EXPECT().Height().Return(block2.Number, nil)
 	mockChain.EXPECT().BlockHeaderByNumber(block1.Number).Return(block1.Header, nil)
 	mockChain.EXPECT().BlockHeaderByNumber(block2.Number).Return(block2.Header, nil)
 
@@ -1242,8 +1233,9 @@ func TestSubscribeNewHeadsReturnsReorgNotification(t *testing.T) {
 	mockChain := mocks.NewMockReader(mockCtrl)
 	handler := New(mockChain, nil, nil, logger)
 
-	mockChain.EXPECT().HeadsHeader().Return(block1.Header, nil)
+	mockChain.EXPECT().Height().Return(block1.Number, nil)
 
+	mockChain.EXPECT().BlockHeaderByNumber(block1.Number).Return(block1.Header, nil)
 	mockChain.EXPECT().BlockCommitmentsByNumber(block1.Number).Return(commitments1, nil)
 	mockChain.EXPECT().StateUpdateByNumber(block1.Number).Return(stateUpdate1, nil)
 	blockIDLatest := BlockIDLatest()
@@ -1296,7 +1288,8 @@ func TestMultipleSubscribeNewHeadsAndUnsubscribe(t *testing.T) {
 	mockChain := mocks.NewMockReader(mockCtrl)
 	handler := New(mockChain, nil, nil, logger)
 
-	mockChain.EXPECT().HeadsHeader().Return(block1.Header, nil).Times(2)
+	mockChain.EXPECT().Height().Return(block1.Number, nil).Times(2)
+	mockChain.EXPECT().BlockHeaderByNumber(block1.Number).Return(block1.Header, nil).Times(2)
 	mockChain.EXPECT().BlockCommitmentsByNumber(block1.Number).Return(commitments1, nil).Times(2)
 	mockChain.EXPECT().StateUpdateByNumber(block1.Number).Return(stateUpdate1, nil).Times(2)
 

--- a/rpc/v9/subscription_events.go
+++ b/rpc/v9/subscription_events.go
@@ -81,7 +81,7 @@ func newEventSubscriber(
 		}
 	}
 
-	requestedHeader, headHeader, rpcErr := handler.resolveBlockRange(blockID)
+	startBlock, latestBlock, rpcErr := handler.resolveBlockRange(blockID)
 	if rpcErr != nil {
 		return subscriber{}, rpcErr
 	}
@@ -107,8 +107,8 @@ func newEventSubscriber(
 	// Historical replay is bounded to the canonical tip even for pre_confirmed
 	// subscribers: the pre_confirmed window is owned exclusively by the realtime
 	// onPreConfirmed handler, which avoids duplicating the tip during handoff.
-	fromBlock := BlockIDFromNumber(requestedHeader.Number)
-	toBlock := BlockIDFromNumber(headHeader.Number)
+	fromBlock := BlockIDFromNumber(startBlock)
+	toBlock := BlockIDFromNumber(latestBlock)
 
 	s := subscriber{
 		onStart: func(ctx context.Context, id string, _ *subscription, _ any) error {
@@ -119,11 +119,11 @@ func newEventSubscriber(
 				&toBlock,
 				fromAddr,
 				keys,
-				headHeader.Number,
+				latestBlock,
 			)
 		},
-		onReorg:   state.onReorg,
 		onNewHead: state.onNewHead,
+		onReorg:   state.onReorg,
 	}
 
 	if finalityStatus != nil && *finalityStatus == TxnFinalityStatusWithoutL1(TxnPreConfirmed) {

--- a/rpc/v9/subscription_heads.go
+++ b/rpc/v9/subscription_heads.go
@@ -24,12 +24,12 @@ func (h *Handler) SubscribeNewHeads(
 		return "", jsonrpc.Err(jsonrpc.MethodNotFound, nil)
 	}
 
-	startHeader, latestHeader, rpcErr := h.resolveBlockRange(blockID)
+	startBlock, latestBlock, rpcErr := h.resolveBlockRange(blockID)
 	if rpcErr != nil {
 		return "", rpcErr
 	}
 
-	return h.subscribe(ctx, w, newHeadsSubscriber(h, w, startHeader, latestHeader))
+	return h.subscribe(ctx, w, newHeadsSubscriber(h, w, startBlock, latestBlock))
 }
 
 type headsSubscriberState struct {
@@ -40,13 +40,14 @@ type headsSubscriberState struct {
 func newHeadsSubscriber(
 	h *Handler,
 	conn jsonrpc.Conn,
-	startHeader, latestHeader *core.Header,
+	startBlock,
+	latestBlock uint64,
 ) subscriber {
 	state := &headsSubscriberState{handler: h, conn: conn}
 
 	return subscriber{
 		onStart: func(ctx context.Context, id string, _ *subscription, _ any) error {
-			return state.sendHistoricalHeaders(ctx, id, startHeader, latestHeader)
+			return state.sendHistoricalHeaders(ctx, id, startBlock, latestBlock)
 		},
 		onReorg:   state.onReorg,
 		onNewHead: state.onNewHead,
@@ -74,34 +75,26 @@ func (s *headsSubscriberState) onNewHead(
 func (s *headsSubscriberState) sendHistoricalHeaders(
 	ctx context.Context,
 	id string,
-	startHeader,
-	latestHeader *core.Header,
+	startBlock,
+	latestBlock uint64,
 ) error {
-	var (
-		err       error
-		curHeader = startHeader
-	)
-
-	for {
+	for currentBlock := startBlock; currentBlock <= latestBlock; currentBlock++ {
 		select {
 		case <-ctx.Done():
 			return ctx.Err()
 		default:
-			err = sendHeader(s.conn, curHeader, id)
-			if err != nil {
-				return err
-			}
+		}
 
-			if curHeader.Number == latestHeader.Number {
-				return nil
-			}
+		currentHeader, err := s.handler.bcReader.BlockHeaderByNumber(currentBlock)
+		if err != nil {
+			return err
+		}
 
-			curHeader, err = s.handler.bcReader.BlockHeaderByNumber(curHeader.Number + 1)
-			if err != nil {
-				return err
-			}
+		if err = sendHeader(s.conn, currentHeader, id); err != nil {
+			return err
 		}
 	}
+	return nil
 }
 
 func sendHeader(w jsonrpc.Conn, header *core.Header, id string) error {

--- a/rpc/v9/subscriptions.go
+++ b/rpc/v9/subscriptions.go
@@ -9,6 +9,7 @@ import (
 	"github.com/NethermindEth/juno/core"
 	"github.com/NethermindEth/juno/core/felt"
 	"github.com/NethermindEth/juno/core/pending"
+	"github.com/NethermindEth/juno/db"
 	"github.com/NethermindEth/juno/feed"
 	"github.com/NethermindEth/juno/jsonrpc"
 	"github.com/NethermindEth/juno/rpc/rpccore"
@@ -209,31 +210,42 @@ func filterTxBySender(txn core.Transaction, senderAddr []felt.Felt) bool {
 	return false
 }
 
-// resolveBlockRange returns the start and latest headers based on the blockID.
-// It will also do some sanity checks and return errors if the blockID is invalid.
+// resolveBlockRange returns the start and latest block numbers based on the blockID.
 func (h *Handler) resolveBlockRange(
 	blockID *SubscriptionBlockID,
-) (*core.Header, *core.Header, *jsonrpc.Error) {
-	latestHeader, err := h.bcReader.HeadsHeader()
+) (uint64, uint64, *jsonrpc.Error) {
+	latestBlock, err := h.bcReader.Height()
 	if err != nil {
-		return nil, nil, rpccore.ErrInternal.CloneWithData(err.Error())
+		return 0, 0, rpccore.ErrInternal.CloneWithData(err.Error())
 	}
 
 	if blockID == nil || blockID.IsLatest() {
-		return latestHeader, latestHeader, nil
+		return latestBlock, latestBlock, nil
 	}
 
-	startHeader, rpcErr := h.blockHeaderByID((*BlockID)(blockID))
-	if rpcErr != nil {
-		return nil, nil, rpcErr
+	var startBlock uint64
+	if blockID.IsHash() {
+		startBlock, err = h.bcReader.BlockNumberByHash(blockID.Hash())
+		if err != nil {
+			if errors.Is(err, db.ErrKeyNotFound) {
+				return 0, 0, rpccore.ErrBlockNotFound
+			}
+			return 0, 0, rpccore.ErrInternal.CloneWithData(err.Error())
+		}
+	} else {
+		startBlock = blockID.Number()
+		if startBlock > latestBlock {
+			return 0, 0, rpccore.ErrBlockNotFound
+		}
 	}
 
-	if latestHeader.Number >= rpccore.MaxBlocksBack &&
-		startHeader.Number <= latestHeader.Number-rpccore.MaxBlocksBack {
-		return nil, nil, rpccore.ErrTooManyBlocksBack
+	tooManyBlocks := latestBlock >= rpccore.MaxBlocksBack &&
+		startBlock <= latestBlock-rpccore.MaxBlocksBack
+	if tooManyBlocks {
+		return 0, 0, rpccore.ErrTooManyBlocksBack
 	}
 
-	return startHeader, latestHeader, nil
+	return startBlock, latestBlock, nil
 }
 
 type ReorgEvent struct {

--- a/rpc/v9/subscriptions_test.go
+++ b/rpc/v9/subscriptions_test.go
@@ -106,7 +106,7 @@ func setupMockEventFilterer(
 	l1HeadNumber uint64,
 	filteredEvents []blockchain.FilteredEvent,
 ) {
-	mockChain.EXPECT().HeadsHeader().Return(header, nil)
+	mockChain.EXPECT().Height().Return(header.Number, nil)
 	mockChain.EXPECT().L1Head().Return(
 		core.L1Head{BlockNumber: l1HeadNumber},
 		nil,
@@ -123,7 +123,7 @@ func setupMockEventFiltererWithMultiple(
 	l1HeadNumber uint64,
 	filteredEvents ...[]blockchain.FilteredEvent,
 ) {
-	mockChain.EXPECT().HeadsHeader().Return(header, nil)
+	mockChain.EXPECT().Height().Return(header.Number, nil)
 	mockChain.EXPECT().L1Head().Return(
 		core.L1Head{BlockNumber: l1HeadNumber},
 		nil,
@@ -192,9 +192,7 @@ func TestSubscribeEventsInvalidInputs(t *testing.T) {
 		// is more than the head, a block not found error will be returned. This behaviour has been
 		// tested in various other tests, and we don't need to test it here again.
 		t.Run("head is 1024", func(t *testing.T) {
-			mockChain.EXPECT().HeadsHeader().Return(&core.Header{Number: 1024}, nil)
-			mockChain.EXPECT().BlockHeaderByNumber(blockID.Number()).
-				Return(&core.Header{Number: 0}, nil)
+			mockChain.EXPECT().Height().Return(uint64(1024), nil)
 
 			id, rpcErr := handler.SubscribeEvents(subCtx, fromAddr, keys, &blockID, nil)
 			assert.Zero(t, id)
@@ -202,9 +200,7 @@ func TestSubscribeEventsInvalidInputs(t *testing.T) {
 		})
 
 		t.Run("head is more than 1024", func(t *testing.T) {
-			mockChain.EXPECT().HeadsHeader().Return(&core.Header{Number: 2024}, nil)
-			mockChain.EXPECT().BlockHeaderByNumber(blockID.Number()).
-				Return(&core.Header{Number: 0}, nil)
+			mockChain.EXPECT().Height().Return(uint64(2024), nil)
 
 			id, rpcErr := handler.SubscribeEvents(subCtx, fromAddr, keys, &blockID, nil)
 			assert.Zero(t, id)
@@ -475,7 +471,6 @@ func TestSubscribeEvents(t *testing.T) {
 				b1Filtered,
 				b2Filtered,
 			)
-			mockChain.EXPECT().BlockHeaderByNumber(b1.Number).Return(b1.Header, nil)
 		},
 		steps: []stepInfo{
 			{
@@ -495,8 +490,7 @@ func TestSubscribeEvents(t *testing.T) {
 		keys:        nil,
 		fromAddr:    nil,
 		setupMocks: func() {
-			mockChain.EXPECT().HeadsHeader().Return(b2.Header, nil)
-			mockChain.EXPECT().BlockHeaderByNumber(b1.Number).Return(b1.Header, nil)
+			mockChain.EXPECT().Height().Return(b2.Number, nil)
 			mockChain.EXPECT().L1Head().Return(
 				core.L1Head{BlockNumber: uint64(max(0, int(b1.Header.Number)-1))},
 				nil,
@@ -938,9 +932,7 @@ func TestSubscribeNewHeads(t *testing.T) {
 		subCtx := context.WithValue(t.Context(), jsonrpc.ConnKey{}, &fakeConn{w: serverConn})
 
 		t.Run("BlockID head is 1024", func(t *testing.T) {
-			mockChain.EXPECT().HeadsHeader().Return(&core.Header{Number: 1024}, nil)
-			mockChain.EXPECT().BlockHeaderByNumber(blockID.Number()).
-				Return(&core.Header{Number: 0}, nil)
+			mockChain.EXPECT().Height().Return(uint64(1024), nil)
 
 			id, rpcErr := handler.SubscribeNewHeads(subCtx, &blockID)
 			assert.Zero(t, id)
@@ -948,9 +940,7 @@ func TestSubscribeNewHeads(t *testing.T) {
 		})
 
 		t.Run("head is more than 1024", func(t *testing.T) {
-			mockChain.EXPECT().HeadsHeader().Return(&core.Header{Number: 2024}, nil)
-			mockChain.EXPECT().BlockHeaderByNumber(blockID.Number()).
-				Return(&core.Header{Number: 0}, nil)
+			mockChain.EXPECT().Height().Return(uint64(2024), nil)
 
 			id, rpcErr := handler.SubscribeNewHeads(subCtx, &blockID)
 			assert.Zero(t, id)
@@ -969,7 +959,8 @@ func TestSubscribeNewHeads(t *testing.T) {
 		syncer := newFakeSyncer()
 
 		l1Feed := feed.New[*core.L1Head]()
-		mockChain.EXPECT().HeadsHeader().Return(&core.Header{}, nil)
+		mockChain.EXPECT().Height().Return(uint64(0), nil)
+		mockChain.EXPECT().BlockHeaderByNumber(uint64(0)).Return(&core.Header{}, nil)
 		mockChain.EXPECT().SubscribeL1Head().Return(blockchain.L1HeadSubscription{Subscription: l1Feed.Subscribe()})
 
 		handler, server := setupRPC(t, ctx, mockChain, syncer)
@@ -1065,7 +1056,8 @@ func TestMultipleSubscribeNewHeadsAndUnsubscribe(t *testing.T) {
 
 	handler, server := setupRPC(t, ctx, mockChain, syncer)
 
-	mockChain.EXPECT().HeadsHeader().Return(&core.Header{}, nil).Times(2)
+	mockChain.EXPECT().Height().Return(uint64(0), nil).Times(2)
+	mockChain.EXPECT().BlockHeaderByNumber(uint64(0)).Return(&core.Header{}, nil).Times(2)
 
 	ws := jsonrpc.NewWebsocket(server, nil, log.NewNopZapLogger())
 	httpSrv := httptest.NewServer(ws)
@@ -1172,7 +1164,8 @@ func TestSubscriptionReorg(t *testing.T) {
 		Return(nil, blockchain.ContinuationToken{}, nil).AnyTimes()
 	mockEventFilterer.EXPECT().Close().Return(nil).AnyTimes()
 
-	mockChain.EXPECT().HeadsHeader().Return(&core.Header{}, nil).Times(2)
+	mockChain.EXPECT().Height().Return(uint64(0), nil).Times(2)
+	mockChain.EXPECT().BlockHeaderByNumber(uint64(0)).Return(&core.Header{}, nil)
 	mockChain.EXPECT().EventFilter(gomock.Any(), gomock.Any(), gomock.Any()).
 		Return(mockEventFilterer, nil).AnyTimes()
 

--- a/rpc/v9/subscriptions_test.go
+++ b/rpc/v9/subscriptions_test.go
@@ -3,6 +3,7 @@ package rpcv9
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net"
@@ -948,6 +949,44 @@ func TestSubscribeNewHeads(t *testing.T) {
 		})
 	})
 
+	t.Run("BlockID - Hash", func(t *testing.T) {
+		mockCtrl := gomock.NewController(t)
+		t.Cleanup(mockCtrl.Finish)
+
+		mockChain := mocks.NewMockReader(mockCtrl)
+		mockSyncer := mocks.NewMockSyncReader(mockCtrl)
+		handler := New(mockChain, mockSyncer, nil, logger)
+
+		blockHash := felt.NewFromUint64[felt.Felt](1)
+		blockID := SubscriptionBlockID(BlockIDFromHash(blockHash))
+
+		serverConn, _ := net.Pipe()
+		t.Cleanup(func() {
+			require.NoError(t, serverConn.Close())
+		})
+
+		subCtx := context.WithValue(t.Context(), jsonrpc.ConnKey{}, &fakeConn{w: serverConn})
+
+		t.Run("block not found", func(t *testing.T) {
+			mockChain.EXPECT().Height().Return(uint64(2), nil)
+			mockChain.EXPECT().BlockNumberByHash(blockHash).Return(uint64(0), db.ErrKeyNotFound)
+
+			id, rpcErr := handler.SubscribeNewHeads(subCtx, &blockID)
+			assert.Zero(t, id)
+			assert.Equal(t, rpccore.ErrBlockNotFound, rpcErr)
+		})
+
+		t.Run("internal error", func(t *testing.T) {
+			internalErr := errors.New("some internal error")
+			mockChain.EXPECT().Height().Return(uint64(2), nil)
+			mockChain.EXPECT().BlockNumberByHash(blockHash).Return(uint64(0), internalErr)
+
+			id, rpcErr := handler.SubscribeNewHeads(subCtx, &blockID)
+			assert.Zero(t, id)
+			assert.Equal(t, rpccore.ErrInternal.CloneWithData(internalErr.Error()), rpcErr)
+		})
+	})
+
 	t.Run("new block is received", func(t *testing.T) {
 		mockCtrl := gomock.NewController(t)
 		t.Cleanup(mockCtrl.Finish)
@@ -1039,6 +1078,70 @@ func TestSubscribeNewHeadsHistorical(t *testing.T) {
 	_, newBlockGot, err := conn.Read(ctx)
 	require.NoError(t, err)
 	require.Equal(t, newHeadsResponse(id), string(newBlockGot))
+}
+
+func TestSubscribeNewHeadsHistoricalByHash(t *testing.T) {
+	client := feeder.NewTestClient(t, &networks.Mainnet)
+	gw := adaptfeeder.New(client)
+
+	block0, err := gw.BlockByNumber(t.Context(), 0)
+	require.NoError(t, err)
+
+	stateUpdate0, err := gw.StateUpdate(t.Context(), 0)
+	require.NoError(t, err)
+
+	testDB := memory.New()
+	chain := blockchain.New(
+		testDB,
+		&networks.Mainnet,
+		blockchain.WithNewState(statetestutils.UseNewState()),
+	)
+	assert.NoError(t, chain.Store(block0, &emptyCommitments, stateUpdate0, nil))
+
+	chain = blockchain.New(
+		testDB,
+		&networks.Mainnet,
+		blockchain.WithNewState(statetestutils.UseNewState()),
+	)
+	syncer := newFakeSyncer()
+
+	ctx, cancel := context.WithCancel(t.Context())
+	t.Cleanup(cancel)
+
+	handler, server := setupRPC(t, ctx, chain, syncer)
+
+	conn := createWsConn(t, ctx, server)
+
+	id := "1"
+	handler.WithIDGen(func() string { return id })
+
+	// Subscribe with block0's hash: the handler resolves it to its block
+	// number and replays from there.
+	subMsg := fmt.Sprintf(
+		`{"jsonrpc":"2.0","id":"1","method":"starknet_subscribeNewHeads",`+
+			` "params":{"block_id":{"block_hash":"%s"}}}`,
+		block0.Hash,
+	)
+	got := sendWsMessage(t, ctx, conn, subMsg)
+	require.Equal(t, subResp(id), got)
+
+	// The first streamed header is block 0, the block the hash resolves to.
+	_, block0Got, err := conn.Read(ctx)
+	require.NoError(t, err)
+
+	var resp struct {
+		Params struct {
+			Result struct {
+				BlockHash   *felt.Felt `json:"block_hash"`
+				BlockNumber uint64     `json:"block_number"`
+			} `json:"result"`
+			SubscriptionID string `json:"subscription_id"`
+		} `json:"params"`
+	}
+	require.NoError(t, json.Unmarshal(block0Got, &resp))
+	assert.Equal(t, block0.Hash, resp.Params.Result.BlockHash)
+	assert.Equal(t, block0.Number, resp.Params.Result.BlockNumber)
+	assert.Equal(t, id, resp.Params.SubscriptionID)
 }
 
 func TestMultipleSubscribeNewHeadsAndUnsubscribe(t *testing.T) {


### PR DESCRIPTION
The header is unnecessarily loaded when finding the block range to which iterate. Just by loading the block number we reduced the load from the micro-seconds to the nano-seconds. We also allocate and use much less memory.

| subscription `block_id` | read | time/op | B/op | allocs/op |
|---|---|---|---:|---:|
| `latest` / omitted | old — `HeadsHeader()` | 4.15 µs | 2,681 | 25 |
| | new — `Height()` | 385 ns (**~11× faster**) | 32 | 3 |
| `block_hash` | old — `BlockHeaderByHash()` | 4.13 µs | 2,729 | 25 |
| | new — `BlockNumberByHash()` | 413 ns (**~10× faster**) | 72 | 3 |
| `block_number` | old — `BlockHeaderByNumber()` | 3.68 µs | 2,657 | 22 |
| | new — *(no DB read)* | 0 | 0 | 0 |


