### PR TITLE
refactor(db): remove unused `View` helper

### DIFF
--- a/db/database.go
+++ b/db/database.go
@@ -40,8 +40,6 @@ type Helper interface {
 	// This will create a write-only batch, apply the callback to it, and flush the changes.
 	// Use this instead of Update when you don't need to read from the batch.
 	Write(func(Batch) error) error
-	// This will create a read-only snapshot and apply the callback to it
-	View(func(Snapshot) error) error
 	// TODO(weiihann): honestly this doesn't make sense, but it's currently needed for the metrics
 	// remove this once the metrics are refactored
 	// Returns the underlying database

--- a/db/memory/db.go
+++ b/db/memory/db.go
@@ -213,15 +213,6 @@ func (d *Database) Write(fn func(db.Batch) error) error {
 	return batch.Write()
 }
 
-func (d *Database) View(fn func(db.Snapshot) error) error {
-	if d.db == nil {
-		return errDBClosed
-	}
-
-	snap := d.NewSnapshot()
-	return fn(snap)
-}
-
 func (d *Database) WithListener(listener db.EventListener) db.KeyValueStore {
 	return d // no-op
 }

--- a/db/pebble/db.go
+++ b/db/pebble/db.go
@@ -92,11 +92,6 @@ func (d *DB) Write(fn func(w db.Batch) error) error {
 	return batch.Write()
 }
 
-func (d *DB) View(fn func(r db.Snapshot) error) error {
-	snap := d.NewSnapshot()
-	return fn(snap)
-}
-
 func (d *DB) WithListener(listener db.EventListener) db.KeyValueStore {
 	d.listener = listener
 	return d

--- a/db/pebblev2/db.go
+++ b/db/pebblev2/db.go
@@ -99,11 +99,6 @@ func (d *DB) Write(fn func(w db.Batch) error) error {
 	return batch.Write()
 }
 
-func (d *DB) View(fn func(r db.Snapshot) error) error {
-	snap := d.NewSnapshot()
-	return fn(snap)
-}
-
 func (d *DB) WithListener(listener db.EventListener) db.KeyValueStore {
 	d.listener = listener
 	return d

--- a/db/remote/db.go
+++ b/db/remote/db.go
@@ -62,16 +62,6 @@ func (d *DB) NewTransaction(write bool) (*transaction, error) {
 	return &transaction{client: txClient, logger: d.logger}, nil
 }
 
-func (d *DB) View(fn func(txn db.Snapshot) error) error {
-	txn, err := d.NewTransaction(false)
-	if err != nil {
-		return err
-	}
-
-	defer discardTxnOnPanic(txn)
-	return errors.Join(fn(txn), txn.Discard())
-}
-
 func (d *DB) Update(fn func(txn db.IndexedBatch) error) error {
 	defer d.listener.OnCommit(time.Now())
 

--- a/db/remote/db_test.go
+++ b/db/remote/db_test.go
@@ -1,8 +1,6 @@
 package remote
 
 import (
-	"bytes"
-	"errors"
 	"net"
 	"testing"
 
@@ -48,63 +46,52 @@ func TestRemote(t *testing.T) {
 	require.NoError(t, err)
 
 	t.Run("Get", func(t *testing.T) {
-		assert.NoError(t, remoteDB.View(func(txn db.Snapshot) error {
-			for i := byte(0); i < 3; i++ {
-				err := txn.Get([]byte{i}, func(data []byte) error {
-					if !bytes.Equal(data, []byte{i}) {
-						return errors.New("wrong value")
-					}
-					return nil
-				})
-				if err != nil {
-					return err
-				}
+		snap := remoteDB.NewSnapshot()
+		defer snap.Close()
 
-				assert.Equal(t, db.ErrKeyNotFound, txn.Get([]byte{0xDE, 0xAD}, func(b []byte) error { return nil }))
-			}
-			return nil
-		}))
+		for i := byte(0); i < 3; i++ {
+			require.NoError(t, snap.Get([]byte{i}, func(data []byte) error {
+				assert.Equal(t, []byte{i}, data)
+				return nil
+			}))
+
+			missing := snap.Get([]byte{0xDE, 0xAD}, func(b []byte) error { return nil })
+			assert.Equal(t, db.ErrKeyNotFound, missing)
+		}
 	})
 
 	t.Run("iterate", func(t *testing.T) {
-		err := remoteDB.View(func(txn db.Snapshot) error {
-			it, err := txn.NewIterator(nil, false)
-			if err != nil {
-				return err
-			}
-			defer it.Close()
+		snap := remoteDB.NewSnapshot()
+		defer snap.Close()
 
-			foundKeys := byte(0)
-			for valid := it.Next(); valid; valid = it.Next() {
-				assert.Equal(t, []byte{foundKeys}, it.Key())
-				v, err := it.Value()
-				require.NoError(t, err)
-				assert.Equal(t, v, []byte{foundKeys})
-				foundKeys++
-			}
-			assert.Equal(t, foundKeys, byte(3))
-			return nil
-		})
-		assert.NoError(t, err)
+		it, err := snap.NewIterator(nil, false)
+		require.NoError(t, err)
+		defer it.Close()
+
+		foundKeys := byte(0)
+		for valid := it.Next(); valid; valid = it.Next() {
+			assert.Equal(t, []byte{foundKeys}, it.Key())
+			v, err := it.Value()
+			require.NoError(t, err)
+			assert.Equal(t, v, []byte{foundKeys})
+			foundKeys++
+		}
+		assert.Equal(t, foundKeys, byte(3))
 	})
 
 	t.Run("seek", func(t *testing.T) {
-		err := remoteDB.View(func(txn db.Snapshot) error {
-			it, err := txn.NewIterator(nil, false)
-			if err != nil {
-				return err
-			}
-			defer it.Close()
+		snap := remoteDB.NewSnapshot()
+		defer snap.Close()
 
-			assert.True(t, it.Seek([]byte{1}))
-			assert.Equal(t, it.Key(), []byte{1})
-			v, err := it.Value()
-			require.NoError(t, err)
-			assert.Equal(t, v, []byte{1})
+		it, err := snap.NewIterator(nil, false)
+		require.NoError(t, err)
+		defer it.Close()
 
-			return nil
-		})
-		assert.NoError(t, err)
+		assert.True(t, it.Seek([]byte{1}))
+		assert.Equal(t, it.Key(), []byte{1})
+		v, err := it.Value()
+		require.NoError(t, err)
+		assert.Equal(t, v, []byte{1})
 	})
 
 	t.Run("write", func(t *testing.T) {

--- a/migration/deprecated/bucket_migrator_test.go
+++ b/migration/deprecated/bucket_migrator_test.go
@@ -1,8 +1,6 @@
 package deprecated_test
 
 import (
-	"bytes"
-	"errors"
 	"testing"
 
 	"github.com/NethermindEth/juno/blockchain/networks"
@@ -44,33 +42,22 @@ func TestBucketMover(t *testing.T) {
 	intermediateState, err = mover.Migrate(t.Context(), testDB, &networks.Mainnet, nil)
 	require.NoError(t, err)
 
-	err = testDB.View(func(txn db.Snapshot) error {
-		err := txn.Get(sourceBucket.Key(), func(data []byte) error {
-			if !bytes.Equal(data, []byte{44}) {
-				return errors.New("shouldnt have changed")
-			}
-			return nil
-		})
-		if err != nil {
-			return err
-		}
+	snap := testDB.NewSnapshot()
+	defer snap.Close()
 
-		for i := byte(0); i < 3; i++ {
-			err := txn.Get(destBucket.Key([]byte{i}), func(data []byte) error {
-				if !bytes.Equal(data, []byte{i}) {
-					return errors.New("shouldve moved")
-				}
-				return nil
-			})
-			if err != nil {
-				return err
-			}
-
-			err = txn.Get(sourceBucket.Key([]byte{i}), func([]byte) error { return nil })
-			require.ErrorIs(t, db.ErrKeyNotFound, err)
-		}
+	require.NoError(t, snap.Get(sourceBucket.Key(), func(data []byte) error {
+		require.Equal(t, []byte{44}, data, "shouldnt have changed")
 		return nil
-	})
-	require.NoError(t, err)
+	}))
+
+	for i := byte(0); i < 3; i++ {
+		require.NoError(t, snap.Get(destBucket.Key([]byte{i}), func(data []byte) error {
+			require.Equal(t, []byte{i}, data, "shouldve moved")
+			return nil
+		}))
+
+		err = snap.Get(sourceBucket.Key([]byte{i}), func([]byte) error { return nil })
+		require.ErrorIs(t, db.ErrKeyNotFound, err)
+	}
 	require.Nil(t, intermediateState)
 }

--- a/migration/deprecated/migration_pkg_test.go
+++ b/migration/deprecated/migration_pkg_test.go
@@ -719,89 +719,89 @@ func TestChangeStateDiffStruct(t *testing.T) {
 	// Assert:
 	// - Both state diffs have been updated.
 	// - There are no extraneous entries in the DB.
-	require.NoError(t, testdb.View(func(txn db.Snapshot) error {
-		iter, err := txn.NewIterator(nil, false)
-		require.NoError(t, err)
-		defer func() {
-			require.NoError(t, iter.Close())
-		}()
+	snap := testdb.NewSnapshot()
+	defer snap.Close()
 
-		updates := []struct {
-			key  []byte
-			want *core.StateUpdate
-		}{
-			//nolint: dupl
-			{
-				key: su0Key,
-				want: &core.StateUpdate{
-					BlockHash: felt.NewUnsafeFromString[felt.Felt]("0x0"),
-					NewRoot:   felt.NewUnsafeFromString[felt.Felt]("0x1"),
-					OldRoot:   felt.NewUnsafeFromString[felt.Felt]("0x2"),
-					StateDiff: &core.StateDiff{
-						StorageDiffs: map[felt.Felt]map[felt.Felt]*felt.Felt{
-							felt.UnsafeFromString[felt.Felt]("0x3"): {
-								felt.UnsafeFromString[felt.Felt]("0x4"): felt.NewUnsafeFromString[felt.Felt]("0x5"),
-							},
+	iter, err := snap.NewIterator(nil, false)
+	require.NoError(t, err)
+	defer func() {
+		require.NoError(t, iter.Close())
+	}()
+
+	updates := []struct {
+		key  []byte
+		want *core.StateUpdate
+	}{
+		//nolint: dupl // the two state-update fixtures differ only in their felt values
+		{
+			key: su0Key,
+			want: &core.StateUpdate{
+				BlockHash: felt.NewUnsafeFromString[felt.Felt]("0x0"),
+				NewRoot:   felt.NewUnsafeFromString[felt.Felt]("0x1"),
+				OldRoot:   felt.NewUnsafeFromString[felt.Felt]("0x2"),
+				StateDiff: &core.StateDiff{
+					StorageDiffs: map[felt.Felt]map[felt.Felt]*felt.Felt{
+						felt.UnsafeFromString[felt.Felt]("0x3"): {
+							felt.UnsafeFromString[felt.Felt]("0x4"): felt.NewUnsafeFromString[felt.Felt]("0x5"),
 						},
-						Nonces: map[felt.Felt]*felt.Felt{
-							felt.UnsafeFromString[felt.Felt]("0x6"): felt.NewUnsafeFromString[felt.Felt]("0x7"),
-						},
-						DeployedContracts: map[felt.Felt]*felt.Felt{
-							felt.UnsafeFromString[felt.Felt]("0x8"): felt.NewUnsafeFromString[felt.Felt]("0x9"),
-						},
-						DeclaredV0Classes: []*felt.Felt{felt.NewUnsafeFromString[felt.Felt]("0x10")},
-						DeclaredV1Classes: map[felt.Felt]*felt.Felt{
-							felt.UnsafeFromString[felt.Felt]("0x11"): felt.NewUnsafeFromString[felt.Felt]("0x12"),
-						},
-						ReplacedClasses: map[felt.Felt]*felt.Felt{
-							felt.UnsafeFromString[felt.Felt]("0x13"): felt.NewUnsafeFromString[felt.Felt]("0x14"),
-						},
+					},
+					Nonces: map[felt.Felt]*felt.Felt{
+						felt.UnsafeFromString[felt.Felt]("0x6"): felt.NewUnsafeFromString[felt.Felt]("0x7"),
+					},
+					DeployedContracts: map[felt.Felt]*felt.Felt{
+						felt.UnsafeFromString[felt.Felt]("0x8"): felt.NewUnsafeFromString[felt.Felt]("0x9"),
+					},
+					DeclaredV0Classes: []*felt.Felt{felt.NewUnsafeFromString[felt.Felt]("0x10")},
+					DeclaredV1Classes: map[felt.Felt]*felt.Felt{
+						felt.UnsafeFromString[felt.Felt]("0x11"): felt.NewUnsafeFromString[felt.Felt]("0x12"),
+					},
+					ReplacedClasses: map[felt.Felt]*felt.Felt{
+						felt.UnsafeFromString[felt.Felt]("0x13"): felt.NewUnsafeFromString[felt.Felt]("0x14"),
 					},
 				},
 			},
-			//nolint: dupl
-			{
-				key: su1Key,
-				want: &core.StateUpdate{
-					BlockHash: felt.NewUnsafeFromString[felt.Felt]("0x15"),
-					NewRoot:   felt.NewUnsafeFromString[felt.Felt]("0x16"),
-					OldRoot:   felt.NewUnsafeFromString[felt.Felt]("0x17"),
-					StateDiff: &core.StateDiff{
-						StorageDiffs: map[felt.Felt]map[felt.Felt]*felt.Felt{
-							felt.UnsafeFromString[felt.Felt]("0x18"): {
-								felt.UnsafeFromString[felt.Felt]("0x19"): felt.NewUnsafeFromString[felt.Felt]("0x20"),
-							},
+		},
+		//nolint: dupl // the two state-update fixtures differ only in their felt values
+		{
+			key: su1Key,
+			want: &core.StateUpdate{
+				BlockHash: felt.NewUnsafeFromString[felt.Felt]("0x15"),
+				NewRoot:   felt.NewUnsafeFromString[felt.Felt]("0x16"),
+				OldRoot:   felt.NewUnsafeFromString[felt.Felt]("0x17"),
+				StateDiff: &core.StateDiff{
+					StorageDiffs: map[felt.Felt]map[felt.Felt]*felt.Felt{
+						felt.UnsafeFromString[felt.Felt]("0x18"): {
+							felt.UnsafeFromString[felt.Felt]("0x19"): felt.NewUnsafeFromString[felt.Felt]("0x20"),
 						},
-						Nonces: map[felt.Felt]*felt.Felt{
-							felt.UnsafeFromString[felt.Felt]("0x21"): felt.NewUnsafeFromString[felt.Felt]("0x22"),
-						},
-						DeployedContracts: map[felt.Felt]*felt.Felt{
-							felt.UnsafeFromString[felt.Felt]("0x23"): felt.NewUnsafeFromString[felt.Felt]("0x24"),
-						},
-						DeclaredV0Classes: []*felt.Felt{felt.NewUnsafeFromString[felt.Felt]("0x25")},
-						DeclaredV1Classes: map[felt.Felt]*felt.Felt{
-							felt.UnsafeFromString[felt.Felt]("0x26"): felt.NewUnsafeFromString[felt.Felt]("0x27"),
-						},
-						ReplacedClasses: map[felt.Felt]*felt.Felt{
-							felt.UnsafeFromString[felt.Felt]("0x28"): felt.NewUnsafeFromString[felt.Felt]("0x29"),
-						},
+					},
+					Nonces: map[felt.Felt]*felt.Felt{
+						felt.UnsafeFromString[felt.Felt]("0x21"): felt.NewUnsafeFromString[felt.Felt]("0x22"),
+					},
+					DeployedContracts: map[felt.Felt]*felt.Felt{
+						felt.UnsafeFromString[felt.Felt]("0x23"): felt.NewUnsafeFromString[felt.Felt]("0x24"),
+					},
+					DeclaredV0Classes: []*felt.Felt{felt.NewUnsafeFromString[felt.Felt]("0x25")},
+					DeclaredV1Classes: map[felt.Felt]*felt.Felt{
+						felt.UnsafeFromString[felt.Felt]("0x26"): felt.NewUnsafeFromString[felt.Felt]("0x27"),
+					},
+					ReplacedClasses: map[felt.Felt]*felt.Felt{
+						felt.UnsafeFromString[felt.Felt]("0x28"): felt.NewUnsafeFromString[felt.Felt]("0x29"),
 					},
 				},
 			},
-		}
-		for _, update := range updates {
-			require.True(t, iter.Next())
-			key := iter.Key()
-			require.Equal(t, update.key, key)
-			value, err := iter.Value()
-			require.NoError(t, err)
-			got := new(core.StateUpdate)
-			require.NoError(t, encoder.Unmarshal(value, got))
-			require.Equal(t, update.want, got)
-		}
-		require.False(t, iter.Next())
-		return nil
-	}))
+		},
+	}
+	for _, update := range updates {
+		require.True(t, iter.Next())
+		key := iter.Key()
+		require.Equal(t, update.key, key)
+		value, err := iter.Value()
+		require.NoError(t, err)
+		got := new(core.StateUpdate)
+		require.NoError(t, encoder.Unmarshal(value, got))
+		require.Equal(t, update.want, got)
+	}
+	require.False(t, iter.Next())
 }
 
 func randSlice(t *testing.T) []felt.Felt {


### PR DESCRIPTION
## What

`KeyValueStore.View` opened a read-only snapshot, handed it to a callback, and never closed it — the snapshot's resources were never released.

An open pebble snapshot pins a sequence number and blocks compaction from reclaiming key versions that were live when the snapshot was taken, so a leaked snapshot keeps dead on-disk data around for the lifetime of the process. Pebble's own `Snapshot.Close` docs are explicit that it must be called or it leaks disk resources.

This PR originally closed the snapshot in a deferred call. Review surfaced a better answer: `View` has no production callers at all — only tests — and none are planned. So rather than maintaining a leak-prone helper nobody uses, this removes it.

## Change

- Drop `View` from the `db.Helper` interface and from the `pebble`, `pebblev2`, `memory` and `remote` backends.
- Rewrite the three test callers to take a snapshot with `NewSnapshot` and close it via `defer`. That is what `View` wrapped anyway, and it makes snapshot lifetime explicit at the call site instead of hiding it behind a callback.

The test rewrites also flatten a level of closure nesting, so `require` failures now abort the test directly instead of being smuggled out as an error return.

No production behaviour changes — there were no production callers to change.

## Notes

`View` was also covered by #3848 (guarding `View`/`Update`/`Write` against a concurrent `Close`). Once this lands I'll narrow that PR and issue #3847 down to `Update`/`Write`.

Fixes #3845
