### PR TITLE
poc(json): using `MarshalText`

### DIFF
--- a/core/felt/address.go
+++ b/core/felt/address.go
@@ -14,8 +14,8 @@ func (a *Address) UnmarshalJSON(data []byte) error {
 	return (*Felt)(a).UnmarshalJSON(data)
 }
 
-func (a Address) MarshalJSON() ([]byte, error) {
-	return Felt(a).MarshalJSON()
+func (a Address) MarshalText() ([]byte, error) {
+	return Felt(a).MarshalText()
 }
 
 func (a *Address) Marshal() []byte {

--- a/core/felt/felt.go
+++ b/core/felt/felt.go
@@ -76,10 +76,15 @@ func (z *Felt) UnmarshalJSON(data []byte) error {
 	return (*fp.Element)(z).SetBytesCanonical(buf[:])
 }
 
-// MarshalJSON returns the felt as a quoted 0x hex string with no
-// unnecessary leading zeros. Uses a value receiver so encoding/json
-// can call it on non-addressable values (struct fields in `any`).
-func (z Felt) MarshalJSON() ([]byte, error) {
+// MarshalText returns the felt as a 0x hex string (UNQUOTED) with no
+// unnecessary leading zeros. Value receiver so encoding/json can call it
+// on non-addressable values (struct fields in `any`) — see PR #3504.
+//
+// PoC: implementing encoding.TextMarshaler instead of json.Marshaler lets
+// encoding/json use its textMarshalerEncoder (string fast-path) and SKIP the
+// per-value appendCompact JSON re-scan that dominated getClass encode CPU.
+// encoding/json adds the surrounding quotes, so output stays "0x..."-identical.
+func (z Felt) MarshalText() ([]byte, error) {
 	var raw [Bytes]byte
 	fp.BigEndian.PutElement(&raw, fp.Element(z))
 
@@ -89,8 +94,8 @@ func (z Felt) MarshalJSON() ([]byte, error) {
 		i++
 	}
 
-	out := make([]byte, 3, 4+(Bytes-i)*2)
-	out[0], out[1], out[2] = '"', '0', 'x'
+	out := make([]byte, 2, 2+(Bytes-i)*2)
+	out[0], out[1] = '0', 'x'
 
 	// First byte may need a single hex digit (e.g. 0x3, not 0x03).
 	if raw[i] < Base16 {
@@ -99,7 +104,7 @@ func (z Felt) MarshalJSON() ([]byte, error) {
 	}
 	out = hex.AppendEncode(out, raw[i:])
 
-	return append(out, '"'), nil
+	return out, nil
 }
 
 // SetBytes forwards the call to underlying field element implementation

--- a/core/felt/felt_benchmark_test.go
+++ b/core/felt/felt_benchmark_test.go
@@ -39,7 +39,7 @@ func BenchmarkMarshalJSON(b *testing.B) {
 			b.ReportAllocs()
 			var out []byte
 			for b.Loop() {
-				out, _ = value.MarshalJSON()
+				out, _ = value.MarshalText()
 			}
 			benchBytesSink = out
 		})

--- a/core/felt/felt_test.go
+++ b/core/felt/felt_test.go
@@ -174,7 +174,7 @@ func TestMarshalJSON(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			f := felt.UnsafeFromString[felt.Felt](tc.hex)
-			got, err := f.MarshalJSON()
+			got, err := json.Marshal(f)
 			require.NoError(t, err)
 			assert.Equal(t, tc.expect, string(got))
 		})

--- a/core/felt/hash.go
+++ b/core/felt/hash.go
@@ -14,8 +14,8 @@ func (h *Hash) UnmarshalJSON(data []byte) error {
 	return (*Felt)(h).UnmarshalJSON(data)
 }
 
-func (h Hash) MarshalJSON() ([]byte, error) {
-	return Felt(h).MarshalJSON()
+func (h Hash) MarshalText() ([]byte, error) {
+	return Felt(h).MarshalText()
 }
 
 func (h *Hash) Marshal() []byte {
@@ -40,8 +40,8 @@ func (h *ClassHash) UnmarshalJSON(data []byte) error {
 	return (*Hash)(h).UnmarshalJSON(data)
 }
 
-func (h ClassHash) MarshalJSON() ([]byte, error) {
-	return Hash(h).MarshalJSON()
+func (h ClassHash) MarshalText() ([]byte, error) {
+	return Hash(h).MarshalText()
 }
 
 func (h *ClassHash) Marshal() []byte {
@@ -66,8 +66,8 @@ func (h *SierraClassHash) UnmarshalJSON(data []byte) error {
 	return (*ClassHash)(h).UnmarshalJSON(data)
 }
 
-func (h SierraClassHash) MarshalJSON() ([]byte, error) {
-	return ClassHash(h).MarshalJSON()
+func (h SierraClassHash) MarshalText() ([]byte, error) {
+	return ClassHash(h).MarshalText()
 }
 
 func (h *SierraClassHash) Marshal() []byte {
@@ -92,8 +92,8 @@ func (h *CasmClassHash) UnmarshalJSON(data []byte) error {
 	return (*ClassHash)(h).UnmarshalJSON(data)
 }
 
-func (h CasmClassHash) MarshalJSON() ([]byte, error) {
-	return ClassHash(h).MarshalJSON()
+func (h CasmClassHash) MarshalText() ([]byte, error) {
+	return ClassHash(h).MarshalText()
 }
 
 func (h *CasmClassHash) Marshal() []byte {
@@ -118,8 +118,8 @@ func (h *TransactionHash) UnmarshalJSON(data []byte) error {
 	return (*Hash)(h).UnmarshalJSON(data)
 }
 
-func (h TransactionHash) MarshalJSON() ([]byte, error) {
-	return Hash(h).MarshalJSON()
+func (h TransactionHash) MarshalText() ([]byte, error) {
+	return Hash(h).MarshalText()
 }
 
 func (h *TransactionHash) Marshal() []byte {
@@ -144,8 +144,8 @@ func (h *StateRootHash) UnmarshalJSON(data []byte) error {
 	return (*Hash)(h).UnmarshalJSON(data)
 }
 
-func (h StateRootHash) MarshalJSON() ([]byte, error) {
-	return Hash(h).MarshalJSON()
+func (h StateRootHash) MarshalText() ([]byte, error) {
+	return Hash(h).MarshalText()
 }
 
 func (h *StateRootHash) Marshal() []byte {

--- a/rpc/v10/storage.go
+++ b/rpc/v10/storage.go
@@ -63,7 +63,7 @@ func (st *StorageAtResponse) MarshalJSON() ([]byte, error) {
 		return json.Marshal((*storageResultAlias)(st))
 	}
 
-	return st.Value.MarshalJSON()
+	return json.Marshal(st.Value)
 }
 
 // UnmarshalJSON implements the [json.Unmarshaler] interface for StorageAtResponse.

--- a/starknet/class.go
+++ b/starknet/class.go
@@ -26,7 +26,7 @@ func (o *EntryPointOffset) UnmarshalJSON(data []byte) error {
 }
 
 func (o EntryPointOffset) MarshalJSON() ([]byte, error) {
-	return (*felt.Felt)(&o).MarshalJSON()
+	return json.Marshal((*felt.Felt)(&o))
 }
 
 func (o EntryPointOffset) String() string {


### PR DESCRIPTION
*POC:* using json `marshalText` instead of `marshal`

It avoids reescanning the json for trimming and other reasons.

I still need to better understand the implications of this change.

The main goal here is to measure blast radius and smoke test.