### PR TITLE
perf(core): Cbor optimization for `[]felt.Felt`

### DIFF
--- a/adapters/sn2core/sn2core_test.go
+++ b/adapters/sn2core/sn2core_test.go
@@ -575,10 +575,10 @@ func TestClassV1(t *testing.T) {
 			require.NoError(t, err)
 
 			assert.Equal(t, feederClass.Sierra.Abi, v1Class.Abi)
-			assert.Equal(t, feederClass.Sierra.Program, v1Class.Program)
+			assert.Equal(t, feederClass.Sierra.Program, []felt.Felt(v1Class.Program))
 			assert.Equal(t, feederClass.Sierra.Version, v1Class.SemanticVersion)
 			assert.Equal(t, compiled.Prime, "0x"+v1Class.Compiled.Prime.Text(felt.Base16))
-			assert.Equal(t, compiled.Bytecode, v1Class.Compiled.Bytecode)
+			assert.Equal(t, compiled.Bytecode, []felt.Felt(v1Class.Compiled.Bytecode))
 			assert.Equal(t, compiled.Hints, v1Class.Compiled.Hints)
 			assert.Equal(t, compiled.CompilerVersion, v1Class.Compiled.CompilerVersion)
 			assert.Equal(t, len(compiled.EntryPoints.External), len(v1Class.Compiled.External))

--- a/core/class.go
+++ b/core/class.go
@@ -72,7 +72,7 @@ type SierraClass struct {
 	Abi         string
 	AbiHash     *felt.Felt
 	EntryPoints SierraEntryPointsByType
-	Program     []felt.Felt
+	Program     felt.Slice
 	ProgramHash *felt.Felt
 	// TODO: Remove this semantic version on a follow up PR. Let's put Sierra version instead
 	SemanticVersion string
@@ -85,7 +85,7 @@ type SegmentLengths struct {
 }
 
 type CasmClass struct {
-	Bytecode               []felt.Felt
+	Bytecode               felt.Slice
 	PythonicHints          json.RawMessage
 	CompilerVersion        string
 	Hints                  json.RawMessage

--- a/core/felt/cbor.go
+++ b/core/felt/cbor.go
@@ -10,13 +10,15 @@ import (
 
 // Fast, felt-specialized CBOR marshaling.
 func (z *Felt) MarshalCBOR() ([]byte, error) {
-	return encodeFeltLimbs(z), nil
+	data := make([]byte, maxCBORFeltLen)
+	n := encodeFeltLimbs(data, z)
+	return data[:n], nil
 }
 
 // Fast, felt-specialized CBOR unmarshaling.
 // Falls back to the generic decoder on shape mismatch
 func (z *Felt) UnmarshalCBOR(data []byte) error {
-	if decodeFeltLimbs(z, data) {
+	if decodeFelt(data, z) {
 		return nil
 	}
 	return cbor.Unmarshal(data, (*fp.Element)(z))
@@ -32,106 +34,116 @@ const (
 	cborUint32AdditionalInfo = 26 // 4 bytes follow
 	cborUint64AdditionalInfo = 27 // 8 bytes follow
 
-	// cborArrayHeader4 is the first byte of a CBOR array of Limbs items.
+	// cborArrayMajor the major type that represents an Array
 	// Top 3 bits are the major type (4 = array), low 5 bits are the length.
-	// Type 4 in the top bits is the same as 1<<7, so this byte is
-	// 0b100_00100: an array with Limbs (4) elements.
-	cborArrayHeader4 = (1 << 7) | Limbs
+	cborArrayMajor = 4 << 5
 
-	// header + 8 bytes following
+	// cborArrayHeader4 is the first byte of a CBOR array of Limbs items.
+	// 0b100_00100: an array with Limbs (4) elements.
+	cborArrayHeader4 = cborArrayMajor | Limbs
+
+	// Header + 8 bytes following
 	maxCBORUintLen = 1 + 8
+	// Header + Limbs * maxCBORUintLen
+	maxCBORFeltLen = 1 + Limbs*maxCBORUintLen
+	// Header + Limbs
+	minCBORFeltLen = 1 + Limbs
 )
 
-func encodeFeltLimbs(value *Felt) []byte {
-	// The buffer format is: [cborArrayHeader4] [limb 0] [limb 1] [limb 2] [limb 3]
-	buffer := make([]byte, 1+Limbs*maxCBORUintLen)
-	buffer[0] = cborArrayHeader4
+// encodeFeltLimbs puts one CBOR felt to data, returning the number of bytes written.
+func encodeFeltLimbs(data []byte, value *Felt) int {
+	// The format is: [cborArrayHeader4] [limb 0] [limb 1] [limb 2] [limb 3].
+	data[0] = cborArrayHeader4
 
-	index := 1
+	offset := 1
 	for limbIndex := range Limbs {
 		limb := value[limbIndex]
+
+		// Starting with the most common path, which is a large limb
 		switch {
 		case limb > math.MaxUint32:
-			buffer[index] = cborUint64AdditionalInfo
-			binary.BigEndian.PutUint64(buffer[index+1:], limb)
-			index += 1 + 8
+			data[offset] = cborUint64AdditionalInfo
+			binary.BigEndian.PutUint64(data[offset+1:], limb)
+			offset += 1 + 8
 
 		case limb > math.MaxUint16:
-			buffer[index] = cborUint32AdditionalInfo
-			binary.BigEndian.PutUint32(buffer[index+1:], uint32(limb))
-			index += 1 + 4
+			data[offset] = cborUint32AdditionalInfo
+			binary.BigEndian.PutUint32(data[offset+1:], uint32(limb))
+			offset += 1 + 4
 
 		case limb > math.MaxUint8:
-			buffer[index] = cborUint16AdditionalInfo
-			binary.BigEndian.PutUint16(buffer[index+1:], uint16(limb))
-			index += 1 + 2
+			data[offset] = cborUint16AdditionalInfo
+			binary.BigEndian.PutUint16(data[offset+1:], uint16(limb))
+			offset += 1 + 2
 
 		case limb >= cborUint8AdditionalInfo:
-			buffer[index] = cborUint8AdditionalInfo
-			buffer[index+1] = byte(limb)
-			index += 2
+			data[offset] = cborUint8AdditionalInfo
+			data[offset+1] = byte(limb)
+			offset += 2
 
 		default:
-			buffer[index] = byte(limb)
-			index++
+			data[offset] = byte(limb)
+			offset++
 		}
 	}
 
-	return buffer[:index]
+	return offset
 }
 
-// Writes value only on success, so a rejected input can't partially
-// corrupt it before falling back to the generic decoder.
-func decodeFeltLimbs(value *Felt, data []byte) bool {
+// decodeFeltLimbs decodes one limb-encoded felt at data[0:],
+// returning the number of bytes consumed. It writes value only on success,
+// so a rejected input can't partially corrupt it before falling back to the generic decoder.
+func decodeFeltLimbs(data []byte, value *Felt) (int, bool) {
 	// The data format is: [cborArrayHeader4] [limb 0] [limb 1] [limb 2] [limb 3]
 	if len(data) == 0 || data[0] != cborArrayHeader4 {
-		return false
+		return 0, false
 	}
 
 	var limbs Felt
-	byteOffset := 1
+	offset := 1
 
 	for limbIndex := range Limbs {
-		if byteOffset >= len(data) {
-			return false
+		if offset >= len(data) {
+			return 0, false
 		}
 
-		headerByte := data[byteOffset]
-		byteOffset++
+		headerByte := data[offset]
+		offset++
 
 		var limb uint64
 
+		// Starting with the most common path, which is a large limb
 		switch {
 		case headerByte > cborUint64AdditionalInfo: // invalid header byte for uint64
-			return false
+			return 0, false
 
 		case headerByte == cborUint64AdditionalInfo:
-			if byteOffset+8 > len(data) {
-				return false
+			if offset+8 > len(data) {
+				return 0, false
 			}
-			limb = binary.BigEndian.Uint64(data[byteOffset:])
-			byteOffset += 8
+			limb = binary.BigEndian.Uint64(data[offset:])
+			offset += 8
 
 		case headerByte == cborUint32AdditionalInfo:
-			if byteOffset+4 > len(data) {
-				return false
+			if offset+4 > len(data) {
+				return 0, false
 			}
-			limb = uint64(binary.BigEndian.Uint32(data[byteOffset:]))
-			byteOffset += 4
+			limb = uint64(binary.BigEndian.Uint32(data[offset:]))
+			offset += 4
 
 		case headerByte == cborUint16AdditionalInfo:
-			if byteOffset+2 > len(data) {
-				return false
+			if offset+2 > len(data) {
+				return 0, false
 			}
-			limb = uint64(binary.BigEndian.Uint16(data[byteOffset:]))
-			byteOffset += 2
+			limb = uint64(binary.BigEndian.Uint16(data[offset:]))
+			offset += 2
 
 		case headerByte == cborUint8AdditionalInfo:
-			if byteOffset+1 > len(data) {
-				return false
+			if offset+1 > len(data) {
+				return 0, false
 			}
-			limb = uint64(data[byteOffset])
-			byteOffset++
+			limb = uint64(data[offset])
+			offset++
 
 		default: // headerByte < cborUint8AdditionalInfo
 			limb = uint64(headerByte)
@@ -140,10 +152,19 @@ func decodeFeltLimbs(value *Felt, data []byte) bool {
 		limbs[limbIndex] = limb
 	}
 
-	if byteOffset != len(data) {
+	*value = limbs
+	return offset, true
+}
+
+// decodeFelt decodes a single felt that must span all of data, rejecting trailing bytes.
+// It writes value only on success.
+func decodeFelt(data []byte, value *Felt) bool {
+	var felt Felt
+	consumed, ok := decodeFeltLimbs(data, &felt)
+	if !ok || consumed != len(data) {
 		return false
 	}
 
-	*value = limbs
+	*value = felt
 	return true
 }

--- a/core/felt/cbor.go
+++ b/core/felt/cbor.go
@@ -91,8 +91,9 @@ func encodeFeltLimbs(data []byte, value *Felt) int {
 }
 
 // decodeFeltLimbs decodes one limb-encoded felt at data[0:],
-// returning the number of bytes consumed. It writes value only on success,
-// so a rejected input can't partially corrupt it before falling back to the generic decoder.
+// returning the number of bytes consumed and a flag to signal succes.
+// It writes value only on success, so a rejected input can't partially
+// corrupt it before falling back to the generic decoder.
 func decodeFeltLimbs(data []byte, value *Felt) (int, bool) {
 	// The data format is: [cborArrayHeader4] [limb 0] [limb 1] [limb 2] [limb 3]
 	if len(data) == 0 || data[0] != cborArrayHeader4 {
@@ -157,7 +158,7 @@ func decodeFeltLimbs(data []byte, value *Felt) (int, bool) {
 }
 
 // decodeFelt decodes a single felt that must span all of data, rejecting trailing bytes.
-// It writes value only on success.
+// It returns a flag to signal success, and writes value only on success.
 func decodeFelt(data []byte, value *Felt) bool {
 	var felt Felt
 	consumed, ok := decodeFeltLimbs(data, &felt)

--- a/core/felt/slice.go
+++ b/core/felt/slice.go
@@ -1,0 +1,130 @@
+package felt
+
+import (
+	"encoding/binary"
+	"math"
+
+	"github.com/fxamacker/cbor/v2"
+)
+
+type Slice []Felt
+
+const (
+	// maxCBORArrayHeaderLen: 1 major/info byte + 4 length bytes (uint32)
+	maxCBORArrayHeaderLen = 1 + 4
+
+	// cborNull is the CBOR encoding of null, which the generic encoder emits for a nil slice.
+	cborNull = 0xf6
+)
+
+func (s Slice) MarshalCBOR() ([]byte, error) {
+	if s == nil {
+		return []byte{cborNull}, nil
+	}
+
+	data := make([]byte, maxCBORArrayHeaderLen+len(s)*maxCBORFeltLen)
+
+	offset := encodeCBORArrayHeader(data, uint32(len(s)))
+	for idx := range s {
+		offset += encodeFeltLimbs(data[offset:], &s[idx])
+	}
+
+	return data[:offset], nil
+}
+
+func (s *Slice) UnmarshalCBOR(data []byte) error {
+	size, offset, ok := decodeCBORArrayHeader(data)
+	if !ok {
+		return s.unmarshalGeneric(data)
+	}
+
+	// Checking if size was corrupted to avoid allocating a malicious amount of data
+	maxPossibleFelts := (len(data) - offset) / minCBORFeltLen
+	if size < 0 || size > maxPossibleFelts {
+		return s.unmarshalGeneric(data)
+	}
+
+	buffer := make([]Felt, size)
+	for i := range buffer {
+		consumed, ok := decodeFeltLimbs(data[offset:], &buffer[i])
+		if !ok {
+			return s.unmarshalGeneric(data)
+		}
+		offset += consumed
+	}
+
+	if offset != len(data) {
+		return s.unmarshalGeneric(data)
+	}
+
+	*s = buffer
+	return nil
+}
+
+// unmarshalGeneric handles any shape the fast path does not recognise.
+func (s *Slice) unmarshalGeneric(data []byte) error {
+	var buffer []Felt
+	if err := cbor.Unmarshal(data, &buffer); err != nil {
+		return err
+	}
+
+	*s = buffer
+	return nil
+}
+
+// encodeCBORArrayHeader writes the CBOR array header for arraySize items into data
+// starting at index 0, returning the number of bytes written.
+func encodeCBORArrayHeader(data []byte, arraySize uint32) int {
+	// Starting with the most common path, which is a small array in this case
+	switch {
+	case arraySize < cborUint8AdditionalInfo:
+		data[0] = cborArrayMajor | byte(arraySize)
+		return 1
+	case arraySize <= math.MaxUint8:
+		data[0] = cborArrayMajor | cborUint8AdditionalInfo
+		data[1] = byte(arraySize)
+		return 2
+	case arraySize <= math.MaxUint16:
+		data[0] = cborArrayMajor | cborUint16AdditionalInfo
+		binary.BigEndian.PutUint16(data[1:], uint16(arraySize))
+		return 3
+	default:
+		// The larger size should fit into an uint32, bigger arrays do not fit the memory
+		data[0] = cborArrayMajor | cborUint32AdditionalInfo
+		binary.BigEndian.PutUint32(data[1:], arraySize)
+		return maxCBORArrayHeaderLen
+	}
+}
+
+// decodeCBORArrayHeader reads a CBOR array header at data[0:],
+// returning the element count and the number of bytes consumed.
+// ok is false when the data is not a CBOR array or its length is encoded larger than a uint32
+func decodeCBORArrayHeader(data []byte) (size, offset int, ok bool) {
+	if len(data) == 0 {
+		return 0, 0, false
+	}
+
+	// majorType (first 3 bits) encodes the object type
+	majorType := data[0] & 0b1110_0000
+	if majorType != cborArrayMajor {
+		return 0, 0, false
+	}
+
+	// additionalInfo (last 5 bits) encodes the array length or how it follows
+	additionalInfo := data[0] & 0b0001_1111
+
+	// Starting with the most common path, which is a small array
+	switch {
+	case additionalInfo < cborUint8AdditionalInfo:
+		return int(additionalInfo), 1, true
+	case additionalInfo == cborUint8AdditionalInfo && len(data) >= 2:
+		return int(data[1]), 2, true
+	case additionalInfo == cborUint16AdditionalInfo && len(data) >= 3:
+		return int(binary.BigEndian.Uint16(data[1:])), 3, true
+	case additionalInfo == cborUint32AdditionalInfo && len(data) >= 5:
+		return int(binary.BigEndian.Uint32(data[1:])), maxCBORArrayHeaderLen, true
+	default:
+		// A size bigger than an uint32 is not allowed in the fast-path
+		return 0, 0, false
+	}
+}

--- a/core/felt/slice_bench_test.go
+++ b/core/felt/slice_bench_test.go
@@ -1,0 +1,47 @@
+package felt_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/NethermindEth/juno/core/felt"
+	"github.com/NethermindEth/juno/encoder"
+)
+
+func BenchmarkSliceVsFeltArray(b *testing.B) {
+	for _, n := range []int{1000, 5000} {
+		slice := randomSlice(n)
+		feltArray := []felt.Felt(slice)
+		encoded, err := encoder.Marshal(slice)
+		if err != nil {
+			b.Fatal(err)
+		}
+
+		b.Run(fmt.Sprintf("marshal/Slice/n=%d", n), func(b *testing.B) {
+			b.ReportAllocs()
+			for b.Loop() {
+				_, _ = encoder.Marshal(slice)
+			}
+		})
+		b.Run(fmt.Sprintf("marshal/FeltArray/n=%d", n), func(b *testing.B) {
+			b.ReportAllocs()
+			for b.Loop() {
+				_, _ = encoder.Marshal(feltArray)
+			}
+		})
+		b.Run(fmt.Sprintf("unmarshal/Slice/n=%d", n), func(b *testing.B) {
+			b.ReportAllocs()
+			for b.Loop() {
+				var out felt.Slice
+				_ = encoder.Unmarshal(encoded, &out)
+			}
+		})
+		b.Run(fmt.Sprintf("unmarshal/FeltArray/n=%d", n), func(b *testing.B) {
+			b.ReportAllocs()
+			for b.Loop() {
+				var out []felt.Felt
+				_ = encoder.Unmarshal(encoded, &out)
+			}
+		})
+	}
+}

--- a/core/felt/slice_test.go
+++ b/core/felt/slice_test.go
@@ -1,0 +1,210 @@
+package felt_test
+
+import (
+	"encoding/binary"
+	"math"
+	"math/rand"
+	"slices"
+	"testing"
+
+	"github.com/NethermindEth/juno/core/felt"
+	"github.com/fxamacker/cbor/v2"
+	"github.com/stretchr/testify/require"
+)
+
+// CBOR initial bytes used to hand-assemble the edge-case payloads. See RFC 8949 §3.
+const (
+	cborUintZero    = 0x00 // unsigned integer 0 (not an array)
+	cborNull        = 0xf6 // null
+	cborArrayEmpty  = 0x80 // array, 0 elements
+	cborArrayOne    = 0x81 // array, 1 element
+	cborArrayTwo    = 0x82 // array, 2 elements
+	cborArrayUint8  = 0x98 // array, element count in the following uint8
+	cborArrayUint16 = 0x99 // array, element count in the following uint16
+	cborArrayUint32 = 0x9a // array, element count in the following uint32
+	cborArrayIndef  = 0x9f // indefinite-length array
+	cborBreak       = 0xff // "break" stop code, ends an indefinite-length item
+)
+
+func randomSlice(size int) felt.Slice {
+	rng := rand.New(rand.NewSource(1))
+	slice := make(felt.Slice, size)
+	for idx := range slice {
+		slice[idx] = feltFromLimbs(rng.Uint64(), rng.Uint64(), rng.Uint64(), rng.Uint64())
+	}
+	return slice
+}
+
+func encodeFeltCBOR(t *testing.T, value felt.Felt) []byte {
+	t.Helper()
+	encoded, err := value.MarshalCBOR()
+	require.NoError(t, err)
+	return encoded
+}
+
+// requireSliceDecodeEquivalent decodes data with both the fast and generic
+// paths, asserts they agree, and returns whether the decode succeeded.
+func requireSliceDecodeEquivalent(t *testing.T, data []byte) (ok bool) {
+	t.Helper()
+
+	var fast felt.Slice
+	errFast := fast.UnmarshalCBOR(data)
+
+	var generic []felt.Felt
+	errGeneric := cbor.Unmarshal(data, &generic)
+
+	if errGeneric != nil {
+		require.Equal(
+			t,
+			errGeneric,
+			errFast,
+			"fast and generic decoders disagree on the error for % x",
+			data,
+		)
+		return false
+	}
+
+	require.NoError(
+		t,
+		errFast,
+		"fast decoder rejected input the generic decoder accepted: % x",
+		data,
+	)
+
+	require.Equal(t, len(generic), len(fast), "length mismatch for % x", data)
+	for i := range generic {
+		require.True(
+			t,
+			generic[i].Equal(&fast[i]),
+			"element %d mismatch for % x: generic=%s fast=%s",
+			i,
+			data,
+			generic[i].String(),
+			fast[i].String(),
+		)
+	}
+	return true
+}
+
+func TestSliceRoundTripBoundarySizes(t *testing.T) {
+	sizes := []struct {
+		name string
+		size int
+	}{
+		{"empty", 0},
+		{"one", 1},
+		{"largest inline length", 23},
+		{"smallest uint8 length", 24},
+		{"largest uint8 length", 255},
+		{"smallest uint16 length", 256},
+		{"largest uint16 length", 65535},
+		{"smallest uint32 length", 65536},
+	}
+	for _, tc := range sizes {
+		t.Run(tc.name, func(t *testing.T) {
+			s := randomSlice(tc.size)
+
+			fast, err := s.MarshalCBOR()
+			require.NoError(t, err)
+			generic, err := cbor.Marshal([]felt.Felt(s))
+			require.NoError(t, err)
+			require.Equal(
+				t,
+				generic,
+				fast,
+				"fast marshal disagrees with generic array framing for len=%d",
+				tc.size,
+			)
+
+			require.True(t, requireSliceDecodeEquivalent(t, fast))
+		})
+	}
+}
+
+// A nil slice must marshal like the generic encoder (null, not an empty array)
+// and round-trip back to nil rather than an empty slice.
+func TestSliceMarshalNil(t *testing.T) {
+	var s felt.Slice // nil
+
+	fast, err := s.MarshalCBOR()
+	require.NoError(t, err)
+	generic, err := cbor.Marshal([]felt.Felt(s))
+	require.NoError(t, err)
+	require.Equal(t, generic, fast, "nil slice must marshal like the generic encoder")
+
+	var back felt.Slice
+	require.NoError(t, back.UnmarshalCBOR(fast))
+	require.Nil(t, back, "nil slice must round-trip back to nil, not empty")
+}
+
+func TestSliceDecodeCornerCases(t *testing.T) {
+	feltBytes1 := encodeFeltCBOR(t, feltFromLimbs(1))
+	feltBytes2 := encodeFeltCBOR(t, feltFromLimbs(2))
+
+	cases := []struct {
+		name string
+		data []byte
+	}{
+		{"empty", []byte{}},
+		{"nil", nil},
+		{"null", []byte{cborNull}},
+		{"not an array (unsigned int)", []byte{cborUintZero}},
+		{"empty array", []byte{cborArrayEmpty}},
+		{"one valid felt", slices.Concat([]byte{cborArrayOne}, feltBytes1)},
+		{"two valid felts", slices.Concat([]byte{cborArrayTwo}, feltBytes1, feltBytes2)},
+		{"array of one, no element", []byte{cborArrayOne}},
+		{"array of two, second element missing", slices.Concat([]byte{cborArrayTwo}, feltBytes1)},
+		{"valid array plus trailing byte", slices.Concat(
+			[]byte{cborArrayOne},
+			feltBytes1,
+			[]byte{cborUintZero},
+		)},
+		{"element is not a felt-shaped array", []byte{cborArrayOne, cborUintZero}},
+		{"indefinite-length array", slices.Concat(
+			[]byte{cborArrayIndef},
+			feltBytes1,
+			[]byte{cborBreak},
+		)},
+		{"uint8-length header for a one-element array", slices.Concat(
+			[]byte{cborArrayUint8, 0x01},
+			feltBytes1,
+		)},
+		{"uint8-length header, missing count byte", []byte{cborArrayUint8}},
+		{"uint16-length header, truncated count", []byte{cborArrayUint16, 0x00}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			requireSliceDecodeEquivalent(t, tc.data)
+		})
+	}
+}
+
+func TestSliceDecodeRejectsOversizedHeader(t *testing.T) {
+	feltBytes := encodeFeltCBOR(t, feltFromLimbs(1))
+
+	// cborArrayUint32 reads the element count
+	// math.MaxUint32 = ~4.29 billion elements, far more than the payload holds.
+	header := binary.BigEndian.AppendUint32([]byte{cborArrayUint32}, math.MaxUint32)
+	data := slices.Concat(header, feltBytes)
+
+	requireSliceDecodeEquivalent(t, data)
+}
+
+// FuzzSliceDecodeEquivalence fuzzes the decode path, the one that can receive
+// arbitrary bytes, to ensure it stays equivalent to the generic decoder and never panics.
+func FuzzSliceDecodeEquivalence(f *testing.F) {
+	for _, n := range []int{0, 1, 2, 23, 24, 255, 256} {
+		encoded, err := randomSlice(n).MarshalCBOR()
+		require.NoError(f, err)
+		f.Add(encoded)
+	}
+	for _, seed := range [][]byte{
+		{cborArrayEmpty}, {cborNull}, {cborUintZero}, {cborArrayOne}, {cborArrayOne, cborUintZero}, nil,
+	} {
+		f.Add(seed)
+	}
+
+	f.Fuzz(func(t *testing.T, data []byte) {
+		requireSliceDecodeEquivalent(t, data)
+	})
+}

--- a/core/state/accessors_test.go
+++ b/core/state/accessors_test.go
@@ -122,7 +122,7 @@ func TestClassAccessors(t *testing.T) {
 		sierra, ok := got.Class.(*core.SierraClass)
 		require.True(t, ok)
 		assert.Equal(t, "0.1.0", sierra.SemanticVersion)
-		assert.Equal(t, []felt.Felt{felt.UnsafeFromString[felt.Felt]("0x1")}, sierra.Program)
+		assert.Equal(t, []felt.Felt{felt.UnsafeFromString[felt.Felt]("0x1")}, []felt.Felt(sierra.Program))
 	})
 
 	t.Run("overwrite reflects latest values", func(t *testing.T) {
@@ -144,7 +144,7 @@ func TestClassAccessors(t *testing.T) {
 		sierra, ok := got.Class.(*core.SierraClass)
 		require.True(t, ok)
 		assert.Equal(t, "0.2.0", sierra.SemanticVersion)
-		assert.Equal(t, []felt.Felt{felt.UnsafeFromString[felt.Felt]("0x2")}, sierra.Program)
+		assert.Equal(t, []felt.Felt{felt.UnsafeFromString[felt.Felt]("0x2")}, []felt.Felt(sierra.Program))
 	})
 
 	t.Run("delete removes the class", func(t *testing.T) {

--- a/migration/deprecated/migration_pkg_test.go
+++ b/migration/deprecated/migration_pkg_test.go
@@ -361,7 +361,7 @@ func TestMigrateCairo1CompiledClass(t *testing.T) {
 		assert.Equal(t, expectedClass.Abi, actualClass.Abi)
 		assert.Equal(t, expectedClass.AbiHash, actualClass.AbiHash)
 		assert.Equal(t, expectedClass.EntryPoints, actualClass.EntryPoints)
-		assert.Equal(t, expectedClass.Program, actualClass.Program)
+		assert.Equal(t, expectedClass.Program, []felt.Felt(actualClass.Program))
 		assert.Equal(t, expectedClass.ProgramHash, actualClass.ProgramHash)
 		assert.Equal(t, expectedClass.SemanticVersion, actualClass.SemanticVersion)
 

--- a/rpc/v10/class_test.go
+++ b/rpc/v10/class_test.go
@@ -378,7 +378,7 @@ func assertEqualDeprecatedCairoClass(
 }
 
 func assertEqualSierraClass(t *testing.T, sierraClass *core.SierraClass, class *rpc.Class) {
-	assert.Equal(t, sierraClass.Program, class.SierraProgram)
+	assert.Equal(t, []felt.Felt(sierraClass.Program), class.SierraProgram)
 	assert.Equal(t, sierraClass.Abi, class.Abi.(string))
 	assert.Equal(t, sierraClass.SemanticVersion, class.ContractClassVersion)
 

--- a/rpc/v8/class_test.go
+++ b/rpc/v8/class_test.go
@@ -318,7 +318,7 @@ func assertEqualDeprecatedCairoClass(
 }
 
 func assertEqualSierraClass(t *testing.T, sierraClass *core.SierraClass, class *rpc.Class) {
-	assert.Equal(t, sierraClass.Program, class.SierraProgram)
+	assert.Equal(t, []felt.Felt(sierraClass.Program), class.SierraProgram)
 	assert.Equal(t, sierraClass.Abi, class.Abi.(string))
 	assert.Equal(t, sierraClass.SemanticVersion, class.ContractClassVersion)
 

--- a/rpc/v9/class_test.go
+++ b/rpc/v9/class_test.go
@@ -378,7 +378,7 @@ func assertEqualDeprecatedCairoClass(
 }
 
 func assertEqualSierraClass(t *testing.T, sierraClass *core.SierraClass, class *rpcv9.Class) {
-	assert.Equal(t, sierraClass.Program, class.SierraProgram)
+	assert.Equal(t, []felt.Felt(sierraClass.Program), class.SierraProgram)
 	assert.Equal(t, sierraClass.Abi, class.Abi.(string))
 	assert.Equal(t, sierraClass.SemanticVersion, class.ContractClassVersion)
 


### PR DESCRIPTION
Use especiallized CBOR marshal/unmarshal  for. `[]felt.Felt`.

Added a defined type around  `[]felt.Felt` to implement the methods.

Avoid allocating memory for each felt.

Allocation optimizations + speed Optimizations.

#### Marshal
| n | `[]felt.Felt` | `Slice` | result |
|---|---------|-----------|--------|
| 1000 | 77.1 µs, 153 KB, 3002 allocs | 27.7 µs, 82 KB, 3 allocs | 2.8× faster, 46% less memory, allocations O(n) → constant |
| 5000 | 396.7 µs, 749 KB, 15002 allocs | 141.3 µs, 377 KB, 3 allocs | 2.8× faster, 50% less memory, allocations O(n) → constant |

#### Unmarshal
| n | `[]felt.Felt` | `Slice` | result |
|---|---------|-----------|--------|
| 1000 | 59.2 µs, 3 allocs | 42.7 µs, 2 allocs | 1.4× faster |
| 5000 | 309.2 µs, 3 allocs | 217.4 µs, 2 allocs | 1.4× faster |

Used tests to compare correctness.

Closes Issue https://github.com/NethermindEth/juno/issues/3823