### PR TITLE
perf(felt): serialize felts via `MarshalText` instead of `MarshalJSON`

### DIFF
--- a/core/felt/address.go
+++ b/core/felt/address.go
@@ -14,8 +14,12 @@ func (a *Address) UnmarshalJSON(data []byte) error {
 	return (*Felt)(a).UnmarshalJSON(data)
 }
 
-func (a Address) MarshalJSON() ([]byte, error) {
-	return Felt(a).MarshalJSON()
+func (a Address) MarshalText() ([]byte, error) {
+	return Felt(a).MarshalText()
+}
+
+func (a Address) AppendText(data []byte) ([]byte, error) {
+	return Felt(a).AppendText(data)
 }
 
 func (a *Address) Marshal() []byte {

--- a/core/felt/felt.go
+++ b/core/felt/felt.go
@@ -1,10 +1,12 @@
 package felt
 
 import (
+	"encoding/binary"
 	"encoding/hex"
 	"errors"
 	"fmt"
 	"math/big"
+	"math/bits"
 	"sync"
 
 	"github.com/consensys/gnark-crypto/ecc/stark-curve/fp"
@@ -19,6 +21,10 @@ const (
 	Limbs = fp.Limbs // number of 64 bits words needed to represent a Element
 	Bits  = fp.Bits  // number of bits needed to represent a Element
 	Bytes = fp.Bytes // number of bytes needed to represent a Element
+
+	// Max number of chars to represent a Felt as Hex.
+	// 0x at the start + 2 chars per byte.
+	MaxFeltAsHexSize = len("0x") + Bytes*2
 )
 
 var Zero = Felt{}
@@ -46,60 +52,78 @@ func (z *Felt) Impl() *fp.Element {
 }
 
 // UnmarshalJSON accepts a quoted, 0x-prefixed hex string and sets z.
-// Zero-alloc: pads hex into a fixed [64]byte and lets hex.Decode do the parsing.
+//
+// TODO(granza): move to UnmarshalText after migrating to json/v2
+//
+// The UnmarshalJSON interface is faster than the UnmarshalText one on json/v1.
+// json/v1 treats the input of UnmarshalText as if it could have escaped chars,
+// so it triggers an upfront check scan. This is no longer the case for json/v2.
 func (z *Felt) UnmarshalJSON(data []byte) error {
-	if len(data) < 5 || data[0] != '"' || data[len(data)-1] != '"' {
-		return errors.New("felt: expected quoted 0x hex string")
-	}
-	if data[1] != '0' || (data[2] != 'x' && data[2] != 'X') {
-		return errors.New("felt: missing 0x prefix")
+	dataSize := len(data)
+	if dataSize < len(`"0x0"`) || data[0] != '"' || data[dataSize-1] != '"' {
+		return errors.New("felt: expected a quoted 0x hex string")
 	}
 
-	src := data[3 : len(data)-1] // hex digits after "0x
-	// maxHexDigits is the maximum number of hex digits in a felt value (32 bytes = 64 hex chars).
-	const maxHexDigits = Bytes * 2
-	if len(src) > maxHexDigits {
+	digits := data[1 : dataSize-1]
+	if digits[0] != '0' || (digits[1] != 'x' && digits[1] != 'X') {
+		return errors.New("felt: expected hex string starting with 0x")
+	}
+	if len(digits) > MaxFeltAsHexSize {
 		return errors.New("felt: value exceeds field size")
 	}
+	digits = digits[2:]
 
-	// Left-pad with '0' to 64 hex chars so hex.Decode produces exactly 32 bytes.
-	var padded [maxHexDigits]byte
-	for i := range padded {
-		padded[i] = '0'
+	// hex.Decode consumes digits in pairs, so an odd number means a leading zero.
+	if len(digits)%2 == 1 {
+		var padded [MaxFeltAsHexSize]byte
+		padded[0] = '0'
+		copiedSize := copy(padded[1:], digits)
+		digits = padded[:copiedSize+1]
 	}
-	copy(padded[maxHexDigits-len(src):], src)
 
-	var buf [Bytes]byte
-	if _, err := hex.Decode(buf[:], padded[:]); err != nil {
+	var buffer [Bytes]byte
+	leadingZeros := Bytes - len(digits)/2
+	if _, err := hex.Decode(buffer[leadingZeros:], digits); err != nil {
 		return fmt.Errorf("felt: couldn't decode hex value: %w", err)
 	}
-	return (*fp.Element)(z).SetBytesCanonical(buf[:])
+
+	return (*fp.Element)(z).SetBytesCanonical(buffer[:])
 }
 
-// MarshalJSON returns the felt as a quoted 0x hex string with no
-// unnecessary leading zeros. Uses a value receiver so encoding/json
-// can call it on non-addressable values (struct fields in `any`).
-func (z Felt) MarshalJSON() ([]byte, error) {
+// MarshalText returns the felt as an unquoted 0x hex string with no
+// unnecessary leading zeros. The quotes are placed at the encoding/json level.
+// Uses a value receiver so encoding/json can call it on non-addressable
+// values (struct fields in `any`).
+func (z Felt) MarshalText() ([]byte, error) {
+	return z.AppendText(make([]byte, 0, MaxFeltAsHexSize))
+}
+
+// AppendText appends the felt's 0x hex representation to data.
+// The quotes are placed at the encoding/json level.
+// It is a json/v2 interface and enforces appending.
+func (z Felt) AppendText(data []byte) ([]byte, error) {
 	var raw [Bytes]byte
 	fp.BigEndian.PutElement(&raw, fp.Element(z))
 
-	// Find first significant byte.
-	i := 0
-	for i < Bytes-1 && raw[i] == 0 {
-		i++
+	// Find the first non zero byte
+	firstByteIdx := Bytes - 1
+	for chunk := 0; chunk < Bytes; chunk += 8 {
+		value := binary.BigEndian.Uint64(raw[chunk:])
+		if value != 0 {
+			firstByteIdx = chunk + bits.LeadingZeros64(value)/8
+			break
+		}
 	}
 
-	out := make([]byte, 3, 4+(Bytes-i)*2)
-	out[0], out[1], out[2] = '"', '0', 'x'
+	data = append(data, '0', 'x')
 
 	// First byte may need a single hex digit (e.g. 0x3, not 0x03).
-	if raw[i] < Base16 {
-		out = append(out, "0123456789abcdef"[raw[i]])
-		i++
+	if raw[firstByteIdx] < Base16 {
+		data = append(data, "0123456789abcdef"[raw[firstByteIdx]])
+		firstByteIdx++
 	}
-	out = hex.AppendEncode(out, raw[i:])
 
-	return append(out, '"'), nil
+	return hex.AppendEncode(data, raw[firstByteIdx:]), nil
 }
 
 // SetBytes forwards the call to underlying field element implementation

--- a/core/felt/felt_benchmark_test.go
+++ b/core/felt/felt_benchmark_test.go
@@ -1,15 +1,10 @@
 package felt_test
 
 import (
+	"encoding/json"
 	"testing"
 
 	"github.com/NethermindEth/juno/core/felt"
-)
-
-// Sinks prevent the compiler from optimising benchmark work away.
-var (
-	benchBytesSink []byte
-	benchFeltSink  felt.Felt
 )
 
 func benchFeltInputs(b *testing.B) []struct {
@@ -26,22 +21,47 @@ func benchFeltInputs(b *testing.B) []struct {
 		{"small", "0xdeadbeef"},
 		{"address", "0x49d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7"},
 		{"max_felt", "0x800000000000011000000000000000000000000000000000000000000000000"},
-		// Full-width (64-hex-char) input exercises the leading-zero-pad path on unmarshal.
+		// Full-width (64-hex-char) input exercises the widest decode on unmarshal.
 		{"padded_address", "0x049d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7"},
 		{"random", random.String()},
 	}
 }
 
-func BenchmarkMarshalJSON(b *testing.B) {
+// Measures both the encoding/json cost + the actual marshaling
+func BenchmarkJSONMarshal(b *testing.B) {
 	for _, tc := range benchFeltInputs(b) {
 		value := felt.UnsafeFromString[felt.Felt](tc.hex)
 		b.Run(tc.name, func(b *testing.B) {
 			b.ReportAllocs()
-			var out []byte
 			for b.Loop() {
-				out, _ = value.MarshalJSON()
+				_, _ = json.Marshal(value)
 			}
-			benchBytesSink = out
+		})
+	}
+}
+
+func BenchmarkMarshalText(b *testing.B) {
+	for _, tc := range benchFeltInputs(b) {
+		value := felt.UnsafeFromString[felt.Felt](tc.hex)
+		b.Run(tc.name, func(b *testing.B) {
+			b.ReportAllocs()
+			for b.Loop() {
+				_, _ = value.MarshalText()
+			}
+		})
+	}
+}
+
+// Measures both the encoding/json cost + the actual unmarshaling
+func BenchmarkJSONUnmarshal(b *testing.B) {
+	for _, tc := range benchFeltInputs(b) {
+		input := []byte(`"` + tc.hex + `"`)
+		b.Run(tc.name, func(b *testing.B) {
+			b.ReportAllocs()
+			var value felt.Felt
+			for b.Loop() {
+				_ = json.Unmarshal(input, &value)
+			}
 		})
 	}
 }
@@ -55,7 +75,6 @@ func BenchmarkUnmarshalJSON(b *testing.B) {
 			for b.Loop() {
 				_ = value.UnmarshalJSON(input)
 			}
-			benchFeltSink = value
 		})
 	}
 }
@@ -75,11 +94,9 @@ func BenchmarkMarshalCBOR(b *testing.B) {
 		value := felt.UnsafeFromString[felt.Felt](tc.hex)
 		b.Run(tc.name, func(b *testing.B) {
 			b.ReportAllocs()
-			var out []byte
 			for b.Loop() {
-				out, _ = value.MarshalCBOR()
+				_, _ = value.MarshalCBOR()
 			}
-			benchBytesSink = out
 		})
 	}
 }
@@ -97,7 +114,6 @@ func BenchmarkUnmarshalCBOR(b *testing.B) {
 			for b.Loop() {
 				_ = out.UnmarshalCBOR(input)
 			}
-			benchFeltSink = out
 		})
 	}
 }

--- a/core/felt/felt_test.go
+++ b/core/felt/felt_test.go
@@ -1,6 +1,7 @@
 package felt_test
 
 import (
+	"encoding"
 	"encoding/json"
 	"strings"
 	"testing"
@@ -10,29 +11,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
-
-func TestUnmarshalJson(t *testing.T) {
-	t.Run("with prefix 0x", func(t *testing.T) {
-		var f felt.Felt
-		assert.NoError(t, f.UnmarshalJSON([]byte(`"0x4437ab"`)))
-	})
-
-	var failF felt.Felt
-
-	fails := []string{
-		"4437ab",
-		"123456",
-		"0x2000000000000000000000000000000000000000000000000000000000000000000",
-		"0x800000000000011000000000000000000000000000000000000000000000001",
-		"0xfb01012100000000000000000000000000000000000000000000000000000000",
-	}
-
-	for _, hex := range fails {
-		t.Run(hex+" fails", func(t *testing.T) {
-			assert.Error(t, failF.UnmarshalJSON([]byte(hex)))
-		})
-	}
-}
 
 func TestFeltCbor(t *testing.T) {
 	val := felt.NewRandom[felt.Felt]()
@@ -61,11 +39,11 @@ func TestShortString(t *testing.T) {
 	})
 }
 
-// TestMarshalJSON_ValueInInterface reproduces a bug where felt types serialised
-// as [4]uint64 limbs instead of hex strings. This happens because MarshalJSON
-// uses a pointer receiver, but encoding/json cannot call pointer-receiver methods
-// on non-addressable values (e.g. struct fields inside a value stored in `any`).
-func TestMarshalJSON_ValueInInterface(t *testing.T) {
+// TestJSONMarshal_ValueInInterface guards against a bug where felt types serialise
+// as [4]uint64 limbs instead of hex strings. This would happen if MarshalText
+// used a pointer receiver, which encoding/json cannot call on non-addressable
+// values (e.g. struct fields inside a value stored in `any`).
+func TestJSONMarshal_ValueInInterface(t *testing.T) {
 	f := felt.UnsafeFromString[felt.Felt]("0xdeadbeef")
 
 	// Simulates how jsonrpc server stores handler results:
@@ -109,6 +87,24 @@ func TestMarshalJSON_ValueInInterface(t *testing.T) {
 			}{V: felt.ClassHash(f)},
 		},
 		{
+			name: "SierraClassHash value field in struct value",
+			input: struct {
+				V felt.SierraClassHash `json:"v"`
+			}{V: felt.SierraClassHash(f)},
+		},
+		{
+			name: "CasmClassHash value field in struct value",
+			input: struct {
+				V felt.CasmClassHash `json:"v"`
+			}{V: felt.CasmClassHash(f)},
+		},
+		{
+			name: "StateRootHash value field in struct value",
+			input: struct {
+				V felt.StateRootHash `json:"v"`
+			}{V: felt.StateRootHash(f)},
+		},
+		{
 			name: "pointer field works (control)",
 			input: struct {
 				V *felt.Felt `json:"v"`
@@ -127,7 +123,7 @@ func TestMarshalJSON_ValueInInterface(t *testing.T) {
 
 			// Must contain "0xdeadbeef" as a hex string, not uint64 limbs
 			assert.Contains(t, s, "0xdeadbeef",
-				"expected hex string, got limbs — pointer-receiver MarshalJSON"+
+				"expected hex string, got limbs — pointer-receiver MarshalText"+
 					" not called on non-addressable value")
 			assert.False(t, strings.Contains(s, "[") && strings.Contains(s, ","),
 				"got JSON array (raw [4]uint64 limbs) instead of hex string")
@@ -146,7 +142,7 @@ func TestFeltMarshalAndUnmarshal(t *testing.T) {
 	assert.True(t, f2.Equal(f))
 }
 
-func TestMarshalJSON(t *testing.T) {
+func TestJSONMarshal(t *testing.T) {
 	tests := []struct {
 		name   string
 		hex    string
@@ -174,14 +170,25 @@ func TestMarshalJSON(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			f := felt.UnsafeFromString[felt.Felt](tc.hex)
-			got, err := f.MarshalJSON()
+			got, err := json.Marshal(f)
 			require.NoError(t, err)
 			assert.Equal(t, tc.expect, string(got))
 		})
 	}
 }
 
-func TestUnmarshalJSON(t *testing.T) {
+func TestJSONMarshalMatchesString(t *testing.T) {
+	for range 1000 {
+		f := felt.Random[felt.Felt]()
+
+		jsonBytes, err := json.Marshal(f)
+		require.NoError(t, err)
+
+		assert.Equal(t, `"`+f.String()+`"`, string(jsonBytes))
+	}
+}
+
+func TestJSONUnmarshal(t *testing.T) {
 	t.Run("valid values", func(t *testing.T) {
 		tests := []struct {
 			name  string
@@ -212,7 +219,7 @@ func TestUnmarshalJSON(t *testing.T) {
 		for _, tc := range tests {
 			t.Run(tc.name, func(t *testing.T) {
 				var f felt.Felt
-				err := f.UnmarshalJSON([]byte(tc.input))
+				err := json.Unmarshal([]byte(tc.input), &f)
 				require.NoError(t, err)
 				assert.Equal(t, tc.hex, f.String())
 			})
@@ -249,7 +256,7 @@ func TestUnmarshalJSON(t *testing.T) {
 		for _, tc := range tests {
 			t.Run(tc.name, func(t *testing.T) {
 				var f felt.Felt
-				assert.Error(t, f.UnmarshalJSON([]byte(tc.input)))
+				assert.Error(t, json.Unmarshal([]byte(tc.input), &f))
 			})
 		}
 	})
@@ -298,4 +305,98 @@ func TestJSONRoundTripRandom(t *testing.T) {
 		assert.True(t, original.Equal(&decoded),
 			"round-trip failed for random felt: marshalled=%s", string(marshalled))
 	}
+}
+
+func TestFeltsWrappers(t *testing.T) {
+	type textCodec interface {
+		encoding.TextMarshaler
+		encoding.TextAppender
+		json.Unmarshaler
+	}
+
+	wrappers := map[string]textCodec{
+		"Felt":            new(felt.Felt),
+		"Address":         new(felt.Address),
+		"Hash":            new(felt.Hash),
+		"ClassHash":       new(felt.ClassHash),
+		"SierraClassHash": new(felt.SierraClassHash),
+		"CasmClassHash":   new(felt.CasmClassHash),
+		"TransactionHash": new(felt.TransactionHash),
+		"StateRootHash":   new(felt.StateRootHash),
+	}
+
+	for name, w := range wrappers {
+		t.Run(name, func(t *testing.T) {
+			require.NoError(t, w.UnmarshalJSON([]byte(`"0xDEADc0de"`)))
+
+			// MarshalText path (via json/v1).
+			got, err := w.MarshalText()
+			require.NoError(t, err)
+			assert.Equal(t, `0xdeadc0de`, string(got))
+
+			// AppendText path (via json/v2).
+			appended, err := w.AppendText([]byte("prefix:"))
+			require.NoError(t, err)
+			assert.Equal(t, "prefix:0xdeadc0de", string(appended))
+
+			require.Error(t, w.UnmarshalJSON([]byte(`"0xerror"`)))
+		})
+	}
+}
+
+func FuzzFeltMarshal(f *testing.F) {
+	f.Add([]byte{0x0})
+	f.Add([]byte{0x1})
+	f.Add([]byte{0xff})
+	f.Add([]byte{0xde, 0xad, 0xbe, 0xef})
+
+	f.Fuzz(func(t *testing.T, b []byte) {
+		original := new(felt.Felt).SetBytes(b)
+
+		text, err := original.MarshalText()
+		require.NoError(t, err)
+		assert.Equal(t, original.String(), string(text))
+
+		marshalled, err := json.Marshal(original)
+		require.NoError(t, err)
+		assert.Equal(t, `"`+string(text)+`"`, string(marshalled))
+
+		var decoded felt.Felt
+		require.NoError(t, json.Unmarshal(marshalled, &decoded))
+		assert.True(t, original.Equal(&decoded),
+			"round-trip failed: marshalled=%s", string(marshalled))
+	})
+}
+
+func FuzzFeltUnmarshal(f *testing.F) {
+	f.Add([]byte(`"0x0"`))
+	f.Add([]byte(`"0xdeadbeef"`))
+	f.Add([]byte(`"0Xabc"`))
+	f.Add([]byte(`"0x800000000000011000000000000000000000000000000000000000000000000"`))
+	f.Add([]byte(`"0x1` + strings.Repeat("0", 64) + `"`)) // 65 digits, over the limit
+	f.Add([]byte(`"0x"`))
+	f.Add([]byte(`""`))
+	f.Add([]byte(`"`))
+	f.Add([]byte(`5`))
+	f.Add([]byte(``))
+
+	f.Fuzz(func(t *testing.T, data []byte) {
+		var decoded felt.Felt
+		if err := decoded.UnmarshalJSON(data); err != nil {
+			return // rejecting is fine
+		}
+
+		reference, err := new(felt.Felt).SetString(string(data[1 : len(data)-1]))
+		require.NoError(t, err, "accepted %q that SetString rejects", data)
+		assert.True(t, decoded.Equal(reference), "input %q: got %s want %s",
+			data, decoded.String(), reference.String(),
+		)
+
+		marshalled, err := json.Marshal(decoded)
+		require.NoError(t, err)
+
+		var roundTrip felt.Felt
+		require.NoError(t, json.Unmarshal(marshalled, &roundTrip))
+		assert.True(t, decoded.Equal(&roundTrip))
+	})
 }

--- a/core/felt/hash.go
+++ b/core/felt/hash.go
@@ -14,8 +14,12 @@ func (h *Hash) UnmarshalJSON(data []byte) error {
 	return (*Felt)(h).UnmarshalJSON(data)
 }
 
-func (h Hash) MarshalJSON() ([]byte, error) {
-	return Felt(h).MarshalJSON()
+func (h Hash) MarshalText() ([]byte, error) {
+	return Felt(h).MarshalText()
+}
+
+func (h Hash) AppendText(data []byte) ([]byte, error) {
+	return Felt(h).AppendText(data)
 }
 
 func (h *Hash) Marshal() []byte {
@@ -40,8 +44,12 @@ func (h *ClassHash) UnmarshalJSON(data []byte) error {
 	return (*Hash)(h).UnmarshalJSON(data)
 }
 
-func (h ClassHash) MarshalJSON() ([]byte, error) {
-	return Hash(h).MarshalJSON()
+func (h ClassHash) MarshalText() ([]byte, error) {
+	return Hash(h).MarshalText()
+}
+
+func (h ClassHash) AppendText(data []byte) ([]byte, error) {
+	return Hash(h).AppendText(data)
 }
 
 func (h *ClassHash) Marshal() []byte {
@@ -66,8 +74,12 @@ func (h *SierraClassHash) UnmarshalJSON(data []byte) error {
 	return (*ClassHash)(h).UnmarshalJSON(data)
 }
 
-func (h SierraClassHash) MarshalJSON() ([]byte, error) {
-	return ClassHash(h).MarshalJSON()
+func (h SierraClassHash) MarshalText() ([]byte, error) {
+	return ClassHash(h).MarshalText()
+}
+
+func (h SierraClassHash) AppendText(data []byte) ([]byte, error) {
+	return ClassHash(h).AppendText(data)
 }
 
 func (h *SierraClassHash) Marshal() []byte {
@@ -92,8 +104,12 @@ func (h *CasmClassHash) UnmarshalJSON(data []byte) error {
 	return (*ClassHash)(h).UnmarshalJSON(data)
 }
 
-func (h CasmClassHash) MarshalJSON() ([]byte, error) {
-	return ClassHash(h).MarshalJSON()
+func (h CasmClassHash) MarshalText() ([]byte, error) {
+	return ClassHash(h).MarshalText()
+}
+
+func (h CasmClassHash) AppendText(data []byte) ([]byte, error) {
+	return ClassHash(h).AppendText(data)
 }
 
 func (h *CasmClassHash) Marshal() []byte {
@@ -118,8 +134,12 @@ func (h *TransactionHash) UnmarshalJSON(data []byte) error {
 	return (*Hash)(h).UnmarshalJSON(data)
 }
 
-func (h TransactionHash) MarshalJSON() ([]byte, error) {
-	return Hash(h).MarshalJSON()
+func (h TransactionHash) MarshalText() ([]byte, error) {
+	return Hash(h).MarshalText()
+}
+
+func (h TransactionHash) AppendText(data []byte) ([]byte, error) {
+	return Hash(h).AppendText(data)
 }
 
 func (h *TransactionHash) Marshal() []byte {
@@ -144,8 +164,12 @@ func (h *StateRootHash) UnmarshalJSON(data []byte) error {
 	return (*Hash)(h).UnmarshalJSON(data)
 }
 
-func (h StateRootHash) MarshalJSON() ([]byte, error) {
-	return Hash(h).MarshalJSON()
+func (h StateRootHash) MarshalText() ([]byte, error) {
+	return Hash(h).MarshalText()
+}
+
+func (h StateRootHash) AppendText(data []byte) ([]byte, error) {
+	return Hash(h).AppendText(data)
 }
 
 func (h *StateRootHash) Marshal() []byte {

--- a/rpc/v10/storage.go
+++ b/rpc/v10/storage.go
@@ -63,7 +63,21 @@ func (st *StorageAtResponse) MarshalJSON() ([]byte, error) {
 		return json.Marshal((*storageResultAlias)(st))
 	}
 
-	return st.Value.MarshalJSON()
+	// Not calling MarshalText directly since we need a quoted JSON hex
+	return st.marshalAsQuotedHex()
+}
+
+func (st *StorageAtResponse) marshalAsQuotedHex() ([]byte, error) {
+	// 2 quotes + MaxFeltAsHexSize
+	out := make([]byte, 0, 2+felt.MaxFeltAsHexSize)
+	out = append(out, '"')
+
+	out, err := st.Value.AppendText(out)
+	if err != nil {
+		return nil, err
+	}
+
+	return append(out, '"'), nil
 }
 
 // UnmarshalJSON implements the [json.Unmarshaler] interface for StorageAtResponse.

--- a/starknet/class.go
+++ b/starknet/class.go
@@ -25,8 +25,12 @@ func (o *EntryPointOffset) UnmarshalJSON(data []byte) error {
 	return err
 }
 
-func (o EntryPointOffset) MarshalJSON() ([]byte, error) {
-	return (*felt.Felt)(&o).MarshalJSON()
+func (o EntryPointOffset) MarshalText() ([]byte, error) {
+	return felt.Felt(o).MarshalText()
+}
+
+func (o EntryPointOffset) AppendText(data []byte) ([]byte, error) {
+	return felt.Felt(o).AppendText(data)
 }
 
 func (o EntryPointOffset) String() string {

--- a/starknet/class_test.go
+++ b/starknet/class_test.go
@@ -47,6 +47,35 @@ func TestEntryPointOffset(t *testing.T) {
 		require.NoError(t, err)
 		assert.Equal(t, `"0xa1"`, string(b))
 	})
+
+	t.Run("append text", func(t *testing.T) {
+		var o EntryPointOffset
+		require.NoError(t, json.Unmarshal([]byte(`"0xa1"`), &o))
+
+		appended, err := o.AppendText([]byte("prefix:"))
+		require.NoError(t, err)
+		assert.Equal(t, "prefix:0xa1", string(appended))
+
+		text, err := o.MarshalText()
+		require.NoError(t, err)
+		assert.Equal(t, "prefix:"+string(text), string(appended))
+	})
+
+	// MarshalText has to keep a value receiver: encoding/json cannot call a
+	// pointer-receiver method on a non-addressable value, and would silently fall
+	// back to encoding the underlying [4]uint64 limbs as a JSON array.
+	t.Run("value field in struct value", func(t *testing.T) {
+		var o EntryPointOffset
+		require.NoError(t, json.Unmarshal([]byte(`"0xa1"`), &o))
+
+		var result any = struct {
+			V EntryPointOffset `json:"v"`
+		}{V: o}
+
+		got, err := json.Marshal(result)
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"v":"0xa1"}`, string(got))
+	})
 }
 
 func TestSegmentLengthsUnmarshal(t *testing.T) {


### PR DESCRIPTION
### *This is the baseline before any migration to json/v2.

It gives a generalized json Marshal optimization for felts without using jsonv2. 
`Felts` are now marshaled as strings as they are hexadecimal values.

It introduces `MarshalText` (instant optimization) and `AppendText` (optimization when jsonv2 is available).

It scales with the json/v2 upgrade. Coming in [following PRs](https://github.com/NethermindEth/juno/pull/3881)

On a saturated node, RPC `getClass` receives 1.28x throughput increment.

#### `json.Marshal`
input | main | this PR | speedup
-- | -- | -- | --
0x0 | 94.9 ns · 48 B · 3 allocs | 75.1 ns · 120 B · 3 allocs | 1.26x
0xdeadbeef | 118.6 ns · 64 B · 3 allocs | 79.9 ns · 128 B · 3 allocs | 1.48x
address (63 díg.) | 297.8 ns · 192 B · 3 allocs | 136.1 ns · 192 B · 3 allocs | 2.19x
max felt | 299.3 ns · 192 B · 3 allocs | 136.0 ns · 192 B · 3 allocs | 2.20x

#### `json.Unmarshal`
input | main | this PR | speedup
-- | -- | -- | --
0x0 | 107.3 ns · 144 B · 1 alloc | 73.4 ns · 144 B · 1 alloc | 1.46x
0xdeadbeef | 124.5 ns · 144 B · 1 alloc | 90.9 ns · 144 B · 1 alloc | 1.37x
address (63 díg.) | 269.0 ns · 144 B · 1 alloc | 255.4 ns · 144 B · 1 alloc | 1.05x
max felt | 269.9 ns · 144 B · 1 alloc | 262.9 ns · 144 B · 1 alloc | 1.03x

## Tests:

- fuzz test up to 2M
- RPC `getClass` stress test outputs comparison


Closes issue: https://github.com/NethermindEth/juno/issues/3824