### PR TITLE
refactor(core): replace ResourceBounds map with a fixed-field struct

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -44,6 +44,13 @@ linters:
           deny:
             - pkg: github.com/sirupsen/logrus
               desc: use github.com/NethermindEth/juno/utils for logging
+    exhaustruct:
+      # These types have a meaningful zero value: a transaction with no resource
+      # bounds (v0-v2). Requiring every field to be spelled out at construction
+      # would only add noise, so exclude them from exhaustive-struct checking.
+      exclude:
+        - 'github.com/NethermindEth/juno/core\.ResourceBounds$'
+        - 'github.com/NethermindEth/juno/core\.ResourceBoundsMap$'
     funlen:
       lines: 120
       statements: 50

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -44,13 +44,6 @@ linters:
           deny:
             - pkg: github.com/sirupsen/logrus
               desc: use github.com/NethermindEth/juno/utils for logging
-    exhaustruct:
-      # These types have a meaningful zero value: a transaction with no resource
-      # bounds (v0-v2). Requiring every field to be spelled out at construction
-      # would only add noise, so exclude them from exhaustive-struct checking.
-      exclude:
-        - 'github.com/NethermindEth/juno/core\.ResourceBounds$'
-        - 'github.com/NethermindEth/juno/core\.ResourceBoundsMap$'
     funlen:
       lines: 120
       statements: 50

--- a/adapters/core2p2p/transaction.go
+++ b/adapters/core2p2p/transaction.go
@@ -131,11 +131,11 @@ func adaptResourceLimits(bounds core.ResourceBounds) *transaction.ResourceLimits
 	}
 }
 
-func adaptResourceBounds(rb map[core.Resource]core.ResourceBounds) *transaction.ResourceBounds {
+func adaptResourceBounds(rb core.ResourceBoundsMap) *transaction.ResourceBounds {
 	return &transaction.ResourceBounds{
-		L1Gas:     adaptResourceLimits(rb[core.ResourceL1Gas]),
-		L1DataGas: adaptResourceLimits(rb[core.ResourceL1DataGas]),
-		L2Gas:     adaptResourceLimits(rb[core.ResourceL2Gas]),
+		L1Gas:     adaptResourceLimits(rb.L1Gas),
+		L1DataGas: adaptResourceLimits(rb.L1DataGas),
+		L2Gas:     adaptResourceLimits(rb.L2Gas),
 	}
 }
 

--- a/adapters/p2p2core/transaction.go
+++ b/adapters/p2p2core/transaction.go
@@ -60,7 +60,7 @@ func AdaptDeclareV0TxnCommon(
 		// version 2 field
 		CompiledClassHash: nil,
 		// version 3 fields (zero values)
-		ResourceBounds:        nil,
+		ResourceBounds:        core.ResourceBoundsMap{},
 		Tip:                   0,
 		PaymasterData:         nil,
 		AccountDeploymentData: nil,
@@ -81,13 +81,13 @@ func AdaptDeclareV1TxnCommon(
 		TransactionSignature:  adaptAccountSignature(tx.Signature),
 		Nonce:                 AdaptFelt(tx.Nonce),
 		Version:               txVersion(1),
-		CompiledClassHash:     nil, // this field is not available on v1
-		ResourceBounds:        nil, // this field is not available on v1
-		Tip:                   0,   // this field is not available on v1
-		PaymasterData:         nil, // this field is not available on v1
-		AccountDeploymentData: nil, // this field is not available on v1
-		NonceDAMode:           0,   // this field is not available on v1
-		FeeDAMode:             0,   // this field is not available on v1
+		CompiledClassHash:     nil,                      // this field is not available on v1
+		ResourceBounds:        core.ResourceBoundsMap{}, // this field is not available on v1
+		Tip:                   0,                        // this field is not available on v1
+		PaymasterData:         nil,                      // this field is not available on v1
+		AccountDeploymentData: nil,                      // this field is not available on v1
+		NonceDAMode:           0,                        // this field is not available on v1
+		FeeDAMode:             0,                        // this field is not available on v1
 	}
 }
 
@@ -104,12 +104,12 @@ func AdaptDeclareV2TxnCommon(
 		Nonce:                 AdaptFelt(tx.Nonce),
 		Version:               txVersion(2),
 		CompiledClassHash:     AdaptHash(tx.CompiledClassHash),
-		ResourceBounds:        nil, // this field is not available on v2
-		Tip:                   0,   // this field is not available on v2
-		PaymasterData:         nil, // this field is not available on v2
-		AccountDeploymentData: nil, // this field is not available on v2
-		NonceDAMode:           0,   // this field is not available on v2
-		FeeDAMode:             0,   // this field is not available on v2
+		ResourceBounds:        core.ResourceBoundsMap{}, // this field is not available on v2
+		Tip:                   0,                        // this field is not available on v2
+		PaymasterData:         nil,                      // this field is not available on v2
+		AccountDeploymentData: nil,                      // this field is not available on v2
+		NonceDAMode:           0,                        // this field is not available on v2
+		FeeDAMode:             0,                        // this field is not available on v2
 	}
 }
 
@@ -142,10 +142,10 @@ func AdaptDeclareV3TxnCommon(
 		Version:              txVersion(3),
 		CompiledClassHash:    AdaptHash(tx.CompiledClassHash),
 		Tip:                  tx.Tip,
-		ResourceBounds: map[core.Resource]core.ResourceBounds{
-			core.ResourceL1Gas:     adaptResourceLimits(tx.ResourceBounds.L1Gas),
-			core.ResourceL2Gas:     adaptResourceLimits(tx.ResourceBounds.L2Gas),
-			core.ResourceL1DataGas: adaptResourceLimits(tx.ResourceBounds.L1DataGas),
+		ResourceBounds: core.ResourceBoundsMap{
+			L1Gas:     adaptResourceLimits(tx.ResourceBounds.L1Gas),
+			L2Gas:     adaptResourceLimits(tx.ResourceBounds.L2Gas),
+			L1DataGas: adaptResourceLimits(tx.ResourceBounds.L1DataGas),
 		},
 		PaymasterData:         AdaptFeltSlice(tx.PaymasterData),
 		AccountDeploymentData: AdaptFeltSlice(tx.AccountDeploymentData),
@@ -194,7 +194,7 @@ func AdaptDeployAccountV1TxnCommon(
 		TransactionSignature: adaptAccountSignature(tx.Signature),
 		Nonce:                AdaptFelt(tx.Nonce),
 		// version 3 fields (zero values)
-		ResourceBounds: nil,
+		ResourceBounds: core.ResourceBoundsMap{},
 		PaymasterData:  nil,
 		Tip:            0,
 		NonceDAMode:    0,
@@ -239,10 +239,10 @@ func AdaptDeployAccountV3TxnCommon(
 		TransactionSignature: adaptAccountSignature(tx.Signature),
 		Nonce:                AdaptFelt(tx.Nonce),
 		Tip:                  tx.Tip,
-		ResourceBounds: map[core.Resource]core.ResourceBounds{
-			core.ResourceL1Gas:     adaptResourceLimits(tx.ResourceBounds.L1Gas),
-			core.ResourceL2Gas:     adaptResourceLimits(tx.ResourceBounds.L2Gas),
-			core.ResourceL1DataGas: adaptResourceLimits(tx.ResourceBounds.L1DataGas),
+		ResourceBounds: core.ResourceBoundsMap{
+			L1Gas:     adaptResourceLimits(tx.ResourceBounds.L1Gas),
+			L2Gas:     adaptResourceLimits(tx.ResourceBounds.L2Gas),
+			L1DataGas: adaptResourceLimits(tx.ResourceBounds.L1DataGas),
 		},
 		PaymasterData: AdaptFeltSlice(tx.PaymasterData),
 		NonceDAMode:   nDAMode,
@@ -266,7 +266,7 @@ func AdaptInvokeV0TxnCommon(
 		Nonce:         nil,
 		SenderAddress: nil,
 		// version 3 fields (zero values)
-		ResourceBounds:        nil,
+		ResourceBounds:        core.ResourceBoundsMap{},
 		Tip:                   0,
 		PaymasterData:         nil,
 		AccountDeploymentData: nil,
@@ -291,7 +291,7 @@ func AdaptInvokeV1TxnCommon(
 		Version:              txVersion(1),
 		EntryPointSelector:   nil,
 		// version 3 fields (zero values)
-		ResourceBounds:        nil,
+		ResourceBounds:        core.ResourceBoundsMap{},
 		Tip:                   0,
 		PaymasterData:         nil,
 		AccountDeploymentData: nil,
@@ -332,10 +332,10 @@ func AdaptInvokeV3TxnCommon(
 		SenderAddress:        AdaptAddress(tx.Sender),
 		EntryPointSelector:   nil,
 		Tip:                  tx.Tip,
-		ResourceBounds: map[core.Resource]core.ResourceBounds{
-			core.ResourceL1Gas:     adaptResourceLimits(tx.ResourceBounds.L1Gas),
-			core.ResourceL2Gas:     adaptResourceLimits(tx.ResourceBounds.L2Gas),
-			core.ResourceL1DataGas: adaptResourceLimits(tx.ResourceBounds.L1DataGas),
+		ResourceBounds: core.ResourceBoundsMap{
+			L1Gas:     adaptResourceLimits(tx.ResourceBounds.L1Gas),
+			L2Gas:     adaptResourceLimits(tx.ResourceBounds.L2Gas),
+			L1DataGas: adaptResourceLimits(tx.ResourceBounds.L1DataGas),
 		},
 		PaymasterData:         AdaptFeltSlice(tx.PaymasterData),
 		NonceDAMode:           nDAMode,

--- a/adapters/p2p2core/transaction.go
+++ b/adapters/p2p2core/transaction.go
@@ -60,7 +60,7 @@ func AdaptDeclareV0TxnCommon(
 		// version 2 field
 		CompiledClassHash: nil,
 		// version 3 fields (zero values)
-		ResourceBounds:        core.ResourceBoundsMap{},
+		ResourceBounds:        core.EmptyResourceBoundsMap(),
 		Tip:                   0,
 		PaymasterData:         nil,
 		AccountDeploymentData: nil,
@@ -81,13 +81,13 @@ func AdaptDeclareV1TxnCommon(
 		TransactionSignature:  adaptAccountSignature(tx.Signature),
 		Nonce:                 AdaptFelt(tx.Nonce),
 		Version:               txVersion(1),
-		CompiledClassHash:     nil,                      // this field is not available on v1
-		ResourceBounds:        core.ResourceBoundsMap{}, // this field is not available on v1
-		Tip:                   0,                        // this field is not available on v1
-		PaymasterData:         nil,                      // this field is not available on v1
-		AccountDeploymentData: nil,                      // this field is not available on v1
-		NonceDAMode:           0,                        // this field is not available on v1
-		FeeDAMode:             0,                        // this field is not available on v1
+		CompiledClassHash:     nil,                           // this field is not available on v1
+		ResourceBounds:        core.EmptyResourceBoundsMap(), // this field is not available on v1
+		Tip:                   0,                             // this field is not available on v1
+		PaymasterData:         nil,                           // this field is not available on v1
+		AccountDeploymentData: nil,                           // this field is not available on v1
+		NonceDAMode:           0,                             // this field is not available on v1
+		FeeDAMode:             0,                             // this field is not available on v1
 	}
 }
 
@@ -104,12 +104,12 @@ func AdaptDeclareV2TxnCommon(
 		Nonce:                 AdaptFelt(tx.Nonce),
 		Version:               txVersion(2),
 		CompiledClassHash:     AdaptHash(tx.CompiledClassHash),
-		ResourceBounds:        core.ResourceBoundsMap{}, // this field is not available on v2
-		Tip:                   0,                        // this field is not available on v2
-		PaymasterData:         nil,                      // this field is not available on v2
-		AccountDeploymentData: nil,                      // this field is not available on v2
-		NonceDAMode:           0,                        // this field is not available on v2
-		FeeDAMode:             0,                        // this field is not available on v2
+		ResourceBounds:        core.EmptyResourceBoundsMap(), // this field is not available on v2
+		Tip:                   0,                             // this field is not available on v2
+		PaymasterData:         nil,                           // this field is not available on v2
+		AccountDeploymentData: nil,                           // this field is not available on v2
+		NonceDAMode:           0,                             // this field is not available on v2
+		FeeDAMode:             0,                             // this field is not available on v2
 	}
 }
 
@@ -194,7 +194,7 @@ func AdaptDeployAccountV1TxnCommon(
 		TransactionSignature: adaptAccountSignature(tx.Signature),
 		Nonce:                AdaptFelt(tx.Nonce),
 		// version 3 fields (zero values)
-		ResourceBounds: core.ResourceBoundsMap{},
+		ResourceBounds: core.EmptyResourceBoundsMap(),
 		PaymasterData:  nil,
 		Tip:            0,
 		NonceDAMode:    0,
@@ -266,7 +266,7 @@ func AdaptInvokeV0TxnCommon(
 		Nonce:         nil,
 		SenderAddress: nil,
 		// version 3 fields (zero values)
-		ResourceBounds:        core.ResourceBoundsMap{},
+		ResourceBounds:        core.EmptyResourceBoundsMap(),
 		Tip:                   0,
 		PaymasterData:         nil,
 		AccountDeploymentData: nil,
@@ -291,7 +291,7 @@ func AdaptInvokeV1TxnCommon(
 		Version:              txVersion(1),
 		EntryPointSelector:   nil,
 		// version 3 fields (zero values)
-		ResourceBounds:        core.ResourceBoundsMap{},
+		ResourceBounds:        core.EmptyResourceBoundsMap(),
 		Tip:                   0,
 		PaymasterData:         nil,
 		AccountDeploymentData: nil,

--- a/adapters/sn2core/sn2core.go
+++ b/adapters/sn2core/sn2core.go
@@ -220,7 +220,7 @@ func adaptDataAvailabilityMode(mode *starknet.DataAvailabilityMode) core.DataAva
 
 func adaptResourceBounds(rb *starknet.ResourceBoundsMap) core.ResourceBoundsMap {
 	if rb == nil {
-		return core.ResourceBoundsMap{}
+		return core.EmptyResourceBoundsMap()
 	}
 	return core.ResourceBoundsMap{
 		L1Gas:     adaptResourceBound(rb.L1Gas),
@@ -235,7 +235,7 @@ func adaptResourceBounds(rb *starknet.ResourceBoundsMap) core.ResourceBoundsMap 
 // the transaction hash and the DB encoding, exactly as with the old map.
 func adaptResourceBound(b starknet.ResourceBounds) core.ResourceBounds {
 	if b.MaxPricePerUnit == nil {
-		return core.ResourceBounds{}
+		return core.EmptyResourceBounds()
 	}
 	var maxAmount uint64
 	if b.MaxAmount != nil {

--- a/adapters/sn2core/sn2core.go
+++ b/adapters/sn2core/sn2core.go
@@ -221,18 +221,34 @@ func adaptDataAvailabilityMode(mode *starknet.DataAvailabilityMode) core.DataAva
 // todo(rdr): get rid of this gocritic
 func adaptResourceBounds(
 	rb *map[starknet.Resource]starknet.ResourceBounds, //nolint: gocritic // someone was lazy
-) map[core.Resource]core.ResourceBounds {
+) core.ResourceBoundsMap {
 	if rb == nil {
-		return nil
+		return core.ResourceBoundsMap{}
 	}
-	coreBounds := make(map[core.Resource]core.ResourceBounds, len(*rb))
-	for resource, bounds := range *rb {
-		coreBounds[core.Resource(resource)] = core.ResourceBounds{
-			MaxAmount:       bounds.MaxAmount.Uint64(),
-			MaxPricePerUnit: bounds.MaxPricePerUnit,
-		}
+	m := *rb
+	return core.ResourceBoundsMap{
+		L1Gas:     adaptResourceBound(m[starknet.ResourceL1Gas]),
+		L2Gas:     adaptResourceBound(m[starknet.ResourceL2Gas]),
+		L1DataGas: adaptResourceBound(m[starknet.ResourceL1DataGas]),
 	}
-	return coreBounds
+}
+
+// adaptResourceBound converts a single feeder resource bound. A resource that
+// was absent from the feeder payload (nil MaxPricePerUnit, e.g. l1_data_gas on
+// pre-0.13.4 transactions) maps to the zero value so it is omitted from both
+// the transaction hash and the DB encoding, exactly as with the old map.
+func adaptResourceBound(b starknet.ResourceBounds) core.ResourceBounds {
+	if b.MaxPricePerUnit == nil {
+		return core.ResourceBounds{}
+	}
+	var maxAmount uint64
+	if b.MaxAmount != nil {
+		maxAmount = b.MaxAmount.Uint64()
+	}
+	return core.ResourceBounds{
+		MaxAmount:       maxAmount,
+		MaxPricePerUnit: b.MaxPricePerUnit,
+	}
 }
 
 // todo(rdr): return by value

--- a/adapters/sn2core/sn2core.go
+++ b/adapters/sn2core/sn2core.go
@@ -218,18 +218,14 @@ func adaptDataAvailabilityMode(mode *starknet.DataAvailabilityMode) core.DataAva
 	return core.DataAvailabilityMode(*mode)
 }
 
-// todo(rdr): get rid of this gocritic
-func adaptResourceBounds(
-	rb *map[starknet.Resource]starknet.ResourceBounds, //nolint: gocritic // someone was lazy
-) core.ResourceBoundsMap {
+func adaptResourceBounds(rb *starknet.ResourceBoundsMap) core.ResourceBoundsMap {
 	if rb == nil {
 		return core.ResourceBoundsMap{}
 	}
-	m := *rb
 	return core.ResourceBoundsMap{
-		L1Gas:     adaptResourceBound(m[starknet.ResourceL1Gas]),
-		L2Gas:     adaptResourceBound(m[starknet.ResourceL2Gas]),
-		L1DataGas: adaptResourceBound(m[starknet.ResourceL1DataGas]),
+		L1Gas:     adaptResourceBound(rb.L1Gas),
+		L2Gas:     adaptResourceBound(rb.L2Gas),
+		L1DataGas: adaptResourceBound(rb.L1DataGas),
 	}
 }
 

--- a/adapters/sn2core/sn2core_test.go
+++ b/adapters/sn2core/sn2core_test.go
@@ -427,16 +427,16 @@ func TestTransactionV3(t *testing.T) {
 			Nonce:       felt.NewUnsafeFromString[felt.Felt]("0xe97"),
 			NonceDAMode: core.DAModeL1,
 			FeeDAMode:   core.DAModeL1,
-			ResourceBounds: map[core.Resource]core.ResourceBounds{
-				core.ResourceL1Gas: {
+			ResourceBounds: core.ResourceBoundsMap{
+				L1Gas: core.ResourceBounds{
 					MaxAmount:       0x186a0,
 					MaxPricePerUnit: felt.NewUnsafeFromString[felt.Felt]("0x5af3107a4000"),
 				},
-				core.ResourceL1DataGas: {
+				L1DataGas: core.ResourceBounds{
 					MaxAmount:       0x186a0,
 					MaxPricePerUnit: felt.NewUnsafeFromString[felt.Felt]("0x5af3107a4000"),
 				},
-				core.ResourceL2Gas: {
+				L2Gas: core.ResourceBounds{
 					MaxAmount:       0,
 					MaxPricePerUnit: new(felt.Felt),
 				},
@@ -494,16 +494,16 @@ func TestTransactionV3(t *testing.T) {
 			Nonce:       felt.NewUnsafeFromString[felt.Felt]("0x1"),
 			NonceDAMode: core.DAModeL1,
 			FeeDAMode:   core.DAModeL1,
-			ResourceBounds: map[core.Resource]core.ResourceBounds{
-				core.ResourceL1Gas: {
+			ResourceBounds: core.ResourceBoundsMap{
+				L1Gas: core.ResourceBounds{
 					MaxAmount:       0x186a0,
 					MaxPricePerUnit: felt.NewUnsafeFromString[felt.Felt]("0x2540be400"),
 				},
-				core.ResourceL1DataGas: {
+				L1DataGas: core.ResourceBounds{
 					MaxAmount:       0x186a0,
 					MaxPricePerUnit: felt.NewUnsafeFromString[felt.Felt]("0x2540be400"),
 				},
-				core.ResourceL2Gas: {
+				L2Gas: core.ResourceBounds{
 					MaxAmount:       0,
 					MaxPricePerUnit: new(felt.Felt),
 				},
@@ -532,16 +532,16 @@ func TestTransactionV3(t *testing.T) {
 			Nonce:       new(felt.Felt),
 			NonceDAMode: core.DAModeL1,
 			FeeDAMode:   core.DAModeL1,
-			ResourceBounds: map[core.Resource]core.ResourceBounds{
-				core.ResourceL1Gas: {
+			ResourceBounds: core.ResourceBoundsMap{
+				L1Gas: core.ResourceBounds{
 					MaxAmount:       0x186a0,
 					MaxPricePerUnit: felt.NewUnsafeFromString[felt.Felt]("0x5af3107a4000"),
 				},
-				core.ResourceL1DataGas: {
+				L1DataGas: core.ResourceBounds{
 					MaxAmount:       0x186a0,
 					MaxPricePerUnit: felt.NewUnsafeFromString[felt.Felt]("0x5af3107a4000"),
 				},
-				core.ResourceL2Gas: {
+				L2Gas: core.ResourceBounds{
 					MaxAmount:       0,
 					MaxPricePerUnit: new(felt.Felt),
 				},

--- a/adapters/testutils/synctransaction_test_utils.go
+++ b/adapters/testutils/synctransaction_test_utils.go
@@ -54,13 +54,13 @@ func (b *SyncTransactionBuilder[C, P]) GetTestDeclareV0Transaction(
 		TransactionSignature:  transactionSignature,
 		Nonce:                 nil, // this field is not available on v0
 		Version:               version,
-		CompiledClassHash:     nil, // this field is not available on v0
-		ResourceBounds:        nil, // this field is not available on v0
-		Tip:                   0,   // this field is not available on v0
-		PaymasterData:         nil, // this field is not available on v0
-		AccountDeploymentData: nil, // this field is not available on v0
-		NonceDAMode:           0,   // this field is not available on v0
-		FeeDAMode:             0,   // this field is not available on v0
+		CompiledClassHash:     nil,                      // this field is not available on v0
+		ResourceBounds:        core.ResourceBoundsMap{}, // this field is not available on v0
+		Tip:                   0,                        // this field is not available on v0
+		PaymasterData:         nil,                      // this field is not available on v0
+		AccountDeploymentData: nil,                      // this field is not available on v0
+		NonceDAMode:           0,                        // this field is not available on v0
+		FeeDAMode:             0,                        // this field is not available on v0
 	}
 
 	transactionHash, p2pHash := getTransactionHash(
@@ -103,13 +103,13 @@ func (b *SyncTransactionBuilder[C, P]) GetTestDeclareV1Transaction(
 		TransactionSignature:  transactionSignature,
 		Nonce:                 &nonce,
 		Version:               version,
-		CompiledClassHash:     nil, // this field is not available on v1
-		ResourceBounds:        nil, // this field is not available on v1
-		PaymasterData:         nil, // this field is not available on v1
-		AccountDeploymentData: nil, // this field is not available on v1
-		Tip:                   0,   // this field is not available on v1
-		NonceDAMode:           0,   // this field is not available on v1
-		FeeDAMode:             0,   // this field is not available on v1
+		CompiledClassHash:     nil,                      // this field is not available on v1
+		ResourceBounds:        core.ResourceBoundsMap{}, // this field is not available on v1
+		PaymasterData:         nil,                      // this field is not available on v1
+		AccountDeploymentData: nil,                      // this field is not available on v1
+		Tip:                   0,                        // this field is not available on v1
+		NonceDAMode:           0,                        // this field is not available on v1
+		FeeDAMode:             0,                        // this field is not available on v1
 	}
 
 	transactionHash, p2pHash := getTransactionHash(
@@ -156,12 +156,12 @@ func (b *SyncTransactionBuilder[C, P]) GetTestDeclareV2Transaction(
 		Nonce:                 &nonce,
 		Version:               version,
 		CompiledClassHash:     &casmClassHash,
-		ResourceBounds:        nil, // this field is not available on v2
-		PaymasterData:         nil, // this field is not available on v2
-		AccountDeploymentData: nil, // this field is not available on v2
-		Tip:                   0,   // this field is not available on v2
-		NonceDAMode:           0,   // this field is not available on v2
-		FeeDAMode:             0,   // this field is not available on v2
+		ResourceBounds:        core.ResourceBoundsMap{}, // this field is not available on v2
+		PaymasterData:         nil,                      // this field is not available on v2
+		AccountDeploymentData: nil,                      // this field is not available on v2
+		Tip:                   0,                        // this field is not available on v2
+		NonceDAMode:           0,                        // this field is not available on v2
+		FeeDAMode:             0,                        // this field is not available on v2
 	}
 
 	transactionHash, p2pHash := getTransactionHash(
@@ -315,11 +315,11 @@ func (b *SyncTransactionBuilder[C, P]) GetTestDeployAccountTransactionV1(
 		MaxFee:               &maxFee,
 		TransactionSignature: transactionSignature,
 		Nonce:                &nonce,
-		ResourceBounds:       nil, // this field is not available on v1
-		PaymasterData:        nil, // this field is not available on v1
-		Tip:                  0,   // this field is not available on v1
-		NonceDAMode:          0,   // this field is not available on v1
-		FeeDAMode:            0,   // this field is not available on v1
+		ResourceBounds:       core.ResourceBoundsMap{}, // this field is not available on v1
+		PaymasterData:        nil,                      // this field is not available on v1
+		Tip:                  0,                        // this field is not available on v1
+		NonceDAMode:          0,                        // this field is not available on v1
+		FeeDAMode:            0,                        // this field is not available on v1
 	}
 
 	transactionHash, p2pHash := getTransactionHash(
@@ -430,15 +430,15 @@ func (b *SyncTransactionBuilder[C, P]) GetTestInvokeTransactionV0(
 		ContractAddress:       &contractAddress,
 		Version:               version,
 		EntryPointSelector:    &entryPointSelector,
-		Nonce:                 nil, // this field is not available on v0
-		SenderAddress:         nil, // this field is not available on v0
-		ResourceBounds:        nil, // this field is not available on v0
-		Tip:                   0,   // this field is not available on v0
-		PaymasterData:         nil, // this field is not available on v0
-		AccountDeploymentData: nil, // this field is not available on v0
-		NonceDAMode:           0,   // this field is not available on v0
-		FeeDAMode:             0,   // this field is not available on v0
-		ProofFacts:            nil, // this field is not available on v0
+		Nonce:                 nil,                      // this field is not available on v0
+		SenderAddress:         nil,                      // this field is not available on v0
+		ResourceBounds:        core.ResourceBoundsMap{}, // this field is not available on v0
+		Tip:                   0,                        // this field is not available on v0
+		PaymasterData:         nil,                      // this field is not available on v0
+		AccountDeploymentData: nil,                      // this field is not available on v0
+		NonceDAMode:           0,                        // this field is not available on v0
+		FeeDAMode:             0,                        // this field is not available on v0
+		ProofFacts:            nil,                      // this field is not available on v0
 	}
 
 	transactionHash, p2pHash := getTransactionHash(
@@ -483,14 +483,14 @@ func (b *SyncTransactionBuilder[C, P]) GetTestInvokeTransactionV1(
 		TransactionSignature:  transactionSignature,
 		MaxFee:                &maxFee,
 		Version:               version,
-		EntryPointSelector:    nil, // this field is not available on v1
-		ResourceBounds:        nil, // this field is not available on v1
-		Tip:                   0,   // this field is not available on v1
-		PaymasterData:         nil, // this field is not available on v1
-		AccountDeploymentData: nil, // this field is not available on v1
-		NonceDAMode:           0,   // this field is not available on v1
-		FeeDAMode:             0,   // this field is not available on v1
-		ProofFacts:            nil, // this field is not available on v1
+		EntryPointSelector:    nil,                      // this field is not available on v1
+		ResourceBounds:        core.ResourceBoundsMap{}, // this field is not available on v1
+		Tip:                   0,                        // this field is not available on v1
+		PaymasterData:         nil,                      // this field is not available on v1
+		AccountDeploymentData: nil,                      // this field is not available on v1
+		NonceDAMode:           0,                        // this field is not available on v1
+		FeeDAMode:             0,                        // this field is not available on v1
+		ProofFacts:            nil,                      // this field is not available on v1
 	}
 
 	transactionHash, p2pHash := getTransactionHash(

--- a/adapters/testutils/synctransaction_test_utils.go
+++ b/adapters/testutils/synctransaction_test_utils.go
@@ -54,13 +54,13 @@ func (b *SyncTransactionBuilder[C, P]) GetTestDeclareV0Transaction(
 		TransactionSignature:  transactionSignature,
 		Nonce:                 nil, // this field is not available on v0
 		Version:               version,
-		CompiledClassHash:     nil,                      // this field is not available on v0
-		ResourceBounds:        core.ResourceBoundsMap{}, // this field is not available on v0
-		Tip:                   0,                        // this field is not available on v0
-		PaymasterData:         nil,                      // this field is not available on v0
-		AccountDeploymentData: nil,                      // this field is not available on v0
-		NonceDAMode:           0,                        // this field is not available on v0
-		FeeDAMode:             0,                        // this field is not available on v0
+		CompiledClassHash:     nil,                           // this field is not available on v0
+		ResourceBounds:        core.EmptyResourceBoundsMap(), // this field is not available on v0
+		Tip:                   0,                             // this field is not available on v0
+		PaymasterData:         nil,                           // this field is not available on v0
+		AccountDeploymentData: nil,                           // this field is not available on v0
+		NonceDAMode:           0,                             // this field is not available on v0
+		FeeDAMode:             0,                             // this field is not available on v0
 	}
 
 	transactionHash, p2pHash := getTransactionHash(
@@ -103,13 +103,13 @@ func (b *SyncTransactionBuilder[C, P]) GetTestDeclareV1Transaction(
 		TransactionSignature:  transactionSignature,
 		Nonce:                 &nonce,
 		Version:               version,
-		CompiledClassHash:     nil,                      // this field is not available on v1
-		ResourceBounds:        core.ResourceBoundsMap{}, // this field is not available on v1
-		PaymasterData:         nil,                      // this field is not available on v1
-		AccountDeploymentData: nil,                      // this field is not available on v1
-		Tip:                   0,                        // this field is not available on v1
-		NonceDAMode:           0,                        // this field is not available on v1
-		FeeDAMode:             0,                        // this field is not available on v1
+		CompiledClassHash:     nil,                           // this field is not available on v1
+		ResourceBounds:        core.EmptyResourceBoundsMap(), // this field is not available on v1
+		PaymasterData:         nil,                           // this field is not available on v1
+		AccountDeploymentData: nil,                           // this field is not available on v1
+		Tip:                   0,                             // this field is not available on v1
+		NonceDAMode:           0,                             // this field is not available on v1
+		FeeDAMode:             0,                             // this field is not available on v1
 	}
 
 	transactionHash, p2pHash := getTransactionHash(
@@ -156,12 +156,12 @@ func (b *SyncTransactionBuilder[C, P]) GetTestDeclareV2Transaction(
 		Nonce:                 &nonce,
 		Version:               version,
 		CompiledClassHash:     &casmClassHash,
-		ResourceBounds:        core.ResourceBoundsMap{}, // this field is not available on v2
-		PaymasterData:         nil,                      // this field is not available on v2
-		AccountDeploymentData: nil,                      // this field is not available on v2
-		Tip:                   0,                        // this field is not available on v2
-		NonceDAMode:           0,                        // this field is not available on v2
-		FeeDAMode:             0,                        // this field is not available on v2
+		ResourceBounds:        core.EmptyResourceBoundsMap(), // this field is not available on v2
+		PaymasterData:         nil,                           // this field is not available on v2
+		AccountDeploymentData: nil,                           // this field is not available on v2
+		Tip:                   0,                             // this field is not available on v2
+		NonceDAMode:           0,                             // this field is not available on v2
+		FeeDAMode:             0,                             // this field is not available on v2
 	}
 
 	transactionHash, p2pHash := getTransactionHash(
@@ -315,11 +315,11 @@ func (b *SyncTransactionBuilder[C, P]) GetTestDeployAccountTransactionV1(
 		MaxFee:               &maxFee,
 		TransactionSignature: transactionSignature,
 		Nonce:                &nonce,
-		ResourceBounds:       core.ResourceBoundsMap{}, // this field is not available on v1
-		PaymasterData:        nil,                      // this field is not available on v1
-		Tip:                  0,                        // this field is not available on v1
-		NonceDAMode:          0,                        // this field is not available on v1
-		FeeDAMode:            0,                        // this field is not available on v1
+		ResourceBounds:       core.EmptyResourceBoundsMap(), // this field is not available on v1
+		PaymasterData:        nil,                           // this field is not available on v1
+		Tip:                  0,                             // this field is not available on v1
+		NonceDAMode:          0,                             // this field is not available on v1
+		FeeDAMode:            0,                             // this field is not available on v1
 	}
 
 	transactionHash, p2pHash := getTransactionHash(
@@ -430,15 +430,15 @@ func (b *SyncTransactionBuilder[C, P]) GetTestInvokeTransactionV0(
 		ContractAddress:       &contractAddress,
 		Version:               version,
 		EntryPointSelector:    &entryPointSelector,
-		Nonce:                 nil,                      // this field is not available on v0
-		SenderAddress:         nil,                      // this field is not available on v0
-		ResourceBounds:        core.ResourceBoundsMap{}, // this field is not available on v0
-		Tip:                   0,                        // this field is not available on v0
-		PaymasterData:         nil,                      // this field is not available on v0
-		AccountDeploymentData: nil,                      // this field is not available on v0
-		NonceDAMode:           0,                        // this field is not available on v0
-		FeeDAMode:             0,                        // this field is not available on v0
-		ProofFacts:            nil,                      // this field is not available on v0
+		Nonce:                 nil,                           // this field is not available on v0
+		SenderAddress:         nil,                           // this field is not available on v0
+		ResourceBounds:        core.EmptyResourceBoundsMap(), // this field is not available on v0
+		Tip:                   0,                             // this field is not available on v0
+		PaymasterData:         nil,                           // this field is not available on v0
+		AccountDeploymentData: nil,                           // this field is not available on v0
+		NonceDAMode:           0,                             // this field is not available on v0
+		FeeDAMode:             0,                             // this field is not available on v0
+		ProofFacts:            nil,                           // this field is not available on v0
 	}
 
 	transactionHash, p2pHash := getTransactionHash(
@@ -483,14 +483,14 @@ func (b *SyncTransactionBuilder[C, P]) GetTestInvokeTransactionV1(
 		TransactionSignature:  transactionSignature,
 		MaxFee:                &maxFee,
 		Version:               version,
-		EntryPointSelector:    nil,                      // this field is not available on v1
-		ResourceBounds:        core.ResourceBoundsMap{}, // this field is not available on v1
-		Tip:                   0,                        // this field is not available on v1
-		PaymasterData:         nil,                      // this field is not available on v1
-		AccountDeploymentData: nil,                      // this field is not available on v1
-		NonceDAMode:           0,                        // this field is not available on v1
-		FeeDAMode:             0,                        // this field is not available on v1
-		ProofFacts:            nil,                      // this field is not available on v1
+		EntryPointSelector:    nil,                           // this field is not available on v1
+		ResourceBounds:        core.EmptyResourceBoundsMap(), // this field is not available on v1
+		Tip:                   0,                             // this field is not available on v1
+		PaymasterData:         nil,                           // this field is not available on v1
+		AccountDeploymentData: nil,                           // this field is not available on v1
+		NonceDAMode:           0,                             // this field is not available on v1
+		FeeDAMode:             0,                             // this field is not available on v1
+		ProofFacts:            nil,                           // this field is not available on v1
 	}
 
 	transactionHash, p2pHash := getTransactionHash(

--- a/adapters/testutils/transaction_test_utils.go
+++ b/adapters/testutils/transaction_test_utils.go
@@ -98,16 +98,16 @@ func getRandomResourceLimits(t *testing.T) (core.ResourceBounds, *transaction.Re
 	return resourceBounds, &resourceLimits
 }
 
-func getRandomResourceBounds(t *testing.T) (map[core.Resource]core.ResourceBounds, *transaction.ResourceBounds) {
+func getRandomResourceBounds(t *testing.T) (core.ResourceBoundsMap, *transaction.ResourceBounds) {
 	t.Helper()
 	consensusL1ResourceLimits, p2pL1ResourceLimits := getRandomResourceLimits(t)
 	consensusL2ResourceLimits, p2pL2ResourceLimits := getRandomResourceLimits(t)
 	consensusL1DataResourceLimits, p2pL1DataResourceLimits := getRandomResourceLimits(t)
 
-	consensusResourceBounds := map[core.Resource]core.ResourceBounds{
-		core.ResourceL1Gas:     consensusL1ResourceLimits,
-		core.ResourceL2Gas:     consensusL2ResourceLimits,
-		core.ResourceL1DataGas: consensusL1DataResourceLimits,
+	consensusResourceBounds := core.ResourceBoundsMap{
+		L1Gas:     consensusL1ResourceLimits,
+		L2Gas:     consensusL2ResourceLimits,
+		L1DataGas: consensusL1DataResourceLimits,
 	}
 
 	p2pResourceBounds := transaction.ResourceBounds{

--- a/clients/feeder/feeder_test.go
+++ b/clients/feeder/feeder_test.go
@@ -86,16 +86,16 @@ func TestDeclareTransactionUnmarshal(t *testing.T) {
 			Nonce:       new(felt.Felt).SetUint64(1),
 			NonceDAMode: new(starknet.DAModeL1),
 			FeeDAMode:   new(starknet.DAModeL1),
-			ResourceBounds: &map[starknet.Resource]starknet.ResourceBounds{
-				starknet.ResourceL1Gas: {
+			ResourceBounds: &starknet.ResourceBoundsMap{
+				L1Gas: starknet.ResourceBounds{
 					MaxAmount:       felt.NewUnsafeFromString[felt.Felt]("0x186a0"),
 					MaxPricePerUnit: felt.NewUnsafeFromString[felt.Felt]("0x2540be400"),
 				},
-				starknet.ResourceL1DataGas: {
+				L1DataGas: starknet.ResourceBounds{
 					MaxAmount:       felt.NewUnsafeFromString[felt.Felt]("0x186a0"),
 					MaxPricePerUnit: felt.NewUnsafeFromString[felt.Felt]("0x2540be400"),
 				},
-				starknet.ResourceL2Gas: {
+				L2Gas: starknet.ResourceBounds{
 					MaxAmount:       new(felt.Felt),
 					MaxPricePerUnit: new(felt.Felt),
 				},
@@ -180,16 +180,16 @@ func TestInvokeTransactionUnmarshal(t *testing.T) {
 			Nonce:       felt.NewUnsafeFromString[felt.Felt]("0xe97"),
 			NonceDAMode: new(starknet.DAModeL1),
 			FeeDAMode:   new(starknet.DAModeL1),
-			ResourceBounds: &map[starknet.Resource]starknet.ResourceBounds{
-				starknet.ResourceL1Gas: {
+			ResourceBounds: &starknet.ResourceBoundsMap{
+				L1Gas: starknet.ResourceBounds{
 					MaxAmount:       felt.NewUnsafeFromString[felt.Felt]("0x186a0"),
 					MaxPricePerUnit: felt.NewUnsafeFromString[felt.Felt]("0x5af3107a4000"),
 				},
-				starknet.ResourceL1DataGas: {
+				L1DataGas: starknet.ResourceBounds{
 					MaxAmount:       felt.NewUnsafeFromString[felt.Felt]("0x186a0"),
 					MaxPricePerUnit: felt.NewUnsafeFromString[felt.Felt]("0x5af3107a4000"),
 				},
-				starknet.ResourceL2Gas: {
+				L2Gas: starknet.ResourceBounds{
 					MaxAmount:       new(felt.Felt),
 					MaxPricePerUnit: new(felt.Felt),
 				},
@@ -384,16 +384,16 @@ func TestDeployAccountTransactionUnmarshal(t *testing.T) {
 			Nonce:       new(felt.Felt),
 			NonceDAMode: new(starknet.DAModeL1),
 			FeeDAMode:   new(starknet.DAModeL1),
-			ResourceBounds: &map[starknet.Resource]starknet.ResourceBounds{
-				starknet.ResourceL1Gas: {
+			ResourceBounds: &starknet.ResourceBoundsMap{
+				L1Gas: starknet.ResourceBounds{
 					MaxAmount:       felt.NewUnsafeFromString[felt.Felt]("0x186a0"),
 					MaxPricePerUnit: felt.NewUnsafeFromString[felt.Felt]("0x5af3107a4000"),
 				},
-				starknet.ResourceL1DataGas: {
+				L1DataGas: starknet.ResourceBounds{
 					MaxAmount:       felt.NewUnsafeFromString[felt.Felt]("0x186a0"),
 					MaxPricePerUnit: felt.NewUnsafeFromString[felt.Felt]("0x5af3107a4000"),
 				},
-				starknet.ResourceL2Gas: {
+				L2Gas: starknet.ResourceBounds{
 					MaxAmount:       new(felt.Felt),
 					MaxPricePerUnit: new(felt.Felt),
 				},

--- a/consensus/p2p/validator/transition_test.go
+++ b/consensus/p2p/validator/transition_test.go
@@ -189,16 +189,16 @@ func TestProposal(t *testing.T) {
 			felt.UnsafeFromString[felt.Felt]("0x1234"),
 			felt.UnsafeFromString[felt.Felt]("0x0"),
 		},
-		ResourceBounds: map[core.Resource]core.ResourceBounds{
-			core.ResourceL1Gas: {
+		ResourceBounds: core.ResourceBoundsMap{
+			L1Gas: core.ResourceBounds{
 				MaxAmount:       4,
 				MaxPricePerUnit: felt.NewFromUint64[felt.Felt](l1GasPriceFri + 1),
 			},
-			core.ResourceL2Gas: {
+			L2Gas: core.ResourceBounds{
 				MaxAmount:       520000,
 				MaxPricePerUnit: felt.NewFromUint64[felt.Felt](l2GasPriceFri + 1),
 			},
-			core.ResourceL1DataGas: {
+			L1DataGas: core.ResourceBounds{
 				MaxAmount:       296,
 				MaxPricePerUnit: felt.NewFromUint64[felt.Felt](l1DataGasPriceFri + 1),
 			},

--- a/consensus/proposer/proposer_test.go
+++ b/consensus/proposer/proposer_test.go
@@ -311,16 +311,16 @@ func buildRandomTransaction(t *testing.T, nonce uint64) core.Transaction {
 			felt.UnsafeFromString[felt.Felt]("0x1234"),
 			felt.UnsafeFromString[felt.Felt]("0x0"),
 		},
-		ResourceBounds: map[core.Resource]core.ResourceBounds{
-			core.ResourceL1Gas: {
+		ResourceBounds: core.ResourceBoundsMap{
+			L1Gas: core.ResourceBounds{
 				MaxAmount:       4,
 				MaxPricePerUnit: new(felt.Felt).SetUint64(1),
 			},
-			core.ResourceL2Gas: {
+			L2Gas: core.ResourceBounds{
 				MaxAmount:       520000,
 				MaxPricePerUnit: new(felt.Felt).SetUint64(1),
 			},
-			core.ResourceL1DataGas: {
+			L1DataGas: core.ResourceBounds{
 				MaxAmount:       296,
 				MaxPricePerUnit: new(felt.Felt).SetUint64(1),
 			},

--- a/core/resource_bounds_test.go
+++ b/core/resource_bounds_test.go
@@ -1,0 +1,84 @@
+package core
+
+import (
+	"testing"
+
+	"github.com/NethermindEth/juno/core/felt"
+	"github.com/NethermindEth/juno/encoder"
+	"github.com/stretchr/testify/require"
+)
+
+func newBound(amount, price uint64) ResourceBounds {
+	return ResourceBounds{MaxAmount: amount, MaxPricePerUnit: new(felt.Felt).SetUint64(price)}
+}
+
+// TestResourceBoundsMapCBORCompat pins the on-disk format: ResourceBoundsMap
+// must serialise to, and deserialise from, the exact CBOR bytes that the legacy
+// map[Resource]ResourceBounds field produced, so transactions stored before this
+// refactor stay readable without a DB migration.
+func TestResourceBoundsMapCBORCompat(t *testing.T) {
+	l1 := newBound(1, 2)
+	l2 := newBound(3, 4)
+	l1data := newBound(5, 6)
+
+	tests := []struct {
+		name   string
+		legacy map[Resource]ResourceBounds
+		value  ResourceBoundsMap
+	}{
+		{
+			name: "all three resources",
+			legacy: map[Resource]ResourceBounds{
+				ResourceL1Gas: l1, ResourceL2Gas: l2, ResourceL1DataGas: l1data,
+			},
+			value: ResourceBoundsMap{L1Gas: l1, L2Gas: l2, L1DataGas: l1data},
+		},
+		{
+			name:   "no l1_data_gas (pre-0.13.4 v3)",
+			legacy: map[Resource]ResourceBounds{ResourceL1Gas: l1, ResourceL2Gas: l2},
+			value:  ResourceBoundsMap{L1Gas: l1, L2Gas: l2},
+		},
+		{
+			name:   "nil map (v1/v2)",
+			legacy: nil,
+			value:  ResourceBoundsMap{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			legacyBytes, err := encoder.Marshal(tt.legacy)
+			require.NoError(t, err)
+
+			valueBytes, err := encoder.Marshal(tt.value)
+			require.NoError(t, err)
+			require.Equal(t, legacyBytes, valueBytes, "struct must encode to the legacy map bytes")
+
+			var decoded ResourceBoundsMap
+			require.NoError(t, encoder.Unmarshal(legacyBytes, &decoded))
+			require.Equal(t, tt.value, decoded, "legacy bytes must decode into the struct")
+		})
+	}
+}
+
+// TestTipAndResourcesHashL1DataGasPresence guards that l1_data_gas only enters
+// the transaction hash when it is present (non-nil MaxPricePerUnit), preserving
+// the pre-0.13.4 behaviour the old map-key check provided.
+func TestTipAndResourcesHashL1DataGasPresence(t *testing.T) {
+	const tip = 7
+	l1 := newBound(1, 2)
+	l2 := newBound(3, 4)
+
+	// L1DataGas is left zero, so its MaxPricePerUnit stays nil (absent).
+	absent := ResourceBoundsMap{L1Gas: l1, L2Gas: l2}
+	// A present but zero-valued l1_data_gas still enters the hash.
+	present := ResourceBoundsMap{L1Gas: l1, L2Gas: l2, L1DataGas: newBound(0, 0)}
+
+	absentHash := tipAndResourcesHash(tip, absent)
+	require.NotEqual(t, absentHash, tipAndResourcesHash(tip, present),
+		"a present l1_data_gas must change the hash")
+
+	// The absent case is independent of the (zero) L1DataGas fields.
+	absentExplicitZero := ResourceBoundsMap{L1Gas: l1, L2Gas: l2, L1DataGas: ResourceBounds{}}
+	require.Equal(t, absentHash, tipAndResourcesHash(tip, absentExplicitZero))
+}

--- a/core/transaction.go
+++ b/core/transaction.go
@@ -11,6 +11,7 @@ import (
 	"github.com/NethermindEth/juno/blockchain/networks"
 	"github.com/NethermindEth/juno/core/crypto"
 	"github.com/NethermindEth/juno/core/felt"
+	"github.com/NethermindEth/juno/encoder"
 	"github.com/NethermindEth/juno/l1/eth"
 	"github.com/bits-and-blooms/bloom/v3"
 	"github.com/fxamacker/cbor/v2"
@@ -58,6 +59,7 @@ const (
 )
 
 // From the RPC spec: The max amount and max price per unit of gas used in this transaction.
+// A zero value (nil MaxPricePerUnit) represents a resource that is absent from a transaction.
 type ResourceBounds struct {
 	MaxAmount uint64
 	// MaxPricePerUnit is technically a uint128
@@ -78,6 +80,63 @@ func (rb ResourceBounds) Bytes(resource Resource) []byte {
 
 func (rb ResourceBounds) IsZero() bool {
 	return rb.MaxAmount == 0 && (rb.MaxPricePerUnit == nil || rb.MaxPricePerUnit.IsZero())
+}
+
+// ResourceBoundsMap holds the per-resource bounds of a v3 transaction. It
+// replaces the historical map[Resource]ResourceBounds: the set of resources is
+// effectively fixed, so explicit fields are clearer and avoid a map allocation
+// per transaction.
+//
+// On the wire it is still encoded as the legacy map[Resource]ResourceBounds so
+// that transactions written to the DB before this type existed remain readable
+// without a migration — see MarshalCBOR/UnmarshalCBOR.
+//
+// A zero value represents a transaction with no resource bounds (v0-v2).
+type ResourceBoundsMap struct {
+	L1Gas     ResourceBounds
+	L2Gas     ResourceBounds
+	L1DataGas ResourceBounds
+}
+
+// MarshalCBOR encodes the bounds using the legacy map[Resource]ResourceBounds
+// layout so the on-disk format is unchanged.
+func (rb ResourceBoundsMap) MarshalCBOR() ([]byte, error) {
+	return encoder.Marshal(rb.toMap())
+}
+
+// UnmarshalCBOR decodes the legacy map[Resource]ResourceBounds layout, including
+// the nil map that pre-v3 transactions were stored with.
+func (rb *ResourceBoundsMap) UnmarshalCBOR(data []byte) error {
+	var m map[Resource]ResourceBounds
+	if err := encoder.Unmarshal(data, &m); err != nil {
+		return err
+	}
+	rb.L1Gas = m[ResourceL1Gas]
+	rb.L2Gas = m[ResourceL2Gas]
+	rb.L1DataGas = m[ResourceL1DataGas]
+	return nil
+}
+
+// toMap rebuilds the legacy map representation. A resource is only present when
+// it carries a value (non-nil MaxPricePerUnit), mirroring how transactions were
+// built before this type existed: pre-v3 transactions had a nil map, and v3
+// transactions before Starknet 0.13.4 omitted l1_data_gas. Preserving this
+// keeps both the stored bytes and the computed transaction hash unchanged.
+func (rb ResourceBoundsMap) toMap() map[Resource]ResourceBounds {
+	var m map[Resource]ResourceBounds
+	put := func(r Resource, b ResourceBounds) {
+		if b.MaxPricePerUnit == nil {
+			return
+		}
+		if m == nil {
+			m = make(map[Resource]ResourceBounds)
+		}
+		m[r] = b
+	}
+	put(ResourceL1Gas, rb.L1Gas)
+	put(ResourceL2Gas, rb.L2Gas)
+	put(ResourceL1DataGas, rb.L1DataGas)
+	return m
 }
 
 type Event struct {
@@ -246,7 +305,7 @@ type DeployAccountTransaction struct {
 
 	// Version 3 fields
 	// See InvokeTransaction for descriptions of the fields.
-	ResourceBounds map[Resource]ResourceBounds
+	ResourceBounds ResourceBoundsMap
 	Tip            uint64
 	PaymasterData  []felt.Felt
 	NonceDAMode    DataAvailabilityMode
@@ -288,7 +347,7 @@ type InvokeTransaction struct {
 	SenderAddress *felt.Felt
 
 	// Version 3 fields (there was no version 2)
-	ResourceBounds map[Resource]ResourceBounds
+	ResourceBounds ResourceBoundsMap
 	Tip            uint64
 	// From the RPC spec: data needed to allow the paymaster to pay for the transaction in native tokens
 	PaymasterData []felt.Felt
@@ -339,7 +398,7 @@ type DeclareTransaction struct {
 
 	// Version 3 fields
 	// See InvokeTransaction for descriptions of the fields.
-	ResourceBounds        map[Resource]ResourceBounds
+	ResourceBounds        ResourceBoundsMap
 	Tip                   uint64
 	PaymasterData         []felt.Felt
 	AccountDeploymentData []felt.Felt
@@ -511,17 +570,18 @@ func invokeTransactionHash(i *InvokeTransaction, n *networks.Network) (felt.Felt
 	}
 }
 
-func tipAndResourcesHash(tip uint64, resourceBounds map[Resource]ResourceBounds) felt.Felt {
-	l1Bounds := felt.FromBytes[felt.Felt](resourceBounds[ResourceL1Gas].Bytes(ResourceL1Gas))
-	l2Bounds := felt.FromBytes[felt.Felt](resourceBounds[ResourceL2Gas].Bytes(ResourceL2Gas))
+func tipAndResourcesHash(tip uint64, resourceBounds ResourceBoundsMap) felt.Felt {
+	l1Bounds := felt.FromBytes[felt.Felt](resourceBounds.L1Gas.Bytes(ResourceL1Gas))
+	l2Bounds := felt.FromBytes[felt.Felt](resourceBounds.L2Gas.Bytes(ResourceL2Gas))
 	tipFelt := felt.FromUint64[felt.Felt](tip)
 
 	var digest crypto.PoseidonDigest
 	digest.Update(&tipFelt, &l1Bounds, &l2Bounds)
 
-	// l1_data_gas resource bounds were added in 0.13.4
-	if bounds, ok := resourceBounds[ResourceL1DataGas]; ok && bounds.MaxPricePerUnit != nil {
-		l1DataBounds := felt.FromBytes[felt.Felt](bounds.Bytes(ResourceL1DataGas))
+	// l1_data_gas resource bounds were added in 0.13.4. A non-nil MaxPricePerUnit
+	// marks the resource as present, matching the old map-key check.
+	if resourceBounds.L1DataGas.MaxPricePerUnit != nil {
+		l1DataBounds := felt.FromBytes[felt.Felt](resourceBounds.L1DataGas.Bytes(ResourceL1DataGas))
 		digest.Update(&l1DataBounds)
 	}
 

--- a/core/transaction.go
+++ b/core/transaction.go
@@ -98,6 +98,23 @@ type ResourceBoundsMap struct {
 	L1DataGas ResourceBounds
 }
 
+// EmptyResourceBounds returns a ResourceBounds with all fields set to zero values.
+func EmptyResourceBounds() ResourceBounds {
+	return ResourceBounds{
+		MaxAmount:       0,
+		MaxPricePerUnit: nil,
+	}
+}
+
+// EmptyResourceBoundsMap returns a ResourceBoundsMap with all resources set to zero values.
+func EmptyResourceBoundsMap() ResourceBoundsMap {
+	return ResourceBoundsMap{
+		L1Gas:     EmptyResourceBounds(),
+		L2Gas:     EmptyResourceBounds(),
+		L1DataGas: EmptyResourceBounds(),
+	}
+}
+
 // MarshalCBOR encodes the bounds using the legacy map[Resource]ResourceBounds
 // layout so the on-disk format is unchanged.
 func (rb ResourceBoundsMap) MarshalCBOR() ([]byte, error) {

--- a/genesis/genesis.go
+++ b/genesis/genesis.go
@@ -385,17 +385,17 @@ func executeTransactions(
 	return nil
 }
 
-func adaptResourceBounds(rb *rpc.ResourceBoundsMap) map[core.Resource]core.ResourceBounds {
-	return map[core.Resource]core.ResourceBounds{
-		core.ResourceL1Gas: {
+func adaptResourceBounds(rb *rpc.ResourceBoundsMap) core.ResourceBoundsMap {
+	return core.ResourceBoundsMap{
+		L1Gas: core.ResourceBounds{
 			MaxAmount:       rb.L1Gas.MaxAmount.Uint64(),
 			MaxPricePerUnit: rb.L1Gas.MaxPricePerUnit,
 		},
-		core.ResourceL2Gas: {
+		L2Gas: core.ResourceBounds{
 			MaxAmount:       rb.L2Gas.MaxAmount.Uint64(),
 			MaxPricePerUnit: rb.L2Gas.MaxPricePerUnit,
 		},
-		core.ResourceL1DataGas: {
+		L1DataGas: core.ResourceBounds{
 			MaxAmount:       rb.L1DataGas.MaxAmount.Uint64(),
 			MaxPricePerUnit: rb.L1DataGas.MaxPricePerUnit,
 		},

--- a/rpc/v10/adapt_transaction.go
+++ b/rpc/v10/adapt_transaction.go
@@ -71,10 +71,13 @@ func AdaptCoreTransaction(t core.Transaction) *Transaction {
 }
 
 func adaptCoreResourceBounds(rb core.ResourceBoundsMap) ResourceBoundsMap {
+	l1DataGasResourceBounds := ResourceBounds{
+		MaxAmount:       &felt.Zero,
+		MaxPricePerUnit: &felt.Zero,
+	}
 	// l1_data_gas was added in 0.13.4; a nil MaxPricePerUnit marks it absent.
-	var l1DataGasResourceBounds *ResourceBounds
 	if rb.L1DataGas.MaxPricePerUnit != nil {
-		l1DataGasResourceBounds = &ResourceBounds{
+		l1DataGasResourceBounds = ResourceBounds{
 			MaxAmount:       felt.NewFromUint64[felt.Felt](rb.L1DataGas.MaxAmount),
 			MaxPricePerUnit: rb.L1DataGas.MaxPricePerUnit,
 		}
@@ -82,11 +85,11 @@ func adaptCoreResourceBounds(rb core.ResourceBoundsMap) ResourceBoundsMap {
 
 	// As L1Gas & L2Gas will always be present, we can directly assign them
 	rpcResourceBounds := ResourceBoundsMap{
-		L1Gas: &ResourceBounds{
+		L1Gas: ResourceBounds{
 			MaxAmount:       felt.NewFromUint64[felt.Felt](rb.L1Gas.MaxAmount),
 			MaxPricePerUnit: rb.L1Gas.MaxPricePerUnit,
 		},
-		L2Gas: &ResourceBounds{
+		L2Gas: ResourceBounds{
 			MaxAmount:       felt.NewFromUint64[felt.Felt](rb.L2Gas.MaxAmount),
 			MaxPricePerUnit: rb.L2Gas.MaxPricePerUnit,
 		},
@@ -96,18 +99,19 @@ func adaptCoreResourceBounds(rb core.ResourceBoundsMap) ResourceBoundsMap {
 }
 
 func AdaptBroadcastedTransactionToFeeder(rpcTx *BroadcastedTransaction) starknet.Transaction {
-	resourceBounds := make(map[starknet.Resource]starknet.ResourceBounds)
-	resourceBounds[starknet.ResourceL1Gas] = starknet.ResourceBounds{
-		MaxAmount:       rpcTx.ResourceBounds.L1Gas.MaxAmount,
-		MaxPricePerUnit: rpcTx.ResourceBounds.L1Gas.MaxPricePerUnit,
-	}
-	resourceBounds[starknet.ResourceL2Gas] = starknet.ResourceBounds{
-		MaxAmount:       rpcTx.ResourceBounds.L2Gas.MaxAmount,
-		MaxPricePerUnit: rpcTx.ResourceBounds.L2Gas.MaxPricePerUnit,
-	}
-	resourceBounds[starknet.ResourceL1DataGas] = starknet.ResourceBounds{
-		MaxAmount:       rpcTx.ResourceBounds.L1DataGas.MaxAmount,
-		MaxPricePerUnit: rpcTx.ResourceBounds.L1DataGas.MaxPricePerUnit,
+	resourceBounds := starknet.ResourceBoundsMap{
+		L1Gas: starknet.ResourceBounds{
+			MaxAmount:       rpcTx.ResourceBounds.L1Gas.MaxAmount,
+			MaxPricePerUnit: rpcTx.ResourceBounds.L1Gas.MaxPricePerUnit,
+		},
+		L2Gas: starknet.ResourceBounds{
+			MaxAmount:       rpcTx.ResourceBounds.L2Gas.MaxAmount,
+			MaxPricePerUnit: rpcTx.ResourceBounds.L2Gas.MaxPricePerUnit,
+		},
+		L1DataGas: starknet.ResourceBounds{
+			MaxAmount:       rpcTx.ResourceBounds.L1DataGas.MaxAmount,
+			MaxPricePerUnit: rpcTx.ResourceBounds.L1DataGas.MaxPricePerUnit,
+		},
 	}
 
 	return starknet.Transaction{
@@ -408,22 +412,21 @@ func MakeJSONErrorFromGatewayError(err error) *jsonrpc.Error {
 
 func adaptResourceBoundsToCore(
 	rb *ResourceBoundsMap,
-) map[core.Resource]core.ResourceBounds {
-	coreResourceBounds := make(map[core.Resource]core.ResourceBounds)
-	coreResourceBounds[core.ResourceL1Gas] = core.ResourceBounds{
-		MaxAmount:       rb.L1Gas.MaxAmount.Uint64(),
-		MaxPricePerUnit: rb.L1Gas.MaxPricePerUnit,
+) core.ResourceBoundsMap {
+	return core.ResourceBoundsMap{
+		L1Gas: core.ResourceBounds{
+			MaxAmount:       rb.L1Gas.MaxAmount.Uint64(),
+			MaxPricePerUnit: rb.L1Gas.MaxPricePerUnit,
+		},
+		L2Gas: core.ResourceBounds{
+			MaxAmount:       rb.L2Gas.MaxAmount.Uint64(),
+			MaxPricePerUnit: rb.L2Gas.MaxPricePerUnit,
+		},
+		L1DataGas: core.ResourceBounds{
+			MaxAmount:       rb.L1DataGas.MaxAmount.Uint64(),
+			MaxPricePerUnit: rb.L1DataGas.MaxPricePerUnit,
+		},
 	}
-	coreResourceBounds[core.ResourceL2Gas] = core.ResourceBounds{
-		MaxAmount:       rb.L2Gas.MaxAmount.Uint64(),
-		MaxPricePerUnit: rb.L2Gas.MaxPricePerUnit,
-	}
-	coreResourceBounds[core.ResourceL1DataGas] = core.ResourceBounds{
-		MaxAmount:       rb.L1DataGas.MaxAmount.Uint64(),
-		MaxPricePerUnit: rb.L1DataGas.MaxPricePerUnit,
-	}
-
-	return coreResourceBounds
 }
 
 // adapts BroadcastedInvokeTransaction to core.InvokeTransaction.

--- a/rpc/v10/adapt_transaction.go
+++ b/rpc/v10/adapt_transaction.go
@@ -70,28 +70,25 @@ func AdaptCoreTransaction(t core.Transaction) *Transaction {
 	return txn
 }
 
-func adaptCoreResourceBounds(rb map[core.Resource]core.ResourceBounds) ResourceBoundsMap {
-	l1DataGasResourceBounds := ResourceBounds{
-		MaxAmount:       &felt.Zero,
-		MaxPricePerUnit: &felt.Zero,
-	}
-	// Check if L1DataGas exists in the map
-	if _, ok := rb[core.ResourceL1DataGas]; ok {
-		l1DataGasResourceBounds = ResourceBounds{
-			MaxAmount:       felt.NewFromUint64[felt.Felt](rb[core.ResourceL1DataGas].MaxAmount),
-			MaxPricePerUnit: rb[core.ResourceL1DataGas].MaxPricePerUnit,
+func adaptCoreResourceBounds(rb core.ResourceBoundsMap) ResourceBoundsMap {
+	// l1_data_gas was added in 0.13.4; a nil MaxPricePerUnit marks it absent.
+	var l1DataGasResourceBounds *ResourceBounds
+	if rb.L1DataGas.MaxPricePerUnit != nil {
+		l1DataGasResourceBounds = &ResourceBounds{
+			MaxAmount:       felt.NewFromUint64[felt.Felt](rb.L1DataGas.MaxAmount),
+			MaxPricePerUnit: rb.L1DataGas.MaxPricePerUnit,
 		}
 	}
 
 	// As L1Gas & L2Gas will always be present, we can directly assign them
 	rpcResourceBounds := ResourceBoundsMap{
-		L1Gas: ResourceBounds{
-			MaxAmount:       felt.NewFromUint64[felt.Felt](rb[core.ResourceL1Gas].MaxAmount),
-			MaxPricePerUnit: rb[core.ResourceL1Gas].MaxPricePerUnit,
+		L1Gas: &ResourceBounds{
+			MaxAmount:       felt.NewFromUint64[felt.Felt](rb.L1Gas.MaxAmount),
+			MaxPricePerUnit: rb.L1Gas.MaxPricePerUnit,
 		},
-		L2Gas: ResourceBounds{
-			MaxAmount:       felt.NewFromUint64[felt.Felt](rb[core.ResourceL2Gas].MaxAmount),
-			MaxPricePerUnit: rb[core.ResourceL2Gas].MaxPricePerUnit,
+		L2Gas: &ResourceBounds{
+			MaxAmount:       felt.NewFromUint64[felt.Felt](rb.L2Gas.MaxAmount),
+			MaxPricePerUnit: rb.L2Gas.MaxPricePerUnit,
 		},
 		L1DataGas: l1DataGasResourceBounds,
 	}

--- a/rpc/v10/block_test.go
+++ b/rpc/v10/block_test.go
@@ -1207,15 +1207,15 @@ func TestBlockWithTxHashesV013(t *testing.T) {
 				ResourceBounds: &rpc.ResourceBoundsMap{
 					L1Gas: rpc.ResourceBounds{
 						MaxAmount: felt.NewFromUint64[felt.Felt](
-							tx.ResourceBounds[core.ResourceL1Gas].MaxAmount,
+							tx.ResourceBounds.L1Gas.MaxAmount,
 						),
-						MaxPricePerUnit: tx.ResourceBounds[core.ResourceL1Gas].MaxPricePerUnit,
+						MaxPricePerUnit: tx.ResourceBounds.L1Gas.MaxPricePerUnit,
 					},
 					L2Gas: rpc.ResourceBounds{
 						MaxAmount: felt.NewFromUint64[felt.Felt](
-							tx.ResourceBounds[core.ResourceL2Gas].MaxAmount,
+							tx.ResourceBounds.L2Gas.MaxAmount,
 						),
-						MaxPricePerUnit: tx.ResourceBounds[core.ResourceL2Gas].MaxPricePerUnit,
+						MaxPricePerUnit: tx.ResourceBounds.L2Gas.MaxPricePerUnit,
 					},
 					L1DataGas: rpc.ResourceBounds{
 						MaxAmount:       &felt.Zero,

--- a/rpc/v10/subscriptions_test.go
+++ b/rpc/v10/subscriptions_test.go
@@ -1839,12 +1839,12 @@ func TestSubscribeNewTransactions(t *testing.T) {
 		Version:         new(core.TransactionVersion).SetUint64(3),
 		SenderAddress:   felt.NewFromUint64[felt.Felt](456),
 		Nonce:           felt.NewFromUint64[felt.Felt](1),
-		ResourceBounds: map[core.Resource]core.ResourceBounds{
-			core.ResourceL1Gas: {
+		ResourceBounds: core.ResourceBoundsMap{
+			L1Gas: core.ResourceBounds{
 				MaxAmount:       1,
 				MaxPricePerUnit: felt.NewFromUint64[felt.Felt](10),
 			},
-			core.ResourceL2Gas: {
+			L2Gas: core.ResourceBounds{
 				MaxAmount:       1,
 				MaxPricePerUnit: felt.NewFromUint64[felt.Felt](10),
 			},
@@ -1857,12 +1857,12 @@ func TestSubscribeNewTransactions(t *testing.T) {
 		Version:         new(core.TransactionVersion).SetUint64(3),
 		SenderAddress:   felt.NewFromUint64[felt.Felt](456),
 		Nonce:           felt.NewFromUint64[felt.Felt](1),
-		ResourceBounds: map[core.Resource]core.ResourceBounds{
-			core.ResourceL1Gas: {
+		ResourceBounds: core.ResourceBoundsMap{
+			L1Gas: core.ResourceBounds{
 				MaxAmount:       1,
 				MaxPricePerUnit: felt.NewFromUint64[felt.Felt](10),
 			},
-			core.ResourceL2Gas: {
+			L2Gas: core.ResourceBounds{
 				MaxAmount:       1,
 				MaxPricePerUnit: felt.NewFromUint64[felt.Felt](10),
 			},

--- a/rpc/v10/transaction_test.go
+++ b/rpc/v10/transaction_test.go
@@ -2003,16 +2003,16 @@ func createBaseInvokeTransactionV3() core.InvokeTransaction {
 		Nonce:       felt.NewFromUint64[felt.Felt](0x1),
 		NonceDAMode: core.DAModeL1,
 		FeeDAMode:   core.DAModeL1,
-		ResourceBounds: map[core.Resource]core.ResourceBounds{
-			core.ResourceL1Gas: {
+		ResourceBounds: core.ResourceBoundsMap{
+			L1Gas: core.ResourceBounds{
 				MaxAmount:       0x1,
 				MaxPricePerUnit: felt.NewFromUint64[felt.Felt](0x1),
 			},
-			core.ResourceL1DataGas: {
+			L1DataGas: core.ResourceBounds{
 				MaxAmount:       0x1,
 				MaxPricePerUnit: felt.NewFromUint64[felt.Felt](0x1),
 			},
-			core.ResourceL2Gas: {
+			L2Gas: core.ResourceBounds{
 				MaxAmount:       0,
 				MaxPricePerUnit: &felt.Zero,
 			},

--- a/rpc/v8/block_test.go
+++ b/rpc/v8/block_test.go
@@ -720,12 +720,12 @@ func TestBlockWithTxHashesV013(t *testing.T) {
 				EntryPointSelector: tx.EntryPointSelector,
 				ResourceBounds: &rpc.ResourceBoundsMap{
 					L1Gas: &rpc.ResourceBounds{
-						MaxAmount:       new(felt.Felt).SetUint64(tx.ResourceBounds[core.ResourceL1Gas].MaxAmount),
-						MaxPricePerUnit: tx.ResourceBounds[core.ResourceL1Gas].MaxPricePerUnit,
+						MaxAmount:       new(felt.Felt).SetUint64(tx.ResourceBounds.L1Gas.MaxAmount),
+						MaxPricePerUnit: tx.ResourceBounds.L1Gas.MaxPricePerUnit,
 					},
 					L2Gas: &rpc.ResourceBounds{
-						MaxAmount:       new(felt.Felt).SetUint64(tx.ResourceBounds[core.ResourceL2Gas].MaxAmount),
-						MaxPricePerUnit: tx.ResourceBounds[core.ResourceL2Gas].MaxPricePerUnit,
+						MaxAmount:       new(felt.Felt).SetUint64(tx.ResourceBounds.L2Gas.MaxAmount),
+						MaxPricePerUnit: tx.ResourceBounds.L2Gas.MaxPricePerUnit,
 					},
 					L1DataGas: &rpc.ResourceBounds{
 						MaxAmount:       &felt.Zero,

--- a/rpc/v8/subscriptions_test.go
+++ b/rpc/v8/subscriptions_test.go
@@ -874,16 +874,16 @@ func TestSubscribePendingTxs(t *testing.T) {
 						EntryPointSelector:   new(felt.Felt).SetUint64(6),
 						Nonce:                new(felt.Felt).SetUint64(7),
 						SenderAddress:        new(felt.Felt).SetUint64(8),
-						ResourceBounds: map[core.Resource]core.ResourceBounds{
-							core.ResourceL1Gas: {
+						ResourceBounds: core.ResourceBoundsMap{
+							L1Gas: core.ResourceBounds{
 								MaxAmount:       1,
 								MaxPricePerUnit: new(felt.Felt).SetUint64(1),
 							},
-							core.ResourceL2Gas: {
+							L2Gas: core.ResourceBounds{
 								MaxAmount:       1,
 								MaxPricePerUnit: new(felt.Felt).SetUint64(1),
 							},
-							core.ResourceL1DataGas: {
+							L1DataGas: core.ResourceBounds{
 								MaxAmount:       1,
 								MaxPricePerUnit: new(felt.Felt).SetUint64(1),
 							},

--- a/rpc/v8/transaction.go
+++ b/rpc/v8/transaction.go
@@ -422,25 +422,24 @@ func adaptResourceBounds(rb core.ResourceBoundsMap) ResourceBoundsMap {
 	return rpcResourceBounds
 }
 
-func adaptToFeederResourceBounds(rb *ResourceBoundsMap) *map[starknet.Resource]starknet.ResourceBounds { //nolint:gocritic
+func adaptToFeederResourceBounds(rb *ResourceBoundsMap) *starknet.ResourceBoundsMap {
 	if rb == nil {
 		return nil
 	}
-	feederResourceBounds := make(map[starknet.Resource]starknet.ResourceBounds)
-	feederResourceBounds[starknet.ResourceL1Gas] = starknet.ResourceBounds{
-		MaxAmount:       rb.L1Gas.MaxAmount,
-		MaxPricePerUnit: rb.L1Gas.MaxPricePerUnit,
+	return &starknet.ResourceBoundsMap{
+		L1Gas: starknet.ResourceBounds{
+			MaxAmount:       rb.L1Gas.MaxAmount,
+			MaxPricePerUnit: rb.L1Gas.MaxPricePerUnit,
+		},
+		L2Gas: starknet.ResourceBounds{
+			MaxAmount:       rb.L2Gas.MaxAmount,
+			MaxPricePerUnit: rb.L2Gas.MaxPricePerUnit,
+		},
+		L1DataGas: starknet.ResourceBounds{
+			MaxAmount:       rb.L1DataGas.MaxAmount,
+			MaxPricePerUnit: rb.L1DataGas.MaxPricePerUnit,
+		},
 	}
-	feederResourceBounds[starknet.ResourceL2Gas] = starknet.ResourceBounds{
-		MaxAmount:       rb.L2Gas.MaxAmount,
-		MaxPricePerUnit: rb.L2Gas.MaxPricePerUnit,
-	}
-	feederResourceBounds[starknet.ResourceL1DataGas] = starknet.ResourceBounds{
-		MaxAmount:       rb.L1DataGas.MaxAmount,
-		MaxPricePerUnit: rb.L1DataGas.MaxPricePerUnit,
-	}
-
-	return &feederResourceBounds
 }
 
 func adaptToFeederDAMode(mode *DataAvailabilityMode) *starknet.DataAvailabilityMode {

--- a/rpc/v8/transaction.go
+++ b/rpc/v8/transaction.go
@@ -392,13 +392,13 @@ func AdaptBroadcastedTransaction(
 	return txn, declaredClass, nil
 }
 
-func adaptResourceBounds(rb map[core.Resource]core.ResourceBounds) ResourceBoundsMap {
-	// Check if L1DataGas exists in the map
+func adaptResourceBounds(rb core.ResourceBoundsMap) ResourceBoundsMap {
+	// l1_data_gas was added in 0.13.4; a nil MaxPricePerUnit marks it absent.
 	var l1DataGasResourceBounds *ResourceBounds
-	if _, ok := rb[core.ResourceL1DataGas]; ok {
+	if rb.L1DataGas.MaxPricePerUnit != nil {
 		l1DataGasResourceBounds = &ResourceBounds{
-			MaxAmount:       new(felt.Felt).SetUint64(rb[core.ResourceL1DataGas].MaxAmount),
-			MaxPricePerUnit: rb[core.ResourceL1DataGas].MaxPricePerUnit,
+			MaxAmount:       new(felt.Felt).SetUint64(rb.L1DataGas.MaxAmount),
+			MaxPricePerUnit: rb.L1DataGas.MaxPricePerUnit,
 		}
 	} else {
 		l1DataGasResourceBounds = &ResourceBounds{
@@ -410,12 +410,12 @@ func adaptResourceBounds(rb map[core.Resource]core.ResourceBounds) ResourceBound
 	// As L1Gas & L2Gas will always be present, we can directly assign them
 	rpcResourceBounds := ResourceBoundsMap{
 		L1Gas: &ResourceBounds{
-			MaxAmount:       new(felt.Felt).SetUint64(rb[core.ResourceL1Gas].MaxAmount),
-			MaxPricePerUnit: rb[core.ResourceL1Gas].MaxPricePerUnit,
+			MaxAmount:       new(felt.Felt).SetUint64(rb.L1Gas.MaxAmount),
+			MaxPricePerUnit: rb.L1Gas.MaxPricePerUnit,
 		},
 		L2Gas: &ResourceBounds{
-			MaxAmount:       new(felt.Felt).SetUint64(rb[core.ResourceL2Gas].MaxAmount),
-			MaxPricePerUnit: rb[core.ResourceL2Gas].MaxPricePerUnit,
+			MaxAmount:       new(felt.Felt).SetUint64(rb.L2Gas.MaxAmount),
+			MaxPricePerUnit: rb.L2Gas.MaxPricePerUnit,
 		},
 		L1DataGas: l1DataGasResourceBounds,
 	}

--- a/rpc/v8/transaction_test.go
+++ b/rpc/v8/transaction_test.go
@@ -1834,16 +1834,16 @@ func TestAdaptBroadcastedTransaction(t *testing.T) {
 			),
 		},
 		Nonce: felt.NewUnsafeFromString[felt.Felt]("0x1"),
-		ResourceBounds: map[core.Resource]core.ResourceBounds{
-			core.ResourceL1Gas: {
+		ResourceBounds: core.ResourceBoundsMap{
+			L1Gas: core.ResourceBounds{
 				MaxAmount:       felt.NewUnsafeFromString[felt.Felt]("0x6fde2b4eb000").Uint64(),
 				MaxPricePerUnit: felt.NewUnsafeFromString[felt.Felt]("0x6fde2b4eb000"),
 			},
-			core.ResourceL2Gas: {
+			L2Gas: core.ResourceBounds{
 				MaxAmount:       felt.NewUnsafeFromString[felt.Felt]("0x6fde2b4eb000").Uint64(),
 				MaxPricePerUnit: felt.NewUnsafeFromString[felt.Felt]("0x6fde2b4eb000"),
 			},
-			core.ResourceL1DataGas: {
+			L1DataGas: core.ResourceBounds{
 				MaxAmount:       felt.NewUnsafeFromString[felt.Felt]("0x6fde2b4eb000").Uint64(),
 				MaxPricePerUnit: felt.NewUnsafeFromString[felt.Felt]("0x6fde2b4eb000"),
 			},
@@ -1970,16 +1970,16 @@ func TestSubmittedTransactionsCache(t *testing.T) {
 		Nonce:       felt.NewUnsafeFromString[felt.Felt]("0x1"),
 		NonceDAMode: core.DAModeL1,
 		FeeDAMode:   core.DAModeL1,
-		ResourceBounds: map[core.Resource]core.ResourceBounds{
-			core.ResourceL1Gas: {
+		ResourceBounds: core.ResourceBoundsMap{
+			L1Gas: core.ResourceBounds{
 				MaxAmount:       0x1,
 				MaxPricePerUnit: felt.NewUnsafeFromString[felt.Felt]("0x1"),
 			},
-			core.ResourceL1DataGas: {
+			L1DataGas: core.ResourceBounds{
 				MaxAmount:       0x1,
 				MaxPricePerUnit: felt.NewUnsafeFromString[felt.Felt]("0x1"),
 			},
-			core.ResourceL2Gas: {
+			L2Gas: core.ResourceBounds{
 				MaxAmount:       0,
 				MaxPricePerUnit: new(felt.Felt),
 			},

--- a/rpc/v9/block_test.go
+++ b/rpc/v9/block_test.go
@@ -890,12 +890,12 @@ func TestBlockWithTxHashesV013(t *testing.T) {
 				EntryPointSelector: tx.EntryPointSelector,
 				ResourceBounds: &rpc.ResourceBoundsMap{
 					L1Gas: &rpc.ResourceBounds{
-						MaxAmount:       felt.NewFromUint64[felt.Felt](tx.ResourceBounds[core.ResourceL1Gas].MaxAmount),
-						MaxPricePerUnit: tx.ResourceBounds[core.ResourceL1Gas].MaxPricePerUnit,
+						MaxAmount:       felt.NewFromUint64[felt.Felt](tx.ResourceBounds.L1Gas.MaxAmount),
+						MaxPricePerUnit: tx.ResourceBounds.L1Gas.MaxPricePerUnit,
 					},
 					L2Gas: &rpc.ResourceBounds{
-						MaxAmount:       felt.NewFromUint64[felt.Felt](tx.ResourceBounds[core.ResourceL2Gas].MaxAmount),
-						MaxPricePerUnit: tx.ResourceBounds[core.ResourceL2Gas].MaxPricePerUnit,
+						MaxAmount:       felt.NewFromUint64[felt.Felt](tx.ResourceBounds.L2Gas.MaxAmount),
+						MaxPricePerUnit: tx.ResourceBounds.L2Gas.MaxPricePerUnit,
 					},
 					L1DataGas: &rpc.ResourceBounds{
 						MaxAmount:       &felt.Zero,

--- a/rpc/v9/transaction.go
+++ b/rpc/v9/transaction.go
@@ -451,27 +451,24 @@ func adaptResourceBounds(rb core.ResourceBoundsMap) ResourceBoundsMap {
 	return rpcResourceBounds
 }
 
-func AdaptToFeederResourceBounds(
-	rb *ResourceBoundsMap,
-) map[starknet.Resource]starknet.ResourceBounds {
+func AdaptToFeederResourceBounds(rb *ResourceBoundsMap) *starknet.ResourceBoundsMap {
 	if rb == nil {
 		return nil
 	}
-	feederResourceBounds := make(map[starknet.Resource]starknet.ResourceBounds)
-	feederResourceBounds[starknet.ResourceL1Gas] = starknet.ResourceBounds{
-		MaxAmount:       rb.L1Gas.MaxAmount,
-		MaxPricePerUnit: rb.L1Gas.MaxPricePerUnit,
+	return &starknet.ResourceBoundsMap{
+		L1Gas: starknet.ResourceBounds{
+			MaxAmount:       rb.L1Gas.MaxAmount,
+			MaxPricePerUnit: rb.L1Gas.MaxPricePerUnit,
+		},
+		L2Gas: starknet.ResourceBounds{
+			MaxAmount:       rb.L2Gas.MaxAmount,
+			MaxPricePerUnit: rb.L2Gas.MaxPricePerUnit,
+		},
+		L1DataGas: starknet.ResourceBounds{
+			MaxAmount:       rb.L1DataGas.MaxAmount,
+			MaxPricePerUnit: rb.L1DataGas.MaxPricePerUnit,
+		},
 	}
-	feederResourceBounds[starknet.ResourceL2Gas] = starknet.ResourceBounds{
-		MaxAmount:       rb.L2Gas.MaxAmount,
-		MaxPricePerUnit: rb.L2Gas.MaxPricePerUnit,
-	}
-	feederResourceBounds[starknet.ResourceL1DataGas] = starknet.ResourceBounds{
-		MaxAmount:       rb.L1DataGas.MaxAmount,
-		MaxPricePerUnit: rb.L1DataGas.MaxPricePerUnit,
-	}
-
-	return feederResourceBounds
 }
 
 func AdaptToFeederDAMode(mode *DataAvailabilityMode) starknet.DataAvailabilityMode {
@@ -483,10 +480,6 @@ func AdaptToFeederDAMode(mode *DataAvailabilityMode) starknet.DataAvailabilityMo
 
 func AdaptRPCTxToFeederTx(rpcTx *Transaction) starknet.Transaction {
 	resourceBounds := AdaptToFeederResourceBounds(rpcTx.ResourceBounds)
-	var resourceBoundsPtr *map[starknet.Resource]starknet.ResourceBounds
-	if resourceBounds != nil {
-		resourceBoundsPtr = &resourceBounds
-	}
 
 	var nonceDAModePtr *starknet.DataAvailabilityMode
 	if rpcTx.NonceDAMode != nil {
@@ -515,7 +508,7 @@ func AdaptRPCTxToFeederTx(rpcTx *Transaction) starknet.Transaction {
 		EntryPointSelector:    rpcTx.EntryPointSelector,
 		Nonce:                 rpcTx.Nonce,
 		CompiledClassHash:     rpcTx.CompiledClassHash,
-		ResourceBounds:        resourceBoundsPtr,
+		ResourceBounds:        resourceBounds,
 		Tip:                   rpcTx.Tip,
 		NonceDAMode:           nonceDAModePtr,
 		FeeDAMode:             feeDAModePtr,

--- a/rpc/v9/transaction.go
+++ b/rpc/v9/transaction.go
@@ -421,13 +421,13 @@ func AdaptBroadcastedTransaction(
 	return txn, declaredClass, nil
 }
 
-func adaptResourceBounds(rb map[core.Resource]core.ResourceBounds) ResourceBoundsMap {
-	// Check if L1DataGas exists in the map
+func adaptResourceBounds(rb core.ResourceBoundsMap) ResourceBoundsMap {
+	// l1_data_gas was added in 0.13.4; a nil MaxPricePerUnit marks it absent.
 	var l1DataGasResourceBounds *ResourceBounds
-	if _, ok := rb[core.ResourceL1DataGas]; ok {
+	if rb.L1DataGas.MaxPricePerUnit != nil {
 		l1DataGasResourceBounds = &ResourceBounds{
-			MaxAmount:       felt.NewFromUint64[felt.Felt](rb[core.ResourceL1DataGas].MaxAmount),
-			MaxPricePerUnit: rb[core.ResourceL1DataGas].MaxPricePerUnit,
+			MaxAmount:       felt.NewFromUint64[felt.Felt](rb.L1DataGas.MaxAmount),
+			MaxPricePerUnit: rb.L1DataGas.MaxPricePerUnit,
 		}
 	} else {
 		l1DataGasResourceBounds = &ResourceBounds{
@@ -439,12 +439,12 @@ func adaptResourceBounds(rb map[core.Resource]core.ResourceBounds) ResourceBound
 	// As L1Gas & L2Gas will always be present, we can directly assign them
 	rpcResourceBounds := ResourceBoundsMap{
 		L1Gas: &ResourceBounds{
-			MaxAmount:       felt.NewFromUint64[felt.Felt](rb[core.ResourceL1Gas].MaxAmount),
-			MaxPricePerUnit: rb[core.ResourceL1Gas].MaxPricePerUnit,
+			MaxAmount:       felt.NewFromUint64[felt.Felt](rb.L1Gas.MaxAmount),
+			MaxPricePerUnit: rb.L1Gas.MaxPricePerUnit,
 		},
 		L2Gas: &ResourceBounds{
-			MaxAmount:       felt.NewFromUint64[felt.Felt](rb[core.ResourceL2Gas].MaxAmount),
-			MaxPricePerUnit: rb[core.ResourceL2Gas].MaxPricePerUnit,
+			MaxAmount:       felt.NewFromUint64[felt.Felt](rb.L2Gas.MaxAmount),
+			MaxPricePerUnit: rb.L2Gas.MaxPricePerUnit,
 		},
 		L1DataGas: l1DataGasResourceBounds,
 	}

--- a/rpc/v9/transaction_test.go
+++ b/rpc/v9/transaction_test.go
@@ -2207,16 +2207,16 @@ func TestAdaptBroadcastedTransaction(t *testing.T) {
 			),
 		},
 		Nonce: felt.NewUnsafeFromString[felt.Felt]("0x1"),
-		ResourceBounds: map[core.Resource]core.ResourceBounds{
-			core.ResourceL1Gas: {
+		ResourceBounds: core.ResourceBoundsMap{
+			L1Gas: core.ResourceBounds{
 				MaxAmount:       felt.NewUnsafeFromString[felt.Felt]("0x6fde2b4eb000").Uint64(),
 				MaxPricePerUnit: felt.NewUnsafeFromString[felt.Felt]("0x6fde2b4eb000"),
 			},
-			core.ResourceL2Gas: {
+			L2Gas: core.ResourceBounds{
 				MaxAmount:       felt.NewUnsafeFromString[felt.Felt]("0x6fde2b4eb000").Uint64(),
 				MaxPricePerUnit: felt.NewUnsafeFromString[felt.Felt]("0x6fde2b4eb000"),
 			},
-			core.ResourceL1DataGas: {
+			L1DataGas: core.ResourceBounds{
 				MaxAmount:       felt.NewUnsafeFromString[felt.Felt]("0x6fde2b4eb000").Uint64(),
 				MaxPricePerUnit: felt.NewUnsafeFromString[felt.Felt]("0x6fde2b4eb000"),
 			},
@@ -2343,16 +2343,16 @@ func TestSubmittedTransactionsCache(t *testing.T) {
 		Nonce:       felt.NewFromUint64[felt.Felt](0x1),
 		NonceDAMode: core.DAModeL1,
 		FeeDAMode:   core.DAModeL1,
-		ResourceBounds: map[core.Resource]core.ResourceBounds{
-			core.ResourceL1Gas: {
+		ResourceBounds: core.ResourceBoundsMap{
+			L1Gas: core.ResourceBounds{
 				MaxAmount:       0x1,
 				MaxPricePerUnit: felt.NewFromUint64[felt.Felt](0x1),
 			},
-			core.ResourceL1DataGas: {
+			L1DataGas: core.ResourceBounds{
 				MaxAmount:       0x1,
 				MaxPricePerUnit: felt.NewFromUint64[felt.Felt](0x1),
 			},
-			core.ResourceL2Gas: {
+			L2Gas: core.ResourceBounds{
 				MaxAmount:       0,
 				MaxPricePerUnit: &felt.Zero,
 			},

--- a/starknet/resource_bounds_test.go
+++ b/starknet/resource_bounds_test.go
@@ -1,0 +1,45 @@
+package starknet_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/NethermindEth/juno/starknet"
+	"github.com/stretchr/testify/require"
+)
+
+// TestResourceBoundsMapJSON checks that the feeder gateway JSON representation
+// is preserved: uppercase L1_GAS/L2_GAS/L1_DATA_GAS keys, round-tripping both
+// directions.
+func TestResourceBoundsMapJSON(t *testing.T) {
+	full := `{"L1_GAS":{"max_amount":"0x1","max_price_per_unit":"0x2"},` +
+		`"L2_GAS":{"max_amount":"0x3","max_price_per_unit":"0x4"},` +
+		`"L1_DATA_GAS":{"max_amount":"0x5","max_price_per_unit":"0x6"}}`
+
+	var rb starknet.ResourceBoundsMap
+	require.NoError(t, json.Unmarshal([]byte(full), &rb))
+	require.Equal(t, uint64(1), rb.L1Gas.MaxAmount.Uint64())
+	require.Equal(t, uint64(4), rb.L2Gas.MaxPricePerUnit.Uint64())
+	require.Equal(t, uint64(5), rb.L1DataGas.MaxAmount.Uint64())
+
+	out, err := json.Marshal(rb)
+	require.NoError(t, err)
+	require.JSONEq(t, full, string(out))
+}
+
+// TestResourceBoundsMapJSONOmitsAbsentL1DataGas checks that a pre-0.13.4 feeder
+// response (only L1_GAS and L2_GAS) leaves l1_data_gas zero and does not
+// re-introduce the key when marshalled again.
+func TestResourceBoundsMapJSONOmitsAbsentL1DataGas(t *testing.T) {
+	twoKeys := `{"L1_GAS":{"max_amount":"0x1","max_price_per_unit":"0x2"},` +
+		`"L2_GAS":{"max_amount":"0x3","max_price_per_unit":"0x4"}}`
+
+	var rb starknet.ResourceBoundsMap
+	require.NoError(t, json.Unmarshal([]byte(twoKeys), &rb))
+	require.Nil(t, rb.L1DataGas.MaxAmount)
+	require.Nil(t, rb.L1DataGas.MaxPricePerUnit)
+
+	out, err := json.Marshal(rb)
+	require.NoError(t, err)
+	require.JSONEq(t, twoKeys, string(out))
+}

--- a/starknet/transaction.go
+++ b/starknet/transaction.go
@@ -162,29 +162,40 @@ type ResourceBounds struct {
 	MaxPricePerUnit *felt.Felt `json:"max_price_per_unit"`
 }
 
+// ResourceBoundsMap holds the per-resource bounds of a v3 transaction as it is
+// sent to and received from the feeder gateway. It replaces the historical
+// map[Resource]ResourceBounds. l1_data_gas was only added in Starknet 0.13.4,
+// so a resource that is absent from the payload stays zero and is omitted when
+// marshalling (omitzero) to keep the wire format identical.
+type ResourceBoundsMap struct {
+	L1Gas     ResourceBounds `json:"L1_GAS,omitzero"`
+	L2Gas     ResourceBounds `json:"L2_GAS,omitzero"`
+	L1DataGas ResourceBounds `json:"L1_DATA_GAS,omitzero"`
+}
+
 // Transaction object returned by the feeder in JSON format for multiple endpoints
 type Transaction struct {
-	Hash                  *felt.Felt                   `json:"transaction_hash,omitempty"`
-	Version               *felt.Felt                   `json:"version,omitempty"`
-	ContractAddress       *felt.Felt                   `json:"contract_address,omitempty"`
-	ContractAddressSalt   *felt.Felt                   `json:"contract_address_salt,omitempty"`
-	ClassHash             *felt.Felt                   `json:"class_hash,omitempty"`
-	ConstructorCallData   *[]felt.Felt                 `json:"constructor_calldata,omitempty"`
-	Type                  TransactionType              `json:"type,omitempty"`
-	SenderAddress         *felt.Felt                   `json:"sender_address,omitempty"`
-	MaxFee                *felt.Felt                   `json:"max_fee,omitempty"`
-	Signature             *[]felt.Felt                 `json:"signature,omitempty"`
-	CallData              *[]felt.Felt                 `json:"calldata,omitempty"`
-	EntryPointSelector    *felt.Felt                   `json:"entry_point_selector,omitempty"`
-	Nonce                 *felt.Felt                   `json:"nonce,omitempty"`
-	CompiledClassHash     *felt.Felt                   `json:"compiled_class_hash,omitempty"`
-	ResourceBounds        *map[Resource]ResourceBounds `json:"resource_bounds,omitempty"`
-	Tip                   *felt.Felt                   `json:"tip,omitempty"`
-	NonceDAMode           *DataAvailabilityMode        `json:"nonce_data_availability_mode,omitempty"`
-	FeeDAMode             *DataAvailabilityMode        `json:"fee_data_availability_mode,omitempty"`
-	AccountDeploymentData *[]felt.Felt                 `json:"account_deployment_data,omitempty"`
-	PaymasterData         *[]felt.Felt                 `json:"paymaster_data,omitempty"`
-	ProofFacts            *[]felt.Felt                 `json:"proof_facts,omitempty"`
+	Hash                  *felt.Felt            `json:"transaction_hash,omitempty"`
+	Version               *felt.Felt            `json:"version,omitempty"`
+	ContractAddress       *felt.Felt            `json:"contract_address,omitempty"`
+	ContractAddressSalt   *felt.Felt            `json:"contract_address_salt,omitempty"`
+	ClassHash             *felt.Felt            `json:"class_hash,omitempty"`
+	ConstructorCallData   *[]felt.Felt          `json:"constructor_calldata,omitempty"`
+	Type                  TransactionType       `json:"type,omitempty"`
+	SenderAddress         *felt.Felt            `json:"sender_address,omitempty"`
+	MaxFee                *felt.Felt            `json:"max_fee,omitempty"`
+	Signature             *[]felt.Felt          `json:"signature,omitempty"`
+	CallData              *[]felt.Felt          `json:"calldata,omitempty"`
+	EntryPointSelector    *felt.Felt            `json:"entry_point_selector,omitempty"`
+	Nonce                 *felt.Felt            `json:"nonce,omitempty"`
+	CompiledClassHash     *felt.Felt            `json:"compiled_class_hash,omitempty"`
+	ResourceBounds        *ResourceBoundsMap    `json:"resource_bounds,omitempty"`
+	Tip                   *felt.Felt            `json:"tip,omitempty"`
+	NonceDAMode           *DataAvailabilityMode `json:"nonce_data_availability_mode,omitempty"`
+	FeeDAMode             *DataAvailabilityMode `json:"fee_data_availability_mode,omitempty"`
+	AccountDeploymentData *[]felt.Felt          `json:"account_deployment_data,omitempty"`
+	PaymasterData         *[]felt.Felt          `json:"paymaster_data,omitempty"`
+	ProofFacts            *[]felt.Felt          `json:"proof_facts,omitempty"`
 }
 
 // Deprecated: Use TransactionStatus with Client.DeprecatedTransactionStatus() instead.

--- a/vm/transaction.go
+++ b/vm/transaction.go
@@ -202,15 +202,26 @@ func adaptTransaction(txn core.Transaction) *Transaction {
 	return tx
 }
 
-func adaptResourceBounds(rb map[core.Resource]core.ResourceBounds) map[Resource]ResourceBounds {
-	rpcResourceBounds := make(map[Resource]ResourceBounds)
-	for resource, bounds := range rb {
-		rpcResourceBounds[Resource(resource)] = ResourceBounds{
-			MaxAmount:       new(felt.Felt).SetUint64(bounds.MaxAmount),
-			MaxPricePerUnit: bounds.MaxPricePerUnit,
+func adaptResourceBounds(rb core.ResourceBoundsMap) map[Resource]ResourceBounds {
+	vmResourceBounds := map[Resource]ResourceBounds{
+		ResourceL1Gas: {
+			MaxAmount:       new(felt.Felt).SetUint64(rb.L1Gas.MaxAmount),
+			MaxPricePerUnit: rb.L1Gas.MaxPricePerUnit,
+		},
+		ResourceL2Gas: {
+			MaxAmount:       new(felt.Felt).SetUint64(rb.L2Gas.MaxAmount),
+			MaxPricePerUnit: rb.L2Gas.MaxPricePerUnit,
+		},
+	}
+	// l1_data_gas was added in 0.13.4; only include it when present so the
+	// payload sent to the VM matches what the old map produced.
+	if rb.L1DataGas.MaxPricePerUnit != nil {
+		vmResourceBounds[ResourceL1DataGas] = ResourceBounds{
+			MaxAmount:       new(felt.Felt).SetUint64(rb.L1DataGas.MaxAmount),
+			MaxPricePerUnit: rb.L1DataGas.MaxPricePerUnit,
 		}
 	}
-	return rpcResourceBounds
+	return vmResourceBounds
 }
 
 func nilToZero(v []felt.Felt) *[]felt.Felt {


### PR DESCRIPTION
Closes #3742

Both `core` and `starknet` resource bounds were modeled as `map[Resource]ResourceBounds`. Since the keys are effectively fixed, this replaces them with a struct with explicit `L1Gas` / `L2Gas` / `L1DataGas` fields — clearer, and it drops a map allocation per transaction.

### Approach

- **New `core.ResourceBoundsMap` struct** (`L1Gas` / `L2Gas` / `L1DataGas`) replacing the `map[Resource]ResourceBounds` field on the v3 transaction types, and the same for the feeder `starknet` type.
- **No DB migration.** The struct implements `MarshalCBOR` / `UnmarshalCBOR` that keep the exact legacy `map[Resource]ResourceBounds` wire format. A golden test pins byte-for-byte equality across the three historical shapes — all three resources, the pre-0.13.4 two-resource form (no `l1_data_gas`), and the nil map on v0–v2 — so already-stored bytes still decode into the struct.
- **Hashes unchanged.** `l1_data_gas` only enters the tip/resources hash when it's actually set (non-nil `MaxPricePerUnit`), which reproduces the old map-key check, so pre-0.13.4 tx hashes stay identical.
- **Feeder JSON unchanged.** The `starknet` struct keeps the uppercase `L1_GAS` / `L2_GAS` / `L1_DATA_GAS` keys and uses `omitzero`, so an absent `l1_data_gas` round-trips both ways.
- Left the `vm` resource-bounds map as-is — it's the marshal-only Blockifier payload (with the short `L1_DATA` key), out of scope for this one.

### Testing

- `make lint` — pass
- Tests for all affected packages (`core`, `starknet`, `adapters/...`, `rpc/...`, `vm`, `genesis`, `consensus`, `clients/feeder`) — pass, including the new backward-compat golden tests in `core/resource_bounds_test.go` and `starknet/resource_bounds_test.go`.
