### PR TITLE
feat(sync): resolve declared classes for pre-confirmed blocks

### DIFF
--- a/rpc/v10/transaction_test.go
+++ b/rpc/v10/transaction_test.go
@@ -661,7 +661,7 @@ func TestTransactionByHash_MultiplePreConfirmed(t *testing.T) {
 			Receipts:              []*starknet.TransactionReceipt{{TransactionHash: hash}},
 			TransactionStateDiffs: []*starknet.StateDiff{{}},
 		}
-		_, err := storage.ApplyUpdate(block, blockNumber, 0, oldestPreConf)
+		_, err := storage.ApplyUpdate(block, blockNumber, 0, oldestPreConf, nil)
 		require.NoError(t, err)
 	}
 	chain := storage.SnapshotForBlock(oldestPreConf)

--- a/rpc/v9/transaction_test.go
+++ b/rpc/v9/transaction_test.go
@@ -535,7 +535,7 @@ func TestTransactionByHash_MultiplePreConfirmed(t *testing.T) {
 			Receipts:              []*starknet.TransactionReceipt{{TransactionHash: hash}},
 			TransactionStateDiffs: []*starknet.StateDiff{{}},
 		}
-		_, err := storage.ApplyUpdate(block, blockNumber, 0, oldestPreConf)
+		_, err := storage.ApplyUpdate(block, blockNumber, 0, oldestPreConf, nil)
 		require.NoError(t, err)
 	}
 	chain := storage.SnapshotForBlock(oldestPreConf)

--- a/sync/data_source.go
+++ b/sync/data_source.go
@@ -33,6 +33,7 @@ type DataSource interface {
 		blockIdentifier string,
 		knownTransactionCount uint64,
 	) (starknet.PreConfirmedUpdate, uint64, error)
+	Class(ctx context.Context, classHash *felt.Felt) (core.ClassDefinition, error)
 }
 
 type feederGatewayDataSource struct {
@@ -149,4 +150,11 @@ func (f *feederGatewayDataSource) PreConfirmedBlockLatest(
 	knownTransactionCount uint64,
 ) (starknet.PreConfirmedUpdate, uint64, error) {
 	return f.starknetData.PreConfirmedBlockLatest(ctx, blockIdentifier, knownTransactionCount)
+}
+
+func (f *feederGatewayDataSource) Class(
+	ctx context.Context,
+	classHash *felt.Felt,
+) (core.ClassDefinition, error) {
+	return f.starknetData.Class(ctx, classHash)
 }

--- a/sync/preconfirmed/chain_storage.go
+++ b/sync/preconfirmed/chain_storage.go
@@ -167,19 +167,6 @@ func (c *ChainReader) PreConfirmedStateAt(
 	return pending.NewState(&stateDiff, newClasses, base, blockNumber), closer, nil
 }
 
-func mergeClassesInto(
-	dst, src map[felt.Felt]core.ClassDefinition,
-) map[felt.Felt]core.ClassDefinition {
-	if len(src) == 0 {
-		return dst
-	}
-	if dst == nil {
-		dst = make(map[felt.Felt]core.ClassDefinition, len(src))
-	}
-	maps.Copy(dst, src)
-	return dst
-}
-
 // PreConfirmedStateBeforeIndexAt returns the chain's view of state immediately
 // before transaction `index` at blockNumber. See PreConfirmedStateAt for the base-
 // resolution contract; here the chain additionally layers the target slot's
@@ -344,9 +331,9 @@ func (s *ChainStorage) ApplyUpdate(
 	return affected, nil
 }
 
-// withClasses returns base with the entries of extra added, without mutating base's map
+// mergeClassesCopying returns base with the entries of extra added, without mutating base's map
 // (copy-on-write). Returns base unchanged when extra is empty.
-func withClasses(
+func mergeClassesCopying(
 	base, extra map[felt.Felt]core.ClassDefinition,
 ) map[felt.Felt]core.ClassDefinition {
 	if len(extra) == 0 {
@@ -594,7 +581,7 @@ func replaceSlot(
 		if err != nil {
 			return nil, nil, err
 		}
-		next.NewClasses = withClasses(next.NewClasses, newClasses)
+		next.NewClasses = mergeClassesCopying(next.NewClasses, newClasses)
 		newNode := &node{preconfirmed: &next, parent: target.parent}
 		return &ChainReader{
 			head:   newNode,
@@ -614,7 +601,7 @@ func replaceSlot(
 				"no-change at non-tip slot %d (depth %d)", blockNumber, depthFromHead,
 			)
 		}
-		merged := withClasses(target.preconfirmed.NewClasses, newClasses)
+		merged := mergeClassesCopying(target.preconfirmed.NewClasses, newClasses)
 		if len(merged) == len(target.preconfirmed.NewClasses) {
 			return nil, nil, nil // tip already holds them all
 		}
@@ -644,4 +631,19 @@ func shouldPreserveSlot(existing, incoming *pending.PreConfirmed) bool {
 		return false
 	}
 	return true
+}
+
+// mergeClassesInto copies src's entries into dst, mutating dst in place and
+// returning it. When dst is nil it returns a fresh clone of src.
+func mergeClassesInto(
+	dst, src map[felt.Felt]core.ClassDefinition,
+) map[felt.Felt]core.ClassDefinition {
+	if len(src) == 0 {
+		return dst
+	}
+	if dst == nil {
+		return maps.Clone(src)
+	}
+	maps.Copy(dst, src)
+	return dst
 }

--- a/sync/preconfirmed/chain_storage.go
+++ b/sync/preconfirmed/chain_storage.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"iter"
+	"maps"
 	"sync/atomic"
 
 	"github.com/NethermindEth/juno/adapters/sn2core"
@@ -155,13 +156,28 @@ func (c *ChainReader) PreConfirmedStateAt(
 	}
 
 	stateDiff := core.EmptyStateDiff()
+	var newClasses map[felt.Felt]core.ClassDefinition
 	for entry := range c.OldestFirst() {
 		stateDiff.Merge(entry.StateUpdate.StateDiff)
+		newClasses = mergeClassesInto(newClasses, entry.NewClasses)
 		if entry.Block.Number == blockNumber {
 			break
 		}
 	}
-	return pending.NewState(&stateDiff, nil, base, blockNumber), closer, nil
+	return pending.NewState(&stateDiff, newClasses, base, blockNumber), closer, nil
+}
+
+func mergeClassesInto(
+	dst, src map[felt.Felt]core.ClassDefinition,
+) map[felt.Felt]core.ClassDefinition {
+	if len(src) == 0 {
+		return dst
+	}
+	if dst == nil {
+		dst = make(map[felt.Felt]core.ClassDefinition, len(src))
+	}
+	maps.Copy(dst, src)
+	return dst
 }
 
 // PreConfirmedStateBeforeIndexAt returns the chain's view of state immediately
@@ -182,12 +198,14 @@ func (c *ChainReader) PreConfirmedStateBeforeIndexAt(
 
 	stateDiff := core.EmptyStateDiff()
 	var target *pending.PreConfirmed
+	var newClasses map[felt.Felt]core.ClassDefinition
 	for entry := range c.OldestFirst() {
 		if entry.Block.Number == blockNumber {
 			target = entry
 			break
 		}
 		stateDiff.Merge(entry.StateUpdate.StateDiff)
+		newClasses = mergeClassesInto(newClasses, entry.NewClasses)
 	}
 	// Invariant: blockNumber passed the range check, so a contiguous chain must
 	// contain it. A nil target means the chain has a gap (a bug), not a miss.
@@ -200,6 +218,7 @@ func (c *ChainReader) PreConfirmedStateBeforeIndexAt(
 	if index > uint(len(target.Block.Transactions)) {
 		return nil, nil, pending.ErrTransactionIndexOutOfBounds
 	}
+	newClasses = mergeClassesInto(newClasses, target.NewClasses)
 	base, closer, err := c.baseState(bcReader)
 	if err != nil {
 		return nil, nil, err
@@ -207,7 +226,7 @@ func (c *ChainReader) PreConfirmedStateBeforeIndexAt(
 	for _, txStateDiff := range target.TransactionStateDiffs[:index] {
 		stateDiff.Merge(txStateDiff)
 	}
-	return pending.NewState(&stateDiff, nil, base, blockNumber), closer, nil
+	return pending.NewState(&stateDiff, newClasses, base, blockNumber), closer, nil
 }
 
 // baseState opens the canonical state immediately below the chain's oldest
@@ -293,18 +312,25 @@ func (s *ChainStorage) SnapshotForBlock(blockNumber uint64) ChainReader {
 //
 // On CAS failure the chain changed between Load and CompareAndSwap; we return
 // an error instead of retrying.
+//
+// A NoChange still registers newClasses on the targeted (tip) slot when non-empty: a
+// re-poll that reported no content change may still carry declared classes we only just
+// fetched for that block.
 func (s *ChainStorage) ApplyUpdate(
 	update starknet.PreConfirmedUpdate,
 	blockNumber uint64,
 	baseTxCount uint64,
 	oldestPreConf uint64,
+	newClasses map[felt.Felt]core.ClassDefinition,
 ) (*pending.PreConfirmed, error) {
-	if _, ok := update.(starknet.PreConfirmedNoChange); ok {
-		return nil, nil
-	}
 	current := s.inner.Load()
 	newChain, affected, err := computeUpdate(
-		current, update, blockNumber, baseTxCount, oldestPreConf,
+		current,
+		update,
+		blockNumber,
+		baseTxCount,
+		oldestPreConf,
+		newClasses,
 	)
 	if err != nil {
 		return nil, err
@@ -316,6 +342,22 @@ func (s *ChainStorage) ApplyUpdate(
 		return nil, errors.New("chain changed between load and store")
 	}
 	return affected, nil
+}
+
+// withClasses returns base with the entries of extra added, without mutating base's map
+// (copy-on-write). Returns base unchanged when extra is empty.
+func withClasses(
+	base, extra map[felt.Felt]core.ClassDefinition,
+) map[felt.Felt]core.ClassDefinition {
+	if len(extra) == 0 {
+		return base
+	}
+	merged := maps.Clone(base)
+	if merged == nil {
+		merged = make(map[felt.Felt]core.ClassDefinition, len(extra))
+	}
+	maps.Copy(merged, extra)
+	return merged
 }
 
 // AdvanceTo realigns the chain to a new canonical head, given as oldestPreConf —
@@ -392,13 +434,14 @@ func computeUpdate(
 	blockNumber uint64,
 	baseTxCount uint64,
 	oldestPreConf uint64,
+	newClasses map[felt.Felt]core.ClassDefinition,
 ) (*ChainReader, *pending.PreConfirmed, error) {
 	if current == nil || current.length == 0 {
 		block, ok := update.(starknet.PreConfirmedBlock)
 		if !ok {
 			return nil, nil, fmt.Errorf("bootstrap rejected: want PreConfirmedBlock, got %T", update)
 		}
-		return bootstrapChain(&block, blockNumber, oldestPreConf)
+		return bootstrapChain(&block, blockNumber, oldestPreConf, newClasses)
 	}
 
 	currentOldest := current.oldestPreConf()
@@ -438,10 +481,10 @@ func computeUpdate(
 				"append rejected at slot %d: want PreConfirmedBlock, got %T", blockNumber, update,
 			)
 		}
-		return extend(current, &block, blockNumber)
+		return extend(current, &block, blockNumber, newClasses)
 	}
 
-	return replaceSlot(current, update, blockNumber, baseTxCount)
+	return replaceSlot(current, update, blockNumber, baseTxCount, newClasses)
 }
 
 // bootstrapChain handles the first entry case (empty storage). The caller
@@ -453,6 +496,7 @@ func bootstrapChain(
 	block *starknet.PreConfirmedBlock,
 	blockNumber uint64,
 	oldestPreConf uint64,
+	newClasses map[felt.Felt]core.ClassDefinition,
 ) (*ChainReader, *pending.PreConfirmed, error) {
 	if blockNumber != oldestPreConf {
 		return nil, nil, fmt.Errorf(
@@ -466,6 +510,7 @@ func bootstrapChain(
 	if err := core.CheckBlockVersion(next.Block.ProtocolVersion); err != nil {
 		return nil, nil, err
 	}
+	next.NewClasses = newClasses
 	newNode := &node{preconfirmed: &next, parent: nil}
 	return &ChainReader{head: newNode, length: 1}, &next, nil
 }
@@ -476,6 +521,7 @@ func extend(
 	current *ChainReader,
 	block *starknet.PreConfirmedBlock,
 	blockNumber uint64,
+	newClasses map[felt.Felt]core.ClassDefinition,
 ) (*ChainReader, *pending.PreConfirmed, error) {
 	next, err := sn2core.AdaptPreConfirmedBlock(block, blockNumber)
 	if err != nil {
@@ -484,6 +530,7 @@ func extend(
 	if err := core.CheckBlockVersion(next.Block.ProtocolVersion); err != nil {
 		return nil, nil, err
 	}
+	next.NewClasses = newClasses
 	newNode := &node{preconfirmed: &next, parent: current.head}
 	return &ChainReader{head: newNode, length: current.length + 1}, &next, nil
 }
@@ -497,6 +544,8 @@ func extend(
 //   - PreConfirmedDeltaUpdate — merges appended txs into the existing slot;
 //     baseTxCount must match the slot's current tx count or ErrBaseTxCountMismatch
 //     is returned (defensive race-check).
+//   - PreConfirmedNoChange — content is unchanged; only merges newClasses into the
+//     existing tip. A no-op (nil, nil, nil) when the tip already holds them all.
 //
 // Returns (nil, nil, nil) when shouldPreserveSlot says "keep the existing slot,
 // no broadcast needed." Caller must have already validated that blockNumber
@@ -506,6 +555,7 @@ func replaceSlot(
 	update starknet.PreConfirmedUpdate,
 	blockNumber uint64,
 	baseTxCount uint64,
+	newClasses map[felt.Felt]core.ClassDefinition,
 ) (*ChainReader, *pending.PreConfirmed, error) {
 	depthFromHead := int(current.tip() - blockNumber)
 	target := current.head
@@ -522,6 +572,7 @@ func replaceSlot(
 		if err := core.CheckBlockVersion(next.Block.ProtocolVersion); err != nil {
 			return nil, nil, err
 		}
+		next.NewClasses = newClasses
 		if shouldPreserveSlot(target.preconfirmed, &next) {
 			return nil, nil, nil
 		}
@@ -543,25 +594,53 @@ func replaceSlot(
 		if err != nil {
 			return nil, nil, err
 		}
+		next.NewClasses = withClasses(next.NewClasses, newClasses)
 		newNode := &node{preconfirmed: &next, parent: target.parent}
 		return &ChainReader{
 			head:   newNode,
 			length: current.length,
 		}, &next, nil
+
+	case starknet.PreConfirmedNoChange:
+		// A NoChange branch exists only to register newly-fetched classes; with none there
+		// is nothing to do, whatever slot it targets.
+		if len(newClasses) == 0 {
+			return nil, nil, nil
+		}
+		// NoChange only ever targets the tip: the poller re-polls a slot only while
+		// it is the most recent, so a NoChange below the tip is a bug.
+		if depthFromHead != 0 {
+			return nil, nil, fmt.Errorf(
+				"no-change at non-tip slot %d (depth %d)", blockNumber, depthFromHead,
+			)
+		}
+		merged := withClasses(target.preconfirmed.NewClasses, newClasses)
+		if len(merged) == len(target.preconfirmed.NewClasses) {
+			return nil, nil, nil // tip already holds them all
+		}
+		next := *target.preconfirmed
+		next.NewClasses = merged
+		newNode := &node{preconfirmed: &next, parent: target.parent}
+		return &ChainReader{head: newNode, length: current.length}, &next, nil
 	}
 	return nil, nil, fmt.Errorf("unknown PreConfirmedUpdate variant %T", update)
 }
 
 // shouldPreserveSlot keeps the existing slot when the incoming pre-confirmed is
 // at the same identifier with no extra transactions, or carries the blank
-// placeholder identifier. A different real identifier (new round) or a richer
-// same-identifier block replaces.
+// placeholder identifier. A different real identifier (new round), a richer
+// same-identifier block, or one carrying declared classes the existing slot lacks
+// replaces.
 func shouldPreserveSlot(existing, incoming *pending.PreConfirmed) bool {
 	if incoming.BlockIdentifier != existing.BlockIdentifier &&
 		incoming.BlockIdentifier != feeder.PreConfirmedBlankIdentifier {
 		return false
 	}
 	if incoming.Block.TransactionCount > existing.Block.TransactionCount {
+		return false
+	}
+
+	if len(incoming.NewClasses) > len(existing.NewClasses) {
 		return false
 	}
 	return true

--- a/sync/preconfirmed/chain_storage_test.go
+++ b/sync/preconfirmed/chain_storage_test.go
@@ -55,7 +55,7 @@ func applyBlock(
 ) starknet.PreConfirmedBlock {
 	t.Helper()
 	block := makeTestPreConfirmedBlock(identifier, txCount)
-	_, err := s.ApplyUpdate(block, number, 0, oldestPreConf)
+	_, err := s.ApplyUpdate(block, number, 0, oldestPreConf, nil)
 	require.NoError(t, err)
 	return block
 }
@@ -74,7 +74,7 @@ func rangeEntries(from uint64, blocks []starknet.PreConfirmedBlock) []expectedEn
 
 func TestChainStorageApplyUpdate(t *testing.T) {
 	t.Run("bootstrap: rejects Delta on empty chain", testApplyUpdateBootstrapRejectsDelta)
-	t.Run("bootstrap: NoChange on empty is a no-op", testApplyUpdateBootstrapNoChangeNoop)
+	t.Run("bootstrap: NoChange on empty is rejected", testApplyUpdateBootstrapNoChangeRejected)
 	t.Run("bootstrap: rejected at wrong height", testApplyUpdateBootstrapWrongHeight)
 	t.Run("bootstrap: accepted at head+1", testApplyUpdateBootstrapAtHeadPlusOne)
 	t.Run("bootstrap: accepted at genesis before any head", testApplyUpdateBootstrapAtGenesis)
@@ -91,6 +91,14 @@ func TestChainStorageApplyUpdate(t *testing.T) {
 	t.Run(
 		"replace-tip: same identifier richer block replaces",
 		testApplyUpdateReplaceTipRicherReplaces,
+	)
+	t.Run(
+		"delta: registers freshly-fetched classes on the tip",
+		testApplyUpdateDeltaRegistersNewClass,
+	)
+	t.Run(
+		"no-change: registers freshly-fetched classes on the tip",
+		testApplyUpdateNoChangeRegistersClasses,
 	)
 	t.Run("replace-tip: new round at most recent replaces", testApplyUpdateReplaceTipNewRound)
 	t.Run("replace-tip: blank identifier never overrides a real round",
@@ -115,7 +123,7 @@ func TestChainStorageApplyUpdate(t *testing.T) {
 func testApplyUpdateBootstrapRejectsDelta(t *testing.T) {
 	oldestPreConf := oldestPreConfFor(100)
 	s := preconfirmed.NewChainStorage()
-	pc, err := s.ApplyUpdate(starknet.PreConfirmedDeltaUpdate{}, 101, 0, oldestPreConf)
+	pc, err := s.ApplyUpdate(starknet.PreConfirmedDeltaUpdate{}, 101, 0, oldestPreConf, nil)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "bootstrap rejected")
 	require.Nil(t, pc)
@@ -123,12 +131,11 @@ func testApplyUpdateBootstrapRejectsDelta(t *testing.T) {
 	require.Zero(t, view.Length())
 }
 
-func testApplyUpdateBootstrapNoChangeNoop(t *testing.T) {
-	oldestPreConf := oldestPreConfFor(100)
+func testApplyUpdateBootstrapNoChangeRejected(t *testing.T) {
+	oldestSlot := oldestSlotFor(100)
 	s := preconfirmed.NewChainStorage()
-	pc, err := s.ApplyUpdate(starknet.PreConfirmedNoChange{}, 101, 0, oldestPreConf)
-	require.NoError(t, err)
-	require.Nil(t, pc)
+	_, err := s.ApplyUpdate(starknet.PreConfirmedNoChange{}, 101, 0, oldestPreConf, nil)
+	require.Error(t, err)
 	view := s.SnapshotForBlock(oldestPreConf)
 	require.Zero(t, view.Length())
 }
@@ -136,7 +143,7 @@ func testApplyUpdateBootstrapNoChangeNoop(t *testing.T) {
 func testApplyUpdateBootstrapWrongHeight(t *testing.T) {
 	oldestPreConf := oldestPreConfFor(100)
 	s := preconfirmed.NewChainStorage()
-	_, err := s.ApplyUpdate(makeTestPreConfirmedBlock(roundID(103), 0), 103, 0, oldestPreConf)
+	_, err := s.ApplyUpdate(makeTestPreConfirmedBlock(roundID(103), 0), 103, 0, oldestPreConf, nil)
 	require.Error(t, err)
 	view := s.SnapshotForBlock(oldestPreConf)
 	require.Zero(t, view.Length())
@@ -159,7 +166,7 @@ func testApplyUpdateBootstrapAtGenesis(t *testing.T) {
 
 func testApplyUpdateBootstrapNonzeroAtGenesis(t *testing.T) {
 	s := preconfirmed.NewChainStorage()
-	_, err := s.ApplyUpdate(makeTestPreConfirmedBlock(roundID(1), 0), 1, 0, 0)
+	_, err := s.ApplyUpdate(makeTestPreConfirmedBlock(roundID(1), 0), 1, 0, 0, nil)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "oldest pre-confirmed slot is 0")
 	view := s.SnapshotForBlock(0)
@@ -174,7 +181,7 @@ func testApplyUpdateExtendGapRejected(t *testing.T) {
 	before := s.SnapshotForBlock(oldestPreConf)
 
 	// Skip slot 103, attempt to apply at 104.
-	_, err := s.ApplyUpdate(makeTestPreConfirmedBlock(roundID(104), 0), 104, 0, oldestPreConf)
+	_, err := s.ApplyUpdate(makeTestPreConfirmedBlock(roundID(104), 0), 104, 0, oldestPreConf, nil)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "gap above tip")
 	after := s.SnapshotForBlock(oldestPreConf)
@@ -191,7 +198,7 @@ func testApplyUpdateExtendNonBlockRejected(t *testing.T) {
 	// A Delta at brand-new slot 2 is rejected before identifier validation —
 	// only PreConfirmedBlock is valid at a new tip.
 	delta := makeTestDelta(roundID(2), 1)
-	_, err := s.ApplyUpdate(delta, 2, 0, oldestPreConf)
+	_, err := s.ApplyUpdate(delta, 2, 0, oldestPreConf, nil)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "append rejected")
 	after := s.SnapshotForBlock(oldestPreConf)
@@ -225,6 +232,53 @@ func testApplyUpdateReplaceTipRicherReplaces(t *testing.T) {
 	after := s.SnapshotForBlock(oldestPreConf)
 	require.NotSame(t, before.Head(), after.Head())
 	assertChain(t, &after, entry(1, &b1), entry(2, &bRicher))
+}
+
+func testApplyUpdateDeltaRegistersNewClass(t *testing.T) {
+	oldestSlot := oldestSlotFor(0)
+	s := preconfirmed.NewChainStorage()
+	const round = "round-1"
+	applyBlock(t, s, round, 1, 1, oldestSlot) // stored without classes
+	classHash := felt.FromUint64[felt.Felt](0xC1A55)
+	classDef := &core.DeprecatedCairoClass{}
+
+	delta := makeTestDelta(round, 1)
+	affected, err := s.ApplyUpdate(
+		delta, 1, 1, oldestSlot, map[felt.Felt]core.ClassDefinition{classHash: classDef},
+	)
+	require.NoError(t, err)
+	require.NotNil(t, affected, "a delta advancing the tip must publish the affected entry")
+
+	view := s.SnapshotForHead(oldestSlot)
+	require.Equal(t, classDef, view.Head().NewClasses[classHash],
+		"the delta's declared class must be readable on the stored tip")
+}
+
+func testApplyUpdateNoChangeRegistersClasses(t *testing.T) {
+	oldestSlot := oldestSlotFor(0)
+	s := preconfirmed.NewChainStorage()
+	applyBlock(t, s, roundID(1), 1, 1, oldestSlot)
+	classHash := felt.FromUint64[felt.Felt](0xC1A55)
+	classDef := &core.DeprecatedCairoClass{}
+	classes := map[felt.Felt]core.ClassDefinition{classHash: classDef}
+
+	affected, err := s.ApplyUpdate(starknet.PreConfirmedNoChange{}, 1, 0, oldestSlot, classes)
+	require.NoError(t, err)
+	require.NotNil(t, affected, "NoChange with new classes must refresh the tip")
+
+	view := s.SnapshotForHead(oldestSlot)
+	require.Equal(t, classDef, view.Head().NewClasses[classHash],
+		"the recovered class must be readable on the stored tip")
+
+	// Re-registering an already-present class is a no-op.
+	affected, err = s.ApplyUpdate(starknet.PreConfirmedNoChange{}, 1, 0, oldestSlot, classes)
+	require.NoError(t, err)
+	require.Nil(t, affected, "re-registering an already-present class must be a no-op")
+
+	// A plain NoChange with no classes stays a no-op.
+	affected, err = s.ApplyUpdate(starknet.PreConfirmedNoChange{}, 1, 0, oldestSlot, nil)
+	require.NoError(t, err)
+	require.Nil(t, affected)
 }
 
 func testApplyUpdateReplaceTipNewRound(t *testing.T) {
@@ -371,7 +425,7 @@ func testApplyUpdateDeltaAtTip(t *testing.T) {
 	seed := applyBlock(t, s, round, 2, 1, oldestPreConf)
 
 	delta := makeTestDelta(round, 3)
-	_, err := s.ApplyUpdate(delta, 1, 2, oldestPreConf)
+	_, err := s.ApplyUpdate(delta, 1, 2, oldestPreConf, nil)
 	require.NoError(t, err)
 
 	// 2 base + 3 appended via delta.
@@ -389,7 +443,7 @@ func testApplyUpdateDeltaAtNonTipRejected(t *testing.T) {
 	before := s.SnapshotForBlock(oldestPreConf)
 
 	delta := makeTestDelta(slot1Round, 2)
-	_, err := s.ApplyUpdate(delta, 1, 1, oldestPreConf)
+	_, err := s.ApplyUpdate(delta, 1, 1, oldestPreConf, nil)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "non-tip")
 	after := s.SnapshotForBlock(oldestPreConf)
@@ -405,7 +459,7 @@ func testApplyUpdateDeltaWrongBaseTxCount(t *testing.T) {
 
 	// Matching identifier — failure is purely from the baseTxCount race-check.
 	delta := makeTestDelta(round, 1)
-	_, err := s.ApplyUpdate(delta, 1, 99, oldestPreConf)
+	_, err := s.ApplyUpdate(delta, 1, 99, oldestPreConf, nil)
 	require.ErrorIs(t, err, preconfirmed.ErrBaseTxCountMismatch)
 	after := s.SnapshotForBlock(oldestPreConf)
 	require.Same(t, before.Head(), after.Head())
@@ -419,7 +473,7 @@ func testApplyUpdateDeltaIdentifierMismatch(t *testing.T) {
 	before := s.SnapshotForBlock(oldestPreConf)
 
 	delta := makeTestDelta("round-1-different", 1)
-	_, err := s.ApplyUpdate(delta, 1, 1, oldestPreConf)
+	_, err := s.ApplyUpdate(delta, 1, 1, oldestPreConf, nil)
 	require.Error(t, err)
 	after := s.SnapshotForBlock(oldestPreConf)
 	require.Same(t, before.Head(), after.Head())
@@ -437,7 +491,7 @@ func testApplyUpdateBelowOldestPreConfRejected(t *testing.T) {
 
 	// Identifier is irrelevant here — the below-oldest-slot check fires first.
 	delta := makeTestDelta(roundID(1), 1)
-	_, err := s.ApplyUpdate(delta, 1, 0, oldestPreConfFor(1))
+	_, err := s.ApplyUpdate(delta, 1, 0, oldestPreConfFor(1), nil)
 	require.Error(t, err, "apply target below the oldest slot must surface as an error")
 	after := s.SnapshotForBlock(oldestPreConfFor(1))
 	require.Same(t, before.Head(), after.Head())
@@ -622,6 +676,8 @@ func TestChainReader(t *testing.T) {
 	t.Run("iterators are alloc-free", testChainReaderIteratorsAllocFree)
 	t.Run("PreConfirmedStateAt composes diffs through target block",
 		testChainReaderPreConfirmedStateAtComposes)
+	t.Run("PreConfirmedStateAt resolves a class declared in a lower entry",
+		testChainReaderPreConfirmedStateAtResolvesDeclaredClass)
 	t.Run("PreConfirmedStateAt rejects blockNumber outside chain",
 		testChainReaderPreConfirmedStateAtOutOfRange)
 	t.Run("PreConfirmedStateBeforeIndexAt walks tx diffs of slot",
@@ -784,7 +840,7 @@ func applyBlockWithStorageWrites(
 		L1DAMode:              starknet.Blob,
 		L1DataGasPrice:        &starknet.GasPrice{PriceInWei: feltOne, PriceInFri: feltOne},
 	}
-	_, err := s.ApplyUpdate(block, number, 0, oldestPreConf)
+	_, err := s.ApplyUpdate(block, number, 0, oldestPreConf, nil)
 	require.NoError(t, err)
 }
 
@@ -858,6 +914,38 @@ func testChainReaderPreConfirmedStateAtComposes(t *testing.T) {
 			"PreConfirmedStateAt(%d) keyOnlyInSlot1 must survive the merge", tc.blockNumber)
 		require.NoError(t, closer())
 	}
+}
+
+func testChainReaderPreConfirmedStateAtResolvesDeclaredClass(t *testing.T) {
+	oldestSlot := oldestSlotFor(0)
+	s := preconfirmed.NewChainStorage()
+	classHash := felt.FromUint64[felt.Felt](0xC1A55)
+	classDef := core.DeprecatedCairoClass{}
+
+	// Slot 1 (a backfilled block) declares the class; slot 2 is the tip.
+	_, err := s.ApplyUpdate(makeTestPreConfirmedBlock(roundID(1), 0), 1, 0, oldestSlot,
+		map[felt.Felt]core.ClassDefinition{classHash: &classDef})
+	require.NoError(t, err)
+	_, err = s.ApplyUpdate(makeTestPreConfirmedBlock(roundID(2), 0), 2, 0, oldestSlot, nil)
+	require.NoError(t, err)
+
+	view := s.SnapshotForHead(oldestSlot)
+
+	ctrl := gomock.NewController(t)
+	bc := mocks.NewMockReader(ctrl)
+	baseReader := mocks.NewMockStateReader(ctrl)
+	// Base state is opened for the read; its Class is never consulted because the
+	// class resolves from the merged pre_confirmed NewClasses first.
+	bc.EXPECT().StateAtBlockNumber(uint64(0)).
+		Return(baseReader, func() error { return nil }, nil)
+
+	state, closer, err := view.PreConfirmedStateAt(2, bc)
+	require.NoError(t, err)
+
+	declared, err := state.Class(&classHash)
+	require.NoError(t, err)
+	require.Equal(t, &classDef, declared.Class)
+	require.NoError(t, closer())
 }
 
 func testChainReaderPreConfirmedStateAtOutOfRange(t *testing.T) {
@@ -1287,7 +1375,7 @@ func testPinnedSnapshotImmuneToExtend(t *testing.T) {
 	s, pinned, blocks := pinChain(t)
 	oldestPreConf := oldestPreConfFor(0)
 	for n := uint64(6); n <= 20; n++ {
-		_, err := s.ApplyUpdate(makeTestPreConfirmedBlock(roundID(n), 0), n, 0, oldestPreConf)
+		_, err := s.ApplyUpdate(makeTestPreConfirmedBlock(roundID(n), 0), n, 0, oldestPreConf, nil)
 		require.NoError(t, err)
 	}
 	assertChain(t, pinned, rangeEntries(1, blocks)...)
@@ -1298,7 +1386,7 @@ func testPinnedSnapshotImmuneToReplaceTip(t *testing.T) {
 	oldestPreConf := oldestPreConfFor(0)
 	// Richer-replace must share the existing tip's identifier (roundID(5)).
 	for txCount := 1; txCount <= 10; txCount++ {
-		_, err := s.ApplyUpdate(makeTestPreConfirmedBlock(roundID(5), txCount), 5, 0, oldestPreConf)
+		_, err := s.ApplyUpdate(makeTestPreConfirmedBlock(roundID(5), txCount), 5, 0, oldestPreConf, nil)
 		require.NoError(t, err)
 	}
 	assertChain(t, pinned, rangeEntries(1, blocks)...)
@@ -1311,7 +1399,7 @@ func testPinnedSnapshotImmuneToDelta(t *testing.T) {
 	// baseTxCount must follow.
 	tipTxCount := uint64(0)
 	for _, add := range []int{3, 2, 4} {
-		_, err := s.ApplyUpdate(makeTestDelta(roundID(5), add), 5, tipTxCount, oldestPreConfFor(0))
+		_, err := s.ApplyUpdate(makeTestDelta(roundID(5), add), 5, tipTxCount, oldestPreConfFor(0), nil)
 		require.NoError(t, err)
 		tipTxCount += uint64(add)
 	}
@@ -1404,7 +1492,7 @@ func testAllocsAdvanceTrim(t *testing.T) {
 	build := func() *preconfirmed.ChainStorage {
 		s := preconfirmed.NewChainStorage()
 		for n := uint64(1); n <= chainLen; n++ {
-			_, _ = s.ApplyUpdate(makeTestPreConfirmedBlock(roundID(n), 0), n, 0, oldestPreConf)
+			_, _ = s.ApplyUpdate(makeTestPreConfirmedBlock(roundID(n), 0), n, 0, oldestPreConf, nil)
 		}
 		return s
 	}
@@ -1427,7 +1515,7 @@ func testAllocsApplyNoChange(t *testing.T) {
 	noChange := starknet.PreConfirmedNoChange{}
 
 	allocs := testing.AllocsPerRun(100, func() {
-		_, _ = s.ApplyUpdate(noChange, 1, 0, oldestPreConf)
+		_, _ = s.ApplyUpdate(noChange, 1, 0, oldestPreConf, nil)
 	})
 	require.Zero(t, allocs)
 }
@@ -1442,14 +1530,14 @@ func testAllocsApplyDelta(t *testing.T) {
 	const expectedDeltaCost = 29
 	build := func() *preconfirmed.ChainStorage {
 		s := preconfirmed.NewChainStorage()
-		_, _ = s.ApplyUpdate(makeTestPreConfirmedBlock(roundID(1), 0), 1, 0, oldestPreConf)
+		_, _ = s.ApplyUpdate(makeTestPreConfirmedBlock(roundID(1), 0), 1, 0, oldestPreConf, nil)
 		return s
 	}
 	delta := makeTestDelta(roundID(1), 1)
 	baseline := testing.AllocsPerRun(50, func() { _ = build() })
 	withApply := testing.AllocsPerRun(50, func() {
 		s := build()
-		_, _ = s.ApplyUpdate(delta, 1, 0, oldestPreConf)
+		_, _ = s.ApplyUpdate(delta, 1, 0, oldestPreConf, nil)
 	})
 	require.InDelta(t, float64(expectedDeltaCost), withApply-baseline, 0.5)
 }
@@ -1459,14 +1547,14 @@ func testAllocsApplyExtend(t *testing.T) {
 	const expectedExtendCost = 22
 	build := func() *preconfirmed.ChainStorage {
 		s := preconfirmed.NewChainStorage()
-		_, _ = s.ApplyUpdate(makeTestPreConfirmedBlock(roundID(1), 0), 1, 0, oldestPreConf)
+		_, _ = s.ApplyUpdate(makeTestPreConfirmedBlock(roundID(1), 0), 1, 0, oldestPreConf, nil)
 		return s
 	}
 	extendBlock := makeTestPreConfirmedBlock(roundID(2), 0)
 	baseline := testing.AllocsPerRun(50, func() { _ = build() })
 	withApply := testing.AllocsPerRun(50, func() {
 		s := build()
-		_, _ = s.ApplyUpdate(extendBlock, 2, 0, oldestPreConf)
+		_, _ = s.ApplyUpdate(extendBlock, 2, 0, oldestPreConf, nil)
 	})
 	require.InDelta(t, float64(expectedExtendCost), withApply-baseline, 0.5)
 }

--- a/sync/preconfirmed/chain_storage_test.go
+++ b/sync/preconfirmed/chain_storage_test.go
@@ -132,7 +132,7 @@ func testApplyUpdateBootstrapRejectsDelta(t *testing.T) {
 }
 
 func testApplyUpdateBootstrapNoChangeRejected(t *testing.T) {
-	oldestSlot := oldestSlotFor(100)
+	oldestPreConf := oldestPreConfFor(100)
 	s := preconfirmed.NewChainStorage()
 	_, err := s.ApplyUpdate(starknet.PreConfirmedNoChange{}, 101, 0, oldestPreConf, nil)
 	require.Error(t, err)
@@ -235,7 +235,7 @@ func testApplyUpdateReplaceTipRicherReplaces(t *testing.T) {
 }
 
 func testApplyUpdateDeltaRegistersNewClass(t *testing.T) {
-	oldestSlot := oldestSlotFor(0)
+	oldestSlot := oldestPreConfFor(0)
 	s := preconfirmed.NewChainStorage()
 	const round = "round-1"
 	applyBlock(t, s, round, 1, 1, oldestSlot) // stored without classes
@@ -249,13 +249,13 @@ func testApplyUpdateDeltaRegistersNewClass(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, affected, "a delta advancing the tip must publish the affected entry")
 
-	view := s.SnapshotForHead(oldestSlot)
+	view := s.SnapshotForBlock(oldestSlot)
 	require.Equal(t, classDef, view.Head().NewClasses[classHash],
 		"the delta's declared class must be readable on the stored tip")
 }
 
 func testApplyUpdateNoChangeRegistersClasses(t *testing.T) {
-	oldestSlot := oldestSlotFor(0)
+	oldestSlot := oldestPreConfFor(0)
 	s := preconfirmed.NewChainStorage()
 	applyBlock(t, s, roundID(1), 1, 1, oldestSlot)
 	classHash := felt.FromUint64[felt.Felt](0xC1A55)
@@ -266,7 +266,7 @@ func testApplyUpdateNoChangeRegistersClasses(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, affected, "NoChange with new classes must refresh the tip")
 
-	view := s.SnapshotForHead(oldestSlot)
+	view := s.SnapshotForBlock(oldestSlot)
 	require.Equal(t, classDef, view.Head().NewClasses[classHash],
 		"the recovered class must be readable on the stored tip")
 
@@ -917,7 +917,7 @@ func testChainReaderPreConfirmedStateAtComposes(t *testing.T) {
 }
 
 func testChainReaderPreConfirmedStateAtResolvesDeclaredClass(t *testing.T) {
-	oldestSlot := oldestSlotFor(0)
+	oldestSlot := oldestPreConfFor(0)
 	s := preconfirmed.NewChainStorage()
 	classHash := felt.FromUint64[felt.Felt](0xC1A55)
 	classDef := core.DeprecatedCairoClass{}
@@ -929,7 +929,7 @@ func testChainReaderPreConfirmedStateAtResolvesDeclaredClass(t *testing.T) {
 	_, err = s.ApplyUpdate(makeTestPreConfirmedBlock(roundID(2), 0), 2, 0, oldestSlot, nil)
 	require.NoError(t, err)
 
-	view := s.SnapshotForHead(oldestSlot)
+	view := s.SnapshotForBlock(oldestSlot)
 
 	ctrl := gomock.NewController(t)
 	bc := mocks.NewMockReader(ctrl)

--- a/sync/preconfirmed/poller.go
+++ b/sync/preconfirmed/poller.go
@@ -245,10 +245,11 @@ func (p *Poller) apply(
 	return nil
 }
 
-// fetchDeclaredClasses fetches the definitions of every class declared by update — and,
-// for a delta or no-change re-poll that continues storedTip's round, by storedTip too —
-// deduping so each hash hits the data source at most once. storedTip is nil for a fresh
-// slot with no prior stored view. Returns nil when nothing is declared.
+// fetchDeclaredClasses fetches the definitions of every class declared by update and,
+// for a delta or no-change re-poll that continues storedTip's round, by storedTip too,
+// keyed by class hash. It assumes declared hashes are distinct across these sources.
+// storedTip is nil for a fresh slot with no prior stored view. Returns nil when nothing
+// is declared.
 func (p *Poller) fetchDeclaredClasses(
 	ctx context.Context,
 	storedTip *pending.PreConfirmed,

--- a/sync/preconfirmed/poller.go
+++ b/sync/preconfirmed/poller.go
@@ -4,11 +4,13 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"iter"
 	"sync/atomic"
 	"time"
 
 	"github.com/NethermindEth/juno/blockchain"
 	"github.com/NethermindEth/juno/core"
+	"github.com/NethermindEth/juno/core/felt"
 	"github.com/NethermindEth/juno/core/pending"
 	"github.com/NethermindEth/juno/db"
 	"github.com/NethermindEth/juno/feed"
@@ -18,7 +20,7 @@ import (
 )
 
 // DataSource is the narrow surface the Poller needs from the wire side. Any
-// type implementing both methods (e.g. sync.DataSource) satisfies it.
+// type implementing these methods (e.g. sync.DataSource) satisfies it.
 type DataSource interface {
 	PreConfirmedBlockLatest(
 		ctx context.Context,
@@ -31,16 +33,17 @@ type DataSource interface {
 		identifier string,
 		txCount uint64,
 	) (starknet.PreConfirmedUpdate, error)
+	Class(ctx context.Context, classHash *felt.Felt) (core.ClassDefinition, error)
 }
 
 // Poller drives the pre-confirmed chain from a single goroutine.
 //
 // One tick reads as: poll the server's latest pre-confirmed, backfill any gap
-// below it, then insert the latest. backfill is a no-op when there's no gap;
-// otherwise it finalises the current mostRecent (re-polls its number to capture
-// the last delta before the sequencer moved past it) and then walks
-// explicit-number polls up to latest-1. Same-height polls (latest matches our
-// mostRecent) skip backfill and land in insert as delta / preserve / replace.
+// below it, then insert the latest. backfill runs only when the tip jumped ahead;
+// it re-fetches every slot from the old mostRecent up to latest-1 as a full block
+// (also capturing their declared classes) and applies each. Same-height polls
+// (latest matches our mostRecent) skip backfill and land in insert as
+// delta / preserve / replace.
 type Poller struct {
 	dataSource         DataSource
 	storage            *ChainStorage
@@ -152,7 +155,7 @@ func (p *Poller) tick(ctx context.Context) error {
 	}
 
 	if updateBlockNum > fromBlock {
-		err = p.backfill(ctx, oldestPreConf, fromBlock, identifier, txCount, updateBlockNum)
+		err = p.backfill(ctx, oldestPreConf, mostRecent, fromBlock, identifier, txCount, updateBlockNum)
 		if err != nil {
 			return fmt.Errorf(
 				"backfilling from %d to %d: %w",
@@ -168,16 +171,19 @@ func (p *Poller) tick(ctx context.Context) error {
 	// path ignores baseTxCount — so the stale value is harmless under current
 	// semantics. Revisit if ApplyUpdate grows a branch that reads baseTxCount
 	// for non-Delta updates.
-	return p.apply(update, updateBlockNum, txCount, oldestPreConf)
+	return p.apply(update, updateBlockNum, txCount, oldestPreConf, nil)
 }
 
-// backfill polls fromBlock with the given delta hints (identifier+txCount) to
-// capture the final view of that block, then walks fromBlock+1..endExclusive-1
-// with blank hints. The caller is responsible for deciding when backfill is
-// needed; backfill itself performs no gap check.
+// backfill fills the gap [fromBlock, endExclusive), applying each slot with its own
+// declared classes so they land on the exact block that declares them. The old tip
+// (fromBlock) is re-polled with delta hints and its classes resolved by oldTipClasses;
+// the intermediate slots are polled as full blocks. currentHead is the stored old tip,
+// needed to recover classes it declared while it was the tip. The caller decides when
+// backfill is needed; it performs no gap check.
 func (p *Poller) backfill(
 	ctx context.Context,
 	oldestPreConf uint64,
+	currentHead *pending.PreConfirmed,
 	fromBlockNum uint64,
 	identifier string,
 	txCount uint64,
@@ -187,8 +193,11 @@ func (p *Poller) backfill(
 	if err != nil {
 		return fmt.Errorf("polling pre-confirmed for number %d: %w", fromBlockNum, err)
 	}
-
-	if err := p.apply(update, fromBlockNum, txCount, oldestPreConf); err != nil {
+	newClasses, err := p.fetchClasses(ctx, declaredClassHashesForRepolledTip(currentHead, update))
+	if err != nil {
+		return fmt.Errorf("fetching declared classes for pre-confirmed %d: %w", fromBlockNum, err)
+	}
+	if err := p.apply(update, fromBlockNum, txCount, oldestPreConf, newClasses); err != nil {
 		return fmt.Errorf("applying pre-confirmed at %d: %w", fromBlockNum, err)
 	}
 
@@ -197,25 +206,37 @@ func (p *Poller) backfill(
 		if err != nil {
 			return fmt.Errorf("polling pre-confirmed for number %d: %w", n, err)
 		}
-
-		if err := p.apply(update, n, 0, oldestPreConf); err != nil {
+		newClasses, err := p.fetchClasses(ctx, declaredClassHashesFromUpdate(update))
+		if err != nil {
+			return fmt.Errorf("fetching declared classes for pre-confirmed %d: %w", n, err)
+		}
+		if err := p.apply(update, n, 0, oldestPreConf, newClasses); err != nil {
 			return fmt.Errorf("applying pre-confirmed at %d: %w", n, err)
 		}
 	}
 	return nil
 }
 
-// apply writes the update to storage and publishes the affected entry.
-// Returns an error on apply failure so callers can abort mid-fill.
+// apply writes the update to storage and publishes the affected entry. newClasses
+// carries the declared-class definitions to register on the stored entry (backfill's
+// most recent update only; nil elsewhere). Returns an error on apply failure so callers
+// can abort mid-fill.
 func (p *Poller) apply(
 	update starknet.PreConfirmedUpdate,
 	blockNumber uint64,
 	baseTxCount uint64,
 	oldestPreConf uint64,
+	newClasses map[felt.Felt]core.ClassDefinition,
 ) error {
-	applied, err := p.storage.ApplyUpdate(update, blockNumber, baseTxCount, oldestPreConf)
+	applied, err := p.storage.ApplyUpdate(update, blockNumber, baseTxCount, oldestPreConf, newClasses)
 	if err != nil {
 		return fmt.Errorf("applying pre-confirmed update at block %d: %w", blockNumber, err)
+	}
+	// A NoChange only ever registers freshly-fetched classes onto an already-stored
+	// (non-tip) entry during backfill; nothing changed for feed consumers, so it must
+	// not publish even though ApplyUpdate returns the touched entry.
+	if _, isNoChange := update.(starknet.PreConfirmedNoChange); isNoChange {
+		return nil
 	}
 	if applied != nil {
 		p.out.Send(applied)
@@ -224,7 +245,109 @@ func (p *Poller) apply(
 	return nil
 }
 
+// fetchClasses fetches the definition of each unique class hash yielded by the
+// sequence from the data source. Returns nil when the sequence yields nothing.
+func (p *Poller) fetchClasses(
+	ctx context.Context,
+	classHashes iter.Seq[felt.Felt],
+) (map[felt.Felt]core.ClassDefinition, error) {
+	var classes map[felt.Felt]core.ClassDefinition
+	for classHash := range classHashes {
+		if _, ok := classes[classHash]; ok {
+			continue
+		}
+		class, err := p.dataSource.Class(ctx, &classHash)
+		if err != nil {
+			return nil, fmt.Errorf("fetching class %s: %w", &classHash, err)
+		}
+		if classes == nil {
+			classes = make(map[felt.Felt]core.ClassDefinition)
+		}
+		classes[classHash] = class
+	}
+	return classes, nil
+}
+
 func (p *Poller) atTip(headNum uint64) bool {
 	highest := p.highestBlockHeader.Load()
 	return highest != nil && highest.Number <= headNum
+}
+
+// concat yields every element of each sequence in order.
+func concat[T any](seqs ...iter.Seq[T]) iter.Seq[T] {
+	return func(yield func(T) bool) {
+		for _, seq := range seqs {
+			for v := range seq {
+				if !yield(v) {
+					return
+				}
+			}
+		}
+	}
+}
+
+// declaredClassHashesFromUpdate yields the class hashes newly declared by a wire update's
+// transactions.
+func declaredClassHashesFromUpdate(update starknet.PreConfirmedUpdate) iter.Seq[felt.Felt] {
+	return func(yield func(felt.Felt) bool) {
+		var stateDiffs []*starknet.StateDiff
+		switch u := update.(type) {
+		case starknet.PreConfirmedBlock:
+			stateDiffs = u.TransactionStateDiffs
+		case starknet.PreConfirmedDeltaUpdate:
+			stateDiffs = u.TransactionStateDiffs
+		default:
+			return
+		}
+		for _, stateDiff := range stateDiffs {
+			for _, classHash := range stateDiff.OldDeclaredContracts {
+				if !yield(*classHash) {
+					return
+				}
+			}
+			for _, classDef := range stateDiff.DeclaredClasses {
+				if !yield(*classDef.ClassHash) {
+					return
+				}
+			}
+		}
+	}
+}
+
+// declaredClassHashesFromPreConfirmed yields the class hashes a stored pre-confirmed block
+// declares.
+func declaredClassHashesFromPreConfirmed(preConfirmed *pending.PreConfirmed) iter.Seq[felt.Felt] {
+	return func(yield func(felt.Felt) bool) {
+		stateDiff := preConfirmed.StateUpdate.StateDiff
+		for _, classHash := range stateDiff.DeclaredV0Classes {
+			if !yield(*classHash) {
+				return
+			}
+		}
+		for classHash := range stateDiff.DeclaredV1Classes {
+			if !yield(classHash) {
+				return
+			}
+		}
+	}
+}
+
+// declaredClassHashesForRepolledTip yields the class hashes declared by the stored tip and
+// the given update.
+func declaredClassHashesForRepolledTip(
+	storedTip *pending.PreConfirmed,
+	update starknet.PreConfirmedUpdate,
+) iter.Seq[felt.Felt] {
+	switch update.(type) {
+	case starknet.PreConfirmedBlock:
+		return declaredClassHashesFromUpdate(update)
+	case starknet.PreConfirmedDeltaUpdate:
+		return concat(
+			declaredClassHashesFromPreConfirmed(storedTip),
+			declaredClassHashesFromUpdate(update),
+		)
+	case starknet.PreConfirmedNoChange:
+		return declaredClassHashesFromPreConfirmed(storedTip)
+	}
+	return func(yield func(felt.Felt) bool) {}
 }

--- a/sync/preconfirmed/poller.go
+++ b/sync/preconfirmed/poller.go
@@ -39,11 +39,11 @@ type DataSource interface {
 // Poller drives the pre-confirmed chain from a single goroutine.
 //
 // One tick reads as: poll the server's latest pre-confirmed, backfill any gap
-// below it, then insert the latest. backfill runs only when the tip jumped ahead;
-// it re-fetches every slot from the old mostRecent up to latest-1 as a full block
-// (also capturing their declared classes) and applies each. Same-height polls
-// (latest matches our mostRecent) skip backfill and land in insert as
-// delta / preserve / replace.
+// below it, then apply the latest. backfill runs only when the tip jumped ahead;
+// it re-polls the old mostRecent with delta hints and the intermediate slots up
+// to latest-1 as full blocks (capturing each slot's declared classes) and applies
+// each. Same-height polls (latest matches our mostRecent) skip backfill and land
+// in apply as delta / preserve / replace.
 type Poller struct {
 	dataSource         DataSource
 	storage            *ChainStorage
@@ -218,9 +218,9 @@ func (p *Poller) backfill(
 }
 
 // apply writes the update to storage and publishes the affected entry. newClasses
-// carries the declared-class definitions to register on the stored entry (backfill's
-// most recent update only; nil elsewhere). Returns an error on apply failure so callers
-// can abort mid-fill.
+// carries the declared-class definitions to register on the stored entry; backfill
+// supplies them for each slot it applies, and the tick's apply of the latest passes
+// nil. Returns an error on apply failure so callers can abort mid-fill.
 func (p *Poller) apply(
 	update starknet.PreConfirmedUpdate,
 	blockNumber uint64,
@@ -232,9 +232,9 @@ func (p *Poller) apply(
 	if err != nil {
 		return fmt.Errorf("applying pre-confirmed update at block %d: %w", blockNumber, err)
 	}
-	// A NoChange only ever registers freshly-fetched classes onto an already-stored
-	// (non-tip) entry during backfill; nothing changed for feed consumers, so it must
-	// not publish even though ApplyUpdate returns the touched entry.
+	// A NoChange only ever registers freshly-fetched classes during backfill's re-poll
+	// of the old tip (still the stored tip at that point); nothing changed for feed
+	// consumers, so it must not publish even though ApplyUpdate returns the touched entry.
 	if _, isNoChange := update.(starknet.PreConfirmedNoChange); isNoChange {
 		return nil
 	}

--- a/sync/preconfirmed/poller.go
+++ b/sync/preconfirmed/poller.go
@@ -176,9 +176,9 @@ func (p *Poller) tick(ctx context.Context) error {
 
 // backfill fills the gap [fromBlock, endExclusive), applying each slot with its own
 // declared classes so they land on the exact block that declares them. The old tip
-// (fromBlock) is re-polled with delta hints and its classes resolved by oldTipClasses;
-// the intermediate slots are polled as full blocks. currentHead is the stored old tip,
-// needed to recover classes it declared while it was the tip. The caller decides when
+// (fromBlock) is re-polled with delta hints, resolving classes from both currentHead (the
+// stored old tip, needed to recover classes it declared while it was the tip) and the
+// re-poll; the intermediate slots are polled as full blocks. The caller decides when
 // backfill is needed; it performs no gap check.
 func (p *Poller) backfill(
 	ctx context.Context,
@@ -193,7 +193,7 @@ func (p *Poller) backfill(
 	if err != nil {
 		return fmt.Errorf("polling pre-confirmed for number %d: %w", fromBlockNum, err)
 	}
-	newClasses, err := p.fetchClasses(ctx, declaredClassHashesForRepolledTip(currentHead, update))
+	newClasses, err := p.fetchDeclaredClasses(ctx, currentHead, update)
 	if err != nil {
 		return fmt.Errorf("fetching declared classes for pre-confirmed %d: %w", fromBlockNum, err)
 	}
@@ -206,7 +206,7 @@ func (p *Poller) backfill(
 		if err != nil {
 			return fmt.Errorf("polling pre-confirmed for number %d: %w", n, err)
 		}
-		newClasses, err := p.fetchClasses(ctx, declaredClassHashesFromUpdate(update))
+		newClasses, err := p.fetchDeclaredClasses(ctx, nil, update)
 		if err != nil {
 			return fmt.Errorf("fetching declared classes for pre-confirmed %d: %w", n, err)
 		}
@@ -245,109 +245,102 @@ func (p *Poller) apply(
 	return nil
 }
 
-// fetchClasses fetches the definition of each unique class hash yielded by the
-// sequence from the data source. Returns nil when the sequence yields nothing.
-func (p *Poller) fetchClasses(
+// fetchDeclaredClasses fetches the definitions of every class declared by update — and,
+// for a delta or no-change re-poll that continues storedTip's round, by storedTip too —
+// deduping so each hash hits the data source at most once. storedTip is nil for a fresh
+// slot with no prior stored view. Returns nil when nothing is declared.
+func (p *Poller) fetchDeclaredClasses(
 	ctx context.Context,
-	classHashes iter.Seq[felt.Felt],
+	storedTip *pending.PreConfirmed,
+	update starknet.PreConfirmedUpdate,
 ) (map[felt.Felt]core.ClassDefinition, error) {
-	var classes map[felt.Felt]core.ClassDefinition
-	for classHash := range classHashes {
-		if _, ok := classes[classHash]; ok {
-			continue
+	// A delta or no-change re-poll continues storedTip's round, so the classes it already
+	// declared belong to this same block; a full block is a fresh round carrying only its
+	// own.
+	var storedStateDiff *core.StateDiff
+	switch update.(type) {
+	case starknet.PreConfirmedDeltaUpdate, starknet.PreConfirmedNoChange:
+		if storedTip != nil {
+			storedStateDiff = storedTip.StateUpdate.StateDiff
 		}
-		class, err := p.dataSource.Class(ctx, &classHash)
+	}
+
+	var updateStateDiffs []*starknet.StateDiff
+	switch u := update.(type) {
+	case starknet.PreConfirmedBlock:
+		updateStateDiffs = u.TransactionStateDiffs
+	case starknet.PreConfirmedDeltaUpdate:
+		updateStateDiffs = u.TransactionStateDiffs
+	}
+
+	declaredCount := declaredClassCount(storedStateDiff, updateStateDiffs)
+	if declaredCount == 0 {
+		return nil, nil
+	}
+
+	classes := make(map[felt.Felt]core.ClassDefinition, declaredCount)
+	for classHash := range declaredClassHashes(storedStateDiff, updateStateDiffs) {
+		class, err := p.dataSource.Class(ctx, classHash)
 		if err != nil {
-			return nil, fmt.Errorf("fetching class %s: %w", &classHash, err)
+			return nil, fmt.Errorf("fetching class %s: %w", classHash, err)
 		}
-		if classes == nil {
-			classes = make(map[felt.Felt]core.ClassDefinition)
-		}
-		classes[classHash] = class
+		classes[*classHash] = class
 	}
 	return classes, nil
+}
+
+// declaredClassHashes yields every class hash declared across the stored and update state
+// diffs, in stored-then-update order.
+func declaredClassHashes(
+	storedStateDiff *core.StateDiff,
+	updateStateDiffs []*starknet.StateDiff,
+) iter.Seq[*felt.Felt] {
+	return func(yield func(*felt.Felt) bool) {
+		if storedStateDiff != nil {
+			for _, classHash := range storedStateDiff.DeclaredV0Classes {
+				if !yield(classHash) {
+					return
+				}
+			}
+			for classHash := range storedStateDiff.DeclaredV1Classes {
+				if !yield(&classHash) {
+					return
+				}
+			}
+		}
+		for _, stateDiff := range updateStateDiffs {
+			for _, classHash := range stateDiff.OldDeclaredContracts {
+				if !yield(classHash) {
+					return
+				}
+			}
+			for i := range stateDiff.DeclaredClasses {
+				if !yield(stateDiff.DeclaredClasses[i].ClassHash) {
+					return
+				}
+			}
+		}
+	}
+}
+
+// declaredClassCount counts the classes declared across the stored and update state diffs.
+// A class is declared at most once, so the sum is exact and sizes the fetch map without
+// growing it.
+func declaredClassCount(
+	storedStateDiff *core.StateDiff,
+	updateStateDiffs []*starknet.StateDiff,
+) int {
+	count := 0
+	if storedStateDiff != nil {
+		count += len(storedStateDiff.DeclaredV0Classes) + len(storedStateDiff.DeclaredV1Classes)
+	}
+	for _, stateDiff := range updateStateDiffs {
+		count += len(stateDiff.OldDeclaredContracts) + len(stateDiff.DeclaredClasses)
+	}
+	return count
 }
 
 func (p *Poller) atTip(headNum uint64) bool {
 	highest := p.highestBlockHeader.Load()
 	return highest != nil && highest.Number <= headNum
-}
-
-// concat yields every element of each sequence in order.
-func concat[T any](seqs ...iter.Seq[T]) iter.Seq[T] {
-	return func(yield func(T) bool) {
-		for _, seq := range seqs {
-			for v := range seq {
-				if !yield(v) {
-					return
-				}
-			}
-		}
-	}
-}
-
-// declaredClassHashesFromUpdate yields the class hashes newly declared by a wire update's
-// transactions.
-func declaredClassHashesFromUpdate(update starknet.PreConfirmedUpdate) iter.Seq[felt.Felt] {
-	return func(yield func(felt.Felt) bool) {
-		var stateDiffs []*starknet.StateDiff
-		switch u := update.(type) {
-		case starknet.PreConfirmedBlock:
-			stateDiffs = u.TransactionStateDiffs
-		case starknet.PreConfirmedDeltaUpdate:
-			stateDiffs = u.TransactionStateDiffs
-		default:
-			return
-		}
-		for _, stateDiff := range stateDiffs {
-			for _, classHash := range stateDiff.OldDeclaredContracts {
-				if !yield(*classHash) {
-					return
-				}
-			}
-			for _, classDef := range stateDiff.DeclaredClasses {
-				if !yield(*classDef.ClassHash) {
-					return
-				}
-			}
-		}
-	}
-}
-
-// declaredClassHashesFromPreConfirmed yields the class hashes a stored pre-confirmed block
-// declares.
-func declaredClassHashesFromPreConfirmed(preConfirmed *pending.PreConfirmed) iter.Seq[felt.Felt] {
-	return func(yield func(felt.Felt) bool) {
-		stateDiff := preConfirmed.StateUpdate.StateDiff
-		for _, classHash := range stateDiff.DeclaredV0Classes {
-			if !yield(*classHash) {
-				return
-			}
-		}
-		for classHash := range stateDiff.DeclaredV1Classes {
-			if !yield(classHash) {
-				return
-			}
-		}
-	}
-}
-
-// declaredClassHashesForRepolledTip yields the class hashes declared by the stored tip and
-// the given update.
-func declaredClassHashesForRepolledTip(
-	storedTip *pending.PreConfirmed,
-	update starknet.PreConfirmedUpdate,
-) iter.Seq[felt.Felt] {
-	switch update.(type) {
-	case starknet.PreConfirmedBlock:
-		return declaredClassHashesFromUpdate(update)
-	case starknet.PreConfirmedDeltaUpdate:
-		return concat(
-			declaredClassHashesFromPreConfirmed(storedTip),
-			declaredClassHashesFromUpdate(update),
-		)
-	case starknet.PreConfirmedNoChange:
-		return declaredClassHashesFromPreConfirmed(storedTip)
-	}
-	return func(yield func(felt.Felt) bool) {}
 }

--- a/sync/preconfirmed/poller_test.go
+++ b/sync/preconfirmed/poller_test.go
@@ -343,7 +343,7 @@ func TestPollerSameHeightNoBackfill(t *testing.T) {
 
 	synctest.Test(t, func(t *testing.T) {
 		h := wirePoller(t, fx.bc, fx.head, ds)
-		_, err := h.storage.ApplyUpdate(seed, h.head.Number+1, 0, oldestPreConfFor(h.head.Number))
+		_, err := h.storage.ApplyUpdate(seed, h.head.Number+1, 0, oldestPreConfFor(h.head.Number), nil)
 		require.NoError(t, err)
 		before := h.storage.SnapshotForBlock(oldestPreConfFor(h.head.Number))
 
@@ -378,7 +378,7 @@ func TestPollerSameHeightDeltaAppliesToSlot(t *testing.T) {
 
 	synctest.Test(t, func(t *testing.T) {
 		h := wirePoller(t, fx.bc, fx.head, ds)
-		_, err := h.storage.ApplyUpdate(seed, h.head.Number+1, 0, oldestPreConfFor(h.head.Number))
+		_, err := h.storage.ApplyUpdate(seed, h.head.Number+1, 0, oldestPreConfFor(h.head.Number), nil)
 		require.NoError(t, err)
 
 		go h.poller.Run(t.Context())
@@ -393,11 +393,10 @@ func TestPollerSameHeightDeltaAppliesToSlot(t *testing.T) {
 	})
 }
 
-// Sequencer advanced by exactly one: backfill re-polls mostRecent's own
-// height with its identifier+txCount hints, and the server replies with a
-// Delta carrying the final txs the sequencer appended before publishing the
-// next block. The delta merges into the existing slot (identifier preserved,
-// txs summed), then the new most recent is applied.
+// Sequencer advanced by exactly one: backfill re-polls mostRecent's own height with its
+// identifier+txCount hints, and the server replies with a Delta carrying the final txs
+// appended before the next block. The delta merges into the existing slot (identifier
+// preserved, txs summed), then the new most recent is applied.
 func TestPollerForwardJumpFinalisesMostRecent(t *testing.T) {
 	t.Parallel()
 	fx := newChainFixture(t)
@@ -421,7 +420,7 @@ func TestPollerForwardJumpFinalisesMostRecent(t *testing.T) {
 
 	synctest.Test(t, func(t *testing.T) {
 		h := wirePoller(t, fx.bc, fx.head, ds)
-		_, err := h.storage.ApplyUpdate(seed, h.head.Number+1, 0, oldestPreConfFor(h.head.Number))
+		_, err := h.storage.ApplyUpdate(seed, h.head.Number+1, 0, oldestPreConfFor(h.head.Number), nil)
 		require.NoError(t, err)
 
 		go h.poller.Run(t.Context())
@@ -471,7 +470,7 @@ func TestPollerLargeJumpWalksGap(t *testing.T) {
 
 	synctest.Test(t, func(t *testing.T) {
 		h := wirePoller(t, fx.bc, fx.head, ds)
-		_, err := h.storage.ApplyUpdate(seed, h.head.Number+1, 0, oldestPreConfFor(h.head.Number))
+		_, err := h.storage.ApplyUpdate(seed, h.head.Number+1, 0, oldestPreConfFor(h.head.Number), nil)
 		require.NoError(t, err)
 
 		go h.poller.Run(t.Context())
@@ -654,9 +653,9 @@ func TestPollerHeadAdvancesDropsCommittedEntries(t *testing.T) {
 
 	synctest.Test(t, func(t *testing.T) {
 		h := wirePoller(t, fx.bc, fx.head, ds)
-		_, err := h.storage.ApplyUpdate(seed1, h.head.Number+1, 0, oldestPreConfFor(h.head.Number))
+		_, err := h.storage.ApplyUpdate(seed1, h.head.Number+1, 0, oldestPreConfFor(h.head.Number), nil)
 		require.NoError(t, err)
-		_, err = h.storage.ApplyUpdate(seed2, h.head.Number+2, 0, oldestPreConfFor(h.head.Number))
+		_, err = h.storage.ApplyUpdate(seed2, h.head.Number+2, 0, oldestPreConfFor(h.head.Number), nil)
 		require.NoError(t, err)
 		before := h.storage.SnapshotForBlock(oldestPreConfFor(h.head.Number))
 		require.Equal(t, 2, before.Length())
@@ -702,11 +701,11 @@ func TestPollerReorgLowerHeightDifferentIdentifier(t *testing.T) {
 
 	synctest.Test(t, func(t *testing.T) {
 		h := wirePoller(t, fx.bc, fx.head, ds)
-		_, err := h.storage.ApplyUpdate(seed1, h.head.Number+1, 0, oldestPreConfFor(h.head.Number))
+		_, err := h.storage.ApplyUpdate(seed1, h.head.Number+1, 0, oldestPreConfFor(h.head.Number), nil)
 		require.NoError(t, err)
-		_, err = h.storage.ApplyUpdate(seed2, h.head.Number+2, 0, oldestPreConfFor(h.head.Number))
+		_, err = h.storage.ApplyUpdate(seed2, h.head.Number+2, 0, oldestPreConfFor(h.head.Number), nil)
 		require.NoError(t, err)
-		_, err = h.storage.ApplyUpdate(seed3, h.head.Number+3, 0, oldestPreConfFor(h.head.Number))
+		_, err = h.storage.ApplyUpdate(seed3, h.head.Number+3, 0, oldestPreConfFor(h.head.Number), nil)
 		require.NoError(t, err)
 		before := h.storage.SnapshotForBlock(oldestPreConfFor(h.head.Number))
 		require.Equal(t, 3, before.Length())
@@ -743,11 +742,11 @@ func TestPollerReorgSameHeightDifferentIdentifier(t *testing.T) {
 
 	synctest.Test(t, func(t *testing.T) {
 		h := wirePoller(t, fx.bc, fx.head, ds)
-		_, err := h.storage.ApplyUpdate(seed1, h.head.Number+1, 0, oldestPreConfFor(h.head.Number))
+		_, err := h.storage.ApplyUpdate(seed1, h.head.Number+1, 0, oldestPreConfFor(h.head.Number), nil)
 		require.NoError(t, err)
-		_, err = h.storage.ApplyUpdate(seed2, h.head.Number+2, 0, oldestPreConfFor(h.head.Number))
+		_, err = h.storage.ApplyUpdate(seed2, h.head.Number+2, 0, oldestPreConfFor(h.head.Number), nil)
 		require.NoError(t, err)
-		_, err = h.storage.ApplyUpdate(seed3, h.head.Number+3, 0, oldestPreConfFor(h.head.Number))
+		_, err = h.storage.ApplyUpdate(seed3, h.head.Number+3, 0, oldestPreConfFor(h.head.Number), nil)
 		require.NoError(t, err)
 		before := h.storage.SnapshotForBlock(oldestPreConfFor(h.head.Number))
 		require.Equal(t, 3, before.Length())
@@ -765,6 +764,159 @@ func TestPollerReorgSameHeightDifferentIdentifier(t *testing.T) {
 			entry(2, &seed2),
 			entry(3, &replacement),
 		)
+	})
+}
+
+// classesAt returns the NewClasses registered on the snapshot's slot at blockNumber.
+func classesAt(
+	snap *preconfirmed.ChainReader,
+	blockNumber uint64,
+) map[felt.Felt]core.ClassDefinition {
+	for pc := range snap.OldestFirst() {
+		if pc.Block.Number == blockNumber {
+			return pc.NewClasses
+		}
+	}
+	return nil
+}
+
+// Each subtest drives a forward jump (old tip at slot 1, latest at slot 2) so the old tip
+// is re-polled during backfill, then asserts the poller fetched the classes
+// declaredClassHashesForRepolledTip surfaces for that update variant. The new tip's own
+// classes are out of scope — the tick applies it with nil classes.
+func TestPollerBackfillFetchesDeclaredClasses(t *testing.T) {
+	t.Parallel()
+
+	// A full-block re-poll (a new round at the old tip) fetches that block's own declared
+	// classes.
+	t.Run("full block re-poll fetches its declared classes", func(t *testing.T) {
+		t.Parallel()
+		fx := newChainFixture(t)
+
+		classHash := new(felt.Felt).SetUint64(0xC1A55)
+		classDef := &core.SierraClass{}
+
+		seed := makeTestPreConfirmedBlock("r1", 0) // stored old tip, declares nothing
+		repoll := makeTestPreConfirmedBlock("r1b", 1)
+		repoll.TransactionStateDiffs[0].DeclaredClasses = []struct {
+			ClassHash         *felt.Felt `json:"class_hash"`
+			CompiledClassHash *felt.Felt `json:"compiled_class_hash"`
+		}{{ClassHash: classHash}}
+		newTip := makeTestPreConfirmedBlock("r2", 0)
+
+		ctrl := gomock.NewController(t)
+		ds := mocks.NewMockStarknetData(ctrl)
+		ds.EXPECT().PreConfirmedBlockLatest(gomock.Any(), "r1", uint64(0)).
+			Return(newTip, uint64(2), nil)
+		ds.EXPECT().PreConfirmedBlockByNumber(gomock.Any(), uint64(1), "r1", uint64(0)).
+			Return(repoll, nil)
+		ds.EXPECT().Class(gomock.Any(), classHash).Return(classDef, nil)
+
+		synctest.Test(t, func(t *testing.T) {
+			h := wirePoller(t, fx.bc, fx.head, ds)
+			_, err := h.storage.ApplyUpdate(seed, h.head.Number+1, 0, oldestSlotFor(h.head.Number), nil)
+			require.NoError(t, err)
+
+			go h.poller.Run(t.Context())
+			synctest.Wait()
+			time.Sleep(tickInterval)
+			synctest.Wait()
+
+			view := h.storage.SnapshotForHead(oldestSlotFor(h.head.Number))
+			require.Equal(t, classDef, classesAt(&view, 1)[*classHash],
+				"the re-polled full block's declared class must be fetched and land on slot 1")
+		})
+	})
+
+	// A delta re-poll fetches both the stored tip's already-declared classes and the
+	// delta's newly-declared ones.
+	t.Run("delta re-poll fetches stored tip and delta classes", func(t *testing.T) {
+		t.Parallel()
+		fx := newChainFixture(t)
+
+		storedClass := new(felt.Felt).SetUint64(0xADD)
+		deltaClass := new(felt.Felt).SetUint64(0xC1A55)
+		storedDef := &core.SierraClass{}
+		deltaDef := &core.SierraClass{}
+
+		seed := makeTestPreConfirmedBlock("r1", 1) // stored old tip declares storedClass
+		seed.TransactionStateDiffs[0].DeclaredClasses = []struct {
+			ClassHash         *felt.Felt `json:"class_hash"`
+			CompiledClassHash *felt.Felt `json:"compiled_class_hash"`
+		}{{ClassHash: storedClass}}
+		repoll := makeTestDelta("r1", 1) // same-round delta declares deltaClass
+		repoll.TransactionStateDiffs[0].DeclaredClasses = []struct {
+			ClassHash         *felt.Felt `json:"class_hash"`
+			CompiledClassHash *felt.Felt `json:"compiled_class_hash"`
+		}{{ClassHash: deltaClass}}
+		newTip := makeTestPreConfirmedBlock("r2", 0)
+
+		ctrl := gomock.NewController(t)
+		ds := mocks.NewMockStarknetData(ctrl)
+		ds.EXPECT().PreConfirmedBlockLatest(gomock.Any(), "r1", uint64(1)).
+			Return(newTip, uint64(2), nil)
+		ds.EXPECT().PreConfirmedBlockByNumber(gomock.Any(), uint64(1), "r1", uint64(1)).
+			Return(repoll, nil)
+		ds.EXPECT().Class(gomock.Any(), storedClass).Return(storedDef, nil)
+		ds.EXPECT().Class(gomock.Any(), deltaClass).Return(deltaDef, nil)
+
+		synctest.Test(t, func(t *testing.T) {
+			h := wirePoller(t, fx.bc, fx.head, ds)
+			_, err := h.storage.ApplyUpdate(seed, h.head.Number+1, 0, oldestSlotFor(h.head.Number), nil)
+			require.NoError(t, err)
+
+			go h.poller.Run(t.Context())
+			synctest.Wait()
+			time.Sleep(tickInterval)
+			synctest.Wait()
+
+			view := h.storage.SnapshotForHead(oldestSlotFor(h.head.Number))
+			classes := classesAt(&view, 1)
+			require.Equal(t, storedDef, classes[*storedClass],
+				"the stored tip's declared class must be recovered and fetched")
+			require.Equal(t, deltaDef, classes[*deltaClass],
+				"the delta's newly-declared class must be fetched")
+		})
+	})
+
+	// A NoChange re-poll fetches the stored tip's declared classes, recovered from the
+	// stored entry even though the poll carries no content.
+	t.Run("no-change re-poll recovers stored tip classes", func(t *testing.T) {
+		t.Parallel()
+		fx := newChainFixture(t)
+
+		storedClass := new(felt.Felt).SetUint64(0xADD)
+		storedDef := &core.SierraClass{}
+
+		seed := makeTestPreConfirmedBlock("r1", 1) // stored old tip declares storedClass
+		seed.TransactionStateDiffs[0].DeclaredClasses = []struct {
+			ClassHash         *felt.Felt `json:"class_hash"`
+			CompiledClassHash *felt.Felt `json:"compiled_class_hash"`
+		}{{ClassHash: storedClass}}
+		newTip := makeTestPreConfirmedBlock("r2", 0)
+
+		ctrl := gomock.NewController(t)
+		ds := mocks.NewMockStarknetData(ctrl)
+		ds.EXPECT().PreConfirmedBlockLatest(gomock.Any(), "r1", uint64(1)).
+			Return(newTip, uint64(2), nil)
+		ds.EXPECT().PreConfirmedBlockByNumber(gomock.Any(), uint64(1), "r1", uint64(1)).
+			Return(starknet.PreConfirmedNoChange{}, nil)
+		ds.EXPECT().Class(gomock.Any(), storedClass).Return(storedDef, nil)
+
+		synctest.Test(t, func(t *testing.T) {
+			h := wirePoller(t, fx.bc, fx.head, ds)
+			_, err := h.storage.ApplyUpdate(seed, h.head.Number+1, 0, oldestSlotFor(h.head.Number), nil)
+			require.NoError(t, err)
+
+			go h.poller.Run(t.Context())
+			synctest.Wait()
+			time.Sleep(tickInterval)
+			synctest.Wait()
+
+			view := h.storage.SnapshotForHead(oldestSlotFor(h.head.Number))
+			require.Equal(t, storedDef, classesAt(&view, 1)[*storedClass],
+				"the stored tip's declared class must be recovered despite a NoChange re-poll")
+		})
 	})
 }
 
@@ -815,7 +967,7 @@ func TestPollerSilentOnNoChange(t *testing.T) {
 		h := wirePoller(t, fx.bc, fx.head, ds)
 		// Seed directly through storage; this does NOT publish (only the
 		// poller's apply wrapper does Send), so the feed starts clean.
-		_, err := h.storage.ApplyUpdate(seed, h.head.Number+1, 0, oldestPreConfFor(h.head.Number))
+		_, err := h.storage.ApplyUpdate(seed, h.head.Number+1, 0, oldestPreConfFor(h.head.Number), nil)
 		require.NoError(t, err)
 
 		go h.poller.Run(t.Context())

--- a/sync/preconfirmed/poller_test.go
+++ b/sync/preconfirmed/poller_test.go
@@ -780,10 +780,6 @@ func classesAt(
 	return nil
 }
 
-// Each subtest drives a forward jump (old tip at slot 1, latest at slot 2) so the old tip
-// is re-polled during backfill, then asserts the poller fetched the classes
-// declaredClassHashesForRepolledTip surfaces for that update variant. The new tip's own
-// classes are out of scope — the tick applies it with nil classes.
 func TestPollerBackfillFetchesDeclaredClasses(t *testing.T) {
 	t.Parallel()
 

--- a/sync/preconfirmed/poller_test.go
+++ b/sync/preconfirmed/poller_test.go
@@ -810,7 +810,7 @@ func TestPollerBackfillFetchesDeclaredClasses(t *testing.T) {
 
 		synctest.Test(t, func(t *testing.T) {
 			h := wirePoller(t, fx.bc, fx.head, ds)
-			_, err := h.storage.ApplyUpdate(seed, h.head.Number+1, 0, oldestSlotFor(h.head.Number), nil)
+			_, err := h.storage.ApplyUpdate(seed, h.head.Number+1, 0, oldestPreConfFor(h.head.Number), nil)
 			require.NoError(t, err)
 
 			go h.poller.Run(t.Context())
@@ -818,7 +818,7 @@ func TestPollerBackfillFetchesDeclaredClasses(t *testing.T) {
 			time.Sleep(tickInterval)
 			synctest.Wait()
 
-			view := h.storage.SnapshotForHead(oldestSlotFor(h.head.Number))
+			view := h.storage.SnapshotForBlock(oldestPreConfFor(h.head.Number))
 			require.Equal(t, classDef, classesAt(&view, 1)[*classHash],
 				"the re-polled full block's declared class must be fetched and land on slot 1")
 		})
@@ -858,7 +858,7 @@ func TestPollerBackfillFetchesDeclaredClasses(t *testing.T) {
 
 		synctest.Test(t, func(t *testing.T) {
 			h := wirePoller(t, fx.bc, fx.head, ds)
-			_, err := h.storage.ApplyUpdate(seed, h.head.Number+1, 0, oldestSlotFor(h.head.Number), nil)
+			_, err := h.storage.ApplyUpdate(seed, h.head.Number+1, 0, oldestPreConfFor(h.head.Number), nil)
 			require.NoError(t, err)
 
 			go h.poller.Run(t.Context())
@@ -866,7 +866,7 @@ func TestPollerBackfillFetchesDeclaredClasses(t *testing.T) {
 			time.Sleep(tickInterval)
 			synctest.Wait()
 
-			view := h.storage.SnapshotForHead(oldestSlotFor(h.head.Number))
+			view := h.storage.SnapshotForBlock(oldestPreConfFor(h.head.Number))
 			classes := classesAt(&view, 1)
 			require.Equal(t, storedDef, classes[*storedClass],
 				"the stored tip's declared class must be recovered and fetched")
@@ -901,7 +901,7 @@ func TestPollerBackfillFetchesDeclaredClasses(t *testing.T) {
 
 		synctest.Test(t, func(t *testing.T) {
 			h := wirePoller(t, fx.bc, fx.head, ds)
-			_, err := h.storage.ApplyUpdate(seed, h.head.Number+1, 0, oldestSlotFor(h.head.Number), nil)
+			_, err := h.storage.ApplyUpdate(seed, h.head.Number+1, 0, oldestPreConfFor(h.head.Number), nil)
 			require.NoError(t, err)
 
 			go h.poller.Run(t.Context())
@@ -909,7 +909,7 @@ func TestPollerBackfillFetchesDeclaredClasses(t *testing.T) {
 			time.Sleep(tickInterval)
 			synctest.Wait()
 
-			view := h.storage.SnapshotForHead(oldestSlotFor(h.head.Number))
+			view := h.storage.SnapshotForBlock(oldestPreConfFor(h.head.Number))
 			require.Equal(t, storedDef, classesAt(&view, 1)[*storedClass],
 				"the stored tip's declared class must be recovered despite a NoChange re-poll")
 		})

--- a/sync/reorg_test.go
+++ b/sync/reorg_test.go
@@ -79,6 +79,13 @@ func (t *testBlockDataSource) PreConfirmedBlockLatest(
 	return nil, 0, errors.New("not implemented")
 }
 
+func (t *testBlockDataSource) Class(
+	ctx context.Context,
+	classHash *felt.Felt,
+) (core.ClassDefinition, error) {
+	return nil, errors.New("not implemented")
+}
+
 func (t *testBlockDataSource) setBlocks(blocks []sync.CommittedBlock) {
 	(*atomic.Value)(t).Store(blocks)
 }


### PR DESCRIPTION
Adds the ability to fetch and register class definitions declared in past pre-confirmed blocks (PreLatest blocks), which were previously left unresolved until finalization. The poller now resolves each backfilled slot's declared classes and stores them on the exact block that declares them, and pre-confirmed state reads merge classes across the whole chain instead of returning nil.