### PR TITLE
refactor(core): use lean header accessors

### DIFF
--- a/blockchain/blockchain.go
+++ b/blockchain/blockchain.go
@@ -40,6 +40,7 @@ type Reader interface {
 
 	HeadsHeader() (header *core.Header, err error)
 	BlockHeaderByNumber(number uint64) (header *core.Header, err error)
+	BlockHeaderHashByNumber(number uint64) (blockHash *felt.Felt, err error)
 	BlockHeaderByHash(hash *felt.Felt) (header *core.Header, err error)
 	BlockTransactionCountByNumber(number uint64) (count uint64, err error)
 
@@ -210,6 +211,16 @@ func (b *Blockchain) BlockHeaderByNumber(number uint64) (*core.Header, error) {
 func (b *Blockchain) BlockTransactionCountByNumber(number uint64) (uint64, error) {
 	b.listener.OnRead("BlockTransactionCountByNumber")
 	return core.GetBlockTransactionCountByNumber(b.database, number)
+}
+
+func (b *Blockchain) BlockHeaderHashByNumber(number uint64) (*felt.Felt, error) {
+	b.listener.OnRead("BlockHeaderHashByNumber")
+	return core.GetBlockHeaderHashByNumber(b.database, number)
+}
+
+func (b *Blockchain) GlobalStateRootByBlockNumber(number uint64) (*felt.Felt, error) {
+	b.listener.OnRead("GlobalStateRootByBlockNumber")
+	return core.GetGlobalStateRootByBlockNumber(b.database, number)
 }
 
 func (b *Blockchain) BlockNumberByHash(hash *felt.Felt) (uint64, error) {

--- a/blockchain/statebackend/block_ops.go
+++ b/blockchain/statebackend/block_ops.go
@@ -12,12 +12,18 @@ import (
 
 var ErrParentDoesNotMatchHead = errors.New("block's parent hash does not match head block hash")
 
-func headsHeader(reader db.KeyValueReader) (*core.Header, error) {
+// headNumberAndHash returns the chain head's number and hash without decoding
+// the heavier header fields.
+func headNumberAndHash(reader db.KeyValueReader) (uint64, *felt.Felt, error) {
 	height, err := core.GetChainHeight(reader)
 	if err != nil {
-		return nil, err
+		return 0, nil, err
 	}
-	return core.GetBlockHeaderByNumber(reader, height)
+	blockHash, err := core.GetBlockHeaderHashByNumber(reader, height)
+	if err != nil {
+		return 0, nil, err
+	}
+	return height, blockHash, nil
 }
 
 // verifyBlockSuccession checks that the block follows the current chain head.
@@ -29,10 +35,10 @@ func verifyBlockSuccession(reader db.KeyValueReader, block *core.Block) error {
 	expectedBlockNumber := uint64(0)
 	expectedParentHash := &felt.Zero
 
-	h, err := headsHeader(reader)
+	blockNumber, blockHash, err := headNumberAndHash(reader)
 	if err == nil {
-		expectedBlockNumber = h.Number + 1
-		expectedParentHash = h.Hash
+		expectedBlockNumber = blockNumber + 1
+		expectedParentHash = blockHash
 	} else if !errors.Is(err, db.ErrKeyNotFound) {
 		return err
 	}
@@ -159,7 +165,7 @@ func deleteBlockContent(
 	stateUpdate *core.StateUpdate,
 	blockNumber uint64,
 ) error {
-	header, err := core.GetBlockHeaderByNumber(reader, blockNumber)
+	blockHash, err := core.GetBlockHeaderHashByNumber(reader, blockNumber)
 	if err != nil {
 		return err
 	}
@@ -171,9 +177,9 @@ func deleteBlockContent(
 	genesisBlock := blockNumber == 0
 
 	for _, key := range [][]byte{
-		db.BlockHeaderByNumberKey(header.Number),
-		db.BlockHeaderNumbersByHashKey(header.Hash),
-		db.BlockCommitmentsKey(header.Number),
+		db.BlockHeaderByNumberKey(blockNumber),
+		db.BlockHeaderNumbersByHashKey(blockHash),
+		db.BlockCommitmentsKey(blockNumber),
 	} {
 		if err = writer.Delete(key); err != nil {
 			return err

--- a/blockchain/statebackend/statebackend.go
+++ b/blockchain/statebackend/statebackend.go
@@ -34,12 +34,15 @@ func (b *stateBackend) HeadState() (core.StateReader, StateCloser, error) {
 func (b *stateBackend) StateAtBlockNumber(
 	blockNumber uint64,
 ) (core.StateReader, StateCloser, error) {
-	header, err := pruner.HeaderByNumberIfStateRetained(b.database, blockNumber)
+	if err := pruner.RequireStateRetainedByBlockNumber(b.database, blockNumber); err != nil {
+		return nil, nil, err
+	}
+	stateRoot, err := core.GetGlobalStateRootByBlockNumber(b.database, blockNumber)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	history, err := state.NewStateHistory(blockNumber, header.GlobalStateRoot, b.stateDB)
+	history, err := state.NewStateHistory(blockNumber, stateRoot, b.stateDB)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -57,12 +60,16 @@ func (b *stateBackend) StateAtBlockHash(
 		return st, NoopStateCloser, nil
 	}
 
-	header, err := pruner.HeaderByHashIfStateRetained(b.database, blockHash)
+	blockNumber, err := core.GetBlockHeaderNumberByHash(b.database, blockHash)
+	if err != nil {
+		return nil, nil, err
+	}
+	stateRoot, err := core.GetGlobalStateRootByBlockNumber(b.database, blockNumber)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	history, err := state.NewStateHistory(header.Number, header.GlobalStateRoot, b.stateDB)
+	history, err := state.NewStateHistory(blockNumber, stateRoot, b.stateDB)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/blockchain/statebackend/statebackend.go
+++ b/blockchain/statebackend/statebackend.go
@@ -34,10 +34,7 @@ func (b *stateBackend) HeadState() (core.StateReader, StateCloser, error) {
 func (b *stateBackend) StateAtBlockNumber(
 	blockNumber uint64,
 ) (core.StateReader, StateCloser, error) {
-	if err := pruner.RequireStateRetainedByBlockNumber(b.database, blockNumber); err != nil {
-		return nil, nil, err
-	}
-	stateRoot, err := core.GetGlobalStateRootByBlockNumber(b.database, blockNumber)
+	stateRoot, err := pruner.StateRootIfStateRetainedByBlockNumber(b.database, blockNumber)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/builder/builder.go
+++ b/builder/builder.go
@@ -130,11 +130,7 @@ func (b *Builder) getRevealedBlockHash(blockHeight uint64) (*felt.Felt, error) {
 		return nil, nil
 	}
 
-	header, err := b.blockchain.BlockHeaderByNumber(blockHeight - BlockHashLag)
-	if err != nil {
-		return nil, err
-	}
-	return header.Hash, nil
+	return b.blockchain.BlockHeaderHashByNumber(blockHeight - BlockHashLag)
 }
 
 func (b *Builder) PendingState(

--- a/builder/builder.go
+++ b/builder/builder.go
@@ -168,6 +168,9 @@ func (b *Builder) Finish(state *BuildState) (BuildResult, error) {
 		return BuildResult{}, err
 	}
 
+	block := state.PreConfirmed.Block
+	block.EventsBloom = core.EventsBloom(block.Receipts)
+
 	if simulatedResult.ConcatCount.IsZero() {
 		simulatedResult.BlockCommitments = &core.BlockCommitments{
 			TransactionCommitment: new(felt.Felt).SetUint64(0),

--- a/builder/builder_test.go
+++ b/builder/builder_test.go
@@ -1,0 +1,56 @@
+package builder_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/NethermindEth/juno/blockchain"
+	"github.com/NethermindEth/juno/blockchain/networks"
+	"github.com/NethermindEth/juno/builder"
+	"github.com/NethermindEth/juno/core"
+	"github.com/NethermindEth/juno/core/felt"
+	statetestutils "github.com/NethermindEth/juno/core/state/testutils"
+	"github.com/NethermindEth/juno/db/memory"
+	"github.com/NethermindEth/juno/mocks"
+	"github.com/NethermindEth/juno/utils/log"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+)
+
+// InitPreconfirmedBlock leaves EventsBloom nil; Finish must populate it.
+// GetBlockHeaderEventsBloomByNumber errors on a nil bloom, so a regression
+// here would break the running event filter on the sequencer path.
+func TestFinishSetsEventsBloom(t *testing.T) {
+	bc := blockchain.New(
+		memory.New(),
+		&networks.Mainnet,
+		blockchain.WithNewState(statetestutils.UseNewState()),
+	)
+	emptyStateDiff := core.EmptyStateDiff()
+	require.NoError(t, bc.StoreGenesis(&emptyStateDiff, nil))
+
+	mockVM := mocks.NewMockVM(gomock.NewController(t))
+	executor := builder.NewExecutor(bc, mockVM, log.NewNopZapLogger(), false, false)
+	testBuilder := builder.New(bc, executor)
+
+	params := builder.BuildParams{
+		Builder:           felt.Zero,
+		Timestamp:         uint64(time.Now().Unix()),
+		L2GasPriceFRI:     felt.One,
+		L1GasPriceWEI:     felt.One,
+		L1DataGasPriceWEI: felt.One,
+		EthToStrkRate:     felt.One,
+		L1DAMode:          core.Blob,
+	}
+
+	state, err := testBuilder.InitPreconfirmedBlock(&params)
+	require.NoError(t, err)
+	require.Nil(t, state.PreConfirmed.Block.EventsBloom)
+
+	result, err := testBuilder.Finish(state)
+	require.NoError(t, err)
+
+	block := result.PreConfirmed.Block
+	require.NotNil(t, block.EventsBloom)
+	require.Equal(t, core.EventsBloom(block.Receipts), block.EventsBloom)
+}

--- a/core/accessors.go
+++ b/core/accessors.go
@@ -398,7 +398,36 @@ func GetBlockHeaderEventsBloomByNumber(
 	err := r.Get(db.BlockHeaderByNumberKey(blockNum), func(data []byte) error {
 		return encoder.Unmarshal(data, &header)
 	})
-	return header.EventsBloom, err
+	if err != nil {
+		return nil, err
+	}
+	if header.EventsBloom == nil {
+		return nil, fmt.Errorf("missing EventsBloom in block header %d", blockNum)
+	}
+	return header.EventsBloom, nil
+}
+
+func GetBlockHeaderHashAndStateRootByNumber(
+	r db.KeyValueReader,
+	blockNum uint64,
+) (hash, stateRoot *felt.Felt, err error) {
+	var header struct {
+		Hash            *felt.Felt
+		GlobalStateRoot *felt.Felt
+	}
+	err = r.Get(db.BlockHeaderByNumberKey(blockNum), func(data []byte) error {
+		return encoder.Unmarshal(data, &header)
+	})
+	if err != nil {
+		return nil, nil, err
+	}
+	if header.Hash == nil {
+		return nil, nil, fmt.Errorf("missing Hash in block header %d", blockNum)
+	}
+	if header.GlobalStateRoot == nil {
+		return nil, nil, fmt.Errorf("missing GlobalStateRoot in block header %d", blockNum)
+	}
+	return header.Hash, header.GlobalStateRoot, nil
 }
 
 func GetBlockHeaderByHash(r db.KeyValueReader, hash *felt.Felt) (*Header, error) {

--- a/core/accessors.go
+++ b/core/accessors.go
@@ -8,6 +8,7 @@ import (
 	"github.com/NethermindEth/juno/core/felt"
 	"github.com/NethermindEth/juno/db"
 	"github.com/NethermindEth/juno/encoder"
+	"github.com/bits-and-blooms/bloom/v3"
 )
 
 /**
@@ -375,6 +376,29 @@ func GetBlockTransactionCountByNumber(r db.KeyValueReader, blockNum uint64) (uin
 		return 0, err
 	}
 	return header.TransactionCount, nil
+}
+
+func GetBlockHeaderTimestampByNumber(r db.KeyValueReader, blockNum uint64) (uint64, error) {
+	var header struct {
+		Timestamp uint64
+	}
+	err := r.Get(db.BlockHeaderByNumberKey(blockNum), func(data []byte) error {
+		return encoder.Unmarshal(data, &header)
+	})
+	return header.Timestamp, err
+}
+
+func GetBlockHeaderEventsBloomByNumber(
+	r db.KeyValueReader,
+	blockNum uint64,
+) (*bloom.BloomFilter, error) {
+	var header struct {
+		EventsBloom *bloom.BloomFilter
+	}
+	err := r.Get(db.BlockHeaderByNumberKey(blockNum), func(data []byte) error {
+		return encoder.Unmarshal(data, &header)
+	})
+	return header.EventsBloom, err
 }
 
 func GetBlockHeaderByHash(r db.KeyValueReader, hash *felt.Felt) (*Header, error) {

--- a/core/accessors.go
+++ b/core/accessors.go
@@ -380,12 +380,18 @@ func GetBlockTransactionCountByNumber(r db.KeyValueReader, blockNum uint64) (uin
 
 func GetBlockHeaderTimestampByNumber(r db.KeyValueReader, blockNum uint64) (uint64, error) {
 	var header struct {
-		Timestamp uint64
+		Timestamp *uint64
 	}
 	err := r.Get(db.BlockHeaderByNumberKey(blockNum), func(data []byte) error {
 		return encoder.Unmarshal(data, &header)
 	})
-	return header.Timestamp, err
+	if err != nil {
+		return 0, err
+	}
+	if header.Timestamp == nil {
+		return 0, fmt.Errorf("missing Timestamp in block header %d", blockNum)
+	}
+	return *header.Timestamp, nil
 }
 
 func GetBlockHeaderEventsBloomByNumber(

--- a/core/accessors_test.go
+++ b/core/accessors_test.go
@@ -379,6 +379,17 @@ func TestGetBlockHeaderTimestampByNumber(t *testing.T) {
 		_, err := core.GetBlockHeaderTimestampByNumber(memDB, nonexistentBlockNumber)
 		require.ErrorIs(t, err, db.ErrKeyNotFound)
 	})
+
+	t.Run("missing field returns error", func(t *testing.T) {
+		t.Parallel()
+		partialHeaderDB := memory.New()
+		data, err := encoder.Marshal(struct{ Hash *felt.Felt }{Hash: block.Hash})
+		require.NoError(t, err)
+		require.NoError(t, partialHeaderDB.Put(db.BlockHeaderByNumberKey(block.Number), data))
+
+		_, err = core.GetBlockHeaderTimestampByNumber(partialHeaderDB, block.Number)
+		require.Error(t, err)
+	})
 }
 
 func TestGetBlockHeaderEventsBloomByNumber(t *testing.T) {

--- a/core/accessors_test.go
+++ b/core/accessors_test.go
@@ -361,3 +361,94 @@ func TestGetBlockTransactionCountByNumber(t *testing.T) {
 		assert.Zero(t, count)
 	})
 }
+
+func TestGetBlockHeaderTimestampByNumber(t *testing.T) {
+	t.Parallel()
+	memDB, block := setupForTxsAndReceiptsTests(t)
+	require.NoError(t, core.WriteBlockHeaderByNumber(memDB, block.Header))
+
+	t.Run("matches full header decode", func(t *testing.T) {
+		t.Parallel()
+		got, err := core.GetBlockHeaderTimestampByNumber(memDB, block.Number)
+		require.NoError(t, err)
+		assert.Equal(t, block.Header.Timestamp, got)
+	})
+
+	t.Run("missing block returns ErrKeyNotFound", func(t *testing.T) {
+		t.Parallel()
+		_, err := core.GetBlockHeaderTimestampByNumber(memDB, nonexistentBlockNumber)
+		require.ErrorIs(t, err, db.ErrKeyNotFound)
+	})
+}
+
+func TestGetBlockHeaderEventsBloomByNumber(t *testing.T) {
+	t.Parallel()
+	memDB, block := setupForTxsAndReceiptsTests(t)
+	require.NoError(t, core.WriteBlockHeaderByNumber(memDB, block.Header))
+
+	t.Run("matches full header decode", func(t *testing.T) {
+		t.Parallel()
+		got, err := core.GetBlockHeaderEventsBloomByNumber(memDB, block.Number)
+		require.NoError(t, err)
+		assert.Equal(t, block.Header.EventsBloom, got)
+	})
+
+	t.Run("missing block returns ErrKeyNotFound", func(t *testing.T) {
+		t.Parallel()
+		_, err := core.GetBlockHeaderEventsBloomByNumber(memDB, nonexistentBlockNumber)
+		require.ErrorIs(t, err, db.ErrKeyNotFound)
+	})
+
+	t.Run("missing field returns error", func(t *testing.T) {
+		t.Parallel()
+		partialHeaderDB := memory.New()
+		data, err := encoder.Marshal(struct{ Hash *felt.Felt }{Hash: block.Hash})
+		require.NoError(t, err)
+		require.NoError(t, partialHeaderDB.Put(db.BlockHeaderByNumberKey(block.Number), data))
+
+		_, err = core.GetBlockHeaderEventsBloomByNumber(partialHeaderDB, block.Number)
+		require.Error(t, err)
+	})
+}
+
+func TestGetBlockHeaderHashAndStateRootByNumber(t *testing.T) {
+	t.Parallel()
+	memDB, block := setupForTxsAndReceiptsTests(t)
+	require.NoError(t, core.WriteBlockHeaderByNumber(memDB, block.Header))
+
+	t.Run("matches full header decode", func(t *testing.T) {
+		t.Parallel()
+		hash, stateRoot, err := core.GetBlockHeaderHashAndStateRootByNumber(memDB, block.Number)
+		require.NoError(t, err)
+		assert.Equal(t, block.Header.Hash, hash)
+		assert.Equal(t, block.Header.GlobalStateRoot, stateRoot)
+	})
+
+	t.Run("missing block returns ErrKeyNotFound", func(t *testing.T) {
+		t.Parallel()
+		_, _, err := core.GetBlockHeaderHashAndStateRootByNumber(memDB, nonexistentBlockNumber)
+		require.ErrorIs(t, err, db.ErrKeyNotFound)
+	})
+
+	t.Run("missing hash returns error", func(t *testing.T) {
+		t.Parallel()
+		partialHeaderDB := memory.New()
+		data, err := encoder.Marshal(struct{ GlobalStateRoot *felt.Felt }{GlobalStateRoot: block.GlobalStateRoot})
+		require.NoError(t, err)
+		require.NoError(t, partialHeaderDB.Put(db.BlockHeaderByNumberKey(block.Number), data))
+
+		_, _, err = core.GetBlockHeaderHashAndStateRootByNumber(partialHeaderDB, block.Number)
+		require.Error(t, err)
+	})
+
+	t.Run("missing state root returns error", func(t *testing.T) {
+		t.Parallel()
+		partialHeaderDB := memory.New()
+		data, err := encoder.Marshal(struct{ Hash *felt.Felt }{Hash: block.Hash})
+		require.NoError(t, err)
+		require.NoError(t, partialHeaderDB.Put(db.BlockHeaderByNumberKey(block.Number), data))
+
+		_, _, err = core.GetBlockHeaderHashAndStateRootByNumber(partialHeaderDB, block.Number)
+		require.Error(t, err)
+	})
+}

--- a/core/accessors_test.go
+++ b/core/accessors_test.go
@@ -362,6 +362,7 @@ func TestGetBlockTransactionCountByNumber(t *testing.T) {
 	})
 }
 
+//nolint:dupl // Similar to the other partial-header accessor tests, but they're different methods
 func TestGetBlockHeaderTimestampByNumber(t *testing.T) {
 	t.Parallel()
 	memDB, block := setupForTxsAndReceiptsTests(t)
@@ -392,6 +393,7 @@ func TestGetBlockHeaderTimestampByNumber(t *testing.T) {
 	})
 }
 
+//nolint:dupl // Similar to the other partial-header accessor tests, but they're different methods
 func TestGetBlockHeaderEventsBloomByNumber(t *testing.T) {
 	t.Parallel()
 	memDB, block := setupForTxsAndReceiptsTests(t)
@@ -444,7 +446,9 @@ func TestGetBlockHeaderHashAndStateRootByNumber(t *testing.T) {
 	t.Run("missing hash returns error", func(t *testing.T) {
 		t.Parallel()
 		partialHeaderDB := memory.New()
-		data, err := encoder.Marshal(struct{ GlobalStateRoot *felt.Felt }{GlobalStateRoot: block.GlobalStateRoot})
+		data, err := encoder.Marshal(
+			struct{ GlobalStateRoot *felt.Felt }{GlobalStateRoot: block.GlobalStateRoot},
+		)
 		require.NoError(t, err)
 		require.NoError(t, partialHeaderDB.Put(db.BlockHeaderByNumberKey(block.Number), data))
 

--- a/core/running_event_filter.go
+++ b/core/running_event_filter.go
@@ -344,11 +344,11 @@ func fillRunningEventFilter(
 	latest uint64,
 ) error {
 	for blockNum := from; blockNum <= latest; blockNum++ {
-		header, err := GetBlockHeaderByNumber(database, blockNum)
+		eventsBloom, err := GetBlockHeaderEventsBloomByNumber(database, blockNum)
 		if err != nil {
 			return fmt.Errorf("getting block header by number %d: %w", blockNum, err)
 		}
-		if err := rf.Insert(header.EventsBloom, blockNum); err != nil {
+		if err := rf.Insert(eventsBloom, blockNum); err != nil {
 			return fmt.Errorf("inserting block %d in events bloom: %w", blockNum, err)
 		}
 	}

--- a/core/running_event_filter.go
+++ b/core/running_event_filter.go
@@ -346,7 +346,7 @@ func fillRunningEventFilter(
 	for blockNum := from; blockNum <= latest; blockNum++ {
 		eventsBloom, err := GetBlockHeaderEventsBloomByNumber(database, blockNum)
 		if err != nil {
-			return fmt.Errorf("getting block header by number %d: %w", blockNum, err)
+			return fmt.Errorf("getting events bloom for block %d: %w", blockNum, err)
 		}
 		if err := rf.Insert(eventsBloom, blockNum); err != nil {
 			return fmt.Errorf("inserting block %d in events bloom: %w", blockNum, err)

--- a/mocks/mock_blockchain.go
+++ b/mocks/mock_blockchain.go
@@ -119,6 +119,21 @@ func (mr *MockReaderMockRecorder) BlockHeaderByNumber(number any) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BlockHeaderByNumber", reflect.TypeOf((*MockReader)(nil).BlockHeaderByNumber), number)
 }
 
+// BlockHeaderHashByNumber mocks base method.
+func (m *MockReader) BlockHeaderHashByNumber(number uint64) (*felt.Felt, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "BlockHeaderHashByNumber", number)
+	ret0, _ := ret[0].(*felt.Felt)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// BlockHeaderHashByNumber indicates an expected call of BlockHeaderHashByNumber.
+func (mr *MockReaderMockRecorder) BlockHeaderHashByNumber(number any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BlockHeaderHashByNumber", reflect.TypeOf((*MockReader)(nil).BlockHeaderHashByNumber), number)
+}
+
 // BlockNumberAndIndexByTxHash mocks base method.
 func (m *MockReader) BlockNumberAndIndexByTxHash(hash *felt.TransactionHash) (uint64, uint64, error) {
 	m.ctrl.T.Helper()

--- a/p2p/sync/sync.go
+++ b/p2p/sync/sync.go
@@ -297,12 +297,12 @@ func (s *BlockFetcher) processSpecBlockParts(
 							if oldHeader, ok := specBlockHeadersAndSigsM[curBlockNum-1]; ok {
 								prevBlockRoot = p2p2core.AdaptHash(oldHeader.header.StateRoot)
 							} else {
-								oldHeader, err := s.blockchain.BlockHeaderByNumber(curBlockNum - 1)
+								stateRoot, err := s.blockchain.GlobalStateRootByBlockNumber(curBlockNum - 1)
 								if err != nil {
 									s.logger.Error("Failed to get Header", zap.Uint64("number", curBlockNum), zap.Error(err))
 									return
 								}
-								prevBlockRoot = oldHeader.GlobalStateRoot
+								prevBlockRoot = stateRoot
 							}
 						}
 

--- a/p2p/sync/sync.go
+++ b/p2p/sync/sync.go
@@ -299,7 +299,8 @@ func (s *BlockFetcher) processSpecBlockParts(
 							} else {
 								stateRoot, err := s.blockchain.GlobalStateRootByBlockNumber(curBlockNum - 1)
 								if err != nil {
-								s.logger.Error("Failed to get previous block state root", zap.Uint64("number", curBlockNum-1), zap.Error(err))
+									s.logger.Error("Failed to get previous block state root",
+										zap.Uint64("number", curBlockNum-1), zap.Error(err))
 									return
 								}
 								prevBlockRoot = stateRoot

--- a/p2p/sync/sync.go
+++ b/p2p/sync/sync.go
@@ -299,7 +299,7 @@ func (s *BlockFetcher) processSpecBlockParts(
 							} else {
 								stateRoot, err := s.blockchain.GlobalStateRootByBlockNumber(curBlockNum - 1)
 								if err != nil {
-									s.logger.Error("Failed to get Header", zap.Uint64("number", curBlockNum), zap.Error(err))
+								s.logger.Error("Failed to get previous block state root", zap.Uint64("number", curBlockNum-1), zap.Error(err))
 									return
 								}
 								prevBlockRoot = stateRoot

--- a/pruner/accessors.go
+++ b/pruner/accessors.go
@@ -176,11 +176,11 @@ func pruneHashKeyedUpto(
 	batch := database.NewBatch()
 	// Clean up the carve-out left by the previous PruneUpto call.
 	if start > 0 {
-		header, err := core.GetBlockHeaderByNumber(database, start-1)
+		blockHash, err := core.GetBlockHeaderHashByNumber(database, start-1)
 		if err != nil {
 			return 0, err
 		}
-		if err := core.DeleteBlockHeaderNumberByHash(batch, header.Hash); err != nil {
+		if err := core.DeleteBlockHeaderNumberByHash(batch, blockHash); err != nil {
 			return 0, err
 		}
 	}

--- a/pruner/pruner.go
+++ b/pruner/pruner.go
@@ -274,11 +274,11 @@ func FindOldestBlockAtOrAfter(
 	low, high := lower, upper+1
 	for low < high {
 		mid := low + (high-low)/2
-		header, err := core.GetBlockHeaderByNumber(database, mid)
+		timestamp, err := core.GetBlockHeaderTimestampByNumber(database, mid)
 		if err != nil {
 			return 0, fmt.Errorf("getting block header for block %d: %w", mid, err)
 		}
-		if header.Timestamp < cutoffUnix {
+		if timestamp < cutoffUnix {
 			low = mid + 1
 		} else {
 			high = mid

--- a/pruner/pruner.go
+++ b/pruner/pruner.go
@@ -276,7 +276,7 @@ func FindOldestBlockAtOrAfter(
 		mid := low + (high-low)/2
 		timestamp, err := core.GetBlockHeaderTimestampByNumber(database, mid)
 		if err != nil {
-			return 0, fmt.Errorf("getting block header for block %d: %w", mid, err)
+			return 0, fmt.Errorf("getting block timestamp for block %d: %w", mid, err)
 		}
 		if timestamp < cutoffUnix {
 			low = mid + 1

--- a/pruner/retention.go
+++ b/pruner/retention.go
@@ -54,24 +54,6 @@ func RequireRetained(r db.KeyValueReader, blockNumber uint64) error {
 	return &BlockPrunedError{BlockNumber: blockNumber, OldestRetained: oldest}
 }
 
-// HeaderByNumberIfStateRetained returns the header for blockNumber only if
-// state at that block is queryable. Use this for state access only; for
-// block-level data (transactions, receipts, etc.) use [RequireRetained] + the
-// plain core accessors instead — the two checks diverge at oldestKept-1,
-// where state is preserved by carve-out but block-level data is not.
-// See [PruneUpto] for the carve-out semantics. Returns db.ErrKeyNotFound
-// when state at blockNumber is not available.
-func HeaderByNumberIfStateRetained(r db.KeyValueReader, blockNumber uint64) (*core.Header, error) {
-	header, err := core.GetBlockHeaderByNumber(r, blockNumber)
-	if err != nil {
-		return nil, err
-	}
-	if _, err := core.GetBlockHeaderNumberByHash(r, header.Hash); err != nil {
-		return nil, err
-	}
-	return header, nil
-}
-
 // RequireStateRetainedByBlockNumber checks state retention by number, avoiding the full
 // header decode (and its heavy fields like EventsBloom) when only the hash is needed.
 func RequireStateRetainedByBlockNumber(r db.KeyValueReader, blockNumber uint64) error {
@@ -97,15 +79,6 @@ func StateRootIfStateRetainedByBlockNumber(
 		return nil, err
 	}
 	return stateRoot, nil
-}
-
-// HeaderByHashIfStateRetained returns the header for blockHash only if
-// state at that block is queryable. Use this for state access only; for
-// block-level data use [RequireRetained] + the plain core accessors instead.
-// See [PruneUpto] for the carve-out semantics. Returns db.ErrKeyNotFound
-// when state at blockHash is not available.
-func HeaderByHashIfStateRetained(r db.KeyValueReader, blockHash *felt.Felt) (*core.Header, error) {
-	return core.GetBlockHeaderByHash(r, blockHash)
 }
 
 // BlockNumberByHashIfStateRetained resolves blockHash to its number, avoiding the full

--- a/pruner/retention.go
+++ b/pruner/retention.go
@@ -83,6 +83,22 @@ func RequireStateRetainedByBlockNumber(r db.KeyValueReader, blockNumber uint64) 
 	return err
 }
 
+// StateRootIfStateRetainedByBlockNumber returns the global state root for blockNumber
+// only if state at that block is queryable, decoding hash and state root in a single header read.
+func StateRootIfStateRetainedByBlockNumber(
+	r db.KeyValueReader,
+	blockNumber uint64,
+) (*felt.Felt, error) {
+	hash, stateRoot, err := core.GetBlockHeaderHashAndStateRootByNumber(r, blockNumber)
+	if err != nil {
+		return nil, err
+	}
+	if _, err := core.GetBlockHeaderNumberByHash(r, hash); err != nil {
+		return nil, err
+	}
+	return stateRoot, nil
+}
+
 // HeaderByHashIfStateRetained returns the header for blockHash only if
 // state at that block is queryable. Use this for state access only; for
 // block-level data use [RequireRetained] + the plain core accessors instead.

--- a/pruner/retention_test.go
+++ b/pruner/retention_test.go
@@ -147,6 +147,43 @@ func TestRequireStateRetainedByBlockNumber(t *testing.T) {
 	})
 }
 
+func TestStateRootIfStateRetainedByBlockNumber(t *testing.T) {
+	t.Run("returns the state root for retained state", func(t *testing.T) {
+		const blockNumber = uint64(3)
+
+		database := memory.New()
+		blocks := make([]*testutils.StoredBlock, 5)
+		for i := range uint64(5) {
+			blocks[i] = testutils.StoreBlock(t, database, i)
+		}
+
+		stateRoot, err := pruner.StateRootIfStateRetainedByBlockNumber(database, blockNumber)
+		require.NoError(t, err)
+		assert.Equal(t, blocks[blockNumber].Header.GlobalStateRoot, stateRoot)
+	})
+
+	t.Run("rejects pruned state when header remains", func(t *testing.T) {
+		const blockNumber = uint64(1)
+
+		database := memory.New()
+		blocks := make([]*testutils.StoredBlock, 5)
+		for i := range uint64(5) {
+			blocks[i] = testutils.StoreBlock(t, database, i)
+		}
+		prunedHash := blocks[blockNumber].Header.Hash
+		require.NoError(t, database.Delete(db.BlockHeaderNumbersByHashKey(prunedHash)))
+
+		_, err := pruner.StateRootIfStateRetainedByBlockNumber(database, blockNumber)
+		require.ErrorIs(t, err, db.ErrKeyNotFound)
+	})
+
+	t.Run("missing block returns ErrKeyNotFound", func(t *testing.T) {
+		database := memory.New()
+		_, err := pruner.StateRootIfStateRetainedByBlockNumber(database, 0)
+		require.ErrorIs(t, err, db.ErrKeyNotFound)
+	})
+}
+
 func TestHeaderByHashIfStateRetained(t *testing.T) {
 	t.Run("fully retained block returns the header", func(t *testing.T) {
 		database := testutils.NewPebbleTestDB(t)

--- a/pruner/retention_test.go
+++ b/pruner/retention_test.go
@@ -4,7 +4,6 @@ import (
 	"errors"
 	"testing"
 
-	"github.com/NethermindEth/juno/core/felt"
 	"github.com/NethermindEth/juno/db"
 	"github.com/NethermindEth/juno/db/memory"
 	_ "github.com/NethermindEth/juno/encoder/registry"
@@ -85,41 +84,6 @@ func TestRequireRetained(t *testing.T) {
 	})
 }
 
-func TestHeaderByNumberIfStateRetained(t *testing.T) {
-	t.Run("fully retained block returns the header", func(t *testing.T) {
-		database := testutils.NewPebbleTestDB(t)
-		blocks := make([]*testutils.StoredBlock, 5)
-		for i := range uint64(5) {
-			blocks[i] = testutils.StoreBlock(t, database, i)
-		}
-		header, err := pruner.HeaderByNumberIfStateRetained(database, 3)
-		require.NoError(t, err)
-		assert.Equal(t, blocks[3].Header.Hash, header.Hash)
-	})
-
-	t.Run("block with header but no hash→number is treated as state-pruned", func(t *testing.T) {
-		// This mirrors the lag-window state of pruned blocks: header kept,
-		// hash→number swept. State accessors must NOT serve these.
-		database := testutils.NewPebbleTestDB(t)
-		blocks := make([]*testutils.StoredBlock, 5)
-		for i := range uint64(5) {
-			blocks[i] = testutils.StoreBlock(t, database, i)
-		}
-		testutils.WithBatch(t, database, func(batch db.Batch) error {
-			return batch.Delete(db.BlockHeaderNumbersByHashKey(blocks[1].Header.Hash))
-		})
-
-		_, err := pruner.HeaderByNumberIfStateRetained(database, 1)
-		require.ErrorIs(t, err, db.ErrKeyNotFound)
-	})
-
-	t.Run("missing block returns ErrKeyNotFound", func(t *testing.T) {
-		database := testutils.NewPebbleTestDB(t)
-		_, err := pruner.HeaderByNumberIfStateRetained(database, 0)
-		require.ErrorIs(t, err, db.ErrKeyNotFound)
-	})
-}
-
 func TestRequireStateRetainedByBlockNumber(t *testing.T) {
 	t.Run("allows retained state", func(t *testing.T) {
 		const blockNumber = uint64(3)
@@ -180,39 +144,6 @@ func TestStateRootIfStateRetainedByBlockNumber(t *testing.T) {
 	t.Run("missing block returns ErrKeyNotFound", func(t *testing.T) {
 		database := memory.New()
 		_, err := pruner.StateRootIfStateRetainedByBlockNumber(database, 0)
-		require.ErrorIs(t, err, db.ErrKeyNotFound)
-	})
-}
-
-func TestHeaderByHashIfStateRetained(t *testing.T) {
-	t.Run("fully retained block returns the header", func(t *testing.T) {
-		database := testutils.NewPebbleTestDB(t)
-		blocks := make([]*testutils.StoredBlock, 5)
-		for i := range uint64(5) {
-			blocks[i] = testutils.StoreBlock(t, database, i)
-		}
-		header, err := pruner.HeaderByHashIfStateRetained(database, blocks[2].Header.Hash)
-		require.NoError(t, err)
-		assert.Equal(t, uint64(2), header.Number)
-	})
-
-	t.Run("missing hash returns ErrKeyNotFound", func(t *testing.T) {
-		database := testutils.NewPebbleTestDB(t)
-		unknownHash := felt.NewRandom[felt.Felt]()
-		_, err := pruner.HeaderByHashIfStateRetained(database, unknownHash)
-		require.ErrorIs(t, err, db.ErrKeyNotFound)
-	})
-
-	t.Run("block whose hash→number was deleted is unreachable by hash", func(t *testing.T) {
-		database := testutils.NewPebbleTestDB(t)
-		blocks := make([]*testutils.StoredBlock, 5)
-		for i := range uint64(5) {
-			blocks[i] = testutils.StoreBlock(t, database, i)
-		}
-		testutils.WithBatch(t, database, func(batch db.Batch) error {
-			return batch.Delete(db.BlockHeaderNumbersByHashKey(blocks[1].Header.Hash))
-		})
-		_, err := pruner.HeaderByHashIfStateRetained(database, blocks[1].Header.Hash)
 		require.ErrorIs(t, err, db.ErrKeyNotFound)
 	})
 }

--- a/pruner/running_event_filter.go
+++ b/pruner/running_event_filter.go
@@ -91,11 +91,11 @@ func fillRunningEventFilter(
 	end uint64,
 ) error {
 	for blockNum := from; blockNum <= end; blockNum++ {
-		header, err := core.GetBlockHeaderByNumber(reader, blockNum)
+		eventsBloom, err := core.GetBlockHeaderEventsBloomByNumber(reader, blockNum)
 		if err != nil {
 			return fmt.Errorf("getting block header by number %d: %w", blockNum, err)
 		}
-		if err := rf.Insert(header.EventsBloom, blockNum); err != nil {
+		if err := rf.Insert(eventsBloom, blockNum); err != nil {
 			return fmt.Errorf("inserting block %d in events bloom: %w", blockNum, err)
 		}
 	}

--- a/pruner/running_event_filter.go
+++ b/pruner/running_event_filter.go
@@ -93,7 +93,7 @@ func fillRunningEventFilter(
 	for blockNum := from; blockNum <= end; blockNum++ {
 		eventsBloom, err := core.GetBlockHeaderEventsBloomByNumber(reader, blockNum)
 		if err != nil {
-			return fmt.Errorf("getting block header by number %d: %w", blockNum, err)
+			return fmt.Errorf("getting events bloom for block %d: %w", blockNum, err)
 		}
 		if err := rf.Insert(eventsBloom, blockNum); err != nil {
 			return fmt.Errorf("inserting block %d in events bloom: %w", blockNum, err)

--- a/rpc/v10/helpers.go
+++ b/rpc/v10/helpers.go
@@ -150,11 +150,7 @@ func (h *Handler) getRevealedBlockHash(blockNumber uint64) (*felt.Felt, error) {
 		return nil, nil
 	}
 
-	header, err := h.bcReader.BlockHeaderByNumber(blockNumber - core.BlockHashLag)
-	if err != nil {
-		return nil, err
-	}
-	return header.Hash, nil
+	return h.bcReader.BlockHeaderHashByNumber(blockNumber - core.BlockHashLag)
 }
 
 func (h *Handler) callAndLogErr(f func() error, msg string) {

--- a/rpc/v10/storage.go
+++ b/rpc/v10/storage.go
@@ -170,7 +170,7 @@ func (h *Handler) StorageProof(
 	// transaction to get the block number. We don't use the head query directly to avoid
 	// race condition where there is a new incoming block. Currently it's still working
 	// because we don't have revert yet. We should figure out a way to merge the two transactions.
-	header, err := h.bcReader.BlockHeaderByNumber(chainHeight)
+	blockHash, err := h.bcReader.BlockHeaderHashByNumber(chainHeight)
 	if err != nil {
 		return nil, rpccore.ErrInternal.CloneWithData(err)
 	}
@@ -233,7 +233,7 @@ func (h *Handler) StorageProof(
 		GlobalRoots: &GlobalRoots{
 			ContractsTreeRoot: &contractTreeRoot,
 			ClassesTreeRoot:   &classTreeRoot,
-			BlockHash:         header.Hash,
+			BlockHash:         blockHash,
 		},
 	}, nil
 }
@@ -279,14 +279,14 @@ func (h *Handler) isBlockSupported(blockID *BlockID, chainHeight uint64) *jsonrp
 	case blockID.IsPreConfirmed():
 		return rpccore.ErrCallOnPreConfirmed
 	case blockID.IsHash():
-		header, err := h.bcReader.BlockHeaderByHash(blockID.Hash())
+		num, err := h.bcReader.BlockNumberByHash(blockID.Hash())
 		if err != nil {
 			if errors.Is(err, db.ErrKeyNotFound) {
 				return rpccore.ErrBlockNotFound
 			}
 			return rpccore.ErrInternal.CloneWithData(err)
 		}
-		blockNumber = header.Number
+		blockNumber = num
 	case blockID.IsNumber():
 		blockNumber = blockID.Number()
 	case blockID.IsL1Accepted():

--- a/rpc/v10/storage_test.go
+++ b/rpc/v10/storage_test.go
@@ -691,8 +691,8 @@ func TestStorageProof(t *testing.T) {
 	handler := rpc.New(mockReader, nil, nil, logger)
 
 	t.Run("global roots are filled", func(t *testing.T) {
-		mockReader.EXPECT().BlockHeaderByNumber(blockNumber).
-			Return(headBlock.Header, nil)
+		mockReader.EXPECT().BlockHeaderHashByNumber(blockNumber).
+			Return(headBlock.Header.Hash, nil)
 
 		proof, rpcErr := handler.StorageProof(&blockLatest, nil, nil, nil)
 
@@ -704,8 +704,8 @@ func TestStorageProof(t *testing.T) {
 		require.Equal(t, root, proof.GlobalRoots.ContractsTreeRoot)
 	})
 	t.Run("error whenever block number is older than the latest", func(t *testing.T) {
-		mockReader.EXPECT().BlockHeaderByNumber(blockNumber).
-			Return(headBlock.Header, nil)
+		mockReader.EXPECT().BlockHeaderHashByNumber(blockNumber).
+			Return(headBlock.Header.Hash, nil)
 
 		blockID := rpc.BlockIDFromNumber(1)
 		proof, rpcErr := handler.StorageProof(&blockID, nil, nil, nil)
@@ -713,8 +713,8 @@ func TestStorageProof(t *testing.T) {
 		require.Nil(t, proof)
 	})
 	t.Run("error whenever block number is newer than the latest", func(t *testing.T) {
-		mockReader.EXPECT().BlockHeaderByNumber(blockNumber).
-			Return(headBlock.Header, nil)
+		mockReader.EXPECT().BlockHeaderHashByNumber(blockNumber).
+			Return(headBlock.Header.Hash, nil)
 
 		blockID := rpc.BlockIDFromNumber(blockNumber + 10)
 		proof, rpcErr := handler.StorageProof(&blockID, nil, nil, nil)
@@ -722,12 +722,12 @@ func TestStorageProof(t *testing.T) {
 		require.Nil(t, proof)
 	})
 	t.Run("error whenever block hash is not the latest", func(t *testing.T) {
-		mockReader.EXPECT().BlockHeaderByNumber(blockNumber).
-			Return(headBlock.Header, nil)
+		mockReader.EXPECT().BlockHeaderHashByNumber(blockNumber).
+			Return(headBlock.Header.Hash, nil)
 
 		blockHash := felt.NewFromUint64[felt.Felt](1)
-		mockReader.EXPECT().BlockHeaderByHash(blockHash).
-			Return(&core.Header{Number: blockNumber - 10}, nil)
+		mockReader.EXPECT().BlockNumberByHash(blockHash).
+			Return(blockNumber-10, nil)
 
 		blockID := rpc.BlockIDFromHash(blockHash)
 		proof, rpcErr := handler.StorageProof(&blockID, nil, nil, nil)
@@ -735,11 +735,11 @@ func TestStorageProof(t *testing.T) {
 		require.Nil(t, proof)
 	})
 	t.Run("error whenever block hash does not exist", func(t *testing.T) {
-		mockReader.EXPECT().BlockHeaderByNumber(blockNumber).
-			Return(headBlock.Header, nil)
+		mockReader.EXPECT().BlockHeaderHashByNumber(blockNumber).
+			Return(headBlock.Header.Hash, nil)
 
 		blockHash := felt.NewFromUint64[felt.Felt](1)
-		mockReader.EXPECT().BlockHeaderByHash(blockHash).Return(nil, db.ErrKeyNotFound)
+		mockReader.EXPECT().BlockNumberByHash(blockHash).Return(uint64(0), db.ErrKeyNotFound)
 
 		blockID := rpc.BlockIDFromHash(blockHash)
 		proof, rpcErr := handler.StorageProof(&blockID, nil, nil, nil)
@@ -747,8 +747,8 @@ func TestStorageProof(t *testing.T) {
 		require.Nil(t, proof)
 	})
 	t.Run("error for pre_confirmed block", func(t *testing.T) {
-		mockReader.EXPECT().BlockHeaderByNumber(blockNumber).
-			Return(headBlock.Header, nil)
+		mockReader.EXPECT().BlockHeaderHashByNumber(blockNumber).
+			Return(headBlock.Header.Hash, nil)
 
 		blockID := rpc.BlockIDPreConfirmed()
 		proof, rpcErr := handler.StorageProof(&blockID, nil, nil, nil)
@@ -756,8 +756,8 @@ func TestStorageProof(t *testing.T) {
 		require.Nil(t, proof)
 	})
 	t.Run("no error when block number matches head", func(t *testing.T) {
-		mockReader.EXPECT().BlockHeaderByNumber(blockNumber).
-			Return(headBlock.Header, nil)
+		mockReader.EXPECT().BlockHeaderHashByNumber(blockNumber).
+			Return(headBlock.Header.Hash, nil)
 
 		blockID := rpc.BlockIDFromNumber(blockNumber)
 		proof, rpcErr := handler.StorageProof(&blockID, nil, nil, nil)
@@ -765,26 +765,26 @@ func TestStorageProof(t *testing.T) {
 		require.NotNil(t, proof)
 	})
 	t.Run("no error when block hash matches head", func(t *testing.T) {
-		mockReader.EXPECT().BlockHeaderByNumber(blockNumber).
-			Return(headBlock.Header, nil)
+		mockReader.EXPECT().BlockHeaderHashByNumber(blockNumber).
+			Return(headBlock.Header.Hash, nil)
 
-		mockReader.EXPECT().BlockHeaderByHash(blkHash).Return(&core.Header{Number: blockNumber}, nil)
+		mockReader.EXPECT().BlockNumberByHash(blkHash).Return(blockNumber, nil)
 		blockID := rpc.BlockIDFromHash(blkHash)
 		proof, rpcErr := handler.StorageProof(&blockID, nil, nil, nil)
 		require.Nil(t, rpcErr)
 		require.NotNil(t, proof)
 	})
 	t.Run("no error when contract storage keys are provided but empty", func(t *testing.T) {
-		mockReader.EXPECT().BlockHeaderByNumber(blockNumber).
-			Return(headBlock.Header, nil)
+		mockReader.EXPECT().BlockHeaderHashByNumber(blockNumber).
+			Return(headBlock.Header.Hash, nil)
 
 		proof, rpcErr := handler.StorageProof(&blockLatest, nil, nil, []rpc.StorageKeys{})
 		assert.Nil(t, rpcErr)
 		require.NotNil(t, proof)
 	})
 	t.Run("error when address in contract storage keys is nil", func(t *testing.T) {
-		mockReader.EXPECT().BlockHeaderByNumber(blockNumber).
-			Return(headBlock.Header, nil)
+		mockReader.EXPECT().BlockHeaderHashByNumber(blockNumber).
+			Return(headBlock.Header.Hash, nil)
 
 		proof, rpcErr := handler.StorageProof(
 			&blockLatest,
@@ -796,8 +796,8 @@ func TestStorageProof(t *testing.T) {
 		require.Nil(t, proof)
 	})
 	t.Run("error when keys in contract storage keys are nil", func(t *testing.T) {
-		mockReader.EXPECT().BlockHeaderByNumber(blockNumber).
-			Return(headBlock.Header, nil)
+		mockReader.EXPECT().BlockHeaderHashByNumber(blockNumber).
+			Return(headBlock.Header.Hash, nil)
 
 		proof, rpcErr := handler.StorageProof(
 			&blockLatest,
@@ -809,8 +809,8 @@ func TestStorageProof(t *testing.T) {
 		require.Nil(t, proof)
 	})
 	t.Run("error when keys in contract storage keys are empty", func(t *testing.T) {
-		mockReader.EXPECT().BlockHeaderByNumber(blockNumber).
-			Return(headBlock.Header, nil)
+		mockReader.EXPECT().BlockHeaderHashByNumber(blockNumber).
+			Return(headBlock.Header.Hash, nil)
 
 		proof, rpcErr := handler.StorageProof(
 			&blockLatest,
@@ -822,8 +822,8 @@ func TestStorageProof(t *testing.T) {
 		require.Nil(t, proof)
 	})
 	t.Run("empty request", func(t *testing.T) {
-		mockReader.EXPECT().BlockHeaderByNumber(blockNumber).
-			Return(headBlock.Header, nil)
+		mockReader.EXPECT().BlockHeaderHashByNumber(blockNumber).
+			Return(headBlock.Header.Hash, nil)
 
 		proof, rpcErr := handler.StorageProof(&blockLatest, nil, nil, nil)
 		require.Nil(t, rpcErr)
@@ -831,8 +831,8 @@ func TestStorageProof(t *testing.T) {
 		arityTest(t, proof, 0, 0, 0, 0)
 	})
 	t.Run("class trie hash does not exist in a trie", func(t *testing.T) {
-		mockReader.EXPECT().BlockHeaderByNumber(blockNumber).
-			Return(headBlock.Header, nil)
+		mockReader.EXPECT().BlockHeaderHashByNumber(blockNumber).
+			Return(headBlock.Header.Hash, nil)
 
 		proof, rpcErr := handler.StorageProof(&blockLatest, []felt.Felt{*noSuchKey}, nil, nil)
 		require.Nil(t, rpcErr)
@@ -841,8 +841,8 @@ func TestStorageProof(t *testing.T) {
 		verifyIf(t, &trieRoot, noSuchKey, nil, proof.ClassesProof, classTrie.HashFn())
 	})
 	t.Run("class trie hash exists in a trie", func(t *testing.T) {
-		mockReader.EXPECT().BlockHeaderByNumber(blockNumber).
-			Return(headBlock.Header, nil)
+		mockReader.EXPECT().BlockHeaderHashByNumber(blockNumber).
+			Return(headBlock.Header.Hash, nil)
 
 		proof, rpcErr := handler.StorageProof(&blockLatest, []felt.Felt{*key}, nil, nil)
 		require.Nil(t, rpcErr)
@@ -851,8 +851,8 @@ func TestStorageProof(t *testing.T) {
 		verifyIf(t, &trieRoot, key, value, proof.ClassesProof, classTrie.HashFn())
 	})
 	t.Run("only unique proof nodes are returned", func(t *testing.T) {
-		mockReader.EXPECT().BlockHeaderByNumber(blockNumber).
-			Return(headBlock.Header, nil)
+		mockReader.EXPECT().BlockHeaderHashByNumber(blockNumber).
+			Return(headBlock.Header.Hash, nil)
 
 		proof, rpcErr := handler.StorageProof(&blockLatest, []felt.Felt{*key, *key2}, nil, nil)
 		require.Nil(t, rpcErr)
@@ -868,8 +868,8 @@ func TestStorageProof(t *testing.T) {
 		verifyIf(t, &trieRoot, key2, value2, proof.ClassesProof, classTrie.HashFn())
 	})
 	t.Run("storage trie address does not exist in a trie", func(t *testing.T) {
-		mockReader.EXPECT().BlockHeaderByNumber(blockNumber).
-			Return(headBlock.Header, nil)
+		mockReader.EXPECT().BlockHeaderHashByNumber(blockNumber).
+			Return(headBlock.Header.Hash, nil)
 		mockState.EXPECT().ContractClassHash(noSuchKey).Return(felt.Zero, db.ErrKeyNotFound).Times(1)
 
 		proof, rpcErr := handler.StorageProof(&blockLatest, nil, []felt.Felt{*noSuchKey}, nil)
@@ -881,8 +881,8 @@ func TestStorageProof(t *testing.T) {
 		verifyIf(t, &trieRoot, noSuchKey, nil, proof.ContractsProof.Nodes, classTrie.HashFn())
 	})
 	t.Run("storage trie address exists in a trie", func(t *testing.T) {
-		mockReader.EXPECT().BlockHeaderByNumber(blockNumber).
-			Return(headBlock.Header, nil)
+		mockReader.EXPECT().BlockHeaderHashByNumber(blockNumber).
+			Return(headBlock.Header.Hash, nil)
 
 		nonce := felt.NewFromUint64[felt.Felt](121)
 		mockState.EXPECT().ContractNonce(key).Return(*nonce, nil).Times(1)
@@ -905,8 +905,8 @@ func TestStorageProof(t *testing.T) {
 	t.Run(
 		"contract leaf StorageRoot is the contract storage trie root, not the global contracts trie root",
 		func(t *testing.T) {
-			mockReader.EXPECT().BlockHeaderByNumber(blockNumber).
-				Return(headBlock.Header, nil)
+			mockReader.EXPECT().BlockHeaderHashByNumber(blockNumber).
+				Return(headBlock.Header.Hash, nil)
 
 			// Build a separate storage trie with different contents so its root differs from
 			// the contracts trie root.
@@ -940,8 +940,8 @@ func TestStorageProof(t *testing.T) {
 				"StorageRoot should be the contract's storage trie root, not the global contracts trie root")
 		})
 	t.Run("contract storage trie address does not exist in a trie", func(t *testing.T) {
-		mockReader.EXPECT().BlockHeaderByNumber(blockNumber).
-			Return(headBlock.Header, nil)
+		mockReader.EXPECT().BlockHeaderHashByNumber(blockNumber).
+			Return(headBlock.Header.Hash, nil)
 
 		contract := felt.NewFromUint64[felt.Felt](0xdead)
 		mockState.EXPECT().ContractStorageTrie(contract).Return(emptyTrie(t), nil).Times(1)
@@ -955,8 +955,8 @@ func TestStorageProof(t *testing.T) {
 	})
 	//nolint:dupl // Similar code, but testing a different case
 	t.Run("contract storage trie key slot does not exist in a trie", func(t *testing.T) {
-		mockReader.EXPECT().BlockHeaderByNumber(blockNumber).
-			Return(headBlock.Header, nil)
+		mockReader.EXPECT().BlockHeaderHashByNumber(blockNumber).
+			Return(headBlock.Header.Hash, nil)
 
 		contract := felt.NewFromUint64[felt.Felt](0xabcd)
 		mockState.EXPECT().ContractStorageTrie(contract).Return(contractTrie, nil).Times(1)
@@ -972,8 +972,8 @@ func TestStorageProof(t *testing.T) {
 	})
 	//nolint:dupl // Similar code, but testing a different case
 	t.Run("contract storage trie address/key exists in a trie", func(t *testing.T) {
-		mockReader.EXPECT().BlockHeaderByNumber(blockNumber).
-			Return(headBlock.Header, nil)
+		mockReader.EXPECT().BlockHeaderHashByNumber(blockNumber).
+			Return(headBlock.Header.Hash, nil)
 
 		contract := felt.NewFromUint64[felt.Felt](0xabcd)
 		mockState.EXPECT().ContractStorageTrie(contract).Return(contractTrie, nil).Times(1)
@@ -988,8 +988,8 @@ func TestStorageProof(t *testing.T) {
 		verifyIf(t, &trieRoot, key, value, proof.ContractsStorageProofs[0], contractTrie.HashFn())
 	})
 	t.Run("class & storage tries proofs requested", func(t *testing.T) {
-		mockReader.EXPECT().BlockHeaderByNumber(blockNumber).
-			Return(headBlock.Header, nil)
+		mockReader.EXPECT().BlockHeaderHashByNumber(blockNumber).
+			Return(headBlock.Header.Hash, nil)
 
 		nonce := felt.NewFromUint64[felt.Felt](121)
 		mockState.EXPECT().ContractNonce(key).Return(*nonce, nil)

--- a/rpc/v10/sync.go
+++ b/rpc/v10/sync.go
@@ -42,7 +42,7 @@ func (h *Handler) Syncing() (*Sync, *jsonrpc.Error) {
 	if err != nil {
 		return defaultSyncState, nil
 	}
-	startingBlockHeader, err := h.bcReader.BlockHeaderByNumber(startingBlockNumber)
+	startingBlockHash, err := h.bcReader.BlockHeaderHashByNumber(startingBlockNumber)
 	if err != nil {
 		return defaultSyncState, nil
 	}
@@ -59,8 +59,8 @@ func (h *Handler) Syncing() (*Sync, *jsonrpc.Error) {
 	}
 
 	return &Sync{
-		StartingBlockHash:   startingBlockHeader.Hash,
-		StartingBlockNumber: &startingBlockHeader.Number,
+		StartingBlockHash:   startingBlockHash,
+		StartingBlockNumber: &startingBlockNumber,
 		CurrentBlockHash:    head.Hash,
 		CurrentBlockNumber:  &head.Number,
 		HighestBlockHash:    highestBlockHeader.Hash,

--- a/rpc/v10/sync_test.go
+++ b/rpc/v10/sync_test.go
@@ -31,7 +31,9 @@ func TestSyncing(t *testing.T) {
 
 	synchronizer.EXPECT().StartingBlockNumber().Return(startingBlock, nil).AnyTimes()
 	t.Run("empty blockchain", func(t *testing.T) {
-		mockReader.EXPECT().BlockHeaderByNumber(startingBlock).Return(nil, errors.New("empty blockchain"))
+		mockReader.EXPECT().
+			BlockHeaderHashByNumber(startingBlock).
+			Return(nil, errors.New("empty blockchain"))
 
 		syncing, err := handler.Syncing()
 		assert.Nil(t, err)
@@ -40,7 +42,7 @@ func TestSyncing(t *testing.T) {
 
 	synchronizer.EXPECT().HighestBlockHeader().Return(nil).Times(2)
 	t.Run("undefined highest block", func(t *testing.T) {
-		mockReader.EXPECT().BlockHeaderByNumber(startingBlock).Return(&core.Header{}, nil)
+		mockReader.EXPECT().BlockHeaderHashByNumber(startingBlock).Return(nil, nil)
 		mockReader.EXPECT().HeadsHeader().Return(&core.Header{}, nil)
 
 		syncing, err := handler.Syncing()
@@ -48,7 +50,7 @@ func TestSyncing(t *testing.T) {
 		assert.Equal(t, &rpc.Sync{Syncing: &defaultSyncState}, syncing)
 	})
 	t.Run("block height is greater than highest block", func(t *testing.T) {
-		mockReader.EXPECT().BlockHeaderByNumber(startingBlock).Return(&core.Header{}, nil)
+		mockReader.EXPECT().BlockHeaderHashByNumber(startingBlock).Return(nil, nil)
 		mockReader.EXPECT().HeadsHeader().Return(&core.Header{Number: 1}, nil)
 
 		syncing, err := handler.Syncing()
@@ -63,7 +65,7 @@ func TestSyncing(t *testing.T) {
 		},
 	).Times(2)
 	t.Run("block height is equal to highest block", func(t *testing.T) {
-		mockReader.EXPECT().BlockHeaderByNumber(startingBlock).Return(&core.Header{}, nil)
+		mockReader.EXPECT().BlockHeaderHashByNumber(startingBlock).Return(nil, nil)
 		mockReader.EXPECT().HeadsHeader().Return(&core.Header{Number: 2}, nil)
 
 		syncing, err := handler.Syncing()
@@ -71,7 +73,7 @@ func TestSyncing(t *testing.T) {
 		assert.Equal(t, &rpc.Sync{Syncing: &defaultSyncState}, syncing)
 	})
 	t.Run("syncing", func(t *testing.T) {
-		mockReader.EXPECT().BlockHeaderByNumber(startingBlock).Return(&core.Header{Hash: &felt.Zero}, nil)
+		mockReader.EXPECT().BlockHeaderHashByNumber(startingBlock).Return(&felt.Zero, nil)
 		mockReader.EXPECT().HeadsHeader().Return(
 			&core.Header{
 				Number: 1,

--- a/rpc/v10/sync_test.go
+++ b/rpc/v10/sync_test.go
@@ -42,7 +42,7 @@ func TestSyncing(t *testing.T) {
 
 	synchronizer.EXPECT().HighestBlockHeader().Return(nil).Times(2)
 	t.Run("undefined highest block", func(t *testing.T) {
-		mockReader.EXPECT().BlockHeaderHashByNumber(startingBlock).Return(nil, nil)
+		mockReader.EXPECT().BlockHeaderHashByNumber(startingBlock).Return(&felt.Zero, nil)
 		mockReader.EXPECT().HeadsHeader().Return(&core.Header{}, nil)
 
 		syncing, err := handler.Syncing()
@@ -50,7 +50,7 @@ func TestSyncing(t *testing.T) {
 		assert.Equal(t, &rpc.Sync{Syncing: &defaultSyncState}, syncing)
 	})
 	t.Run("block height is greater than highest block", func(t *testing.T) {
-		mockReader.EXPECT().BlockHeaderHashByNumber(startingBlock).Return(nil, nil)
+		mockReader.EXPECT().BlockHeaderHashByNumber(startingBlock).Return(&felt.Zero, nil)
 		mockReader.EXPECT().HeadsHeader().Return(&core.Header{Number: 1}, nil)
 
 		syncing, err := handler.Syncing()
@@ -65,7 +65,7 @@ func TestSyncing(t *testing.T) {
 		},
 	).Times(2)
 	t.Run("block height is equal to highest block", func(t *testing.T) {
-		mockReader.EXPECT().BlockHeaderHashByNumber(startingBlock).Return(nil, nil)
+		mockReader.EXPECT().BlockHeaderHashByNumber(startingBlock).Return(&felt.Zero, nil)
 		mockReader.EXPECT().HeadsHeader().Return(&core.Header{Number: 2}, nil)
 
 		syncing, err := handler.Syncing()

--- a/rpc/v10/trace_test.go
+++ b/rpc/v10/trace_test.go
@@ -1360,7 +1360,7 @@ func TestTraceBlockTransactionsWithReturnInitialReads(t *testing.T) {
 			mockReader.EXPECT().StateAtBlockHash(&parentHash).Return(mockState, nopCloser, nil)
 			mockReader.EXPECT().HeadState().Return(mockState, nopCloser, nil)
 			mockReader.EXPECT().L1Head().Return(core.L1Head{}, db.ErrKeyNotFound).AnyTimes()
-			mockReader.EXPECT().BlockHeaderByNumber(uint64(90)).Return(revealedHeader, nil)
+			mockReader.EXPECT().BlockHeaderHashByNumber(uint64(90)).Return(revealedHeader.Hash, nil)
 
 			returnInitialReads := slices.Contains(test.simulationFlags, rpcv10.ReturnInitialReadsFlag)
 
@@ -1473,7 +1473,10 @@ func TestTraceBlockTransactionsInitialReadsCacheCoherence(t *testing.T) {
 
 		mockReader.EXPECT().Network().Return(n).AnyTimes()
 		mockReader.EXPECT().L1Head().Return(core.L1Head{}, db.ErrKeyNotFound).AnyTimes()
-		mockReader.EXPECT().BlockHeaderByNumber(uint64(90)).Return(revealedHeader, nil).AnyTimes()
+		mockReader.EXPECT().
+			BlockHeaderHashByNumber(uint64(90)).
+			Return(revealedHeader.Hash, nil).
+			AnyTimes()
 		mockReader.EXPECT().Receipt(txHash).Return(nil, blockHash, block.Number, nil)
 		mockReader.EXPECT().BlockByHash(blockHash).Return(block, nil).Times(2)
 		mockReader.EXPECT().StateAtBlockHash(block.ParentHash).Return(mockState, nopCloser, nil).Times(2)
@@ -1518,7 +1521,10 @@ func TestTraceBlockTransactionsInitialReadsCacheCoherence(t *testing.T) {
 
 		mockReader.EXPECT().Network().Return(n).AnyTimes()
 		mockReader.EXPECT().L1Head().Return(core.L1Head{}, db.ErrKeyNotFound).AnyTimes()
-		mockReader.EXPECT().BlockHeaderByNumber(uint64(90)).Return(revealedHeader, nil).AnyTimes()
+		mockReader.EXPECT().
+			BlockHeaderHashByNumber(uint64(90)).
+			Return(revealedHeader.Hash, nil).
+			AnyTimes()
 		mockReader.EXPECT().BlockByHash(blockHash).Return(block, nil).Times(2)
 		mockReader.EXPECT().StateAtBlockHash(block.ParentHash).Return(mockState, nopCloser, nil)
 		mockReader.EXPECT().HeadState().Return(mockState, nopCloser, nil)
@@ -1554,7 +1560,10 @@ func TestTraceBlockTransactionsInitialReadsCacheCoherence(t *testing.T) {
 
 		mockReader.EXPECT().Network().Return(n).AnyTimes()
 		mockReader.EXPECT().L1Head().Return(core.L1Head{}, db.ErrKeyNotFound).AnyTimes()
-		mockReader.EXPECT().BlockHeaderByNumber(uint64(90)).Return(revealedHeader, nil).AnyTimes()
+		mockReader.EXPECT().
+			BlockHeaderHashByNumber(uint64(90)).
+			Return(revealedHeader.Hash, nil).
+			AnyTimes()
 		mockReader.EXPECT().BlockByHash(blockHash).Return(block, nil).Times(2)
 		mockReader.EXPECT().StateAtBlockHash(block.ParentHash).Return(mockState, nopCloser, nil)
 		mockReader.EXPECT().HeadState().Return(mockState, nopCloser, nil)

--- a/rpc/v8/block_test.go
+++ b/rpc/v8/block_test.go
@@ -237,8 +237,8 @@ func TestBlockTransactionCount(t *testing.T) {
 			Hash:   felt.NewUnsafeFromString[felt.Felt]("0xFFFF"),
 			Number: latestBlock.Number + 1 - 10,
 		}
-		mockReader.EXPECT().BlockHeaderByNumber(blockToRegisterHash.Number).
-			Return(&blockToRegisterHash, nil)
+		mockReader.EXPECT().BlockHeaderHashByNumber(blockToRegisterHash.Number).
+			Return(blockToRegisterHash.Hash, nil)
 		mockReader.EXPECT().HeadsHeader().Return(latestBlock.Header, nil)
 		expectedCount := uint64(0)
 		count, rpcErr := handler.BlockTransactionCount(blockIDPending(t))
@@ -377,8 +377,8 @@ func TestBlockWithTxHashes(t *testing.T) {
 			Hash:   felt.NewUnsafeFromString[felt.Felt]("0xFFFF"),
 			Number: latestBlock.Number + 1 - 10,
 		}
-		mockReader.EXPECT().BlockHeaderByNumber(blockToRegisterHash.Number).
-			Return(&blockToRegisterHash, nil).Times(2)
+		mockReader.EXPECT().BlockHeaderHashByNumber(blockToRegisterHash.Number).
+			Return(blockToRegisterHash.Hash, nil).Times(2)
 		mockReader.EXPECT().HeadsHeader().Return(latestBlock.Header, nil).Times(2)
 		mockReader.EXPECT().L1Head().Return(core.L1Head{}, db.ErrKeyNotFound)
 		pending := blockIDPending(t)
@@ -596,8 +596,8 @@ func TestBlockWithTxs(t *testing.T) {
 			Hash:   felt.NewUnsafeFromString[felt.Felt]("0xFFFF"),
 			Number: latestBlock.Number + 1 - 10,
 		}
-		mockReader.EXPECT().BlockHeaderByNumber(blockToRegisterHash.Number).
-			Return(&blockToRegisterHash, nil).Times(2)
+		mockReader.EXPECT().BlockHeaderHashByNumber(blockToRegisterHash.Number).
+			Return(blockToRegisterHash.Hash, nil).Times(2)
 		mockReader.EXPECT().HeadsHeader().Return(latestBlock.Header, nil).Times(2)
 		mockReader.EXPECT().L1Head().Return(core.L1Head{}, db.ErrKeyNotFound)
 		pending := blockIDPending(t)

--- a/rpc/v8/pending_wrapper_test.go
+++ b/rpc/v8/pending_wrapper_test.go
@@ -33,9 +33,9 @@ func TestPendingWrapper_Pending(t *testing.T) {
 
 	t.Run("Returns empty pending placeholder based on latest header", func(t *testing.T) {
 		mockReader.EXPECT().HeadsHeader().Return(latestBlock.Header, nil)
-		mockReader.EXPECT().BlockHeaderByNumber(
+		mockReader.EXPECT().BlockHeaderHashByNumber(
 			latestBlock.Header.Number+1-core.BlockHashLag,
-		).Return(&core.Header{Hash: felt.NewFromUint64[felt.Felt](1234567)}, nil).Times(2)
+		).Return(felt.NewFromUint64[felt.Felt](1234567), nil).Times(2)
 
 		expectedPending, err := sync.MakeEmptyPendingForParent(
 			mockReader,

--- a/rpc/v8/state_update_test.go
+++ b/rpc/v8/state_update_test.go
@@ -183,8 +183,8 @@ func TestStateUpdate(t *testing.T) {
 			Number: 21647,
 		}
 		// to update block hash registry
-		mockReader.EXPECT().BlockHeaderByNumber(blockToRegisterHash.Number).
-			Return(&blockToRegisterHash, nil)
+		mockReader.EXPECT().BlockHeaderHashByNumber(blockToRegisterHash.Number).
+			Return(blockToRegisterHash.Hash, nil)
 		mockReader.EXPECT().HeadsHeader().Return(&core.Header{
 			GlobalStateRoot: update21656.NewRoot,
 			Number:          21656,

--- a/rpc/v9/helpers.go
+++ b/rpc/v9/helpers.go
@@ -167,11 +167,7 @@ func (h *Handler) getRevealedBlockHash(blockNumber uint64) (*felt.Felt, error) {
 		return nil, nil
 	}
 
-	header, err := h.bcReader.BlockHeaderByNumber(blockNumber - core.BlockHashLag)
-	if err != nil {
-		return nil, err
-	}
-	return header.Hash, nil
+	return h.bcReader.BlockHeaderHashByNumber(blockNumber - core.BlockHashLag)
 }
 
 func (h *Handler) callAndLogErr(f func() error, msg string) {

--- a/rpc/v9/storage.go
+++ b/rpc/v9/storage.go
@@ -185,14 +185,14 @@ func (h *Handler) isBlockSupported(blockID *BlockID, chainHeight uint64) *jsonrp
 	case blockID.IsPreConfirmed():
 		return rpccore.ErrCallOnPreConfirmed
 	case blockID.IsHash():
-		header, err := h.bcReader.BlockHeaderByHash(blockID.Hash())
+		num, err := h.bcReader.BlockNumberByHash(blockID.Hash())
 		if err != nil {
 			if errors.Is(err, db.ErrKeyNotFound) {
 				return rpccore.ErrBlockNotFound
 			}
 			return rpccore.ErrInternal.CloneWithData(err)
 		}
-		blockNumber = header.Number
+		blockNumber = num
 	case blockID.IsNumber():
 		blockNumber = blockID.Number()
 	case blockID.IsL1Accepted():

--- a/rpc/v9/storage_test.go
+++ b/rpc/v9/storage_test.go
@@ -397,8 +397,8 @@ func TestStorageProof(t *testing.T) {
 			Return(headBlock.Header, nil)
 
 		blockHash := felt.NewFromUint64[felt.Felt](1)
-		mockReader.EXPECT().BlockHeaderByHash(blockHash).
-			Return(&core.Header{Number: blockNumber - 10}, nil)
+		mockReader.EXPECT().BlockNumberByHash(blockHash).
+			Return(blockNumber-10, nil)
 
 		blockID := blockIDHash(t, blockHash)
 		proof, rpcErr := handler.StorageProof(&blockID, nil, nil, nil)
@@ -410,7 +410,7 @@ func TestStorageProof(t *testing.T) {
 			Return(headBlock.Header, nil)
 
 		blockHash := felt.NewFromUint64[felt.Felt](1)
-		mockReader.EXPECT().BlockHeaderByHash(blockHash).Return(nil, db.ErrKeyNotFound)
+		mockReader.EXPECT().BlockNumberByHash(blockHash).Return(uint64(0), db.ErrKeyNotFound)
 
 		blockID := blockIDHash(t, blockHash)
 		proof, rpcErr := handler.StorageProof(&blockID, nil, nil, nil)
@@ -439,7 +439,7 @@ func TestStorageProof(t *testing.T) {
 		mockReader.EXPECT().BlockHeaderByNumber(blockNumber).
 			Return(headBlock.Header, nil)
 
-		mockReader.EXPECT().BlockHeaderByHash(blkHash).Return(&core.Header{Number: blockNumber}, nil)
+		mockReader.EXPECT().BlockNumberByHash(blkHash).Return(blockNumber, nil)
 		blockID := blockIDHash(t, blkHash)
 		proof, rpcErr := handler.StorageProof(&blockID, nil, nil, nil)
 		require.Nil(t, rpcErr)

--- a/rpc/v9/sync.go
+++ b/rpc/v9/sync.go
@@ -42,7 +42,7 @@ func (h *Handler) Syncing() (*Sync, *jsonrpc.Error) {
 	if err != nil {
 		return defaultSyncState, nil
 	}
-	startingBlockHeader, err := h.bcReader.BlockHeaderByNumber(startingBlockNumber)
+	startingBlockHash, err := h.bcReader.BlockHeaderHashByNumber(startingBlockNumber)
 	if err != nil {
 		return defaultSyncState, nil
 	}
@@ -59,8 +59,8 @@ func (h *Handler) Syncing() (*Sync, *jsonrpc.Error) {
 	}
 
 	return &Sync{
-		StartingBlockHash:   startingBlockHeader.Hash,
-		StartingBlockNumber: &startingBlockHeader.Number,
+		StartingBlockHash:   startingBlockHash,
+		StartingBlockNumber: &startingBlockNumber,
 		CurrentBlockHash:    head.Hash,
 		CurrentBlockNumber:  &head.Number,
 		HighestBlockHash:    highestBlockHeader.Hash,

--- a/rpc/v9/sync_test.go
+++ b/rpc/v9/sync_test.go
@@ -31,7 +31,9 @@ func TestSyncing(t *testing.T) {
 
 	synchronizer.EXPECT().StartingBlockNumber().Return(startingBlock, nil).AnyTimes()
 	t.Run("empty blockchain", func(t *testing.T) {
-		mockReader.EXPECT().BlockHeaderByNumber(startingBlock).Return(nil, errors.New("empty blockchain"))
+		mockReader.EXPECT().
+			BlockHeaderHashByNumber(startingBlock).
+			Return(nil, errors.New("empty blockchain"))
 
 		syncing, err := handler.Syncing()
 		assert.Nil(t, err)
@@ -40,7 +42,7 @@ func TestSyncing(t *testing.T) {
 
 	synchronizer.EXPECT().HighestBlockHeader().Return(nil).Times(2)
 	t.Run("undefined highest block", func(t *testing.T) {
-		mockReader.EXPECT().BlockHeaderByNumber(startingBlock).Return(&core.Header{}, nil)
+		mockReader.EXPECT().BlockHeaderHashByNumber(startingBlock).Return(nil, nil)
 		mockReader.EXPECT().HeadsHeader().Return(&core.Header{}, nil)
 
 		syncing, err := handler.Syncing()
@@ -48,7 +50,7 @@ func TestSyncing(t *testing.T) {
 		assert.Equal(t, &rpc.Sync{Syncing: &defaultSyncState}, syncing)
 	})
 	t.Run("block height is greater than highest block", func(t *testing.T) {
-		mockReader.EXPECT().BlockHeaderByNumber(startingBlock).Return(&core.Header{}, nil)
+		mockReader.EXPECT().BlockHeaderHashByNumber(startingBlock).Return(nil, nil)
 		mockReader.EXPECT().HeadsHeader().Return(&core.Header{Number: 1}, nil)
 
 		syncing, err := handler.Syncing()
@@ -63,7 +65,7 @@ func TestSyncing(t *testing.T) {
 		},
 	).Times(2)
 	t.Run("block height is equal to highest block", func(t *testing.T) {
-		mockReader.EXPECT().BlockHeaderByNumber(startingBlock).Return(&core.Header{}, nil)
+		mockReader.EXPECT().BlockHeaderHashByNumber(startingBlock).Return(nil, nil)
 		mockReader.EXPECT().HeadsHeader().Return(&core.Header{Number: 2}, nil)
 
 		syncing, err := handler.Syncing()
@@ -71,7 +73,7 @@ func TestSyncing(t *testing.T) {
 		assert.Equal(t, &rpc.Sync{Syncing: &defaultSyncState}, syncing)
 	})
 	t.Run("syncing", func(t *testing.T) {
-		mockReader.EXPECT().BlockHeaderByNumber(startingBlock).Return(&core.Header{Hash: &felt.Zero}, nil)
+		mockReader.EXPECT().BlockHeaderHashByNumber(startingBlock).Return(&felt.Zero, nil)
 		mockReader.EXPECT().HeadsHeader().Return(
 			&core.Header{
 				Number: 1,

--- a/rpc/v9/sync_test.go
+++ b/rpc/v9/sync_test.go
@@ -42,7 +42,7 @@ func TestSyncing(t *testing.T) {
 
 	synchronizer.EXPECT().HighestBlockHeader().Return(nil).Times(2)
 	t.Run("undefined highest block", func(t *testing.T) {
-		mockReader.EXPECT().BlockHeaderHashByNumber(startingBlock).Return(nil, nil)
+		mockReader.EXPECT().BlockHeaderHashByNumber(startingBlock).Return(&felt.Zero, nil)
 		mockReader.EXPECT().HeadsHeader().Return(&core.Header{}, nil)
 
 		syncing, err := handler.Syncing()
@@ -50,7 +50,7 @@ func TestSyncing(t *testing.T) {
 		assert.Equal(t, &rpc.Sync{Syncing: &defaultSyncState}, syncing)
 	})
 	t.Run("block height is greater than highest block", func(t *testing.T) {
-		mockReader.EXPECT().BlockHeaderHashByNumber(startingBlock).Return(nil, nil)
+		mockReader.EXPECT().BlockHeaderHashByNumber(startingBlock).Return(&felt.Zero, nil)
 		mockReader.EXPECT().HeadsHeader().Return(&core.Header{Number: 1}, nil)
 
 		syncing, err := handler.Syncing()
@@ -65,7 +65,7 @@ func TestSyncing(t *testing.T) {
 		},
 	).Times(2)
 	t.Run("block height is equal to highest block", func(t *testing.T) {
-		mockReader.EXPECT().BlockHeaderHashByNumber(startingBlock).Return(nil, nil)
+		mockReader.EXPECT().BlockHeaderHashByNumber(startingBlock).Return(&felt.Zero, nil)
 		mockReader.EXPECT().HeadsHeader().Return(&core.Header{Number: 2}, nil)
 
 		syncing, err := handler.Syncing()

--- a/sync/helpers.go
+++ b/sync/helpers.go
@@ -27,13 +27,14 @@ func makeStateDiffForEmptyBlock(bc blockchain.Reader, blockNumber uint64) (*core
 		return stateDiff, nil
 	}
 
-	header, err := bc.BlockHeaderByNumber(blockNumber - core.BlockHashLag)
+	targetBlock := blockNumber - core.BlockHashLag
+	blockHash, err := bc.BlockHeaderHashByNumber(targetBlock)
 	if err != nil {
 		return nil, err
 	}
 
 	stateDiff.StorageDiffs[*core.BlockHashStorageContract] = map[felt.Felt]*felt.Felt{
-		*new(felt.Felt).SetUint64(header.Number): header.Hash,
+		*new(felt.Felt).SetUint64(targetBlock): blockHash,
 	}
 	return stateDiff, nil
 }


### PR DESCRIPTION
Note: pruner.HeaderByNumberIfStateRetained / HeaderByHashIfStateRetained are now prod-unused. Not sure if we will potentially need it in the future.  