### PR TITLE
refactor(crypto): zero-copy hashes for classes

### DIFF
--- a/adapters/p2p2core/class.go
+++ b/adapters/p2p2core/class.go
@@ -34,8 +34,7 @@ func AdaptSierraClass(
 		return utils.Map(utils.NonNilSlice(points), adaptSierra)
 	}
 
-	// TODO(granza): update hash to also receive []felt.Felt
-	programHash := crypto.PoseidonArray(utils.ToPtrSlice(program)...)
+	programHash := crypto.PoseidonArrayFelts(program)
 	entryPoints := cairo1.EntryPoints
 	return core.SierraClass{
 		Abi:     cairo1.Abi,

--- a/adapters/p2p2core/class.go
+++ b/adapters/p2p2core/class.go
@@ -34,7 +34,7 @@ func AdaptSierraClass(
 		return utils.Map(utils.NonNilSlice(points), adaptSierra)
 	}
 
-	programHash := crypto.PoseidonArrayFelts(program)
+	programHash := crypto.PoseidonArray(program)
 	entryPoints := cairo1.EntryPoints
 	return core.SierraClass{
 		Abi:     cairo1.Abi,

--- a/adapters/sn2core/sn2core.go
+++ b/adapters/sn2core/sn2core.go
@@ -349,8 +349,7 @@ func AdaptSierraClass(
 		return nil, err
 	}
 
-	// TODO(granza): update hash to also receive []felt.Felt
-	programHash := crypto.PoseidonArray(utils.ToPtrSlice(response.Program)...)
+	programHash := crypto.PoseidonArrayFelts(response.Program)
 	abiHash := crypto.StarknetKeccak([]byte(response.Abi))
 	return &core.SierraClass{
 		SemanticVersion: response.Version,

--- a/adapters/sn2core/sn2core.go
+++ b/adapters/sn2core/sn2core.go
@@ -349,7 +349,7 @@ func AdaptSierraClass(
 		return nil, err
 	}
 
-	programHash := crypto.PoseidonArrayFelts(response.Program)
+	programHash := crypto.PoseidonArray(response.Program)
 	abiHash := crypto.StarknetKeccak([]byte(response.Abi))
 	return &core.SierraClass{
 		SemanticVersion: response.Version,

--- a/core/block.go
+++ b/core/block.go
@@ -277,7 +277,7 @@ func post0134Hash(
 		*b.L2GasPrice,
 	)
 
-	return crypto.PoseidonArrayPtr(
+	return crypto.PoseidonElems(
 			starknetBlockHash1,
 			new(felt.Felt).SetUint64(b.Number),    // block number
 			b.GlobalStateRoot,                     // global state root
@@ -361,7 +361,7 @@ func Post0132Hash(
 		}
 	}
 
-	return crypto.PoseidonArrayPtr(
+	return crypto.PoseidonElems(
 			starknetBlockHash0,
 			new(felt.Felt).SetUint64(b.Number),    // block number
 			b.GlobalStateRoot,                     // global state root
@@ -491,7 +491,7 @@ func ConcatCounts(txCount, eventCount, stateDiffLen uint64, l1Mode L1DAMode) fel
 }
 
 func gasPricesHash(gasPrices, dataGasPrices, l2GasPrices GasPrice) felt.Felt {
-	return crypto.PoseidonArrayPtr(
+	return crypto.PoseidonElems(
 		starknetGasPrices0,
 		// gas prices
 		gasPrices.PriceInWei,

--- a/core/block.go
+++ b/core/block.go
@@ -277,7 +277,7 @@ func post0134Hash(
 		*b.L2GasPrice,
 	)
 
-	return crypto.PoseidonArray(
+	return crypto.PoseidonArrayPtr(
 			starknetBlockHash1,
 			new(felt.Felt).SetUint64(b.Number),    // block number
 			b.GlobalStateRoot,                     // global state root
@@ -361,7 +361,7 @@ func Post0132Hash(
 		}
 	}
 
-	return crypto.PoseidonArray(
+	return crypto.PoseidonArrayPtr(
 			starknetBlockHash0,
 			new(felt.Felt).SetUint64(b.Number),    // block number
 			b.GlobalStateRoot,                     // global state root
@@ -491,7 +491,7 @@ func ConcatCounts(txCount, eventCount, stateDiffLen uint64, l1Mode L1DAMode) fel
 }
 
 func gasPricesHash(gasPrices, dataGasPrices, l2GasPrices GasPrice) felt.Felt {
-	return crypto.PoseidonArray(
+	return crypto.PoseidonArrayPtr(
 		starknetGasPrices0,
 		// gas prices
 		gasPrices.PriceInWei,

--- a/core/class.go
+++ b/core/class.go
@@ -13,7 +13,6 @@ import (
 	"github.com/NethermindEth/juno/core/felt"
 	"github.com/NethermindEth/juno/db"
 	"github.com/NethermindEth/juno/encoder"
-	"github.com/NethermindEth/juno/utils"
 )
 
 var (
@@ -169,14 +168,14 @@ const (
 
 // Hasher wraps hash algorithm operations
 type Hasher interface {
-	HashArray(felts ...*felt.Felt) felt.Felt
+	HashArray(felts []felt.Felt) felt.Felt
 	NewDigest() crypto.Digest
 }
 
 type poseidonHasher struct{}
 
-func (h poseidonHasher) HashArray(felts ...*felt.Felt) felt.Felt {
-	return crypto.PoseidonArray(felts...)
+func (h poseidonHasher) HashArray(felts []felt.Felt) felt.Felt {
+	return crypto.PoseidonArrayFelts(felts)
 }
 
 func (h poseidonHasher) NewDigest() crypto.Digest {
@@ -185,8 +184,8 @@ func (h poseidonHasher) NewDigest() crypto.Digest {
 
 type blake2sHasher struct{}
 
-func (h blake2sHasher) HashArray(felts ...*felt.Felt) felt.Felt {
-	hash := blake2s.Blake2sArray(felts...)
+func (h blake2sHasher) HashArray(felts []felt.Felt) felt.Felt {
+	hash := blake2s.Blake2sArray(felts)
 	return felt.Felt(hash)
 }
 
@@ -215,8 +214,7 @@ func (c *CasmClass) Hash(version CasmHashVersion) felt.Felt {
 
 	var bytecodeHash felt.Felt
 	if len(c.BytecodeSegmentLengths.Children) == 0 {
-		// TODO(granza): update hash to also receive []felt.Felt
-		bytecodeHash = hasher.HashArray(utils.ToPtrSlice(c.Bytecode)...)
+		bytecodeHash = hasher.HashArray(c.Bytecode)
 	} else {
 		bytecodeHash = SegmentedBytecodeHash(c.Bytecode, c.BytecodeSegmentLengths.Children, hasher)
 	}
@@ -225,13 +223,13 @@ func (c *CasmClass) Hash(version CasmHashVersion) felt.Felt {
 	l1HandlerEntryPointsHash := compiledEntryPointsHash(c.L1Handler, hasher)
 	constructorHash := compiledEntryPointsHash(c.Constructor, hasher)
 
-	return hasher.HashArray(
-		compiledClassV1Prefix,
-		&externalEntryPointsHash,
-		&l1HandlerEntryPointsHash,
-		&constructorHash,
-		&bytecodeHash,
-	)
+	return hasher.HashArray([]felt.Felt{
+		*compiledClassV1Prefix,
+		externalEntryPointsHash,
+		l1HandlerEntryPointsHash,
+		constructorHash,
+		bytecodeHash,
+	})
 }
 
 func SegmentedBytecodeHash(
@@ -252,8 +250,7 @@ func SegmentedBytecodeHash(
 			if len(segment.Children) == 0 {
 				curSegmentLength = segment.Length
 				segmentBytecode := bytecode[startingOffset : startingOffset+segment.Length]
-				// TODO(granza): update hash to also receive []felt.Felt
-				curSegmentHash = hasher.HashArray(utils.ToPtrSlice(segmentBytecode)...)
+				curSegmentHash = hasher.HashArray(segmentBytecode)
 			} else {
 				curSegmentLength, curSegmentHash = digestSegment(segment.Children)
 			}

--- a/core/class.go
+++ b/core/class.go
@@ -121,7 +121,7 @@ func (c *SierraClass) Hash() (felt.Felt, error) {
 	externalEntryPointsHash := sierraEntryPointsHash(c.EntryPoints.External)
 	l1HandlerEntryPointsHash := sierraEntryPointsHash(c.EntryPoints.L1Handler)
 	constructorHash := sierraEntryPointsHash(c.EntryPoints.Constructor)
-	return crypto.PoseidonArrayPtr(
+	return crypto.PoseidonElems(
 		felt.NewFromBytes[felt.Felt]([]byte("CONTRACT_CLASS_V"+c.SemanticVersion)),
 		&externalEntryPointsHash,
 		&l1HandlerEntryPointsHash,

--- a/core/class.go
+++ b/core/class.go
@@ -121,7 +121,7 @@ func (c *SierraClass) Hash() (felt.Felt, error) {
 	externalEntryPointsHash := sierraEntryPointsHash(c.EntryPoints.External)
 	l1HandlerEntryPointsHash := sierraEntryPointsHash(c.EntryPoints.L1Handler)
 	constructorHash := sierraEntryPointsHash(c.EntryPoints.Constructor)
-	return crypto.PoseidonArray(
+	return crypto.PoseidonArrayPtr(
 		felt.NewFromBytes[felt.Felt]([]byte("CONTRACT_CLASS_V"+c.SemanticVersion)),
 		&externalEntryPointsHash,
 		&l1HandlerEntryPointsHash,
@@ -175,7 +175,7 @@ type Hasher interface {
 type poseidonHasher struct{}
 
 func (h poseidonHasher) HashArray(felts []felt.Felt) felt.Felt {
-	return crypto.PoseidonArrayFelts(felts)
+	return crypto.PoseidonArray(felts)
 }
 
 func (h poseidonHasher) NewDigest() crypto.Digest {

--- a/core/crypto/blake2s/hash.go
+++ b/core/crypto/blake2s/hash.go
@@ -3,7 +3,6 @@ package blake2s
 import (
 	"hash"
 	"slices"
-	"unsafe"
 
 	"github.com/NethermindEth/juno/core/crypto"
 	"github.com/NethermindEth/juno/core/felt"
@@ -13,24 +12,17 @@ import (
 // Following the same implementation behind
 // https://github.com/starknet-io/types-rs/blob/main/crates/starknet-types-core/src/hash/blake2s.rs
 
-func Blake2s[F felt.FeltLike](x, y *F) felt.Hash {
-	return Blake2sArray(x, y)
-}
+func Blake2sArray(felts []felt.Felt) felt.Hash {
+	const expectedCapMult = 5
 
-func Blake2sArray[F felt.FeltLike](feltLikes ...*F) felt.Hash {
-	var felts []*felt.Felt
-	if len(feltLikes) > 0 {
-		// It is assumed that type F follows the exact same memory layout as felt.Felt
-		felts = unsafe.Slice((**felt.Felt)(unsafe.Pointer(&feltLikes[0])), len(feltLikes))
-	} else {
-		felts = []*felt.Felt{}
+	buf := make([]byte, 0, len(felts)*expectedCapMult*4)
+	for i := range felts {
+		buf = appendFeltBytes(buf, &felts[i])
 	}
-
-	encoding := encodeFeltsToBytes(felts...)
 
 	// Sum256 returns a fixed [32]byte value, avoiding the digest struct and result
 	// slice that New256/Write/Sum would heap-allocate.
-	result := blake2s.Sum256(encoding)
+	result := blake2s.Sum256(buf)
 
 	// Sum256 is big endian, reverse to little endian.
 	slices.Reverse(result[:])

--- a/core/crypto/blake2s/hash.go
+++ b/core/crypto/blake2s/hash.go
@@ -13,16 +13,15 @@ import (
 // https://github.com/starknet-io/types-rs/blob/main/crates/starknet-types-core/src/hash/blake2s.rs
 
 func Blake2sArray(felts []felt.Felt) felt.Hash {
-	const expectedCapMult = 5
-
-	buf := make([]byte, 0, len(felts)*expectedCapMult*4)
+	buf := make([]byte, len(felts)*maxWordsPerFelt*4)
+	offset := 0
 	for i := range felts {
-		buf = appendFeltBytes(buf, &felts[i])
+		offset += encodeFeltInto(buf[offset:], &felts[i])
 	}
 
 	// Sum256 returns a fixed [32]byte value, avoiding the digest struct and result
 	// slice that New256/Write/Sum would heap-allocate.
-	result := blake2s.Sum256(buf)
+	result := blake2s.Sum256(buf[:offset])
 
 	// Sum256 is big endian, reverse to little endian.
 	slices.Reverse(result[:])
@@ -44,7 +43,7 @@ func NewDigest() Blake2sDigest {
 }
 
 func (d *Blake2sDigest) Update(elems ...*felt.Felt) crypto.Digest {
-	encoding := encodeFeltsToBytes(elems...)
+	encoding := encodeFelts(elems...)
 	_, err := d.hasher.Write(encoding)
 	if err != nil {
 		panic(err)

--- a/core/crypto/blake2s/hash_test.go
+++ b/core/crypto/blake2s/hash_test.go
@@ -10,7 +10,7 @@ import (
 
 func TestBlakeHash(t *testing.T) {
 	t.Run("hash zero", func(t *testing.T) {
-		actual := blake2s.Blake2sArray(&felt.Zero)
+		actual := blake2s.Blake2sArray([]felt.Felt{felt.Zero})
 
 		expected := felt.UnsafeFromString[felt.Hash](
 			"0x5768af071a2f8df7c9df9dc4ca0e7a1c5908d5eff88af963c3264f412dbdf43",
@@ -20,10 +20,10 @@ func TestBlakeHash(t *testing.T) {
 	})
 
 	t.Run("hash one two", func(t *testing.T) {
-		val1 := felt.FromUint64[felt.Felt](1)
-		val2 := felt.FromUint64[felt.Felt](2)
-
-		actual := blake2s.Blake2sArray(&val1, &val2)
+		actual := blake2s.Blake2sArray([]felt.Felt{
+			felt.FromUint64[felt.Felt](1),
+			felt.FromUint64[felt.Felt](2),
+		})
 
 		expected := felt.UnsafeFromString[felt.Hash](
 			"0x5534c03a14b214436366f30e9c77b6e56c8835de7dc5aee36957d4384cce66d",
@@ -32,7 +32,7 @@ func TestBlakeHash(t *testing.T) {
 	})
 
 	t.Run("empty array", func(t *testing.T) {
-		actual := blake2s.Blake2sArray[felt.Felt]()
+		actual := blake2s.Blake2sArray(nil)
 
 		expected := felt.UnsafeFromString[felt.Hash](
 			"0x1eed01efd0d230c1ea5a12c48b6551f7c4a3542d02111e194809079307a214a",
@@ -42,7 +42,7 @@ func TestBlakeHash(t *testing.T) {
 	})
 
 	t.Run("small felt", func(t *testing.T) {
-		actual := blake2s.Blake2sArray(felt.NewFromUint64[felt.Felt](1<<63 - 1))
+		actual := blake2s.Blake2sArray([]felt.Felt{felt.FromUint64[felt.Felt](1<<63 - 1)})
 
 		expected := felt.UnsafeFromString[felt.Hash](
 			"0x354aef67e2b1a01d5afe9a85707d79349c8be8a4b261629360b2129810d8dd",
@@ -51,7 +51,7 @@ func TestBlakeHash(t *testing.T) {
 	})
 
 	t.Run("at boundary", func(t *testing.T) {
-		actual := blake2s.Blake2sArray(felt.NewFromUint64[felt.Felt](1 << 63))
+		actual := blake2s.Blake2sArray([]felt.Felt{felt.FromUint64[felt.Felt](1 << 63)})
 
 		expected := felt.UnsafeFromString[felt.Hash](
 			"0xb44aeea3e1288e4614b3de3a7a6bee8d592ef9cd30c70304e7e84b52702ef2",
@@ -61,10 +61,11 @@ func TestBlakeHash(t *testing.T) {
 	})
 
 	t.Run("large felt", func(t *testing.T) {
-		actual := blake2s.Blake2sArray(
-			felt.NewUnsafeFromString[felt.Felt](
+		actual := blake2s.Blake2sArray([]felt.Felt{
+			felt.UnsafeFromString[felt.Felt](
 				"0x800000000000011000000000000000000000000000000000000000000000000",
-			))
+			),
+		})
 
 		expected := felt.UnsafeFromString[felt.Hash](
 			"0x7c018937c4b4968cc90a67326b1715ca808b7546ad91fb91fbc42a3dc6c52f1",
@@ -74,11 +75,11 @@ func TestBlakeHash(t *testing.T) {
 	})
 
 	t.Run("mixed small large felts", func(t *testing.T) {
-		actual := blake2s.Blake2sArray(
-			felt.NewFromUint64[felt.Felt](42),
-			felt.NewFromUint64[felt.Felt](1<<63),
-			felt.NewFromUint64[felt.Felt](1337),
-		)
+		actual := blake2s.Blake2sArray([]felt.Felt{
+			felt.FromUint64[felt.Felt](42),
+			felt.FromUint64[felt.Felt](1 << 63),
+			felt.FromUint64[felt.Felt](1337),
+		})
 
 		expected := felt.UnsafeFromString[felt.Hash](
 			"0x27e2140360d26bf4a53778d8bc2f9b103ddfa83abf3451308190b9c340d11a5",
@@ -88,7 +89,7 @@ func TestBlakeHash(t *testing.T) {
 	})
 
 	t.Run("max u64", func(t *testing.T) {
-		actual := blake2s.Blake2sArray(felt.NewFromUint64[felt.Felt](^uint64(0)))
+		actual := blake2s.Blake2sArray([]felt.Felt{felt.FromUint64[felt.Felt](^uint64(0))})
 
 		expected := felt.UnsafeFromString[felt.Hash](
 			"0x7c576253e278f7f66f8a9a8776b2d9e1c6f03b1bbdb8e25c9cbcab854199426",

--- a/core/crypto/blake2s/utils.go
+++ b/core/crypto/blake2s/utils.go
@@ -1,27 +1,39 @@
 package blake2s
 
-import "github.com/NethermindEth/juno/core/felt"
+import (
+	"encoding/binary"
 
-//nolint:mnd // number represents 2**63
-const smallFeltThresholdLow uint64 = 0x8000000000000000
+	"github.com/NethermindEth/juno/core/felt"
+)
 
-// encodeFeltsToBytes encodes felts as little-endian u32 words.
+const (
+	//nolint:mnd // number represents 2**63
+	smallFeltThresholdLow uint64 = 0x8000000000000000
+
+	// maxWordsPerFelt is the worst-case number of u32 words a single felt encodes
+	// to (large felts use eight words; small ones use two).
+	maxWordsPerFelt int = 8
+)
+
+// encodeFelts encodes felts as little-endian u32 words.
 // Small values (< 2**63) use two words.
 // Larger values use eight words with a marker bit on the first word.
-func encodeFeltsToBytes(felts ...*felt.Felt) []byte {
-	const expectedCapMult = 5
-	buf := make([]byte, 0, len(felts)*expectedCapMult*4)
-	return appendFeltsToBytes(buf, felts...)
+func encodeFelts(felts ...*felt.Felt) []byte {
+	buf := make([]byte, len(felts)*maxWordsPerFelt*4)
+	return buf[:encodeFeltsInto(buf, felts...)]
 }
 
-func appendFeltsToBytes(buf []byte, felts ...*felt.Felt) []byte {
+// encodeFeltsInto encodes felts into data and returns the number of bytes written.
+func encodeFeltsInto(data []byte, felts ...*felt.Felt) int {
+	offset := 0
 	for _, f := range felts {
-		buf = appendFeltBytes(buf, f)
+		offset += encodeFeltInto(data[offset:], f)
 	}
-	return buf
+	return offset
 }
 
-func appendFeltBytes(buf []byte, f *felt.Felt) []byte {
+// encodeFeltInto encodes a single felt into data and returns the number of bytes written.
+func encodeFeltInto(data []byte, f *felt.Felt) int {
 	const largeFeltMarker uint32 = 1 << 31
 
 	// Bits() leaves Montgomery form once.
@@ -30,25 +42,20 @@ func appendFeltBytes(buf []byte, f *felt.Felt) []byte {
 	fb := f.Bits()
 	if fb[3] == 0 && fb[2] == 0 && fb[1] == 0 && fb[0] < smallFeltThresholdLow {
 		val := fb[0]
-		buf = appendUint32LE(buf, uint32(val>>32))
-		buf = appendUint32LE(buf, uint32(val))
-		return buf
+		binary.LittleEndian.PutUint32(data, uint32(val>>32))
+		binary.LittleEndian.PutUint32(data[4:], uint32(val))
+		return 8
 	}
 
-	// Word order is most-significant to least-significant.
-	// appendUint32LE handles the byte order within each word.
-	buf = appendUint32LE(buf, uint32(fb[3]>>32)|largeFeltMarker)
-	buf = appendUint32LE(buf, uint32(fb[3]))
-	buf = appendUint32LE(buf, uint32(fb[2]>>32))
-	buf = appendUint32LE(buf, uint32(fb[2]))
-	buf = appendUint32LE(buf, uint32(fb[1]>>32))
-	buf = appendUint32LE(buf, uint32(fb[1]))
-	buf = appendUint32LE(buf, uint32(fb[0]>>32))
-	buf = appendUint32LE(buf, uint32(fb[0]))
-	return buf
-}
-
-// LE is shorthand for little endian.
-func appendUint32LE(buf []byte, val uint32) []byte {
-	return append(buf, byte(val), byte(val>>8), byte(val>>16), byte(val>>24))
+	// Each limb is written as two little-endian u32 words, high word first.
+	// Word order across the whole felt is most-significant to least-significant.
+	binary.LittleEndian.PutUint32(data, uint32(fb[3]>>32)|largeFeltMarker)
+	binary.LittleEndian.PutUint32(data[4:], uint32(fb[3]))
+	binary.LittleEndian.PutUint32(data[8:], uint32(fb[2]>>32))
+	binary.LittleEndian.PutUint32(data[12:], uint32(fb[2]))
+	binary.LittleEndian.PutUint32(data[16:], uint32(fb[1]>>32))
+	binary.LittleEndian.PutUint32(data[20:], uint32(fb[1]))
+	binary.LittleEndian.PutUint32(data[24:], uint32(fb[0]>>32))
+	binary.LittleEndian.PutUint32(data[28:], uint32(fb[0]))
+	return 32
 }

--- a/core/crypto/blake2s/utils_test.go
+++ b/core/crypto/blake2s/utils_test.go
@@ -10,7 +10,7 @@ import (
 func TestFeltToBytesEncoding(t *testing.T) {
 	t.Run("small felt", func(t *testing.T) {
 		val := felt.FromUint64[felt.Felt](0x1122334455667788)
-		actual := encodeFeltsToBytes(&val)
+		actual := encodeFelts(&val)
 		expected := []byte{
 			0x44, 0x33, 0x22, 0x11, 0x88, 0x77, 0x66, 0x55,
 		}
@@ -20,7 +20,7 @@ func TestFeltToBytesEncoding(t *testing.T) {
 
 	t.Run("big felt", func(t *testing.T) {
 		val := felt.FromUint64[felt.Felt](0x8000000000000000)
-		actual := encodeFeltsToBytes(&val)
+		actual := encodeFelts(&val)
 
 		// The expected array of bytes divided in 4 rows of 8 bytes.
 		// We expect the mark at the most significant word (first four bytes)

--- a/core/crypto/poseidon_hash.go
+++ b/core/crypto/poseidon_hash.go
@@ -72,10 +72,10 @@ func Poseidon(x, y *felt.Felt) felt.Felt {
 	return state[0]
 }
 
-// PoseidonArrayPtr is the pointer-element variant of [PoseidonArray], for
+// PoseidonElems is the pointer-element variant of [PoseidonArray], for
 // callers that already hold a []*felt.Felt (e.g. transaction hashing) and would
 // otherwise pay a copy to convert into a value slice.
-func PoseidonArrayPtr(elems ...*felt.Felt) felt.Felt {
+func PoseidonElems(elems ...*felt.Felt) felt.Felt {
 	state := [3]felt.Felt{}
 
 	for i := range len(elems) / 2 {

--- a/core/crypto/poseidon_hash.go
+++ b/core/crypto/poseidon_hash.go
@@ -98,6 +98,28 @@ func PoseidonArray(elems ...*felt.Felt) felt.Felt {
 	return state[0]
 }
 
+// PoseidonArrayFelts is the value-slice variant of [PoseidonArray].
+//
+// TODO(granza): rename PoseidonArray to PoseidonArrayPtr and this one to PoseidonArray
+func PoseidonArrayFelts(elems []felt.Felt) felt.Felt {
+	state := [3]felt.Felt{}
+
+	for i := range len(elems) / 2 {
+		state[0].Add(&state[0], &elems[2*i])
+		state[1].Add(&state[1], &elems[2*i+1])
+		HadesPermutation(&state)
+	}
+
+	rem := len(elems) % 2
+	if rem == 1 {
+		state[0].Add(&state[0], &elems[len(elems)-1])
+	}
+	state[rem].Add(&state[rem], &felt.One)
+	HadesPermutation(&state)
+
+	return state[0]
+}
+
 var (
 	poseidonInit sync.Once
 	roundKeys    [totalRounds][3]felt.Felt

--- a/core/crypto/poseidon_hash.go
+++ b/core/crypto/poseidon_hash.go
@@ -72,14 +72,10 @@ func Poseidon(x, y *felt.Felt) felt.Felt {
 	return state[0]
 }
 
-// PoseidonArray calculates Poseidon hash over elems
-// If len(elems) is odd, pads with [1]
-// If len(elems) is even, pads with [1, 0]
-//
-// PoseidonArray implements [Poseidon array hashing].
-//
-// [Poseidon array hashing]: https://docs.starknet.io/learn/protocol/cryptography#array-hashing
-func PoseidonArray(elems ...*felt.Felt) felt.Felt {
+// PoseidonArrayPtr is the pointer-element variant of [PoseidonArray], for
+// callers that already hold a []*felt.Felt (e.g. transaction hashing) and would
+// otherwise pay a copy to convert into a value slice.
+func PoseidonArrayPtr(elems ...*felt.Felt) felt.Felt {
 	state := [3]felt.Felt{}
 
 	for i := range len(elems) / 2 {
@@ -98,10 +94,14 @@ func PoseidonArray(elems ...*felt.Felt) felt.Felt {
 	return state[0]
 }
 
-// PoseidonArrayFelts is the value-slice variant of [PoseidonArray].
+// PoseidonArray calculates Poseidon hash over elems
+// If len(elems) is odd, pads with [1]
+// If len(elems) is even, pads with [1, 0]
 //
-// TODO(granza): rename PoseidonArray to PoseidonArrayPtr and this one to PoseidonArray
-func PoseidonArrayFelts(elems []felt.Felt) felt.Felt {
+// PoseidonArray implements [Poseidon array hashing].
+//
+// [Poseidon array hashing]: https://docs.starknet.io/learn/protocol/cryptography#array-hashing
+func PoseidonArray(elems []felt.Felt) felt.Felt {
 	state := [3]felt.Felt{}
 
 	for i := range len(elems) / 2 {

--- a/core/crypto/poseidon_hash_test.go
+++ b/core/crypto/poseidon_hash_test.go
@@ -47,15 +47,15 @@ func TestPoseidonArray(t *testing.T) {
 	} {
 		t.Run(name, func(t *testing.T) {
 			var digest, digestWhole crypto.PoseidonDigest
-			hash := crypto.PoseidonArray(test.elems...)
+			hash := crypto.PoseidonArrayPtr(test.elems...)
 			assert.Equal(t, test.expected, hash.String())
 
-			// PoseidonArrayFelts (value slice) must match the pointer version exactly.
+			// PoseidonArray (value slice) must match the pointer version exactly.
 			vals := make([]felt.Felt, len(test.elems))
 			for i, e := range test.elems {
 				vals[i] = *e
 			}
-			valsHash := crypto.PoseidonArrayFelts(vals)
+			valsHash := crypto.PoseidonArray(vals)
 			assert.Equal(t, test.expected, valsHash.String())
 
 			hash = digestWhole.Update(test.elems...).Finish()
@@ -75,10 +75,33 @@ func BenchmarkPoseidonArray(b *testing.B) {
 
 	for _, n := range numOfElems {
 		b.Run(fmt.Sprintf("Number of felts: %d", n), func(b *testing.B) {
+			pointerSlice := genRandomFelts(b, n)
+
+			feltsArray := make([]felt.Felt, len(pointerSlice))
+			for i, p := range pointerSlice {
+				if p != nil {
+					feltsArray[i] = *p
+				}
+			}
+
+			var f felt.Felt
+			for b.Loop() {
+				f = crypto.PoseidonArray(feltsArray)
+			}
+			benchHashR = f
+		})
+	}
+}
+
+func BenchmarkPoseidonArrayPtr(b *testing.B) {
+	numOfElems := []int{3, 5, 10, 15, 20, 25, 30, 35, 40}
+
+	for _, n := range numOfElems {
+		b.Run(fmt.Sprintf("Number of felts: %d", n), func(b *testing.B) {
 			elems := genRandomFelts(b, n)
 			var f felt.Felt
 			for b.Loop() {
-				f = crypto.PoseidonArray(elems...)
+				f = crypto.PoseidonArrayPtr(elems...)
 			}
 			benchHashR = f
 		})

--- a/core/crypto/poseidon_hash_test.go
+++ b/core/crypto/poseidon_hash_test.go
@@ -47,7 +47,7 @@ func TestPoseidonArray(t *testing.T) {
 	} {
 		t.Run(name, func(t *testing.T) {
 			var digest, digestWhole crypto.PoseidonDigest
-			hash := crypto.PoseidonArrayPtr(test.elems...)
+			hash := crypto.PoseidonElems(test.elems...)
 			assert.Equal(t, test.expected, hash.String())
 
 			// PoseidonArray (value slice) must match the pointer version exactly.
@@ -93,7 +93,7 @@ func BenchmarkPoseidonArray(b *testing.B) {
 	}
 }
 
-func BenchmarkPoseidonArrayPtr(b *testing.B) {
+func BenchmarkPoseidonElems(b *testing.B) {
 	numOfElems := []int{3, 5, 10, 15, 20, 25, 30, 35, 40}
 
 	for _, n := range numOfElems {
@@ -101,7 +101,7 @@ func BenchmarkPoseidonArrayPtr(b *testing.B) {
 			elems := genRandomFelts(b, n)
 			var f felt.Felt
 			for b.Loop() {
-				f = crypto.PoseidonArrayPtr(elems...)
+				f = crypto.PoseidonElems(elems...)
 			}
 			benchHashR = f
 		})

--- a/core/crypto/poseidon_hash_test.go
+++ b/core/crypto/poseidon_hash_test.go
@@ -49,6 +49,15 @@ func TestPoseidonArray(t *testing.T) {
 			var digest, digestWhole crypto.PoseidonDigest
 			hash := crypto.PoseidonArray(test.elems...)
 			assert.Equal(t, test.expected, hash.String())
+
+			// PoseidonArrayFelts (value slice) must match the pointer version exactly.
+			vals := make([]felt.Felt, len(test.elems))
+			for i, e := range test.elems {
+				vals[i] = *e
+			}
+			valsHash := crypto.PoseidonArrayFelts(vals)
+			assert.Equal(t, test.expected, valsHash.String())
+
 			hash = digestWhole.Update(test.elems...).Finish()
 			assert.Equal(t, test.expected, hash.String())
 

--- a/core/deprecatedstate/state.go
+++ b/core/deprecatedstate/state.go
@@ -127,7 +127,7 @@ func (s *State) Commitment(protocolVersion string) (felt.Felt, error) {
 		return storageRoot, nil
 	}
 
-	root := crypto.PoseidonArrayPtr(stateVersion, &storageRoot, &classesRoot)
+	root := crypto.PoseidonElems(stateVersion, &storageRoot, &classesRoot)
 	return root, nil
 }
 

--- a/core/deprecatedstate/state.go
+++ b/core/deprecatedstate/state.go
@@ -127,7 +127,7 @@ func (s *State) Commitment(protocolVersion string) (felt.Felt, error) {
 		return storageRoot, nil
 	}
 
-	root := crypto.PoseidonArray(stateVersion, &storageRoot, &classesRoot)
+	root := crypto.PoseidonArrayPtr(stateVersion, &storageRoot, &classesRoot)
 	return root, nil
 }
 

--- a/core/receipt.go
+++ b/core/receipt.go
@@ -42,7 +42,7 @@ func (r *TransactionReceipt) hash() felt.Felt {
 	sentMessageHash := messagesSentHash(r.L2ToL1Message)
 	l1GasFelt := felt.FromUint64[felt.Felt](totalGasConsumed.L1Gas)
 	l1DataGasFelt := felt.FromUint64[felt.Felt](totalGasConsumed.L1DataGas)
-	return crypto.PoseidonArray(
+	return crypto.PoseidonArrayPtr(
 		r.TransactionHash,
 		r.Fee,
 		&sentMessageHash,

--- a/core/receipt.go
+++ b/core/receipt.go
@@ -42,7 +42,7 @@ func (r *TransactionReceipt) hash() felt.Felt {
 	sentMessageHash := messagesSentHash(r.L2ToL1Message)
 	l1GasFelt := felt.FromUint64[felt.Felt](totalGasConsumed.L1Gas)
 	l1DataGasFelt := felt.FromUint64[felt.Felt](totalGasConsumed.L1DataGas)
-	return crypto.PoseidonArrayPtr(
+	return crypto.PoseidonElems(
 		r.TransactionHash,
 		r.Fee,
 		&sentMessageHash,

--- a/core/state/state_reader.go
+++ b/core/state/state_reader.go
@@ -353,5 +353,5 @@ func stateCommitment(contractRoot, classRoot *felt.Felt, protocolVersion string)
 		return *contractRoot
 	}
 
-	return crypto.PoseidonArrayPtr(stateVersion0, contractRoot, classRoot)
+	return crypto.PoseidonElems(stateVersion0, contractRoot, classRoot)
 }

--- a/core/state/state_reader.go
+++ b/core/state/state_reader.go
@@ -353,5 +353,5 @@ func stateCommitment(contractRoot, classRoot *felt.Felt, protocolVersion string)
 		return *contractRoot
 	}
 
-	return crypto.PoseidonArray(stateVersion0, contractRoot, classRoot)
+	return crypto.PoseidonArrayPtr(stateVersion0, contractRoot, classRoot)
 }

--- a/core/transaction.go
+++ b/core/transaction.go
@@ -479,9 +479,9 @@ func invokeTransactionHash(i *InvokeTransaction, n *networks.Network) (felt.Felt
 		), nil
 	case i.Version.Is(3):
 		tipAndResourceBoundsHash := tipAndResourcesHash(i.Tip, i.ResourceBounds)
-		paymasterDataHash := crypto.PoseidonArray(i.PaymasterData...)
-		accountDeploymentDataHash := crypto.PoseidonArray(i.AccountDeploymentData...)
-		calldataHash := crypto.PoseidonArray(i.CallData...)
+		paymasterDataHash := crypto.PoseidonArrayPtr(i.PaymasterData...)
+		accountDeploymentDataHash := crypto.PoseidonArrayPtr(i.AccountDeploymentData...)
+		calldataHash := crypto.PoseidonArrayPtr(i.CallData...)
 		daMode := felt.FromUint64[felt.Felt](dataAvailabilityMode(i.FeeDAMode, i.NonceDAMode))
 
 		var digest crypto.PoseidonDigest
@@ -585,10 +585,10 @@ func declareTransactionHash(d *DeclareTransaction, n *networks.Network) (felt.Fe
 		), nil
 	case d.Version.Is(3):
 		resourceHash := tipAndResourcesHash(d.Tip, d.ResourceBounds)
-		paymasterDataHash := crypto.PoseidonArray(d.PaymasterData...)
-		accountDeploymentDataHash := crypto.PoseidonArray(d.AccountDeploymentData...)
+		paymasterDataHash := crypto.PoseidonArrayPtr(d.PaymasterData...)
+		accountDeploymentDataHash := crypto.PoseidonArrayPtr(d.AccountDeploymentData...)
 		daMode := felt.FromUint64[felt.Felt](dataAvailabilityMode(d.FeeDAMode, d.NonceDAMode))
-		return crypto.PoseidonArray(
+		return crypto.PoseidonArrayPtr(
 			declareFelt,
 			d.Version.AsFelt(),
 			d.SenderAddress,
@@ -655,10 +655,10 @@ func deployAccountTransactionHash(
 		), nil
 	case d.Version.Is(3):
 		resourcesHash := tipAndResourcesHash(d.Tip, d.ResourceBounds)
-		paymasterDataHash := crypto.PoseidonArray(d.PaymasterData...)
-		ctorCallDataHash := crypto.PoseidonArray(d.ConstructorCallData...)
+		paymasterDataHash := crypto.PoseidonArrayPtr(d.PaymasterData...)
+		ctorCallDataHash := crypto.PoseidonArrayPtr(d.ConstructorCallData...)
 		daMode := felt.FromUint64[felt.Felt](dataAvailabilityMode(d.FeeDAMode, d.NonceDAMode))
-		return crypto.PoseidonArray(
+		return crypto.PoseidonArrayPtr(
 			deployAccountFelt,
 			d.Version.AsFelt(),
 			d.ContractAddress,
@@ -806,7 +806,7 @@ func eventCommitmentPoseidon(
 		items,
 		backend.RunOnTempTriePoseidon,
 		func(item *eventWithTxHash) felt.Felt {
-			return crypto.PoseidonArray(
+			return crypto.PoseidonArrayPtr(
 				slices.Concat(
 					[]*felt.Felt{
 						item.Event.From,

--- a/core/transaction.go
+++ b/core/transaction.go
@@ -479,9 +479,9 @@ func invokeTransactionHash(i *InvokeTransaction, n *networks.Network) (felt.Felt
 		), nil
 	case i.Version.Is(3):
 		tipAndResourceBoundsHash := tipAndResourcesHash(i.Tip, i.ResourceBounds)
-		paymasterDataHash := crypto.PoseidonArrayPtr(i.PaymasterData...)
-		accountDeploymentDataHash := crypto.PoseidonArrayPtr(i.AccountDeploymentData...)
-		calldataHash := crypto.PoseidonArrayPtr(i.CallData...)
+		paymasterDataHash := crypto.PoseidonElems(i.PaymasterData...)
+		accountDeploymentDataHash := crypto.PoseidonElems(i.AccountDeploymentData...)
+		calldataHash := crypto.PoseidonElems(i.CallData...)
 		daMode := felt.FromUint64[felt.Felt](dataAvailabilityMode(i.FeeDAMode, i.NonceDAMode))
 
 		var digest crypto.PoseidonDigest
@@ -585,10 +585,10 @@ func declareTransactionHash(d *DeclareTransaction, n *networks.Network) (felt.Fe
 		), nil
 	case d.Version.Is(3):
 		resourceHash := tipAndResourcesHash(d.Tip, d.ResourceBounds)
-		paymasterDataHash := crypto.PoseidonArrayPtr(d.PaymasterData...)
-		accountDeploymentDataHash := crypto.PoseidonArrayPtr(d.AccountDeploymentData...)
+		paymasterDataHash := crypto.PoseidonElems(d.PaymasterData...)
+		accountDeploymentDataHash := crypto.PoseidonElems(d.AccountDeploymentData...)
 		daMode := felt.FromUint64[felt.Felt](dataAvailabilityMode(d.FeeDAMode, d.NonceDAMode))
-		return crypto.PoseidonArrayPtr(
+		return crypto.PoseidonElems(
 			declareFelt,
 			d.Version.AsFelt(),
 			d.SenderAddress,
@@ -655,10 +655,10 @@ func deployAccountTransactionHash(
 		), nil
 	case d.Version.Is(3):
 		resourcesHash := tipAndResourcesHash(d.Tip, d.ResourceBounds)
-		paymasterDataHash := crypto.PoseidonArrayPtr(d.PaymasterData...)
-		ctorCallDataHash := crypto.PoseidonArrayPtr(d.ConstructorCallData...)
+		paymasterDataHash := crypto.PoseidonElems(d.PaymasterData...)
+		ctorCallDataHash := crypto.PoseidonElems(d.ConstructorCallData...)
 		daMode := felt.FromUint64[felt.Felt](dataAvailabilityMode(d.FeeDAMode, d.NonceDAMode))
-		return crypto.PoseidonArrayPtr(
+		return crypto.PoseidonElems(
 			deployAccountFelt,
 			d.Version.AsFelt(),
 			d.ContractAddress,
@@ -806,7 +806,7 @@ func eventCommitmentPoseidon(
 		items,
 		backend.RunOnTempTriePoseidon,
 		func(item *eventWithTxHash) felt.Felt {
-			return crypto.PoseidonArrayPtr(
+			return crypto.PoseidonElems(
 				slices.Concat(
 					[]*felt.Felt{
 						item.Event.From,

--- a/core/trie2/triedb/pathdb/journal.go
+++ b/core/trie2/triedb/pathdb/journal.go
@@ -306,6 +306,6 @@ func (d *Database) getStateRoot() felt.StateRootHash {
 	}
 	classRootHash := classRootNode.Hash(crypto.Pedersen)
 
-	stateRoot := crypto.PoseidonArray(stateVersion, &contractRootHash, &classRootHash)
+	stateRoot := crypto.PoseidonArrayPtr(stateVersion, &contractRootHash, &classRootHash)
 	return felt.StateRootHash(stateRoot)
 }

--- a/core/trie2/triedb/pathdb/journal.go
+++ b/core/trie2/triedb/pathdb/journal.go
@@ -306,6 +306,6 @@ func (d *Database) getStateRoot() felt.StateRootHash {
 	}
 	classRootHash := classRootNode.Hash(crypto.Pedersen)
 
-	stateRoot := crypto.PoseidonArrayPtr(stateVersion, &contractRootHash, &classRootHash)
+	stateRoot := crypto.PoseidonElems(stateVersion, &contractRootHash, &classRootHash)
 	return felt.StateRootHash(stateRoot)
 }

--- a/rpc/v10/storage_test.go
+++ b/rpc/v10/storage_test.go
@@ -1644,6 +1644,6 @@ func verifyGlobalStateRoot(t *testing.T, globalStateRoot, classRoot, storageRoot
 	if classRoot.IsZero() {
 		assert.Equal(t, globalStateRoot, storageRoot)
 	} else {
-		assert.Equal(t, globalStateRoot, crypto.PoseidonArray(stateVersion, storageRoot, classRoot))
+		assert.Equal(t, globalStateRoot, crypto.PoseidonArrayPtr(stateVersion, storageRoot, classRoot))
 	}
 }

--- a/rpc/v10/storage_test.go
+++ b/rpc/v10/storage_test.go
@@ -1644,6 +1644,6 @@ func verifyGlobalStateRoot(t *testing.T, globalStateRoot, classRoot, storageRoot
 	if classRoot.IsZero() {
 		assert.Equal(t, globalStateRoot, storageRoot)
 	} else {
-		assert.Equal(t, globalStateRoot, crypto.PoseidonArrayPtr(stateVersion, storageRoot, classRoot))
+		assert.Equal(t, globalStateRoot, crypto.PoseidonElems(stateVersion, storageRoot, classRoot))
 	}
 }

--- a/rpc/v8/storage_test.go
+++ b/rpc/v8/storage_test.go
@@ -1007,6 +1007,6 @@ func verifyGlobalStateRoot(t *testing.T, globalStateRoot, classRoot, storageRoot
 	if classRoot.IsZero() {
 		assert.Equal(t, globalStateRoot, storageRoot)
 	} else {
-		assert.Equal(t, globalStateRoot, crypto.PoseidonArrayPtr(stateVersion, storageRoot, classRoot))
+		assert.Equal(t, globalStateRoot, crypto.PoseidonElems(stateVersion, storageRoot, classRoot))
 	}
 }

--- a/rpc/v8/storage_test.go
+++ b/rpc/v8/storage_test.go
@@ -1007,6 +1007,6 @@ func verifyGlobalStateRoot(t *testing.T, globalStateRoot, classRoot, storageRoot
 	if classRoot.IsZero() {
 		assert.Equal(t, globalStateRoot, storageRoot)
 	} else {
-		assert.Equal(t, globalStateRoot, crypto.PoseidonArray(stateVersion, storageRoot, classRoot))
+		assert.Equal(t, globalStateRoot, crypto.PoseidonArrayPtr(stateVersion, storageRoot, classRoot))
 	}
 }

--- a/rpc/v9/storage_test.go
+++ b/rpc/v9/storage_test.go
@@ -1088,6 +1088,6 @@ func verifyGlobalStateRoot(t *testing.T, globalStateRoot, classRoot, storageRoot
 	if classRoot.IsZero() {
 		assert.Equal(t, globalStateRoot, storageRoot)
 	} else {
-		assert.Equal(t, globalStateRoot, crypto.PoseidonArrayPtr(stateVersion, storageRoot, classRoot))
+		assert.Equal(t, globalStateRoot, crypto.PoseidonElems(stateVersion, storageRoot, classRoot))
 	}
 }

--- a/rpc/v9/storage_test.go
+++ b/rpc/v9/storage_test.go
@@ -1088,6 +1088,6 @@ func verifyGlobalStateRoot(t *testing.T, globalStateRoot, classRoot, storageRoot
 	if classRoot.IsZero() {
 		assert.Equal(t, globalStateRoot, storageRoot)
 	} else {
-		assert.Equal(t, globalStateRoot, crypto.PoseidonArray(stateVersion, storageRoot, classRoot))
+		assert.Equal(t, globalStateRoot, crypto.PoseidonArrayPtr(stateVersion, storageRoot, classRoot))
 	}
 }

--- a/sequencer/sequencer_utils.go
+++ b/sequencer/sequencer_utils.go
@@ -52,7 +52,7 @@ func (s *Sequencer) RunOnce() (*core.Header, error) {
 
 func newBlockSigner(privKey *ecdsa.PrivateKey) core.BlockSignFunc {
 	return func(blockHash, stateDiffCommitment *felt.Felt) ([]*felt.Felt, error) {
-		data := crypto.PoseidonArray(blockHash, stateDiffCommitment)
+		data := crypto.PoseidonArrayPtr(blockHash, stateDiffCommitment)
 		dataBytes := data.Bytes()
 		signatureBytes, err := privKey.Sign(dataBytes[:], nil)
 		if err != nil {

--- a/sequencer/sequencer_utils.go
+++ b/sequencer/sequencer_utils.go
@@ -52,7 +52,7 @@ func (s *Sequencer) RunOnce() (*core.Header, error) {
 
 func newBlockSigner(privKey *ecdsa.PrivateKey) core.BlockSignFunc {
 	return func(blockHash, stateDiffCommitment *felt.Felt) ([]*felt.Felt, error) {
-		data := crypto.PoseidonArrayPtr(blockHash, stateDiffCommitment)
+		data := crypto.PoseidonElems(blockHash, stateDiffCommitment)
 		dataBytes := data.Bytes()
 		signatureBytes, err := privKey.Sign(dataBytes[:], nil)
 		if err != nil {

--- a/sequencer/sequencer_utils_test.go
+++ b/sequencer/sequencer_utils_test.go
@@ -27,7 +27,7 @@ func TestNewBlockSigner(t *testing.T) {
 	copy(sigBytes[0:felt.Bytes], r[:])
 	copy(sigBytes[felt.Bytes:], s[:])
 
-	msg := crypto.PoseidonArray(blockHash, stateDiffCommitment)
+	msg := crypto.PoseidonArrayPtr(blockHash, stateDiffCommitment)
 	msgBytes := msg.Bytes()
 
 	ok, err := privKey.PublicKey.Verify(sigBytes[:], msgBytes[:], nil)

--- a/sequencer/sequencer_utils_test.go
+++ b/sequencer/sequencer_utils_test.go
@@ -27,7 +27,7 @@ func TestNewBlockSigner(t *testing.T) {
 	copy(sigBytes[0:felt.Bytes], r[:])
 	copy(sigBytes[felt.Bytes:], s[:])
 
-	msg := crypto.PoseidonArrayPtr(blockHash, stateDiffCommitment)
+	msg := crypto.PoseidonElems(blockHash, stateDiffCommitment)
 	msgBytes := msg.Bytes()
 
 	ok, err := privKey.PublicKey.Verify(sigBytes[:], msgBytes[:], nil)


### PR DESCRIPTION
Added support for hashing `[]felt.Felt`, so that hash calls can be zero-copy.