### PR TITLE
ci(test): gate slow consensus cluster test on consensus path changes

### DIFF
--- a/.github/workflows/juno-test.yml
+++ b/.github/workflows/juno-test.yml
@@ -23,6 +23,21 @@ jobs:
       VM_DEBUG: true
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Detect consensus changes
+        uses: dorny/paths-filter@d1c1ffe0248fe513906c8e24db8ea791d46f8590 # v3.0.3
+        if: github.event_name == 'pull_request'
+        id: filter
+        with:
+          filters: |
+            consensus:
+              - 'consensus/**'
+              - 'p2p/**'
+              - 'Makefile'
+              - 'go.mod'
+              - 'go.sum'
+              - '.github/workflows/juno-test.yml'
+
       - name: Set up go
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v6.0.0
         with:
@@ -51,10 +66,14 @@ jobs:
 
       - name: Tests (Coverage)
         if: matrix.os == 'ubuntu-latest'
+        env:
+          FULL_TESTS: ${{ github.event_name != 'pull_request' || steps.filter.outputs.consensus == 'true' }}
         run: make test-cover
 
       - name: Tests (No Coverage)
         if: matrix.os != 'ubuntu-latest'
+        env:
+          FULL_TESTS: ${{ github.event_name != 'pull_request' || steps.filter.outputs.consensus == 'true' }}
         run: make test
 
       #    Tests with race condition detector are flaky; we're disabling them for now

--- a/Makefile
+++ b/Makefile
@@ -67,25 +67,32 @@ generate: ## Generate mocks and code
 clean-testcache: ## Clean Go test cache
 	go clean -testcache
 
+# FULL_TESTS=true drops -short, enabling slow tests like the consensus cluster test (which needs more than the default 10m timeout)
+ifeq ($(FULL_TESTS),true)
+    TEST_MODE_FLAGS = -timeout 30m
+else
+    TEST_MODE_FLAGS = -short
+endif
+
 test: clean-testcache rustdeps ## Run tests
-	go test $(GO_TAGS) ./...
+	go test $(GO_TAGS) $(TEST_MODE_FLAGS) ./...
 
 test-new-state: clean-testcache rustdeps ## Run tests with new state
-	JUNO_NEW_STATE=true go test $(GO_TAGS) ./...
+	JUNO_NEW_STATE=true go test $(GO_TAGS) $(TEST_MODE_FLAGS) ./...
 
 test-cached: rustdeps ## Run cached tests
-	go test $(GO_TAGS) ./...
+	go test $(GO_TAGS) $(TEST_MODE_FLAGS) ./...
 
 test-race: clean-testcache rustdeps ## Run tests with race detection
-	go test $(GO_TAGS) ./... -race $(TEST_RACE_LDFLAGS)
+	go test $(GO_TAGS) $(TEST_MODE_FLAGS) ./... -race $(TEST_RACE_LDFLAGS)
 
 benchmarks: rustdeps ## Run benchmarks
 	go test $(GO_TAGS) ./... -run=^# -bench=. -benchmem
 
 test-cover: clean-testcache rustdeps ## Run tests with coverage in both old- and new-state modes
 	mkdir -p coverage
-	go test $(GO_TAGS) -coverpkg=$(PKG) -coverprofile=coverage/coverage.old.out -covermode=atomic $(PKG)
-	JUNO_NEW_STATE=true go test $(GO_TAGS) -coverpkg=$(PKG) -coverprofile=coverage/coverage.new.out -covermode=atomic $(PKG)
+	go test $(GO_TAGS) $(TEST_MODE_FLAGS) -coverpkg=$(PKG) -coverprofile=coverage/coverage.old.out -covermode=atomic $(PKG)
+	JUNO_NEW_STATE=true go test $(GO_TAGS) $(TEST_MODE_FLAGS) -coverpkg=$(PKG) -coverprofile=coverage/coverage.new.out -covermode=atomic $(PKG)
 	go tool cover -html=coverage/coverage.old.out -o coverage/coverage.html
 
 install-deps: install-gofumpt install-mockgen install-golangci-lint check-rust ## Install dependencies

--- a/consensus/consensus_test.go
+++ b/consensus/consensus_test.go
@@ -371,6 +371,10 @@ func runWithAllHonestAndSilentFaultyNodes(t *testing.T, cfg testConfig) {
 }
 
 func TestTendermintCluster(t *testing.T) {
+	if testing.Short() {
+		t.Skip("slow cluster test; run via FULL_TESTS=true make test")
+	}
+
 	runWithAllHonestAndSilentFaultyNodes(t, testConfig{
 		nodeCount:    4,
 		targetHeight: 60,


### PR DESCRIPTION
## Summary
- Add a `dorny/paths-filter` step to detect changes under `consensus/**`, `p2p/**`, `Makefile`, `go.mod`/`go.sum`, or the workflow itself on PR runs
- Introduce `FULL_TESTS` env var, set to `true` outside PR runs or when consensus paths changed, and thread it into `make test`/`test-cover` via a new `TEST_MODE_FLAGS` (`-short` by default, `-timeout 30m` when full)
- Skip `TestTendermintCluster` under `testing.Short()`, so the slow 4-node consensus cluster test only runs when relevant paths change (or outside PRs)