### PR TITLE
refactor(crypto): accept `[]felt.Felt` in Pedersen array and digest hashing

### DIFF
--- a/core/block.go
+++ b/core/block.go
@@ -213,7 +213,7 @@ func pre07Hash(
 	if err != nil {
 		return felt.Felt{}, nil, err
 	}
-	return crypto.PedersenArray(
+	return crypto.PedersenElems(
 		new(felt.Felt).SetUint64(b.Number), // block number
 		b.GlobalStateRoot,                  // global state root
 		&felt.Zero,                         // reserved: sequencer address
@@ -435,7 +435,7 @@ func post07Hash(
 	// - block timestamp
 	// - number of events
 	// - event commitment
-	return crypto.PedersenArray(
+	return crypto.PedersenElems(
 			felt.NewFromUint64[felt.Felt](b.Number), // block number
 			b.GlobalStateRoot,                       // global state root
 			seqAddr,                                 // sequencer address

--- a/core/class_hash.go
+++ b/core/class_hash.go
@@ -52,7 +52,7 @@ func deprecatedCairoClassHash(class *DeprecatedCairoClass) (felt.Felt, error) {
 		return felt.Felt{}, hintedClassHashErr
 	}
 
-	hash := crypto.PedersenArray(
+	hash := crypto.PedersenElems(
 		&felt.Zero,
 		&externalEntryPointsHash,
 		&l1HandlerEntryPointsHash,

--- a/core/crypto/benchmark_test.go
+++ b/core/crypto/benchmark_test.go
@@ -1,0 +1,25 @@
+package crypto_test
+
+import (
+	"testing"
+
+	"github.com/NethermindEth/juno/core/felt"
+)
+
+func genRandomFelts(b *testing.B, n int) []felt.Felt {
+	b.Helper()
+	felts := make([]felt.Felt, n)
+	for i := range n {
+		felts[i] = felt.Random[felt.Felt]()
+	}
+	return felts
+}
+
+func genRandomFeltsPtr(b *testing.B, n int) []*felt.Felt {
+	b.Helper()
+	felts := make([]*felt.Felt, n)
+	for i := range n {
+		felts[i] = felt.NewRandom[felt.Felt]()
+	}
+	return felts
+}

--- a/core/crypto/pedersen_benchmark_test.go
+++ b/core/crypto/pedersen_benchmark_test.go
@@ -1,0 +1,42 @@
+package crypto_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/NethermindEth/juno/core/crypto"
+)
+
+// go test -bench=. -run=^# -cpu=1,2,4,8,16
+func BenchmarkPedersenArray(b *testing.B) {
+	numOfElems := []int{3, 5, 10, 15, 20, 25, 30, 35, 40}
+
+	for _, n := range numOfElems {
+		b.Run(fmt.Sprintf("Number of felts: %d", n), func(b *testing.B) {
+			feltsArray := genRandomFelts(b, n)
+			for b.Loop() {
+				crypto.PedersenArray(feltsArray)
+			}
+		})
+	}
+}
+
+func BenchmarkPedersenElems(b *testing.B) {
+	numOfElems := []int{3, 5, 10, 15, 20, 25, 30, 35, 40}
+
+	for _, n := range numOfElems {
+		b.Run(fmt.Sprintf("Number of felts: %d", n), func(b *testing.B) {
+			elems := genRandomFeltsPtr(b, n)
+			for b.Loop() {
+				crypto.PedersenElems(elems...)
+			}
+		})
+	}
+}
+
+func BenchmarkPedersen(b *testing.B) {
+	felts := genRandomFeltsPtr(b, 2)
+	for b.Loop() {
+		crypto.Pedersen(felts[0], felts[1])
+	}
+}

--- a/core/crypto/pedersen_hash.go
+++ b/core/crypto/pedersen_hash.go
@@ -129,12 +129,17 @@ func mulBy256(point *starkcurve.G1Jac) {
 	}
 }
 
+func PedersenElems(elems ...*felt.Felt) felt.Felt {
+	var digest PedersenDigest
+	return digest.Update(elems...).Finish()
+}
+
 // PedersenArray implements [Pedersen array hashing].
 //
 // [Pedersen array hashing]: https://docs.starknet.io/learn/protocol/cryptography#array-hashing
-func PedersenArray(elems ...*felt.Felt) felt.Felt {
+func PedersenArray(elems []felt.Felt) felt.Felt {
 	var digest PedersenDigest
-	return digest.Update(elems...).Finish()
+	return digest.UpdateArray(elems).Finish()
 }
 
 // Pedersen implements the [Pedersen hash].
@@ -152,6 +157,14 @@ type PedersenDigest struct {
 }
 
 func (d *PedersenDigest) Update(elems ...*felt.Felt) Digest {
+	for idx := range elems {
+		d.digest = pedersen(&d.digest, elems[idx].Impl())
+	}
+	d.count += uint64(len(elems))
+	return d
+}
+
+func (d *PedersenDigest) UpdateArray(elems []felt.Felt) Digest {
 	for idx := range elems {
 		d.digest = pedersen(&d.digest, elems[idx].Impl())
 	}

--- a/core/crypto/pedersen_hash_test.go
+++ b/core/crypto/pedersen_hash_test.go
@@ -101,10 +101,31 @@ func TestPedersenArray(t *testing.T) {
 		}
 		digestWhole.Update(data...)
 		want := felt.UnsafeFromString[felt.Felt](tt.want)
-		got := crypto.PedersenArray(data...)
-		assert.Equal(t, want, got)
+		// PedersenArray (value slice) must match the pointer version exactly.
+		vals := make([]felt.Felt, len(data))
+		for i, e := range data {
+			vals[i] = *e
+		}
+		assert.Equal(t, want, crypto.PedersenElems(data...))
+		assert.Equal(t, want, crypto.PedersenArray(vals))
 		assert.Equal(t, want, digest.Finish())
 		assert.Equal(t, want, digestWhole.Finish())
+	}
+}
+
+func TestPedersenDigestUpdateArrayMatchesUpdate(t *testing.T) {
+	for size := range 33 {
+		vals := make([]felt.Felt, size)
+		ptrs := make([]*felt.Felt, size)
+		for idx := range size {
+			vals[idx] = felt.Random[felt.Felt]()
+			ptrs[idx] = &vals[idx]
+		}
+
+		var byArray, byElems crypto.PedersenDigest
+		byArray.UpdateArray(vals)
+		byElems.Update(ptrs...)
+		assert.Equal(t, byElems.Finish(), byArray.Finish())
 	}
 }
 
@@ -127,7 +148,7 @@ func TestPedersenArrayMatchesGnarkCryptoOnRandomSlices(t *testing.T) {
 			data[i] = elem
 		}
 
-		got := crypto.PedersenArray(data...)
+		got := crypto.PedersenElems(data...)
 		want := felt.Felt(pedersenhash.PedersenArray(mapFeltsToFPElems(data)...))
 		assert.Equal(t, want, got)
 	}
@@ -139,62 +160,4 @@ func mapFeltsToFPElems(felts []*felt.Felt) []*fp.Element {
 		fpElems[i] = elem.Impl()
 	}
 	return fpElems
-}
-
-// By having a package and local level variable compiler optimisations can be eliminated for more accurate results.
-// See here: https://dave.cheney.net/2013/06/30/how-to-write-benchmarks-in-go
-var benchHashR felt.Felt
-
-// go test -bench=. -run=^# -cpu=1,2,4,8,16
-func BenchmarkPedersenArray(b *testing.B) {
-	numOfElems := []int{3, 5, 10, 15, 20, 25, 30, 35, 40}
-
-	for _, i := range numOfElems {
-		b.Run(fmt.Sprintf("Number of felts: %d", i), func(b *testing.B) {
-			randomFeltSls := genRandomFeltSls(b, i)
-			var f felt.Felt
-			b.ResetTimer()
-			for n := range b.N {
-				f = crypto.PedersenArray(randomFeltSls[n]...)
-			}
-			benchHashR = f
-		})
-	}
-}
-
-func BenchmarkPedersen(b *testing.B) {
-	randFelts := genRandomFeltPairs(b)
-	var f felt.Felt
-	b.ResetTimer()
-	for n := range b.N {
-		f = crypto.Pedersen(randFelts[n][0], randFelts[n][1])
-	}
-	benchHashR = f
-}
-
-func genRandomFeltSls(b *testing.B, n int) [][]*felt.Felt {
-	randomFeltSls := make([][]*felt.Felt, 0, b.N)
-	for b.Loop() {
-		randomFeltSls = append(randomFeltSls, genRandomFelts(b, n))
-	}
-	return randomFeltSls
-}
-
-func genRandomFelts(b *testing.B, n int) []*felt.Felt {
-	b.Helper()
-	felts := make([]*felt.Felt, n)
-	for i := range n {
-		felts[i] = felt.NewRandom[felt.Felt]()
-	}
-	return felts
-}
-
-func genRandomFeltPairs(b *testing.B) [][2]*felt.Felt {
-	b.Helper()
-	randFelts := make([][2]*felt.Felt, b.N)
-	for i := range b.N {
-		randFelts[i][0] = felt.NewRandom[felt.Felt]()
-		randFelts[i][1] = felt.NewRandom[felt.Felt]()
-	}
-	return randFelts
 }

--- a/core/crypto/poseidon_benchmark_test.go
+++ b/core/crypto/poseidon_benchmark_test.go
@@ -1,0 +1,57 @@
+package crypto_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/NethermindEth/juno/core/crypto"
+)
+
+func BenchmarkPoseidonArray(b *testing.B) {
+	numOfElems := []int{3, 5, 10, 15, 20, 25, 30, 35, 40}
+
+	for _, n := range numOfElems {
+		b.Run(fmt.Sprintf("Number of felts: %d", n), func(b *testing.B) {
+			feltsArray := genRandomFelts(b, n)
+
+			for b.Loop() {
+				crypto.PoseidonArray(feltsArray)
+			}
+		})
+	}
+}
+
+func BenchmarkPoseidonElems(b *testing.B) {
+	numOfElems := []int{3, 5, 10, 15, 20, 25, 30, 35, 40}
+
+	for _, n := range numOfElems {
+		b.Run(fmt.Sprintf("Number of felts: %d", n), func(b *testing.B) {
+			elems := genRandomFeltsPtr(b, n)
+			for b.Loop() {
+				crypto.PoseidonElems(elems...)
+			}
+		})
+	}
+}
+
+func BenchmarkPoseidon(b *testing.B) {
+	in := genRandomFelts(b, 2)
+
+	for b.Loop() {
+		crypto.Poseidon(&in[0], &in[1])
+	}
+}
+
+// BenchmarkPoseidonDigest locks in the allocation count of the streaming
+// digest path (Update + Finish), which struct/array hashing relies on.
+// 40 felts exercises ~20 Hades permutations.
+func BenchmarkPoseidonDigest(b *testing.B) {
+	elems := genRandomFeltsPtr(b, 40)
+
+	b.ReportAllocs()
+	for b.Loop() {
+		var digest crypto.PoseidonDigest
+		digest.Update(elems...)
+		digest.Finish()
+	}
+}

--- a/core/crypto/poseidon_hash.go
+++ b/core/crypto/poseidon_hash.go
@@ -155,6 +155,21 @@ type PoseidonDigest struct {
 	hasLast  bool
 }
 
+func (d *PoseidonDigest) UpdateArray(elems []felt.Felt) Digest {
+	for idx := range elems {
+		if !d.hasLast {
+			d.lastElem = elems[idx]
+			d.hasLast = true
+		} else {
+			d.state[0].Add(&d.state[0], &d.lastElem)
+			d.state[1].Add(&d.state[1], &elems[idx])
+			HadesPermutation(&d.state)
+			d.hasLast = false
+		}
+	}
+	return d
+}
+
 func (d *PoseidonDigest) Update(elems ...*felt.Felt) Digest {
 	for idx := range elems {
 		if !d.hasLast {

--- a/core/crypto/poseidon_hash_test.go
+++ b/core/crypto/poseidon_hash_test.go
@@ -1,7 +1,6 @@
 package crypto_test
 
 import (
-	"fmt"
 	"testing"
 
 	"github.com/NethermindEth/juno/core/crypto"
@@ -70,66 +69,18 @@ func TestPoseidonArray(t *testing.T) {
 	}
 }
 
-func BenchmarkPoseidonArray(b *testing.B) {
-	numOfElems := []int{3, 5, 10, 15, 20, 25, 30, 35, 40}
+func TestPoseidonDigestUpdateArrayMatchesUpdate(t *testing.T) {
+	for size := range 33 {
+		vals := make([]felt.Felt, size)
+		ptrs := make([]*felt.Felt, size)
+		for idx := range size {
+			vals[idx] = felt.Random[felt.Felt]()
+			ptrs[idx] = &vals[idx]
+		}
 
-	for _, n := range numOfElems {
-		b.Run(fmt.Sprintf("Number of felts: %d", n), func(b *testing.B) {
-			pointerSlice := genRandomFelts(b, n)
-
-			feltsArray := make([]felt.Felt, len(pointerSlice))
-			for i, p := range pointerSlice {
-				if p != nil {
-					feltsArray[i] = *p
-				}
-			}
-
-			var f felt.Felt
-			for b.Loop() {
-				f = crypto.PoseidonArray(feltsArray)
-			}
-			benchHashR = f
-		})
+		var byArray, byElems crypto.PoseidonDigest
+		byArray.UpdateArray(vals)
+		byElems.Update(ptrs...)
+		assert.Equal(t, byElems.Finish(), byArray.Finish())
 	}
-}
-
-func BenchmarkPoseidonElems(b *testing.B) {
-	numOfElems := []int{3, 5, 10, 15, 20, 25, 30, 35, 40}
-
-	for _, n := range numOfElems {
-		b.Run(fmt.Sprintf("Number of felts: %d", n), func(b *testing.B) {
-			elems := genRandomFelts(b, n)
-			var f felt.Felt
-			for b.Loop() {
-				f = crypto.PoseidonElems(elems...)
-			}
-			benchHashR = f
-		})
-	}
-}
-
-func BenchmarkPoseidon(b *testing.B) {
-	in := genRandomFelts(b, 2)
-
-	var f felt.Felt
-	for b.Loop() {
-		f = crypto.Poseidon(in[0], in[1])
-	}
-	benchHashR = f
-}
-
-// BenchmarkPoseidonDigest locks in the allocation count of the streaming
-// digest path (Update + Finish), which struct/array hashing relies on.
-// 40 felts exercises ~20 Hades permutations.
-func BenchmarkPoseidonDigest(b *testing.B) {
-	elems := genRandomFelts(b, 40)
-
-	var f felt.Felt
-	b.ReportAllocs()
-	for b.Loop() {
-		var digest crypto.PoseidonDigest
-		digest.Update(elems...)
-		f = digest.Finish()
-	}
-	benchHashR = f
 }

--- a/core/receipt.go
+++ b/core/receipt.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/NethermindEth/juno/core/crypto"
 	"github.com/NethermindEth/juno/core/felt"
-	"github.com/NethermindEth/juno/utils"
 )
 
 type GasConsumed struct {
@@ -63,8 +62,7 @@ func messagesSentHash(messages []*L2ToL1Message) felt.Felt {
 		msgTo.SetBytes(msg.To.Bytes())
 		payloadSize.SetUint64(uint64(len(msg.Payload)))
 		digest.Update(msg.From, &msgTo, &payloadSize)
-		// TODO(granza): update hash to also receive []felt.Felt
-		digest.Update(utils.ToPtrSlice(msg.Payload)...)
+		digest.UpdateArray(msg.Payload)
 	}
 
 	return digest.Finish()

--- a/core/transaction.go
+++ b/core/transaction.go
@@ -12,7 +12,6 @@ import (
 	"github.com/NethermindEth/juno/core/crypto"
 	"github.com/NethermindEth/juno/core/felt"
 	"github.com/NethermindEth/juno/l1/eth"
-	"github.com/NethermindEth/juno/utils"
 	"github.com/bits-and-blooms/bloom/v3"
 	"github.com/fxamacker/cbor/v2"
 	"golang.org/x/crypto/sha3"
@@ -456,9 +455,8 @@ func errInvalidTransactionVersion(t Transaction, version *TransactionVersion) er
 func invokeTransactionHash(i *InvokeTransaction, n *networks.Network) (felt.Felt, error) {
 	switch {
 	case i.Version.Is(0):
-		// TODO(granza): update hash to also receive []felt.Felt
-		calldataHash := crypto.PedersenArray(utils.ToPtrSlice(i.CallData)...)
-		return crypto.PedersenArray(
+		calldataHash := crypto.PedersenArray(i.CallData)
+		return crypto.PedersenElems(
 			invokeFelt,
 			i.Version.AsFelt(),
 			i.ContractAddress,
@@ -468,9 +466,8 @@ func invokeTransactionHash(i *InvokeTransaction, n *networks.Network) (felt.Felt
 			n.L2ChainIDFelt(),
 		), nil
 	case i.Version.Is(1):
-		// TODO(granza): update hash to also receive []felt.Felt
-		calldataHash := crypto.PedersenArray(utils.ToPtrSlice(i.CallData)...)
-		return crypto.PedersenArray(
+		calldataHash := crypto.PedersenArray(i.CallData)
+		return crypto.PedersenElems(
 			invokeFelt,
 			i.Version.AsFelt(),
 			i.SenderAddress,
@@ -503,9 +500,7 @@ func invokeTransactionHash(i *InvokeTransaction, n *networks.Network) (felt.Felt
 
 		if len(i.ProofFacts) > 0 {
 			var proofFactsDigest crypto.PoseidonDigest
-			for j := range i.ProofFacts {
-				proofFactsDigest.Update(&i.ProofFacts[j])
-			}
+			proofFactsDigest.UpdateArray(i.ProofFacts)
 			proofFactsHash := proofFactsDigest.Finish()
 			digest.Update(&proofFactsHash)
 		}
@@ -546,8 +541,8 @@ func declareTransactionHash(d *DeclareTransaction, n *networks.Network) (felt.Fe
 			// This is only going to happen when a transaction is received from p2p as no hash is passed along with a p2p transaction.
 			// Therefore, we have to calculate the transaction hash.
 			// This may become problematic if blockifier create a hash which is different from below.
-			emptyHash := crypto.PedersenArray()
-			h := crypto.PedersenArray(
+			emptyHash := crypto.PedersenElems()
+			h := crypto.PedersenElems(
 				declareFelt,
 				d.Version.AsFelt(),
 				d.SenderAddress,
@@ -562,8 +557,8 @@ func declareTransactionHash(d *DeclareTransaction, n *networks.Network) (felt.Fe
 
 		return *d.TransactionHash, nil
 	case d.Version.Is(1):
-		classHash := crypto.PedersenArray(d.ClassHash)
-		return crypto.PedersenArray(
+		classHash := crypto.PedersenElems(d.ClassHash)
+		return crypto.PedersenElems(
 			declareFelt,
 			d.Version.AsFelt(),
 			d.SenderAddress,
@@ -574,8 +569,8 @@ func declareTransactionHash(d *DeclareTransaction, n *networks.Network) (felt.Fe
 			d.Nonce,
 		), nil
 	case d.Version.Is(2):
-		classHash := crypto.PedersenArray(d.ClassHash)
-		return crypto.PedersenArray(
+		classHash := crypto.PedersenElems(d.ClassHash)
+		return crypto.PedersenElems(
 			declareFelt,
 			d.Version.AsFelt(),
 			d.SenderAddress,
@@ -617,9 +612,8 @@ func l1HandlerTransactionHash(l *L1HandlerTransaction, n *networks.Network) (fel
 		if l.Nonce == nil {
 			return *l.TransactionHash, nil
 		}
-		// TODO(granza): update hash to also receive []felt.Felt
-		calldataHash := crypto.PedersenArray(utils.ToPtrSlice(l.CallData)...)
-		return crypto.PedersenArray(
+		calldataHash := crypto.PedersenArray(l.CallData)
+		return crypto.PedersenElems(
 			l1HandlerFelt,
 			l.Version.AsFelt(),
 			l.ContractAddress,
@@ -644,10 +638,10 @@ func deployAccountTransactionHash(
 		var digest crypto.PedersenDigest
 		digest.Update(d.ClassHash)
 		digest.Update(d.ContractAddressSalt)
-		digest.Update(utils.ToPtrSlice(d.ConstructorCallData)...)
+		digest.UpdateArray(d.ConstructorCallData)
 		callDataHash := digest.Finish()
 
-		return crypto.PedersenArray(
+		return crypto.PedersenElems(
 			deployAccountFelt,
 			d.Version.AsFelt(),
 			d.ContractAddress,
@@ -722,16 +716,14 @@ func transactionCommitmentPedersen(
 	var hashFunc processFunc[Transaction]
 	if blockVersion.GreaterThanEqual(v0_11_1) {
 		hashFunc = func(transaction Transaction) felt.Felt {
-			// TODO(granza): update hash to also receive []felt.Felt
-			signatureHash := crypto.PedersenArray(utils.ToPtrSlice(transaction.Signature())...)
+			signatureHash := crypto.PedersenArray(transaction.Signature())
 			return crypto.Pedersen(transaction.Hash(), &signatureHash)
 		}
 	} else {
 		hashFunc = func(transaction Transaction) felt.Felt {
-			signatureHash := crypto.PedersenArray()
+			signatureHash := crypto.PedersenElems()
 			if _, ok := transaction.(*InvokeTransaction); ok {
-				// TODO(granza): update hash to also receive []felt.Felt
-				signatureHash = crypto.PedersenArray(utils.ToPtrSlice(transaction.Signature())...)
+				signatureHash = crypto.PedersenArray(transaction.Signature())
 			}
 			return crypto.Pedersen(transaction.Hash(), &signatureHash)
 		}
@@ -754,8 +746,7 @@ func transactionCommitmentPoseidon0134(
 			digest.Update(transaction.Hash())
 
 			if txSignature := transaction.Signature(); len(txSignature) > 0 {
-				// TODO(granza): update hash to also receive []felt.Felt
-				digest.Update(utils.ToPtrSlice(txSignature)...)
+				digest.UpdateArray(txSignature)
 			}
 
 			return digest.Finish()
@@ -776,8 +767,7 @@ func transactionCommitmentPoseidon0132(
 			digest.Update(transaction.Hash())
 
 			if txSignature := transaction.Signature(); len(txSignature) > 0 {
-				// TODO(granza): update hash to also receive []felt.Felt
-				digest.Update(utils.ToPtrSlice(txSignature)...)
+				digest.UpdateArray(txSignature)
 			} else {
 				digest.Update(&felt.Zero)
 			}
@@ -814,20 +804,15 @@ func eventCommitmentPoseidon(
 		items,
 		backend.RunOnTempTriePoseidon,
 		func(item *eventWithTxHash) felt.Felt {
-			return crypto.PoseidonArray(
-				slices.Concat(
-					[]felt.Felt{
-						*item.Event.From,
-						*item.TxHash,
-						felt.FromUint64[felt.Felt](uint64(len(item.Event.Keys))),
-					},
-					item.Event.Keys,
-					[]felt.Felt{
-						felt.FromUint64[felt.Felt](uint64(len(item.Event.Data))),
-					},
-					item.Event.Data,
-				),
-			)
+			keysLen := felt.FromUint64[felt.Felt](uint64(len(item.Event.Keys)))
+			dataLen := felt.FromUint64[felt.Felt](uint64(len(item.Event.Data)))
+
+			var digest crypto.PoseidonDigest
+			digest.Update(item.Event.From, item.TxHash, &keysLen)
+			digest.UpdateArray(item.Event.Keys)
+			digest.Update(&dataLen)
+			digest.UpdateArray(item.Event.Data)
+			return digest.Finish()
 		},
 	)
 }
@@ -846,10 +831,9 @@ func eventCommitmentPedersen(
 		events = append(events, receipt.Events...)
 	}
 	return calculateCommitment(events, backend.RunOnTempTriePedersen, func(event *Event) felt.Felt {
-		// TODO(granza): update hash to also receive []felt.Felt
-		keysHash := crypto.PedersenArray(utils.ToPtrSlice(event.Keys)...)
-		dataHash := crypto.PedersenArray(utils.ToPtrSlice(event.Data)...)
-		return crypto.PedersenArray(
+		keysHash := crypto.PedersenArray(event.Keys)
+		dataHash := crypto.PedersenArray(event.Data)
+		return crypto.PedersenElems(
 			event.From,
 			&keysHash,
 			&dataHash,
@@ -882,11 +866,10 @@ func ContractAddress(
 	constructorCallData []felt.Felt,
 ) felt.Felt {
 	prefix := felt.FromBytes[felt.Felt]([]byte("STARKNET_CONTRACT_ADDRESS"))
-	// TODO(granza): update hash to also receive []felt.Felt
-	callDataHash := crypto.PedersenArray(utils.ToPtrSlice(constructorCallData)...)
+	callDataHash := crypto.PedersenArray(constructorCallData)
 
 	// https://www.starknet.io/cairo-book/ch100-01-contracts-classes-and-instances.html
-	return crypto.PedersenArray(
+	return crypto.PedersenElems(
 		&prefix,
 		callerAddress,
 		salt,

--- a/utils/slices.go
+++ b/utils/slices.go
@@ -64,19 +64,6 @@ func Set[T comparable](slice []T) []T {
 	return result
 }
 
-// ToPtrSlice returns a slice of pointers, where each pointer refers to a
-// copy of the corresponding input element.
-func ToPtrSlice[T any](s []T) []*T {
-	if s == nil {
-		return nil
-	}
-	result := make([]*T, len(s))
-	for i, v := range s {
-		result[i] = &v
-	}
-	return result
-}
-
 func NonNilSlice[T any](sl []T) []T {
 	if sl == nil {
 		return []T{}

--- a/utils/slices_test.go
+++ b/utils/slices_test.go
@@ -75,26 +75,6 @@ func TestAnyOf(t *testing.T) {
 	})
 }
 
-func TestToPtrSlice(t *testing.T) {
-	t.Run("nil slice", func(t *testing.T) {
-		var input []int
-		assert.Nil(t, ToPtrSlice(input))
-	})
-
-	t.Run("pointers dereference to input values", func(t *testing.T) {
-		input := []int{1, 2, 3}
-		actual := ToPtrSlice(input)
-		assert.Equal(t, []int{1, 2, 3}, []int{*actual[0], *actual[1], *actual[2]})
-	})
-
-	t.Run("pointers do not alias the input's backing array", func(t *testing.T) {
-		input := []int{1, 2, 3}
-		actual := ToPtrSlice(input)
-		input[0] = 99
-		assert.Equal(t, 1, *actual[0], "mutation of input should not affect copied pointers")
-	})
-}
-
 func TestSet(t *testing.T) {
 	t.Run("nil slice", func(t *testing.T) {
 		var input []int


### PR DESCRIPTION
Support for hashing `[]felt.Felt` on `Pedersen` and digest `Update`, so that hash calls can be zero-copy.

Also, `utils.ToPtrSlice` is removed since it is no longer used in the codebase.