### PR TITLE
feat(core/felt): make felt.Slice generic

### DIFF
--- a/core/class.go
+++ b/core/class.go
@@ -72,7 +72,7 @@ type SierraClass struct {
 	Abi         string
 	AbiHash     *felt.Felt
 	EntryPoints SierraEntryPointsByType
-	Program     felt.Slice
+	Program     felt.Slice[felt.Felt]
 	ProgramHash *felt.Felt
 	// TODO: Remove this semantic version on a follow up PR. Let's put Sierra version instead
 	SemanticVersion string
@@ -85,7 +85,7 @@ type SegmentLengths struct {
 }
 
 type CasmClass struct {
-	Bytecode               felt.Slice
+	Bytecode               felt.Slice[felt.Felt]
 	PythonicHints          json.RawMessage
 	CompilerVersion        string
 	Hints                  json.RawMessage

--- a/core/felt/cbor.go
+++ b/core/felt/cbor.go
@@ -11,7 +11,7 @@ import (
 // Fast, felt-specialized CBOR marshaling.
 func (z *Felt) MarshalCBOR() ([]byte, error) {
 	data := make([]byte, maxCBORFeltLen)
-	n := encodeFeltLimbs(data, z)
+	n := encodeLimbs(data, z)
 	return data[:n], nil
 }
 
@@ -50,14 +50,14 @@ const (
 	minCBORFeltLen = 1 + Limbs
 )
 
-// encodeFeltLimbs puts one CBOR felt to data, returning the number of bytes written.
-func encodeFeltLimbs(data []byte, value *Felt) int {
+// encodeLimbs puts one CBOR felt to data, returning the number of bytes written.
+func encodeLimbs[F FeltLike](data []byte, value *F) int {
 	// The format is: [cborArrayHeader4] [limb 0] [limb 1] [limb 2] [limb 3].
 	data[0] = cborArrayHeader4
 
 	offset := 1
 	for limbIndex := range Limbs {
-		limb := value[limbIndex]
+		limb := asFeltPtr(value)[limbIndex]
 
 		// Starting with the most common path, which is a large limb
 		switch {
@@ -90,17 +90,17 @@ func encodeFeltLimbs(data []byte, value *Felt) int {
 	return offset
 }
 
-// decodeFeltLimbs decodes one limb-encoded felt at data[0:],
+// decodeLimbs decodes one limb-encoded felt at data[0:],
 // returning the number of bytes consumed and a flag to signal succes.
 // It writes value only on success, so a rejected input can't partially
 // corrupt it before falling back to the generic decoder.
-func decodeFeltLimbs(data []byte, value *Felt) (int, bool) {
+func decodeLimbs[F FeltLike](data []byte, value *F) (int, bool) {
 	// The data format is: [cborArrayHeader4] [limb 0] [limb 1] [limb 2] [limb 3]
 	if len(data) == 0 || data[0] != cborArrayHeader4 {
 		return 0, false
 	}
 
-	var limbs Felt
+	var limbs F
 	offset := 1
 
 	for limbIndex := range Limbs {
@@ -112,8 +112,6 @@ func decodeFeltLimbs(data []byte, value *Felt) (int, bool) {
 		offset++
 
 		var limb uint64
-
-		// Starting with the most common path, which is a large limb
 		switch {
 		case headerByte > cborUint64AdditionalInfo: // invalid header byte for uint64
 			return 0, false
@@ -161,7 +159,7 @@ func decodeFeltLimbs(data []byte, value *Felt) (int, bool) {
 // It returns a flag to signal success, and writes value only on success.
 func decodeFelt(data []byte, value *Felt) bool {
 	var felt Felt
-	consumed, ok := decodeFeltLimbs(data, &felt)
+	consumed, ok := decodeLimbs(data, &felt)
 	if !ok || consumed != len(data) {
 		return false
 	}

--- a/core/felt/cbor.go
+++ b/core/felt/cbor.go
@@ -57,7 +57,7 @@ func encodeLimbs[F FeltLike](data []byte, value *F) int {
 
 	offset := 1
 	for limbIndex := range Limbs {
-		limb := asFeltPtr(value)[limbIndex]
+		limb := (*value)[limbIndex]
 
 		// Starting with the most common path, which is a large limb
 		switch {

--- a/core/felt/cbor_fastpath_test.go
+++ b/core/felt/cbor_fastpath_test.go
@@ -89,12 +89,12 @@ func feltFromBigInt(n *big.Int) felt.Felt {
 	return value
 }
 
-// feltFromLimbs bypasses SetBigInt's Montgomery conversion, so a small
+// fromLimbs bypasses SetBigInt's Montgomery conversion, so a small
 // argument here actually lands in a limb. SetBigInt() does not.
-func feltFromLimbs(limbs ...uint64) felt.Felt {
+func fromLimbs[F felt.FeltLike](limbs ...uint64) F {
 	var l [4]uint64
 	copy(l[:], limbs)
-	return felt.Felt(fp.Element(l))
+	return F(fp.Element(l))
 }
 
 func TestCBORFastPathValues(t *testing.T) {
@@ -121,11 +121,11 @@ func TestCBORFastPathValues(t *testing.T) {
 		{"smallest 8-byte", math.MaxUint32 + 1},
 		{"largest 8-byte (max uint64)", math.MaxUint64},
 	} {
-		cases = append(cases, valueCase{"limb: " + boundary.name, feltFromLimbs(boundary.limb)})
+		cases = append(cases, valueCase{"limb: " + boundary.name, fromLimbs[felt.Felt](boundary.limb)})
 	}
 	cases = append(cases, valueCase{
 		"limb: boundary values spread across all four limbs",
-		feltFromLimbs(23, math.MaxUint8, math.MaxUint16, math.MaxUint64),
+		fromLimbs[felt.Felt](23, math.MaxUint8, math.MaxUint16, math.MaxUint64),
 	})
 
 	// Starknet's default modulus for felts.
@@ -178,7 +178,7 @@ func TestCBORFastPathStress(t *testing.T) {
 	const logEvery = 50_000_000
 
 	for i := range n {
-		value := feltFromLimbs(rng.Uint64(), rng.Uint64(), rng.Uint64(), rng.Uint64())
+		value := fromLimbs[felt.Felt](rng.Uint64(), rng.Uint64(), rng.Uint64(), rng.Uint64())
 
 		fast, generic, err := encodeBoth(&value)
 		require.NoError(t, err)
@@ -233,7 +233,7 @@ func FuzzCBORFastPathMarshalEquivalence(f *testing.F) {
 	)
 
 	f.Fuzz(func(t *testing.T, l0, l1, l2, l3 uint64) {
-		value := feltFromLimbs(l0, l1, l2, l3)
+		value := fromLimbs[felt.Felt](l0, l1, l2, l3)
 		requireMarshalEquivalent(t, &value)
 	})
 }

--- a/core/felt/ctors_test.go
+++ b/core/felt/ctors_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-type f = [4]uint64
+type f [4]uint64
 
 func TestNumberCtor(t *testing.T) {
 	const posValue = 100

--- a/core/felt/ctors_test.go
+++ b/core/felt/ctors_test.go
@@ -7,33 +7,35 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-type f [4]uint64
+// feltoid is the minimal implementation satisfying [felt.FeltLike] defined to test
+// the package generic methods.
+type feltoid [4]uint64
 
 func TestNumberCtor(t *testing.T) {
 	const posValue = 100
-	expectedPos := (*f)(new(felt.Felt).SetUint64(posValue))
+	expectedPos := (*feltoid)(new(felt.Felt).SetUint64(posValue))
 
 	t.Run("FromUint64", func(t *testing.T) {
-		actual := felt.FromUint64[f](uint64(posValue))
+		actual := felt.FromUint64[feltoid](uint64(posValue))
 		assert.Equal(t, *expectedPos, actual)
 	})
 
 	t.Run("NewFromUint64", func(t *testing.T) {
-		actual := felt.NewFromUint64[f](posValue)
+		actual := felt.NewFromUint64[feltoid](posValue)
 		assert.Equal(t, expectedPos, actual)
 	})
 }
 
 func TestBytesCtor(t *testing.T) {
 	value := []byte("holahola")
-	expected := (*f)(new(felt.Felt).SetBytes(value))
+	expected := (*feltoid)(new(felt.Felt).SetBytes(value))
 
 	t.Run("FromBytes", func(t *testing.T) {
-		actual := felt.FromBytes[f](value)
+		actual := felt.FromBytes[feltoid](value)
 		assert.Equal(t, *expected, actual)
 	})
 	t.Run("NewBytes", func(t *testing.T) {
-		actual := felt.NewFromBytes[f](value)
+		actual := felt.NewFromBytes[feltoid](value)
 		assert.Equal(t, expected, actual)
 	})
 }
@@ -59,9 +61,9 @@ func TestStringCtor(t *testing.T) {
 
 	for _, test := range values {
 		expectedFelt, expectedErr := new(felt.Felt).SetString(test.value)
-		expected := (*f)(expectedFelt)
+		expected := (*feltoid)(expectedFelt)
 		t.Run("FromString"+test.value, func(t *testing.T) {
-			actual, actualErr := felt.FromString[f](test.value)
+			actual, actualErr := felt.FromString[feltoid](test.value)
 			if test.error {
 				assert.EqualError(t, actualErr, expectedErr.Error())
 			} else {
@@ -72,16 +74,16 @@ func TestStringCtor(t *testing.T) {
 		t.Run("UnsafeFromString"+test.value, func(t *testing.T) {
 			if test.error {
 				assert.PanicsWithError(t, expectedErr.Error(), func() {
-					felt.UnsafeFromString[f](test.value)
+					felt.UnsafeFromString[feltoid](test.value)
 				})
 			} else {
-				actual := felt.UnsafeFromString[f](test.value)
+				actual := felt.UnsafeFromString[feltoid](test.value)
 				assert.Equal(t, *expected, actual)
 			}
 		})
 
 		t.Run("NewString"+test.value, func(t *testing.T) {
-			actual, actualErr := felt.NewFromString[f](test.value)
+			actual, actualErr := felt.NewFromString[feltoid](test.value)
 			if test.error {
 				assert.EqualError(t, actualErr, expectedErr.Error())
 			} else {
@@ -92,10 +94,10 @@ func TestStringCtor(t *testing.T) {
 		t.Run("NewUnsafeFromString"+test.value, func(t *testing.T) {
 			if test.error {
 				assert.PanicsWithError(t, expectedErr.Error(), func() {
-					felt.NewUnsafeFromString[f](test.value)
+					felt.NewUnsafeFromString[feltoid](test.value)
 				})
 			} else {
-				actual := felt.NewUnsafeFromString[f](test.value)
+				actual := felt.NewUnsafeFromString[feltoid](test.value)
 				assert.Equal(t, expected, actual)
 			}
 		})
@@ -105,10 +107,10 @@ func TestStringCtor(t *testing.T) {
 func TestRandomCtor(t *testing.T) {
 	//  Normal random doesn't error
 	assert.NotPanics(t, func() {
-		felt.Random[f]()
+		felt.Random[feltoid]()
 	})
 
 	assert.NotPanics(t, func() {
-		felt.NewRandom[f]()
+		felt.NewRandom[feltoid]()
 	})
 }

--- a/core/felt/slice.go
+++ b/core/felt/slice.go
@@ -7,7 +7,7 @@ import (
 	"github.com/fxamacker/cbor/v2"
 )
 
-type Slice []Felt
+type Slice[F FeltLike] []F
 
 const (
 	// maxCBORArrayHeaderLen: 1 major/info byte + 4 length bytes (uint32)
@@ -17,7 +17,7 @@ const (
 	cborNull = 0xf6
 )
 
-func (s Slice) MarshalCBOR() ([]byte, error) {
+func (s Slice[F]) MarshalCBOR() ([]byte, error) {
 	if s == nil {
 		return []byte{cborNull}, nil
 	}
@@ -26,13 +26,13 @@ func (s Slice) MarshalCBOR() ([]byte, error) {
 
 	offset := encodeCBORArrayHeader(data, uint32(len(s)))
 	for idx := range s {
-		offset += encodeFeltLimbs(data[offset:], &s[idx])
+		offset += encodeLimbs(data[offset:], &s[idx])
 	}
 
 	return data[:offset], nil
 }
 
-func (s *Slice) UnmarshalCBOR(data []byte) error {
+func (s *Slice[F]) UnmarshalCBOR(data []byte) error {
 	size, offset, ok := decodeCBORArrayHeader(data)
 	if !ok {
 		return s.unmarshalGeneric(data)
@@ -44,9 +44,9 @@ func (s *Slice) UnmarshalCBOR(data []byte) error {
 		return s.unmarshalGeneric(data)
 	}
 
-	buffer := make([]Felt, size)
+	buffer := make([]F, size)
 	for i := range buffer {
-		consumed, ok := decodeFeltLimbs(data[offset:], &buffer[i])
+		consumed, ok := decodeLimbs(data[offset:], &buffer[i])
 		if !ok {
 			return s.unmarshalGeneric(data)
 		}
@@ -62,8 +62,8 @@ func (s *Slice) UnmarshalCBOR(data []byte) error {
 }
 
 // unmarshalGeneric handles any shape the fast path does not recognise.
-func (s *Slice) unmarshalGeneric(data []byte) error {
-	var buffer []Felt
+func (s *Slice[F]) unmarshalGeneric(data []byte) error {
+	var buffer []F
 	if err := cbor.Unmarshal(data, &buffer); err != nil {
 		return err
 	}

--- a/core/felt/slice_bench_test.go
+++ b/core/felt/slice_bench_test.go
@@ -10,8 +10,8 @@ import (
 
 func BenchmarkSliceVsFeltArray(b *testing.B) {
 	for _, n := range []int{1000, 5000} {
-		slice := randomSlice[f](n)
-		feltArray := []f(slice)
+		slice := randomSlice[feltoid](n)
+		feltArray := []feltoid(slice)
 		encoded, err := encoder.Marshal(slice)
 		if err != nil {
 			b.Fatal(err)
@@ -32,7 +32,7 @@ func BenchmarkSliceVsFeltArray(b *testing.B) {
 		b.Run(fmt.Sprintf("unmarshal/Slice/n=%d", n), func(b *testing.B) {
 			b.ReportAllocs()
 			for b.Loop() {
-				var out felt.Slice[f]
+				var out felt.Slice[feltoid]
 				_ = encoder.Unmarshal(encoded, &out)
 			}
 		})

--- a/core/felt/slice_bench_test.go
+++ b/core/felt/slice_bench_test.go
@@ -10,8 +10,8 @@ import (
 
 func BenchmarkSliceVsFeltArray(b *testing.B) {
 	for _, n := range []int{1000, 5000} {
-		slice := randomSlice(n)
-		feltArray := []felt.Felt(slice)
+		slice := randomSlice[f](n)
+		feltArray := []f(slice)
 		encoded, err := encoder.Marshal(slice)
 		if err != nil {
 			b.Fatal(err)
@@ -32,7 +32,7 @@ func BenchmarkSliceVsFeltArray(b *testing.B) {
 		b.Run(fmt.Sprintf("unmarshal/Slice/n=%d", n), func(b *testing.B) {
 			b.ReportAllocs()
 			for b.Loop() {
-				var out felt.Slice
+				var out felt.Slice[f]
 				_ = encoder.Unmarshal(encoded, &out)
 			}
 		})

--- a/core/felt/slice_test.go
+++ b/core/felt/slice_test.go
@@ -26,11 +26,11 @@ const (
 	cborBreak       = 0xff // "break" stop code, ends an indefinite-length item
 )
 
-func randomSlice(size int) felt.Slice {
+func randomSlice[F felt.FeltLike](size int) felt.Slice[F] {
 	rng := rand.New(rand.NewSource(1))
-	slice := make(felt.Slice, size)
+	slice := make(felt.Slice[F], size)
 	for idx := range slice {
-		slice[idx] = feltFromLimbs(rng.Uint64(), rng.Uint64(), rng.Uint64(), rng.Uint64())
+		slice[idx] = fromLimbs[F](rng.Uint64(), rng.Uint64(), rng.Uint64(), rng.Uint64())
 	}
 	return slice
 }
@@ -43,14 +43,14 @@ func encodeFeltCBOR(t *testing.T, value felt.Felt) []byte {
 }
 
 // requireSliceDecodeEquivalent decodes data with both the fast and generic
-// paths, asserts they agree, and returns whether the decode succeeded.
-func requireSliceDecodeEquivalent(t *testing.T, data []byte) (ok bool) {
+// paths and asserts they agree, either on the decoded felts or on the error.
+func requireSliceDecodeEquivalent[F felt.FeltLike](t *testing.T, data []byte) {
 	t.Helper()
 
-	var fast felt.Slice
+	var fast felt.Slice[F]
 	errFast := fast.UnmarshalCBOR(data)
 
-	var generic []felt.Felt
+	var generic []F
 	errGeneric := cbor.Unmarshal(data, &generic)
 
 	if errGeneric != nil {
@@ -61,7 +61,7 @@ func requireSliceDecodeEquivalent(t *testing.T, data []byte) (ok bool) {
 			"fast and generic decoders disagree on the error for % x",
 			data,
 		)
-		return false
+		return
 	}
 
 	require.NoError(
@@ -75,15 +75,14 @@ func requireSliceDecodeEquivalent(t *testing.T, data []byte) (ok bool) {
 	for i := range generic {
 		require.True(
 			t,
-			generic[i].Equal(&fast[i]),
-			"element %d mismatch for % x: generic=%s fast=%s",
+			felt.Equal(&generic[i], &fast[i]),
+			"element %d mismatch for % x: generic=%v fast=%v",
 			i,
 			data,
-			generic[i].String(),
-			fast[i].String(),
+			generic[i],
+			fast[i],
 		)
 	}
-	return true
 }
 
 func TestSliceRoundTripBoundarySizes(t *testing.T) {
@@ -102,7 +101,7 @@ func TestSliceRoundTripBoundarySizes(t *testing.T) {
 	}
 	for _, tc := range sizes {
 		t.Run(tc.name, func(t *testing.T) {
-			s := randomSlice(tc.size)
+			s := randomSlice[felt.Felt](tc.size)
 
 			fast, err := s.MarshalCBOR()
 			require.NoError(t, err)
@@ -116,7 +115,8 @@ func TestSliceRoundTripBoundarySizes(t *testing.T) {
 				tc.size,
 			)
 
-			require.True(t, requireSliceDecodeEquivalent(t, fast))
+			requireSliceDecodeEquivalent[felt.Felt](t, fast)
+			requireSliceDecodeEquivalent[f](t, fast)
 		})
 	}
 }
@@ -124,7 +124,7 @@ func TestSliceRoundTripBoundarySizes(t *testing.T) {
 // A nil slice must marshal like the generic encoder (null, not an empty array)
 // and round-trip back to nil rather than an empty slice.
 func TestSliceMarshalNil(t *testing.T) {
-	var s felt.Slice // nil
+	var s felt.Slice[felt.Felt] // nil
 
 	fast, err := s.MarshalCBOR()
 	require.NoError(t, err)
@@ -132,14 +132,14 @@ func TestSliceMarshalNil(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, generic, fast, "nil slice must marshal like the generic encoder")
 
-	var back felt.Slice
+	var back felt.Slice[f]
 	require.NoError(t, back.UnmarshalCBOR(fast))
 	require.Nil(t, back, "nil slice must round-trip back to nil, not empty")
 }
 
 func TestSliceDecodeCornerCases(t *testing.T) {
-	feltBytes1 := encodeFeltCBOR(t, feltFromLimbs(1))
-	feltBytes2 := encodeFeltCBOR(t, feltFromLimbs(2))
+	feltBytes1 := encodeFeltCBOR(t, fromLimbs[felt.Felt](1))
+	feltBytes2 := encodeFeltCBOR(t, fromLimbs[felt.Felt](2))
 
 	cases := []struct {
 		name string
@@ -174,37 +174,40 @@ func TestSliceDecodeCornerCases(t *testing.T) {
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			requireSliceDecodeEquivalent(t, tc.data)
+			requireSliceDecodeEquivalent[felt.Felt](t, tc.data)
+			requireSliceDecodeEquivalent[f](t, tc.data)
 		})
 	}
 }
 
 func TestSliceDecodeRejectsOversizedHeader(t *testing.T) {
-	feltBytes := encodeFeltCBOR(t, feltFromLimbs(1))
+	feltBytes := encodeFeltCBOR(t, fromLimbs[felt.Felt](1))
 
 	// cborArrayUint32 reads the element count
 	// math.MaxUint32 = ~4.29 billion elements, far more than the payload holds.
 	header := binary.BigEndian.AppendUint32([]byte{cborArrayUint32}, math.MaxUint32)
 	data := slices.Concat(header, feltBytes)
 
-	requireSliceDecodeEquivalent(t, data)
+	requireSliceDecodeEquivalent[felt.Felt](t, data)
+	requireSliceDecodeEquivalent[f](t, data)
 }
 
 // FuzzSliceDecodeEquivalence fuzzes the decode path, the one that can receive
 // arbitrary bytes, to ensure it stays equivalent to the generic decoder and never panics.
-func FuzzSliceDecodeEquivalence(f *testing.F) {
+func FuzzSliceDecodeEquivalence(fz *testing.F) {
 	for _, n := range []int{0, 1, 2, 23, 24, 255, 256} {
-		encoded, err := randomSlice(n).MarshalCBOR()
-		require.NoError(f, err)
-		f.Add(encoded)
+		encoded, err := randomSlice[felt.Felt](n).MarshalCBOR()
+		require.NoError(fz, err)
+		fz.Add(encoded)
 	}
 	for _, seed := range [][]byte{
 		{cborArrayEmpty}, {cborNull}, {cborUintZero}, {cborArrayOne}, {cborArrayOne, cborUintZero}, nil,
 	} {
-		f.Add(seed)
+		fz.Add(seed)
 	}
 
-	f.Fuzz(func(t *testing.T, data []byte) {
-		requireSliceDecodeEquivalent(t, data)
+	fz.Fuzz(func(t *testing.T, data []byte) {
+		requireSliceDecodeEquivalent[felt.Felt](t, data)
+		requireSliceDecodeEquivalent[f](t, data)
 	})
 }

--- a/core/felt/slice_test.go
+++ b/core/felt/slice_test.go
@@ -116,7 +116,7 @@ func TestSliceRoundTripBoundarySizes(t *testing.T) {
 			)
 
 			requireSliceDecodeEquivalent[felt.Felt](t, fast)
-			requireSliceDecodeEquivalent[f](t, fast)
+			requireSliceDecodeEquivalent[feltoid](t, fast)
 		})
 	}
 }
@@ -132,7 +132,7 @@ func TestSliceMarshalNil(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, generic, fast, "nil slice must marshal like the generic encoder")
 
-	var back felt.Slice[f]
+	var back felt.Slice[feltoid]
 	require.NoError(t, back.UnmarshalCBOR(fast))
 	require.Nil(t, back, "nil slice must round-trip back to nil, not empty")
 }
@@ -175,7 +175,7 @@ func TestSliceDecodeCornerCases(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			requireSliceDecodeEquivalent[felt.Felt](t, tc.data)
-			requireSliceDecodeEquivalent[f](t, tc.data)
+			requireSliceDecodeEquivalent[feltoid](t, tc.data)
 		})
 	}
 }
@@ -189,7 +189,7 @@ func TestSliceDecodeRejectsOversizedHeader(t *testing.T) {
 	data := slices.Concat(header, feltBytes)
 
 	requireSliceDecodeEquivalent[felt.Felt](t, data)
-	requireSliceDecodeEquivalent[f](t, data)
+	requireSliceDecodeEquivalent[feltoid](t, data)
 }
 
 // FuzzSliceDecodeEquivalence fuzzes the decode path, the one that can receive
@@ -208,6 +208,6 @@ func FuzzSliceDecodeEquivalence(fz *testing.F) {
 
 	fz.Fuzz(func(t *testing.T, data []byte) {
 		requireSliceDecodeEquivalent[felt.Felt](t, data)
-		requireSliceDecodeEquivalent[f](t, data)
+		requireSliceDecodeEquivalent[feltoid](t, data)
 	})
 }

--- a/core/felt/unsafe.go
+++ b/core/felt/unsafe.go
@@ -1,0 +1,9 @@
+package felt
+
+import "unsafe"
+
+// asFeltPtr reinterprets a *FeltLike as a *Felt.
+// It is safe because every FeltLike has the exact same memory layout.
+func asFeltPtr[F FeltLike](val *F) *Felt {
+	return (*Felt)(unsafe.Pointer(val))
+}

--- a/core/felt/utils.go
+++ b/core/felt/utils.go
@@ -1,12 +1,9 @@
 package felt
 
 func IsZero[F FeltLike](v *F) bool {
-	f := Felt(*v)
-	return f.IsZero()
+	return asFeltPtr(v).IsZero()
 }
 
 func Equal[F FeltLike](a, b *F) bool {
-	fa := Felt(*a)
-	fb := Felt(*b)
-	return fa.Equal(&fb)
+	return asFeltPtr(a).Equal(asFeltPtr(b))
 }

--- a/core/felt/utils_test.go
+++ b/core/felt/utils_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func TestIsZero(t *testing.T) {
-	var val f
+	var val feltoid
 	require.True(t, felt.IsZero(&val))
 
 	val[0] = 1
@@ -17,8 +17,8 @@ func TestIsZero(t *testing.T) {
 
 func TestEqual(t *testing.T) {
 	base := [4]uint64{1, 2, 3, 4}
-	v1 := f(base)
-	v2 := f(base)
+	v1 := feltoid(base)
+	v2 := feltoid(base)
 	require.True(t, felt.Equal(&v1, &v2))
 
 	v2[0] += 100

--- a/core/felt/utils_test.go
+++ b/core/felt/utils_test.go
@@ -1,0 +1,26 @@
+package felt_test
+
+import (
+	"testing"
+
+	"github.com/NethermindEth/juno/core/felt"
+	"github.com/stretchr/testify/require"
+)
+
+func TestIsZero(t *testing.T) {
+	var val f
+	require.True(t, felt.IsZero(&val))
+
+	val[0] = 1
+	require.False(t, felt.IsZero(&val))
+}
+
+func TestEqual(t *testing.T) {
+	base := [4]uint64{1, 2, 3, 4}
+	v1 := f(base)
+	v2 := f(base)
+	require.True(t, felt.Equal(&v1, &v2))
+
+	v2[0] += 100
+	require.False(t, felt.Equal(&v1, &v2))
+}


### PR DESCRIPTION
Update the `felt.Slice` type (included in #3850) to make it generic over `FeltLike`. Performance stays the same.