### PR TITLE
refactor(core): use `[]felt.Felt` for class `Program` and `Bytecode`

### DIFF
--- a/adapters/core2p2p/class.go
+++ b/adapters/core2p2p/class.go
@@ -54,7 +54,7 @@ func AdaptSierraClass(cls *core.SierraClass) *class.Cairo1Class {
 			L1Handlers:   utils.Map(cls.EntryPoints.L1Handler, adaptSierra),
 			Constructors: utils.Map(cls.EntryPoints.Constructor, adaptSierra),
 		},
-		Program:              utils.Map(cls.Program, AdaptFelt),
+		Program:              utils.Map(cls.Program, adaptFeltValue),
 		ContractClassVersion: cls.SemanticVersion,
 	}
 }

--- a/adapters/core2p2p/felt.go
+++ b/adapters/core2p2p/felt.go
@@ -33,6 +33,10 @@ func AdaptFelt(f *felt.Felt) *common.Felt252 {
 	}
 }
 
+func adaptFeltValue(f felt.Felt) *common.Felt252 {
+	return &common.Felt252{Elements: f.Marshal()}
+}
+
 func AdaptFeltSlice(sl []*felt.Felt) []*common.Felt252 {
 	return utils.Map(sl, AdaptFelt)
 }

--- a/adapters/p2p2core/class.go
+++ b/adapters/p2p2core/class.go
@@ -22,7 +22,8 @@ func AdaptSierraClass(
 ) (core.SierraClass, error) {
 	abiHash := crypto.StarknetKeccak([]byte(cairo1.Abi))
 
-	program := utils.Map(cairo1.Program, AdaptFelt)
+	// protoc generates cairo1.Program as []*common.Felt252
+	program := utils.Map(cairo1.Program, adaptFeltValue)
 	compiled, err := createCompiledClass(ctx, compiler, cairo1)
 	if err != nil {
 		return core.SierraClass{}, fmt.Errorf("invalid compiled class: %w", err)
@@ -33,7 +34,8 @@ func AdaptSierraClass(
 		return utils.Map(utils.NonNilSlice(points), adaptSierra)
 	}
 
-	programHash := crypto.PoseidonArray(program...)
+	// TODO(granza): update hash to also receive []felt.Felt
+	programHash := crypto.PoseidonArray(utils.ToPtrSlice(program)...)
 	entryPoints := cairo1.EntryPoints
 	return core.SierraClass{
 		Abi:     cairo1.Abi,
@@ -125,7 +127,7 @@ func createCompiledClass(
 			External:    utils.Map(utils.NonNilSlice(ep.Externals), adapt),
 			L1Handler:   utils.Map(utils.NonNilSlice(ep.L1Handlers), adapt),
 		},
-		Program: utils.Map(cairo1.Program, AdaptFelt),
+		Program: utils.Map(cairo1.Program, adaptFeltValue),
 		Version: cairo1.ContractClassVersion,
 	}
 

--- a/adapters/p2p2core/felt.go
+++ b/adapters/p2p2core/felt.go
@@ -26,6 +26,10 @@ func AdaptFelt(f *common.Felt252) *felt.Felt {
 	return adapt(f)
 }
 
+func adaptFeltValue(f *common.Felt252) felt.Felt {
+	return felt.FromBytes[felt.Felt](f.GetElements())
+}
+
 func adapt(v interface{ GetElements() []byte }) *felt.Felt {
 	if utils.IsNil(v) {
 		return nil

--- a/adapters/sn2core/sn2core.go
+++ b/adapters/sn2core/sn2core.go
@@ -349,7 +349,8 @@ func AdaptSierraClass(
 		return nil, err
 	}
 
-	programHash := crypto.PoseidonArray(response.Program...)
+	// TODO(granza): update hash to also receive []felt.Felt
+	programHash := crypto.PoseidonArray(utils.ToPtrSlice(response.Program)...)
 	abiHash := crypto.StarknetKeccak([]byte(response.Abi))
 	return &core.SierraClass{
 		SemanticVersion: response.Version,

--- a/adapters/sn2core/sn2core_test.go
+++ b/adapters/sn2core/sn2core_test.go
@@ -625,8 +625,8 @@ func TestClassV1(t *testing.T) {
 	t.Run("sierra class doesn't have the minimum size", func(t *testing.T) {
 		snClass := starknet.SierraClass{
 			Program: []felt.Felt{
-				{}, // this value doesn't matter as long as their different from `SierraVersion010`
-				{},
+				felt.Zero, // this value doesn't matter as long as their different from `SierraVersion010`
+				felt.Zero,
 			},
 		}
 		class, err := sn2core.AdaptSierraClass(&snClass, nil)

--- a/adapters/sn2core/sn2core_test.go
+++ b/adapters/sn2core/sn2core_test.go
@@ -624,9 +624,9 @@ func TestClassV1(t *testing.T) {
 
 	t.Run("sierra class doesn't have the minimum size", func(t *testing.T) {
 		snClass := starknet.SierraClass{
-			Program: []*felt.Felt{
-				new(felt.Felt), // this value doesn't matter as long as their different from `SierraVersion010`
-				new(felt.Felt),
+			Program: []felt.Felt{
+				{}, // this value doesn't matter as long as their different from `SierraVersion010`
+				{},
 			},
 		}
 		class, err := sn2core.AdaptSierraClass(&snClass, nil)

--- a/core/class.go
+++ b/core/class.go
@@ -13,6 +13,7 @@ import (
 	"github.com/NethermindEth/juno/core/felt"
 	"github.com/NethermindEth/juno/db"
 	"github.com/NethermindEth/juno/encoder"
+	"github.com/NethermindEth/juno/utils"
 )
 
 var (
@@ -72,7 +73,7 @@ type SierraClass struct {
 	Abi         string
 	AbiHash     *felt.Felt
 	EntryPoints SierraEntryPointsByType
-	Program     []*felt.Felt
+	Program     []felt.Felt
 	ProgramHash *felt.Felt
 	// TODO: Remove this semantic version on a follow up PR. Let's put Sierra version instead
 	SemanticVersion string
@@ -85,7 +86,7 @@ type SegmentLengths struct {
 }
 
 type CasmClass struct {
-	Bytecode               []*felt.Felt
+	Bytecode               []felt.Felt
 	PythonicHints          json.RawMessage
 	CompilerVersion        string
 	Hints                  json.RawMessage
@@ -214,7 +215,8 @@ func (c *CasmClass) Hash(version CasmHashVersion) felt.Felt {
 
 	var bytecodeHash felt.Felt
 	if len(c.BytecodeSegmentLengths.Children) == 0 {
-		bytecodeHash = hasher.HashArray(c.Bytecode...)
+		// TODO(granza): update hash to also receive []felt.Felt
+		bytecodeHash = hasher.HashArray(utils.ToPtrSlice(c.Bytecode)...)
 	} else {
 		bytecodeHash = SegmentedBytecodeHash(c.Bytecode, c.BytecodeSegmentLengths.Children, hasher)
 	}
@@ -233,7 +235,7 @@ func (c *CasmClass) Hash(version CasmHashVersion) felt.Felt {
 }
 
 func SegmentedBytecodeHash(
-	bytecode []*felt.Felt,
+	bytecode []felt.Felt,
 	segmentLengths []SegmentLengths,
 	hasher Hasher,
 ) felt.Felt {
@@ -250,7 +252,8 @@ func SegmentedBytecodeHash(
 			if len(segment.Children) == 0 {
 				curSegmentLength = segment.Length
 				segmentBytecode := bytecode[startingOffset : startingOffset+segment.Length]
-				curSegmentHash = hasher.HashArray(segmentBytecode...)
+				// TODO(granza): update hash to also receive []felt.Felt
+				curSegmentHash = hasher.HashArray(utils.ToPtrSlice(segmentBytecode)...)
 			} else {
 				curSegmentLength, curSegmentHash = digestSegment(segment.Children)
 			}

--- a/core/class_test.go
+++ b/core/class_test.go
@@ -270,8 +270,8 @@ func TestClassEncoding(t *testing.T) {
 					L1Handler: []core.SierraEntryPoint{},
 				},
 				Program: []felt.Felt{
-					*felt.NewUnsafeFromString[felt.Felt]("0xDEAD"),
-					*felt.NewUnsafeFromString[felt.Felt]("0xBEEF"),
+					felt.UnsafeFromString[felt.Felt]("0xDEAD"),
+					felt.UnsafeFromString[felt.Felt]("0xBEEF"),
 				},
 				ProgramHash:     felt.NewUnsafeFromString[felt.Felt]("0xBEEFDEAD"),
 				SemanticVersion: "0.1.0",

--- a/core/class_test.go
+++ b/core/class_test.go
@@ -269,7 +269,10 @@ func TestClassEncoding(t *testing.T) {
 					},
 					L1Handler: []core.SierraEntryPoint{},
 				},
-				Program:         []*felt.Felt{felt.NewUnsafeFromString[felt.Felt]("0xDEAD"), felt.NewUnsafeFromString[felt.Felt]("0xBEEF")},
+				Program: []felt.Felt{
+					*felt.NewUnsafeFromString[felt.Felt]("0xDEAD"),
+					*felt.NewUnsafeFromString[felt.Felt]("0xBEEF"),
+				},
 				ProgramHash:     felt.NewUnsafeFromString[felt.Felt]("0xBEEFDEAD"),
 				SemanticVersion: "0.1.0",
 			},
@@ -366,10 +369,10 @@ func TestVerifyClassHash(t *testing.T) {
 }
 
 func TestSegmentedBytecodeHash(t *testing.T) {
-	byteCode := []*felt.Felt{
-		felt.NewFromUint64[felt.Felt](1),
-		felt.NewFromUint64[felt.Felt](2),
-		felt.NewFromUint64[felt.Felt](3),
+	byteCode := []felt.Felt{
+		felt.FromUint64[felt.Felt](1),
+		felt.FromUint64[felt.Felt](2),
+		felt.FromUint64[felt.Felt](3),
 	}
 	segmentLengths := []core.SegmentLengths{
 		{
@@ -434,8 +437,8 @@ func TestSierraVersion(t *testing.T) {
 				576348180530977296,
 			})
 		class := core.SierraClass{
-			Program: []*felt.Felt{
-				&sierraVersion010,
+			Program: []felt.Felt{
+				sierraVersion010,
 			},
 		}
 		sierraVersion := class.SierraVersion()
@@ -444,10 +447,10 @@ func TestSierraVersion(t *testing.T) {
 
 	t.Run("cairo one should return based on the program data", func(t *testing.T) {
 		class := core.SierraClass{
-			Program: []*felt.Felt{
-				new(felt.Felt).SetUint64(7),
-				new(felt.Felt).SetUint64(3),
-				new(felt.Felt).SetUint64(11),
+			Program: []felt.Felt{
+				felt.FromUint64[felt.Felt](7),
+				felt.FromUint64[felt.Felt](3),
+				felt.FromUint64[felt.Felt](11),
 			},
 		}
 		sierraVersion := class.SierraVersion()

--- a/core/deprecatedstate/state_test.go
+++ b/core/deprecatedstate/state_test.go
@@ -609,7 +609,7 @@ func TestRevert(t *testing.T) {
 					Selector: felt.NewFromBytes[felt.Felt]([]byte("l1")),
 				}},
 			},
-			Program:         []*felt.Felt{felt.NewFromBytes[felt.Felt]([]byte("random program"))},
+			Program:         []felt.Felt{felt.FromBytes[felt.Felt]([]byte("random program"))},
 			ProgramHash:     felt.NewFromBytes[felt.Felt]([]byte("random program hash")),
 			SemanticVersion: "version 1",
 			Compiled:        &core.CasmClass{},

--- a/core/deprecatedstate/state_test.go
+++ b/core/deprecatedstate/state_test.go
@@ -95,7 +95,9 @@ func TestUpdate(t *testing.T) {
 		),
 		StateDiff: &core.StateDiff{
 			DeclaredV1Classes: map[felt.Felt]*felt.Felt{
-				*felt.NewUnsafeFromString[felt.Felt]("0xDEADBEEF"): felt.NewUnsafeFromString[felt.Felt]("0xBEEFDEAD"),
+				felt.UnsafeFromString[felt.Felt]("0xDEADBEEF"): felt.NewUnsafeFromString[felt.Felt](
+					"0xBEEFDEAD",
+				),
 			},
 		},
 	}
@@ -105,7 +107,7 @@ func TestUpdate(t *testing.T) {
 			require.Error(t, state.Update(&core.Header{Number: 3}, su3, nil, false))
 		})
 		require.NoError(t, state.Update(&core.Header{Number: 3}, su3, map[felt.Felt]core.ClassDefinition{
-			*felt.NewUnsafeFromString[felt.Felt]("0xDEADBEEF"): &core.SierraClass{},
+			felt.UnsafeFromString[felt.Felt]("0xDEADBEEF"): &core.SierraClass{},
 		}, false))
 		assert.NotEqual(t, su3.NewRoot, su3.OldRoot)
 	})

--- a/core/state/accessors_test.go
+++ b/core/state/accessors_test.go
@@ -91,7 +91,7 @@ func TestClassAccessors(t *testing.T) {
 			At: 12,
 			Class: &core.SierraClass{
 				SemanticVersion: "0.1.0",
-				Program:         []*felt.Felt{felt.NewUnsafeFromString[felt.Felt]("0x1")},
+				Program:         []felt.Felt{*felt.NewUnsafeFromString[felt.Felt]("0x1")},
 			},
 		}
 	}
@@ -122,7 +122,7 @@ func TestClassAccessors(t *testing.T) {
 		sierra, ok := got.Class.(*core.SierraClass)
 		require.True(t, ok)
 		assert.Equal(t, "0.1.0", sierra.SemanticVersion)
-		assert.Equal(t, []*felt.Felt{felt.NewUnsafeFromString[felt.Felt]("0x1")}, sierra.Program)
+		assert.Equal(t, []felt.Felt{*felt.NewUnsafeFromString[felt.Felt]("0x1")}, sierra.Program)
 	})
 
 	t.Run("overwrite reflects latest values", func(t *testing.T) {
@@ -133,7 +133,7 @@ func TestClassAccessors(t *testing.T) {
 			At: 99,
 			Class: &core.SierraClass{
 				SemanticVersion: "0.2.0",
-				Program:         []*felt.Felt{felt.NewUnsafeFromString[felt.Felt]("0x2")},
+				Program:         []felt.Felt{*felt.NewUnsafeFromString[felt.Felt]("0x2")},
 			},
 		}
 		require.NoError(t, state.WriteClass(disk, classHash, updated))
@@ -144,7 +144,7 @@ func TestClassAccessors(t *testing.T) {
 		sierra, ok := got.Class.(*core.SierraClass)
 		require.True(t, ok)
 		assert.Equal(t, "0.2.0", sierra.SemanticVersion)
-		assert.Equal(t, []*felt.Felt{felt.NewUnsafeFromString[felt.Felt]("0x2")}, sierra.Program)
+		assert.Equal(t, []felt.Felt{*felt.NewUnsafeFromString[felt.Felt]("0x2")}, sierra.Program)
 	})
 
 	t.Run("delete removes the class", func(t *testing.T) {

--- a/core/state/accessors_test.go
+++ b/core/state/accessors_test.go
@@ -91,7 +91,7 @@ func TestClassAccessors(t *testing.T) {
 			At: 12,
 			Class: &core.SierraClass{
 				SemanticVersion: "0.1.0",
-				Program:         []felt.Felt{*felt.NewUnsafeFromString[felt.Felt]("0x1")},
+				Program:         []felt.Felt{felt.UnsafeFromString[felt.Felt]("0x1")},
 			},
 		}
 	}
@@ -122,7 +122,7 @@ func TestClassAccessors(t *testing.T) {
 		sierra, ok := got.Class.(*core.SierraClass)
 		require.True(t, ok)
 		assert.Equal(t, "0.1.0", sierra.SemanticVersion)
-		assert.Equal(t, []felt.Felt{*felt.NewUnsafeFromString[felt.Felt]("0x1")}, sierra.Program)
+		assert.Equal(t, []felt.Felt{felt.UnsafeFromString[felt.Felt]("0x1")}, sierra.Program)
 	})
 
 	t.Run("overwrite reflects latest values", func(t *testing.T) {
@@ -133,7 +133,7 @@ func TestClassAccessors(t *testing.T) {
 			At: 99,
 			Class: &core.SierraClass{
 				SemanticVersion: "0.2.0",
-				Program:         []felt.Felt{*felt.NewUnsafeFromString[felt.Felt]("0x2")},
+				Program:         []felt.Felt{felt.UnsafeFromString[felt.Felt]("0x2")},
 			},
 		}
 		require.NoError(t, state.WriteClass(disk, classHash, updated))
@@ -144,7 +144,7 @@ func TestClassAccessors(t *testing.T) {
 		sierra, ok := got.Class.(*core.SierraClass)
 		require.True(t, ok)
 		assert.Equal(t, "0.2.0", sierra.SemanticVersion)
-		assert.Equal(t, []felt.Felt{*felt.NewUnsafeFromString[felt.Felt]("0x2")}, sierra.Program)
+		assert.Equal(t, []felt.Felt{felt.UnsafeFromString[felt.Felt]("0x2")}, sierra.Program)
 	})
 
 	t.Run("delete removes the class", func(t *testing.T) {

--- a/core/state/state_test.go
+++ b/core/state/state_test.go
@@ -358,7 +358,7 @@ func TestRevert(t *testing.T) {
 					Selector: felt.NewUnsafeFromString[felt.Felt]("0xb1"),
 				}},
 			},
-			Program:         []*felt.Felt{felt.NewUnsafeFromString[felt.Felt]("0x9999")},
+			Program:         []felt.Felt{*felt.NewUnsafeFromString[felt.Felt]("0x9999")},
 			ProgramHash:     felt.NewUnsafeFromString[felt.Felt]("0x8888"),
 			SemanticVersion: "version 1",
 			Compiled:        &core.CasmClass{},

--- a/core/state/state_test.go
+++ b/core/state/state_test.go
@@ -74,7 +74,9 @@ func TestUpdate(t *testing.T) {
 		),
 		StateDiff: &core.StateDiff{
 			DeclaredV1Classes: map[felt.Felt]*felt.Felt{
-				*felt.NewUnsafeFromString[felt.Felt]("0xDEADBEEF"): felt.NewUnsafeFromString[felt.Felt]("0xBEEFDEAD"),
+				felt.UnsafeFromString[felt.Felt]("0xDEADBEEF"): felt.NewUnsafeFromString[felt.Felt](
+					"0xBEEFDEAD",
+				),
 			},
 		},
 	}
@@ -358,7 +360,7 @@ func TestRevert(t *testing.T) {
 					Selector: felt.NewUnsafeFromString[felt.Felt]("0xb1"),
 				}},
 			},
-			Program:         []felt.Felt{*felt.NewUnsafeFromString[felt.Felt]("0x9999")},
+			Program:         []felt.Felt{felt.UnsafeFromString[felt.Felt]("0x9999")},
 			ProgramHash:     felt.NewUnsafeFromString[felt.Felt]("0x8888"),
 			SemanticVersion: "version 1",
 			Compiled:        &core.CasmClass{},

--- a/migration/deprecated/migration.go
+++ b/migration/deprecated/migration.go
@@ -780,7 +780,7 @@ type oldCairo1Class struct {
 	Abi             string
 	AbiHash         *felt.Felt
 	EntryPoints     core.SierraEntryPointsByType
-	Program         []*felt.Felt
+	Program         []felt.Felt
 	ProgramHash     *felt.Felt
 	SemanticVersion string
 	Compiled        json.RawMessage

--- a/migration/deprecated/migration_pkg_test.go
+++ b/migration/deprecated/migration_pkg_test.go
@@ -798,14 +798,14 @@ func TestChangeStateDiffStruct(t *testing.T) {
 	}))
 }
 
-func randSlice(t *testing.T) []*felt.Felt {
+func randSlice(t *testing.T) []felt.Felt {
 	t.Helper()
 
 	n := rand.Intn(10)
-	sl := make([]*felt.Felt, n)
+	sl := make([]felt.Felt, n)
 
 	for i := range sl {
-		sl[i] = felt.NewRandom[felt.Felt]()
+		sl[i] = *felt.NewRandom[felt.Felt]()
 	}
 	return sl
 }

--- a/migration/deprecated/migration_pkg_test.go
+++ b/migration/deprecated/migration_pkg_test.go
@@ -664,10 +664,13 @@ func TestChangeStateDiffStruct(t *testing.T) {
 			OldRoot:   felt.NewUnsafeFromString[felt.Felt]("0x2"),
 			StateDiff: &oldStateDiff{
 				StorageDiffs: map[felt.Felt][]oldStorageDiff{
-					*felt.NewUnsafeFromString[felt.Felt]("0x3"): {{Key: felt.NewUnsafeFromString[felt.Felt]("0x4"), Value: felt.NewUnsafeFromString[felt.Felt]("0x5")}},
+					felt.UnsafeFromString[felt.Felt]("0x3"): {{
+						Key:   felt.NewUnsafeFromString[felt.Felt]("0x4"),
+						Value: felt.NewUnsafeFromString[felt.Felt]("0x5"),
+					}},
 				},
 				Nonces: map[felt.Felt]*felt.Felt{
-					*felt.NewUnsafeFromString[felt.Felt]("0x6"): felt.NewUnsafeFromString[felt.Felt]("0x7"),
+					felt.UnsafeFromString[felt.Felt]("0x6"): felt.NewUnsafeFromString[felt.Felt]("0x7"),
 				},
 				DeployedContracts: []oldAddressClassHashPair{{Address: felt.NewUnsafeFromString[felt.Felt]("0x8"), ClassHash: felt.NewUnsafeFromString[felt.Felt]("0x9")}},
 				DeclaredV0Classes: []*felt.Felt{felt.NewUnsafeFromString[felt.Felt]("0x10")},
@@ -686,10 +689,13 @@ func TestChangeStateDiffStruct(t *testing.T) {
 			OldRoot:   felt.NewUnsafeFromString[felt.Felt]("0x17"),
 			StateDiff: &oldStateDiff{
 				StorageDiffs: map[felt.Felt][]oldStorageDiff{
-					*felt.NewUnsafeFromString[felt.Felt]("0x18"): {{Key: felt.NewUnsafeFromString[felt.Felt]("0x19"), Value: felt.NewUnsafeFromString[felt.Felt]("0x20")}},
+					felt.UnsafeFromString[felt.Felt]("0x18"): {{
+						Key:   felt.NewUnsafeFromString[felt.Felt]("0x19"),
+						Value: felt.NewUnsafeFromString[felt.Felt]("0x20"),
+					}},
 				},
 				Nonces: map[felt.Felt]*felt.Felt{
-					*felt.NewUnsafeFromString[felt.Felt]("0x21"): felt.NewUnsafeFromString[felt.Felt]("0x22"),
+					felt.UnsafeFromString[felt.Felt]("0x21"): felt.NewUnsafeFromString[felt.Felt]("0x22"),
 				},
 				DeployedContracts: []oldAddressClassHashPair{{Address: felt.NewUnsafeFromString[felt.Felt]("0x23"), ClassHash: felt.NewUnsafeFromString[felt.Felt]("0x24")}},
 				DeclaredV0Classes: []*felt.Felt{felt.NewUnsafeFromString[felt.Felt]("0x25")},
@@ -733,22 +739,22 @@ func TestChangeStateDiffStruct(t *testing.T) {
 					OldRoot:   felt.NewUnsafeFromString[felt.Felt]("0x2"),
 					StateDiff: &core.StateDiff{
 						StorageDiffs: map[felt.Felt]map[felt.Felt]*felt.Felt{
-							*felt.NewUnsafeFromString[felt.Felt]("0x3"): {
-								*felt.NewUnsafeFromString[felt.Felt]("0x4"): felt.NewUnsafeFromString[felt.Felt]("0x5"),
+							felt.UnsafeFromString[felt.Felt]("0x3"): {
+								felt.UnsafeFromString[felt.Felt]("0x4"): felt.NewUnsafeFromString[felt.Felt]("0x5"),
 							},
 						},
 						Nonces: map[felt.Felt]*felt.Felt{
-							*felt.NewUnsafeFromString[felt.Felt]("0x6"): felt.NewUnsafeFromString[felt.Felt]("0x7"),
+							felt.UnsafeFromString[felt.Felt]("0x6"): felt.NewUnsafeFromString[felt.Felt]("0x7"),
 						},
 						DeployedContracts: map[felt.Felt]*felt.Felt{
-							*felt.NewUnsafeFromString[felt.Felt]("0x8"): felt.NewUnsafeFromString[felt.Felt]("0x9"),
+							felt.UnsafeFromString[felt.Felt]("0x8"): felt.NewUnsafeFromString[felt.Felt]("0x9"),
 						},
 						DeclaredV0Classes: []*felt.Felt{felt.NewUnsafeFromString[felt.Felt]("0x10")},
 						DeclaredV1Classes: map[felt.Felt]*felt.Felt{
-							*felt.NewUnsafeFromString[felt.Felt]("0x11"): felt.NewUnsafeFromString[felt.Felt]("0x12"),
+							felt.UnsafeFromString[felt.Felt]("0x11"): felt.NewUnsafeFromString[felt.Felt]("0x12"),
 						},
 						ReplacedClasses: map[felt.Felt]*felt.Felt{
-							*felt.NewUnsafeFromString[felt.Felt]("0x13"): felt.NewUnsafeFromString[felt.Felt]("0x14"),
+							felt.UnsafeFromString[felt.Felt]("0x13"): felt.NewUnsafeFromString[felt.Felt]("0x14"),
 						},
 					},
 				},
@@ -762,22 +768,22 @@ func TestChangeStateDiffStruct(t *testing.T) {
 					OldRoot:   felt.NewUnsafeFromString[felt.Felt]("0x17"),
 					StateDiff: &core.StateDiff{
 						StorageDiffs: map[felt.Felt]map[felt.Felt]*felt.Felt{
-							*felt.NewUnsafeFromString[felt.Felt]("0x18"): {
-								*felt.NewUnsafeFromString[felt.Felt]("0x19"): felt.NewUnsafeFromString[felt.Felt]("0x20"),
+							felt.UnsafeFromString[felt.Felt]("0x18"): {
+								felt.UnsafeFromString[felt.Felt]("0x19"): felt.NewUnsafeFromString[felt.Felt]("0x20"),
 							},
 						},
 						Nonces: map[felt.Felt]*felt.Felt{
-							*felt.NewUnsafeFromString[felt.Felt]("0x21"): felt.NewUnsafeFromString[felt.Felt]("0x22"),
+							felt.UnsafeFromString[felt.Felt]("0x21"): felt.NewUnsafeFromString[felt.Felt]("0x22"),
 						},
 						DeployedContracts: map[felt.Felt]*felt.Felt{
-							*felt.NewUnsafeFromString[felt.Felt]("0x23"): felt.NewUnsafeFromString[felt.Felt]("0x24"),
+							felt.UnsafeFromString[felt.Felt]("0x23"): felt.NewUnsafeFromString[felt.Felt]("0x24"),
 						},
 						DeclaredV0Classes: []*felt.Felt{felt.NewUnsafeFromString[felt.Felt]("0x25")},
 						DeclaredV1Classes: map[felt.Felt]*felt.Felt{
-							*felt.NewUnsafeFromString[felt.Felt]("0x26"): felt.NewUnsafeFromString[felt.Felt]("0x27"),
+							felt.UnsafeFromString[felt.Felt]("0x26"): felt.NewUnsafeFromString[felt.Felt]("0x27"),
 						},
 						ReplacedClasses: map[felt.Felt]*felt.Felt{
-							*felt.NewUnsafeFromString[felt.Felt]("0x28"): felt.NewUnsafeFromString[felt.Felt]("0x29"),
+							felt.UnsafeFromString[felt.Felt]("0x28"): felt.NewUnsafeFromString[felt.Felt]("0x29"),
 						},
 					},
 				},
@@ -805,7 +811,7 @@ func randSlice(t *testing.T) []felt.Felt {
 	sl := make([]felt.Felt, n)
 
 	for i := range sl {
-		sl[i] = *felt.NewRandom[felt.Felt]()
+		sl[i] = felt.Random[felt.Felt]()
 	}
 	return sl
 }

--- a/rpc/v10/adapt_transaction.go
+++ b/rpc/v10/adapt_transaction.go
@@ -351,7 +351,7 @@ func adaptContractClassToStarknet(class *ContractClass) starknet.SierraClass {
 	return starknet.SierraClass{
 		Abi:     class.ABI,
 		Version: class.ContractClassVersion,
-		Program: utils.ToPtrSlice(class.SierraProgram),
+		Program: class.SierraProgram,
 		EntryPoints: starknet.SierraEntryPoints{
 			Constructor: handleEntryPoints(class.EntryPoints.Constructor),
 			External:    handleEntryPoints(class.EntryPoints.External),

--- a/rpc/v10/class.go
+++ b/rpc/v10/class.go
@@ -9,7 +9,7 @@ import (
 
 // https://github.com/starkware-libs/starknet-specs/blob/release/v0.10.2/api/starknet_api_openrpc.json#L506-L522
 type Class struct {
-	SierraProgram        []*felt.Felt           `json:"sierra_program,omitempty"`
+	SierraProgram        []felt.Felt            `json:"sierra_program,omitempty"`
 	Program              string                 `json:"program,omitempty"`
 	ContractClassVersion string                 `json:"contract_class_version,omitempty"`
 	EntryPoints          ClassEntryPointsByType `json:"entry_points_by_type"`

--- a/rpc/v10/compiled_casm.go
+++ b/rpc/v10/compiled_casm.go
@@ -31,7 +31,7 @@ type CompiledCasmResponse struct {
 	// can't use felt.Felt here because prime is larger than felt
 	Prime                  string          `json:"prime"`
 	CompilerVersion        string          `json:"compiler_version"`
-	Bytecode               []*felt.Felt    `json:"bytecode"`
+	Bytecode               []felt.Felt     `json:"bytecode"`
 	Hints                  json.RawMessage `json:"hints"`
 	BytecodeSegmentLengths []int           `json:"bytecode_segment_lengths,omitempty"`
 }

--- a/rpc/v10/compiled_casm_test.go
+++ b/rpc/v10/compiled_casm_test.go
@@ -80,7 +80,7 @@ func TestCompiledCasm(t *testing.T) {
 			},
 			Constructor: []core.CasmEntryPoint{},
 			L1Handler:   []core.CasmEntryPoint{},
-			Bytecode:    []felt.Felt{*felt.NewUnsafeFromString[felt.Felt]("0x123")},
+			Bytecode:    []felt.Felt{felt.UnsafeFromString[felt.Felt]("0x123")},
 		}
 
 		cairoClass := &core.SierraClass{
@@ -99,7 +99,7 @@ func TestCompiledCasm(t *testing.T) {
 		assert.Equal(t, uint64(42), resp.EntryPointsByType.External[0].Offset)
 		assert.Equal(
 			t,
-			*felt.NewUnsafeFromString[felt.Felt]("0xabc"),
+			felt.UnsafeFromString[felt.Felt]("0xabc"),
 			resp.EntryPointsByType.External[0].Selector,
 		)
 		assert.Equal(t, []string{"range_check"}, resp.EntryPointsByType.External[0].Builtins)

--- a/rpc/v10/compiled_casm_test.go
+++ b/rpc/v10/compiled_casm_test.go
@@ -80,7 +80,7 @@ func TestCompiledCasm(t *testing.T) {
 			},
 			Constructor: []core.CasmEntryPoint{},
 			L1Handler:   []core.CasmEntryPoint{},
-			Bytecode:    []*felt.Felt{felt.NewUnsafeFromString[felt.Felt]("0x123")},
+			Bytecode:    []felt.Felt{*felt.NewUnsafeFromString[felt.Felt]("0x123")},
 		}
 
 		cairoClass := &core.SierraClass{

--- a/rpc/v8/class.go
+++ b/rpc/v8/class.go
@@ -17,11 +17,11 @@ import (
 
 // https://github.com/starkware-libs/starknet-specs/blob/v0.8.1/api/starknet_api_openrpc.json#L3159
 type Class struct {
-	SierraProgram        []*felt.Felt `json:"sierra_program,omitempty"`
-	Program              string       `json:"program,omitempty"`
-	ContractClassVersion string       `json:"contract_class_version,omitempty"`
-	EntryPoints          EntryPoints  `json:"entry_points_by_type"`
-	Abi                  any          `json:"abi"`
+	SierraProgram        []felt.Felt `json:"sierra_program,omitempty"`
+	Program              string      `json:"program,omitempty"`
+	ContractClassVersion string      `json:"contract_class_version,omitempty"`
+	EntryPoints          EntryPoints `json:"entry_points_by_type"`
+	Abi                  any         `json:"abi"`
 }
 
 type EntryPoints struct {

--- a/rpc/v8/compiled_casm.go
+++ b/rpc/v8/compiled_casm.go
@@ -32,7 +32,7 @@ type CasmCompiledContractClass struct {
 	// can't use felt.Felt here because prime is larger than felt
 	Prime                  string          `json:"prime"`
 	CompilerVersion        string          `json:"compiler_version"`
-	Bytecode               []*felt.Felt    `json:"bytecode"`
+	Bytecode               []felt.Felt     `json:"bytecode"`
 	Hints                  json.RawMessage `json:"hints"`
 	BytecodeSegmentLengths []int           `json:"bytecode_segment_lengths,omitempty"`
 }

--- a/rpc/v8/compiled_casm_test.go
+++ b/rpc/v8/compiled_casm_test.go
@@ -78,7 +78,7 @@ func TestCompiledCasm(t *testing.T) {
 			},
 			Constructor: []core.CasmEntryPoint{},
 			L1Handler:   []core.CasmEntryPoint{},
-			Bytecode:    []felt.Felt{*felt.NewUnsafeFromString[felt.Felt]("0x123")},
+			Bytecode:    []felt.Felt{felt.UnsafeFromString[felt.Felt]("0x123")},
 		}
 
 		sierraClass := &core.SierraClass{

--- a/rpc/v8/compiled_casm_test.go
+++ b/rpc/v8/compiled_casm_test.go
@@ -78,7 +78,7 @@ func TestCompiledCasm(t *testing.T) {
 			},
 			Constructor: []core.CasmEntryPoint{},
 			L1Handler:   []core.CasmEntryPoint{},
-			Bytecode:    []*felt.Felt{felt.NewUnsafeFromString[felt.Felt]("0x123")},
+			Bytecode:    []felt.Felt{*felt.NewUnsafeFromString[felt.Felt]("0x123")},
 		}
 
 		sierraClass := &core.SierraClass{

--- a/rpc/v9/class.go
+++ b/rpc/v9/class.go
@@ -19,7 +19,7 @@ type CalldataInputs = rpccore.LimitSlice[felt.Felt, rpccore.FunctionCalldataLimi
 
 // https://github.com/starkware-libs/starknet-specs/blob/e0b76ed0d8d8eba405e182371f9edac8b2bcbc5a/api/starknet_api_openrpc.json#L268-L280
 type Class struct {
-	SierraProgram        []*felt.Felt           `json:"sierra_program,omitempty"`
+	SierraProgram        []felt.Felt            `json:"sierra_program,omitempty"`
 	Program              string                 `json:"program,omitempty"`
 	ContractClassVersion string                 `json:"contract_class_version,omitempty"`
 	EntryPoints          ClassEntryPointsByType `json:"entry_points_by_type"`

--- a/rpc/v9/compiled_casm.go
+++ b/rpc/v9/compiled_casm.go
@@ -31,7 +31,7 @@ type CompiledCasmResponse struct {
 	// can't use felt.Felt here because prime is larger than felt
 	Prime                  string          `json:"prime"`
 	CompilerVersion        string          `json:"compiler_version"`
-	Bytecode               []*felt.Felt    `json:"bytecode"`
+	Bytecode               []felt.Felt     `json:"bytecode"`
 	Hints                  json.RawMessage `json:"hints"`
 	BytecodeSegmentLengths []int           `json:"bytecode_segment_lengths,omitempty"`
 }

--- a/rpc/v9/compiled_casm_test.go
+++ b/rpc/v9/compiled_casm_test.go
@@ -78,7 +78,7 @@ func TestCompiledCasm(t *testing.T) {
 			},
 			Constructor: []core.CasmEntryPoint{},
 			L1Handler:   []core.CasmEntryPoint{},
-			Bytecode:    []*felt.Felt{felt.NewUnsafeFromString[felt.Felt]("0x123")},
+			Bytecode:    []felt.Felt{*felt.NewUnsafeFromString[felt.Felt]("0x123")},
 		}
 
 		cairoClass := &core.SierraClass{

--- a/rpc/v9/compiled_casm_test.go
+++ b/rpc/v9/compiled_casm_test.go
@@ -78,7 +78,7 @@ func TestCompiledCasm(t *testing.T) {
 			},
 			Constructor: []core.CasmEntryPoint{},
 			L1Handler:   []core.CasmEntryPoint{},
-			Bytecode:    []felt.Felt{*felt.NewUnsafeFromString[felt.Felt]("0x123")},
+			Bytecode:    []felt.Felt{felt.UnsafeFromString[felt.Felt]("0x123")},
 		}
 
 		cairoClass := &core.SierraClass{
@@ -95,7 +95,10 @@ func TestCompiledCasm(t *testing.T) {
 		// Verify that the offset is correctly passed as uint64
 		require.Len(t, resp.EntryPointsByType.External, 1)
 		assert.Equal(t, uint64(42), resp.EntryPointsByType.External[0].Offset)
-		assert.Equal(t, *felt.NewUnsafeFromString[felt.Felt]("0xabc"), resp.EntryPointsByType.External[0].Selector)
+		assert.Equal(t,
+			felt.UnsafeFromString[felt.Felt]("0xabc"),
+			resp.EntryPointsByType.External[0].Selector,
+		)
 		assert.Equal(t, []string{"range_check"}, resp.EntryPointsByType.External[0].Builtins)
 		assert.Equal(t, fmt.Sprintf("0x%x", big.NewInt(123)), resp.Prime)
 		assert.Equal(t, "1.0.0", resp.CompilerVersion)

--- a/starknet/class.go
+++ b/starknet/class.go
@@ -47,7 +47,7 @@ type SierraEntryPoints struct {
 type SierraClass struct {
 	Abi         string            `json:"abi,omitempty"`
 	EntryPoints SierraEntryPoints `json:"entry_points_by_type"`
-	Program     []*felt.Felt      `json:"sierra_program"`
+	Program     []felt.Felt       `json:"sierra_program"`
 	Version     string            `json:"contract_class_version"`
 }
 
@@ -116,7 +116,7 @@ func (n SegmentLengths) MarshalJSON() ([]byte, error) {
 
 type CasmClass struct {
 	Prime                  string          `json:"prime"`
-	Bytecode               []*felt.Felt    `json:"bytecode"`
+	Bytecode               []felt.Felt     `json:"bytecode"`
 	Hints                  json.RawMessage `json:"hints"`
 	PythonicHints          json.RawMessage `json:"pythonic_hints"`
 	CompilerVersion        string          `json:"compiler_version"`


### PR DESCRIPTION
Replaces `[]*felt.Felt` for `[]felt.Felt` as class `Program` and `Bytecode`.

The `GetClass` RPC method throughput got 17% faster compared to main in a saturated node.

An speciallized CBOR Unmarshalling/Marshalling is still 1.65x - 2x faster than the current one, so I'll introduce it in a following PR.

This PR also introduces extra copies before hashing due to signature conflicts. These are treated in [this PR](https://github.com/NethermindEth/juno/pull/3844). 