### PR TITLE
feat(sync): add a genesis before polling pre-confirmed

### DIFF
--- a/blockchain/event_filter.go
+++ b/blockchain/event_filter.go
@@ -151,7 +151,7 @@ func (e *EventFilter) Events(
 	// neither the canonical range (stopped at the stale latest) nor pre_confirmed
 	// (based above them), a gap. This order makes latest >= the snapshot's base,
 	// so the ranges overlap instead. Pinning a fixed head wouldn't help: once a
-	// block commits, SnapshotForHead trims it, so a stale head yields an empty
+	// block commits, SnapshotForBlock trims it, so a stale head yields an empty
 	// view. On error, drop it and serve canonical only.
 	preConfirmed, err := e.preConfirmedFn()
 	if err != nil {

--- a/sync/preconfirmed/chain_storage.go
+++ b/sync/preconfirmed/chain_storage.go
@@ -33,16 +33,16 @@ type node struct {
 
 // ChainReader is an immutable snapshot of a contiguous run of pre-confirmed
 // blocks, ordered newest-first via parent pointers. Iteration must respect Length
-// — head-aligned views (see ChainStorage.SnapshotForHead) may stop
+// — head-aligned views (see [ChainStorage.SnapshotForBlock]) may stop
 // before the underlying linked list's nil terminator.
 type ChainReader struct {
 	head   *node
 	length int
 }
 
-// NewChain builds a ChainReader from non-nil pre-confirmed entries given in
+// NewChain builds a [ChainReader] from non-nil pre-confirmed entries given in
 // oldest-first order with contiguous block numbers. No args returns the
-// zero-value ChainReader.
+// zero-value [ChainReader]. If an entry has block number 0 behaviour is undefined.
 func NewChain(entries ...*pending.PreConfirmed) (ChainReader, error) {
 	if len(entries) == 0 {
 		return ChainReader{}, nil
@@ -52,6 +52,7 @@ func NewChain(entries ...*pending.PreConfirmed) (ChainReader, error) {
 		if entry == nil {
 			return ChainReader{}, fmt.Errorf("entry %d is nil", index)
 		}
+
 		if index > 0 && entry.Block.Number != entries[index-1].Block.Number+1 {
 			return ChainReader{}, fmt.Errorf(
 				"non-contiguous block numbers at index %d (%d after %d)",
@@ -215,11 +216,7 @@ func (c *ChainReader) PreConfirmedStateBeforeIndexAt(
 func (c *ChainReader) baseState(
 	bcReader blockchain.Reader,
 ) (core.StateReader, blockchain.StateCloser, error) {
-	oldest := c.oldestPreConf()
-	if oldest == 0 {
-		return bcReader.StateAtBlockHash(&felt.Zero)
-	}
-	return bcReader.StateAtBlockNumber(oldest - 1)
+	return bcReader.StateAtBlockNumber(c.oldestPreConf() - 1)
 }
 
 // contains returns true when a non-empty chain reader contains a block with `blockNum`
@@ -241,7 +238,7 @@ func (c *ChainReader) oldestPreConf() uint64 {
 // the way back up, producing oldest-first iteration order without
 // materialising a slice. remaining bounds the depth so head-aligned views
 // stop short of the underlying linked list's nil terminator (relevant after
-// SnapshotForHead trims entries at or below the canonical head). Returns false
+// SnapshotForBlock trims entries at or below the canonical head). Returns false
 // when the yield callback aborts iteration. Depth equals the caller's Length.
 func walkOldestFirst(
 	current *node,
@@ -306,7 +303,9 @@ func (s *ChainStorage) ApplyUpdate(
 		return nil, nil
 	}
 	current := s.inner.Load()
-	newChain, affected, err := computeUpdate(current, update, blockNumber, baseTxCount, oldestPreConf)
+	newChain, affected, err := computeUpdate(
+		current, update, blockNumber, baseTxCount, oldestPreConf,
+	)
 	if err != nil {
 		return nil, err
 	}

--- a/sync/preconfirmed/chain_storage_test.go
+++ b/sync/preconfirmed/chain_storage_test.go
@@ -632,7 +632,7 @@ func TestChainReader(t *testing.T) {
 		testChainReaderPreConfirmedStateBeforeIndexAtBlockOutOfRange)
 	t.Run("PreConfirmedStateAt resolves base at the oldest slot minus one",
 		testChainReaderPreConfirmedStateAtBaseAlignsWithOldestPreConf)
-	t.Run("PreConfirmedStateAt at genesis resolves base via zero hash",
+	t.Run("PreConfirmedStateAt at genesis underflows",
 		testChainReaderPreConfirmedStateAtBaseAtGenesis)
 	t.Run("PreConfirmedStateAt surfaces bcReader error from base lookup",
 		testChainReaderPreConfirmedStateAtBaseError)
@@ -1055,12 +1055,11 @@ func testChainReaderPreConfirmedStateAtBaseAtGenesis(t *testing.T) {
 	view := s.SnapshotForBlock(0)
 
 	bc := mocks.NewMockReader(gomock.NewController(t))
-	bc.EXPECT().StateAtBlockHash(&felt.Zero).
-		Return(nil, func() error { return nil }, nil)
+	bc.EXPECT().StateAtBlockNumber(^uint64(0)).
+		Return(nil, func() error { return nil }, errors.New("some kind of underflow"))
 
-	_, closer, err := view.PreConfirmedStateAt(0, bc)
-	require.NoError(t, err)
-	require.NoError(t, closer())
+	_, _, err := view.PreConfirmedStateAt(0, bc)
+	require.ErrorContains(t, err, "some kind of underflow")
 }
 
 // testChainReaderPreConfirmedStateAtBaseError verifies that a bcReader failure

--- a/sync/preconfirmed/chain_storage_test.go
+++ b/sync/preconfirmed/chain_storage_test.go
@@ -506,7 +506,7 @@ func testAdvanceToFullDrop(t *testing.T) {
 // testAdvanceToReorgClearsAndRecovers simulates a canonical head reorg: the
 // chain was built on top of head=5 (entries at slots 6,7), then the canonical
 // head reverts to 3. Every stored entry's parent now references a discarded
-// block, so AdvanceTo must drop the whole chain. SnapshotForHead at the new
+// block, so AdvanceTo must drop the whole chain. SnapshotForBlock at the new
 // head reports empty (callers see no pre_confirmed), and the next poll
 // (applying a fresh block at the new head+1) bootstraps cleanly.
 func testAdvanceToReorgClearsAndRecovers(t *testing.T) {
@@ -534,22 +534,22 @@ func testAdvanceToReorgClearsAndRecovers(t *testing.T) {
 	assertChain(t, &recovered, entry(4, &b4))
 }
 
-// ---- TestChainStorageSnapshotForHead --------------------------------------
+// ---- TestChainStorageSnapshotForBlock -------------------------------------
 
-func TestChainStorageSnapshotForHead(t *testing.T) {
-	t.Run("empty storage returns zero-value view", testSnapshotForHeadEmpty)
-	t.Run("trims view when storage is briefly stale", testSnapshotForHeadStaleTrim)
-	t.Run("zero-value when head+1 is above most recent", testSnapshotForHeadEmptyAboveTip)
+func TestChainStorageSnapshotForBlock(t *testing.T) {
+	t.Run("empty storage returns zero-value view", testSnapshotForBlockEmpty)
+	t.Run("trims view when storage is briefly stale", testSnapshotForBlockStaleTrim)
+	t.Run("zero-value when head+1 is above most recent", testSnapshotForBlockEmptyAboveTip)
 }
 
-func testSnapshotForHeadEmpty(t *testing.T) {
+func testSnapshotForBlockEmpty(t *testing.T) {
 	s := preconfirmed.NewChainStorage()
 	view := s.SnapshotForBlock(oldestPreConfFor(100))
 	require.Zero(t, view.Length())
 	require.Nil(t, view.Head())
 }
 
-func testSnapshotForHeadStaleTrim(t *testing.T) {
+func testSnapshotForBlockStaleTrim(t *testing.T) {
 	// Bootstrap under head=0 → the chain's oldest slot is 1. Then a reader passes head=2
 	// before AdvanceTo has run.
 	storedOldest := oldestPreConfFor(0)
@@ -568,7 +568,7 @@ func testSnapshotForHeadStaleTrim(t *testing.T) {
 	assertChain(t, &full, rangeEntries(1, blocks)...)
 }
 
-func testSnapshotForHeadEmptyAboveTip(t *testing.T) {
+func testSnapshotForBlockEmptyAboveTip(t *testing.T) {
 	oldestPreConf := oldestPreConfFor(0)
 	s := preconfirmed.NewChainStorage()
 	for n := uint64(1); n <= 5; n++ {
@@ -1335,8 +1335,8 @@ func testPinnedSnapshotImmuneToAdvance(t *testing.T) {
 // view rebuild, 1 ChainReader + keep nodes for AdvanceTo) so a regression
 // that walks the whole chain or wraps the reader in a defensive copy shows up.
 func TestChainStorageAllocations(t *testing.T) {
-	t.Run("SnapshotForHead cached path is alloc-free", testAllocsSnapshotCached)
-	t.Run("SnapshotForHead view-trim is alloc-free", testAllocsSnapshotTrim)
+	t.Run("SnapshotForBlock cached path is alloc-free", testAllocsSnapshotCached)
+	t.Run("SnapshotForBlock view-trim is alloc-free", testAllocsSnapshotTrim)
 	t.Run("AdvanceTo when head hasn't moved is alloc-free", testAllocsAdvanceNoOp)
 	t.Run("AdvanceTo trim allocates 1 ChainReader + keep nodes", testAllocsAdvanceTrim)
 	t.Run("ApplyUpdate NoChange is alloc-free", testAllocsApplyNoChange)
@@ -1346,7 +1346,7 @@ func TestChainStorageAllocations(t *testing.T) {
 
 // testAllocsSnapshotCached pins the fast path where the reader's head aligns
 // with the storage's oldest slot, so the view length equals the stored length
-// and SnapshotForHead returns the stored ChainReader without rebuilding.
+// and SnapshotForBlock returns the stored ChainReader without rebuilding.
 func testAllocsSnapshotCached(t *testing.T) {
 	oldestPreConf := oldestPreConfFor(0)
 	s := preconfirmed.NewChainStorage()
@@ -1363,7 +1363,7 @@ func testAllocsSnapshotCached(t *testing.T) {
 // testAllocsSnapshotTrim pins the view-trim path: the reader's head sits above
 // the stored chain's oldest slot (storage briefly stale before AdvanceTo runs), so
 // the view is shorter than the stored chain and can't reuse the stored pointer.
-// Value-returning SnapshotForHead constructs the trimmed ChainReader in the
+// Value-returning SnapshotForBlock constructs the trimmed ChainReader in the
 // return slot — no heap allocation.
 func testAllocsSnapshotTrim(t *testing.T) {
 	storedOldest := oldestPreConfFor(0)

--- a/sync/preconfirmed/poller.go
+++ b/sync/preconfirmed/poller.go
@@ -2,6 +2,7 @@ package preconfirmed
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"sync/atomic"
 	"time"
@@ -9,6 +10,7 @@ import (
 	"github.com/NethermindEth/juno/blockchain"
 	"github.com/NethermindEth/juno/core"
 	"github.com/NethermindEth/juno/core/pending"
+	"github.com/NethermindEth/juno/db"
 	"github.com/NethermindEth/juno/feed"
 	"github.com/NethermindEth/juno/starknet"
 	"github.com/NethermindEth/juno/utils/log"
@@ -69,6 +71,9 @@ func NewPoller(
 	}
 }
 
+// Run polls the sequencer every interval and builds the pre-confirmed chain from it.
+// If the blockchain is empty (pre-genesis) then it will stall until the genesis block
+// is synced. It only stops on context cancellation.
 func (p *Poller) Run(ctx context.Context) {
 	if p.interval == 0 {
 		p.logger.Info("Pre-confirmed block polling is disabled")
@@ -76,6 +81,20 @@ func (p *Poller) Run(ctx context.Context) {
 	}
 	ticker := time.NewTicker(p.interval)
 	defer ticker.Stop()
+
+	// Guard to prevent the poller from initially running when we are at the genesis
+	// state. If the error is different than [db.ErrKeyNotFound] we assume the issue is
+	// something else and continue execution.
+	for {
+		if _, err := p.blockchain.Height(); !errors.Is(err, db.ErrKeyNotFound) {
+			break
+		}
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+		}
+	}
 
 	for {
 		select {

--- a/sync/preconfirmed/poller_test.go
+++ b/sync/preconfirmed/poller_test.go
@@ -281,6 +281,53 @@ func TestPollerColdBootstrapWithGap(t *testing.T) {
 	})
 }
 
+// Empty blockchain (pre-genesis): Run stalls without touching the data source.
+// Once the genesis block lands, the next tick bootstraps the chain as usual.
+func TestPollerStallsUntilGenesis(t *testing.T) {
+	t.Parallel()
+
+	// No header and no chain height written: Height() fails with ErrKeyNotFound.
+	testDB := memory.New()
+	bc := blockchain.New(testDB, &networks.Sepolia)
+	genesis := &core.Header{
+		Number:     0,
+		Hash:       new(felt.Felt).SetUint64(1),
+		ParentHash: &felt.Zero,
+	}
+
+	block1 := makeTestPreConfirmedBlock("r0", 1)
+
+	ctrl := gomock.NewController(t)
+	ds := mocks.NewMockStarknetData(ctrl)
+
+	synctest.Test(t, func(t *testing.T) {
+		h := wirePoller(t, bc, genesis, ds)
+		go h.poller.Run(t.Context())
+		synctest.Wait()
+
+		// Pre-genesis ticks: no expectations are registered on the mock yet, so
+		// any data-source call fails the test. Storage must stay empty.
+		time.Sleep(3 * tickInterval)
+		synctest.Wait()
+		view := h.storage.SnapshotForBlock(oldestPreConfFor(genesis.Number))
+		assertChain(t, &view)
+
+		// Genesis lands; the poll expectation only exists from here on.
+		require.NoError(t, core.WriteBlockHeaderByNumber(testDB, genesis))
+		require.NoError(t, core.WriteChainHeight(testDB, 0))
+		ds.EXPECT().PreConfirmedBlockLatest(gomock.Any(), "", uint64(0)).
+			Return(block1, uint64(1), nil)
+
+		// One interval for the guard to observe the new head, one more for the
+		// first real polling tick.
+		time.Sleep(2 * tickInterval)
+		synctest.Wait()
+
+		view = h.storage.SnapshotForBlock(oldestPreConfFor(genesis.Number))
+		assertChain(t, &view, entry(1, &block1))
+	})
+}
+
 // mostRecent already at target height and server returns NoChange: tick is a
 // pure no-op — no backfill, no apply, storage pointer unchanged.
 func TestPollerSameHeightNoBackfill(t *testing.T) {

--- a/sync/sync.go
+++ b/sync/sync.go
@@ -407,7 +407,9 @@ func (s *Synchronizer) storeTask(
 	}
 }
 
-func (s *Synchronizer) revertTask(ctx context.Context, lastPossiblyValidHeight uint64, resetStreams context.CancelFunc) {
+func (s *Synchronizer) revertTask(
+	ctx context.Context, lastPossiblyValidHeight uint64, resetStreams context.CancelFunc,
+) {
 	defer resetStreams()
 	shouldContinue := true
 	for shouldContinue {
@@ -444,11 +446,10 @@ func (s *Synchronizer) revertTask(ctx context.Context, lastPossiblyValidHeight u
 }
 
 func (s *Synchronizer) nextHeight() uint64 {
-	nextHeight := uint64(0)
-	if h, err := s.blockchain.Height(); err == nil {
-		nextHeight = h + 1
+	if height, err := s.blockchain.Height(); err == nil {
+		return height + 1
 	}
-	return nextHeight
+	return 0
 }
 
 func (s *Synchronizer) syncBlocks(syncCtx context.Context) {
@@ -592,18 +593,13 @@ func (s *Synchronizer) pollLatest(ctx context.Context) {
 
 func (s *Synchronizer) PreConfirmedChain() (preconfirmed.ChainReader, error) {
 	height, err := s.blockchain.Height()
-	preGenesis := errors.Is(err, db.ErrKeyNotFound)
-	if err != nil && !preGenesis {
+	if err != nil {
 		return preconfirmed.ChainReader{}, err
 	}
 
 	snapshot := s.preConfirmed.SnapshotForBlock(height + 1)
 	if snapshot.Length() > 0 {
 		return snapshot, nil
-	}
-
-	if preGenesis {
-		return preconfirmed.ChainReader{}, pending.ErrPreConfirmedNotFound
 	}
 
 	head, err := s.blockchain.HeadsHeader()


### PR DESCRIPTION
And remove all the guards required by genesis scattered around the code.