### PR TITLE
perf(rpc): derive tx status subscription updates from notification payloads

### DIFF
--- a/rpc/v10/subscription_status.go
+++ b/rpc/v10/subscription_status.go
@@ -94,21 +94,27 @@ func (s *txStatusSubscriberState) onReorg(
 }
 
 func (s *txStatusSubscriberState) onNewHead(
-	ctx context.Context,
+	_ context.Context,
 	id string,
 	sub *subscription,
-	_ *core.Block,
+	head *core.Block,
 ) error {
-	return s.checkTxStatusIfPending(ctx, id, sub)
+	if s.lastStatus >= TxnStatusAcceptedOnL2 {
+		return nil
+	}
+	return s.sendStatusFromBlock(head, TxnStatusAcceptedOnL2, id, sub)
 }
 
 func (s *txStatusSubscriberState) onPreConfirmed(
-	ctx context.Context,
+	_ context.Context,
 	id string,
 	sub *subscription,
-	_ *pending.PreConfirmed,
+	preConfirmed *pending.PreConfirmed,
 ) error {
-	return s.checkTxStatusIfPending(ctx, id, sub)
+	if s.lastStatus >= TxnStatusPreConfirmed {
+		return nil
+	}
+	return s.sendStatusFromBlock(preConfirmed.GetBlock(), TxnStatusPreConfirmed, id, sub)
 }
 
 func (s *txStatusSubscriberState) onL1Head(
@@ -153,17 +159,29 @@ func (s *txStatusSubscriberState) getInitialTxStatus(
 	}
 }
 
-// checkTxStatusIfPending checks the transaction status only if the last known status
-// is less than TxnStatusAcceptedOnL2 (i.e., the transaction is still pending).
-// If the transaction has already reached or surpassed TxnStatusAcceptedOnL2,
-// it returns the last known status without making an additional status check.
-func (s *txStatusSubscriberState) checkTxStatusIfPending(
-	ctx context.Context,
+// sendStatusFromBlock sends a status update if the subscribed transaction is
+// included in the given notification payload block, deriving its execution
+// result from the index-aligned receipt. Blocks that don't include the
+// transaction are ignored; no DB or feeder gateway lookups are performed.
+func (s *txStatusSubscriberState) sendStatusFromBlock(
+	block *core.Block,
+	finality TxnStatus,
 	id string,
 	sub *subscription,
 ) error {
-	if s.lastStatus < TxnStatusAcceptedOnL2 {
-		return s.checkTxStatus(ctx, id, sub)
+	for i, txn := range block.Transactions {
+		if txn.Hash().Equal(s.txHash) {
+			status := TransactionStatus{Finality: finality}
+			if i < len(block.Receipts) {
+				if receipt := block.Receipts[i]; receipt.Reverted {
+					status.Execution = TxnFailure
+					status.FailureReason = receipt.RevertReason
+				} else {
+					status.Execution = TxnSuccess
+				}
+			}
+			return s.sendStatus(status, id, sub)
+		}
 	}
 	return nil
 }
@@ -185,6 +203,16 @@ func (s *txStatusSubscriberState) checkTxStatus(
 		return errorTxnHashNotFound{*s.txHash}
 	}
 
+	return s.sendStatus(status, id, sub)
+}
+
+// sendStatus sends the status to the subscriber unless it matches the last
+// sent one, and closes the subscription once the transaction is accepted on L1.
+func (s *txStatusSubscriberState) sendStatus(
+	status TransactionStatus,
+	id string,
+	sub *subscription,
+) error {
 	if status.Finality == s.lastStatus {
 		return nil
 	}

--- a/rpc/v10/subscriptions_test.go
+++ b/rpc/v10/subscriptions_test.go
@@ -954,8 +954,7 @@ func TestSubscribeTxnStatus(t *testing.T) {
 				Receipts: []*core.TransactionReceipt{block.Receipts[0]},
 			},
 		}
-		mockSyncer.EXPECT().PreConfirmedChain().
-			Return(mustNewChain(t, preConfirmed), nil).Times(1)
+		// PreConfirmed status is derived from the notification payload, no DB lookups.
 		handler.preConfirmedFeed.Send(preConfirmed)
 		assertNextTxnStatus(
 			t,
@@ -978,20 +977,7 @@ func TestSubscribeTxnStatus(t *testing.T) {
 				Receipts:     []*core.TransactionReceipt{},
 			},
 		}
-		mockSyncer.EXPECT().PreConfirmedChain().
-			Return(mustNewChain(t, preConfirmed), nil).Times(1)
-		// Accepted on l2 Status
-		mockChain.EXPECT().BlockNumberAndIndexByTxHash(
-			&txHash,
-		).Return(block.Number, uint64(0), nil)
-		mockChain.EXPECT().TransactionByBlockNumberAndIndex(
-			block.Number, uint64(0),
-		).Return(block.Transactions[0], nil)
-		mockChain.EXPECT().ReceiptByBlockNumberAndIndex(
-			block.Number, uint64(0),
-		).Return(*block.Receipts[0], block.Hash, nil)
-		mockChain.EXPECT().L1Head().Return(core.L1Head{}, db.ErrKeyNotFound)
-
+		// Accepted on l2 status is derived from the new head payload, no DB lookups.
 		handler.newHeads.Send(block)
 		assertNextTxnStatus(
 			t,
@@ -1025,6 +1011,65 @@ func TestSubscribeTxnStatus(t *testing.T) {
 			TxnStatusAcceptedOnL1,
 			TxnSuccess,
 			"",
+		)
+	})
+
+	t.Run("Reverted execution status from new head payload", func(t *testing.T) {
+		mockCtrl := gomock.NewController(t)
+		t.Cleanup(mockCtrl.Finish)
+
+		client := feeder.NewTestClient(t, &networks.SepoliaIntegration)
+		adapterFeeder := adaptfeeder.New(client)
+		mockSyncer := mocks.NewMockSyncReader(mockCtrl)
+		handler := New(nil, mockSyncer, nil, logger)
+		block, err := adapterFeeder.BlockByNumber(t.Context(), 38748)
+		require.NoError(t, err)
+
+		targetTxn := block.Transactions[0]
+		revertedReceipt := *block.Receipts[0]
+		revertedReceipt.Reverted = true
+		revertedReceipt.RevertReason = "tx reverted"
+
+		preConfirmedData := &pending.PreConfirmed{
+			Block: &core.Block{
+				Header: &core.Header{
+					Number:           block.Number,
+					ParentHash:       block.ParentHash,
+					TransactionCount: 1,
+				},
+				Transactions: []core.Transaction{targetTxn},
+				Receipts:     []*core.TransactionReceipt{&revertedReceipt},
+			},
+		}
+
+		// We need to return some status at start, otherwise it will re-try for a while.
+		mockSyncer.EXPECT().PreConfirmedChain().
+			Return(mustNewChain(t, preConfirmedData), nil).AnyTimes()
+		id, conn := createTestTxStatusWebsocket(t, handler, targetTxn.Hash())
+		assertNextTxnStatus(
+			t,
+			conn,
+			id,
+			targetTxn.Hash(),
+			TxnStatusPreConfirmed,
+			TxnFailure,
+			"tx reverted",
+		)
+
+		newHead := &core.Block{
+			Header:       &core.Header{Number: block.Number},
+			Transactions: []core.Transaction{targetTxn},
+			Receipts:     []*core.TransactionReceipt{&revertedReceipt},
+		}
+		handler.newHeads.Send(newHead)
+		assertNextTxnStatus(
+			t,
+			conn,
+			id,
+			targetTxn.Hash(),
+			TxnStatusAcceptedOnL2,
+			TxnFailure,
+			"tx reverted",
 		)
 	})
 

--- a/rpc/v10/subscriptions_test.go
+++ b/rpc/v10/subscriptions_test.go
@@ -944,9 +944,6 @@ func TestSubscribeTxnStatus(t *testing.T) {
 		)
 
 		// PreConfirmed Status
-		rpcTx := AdaptCoreTransaction(block.Transactions[0])
-		rpcTx.Hash = (*felt.Felt)(&txHash)
-
 		preConfirmed := &pending.PreConfirmed{
 			Block: &core.Block{
 				Header: &core.Header{

--- a/rpc/v10/subscriptions_test.go
+++ b/rpc/v10/subscriptions_test.go
@@ -939,9 +939,6 @@ func TestSubscribeTxnStatus(t *testing.T) {
 		)
 
 		// PreConfirmed Status
-		rpcTx := AdaptCoreTransaction(block.Transactions[0])
-		rpcTx.Hash = (*felt.Felt)(&txHash)
-
 		preConfirmed := &pending.PreConfirmed{
 			Block: &core.Block{
 				Header: &core.Header{

--- a/rpc/v10/subscriptions_test.go
+++ b/rpc/v10/subscriptions_test.go
@@ -959,8 +959,7 @@ func TestSubscribeTxnStatus(t *testing.T) {
 				Receipts: []*core.TransactionReceipt{block.Receipts[0]},
 			},
 		}
-		mockSyncer.EXPECT().PreConfirmedChain().
-			Return(mustNewChain(t, preConfirmed), nil).Times(1)
+		// PreConfirmed status is derived from the notification payload, no DB lookups.
 		handler.preConfirmedFeed.Send(preConfirmed)
 		assertNextTxnStatus(
 			t,
@@ -983,20 +982,7 @@ func TestSubscribeTxnStatus(t *testing.T) {
 				Receipts:     []*core.TransactionReceipt{},
 			},
 		}
-		mockSyncer.EXPECT().PreConfirmedChain().
-			Return(mustNewChain(t, preConfirmed), nil).Times(1)
-		// Accepted on l2 Status
-		mockChain.EXPECT().BlockNumberAndIndexByTxHash(
-			&txHash,
-		).Return(block.Number, uint64(0), nil)
-		mockChain.EXPECT().TransactionExecutionStatusByBlockNumberAndIndex(
-			block.Number, uint64(0),
-		).Return(core.TransactionExecutionStatus{
-			Reverted:     block.Receipts[0].Reverted,
-			RevertReason: block.Receipts[0].RevertReason,
-		}, nil)
-		mockChain.EXPECT().L1Head().Return(core.L1Head{}, db.ErrKeyNotFound)
-
+		// Accepted on l2 status is derived from the new head payload, no DB lookups.
 		handler.newHeads.Send(block)
 		assertNextTxnStatus(
 			t,
@@ -1030,6 +1016,65 @@ func TestSubscribeTxnStatus(t *testing.T) {
 			TxnStatusAcceptedOnL1,
 			TxnSuccess,
 			"",
+		)
+	})
+
+	t.Run("Reverted execution status from new head payload", func(t *testing.T) {
+		mockCtrl := gomock.NewController(t)
+		t.Cleanup(mockCtrl.Finish)
+
+		client := feeder.NewTestClient(t, &networks.SepoliaIntegration)
+		adapterFeeder := adaptfeeder.New(client)
+		mockSyncer := mocks.NewMockSyncReader(mockCtrl)
+		handler := New(nil, mockSyncer, nil, logger)
+		block, err := adapterFeeder.BlockByNumber(t.Context(), 38748)
+		require.NoError(t, err)
+
+		targetTxn := block.Transactions[0]
+		revertedReceipt := *block.Receipts[0]
+		revertedReceipt.Reverted = true
+		revertedReceipt.RevertReason = "tx reverted"
+
+		preConfirmedData := &pending.PreConfirmed{
+			Block: &core.Block{
+				Header: &core.Header{
+					Number:           block.Number,
+					ParentHash:       block.ParentHash,
+					TransactionCount: 1,
+				},
+				Transactions: []core.Transaction{targetTxn},
+				Receipts:     []*core.TransactionReceipt{&revertedReceipt},
+			},
+		}
+
+		// We need to return some status at start, otherwise it will re-try for a while.
+		mockSyncer.EXPECT().PreConfirmedChain().
+			Return(mustNewChain(t, preConfirmedData), nil).AnyTimes()
+		id, conn := createTestTxStatusWebsocket(t, handler, targetTxn.Hash())
+		assertNextTxnStatus(
+			t,
+			conn,
+			id,
+			targetTxn.Hash(),
+			TxnStatusPreConfirmed,
+			TxnFailure,
+			"tx reverted",
+		)
+
+		newHead := &core.Block{
+			Header:       &core.Header{Number: block.Number},
+			Transactions: []core.Transaction{targetTxn},
+			Receipts:     []*core.TransactionReceipt{&revertedReceipt},
+		}
+		handler.newHeads.Send(newHead)
+		assertNextTxnStatus(
+			t,
+			conn,
+			id,
+			targetTxn.Hash(),
+			TxnStatusAcceptedOnL2,
+			TxnFailure,
+			"tx reverted",
 		)
 	})
 

--- a/rpc/v9/subscription_status.go
+++ b/rpc/v9/subscription_status.go
@@ -99,21 +99,27 @@ func (s *txStatusSubscriberState) onReorg(
 }
 
 func (s *txStatusSubscriberState) onNewHead(
-	ctx context.Context,
+	_ context.Context,
 	id string,
 	sub *subscription,
-	_ *core.Block,
+	head *core.Block,
 ) error {
-	return s.checkTxStatusIfPending(ctx, id, sub)
+	if s.lastStatus >= TxnStatusAcceptedOnL2 {
+		return nil
+	}
+	return s.sendStatusFromBlock(head, TxnStatusAcceptedOnL2, id, sub)
 }
 
 func (s *txStatusSubscriberState) onPreConfirmed(
-	ctx context.Context,
+	_ context.Context,
 	id string,
 	sub *subscription,
-	_ *pending.PreConfirmed,
+	preConfirmed *pending.PreConfirmed,
 ) error {
-	return s.checkTxStatusIfPending(ctx, id, sub)
+	if s.lastStatus >= TxnStatusPreConfirmed {
+		return nil
+	}
+	return s.sendStatusFromBlock(preConfirmed.GetBlock(), TxnStatusPreConfirmed, id, sub)
 }
 
 func (s *txStatusSubscriberState) onL1Head(
@@ -158,17 +164,29 @@ func (s *txStatusSubscriberState) getInitialTxStatus(
 	}
 }
 
-// checkTxStatusIfPending checks the transaction status only if the last known status
-// is less than TxnStatusAcceptedOnL2 (i.e., the transaction is still pending).
-// If the transaction has already reached or surpassed TxnStatusAcceptedOnL2,
-// it returns the last known status without making an additional status check.
-func (s *txStatusSubscriberState) checkTxStatusIfPending(
-	ctx context.Context,
+// sendStatusFromBlock sends a status update if the subscribed transaction is
+// included in the given notification payload block, deriving its execution
+// result from the index-aligned receipt. Blocks that don't include the
+// transaction are ignored; no DB or feeder gateway lookups are performed.
+func (s *txStatusSubscriberState) sendStatusFromBlock(
+	block *core.Block,
+	finality TxnStatus,
 	id string,
 	sub *subscription,
 ) error {
-	if s.lastStatus < TxnStatusAcceptedOnL2 {
-		return s.checkTxStatus(ctx, id, sub)
+	for i, txn := range block.Transactions {
+		if txn.Hash().Equal(s.txHash) {
+			status := TransactionStatus{Finality: finality}
+			if i < len(block.Receipts) {
+				if receipt := block.Receipts[i]; receipt.Reverted {
+					status.Execution = TxnFailure
+					status.FailureReason = receipt.RevertReason
+				} else {
+					status.Execution = TxnSuccess
+				}
+			}
+			return s.sendStatus(status, id, sub)
+		}
 	}
 	return nil
 }
@@ -190,6 +208,16 @@ func (s *txStatusSubscriberState) checkTxStatus(
 		return errorTxnHashNotFound{*s.txHash}
 	}
 
+	return s.sendStatus(status, id, sub)
+}
+
+// sendStatus sends the status to the subscriber unless it matches the last
+// sent one, and closes the subscription once the transaction is accepted on L1.
+func (s *txStatusSubscriberState) sendStatus(
+	status TransactionStatus,
+	id string,
+	sub *subscription,
+) error {
 	if status.Finality == s.lastStatus {
 		return nil
 	}

--- a/rpc/v9/subscriptions_test.go
+++ b/rpc/v9/subscriptions_test.go
@@ -868,8 +868,7 @@ func TestSubscribeTxnStatus(t *testing.T) {
 				Receipts: []*core.TransactionReceipt{block.Receipts[0]},
 			},
 		}
-		mockSyncer.EXPECT().PreConfirmedChain().
-			Return(mustNewChain(t, preConfirmed), nil).Times(1)
+		// PreConfirmed status is derived from the notification payload, no DB lookups.
 		handler.preConfirmedFeed.Send(preConfirmed)
 		assertNextTxnStatus(t, conn, id, txHash, TxnStatusPreConfirmed, TxnSuccess, "")
 
@@ -883,20 +882,7 @@ func TestSubscribeTxnStatus(t *testing.T) {
 				Receipts:     []*core.TransactionReceipt{},
 			},
 		}
-		mockSyncer.EXPECT().PreConfirmedChain().
-			Return(mustNewChain(t, preConfirmed), nil).Times(1)
-		// Accepted on l2 Status
-		mockChain.EXPECT().BlockNumberAndIndexByTxHash(
-			(*felt.TransactionHash)(txHash),
-		).Return(block.Number, uint64(0), nil)
-		mockChain.EXPECT().TransactionExecutionStatusByBlockNumberAndIndex(
-			block.Number, uint64(0),
-		).Return(core.TransactionExecutionStatus{
-			Reverted:     block.Receipts[0].Reverted,
-			RevertReason: block.Receipts[0].RevertReason,
-		}, nil)
-		mockChain.EXPECT().L1Head().Return(core.L1Head{}, db.ErrKeyNotFound)
-
+		// Accepted on l2 status is derived from the new head payload, no DB lookups.
 		handler.newHeads.Send(block)
 		assertNextTxnStatus(t, conn, id, txHash, TxnStatusAcceptedOnL2, TxnSuccess, "")
 
@@ -915,6 +901,53 @@ func TestSubscribeTxnStatus(t *testing.T) {
 		mockChain.EXPECT().L1Head().Return(l1Head, nil)
 		handler.l1Heads.Send(&l1Head)
 		assertNextTxnStatus(t, conn, id, txHash, TxnStatusAcceptedOnL1, TxnSuccess, "")
+	})
+
+	t.Run("Reverted execution status from new head payload", func(t *testing.T) {
+		mockCtrl := gomock.NewController(t)
+		t.Cleanup(mockCtrl.Finish)
+
+		client := feeder.NewTestClient(t, &networks.SepoliaIntegration)
+		adapterFeeder := adaptfeeder.New(client)
+		mockSyncer := mocks.NewMockSyncReader(mockCtrl)
+		handler := New(nil, mockSyncer, nil, logger)
+		block, err := adapterFeeder.BlockByNumber(t.Context(), 38748)
+		require.NoError(t, err)
+
+		targetTxn := block.Transactions[0]
+		revertedReceipt := *block.Receipts[0]
+		revertedReceipt.Reverted = true
+		revertedReceipt.RevertReason = "tx reverted"
+
+		preConfirmedData := &pending.PreConfirmed{
+			Block: &core.Block{
+				Header: &core.Header{
+					Number:           block.Number,
+					ParentHash:       block.ParentHash,
+					TransactionCount: 1,
+				},
+				Transactions: []core.Transaction{targetTxn},
+				Receipts:     []*core.TransactionReceipt{&revertedReceipt},
+			},
+		}
+
+		// We need to return some status at start, otherwise it will re-try for a while.
+		mockSyncer.EXPECT().PreConfirmedChain().
+			Return(mustNewChain(t, preConfirmedData), nil).AnyTimes()
+		id, conn := createTestTxStatusWebsocket(t, handler, targetTxn.Hash())
+		assertNextTxnStatus(
+			t, conn, id, targetTxn.Hash(), TxnStatusPreConfirmed, TxnFailure, "tx reverted",
+		)
+
+		newHead := &core.Block{
+			Header:       &core.Header{Number: block.Number},
+			Transactions: []core.Transaction{targetTxn},
+			Receipts:     []*core.TransactionReceipt{&revertedReceipt},
+		}
+		handler.newHeads.Send(newHead)
+		assertNextTxnStatus(
+			t, conn, id, targetTxn.Hash(), TxnStatusAcceptedOnL2, TxnFailure, "tx reverted",
+		)
 	})
 }
 

--- a/rpc/v9/subscriptions_test.go
+++ b/rpc/v9/subscriptions_test.go
@@ -863,8 +863,7 @@ func TestSubscribeTxnStatus(t *testing.T) {
 				Receipts: []*core.TransactionReceipt{block.Receipts[0]},
 			},
 		}
-		mockSyncer.EXPECT().PreConfirmedChain().
-			Return(mustNewChain(t, preConfirmed), nil).Times(1)
+		// PreConfirmed status is derived from the notification payload, no DB lookups.
 		handler.preConfirmedFeed.Send(preConfirmed)
 		assertNextTxnStatus(t, conn, id, txHash, TxnStatusPreConfirmed, TxnSuccess, "")
 
@@ -878,20 +877,7 @@ func TestSubscribeTxnStatus(t *testing.T) {
 				Receipts:     []*core.TransactionReceipt{},
 			},
 		}
-		mockSyncer.EXPECT().PreConfirmedChain().
-			Return(mustNewChain(t, preConfirmed), nil).Times(1)
-		// Accepted on l2 Status
-		mockChain.EXPECT().BlockNumberAndIndexByTxHash(
-			(*felt.TransactionHash)(txHash),
-		).Return(block.Number, uint64(0), nil)
-		mockChain.EXPECT().TransactionByBlockNumberAndIndex(
-			block.Number, uint64(0),
-		).Return(block.Transactions[0], nil)
-		mockChain.EXPECT().ReceiptByBlockNumberAndIndex(
-			block.Number, uint64(0),
-		).Return(*block.Receipts[0], block.Hash, nil)
-		mockChain.EXPECT().L1Head().Return(core.L1Head{}, db.ErrKeyNotFound)
-
+		// Accepted on l2 status is derived from the new head payload, no DB lookups.
 		handler.newHeads.Send(block)
 		assertNextTxnStatus(t, conn, id, txHash, TxnStatusAcceptedOnL2, TxnSuccess, "")
 
@@ -909,6 +895,53 @@ func TestSubscribeTxnStatus(t *testing.T) {
 		mockChain.EXPECT().L1Head().Return(l1Head, nil)
 		handler.l1Heads.Send(&l1Head)
 		assertNextTxnStatus(t, conn, id, txHash, TxnStatusAcceptedOnL1, TxnSuccess, "")
+	})
+
+	t.Run("Reverted execution status from new head payload", func(t *testing.T) {
+		mockCtrl := gomock.NewController(t)
+		t.Cleanup(mockCtrl.Finish)
+
+		client := feeder.NewTestClient(t, &networks.SepoliaIntegration)
+		adapterFeeder := adaptfeeder.New(client)
+		mockSyncer := mocks.NewMockSyncReader(mockCtrl)
+		handler := New(nil, mockSyncer, nil, logger)
+		block, err := adapterFeeder.BlockByNumber(t.Context(), 38748)
+		require.NoError(t, err)
+
+		targetTxn := block.Transactions[0]
+		revertedReceipt := *block.Receipts[0]
+		revertedReceipt.Reverted = true
+		revertedReceipt.RevertReason = "tx reverted"
+
+		preConfirmedData := &pending.PreConfirmed{
+			Block: &core.Block{
+				Header: &core.Header{
+					Number:           block.Number,
+					ParentHash:       block.ParentHash,
+					TransactionCount: 1,
+				},
+				Transactions: []core.Transaction{targetTxn},
+				Receipts:     []*core.TransactionReceipt{&revertedReceipt},
+			},
+		}
+
+		// We need to return some status at start, otherwise it will re-try for a while.
+		mockSyncer.EXPECT().PreConfirmedChain().
+			Return(mustNewChain(t, preConfirmedData), nil).AnyTimes()
+		id, conn := createTestTxStatusWebsocket(t, handler, targetTxn.Hash())
+		assertNextTxnStatus(
+			t, conn, id, targetTxn.Hash(), TxnStatusPreConfirmed, TxnFailure, "tx reverted",
+		)
+
+		newHead := &core.Block{
+			Header:       &core.Header{Number: block.Number},
+			Transactions: []core.Transaction{targetTxn},
+			Receipts:     []*core.TransactionReceipt{&revertedReceipt},
+		}
+		handler.newHeads.Send(newHead)
+		assertNextTxnStatus(
+			t, conn, id, targetTxn.Hash(), TxnStatusAcceptedOnL2, TxnFailure, "tx reverted",
+		)
 	})
 }
 

--- a/rpc/v9/subscriptions_test.go
+++ b/rpc/v9/subscriptions_test.go
@@ -848,9 +848,6 @@ func TestSubscribeTxnStatus(t *testing.T) {
 		assertNextTxnStatus(t, conn, id, txHash, TxnStatusReceived, UnknownExecution, "")
 
 		// PreConfirmed Status
-		rpcTx := AdaptTransaction(block.Transactions[0])
-		rpcTx.Hash = txHash
-
 		preConfirmed := &pending.PreConfirmed{
 			Block: &core.Block{
 				Header: &core.Header{

--- a/rpc/v9/subscriptions_test.go
+++ b/rpc/v9/subscriptions_test.go
@@ -853,9 +853,6 @@ func TestSubscribeTxnStatus(t *testing.T) {
 		assertNextTxnStatus(t, conn, id, txHash, TxnStatusReceived, UnknownExecution, "")
 
 		// PreConfirmed Status
-		rpcTx := AdaptTransaction(block.Transactions[0])
-		rpcTx.Hash = txHash
-
 		preConfirmed := &pending.PreConfirmed{
 			Block: &core.Block{
 				Header: &core.Header{


### PR DESCRIPTION
Closes #3862

`SubscribeTransactionStatus` used to run the full `TransactionStatus` RPC on every new head / pre-confirmed notification, re-reading receipts from the DB and potentially falling back to the feeder gateway. The notification payloads already carry everything we need though:

- tx in a new head block → `ACCEPTED_ON_L2`
- tx in a pre-confirmed block → `PRE_CONFIRMED`

The execution result (success / reverted + revert reason) comes from the index-aligned receipt in the same payload, so these handlers are now served purely from memory. Status only moves forward, so re-published pre-confirmed rounds don't emit duplicates or downgrades.

The initial check on subscribe and `onL1Head` keep the full lookup: neither the subscribe call nor an L1 head event carries the transaction, and L1 head events are infrequent so the cost is negligible.

One trade-off worth calling out: subscription feeds keep only the last event (`SubscribeKeepLast`, buffer of 1), so a slow subscriber can in theory miss the exact head block containing its tx. Previously the next head's full lookup would catch that; now the update is recovered at the next L1 head event instead, which still does a full check and delivers whatever status the tx has by then (usually `ACCEPTED_ON_L2`, since L1 lags L2). That felt in line with the issue's "served purely from the notification payloads", with `onL1Head` acting as the safety net.

Applied to both `rpc/v9` and `rpc/v10`, tests adjusted accordingly plus a new case covering a reverted tx derived from the new head payload.