### PR TITLE
fix(rpc): report correct sync status in pruned mode

### DIFF
--- a/mocks/mock_synchronizer.go
+++ b/mocks/mock_synchronizer.go
@@ -86,21 +86,6 @@ func (mr *MockSyncReaderMockRecorder) PreConfirmedChain() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PreConfirmedChain", reflect.TypeOf((*MockSyncReader)(nil).PreConfirmedChain))
 }
 
-// StartingBlockNumber mocks base method.
-func (m *MockSyncReader) StartingBlockNumber() (uint64, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "StartingBlockNumber")
-	ret0, _ := ret[0].(uint64)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// StartingBlockNumber indicates an expected call of StartingBlockNumber.
-func (mr *MockSyncReaderMockRecorder) StartingBlockNumber() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StartingBlockNumber", reflect.TypeOf((*MockSyncReader)(nil).StartingBlockNumber))
-}
-
 // SubscribeNewHeads mocks base method.
 func (m *MockSyncReader) SubscribeNewHeads() sync.NewHeadSubscription {
 	m.ctrl.T.Helper()

--- a/mocks/mock_synchronizer.go
+++ b/mocks/mock_synchronizer.go
@@ -56,6 +56,21 @@ func (mr *MockSyncReaderMockRecorder) HighestBlockHeader() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "HighestBlockHeader", reflect.TypeOf((*MockSyncReader)(nil).HighestBlockHeader))
 }
 
+// StartingBlockHeader mocks base method.
+func (m *MockSyncReader) StartingBlockHeader() (*core.Header, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "StartingBlockHeader")
+	ret0, _ := ret[0].(*core.Header)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// StartingBlockHeader indicates an expected call of StartingBlockHeader.
+func (mr *MockSyncReaderMockRecorder) StartingBlockHeader() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StartingBlockHeader", reflect.TypeOf((*MockSyncReader)(nil).StartingBlockHeader))
+}
+
 // PreConfirmedChain mocks base method.
 func (m *MockSyncReader) PreConfirmedChain() (preconfirmed.ChainReader, error) {
 	m.ctrl.T.Helper()

--- a/mocks/mock_synchronizer.go
+++ b/mocks/mock_synchronizer.go
@@ -68,7 +68,11 @@ func (m *MockSyncReader) StartingBlockHeader() (*core.Header, error) {
 // StartingBlockHeader indicates an expected call of StartingBlockHeader.
 func (mr *MockSyncReaderMockRecorder) StartingBlockHeader() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StartingBlockHeader", reflect.TypeOf((*MockSyncReader)(nil).StartingBlockHeader))
+	return mr.mock.ctrl.RecordCallWithMethodType(
+		mr.mock,
+		"StartingBlockHeader",
+		reflect.TypeOf((*MockSyncReader)(nil).StartingBlockHeader),
+	)
 }
 
 // PreConfirmedChain mocks base method.
@@ -83,7 +87,11 @@ func (m *MockSyncReader) PreConfirmedChain() (preconfirmed.ChainReader, error) {
 // PreConfirmedChain indicates an expected call of PreConfirmedChain.
 func (mr *MockSyncReaderMockRecorder) PreConfirmedChain() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PreConfirmedChain", reflect.TypeOf((*MockSyncReader)(nil).PreConfirmedChain))
+	return mr.mock.ctrl.RecordCallWithMethodType(
+		mr.mock,
+		"PreConfirmedChain",
+		reflect.TypeOf((*MockSyncReader)(nil).PreConfirmedChain),
+	)
 }
 
 // SubscribeNewHeads mocks base method.

--- a/rpc/v10/subscriptions_test.go
+++ b/rpc/v10/subscriptions_test.go
@@ -90,6 +90,10 @@ func (fs *fakeSyncer) StartingBlockNumber() (uint64, error) {
 	return 0, nil
 }
 
+func (fs *fakeSyncer) StartingBlockHeader() (*core.Header, error) {
+	return nil, nil
+}
+
 func (fs *fakeSyncer) HighestBlockHeader() *core.Header {
 	return nil
 }

--- a/rpc/v10/subscriptions_test.go
+++ b/rpc/v10/subscriptions_test.go
@@ -91,10 +91,6 @@ func (fs *fakeSyncer) SubscribePreConfirmed() sync.PreConfirmedDataSubscription 
 	return sync.PreConfirmedDataSubscription{Subscription: fs.preConfirmed.Subscribe()}
 }
 
-func (fs *fakeSyncer) StartingBlockNumber() (uint64, error) {
-	return 0, nil
-}
-
 func (fs *fakeSyncer) StartingBlockHeader() (*core.Header, error) {
 	return nil, errors.New("StartingBlockHeader() not implemented")
 }

--- a/rpc/v10/subscriptions_test.go
+++ b/rpc/v10/subscriptions_test.go
@@ -91,7 +91,7 @@ func (fs *fakeSyncer) StartingBlockNumber() (uint64, error) {
 }
 
 func (fs *fakeSyncer) StartingBlockHeader() (*core.Header, error) {
-	return nil, nil
+	return nil, errors.New("StartingBlockHeader() not implemented")
 }
 
 func (fs *fakeSyncer) HighestBlockHeader() *core.Header {

--- a/rpc/v10/subscriptions_test.go
+++ b/rpc/v10/subscriptions_test.go
@@ -96,7 +96,7 @@ func (fs *fakeSyncer) StartingBlockNumber() (uint64, error) {
 }
 
 func (fs *fakeSyncer) StartingBlockHeader() (*core.Header, error) {
-	return nil, nil
+	return nil, errors.New("StartingBlockHeader() not implemented")
 }
 
 func (fs *fakeSyncer) HighestBlockHeader() *core.Header {

--- a/rpc/v10/subscriptions_test.go
+++ b/rpc/v10/subscriptions_test.go
@@ -86,10 +86,6 @@ func (fs *fakeSyncer) SubscribePreConfirmed() sync.PreConfirmedDataSubscription 
 	return sync.PreConfirmedDataSubscription{Subscription: fs.preConfirmed.Subscribe()}
 }
 
-func (fs *fakeSyncer) StartingBlockNumber() (uint64, error) {
-	return 0, nil
-}
-
 func (fs *fakeSyncer) StartingBlockHeader() (*core.Header, error) {
 	return nil, errors.New("StartingBlockHeader() not implemented")
 }

--- a/rpc/v10/subscriptions_test.go
+++ b/rpc/v10/subscriptions_test.go
@@ -95,6 +95,10 @@ func (fs *fakeSyncer) StartingBlockNumber() (uint64, error) {
 	return 0, nil
 }
 
+func (fs *fakeSyncer) StartingBlockHeader() (*core.Header, error) {
+	return nil, nil
+}
+
 func (fs *fakeSyncer) HighestBlockHeader() *core.Header {
 	return nil
 }

--- a/rpc/v10/sync.go
+++ b/rpc/v10/sync.go
@@ -38,10 +38,6 @@ func (s Sync) MarshalJSON() ([]byte, error) {
 func (h *Handler) Syncing() (*Sync, *jsonrpc.Error) {
 	defaultSyncState := &Sync{Syncing: new(bool)}
 
-	startingBlockHeader, err := h.syncReader.StartingBlockHeader()
-	if err != nil {
-		return defaultSyncState, nil
-	}
 	head, err := h.bcReader.HeadsHeader()
 	if err != nil {
 		return defaultSyncState, nil
@@ -51,6 +47,10 @@ func (h *Handler) Syncing() (*Sync, *jsonrpc.Error) {
 		return defaultSyncState, nil
 	}
 	if highestBlockHeader.Number <= head.Number {
+		return defaultSyncState, nil
+	}
+	startingBlockHeader, err := h.syncReader.StartingBlockHeader()
+	if err != nil || startingBlockHeader == nil {
 		return defaultSyncState, nil
 	}
 

--- a/rpc/v10/sync.go
+++ b/rpc/v10/sync.go
@@ -50,7 +50,7 @@ func (h *Handler) Syncing() (*Sync, *jsonrpc.Error) {
 		return defaultSyncState, nil
 	}
 	startingBlockHeader, err := h.syncReader.StartingBlockHeader()
-	if err != nil || startingBlockHeader == nil {
+	if err != nil {
 		return defaultSyncState, nil
 	}
 

--- a/rpc/v10/sync.go
+++ b/rpc/v10/sync.go
@@ -38,11 +38,7 @@ func (s Sync) MarshalJSON() ([]byte, error) {
 func (h *Handler) Syncing() (*Sync, *jsonrpc.Error) {
 	defaultSyncState := &Sync{Syncing: new(bool)}
 
-	startingBlockNumber, err := h.syncReader.StartingBlockNumber()
-	if err != nil {
-		return defaultSyncState, nil
-	}
-	startingBlockHash, err := h.bcReader.BlockHeaderHashByNumber(startingBlockNumber)
+	startingBlockHeader, err := h.syncReader.StartingBlockHeader()
 	if err != nil {
 		return defaultSyncState, nil
 	}
@@ -59,8 +55,8 @@ func (h *Handler) Syncing() (*Sync, *jsonrpc.Error) {
 	}
 
 	return &Sync{
-		StartingBlockHash:   startingBlockHash,
-		StartingBlockNumber: &startingBlockNumber,
+		StartingBlockHash:   startingBlockHeader.Hash,
+		StartingBlockNumber: &startingBlockHeader.Number,
 		CurrentBlockHash:    head.Hash,
 		CurrentBlockNumber:  &head.Number,
 		HighestBlockHash:    highestBlockHeader.Hash,

--- a/rpc/v10/sync_test.go
+++ b/rpc/v10/sync_test.go
@@ -34,18 +34,6 @@ func TestSyncing(t *testing.T) {
 		assert.Equal(t, &rpc.Sync{Syncing: &defaultSyncState}, syncing)
 	})
 
-	t.Run("nil starting block header", func(t *testing.T) {
-		mockReader.EXPECT().HeadsHeader().Return(&core.Header{Number: 1}, nil)
-		synchronizer.EXPECT().HighestBlockHeader().Return(
-			&core.Header{Number: 2, Hash: felt.NewFromUint64[felt.Felt](2)},
-		)
-		synchronizer.EXPECT().StartingBlockHeader().Return(nil, nil)
-
-		syncing, err := handler.Syncing()
-		assert.Nil(t, err)
-		assert.Equal(t, &rpc.Sync{Syncing: &defaultSyncState}, syncing)
-	})
-
 	t.Run("empty blockchain", func(t *testing.T) {
 		mockReader.EXPECT().HeadsHeader().Return(nil, errors.New("empty blockchain"))
 

--- a/rpc/v10/sync_test.go
+++ b/rpc/v10/sync_test.go
@@ -22,29 +22,30 @@ func TestSyncing(t *testing.T) {
 	defaultSyncState := false
 
 	startingBlockHeader := &core.Header{Number: 0, Hash: &felt.Zero}
-	mockReader.EXPECT().HeadsHeader().Return(&core.Header{Number: 1}, nil)
-	synchronizer.EXPECT().HighestBlockHeader().Return(
-		&core.Header{Number: 2, Hash: felt.NewFromUint64[felt.Felt](2)},
-	)
-	synchronizer.EXPECT().StartingBlockHeader().Return(nil, errors.New("nope"))
 	t.Run("undefined starting block header", func(t *testing.T) {
+		mockReader.EXPECT().HeadsHeader().Return(&core.Header{Number: 1}, nil)
+		synchronizer.EXPECT().HighestBlockHeader().Return(
+			&core.Header{Number: 2, Hash: felt.NewFromUint64[felt.Felt](2)},
+		)
+		synchronizer.EXPECT().StartingBlockHeader().Return(nil, errors.New("nope"))
+
 		syncing, err := handler.Syncing()
 		assert.Nil(t, err)
 		assert.Equal(t, &rpc.Sync{Syncing: &defaultSyncState}, syncing)
 	})
 
-	mockReader.EXPECT().HeadsHeader().Return(&core.Header{Number: 1}, nil)
-	synchronizer.EXPECT().HighestBlockHeader().Return(
-		&core.Header{Number: 2, Hash: felt.NewFromUint64[felt.Felt](2)},
-	)
-	synchronizer.EXPECT().StartingBlockHeader().Return(nil, nil)
 	t.Run("nil starting block header", func(t *testing.T) {
+		mockReader.EXPECT().HeadsHeader().Return(&core.Header{Number: 1}, nil)
+		synchronizer.EXPECT().HighestBlockHeader().Return(
+			&core.Header{Number: 2, Hash: felt.NewFromUint64[felt.Felt](2)},
+		)
+		synchronizer.EXPECT().StartingBlockHeader().Return(nil, nil)
+
 		syncing, err := handler.Syncing()
 		assert.Nil(t, err)
 		assert.Equal(t, &rpc.Sync{Syncing: &defaultSyncState}, syncing)
 	})
 
-	synchronizer.EXPECT().StartingBlockHeader().Return(startingBlockHeader, nil).AnyTimes()
 	t.Run("empty blockchain", func(t *testing.T) {
 		mockReader.EXPECT().HeadsHeader().Return(nil, errors.New("empty blockchain"))
 
@@ -53,9 +54,9 @@ func TestSyncing(t *testing.T) {
 		assert.Equal(t, &rpc.Sync{Syncing: &defaultSyncState}, syncing)
 	})
 
-	synchronizer.EXPECT().HighestBlockHeader().Return(nil).Times(2)
 	t.Run("undefined highest block", func(t *testing.T) {
 		mockReader.EXPECT().HeadsHeader().Return(&core.Header{}, nil)
+		synchronizer.EXPECT().HighestBlockHeader().Return(nil)
 
 		syncing, err := handler.Syncing()
 		assert.Nil(t, err)
@@ -63,20 +64,21 @@ func TestSyncing(t *testing.T) {
 	})
 	t.Run("block height is greater than highest block", func(t *testing.T) {
 		mockReader.EXPECT().HeadsHeader().Return(&core.Header{Number: 1}, nil)
+		synchronizer.EXPECT().HighestBlockHeader().Return(nil)
 
 		syncing, err := handler.Syncing()
 		assert.Nil(t, err)
 		assert.Equal(t, &rpc.Sync{Syncing: &defaultSyncState}, syncing)
 	})
 
-	synchronizer.EXPECT().HighestBlockHeader().Return(
-		&core.Header{
-			Number: 2,
-			Hash:   felt.NewFromUint64[felt.Felt](2),
-		},
-	).Times(2)
 	t.Run("block height is equal to highest block", func(t *testing.T) {
 		mockReader.EXPECT().HeadsHeader().Return(&core.Header{Number: 2}, nil)
+		synchronizer.EXPECT().HighestBlockHeader().Return(
+			&core.Header{
+				Number: 2,
+				Hash:   felt.NewFromUint64[felt.Felt](2),
+			},
+		)
 
 		syncing, err := handler.Syncing()
 		assert.Nil(t, err)
@@ -90,6 +92,13 @@ func TestSyncing(t *testing.T) {
 			},
 			nil,
 		)
+		synchronizer.EXPECT().HighestBlockHeader().Return(
+			&core.Header{
+				Number: 2,
+				Hash:   felt.NewFromUint64[felt.Felt](2),
+			},
+		)
+		synchronizer.EXPECT().StartingBlockHeader().Return(startingBlockHeader, nil)
 
 		currentBlockNumber := uint64(1)
 		highestBlockNumber := uint64(2)

--- a/rpc/v10/sync_test.go
+++ b/rpc/v10/sync_test.go
@@ -74,7 +74,7 @@ func TestSyncing(t *testing.T) {
 			Number: 2,
 			Hash:   felt.NewFromUint64[felt.Felt](2),
 		},
-	).Times(3)
+	).Times(2)
 	t.Run("block height is equal to highest block", func(t *testing.T) {
 		mockReader.EXPECT().HeadsHeader().Return(&core.Header{Number: 2}, nil)
 
@@ -83,29 +83,6 @@ func TestSyncing(t *testing.T) {
 		assert.Equal(t, &rpc.Sync{Syncing: &defaultSyncState}, syncing)
 	})
 	t.Run("syncing", func(t *testing.T) {
-		mockReader.EXPECT().HeadsHeader().Return(
-			&core.Header{
-				Number: 1,
-				Hash:   felt.NewFromUint64[felt.Felt](1),
-			},
-			nil,
-		)
-
-		currentBlockNumber := uint64(1)
-		highestBlockNumber := uint64(2)
-		expectedSyncing := &rpc.Sync{
-			StartingBlockHash:   &felt.Zero,
-			StartingBlockNumber: &startingBlockHeader.Number,
-			CurrentBlockHash:    felt.NewFromUint64[felt.Felt](1),
-			CurrentBlockNumber:  &currentBlockNumber,
-			HighestBlockHash:    felt.NewFromUint64[felt.Felt](2),
-			HighestBlockNumber:  &highestBlockNumber,
-		}
-		syncing, err := handler.Syncing()
-		assert.Nil(t, err)
-		assert.Equal(t, expectedSyncing, syncing)
-	})
-	t.Run("syncing with pruned starting block header", func(t *testing.T) {
 		mockReader.EXPECT().HeadsHeader().Return(
 			&core.Header{
 				Number: 1,

--- a/rpc/v10/sync_test.go
+++ b/rpc/v10/sync_test.go
@@ -21,19 +21,17 @@ func TestSyncing(t *testing.T) {
 	handler := rpc.New(mockReader, synchronizer, nil, nil)
 	defaultSyncState := false
 
-	startingBlock := uint64(0)
-	synchronizer.EXPECT().StartingBlockNumber().Return(startingBlock, errors.New("nope"))
-	t.Run("undefined starting block", func(t *testing.T) {
+	startingBlockHeader := &core.Header{Number: 0, Hash: &felt.Zero}
+	synchronizer.EXPECT().StartingBlockHeader().Return(nil, errors.New("nope"))
+	t.Run("undefined starting block header", func(t *testing.T) {
 		syncing, err := handler.Syncing()
 		assert.Nil(t, err)
 		assert.Equal(t, &rpc.Sync{Syncing: &defaultSyncState}, syncing)
 	})
 
-	synchronizer.EXPECT().StartingBlockNumber().Return(startingBlock, nil).AnyTimes()
+	synchronizer.EXPECT().StartingBlockHeader().Return(startingBlockHeader, nil).AnyTimes()
 	t.Run("empty blockchain", func(t *testing.T) {
-		mockReader.EXPECT().
-			BlockHeaderHashByNumber(startingBlock).
-			Return(nil, errors.New("empty blockchain"))
+		mockReader.EXPECT().HeadsHeader().Return(nil, errors.New("empty blockchain"))
 
 		syncing, err := handler.Syncing()
 		assert.Nil(t, err)
@@ -42,7 +40,6 @@ func TestSyncing(t *testing.T) {
 
 	synchronizer.EXPECT().HighestBlockHeader().Return(nil).Times(2)
 	t.Run("undefined highest block", func(t *testing.T) {
-		mockReader.EXPECT().BlockHeaderHashByNumber(startingBlock).Return(&felt.Zero, nil)
 		mockReader.EXPECT().HeadsHeader().Return(&core.Header{}, nil)
 
 		syncing, err := handler.Syncing()
@@ -50,7 +47,6 @@ func TestSyncing(t *testing.T) {
 		assert.Equal(t, &rpc.Sync{Syncing: &defaultSyncState}, syncing)
 	})
 	t.Run("block height is greater than highest block", func(t *testing.T) {
-		mockReader.EXPECT().BlockHeaderHashByNumber(startingBlock).Return(&felt.Zero, nil)
 		mockReader.EXPECT().HeadsHeader().Return(&core.Header{Number: 1}, nil)
 
 		syncing, err := handler.Syncing()
@@ -63,9 +59,8 @@ func TestSyncing(t *testing.T) {
 			Number: 2,
 			Hash:   felt.NewFromUint64[felt.Felt](2),
 		},
-	).Times(2)
+	).Times(3)
 	t.Run("block height is equal to highest block", func(t *testing.T) {
-		mockReader.EXPECT().BlockHeaderHashByNumber(startingBlock).Return(&felt.Zero, nil)
 		mockReader.EXPECT().HeadsHeader().Return(&core.Header{Number: 2}, nil)
 
 		syncing, err := handler.Syncing()
@@ -73,7 +68,6 @@ func TestSyncing(t *testing.T) {
 		assert.Equal(t, &rpc.Sync{Syncing: &defaultSyncState}, syncing)
 	})
 	t.Run("syncing", func(t *testing.T) {
-		mockReader.EXPECT().BlockHeaderHashByNumber(startingBlock).Return(&felt.Zero, nil)
 		mockReader.EXPECT().HeadsHeader().Return(
 			&core.Header{
 				Number: 1,
@@ -86,7 +80,30 @@ func TestSyncing(t *testing.T) {
 		highestBlockNumber := uint64(2)
 		expectedSyncing := &rpc.Sync{
 			StartingBlockHash:   &felt.Zero,
-			StartingBlockNumber: &startingBlock,
+			StartingBlockNumber: &startingBlockHeader.Number,
+			CurrentBlockHash:    felt.NewFromUint64[felt.Felt](1),
+			CurrentBlockNumber:  &currentBlockNumber,
+			HighestBlockHash:    felt.NewFromUint64[felt.Felt](2),
+			HighestBlockNumber:  &highestBlockNumber,
+		}
+		syncing, err := handler.Syncing()
+		assert.Nil(t, err)
+		assert.Equal(t, expectedSyncing, syncing)
+	})
+	t.Run("syncing with pruned starting block header", func(t *testing.T) {
+		mockReader.EXPECT().HeadsHeader().Return(
+			&core.Header{
+				Number: 1,
+				Hash:   felt.NewFromUint64[felt.Felt](1),
+			},
+			nil,
+		)
+
+		currentBlockNumber := uint64(1)
+		highestBlockNumber := uint64(2)
+		expectedSyncing := &rpc.Sync{
+			StartingBlockHash:   &felt.Zero,
+			StartingBlockNumber: &startingBlockHeader.Number,
 			CurrentBlockHash:    felt.NewFromUint64[felt.Felt](1),
 			CurrentBlockNumber:  &currentBlockNumber,
 			HighestBlockHash:    felt.NewFromUint64[felt.Felt](2),

--- a/rpc/v10/sync_test.go
+++ b/rpc/v10/sync_test.go
@@ -22,8 +22,23 @@ func TestSyncing(t *testing.T) {
 	defaultSyncState := false
 
 	startingBlockHeader := &core.Header{Number: 0, Hash: &felt.Zero}
+	mockReader.EXPECT().HeadsHeader().Return(&core.Header{Number: 1}, nil)
+	synchronizer.EXPECT().HighestBlockHeader().Return(
+		&core.Header{Number: 2, Hash: felt.NewFromUint64[felt.Felt](2)},
+	)
 	synchronizer.EXPECT().StartingBlockHeader().Return(nil, errors.New("nope"))
 	t.Run("undefined starting block header", func(t *testing.T) {
+		syncing, err := handler.Syncing()
+		assert.Nil(t, err)
+		assert.Equal(t, &rpc.Sync{Syncing: &defaultSyncState}, syncing)
+	})
+
+	mockReader.EXPECT().HeadsHeader().Return(&core.Header{Number: 1}, nil)
+	synchronizer.EXPECT().HighestBlockHeader().Return(
+		&core.Header{Number: 2, Hash: felt.NewFromUint64[felt.Felt](2)},
+	)
+	synchronizer.EXPECT().StartingBlockHeader().Return(nil, nil)
+	t.Run("nil starting block header", func(t *testing.T) {
 		syncing, err := handler.Syncing()
 		assert.Nil(t, err)
 		assert.Equal(t, &rpc.Sync{Syncing: &defaultSyncState}, syncing)

--- a/rpc/v8/subscriptions_test.go
+++ b/rpc/v8/subscriptions_test.go
@@ -458,10 +458,6 @@ func (fs *fakeSyncer) SubscribePreConfirmed() sync.PreConfirmedDataSubscription 
 	return sync.PreConfirmedDataSubscription{Subscription: fs.preConfirmed.Subscribe()}
 }
 
-func (fs *fakeSyncer) StartingBlockNumber() (uint64, error) {
-	return 0, nil
-}
-
 func (fs *fakeSyncer) StartingBlockHeader() (*core.Header, error) {
 	return nil, errors.New("StartingBlockHeader() not implemented")
 }

--- a/rpc/v8/subscriptions_test.go
+++ b/rpc/v8/subscriptions_test.go
@@ -4,6 +4,7 @@ package rpcv8
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net"
@@ -455,7 +456,7 @@ func (fs *fakeSyncer) StartingBlockNumber() (uint64, error) {
 }
 
 func (fs *fakeSyncer) StartingBlockHeader() (*core.Header, error) {
-	return nil, nil
+	return nil, errors.New("StartingBlockHeader() not implemented")
 }
 
 func (fs *fakeSyncer) HighestBlockHeader() *core.Header {

--- a/rpc/v8/subscriptions_test.go
+++ b/rpc/v8/subscriptions_test.go
@@ -4,6 +4,7 @@ package rpcv8
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net"
@@ -462,7 +463,7 @@ func (fs *fakeSyncer) StartingBlockNumber() (uint64, error) {
 }
 
 func (fs *fakeSyncer) StartingBlockHeader() (*core.Header, error) {
-	return nil, nil
+	return nil, errors.New("StartingBlockHeader() not implemented")
 }
 
 func (fs *fakeSyncer) HighestBlockHeader() *core.Header {

--- a/rpc/v8/subscriptions_test.go
+++ b/rpc/v8/subscriptions_test.go
@@ -451,10 +451,6 @@ func (fs *fakeSyncer) SubscribePreConfirmed() sync.PreConfirmedDataSubscription 
 	return sync.PreConfirmedDataSubscription{Subscription: fs.preConfirmed.Subscribe()}
 }
 
-func (fs *fakeSyncer) StartingBlockNumber() (uint64, error) {
-	return 0, nil
-}
-
 func (fs *fakeSyncer) StartingBlockHeader() (*core.Header, error) {
 	return nil, errors.New("StartingBlockHeader() not implemented")
 }

--- a/rpc/v8/subscriptions_test.go
+++ b/rpc/v8/subscriptions_test.go
@@ -454,6 +454,10 @@ func (fs *fakeSyncer) StartingBlockNumber() (uint64, error) {
 	return 0, nil
 }
 
+func (fs *fakeSyncer) StartingBlockHeader() (*core.Header, error) {
+	return nil, nil
+}
+
 func (fs *fakeSyncer) HighestBlockHeader() *core.Header {
 	return nil
 }

--- a/rpc/v8/subscriptions_test.go
+++ b/rpc/v8/subscriptions_test.go
@@ -461,6 +461,10 @@ func (fs *fakeSyncer) StartingBlockNumber() (uint64, error) {
 	return 0, nil
 }
 
+func (fs *fakeSyncer) StartingBlockHeader() (*core.Header, error) {
+	return nil, nil
+}
+
 func (fs *fakeSyncer) HighestBlockHeader() *core.Header {
 	return nil
 }

--- a/rpc/v8/sync.go
+++ b/rpc/v8/sync.go
@@ -38,11 +38,7 @@ func (s Sync) MarshalJSON() ([]byte, error) {
 func (h *Handler) Syncing() (*Sync, *jsonrpc.Error) {
 	defaultSyncState := &Sync{Syncing: new(bool)}
 
-	startingBlockNumber, err := h.syncReader.StartingBlockNumber()
-	if err != nil {
-		return defaultSyncState, nil
-	}
-	startingBlockHeader, err := h.bcReader.BlockHeaderByNumber(startingBlockNumber)
+	startingBlockHeader, err := h.syncReader.StartingBlockHeader()
 	if err != nil {
 		return defaultSyncState, nil
 	}

--- a/rpc/v8/sync.go
+++ b/rpc/v8/sync.go
@@ -38,10 +38,6 @@ func (s Sync) MarshalJSON() ([]byte, error) {
 func (h *Handler) Syncing() (*Sync, *jsonrpc.Error) {
 	defaultSyncState := &Sync{Syncing: new(bool)}
 
-	startingBlockHeader, err := h.syncReader.StartingBlockHeader()
-	if err != nil {
-		return defaultSyncState, nil
-	}
 	head, err := h.bcReader.HeadsHeader()
 	if err != nil {
 		return defaultSyncState, nil
@@ -51,6 +47,10 @@ func (h *Handler) Syncing() (*Sync, *jsonrpc.Error) {
 		return defaultSyncState, nil
 	}
 	if highestBlockHeader.Number <= head.Number {
+		return defaultSyncState, nil
+	}
+	startingBlockHeader, err := h.syncReader.StartingBlockHeader()
+	if err != nil || startingBlockHeader == nil {
 		return defaultSyncState, nil
 	}
 

--- a/rpc/v8/sync.go
+++ b/rpc/v8/sync.go
@@ -50,7 +50,7 @@ func (h *Handler) Syncing() (*Sync, *jsonrpc.Error) {
 		return defaultSyncState, nil
 	}
 	startingBlockHeader, err := h.syncReader.StartingBlockHeader()
-	if err != nil || startingBlockHeader == nil {
+	if err != nil {
 		return defaultSyncState, nil
 	}
 

--- a/rpc/v8/sync_test.go
+++ b/rpc/v8/sync_test.go
@@ -22,29 +22,30 @@ func TestSyncing(t *testing.T) {
 	defaultSyncState := false
 
 	startingBlockHeader := &core.Header{Number: 0, Hash: &felt.Zero}
-	mockReader.EXPECT().HeadsHeader().Return(&core.Header{Number: 1}, nil)
-	synchronizer.EXPECT().HighestBlockHeader().Return(
-		&core.Header{Number: 2, Hash: new(felt.Felt).SetUint64(2)},
-	)
-	synchronizer.EXPECT().StartingBlockHeader().Return(nil, errors.New("nope"))
 	t.Run("undefined starting block header", func(t *testing.T) {
+		mockReader.EXPECT().HeadsHeader().Return(&core.Header{Number: 1}, nil)
+		synchronizer.EXPECT().HighestBlockHeader().Return(
+			&core.Header{Number: 2, Hash: new(felt.Felt).SetUint64(2)},
+		)
+		synchronizer.EXPECT().StartingBlockHeader().Return(nil, errors.New("nope"))
+
 		syncing, err := handler.Syncing()
 		assert.Nil(t, err)
 		assert.Equal(t, &rpc.Sync{Syncing: &defaultSyncState}, syncing)
 	})
 
-	mockReader.EXPECT().HeadsHeader().Return(&core.Header{Number: 1}, nil)
-	synchronizer.EXPECT().HighestBlockHeader().Return(
-		&core.Header{Number: 2, Hash: new(felt.Felt).SetUint64(2)},
-	)
-	synchronizer.EXPECT().StartingBlockHeader().Return(nil, nil)
 	t.Run("nil starting block header", func(t *testing.T) {
+		mockReader.EXPECT().HeadsHeader().Return(&core.Header{Number: 1}, nil)
+		synchronizer.EXPECT().HighestBlockHeader().Return(
+			&core.Header{Number: 2, Hash: new(felt.Felt).SetUint64(2)},
+		)
+		synchronizer.EXPECT().StartingBlockHeader().Return(nil, nil)
+
 		syncing, err := handler.Syncing()
 		assert.Nil(t, err)
 		assert.Equal(t, &rpc.Sync{Syncing: &defaultSyncState}, syncing)
 	})
 
-	synchronizer.EXPECT().StartingBlockHeader().Return(startingBlockHeader, nil).AnyTimes()
 	t.Run("empty blockchain", func(t *testing.T) {
 		mockReader.EXPECT().HeadsHeader().Return(nil, errors.New("empty blockchain"))
 
@@ -53,9 +54,9 @@ func TestSyncing(t *testing.T) {
 		assert.Equal(t, &rpc.Sync{Syncing: &defaultSyncState}, syncing)
 	})
 
-	synchronizer.EXPECT().HighestBlockHeader().Return(nil).Times(2)
 	t.Run("undefined highest block", func(t *testing.T) {
 		mockReader.EXPECT().HeadsHeader().Return(&core.Header{}, nil)
+		synchronizer.EXPECT().HighestBlockHeader().Return(nil)
 
 		syncing, err := handler.Syncing()
 		assert.Nil(t, err)
@@ -63,17 +64,18 @@ func TestSyncing(t *testing.T) {
 	})
 	t.Run("block height is greater than highest block", func(t *testing.T) {
 		mockReader.EXPECT().HeadsHeader().Return(&core.Header{Number: 1}, nil)
+		synchronizer.EXPECT().HighestBlockHeader().Return(nil)
 
 		syncing, err := handler.Syncing()
 		assert.Nil(t, err)
 		assert.Equal(t, &rpc.Sync{Syncing: &defaultSyncState}, syncing)
 	})
 
-	synchronizer.EXPECT().HighestBlockHeader().Return(
-		&core.Header{Number: 2, Hash: new(felt.Felt).SetUint64(2)},
-	).Times(2)
 	t.Run("block height is equal to highest block", func(t *testing.T) {
 		mockReader.EXPECT().HeadsHeader().Return(&core.Header{Number: 2}, nil)
+		synchronizer.EXPECT().HighestBlockHeader().Return(
+			&core.Header{Number: 2, Hash: new(felt.Felt).SetUint64(2)},
+		)
 
 		syncing, err := handler.Syncing()
 		assert.Nil(t, err)
@@ -84,6 +86,10 @@ func TestSyncing(t *testing.T) {
 			&core.Header{Number: 1, Hash: new(felt.Felt).SetUint64(1)},
 			nil,
 		)
+		synchronizer.EXPECT().HighestBlockHeader().Return(
+			&core.Header{Number: 2, Hash: new(felt.Felt).SetUint64(2)},
+		)
+		synchronizer.EXPECT().StartingBlockHeader().Return(startingBlockHeader, nil)
 
 		currentBlockNumber := uint64(1)
 		highestBlockNumber := uint64(2)

--- a/rpc/v8/sync_test.go
+++ b/rpc/v8/sync_test.go
@@ -21,17 +21,17 @@ func TestSyncing(t *testing.T) {
 	handler := rpc.New(mockReader, synchronizer, nil, nil)
 	defaultSyncState := false
 
-	startingBlock := uint64(0)
-	synchronizer.EXPECT().StartingBlockNumber().Return(startingBlock, errors.New("nope"))
-	t.Run("undefined starting block", func(t *testing.T) {
+	startingBlockHeader := &core.Header{Number: 0, Hash: &felt.Zero}
+	synchronizer.EXPECT().StartingBlockHeader().Return(nil, errors.New("nope"))
+	t.Run("undefined starting block header", func(t *testing.T) {
 		syncing, err := handler.Syncing()
 		assert.Nil(t, err)
 		assert.Equal(t, &rpc.Sync{Syncing: &defaultSyncState}, syncing)
 	})
 
-	synchronizer.EXPECT().StartingBlockNumber().Return(startingBlock, nil).AnyTimes()
+	synchronizer.EXPECT().StartingBlockHeader().Return(startingBlockHeader, nil).AnyTimes()
 	t.Run("empty blockchain", func(t *testing.T) {
-		mockReader.EXPECT().BlockHeaderByNumber(startingBlock).Return(nil, errors.New("empty blockchain"))
+		mockReader.EXPECT().HeadsHeader().Return(nil, errors.New("empty blockchain"))
 
 		syncing, err := handler.Syncing()
 		assert.Nil(t, err)
@@ -40,7 +40,6 @@ func TestSyncing(t *testing.T) {
 
 	synchronizer.EXPECT().HighestBlockHeader().Return(nil).Times(2)
 	t.Run("undefined highest block", func(t *testing.T) {
-		mockReader.EXPECT().BlockHeaderByNumber(startingBlock).Return(&core.Header{}, nil)
 		mockReader.EXPECT().HeadsHeader().Return(&core.Header{}, nil)
 
 		syncing, err := handler.Syncing()
@@ -48,7 +47,6 @@ func TestSyncing(t *testing.T) {
 		assert.Equal(t, &rpc.Sync{Syncing: &defaultSyncState}, syncing)
 	})
 	t.Run("block height is greater than highest block", func(t *testing.T) {
-		mockReader.EXPECT().BlockHeaderByNumber(startingBlock).Return(&core.Header{}, nil)
 		mockReader.EXPECT().HeadsHeader().Return(&core.Header{Number: 1}, nil)
 
 		syncing, err := handler.Syncing()
@@ -58,9 +56,8 @@ func TestSyncing(t *testing.T) {
 
 	synchronizer.EXPECT().HighestBlockHeader().Return(
 		&core.Header{Number: 2, Hash: new(felt.Felt).SetUint64(2)},
-	).Times(2)
+	).Times(3)
 	t.Run("block height is equal to highest block", func(t *testing.T) {
-		mockReader.EXPECT().BlockHeaderByNumber(startingBlock).Return(&core.Header{}, nil)
 		mockReader.EXPECT().HeadsHeader().Return(&core.Header{Number: 2}, nil)
 
 		syncing, err := handler.Syncing()
@@ -68,7 +65,6 @@ func TestSyncing(t *testing.T) {
 		assert.Equal(t, &rpc.Sync{Syncing: &defaultSyncState}, syncing)
 	})
 	t.Run("syncing", func(t *testing.T) {
-		mockReader.EXPECT().BlockHeaderByNumber(startingBlock).Return(&core.Header{Hash: &felt.Zero}, nil)
 		mockReader.EXPECT().HeadsHeader().Return(
 			&core.Header{Number: 1, Hash: new(felt.Felt).SetUint64(1)},
 			nil,
@@ -78,7 +74,27 @@ func TestSyncing(t *testing.T) {
 		highestBlockNumber := uint64(2)
 		expectedSyncing := &rpc.Sync{
 			StartingBlockHash:   &felt.Zero,
-			StartingBlockNumber: &startingBlock,
+			StartingBlockNumber: &startingBlockHeader.Number,
+			CurrentBlockHash:    new(felt.Felt).SetUint64(1),
+			CurrentBlockNumber:  &currentBlockNumber,
+			HighestBlockHash:    new(felt.Felt).SetUint64(2),
+			HighestBlockNumber:  &highestBlockNumber,
+		}
+		syncing, err := handler.Syncing()
+		assert.Nil(t, err)
+		assert.Equal(t, expectedSyncing, syncing)
+	})
+	t.Run("syncing with pruned starting block header", func(t *testing.T) {
+		mockReader.EXPECT().HeadsHeader().Return(
+			&core.Header{Number: 1, Hash: new(felt.Felt).SetUint64(1)},
+			nil,
+		)
+
+		currentBlockNumber := uint64(1)
+		highestBlockNumber := uint64(2)
+		expectedSyncing := &rpc.Sync{
+			StartingBlockHash:   &felt.Zero,
+			StartingBlockNumber: &startingBlockHeader.Number,
 			CurrentBlockHash:    new(felt.Felt).SetUint64(1),
 			CurrentBlockNumber:  &currentBlockNumber,
 			HighestBlockHash:    new(felt.Felt).SetUint64(2),

--- a/rpc/v8/sync_test.go
+++ b/rpc/v8/sync_test.go
@@ -71,7 +71,7 @@ func TestSyncing(t *testing.T) {
 
 	synchronizer.EXPECT().HighestBlockHeader().Return(
 		&core.Header{Number: 2, Hash: new(felt.Felt).SetUint64(2)},
-	).Times(3)
+	).Times(2)
 	t.Run("block height is equal to highest block", func(t *testing.T) {
 		mockReader.EXPECT().HeadsHeader().Return(&core.Header{Number: 2}, nil)
 
@@ -80,26 +80,6 @@ func TestSyncing(t *testing.T) {
 		assert.Equal(t, &rpc.Sync{Syncing: &defaultSyncState}, syncing)
 	})
 	t.Run("syncing", func(t *testing.T) {
-		mockReader.EXPECT().HeadsHeader().Return(
-			&core.Header{Number: 1, Hash: new(felt.Felt).SetUint64(1)},
-			nil,
-		)
-
-		currentBlockNumber := uint64(1)
-		highestBlockNumber := uint64(2)
-		expectedSyncing := &rpc.Sync{
-			StartingBlockHash:   &felt.Zero,
-			StartingBlockNumber: &startingBlockHeader.Number,
-			CurrentBlockHash:    new(felt.Felt).SetUint64(1),
-			CurrentBlockNumber:  &currentBlockNumber,
-			HighestBlockHash:    new(felt.Felt).SetUint64(2),
-			HighestBlockNumber:  &highestBlockNumber,
-		}
-		syncing, err := handler.Syncing()
-		assert.Nil(t, err)
-		assert.Equal(t, expectedSyncing, syncing)
-	})
-	t.Run("syncing with pruned starting block header", func(t *testing.T) {
 		mockReader.EXPECT().HeadsHeader().Return(
 			&core.Header{Number: 1, Hash: new(felt.Felt).SetUint64(1)},
 			nil,

--- a/rpc/v8/sync_test.go
+++ b/rpc/v8/sync_test.go
@@ -34,18 +34,6 @@ func TestSyncing(t *testing.T) {
 		assert.Equal(t, &rpc.Sync{Syncing: &defaultSyncState}, syncing)
 	})
 
-	t.Run("nil starting block header", func(t *testing.T) {
-		mockReader.EXPECT().HeadsHeader().Return(&core.Header{Number: 1}, nil)
-		synchronizer.EXPECT().HighestBlockHeader().Return(
-			&core.Header{Number: 2, Hash: new(felt.Felt).SetUint64(2)},
-		)
-		synchronizer.EXPECT().StartingBlockHeader().Return(nil, nil)
-
-		syncing, err := handler.Syncing()
-		assert.Nil(t, err)
-		assert.Equal(t, &rpc.Sync{Syncing: &defaultSyncState}, syncing)
-	})
-
 	t.Run("empty blockchain", func(t *testing.T) {
 		mockReader.EXPECT().HeadsHeader().Return(nil, errors.New("empty blockchain"))
 

--- a/rpc/v8/sync_test.go
+++ b/rpc/v8/sync_test.go
@@ -22,8 +22,23 @@ func TestSyncing(t *testing.T) {
 	defaultSyncState := false
 
 	startingBlockHeader := &core.Header{Number: 0, Hash: &felt.Zero}
+	mockReader.EXPECT().HeadsHeader().Return(&core.Header{Number: 1}, nil)
+	synchronizer.EXPECT().HighestBlockHeader().Return(
+		&core.Header{Number: 2, Hash: new(felt.Felt).SetUint64(2)},
+	)
 	synchronizer.EXPECT().StartingBlockHeader().Return(nil, errors.New("nope"))
 	t.Run("undefined starting block header", func(t *testing.T) {
+		syncing, err := handler.Syncing()
+		assert.Nil(t, err)
+		assert.Equal(t, &rpc.Sync{Syncing: &defaultSyncState}, syncing)
+	})
+
+	mockReader.EXPECT().HeadsHeader().Return(&core.Header{Number: 1}, nil)
+	synchronizer.EXPECT().HighestBlockHeader().Return(
+		&core.Header{Number: 2, Hash: new(felt.Felt).SetUint64(2)},
+	)
+	synchronizer.EXPECT().StartingBlockHeader().Return(nil, nil)
+	t.Run("nil starting block header", func(t *testing.T) {
 		syncing, err := handler.Syncing()
 		assert.Nil(t, err)
 		assert.Equal(t, &rpc.Sync{Syncing: &defaultSyncState}, syncing)

--- a/rpc/v9/subscriptions_test.go
+++ b/rpc/v9/subscriptions_test.go
@@ -97,7 +97,7 @@ func (fs *fakeSyncer) StartingBlockNumber() (uint64, error) {
 }
 
 func (fs *fakeSyncer) StartingBlockHeader() (*core.Header, error) {
-	return nil, nil
+	return nil, errors.New("StartingBlockHeader() not implemented")
 }
 
 func (fs *fakeSyncer) HighestBlockHeader() *core.Header {

--- a/rpc/v9/subscriptions_test.go
+++ b/rpc/v9/subscriptions_test.go
@@ -96,6 +96,10 @@ func (fs *fakeSyncer) StartingBlockNumber() (uint64, error) {
 	return 0, nil
 }
 
+func (fs *fakeSyncer) StartingBlockHeader() (*core.Header, error) {
+	return nil, nil
+}
+
 func (fs *fakeSyncer) HighestBlockHeader() *core.Header {
 	return nil
 }

--- a/rpc/v9/subscriptions_test.go
+++ b/rpc/v9/subscriptions_test.go
@@ -92,7 +92,7 @@ func (fs *fakeSyncer) StartingBlockNumber() (uint64, error) {
 }
 
 func (fs *fakeSyncer) StartingBlockHeader() (*core.Header, error) {
-	return nil, nil
+	return nil, errors.New("StartingBlockHeader() not implemented")
 }
 
 func (fs *fakeSyncer) HighestBlockHeader() *core.Header {

--- a/rpc/v9/subscriptions_test.go
+++ b/rpc/v9/subscriptions_test.go
@@ -87,10 +87,6 @@ func (fs *fakeSyncer) SubscribePreConfirmed() sync.PreConfirmedDataSubscription 
 	return sync.PreConfirmedDataSubscription{Subscription: fs.preConfirmed.Subscribe()}
 }
 
-func (fs *fakeSyncer) StartingBlockNumber() (uint64, error) {
-	return 0, nil
-}
-
 func (fs *fakeSyncer) StartingBlockHeader() (*core.Header, error) {
 	return nil, errors.New("StartingBlockHeader() not implemented")
 }

--- a/rpc/v9/subscriptions_test.go
+++ b/rpc/v9/subscriptions_test.go
@@ -92,10 +92,6 @@ func (fs *fakeSyncer) SubscribePreConfirmed() sync.PreConfirmedDataSubscription 
 	return sync.PreConfirmedDataSubscription{Subscription: fs.preConfirmed.Subscribe()}
 }
 
-func (fs *fakeSyncer) StartingBlockNumber() (uint64, error) {
-	return 0, nil
-}
-
 func (fs *fakeSyncer) StartingBlockHeader() (*core.Header, error) {
 	return nil, errors.New("StartingBlockHeader() not implemented")
 }

--- a/rpc/v9/subscriptions_test.go
+++ b/rpc/v9/subscriptions_test.go
@@ -91,6 +91,10 @@ func (fs *fakeSyncer) StartingBlockNumber() (uint64, error) {
 	return 0, nil
 }
 
+func (fs *fakeSyncer) StartingBlockHeader() (*core.Header, error) {
+	return nil, nil
+}
+
 func (fs *fakeSyncer) HighestBlockHeader() *core.Header {
 	return nil
 }

--- a/rpc/v9/sync.go
+++ b/rpc/v9/sync.go
@@ -38,10 +38,6 @@ func (s Sync) MarshalJSON() ([]byte, error) {
 func (h *Handler) Syncing() (*Sync, *jsonrpc.Error) {
 	defaultSyncState := &Sync{Syncing: new(bool)}
 
-	startingBlockHeader, err := h.syncReader.StartingBlockHeader()
-	if err != nil {
-		return defaultSyncState, nil
-	}
 	head, err := h.bcReader.HeadsHeader()
 	if err != nil {
 		return defaultSyncState, nil
@@ -51,6 +47,10 @@ func (h *Handler) Syncing() (*Sync, *jsonrpc.Error) {
 		return defaultSyncState, nil
 	}
 	if highestBlockHeader.Number <= head.Number {
+		return defaultSyncState, nil
+	}
+	startingBlockHeader, err := h.syncReader.StartingBlockHeader()
+	if err != nil || startingBlockHeader == nil {
 		return defaultSyncState, nil
 	}
 

--- a/rpc/v9/sync.go
+++ b/rpc/v9/sync.go
@@ -50,7 +50,7 @@ func (h *Handler) Syncing() (*Sync, *jsonrpc.Error) {
 		return defaultSyncState, nil
 	}
 	startingBlockHeader, err := h.syncReader.StartingBlockHeader()
-	if err != nil || startingBlockHeader == nil {
+	if err != nil {
 		return defaultSyncState, nil
 	}
 

--- a/rpc/v9/sync.go
+++ b/rpc/v9/sync.go
@@ -38,11 +38,7 @@ func (s Sync) MarshalJSON() ([]byte, error) {
 func (h *Handler) Syncing() (*Sync, *jsonrpc.Error) {
 	defaultSyncState := &Sync{Syncing: new(bool)}
 
-	startingBlockNumber, err := h.syncReader.StartingBlockNumber()
-	if err != nil {
-		return defaultSyncState, nil
-	}
-	startingBlockHash, err := h.bcReader.BlockHeaderHashByNumber(startingBlockNumber)
+	startingBlockHeader, err := h.syncReader.StartingBlockHeader()
 	if err != nil {
 		return defaultSyncState, nil
 	}
@@ -59,8 +55,8 @@ func (h *Handler) Syncing() (*Sync, *jsonrpc.Error) {
 	}
 
 	return &Sync{
-		StartingBlockHash:   startingBlockHash,
-		StartingBlockNumber: &startingBlockNumber,
+		StartingBlockHash:   startingBlockHeader.Hash,
+		StartingBlockNumber: &startingBlockHeader.Number,
 		CurrentBlockHash:    head.Hash,
 		CurrentBlockNumber:  &head.Number,
 		HighestBlockHash:    highestBlockHeader.Hash,

--- a/rpc/v9/sync_test.go
+++ b/rpc/v9/sync_test.go
@@ -21,19 +21,17 @@ func TestSyncing(t *testing.T) {
 	handler := rpc.New(mockReader, synchronizer, nil, nil)
 	defaultSyncState := false
 
-	startingBlock := uint64(0)
-	synchronizer.EXPECT().StartingBlockNumber().Return(startingBlock, errors.New("nope"))
-	t.Run("undefined starting block", func(t *testing.T) {
+	startingBlockHeader := &core.Header{Number: 0, Hash: &felt.Zero}
+	synchronizer.EXPECT().StartingBlockHeader().Return(nil, errors.New("nope"))
+	t.Run("undefined starting block header", func(t *testing.T) {
 		syncing, err := handler.Syncing()
 		assert.Nil(t, err)
 		assert.Equal(t, &rpc.Sync{Syncing: &defaultSyncState}, syncing)
 	})
 
-	synchronizer.EXPECT().StartingBlockNumber().Return(startingBlock, nil).AnyTimes()
+	synchronizer.EXPECT().StartingBlockHeader().Return(startingBlockHeader, nil).AnyTimes()
 	t.Run("empty blockchain", func(t *testing.T) {
-		mockReader.EXPECT().
-			BlockHeaderHashByNumber(startingBlock).
-			Return(nil, errors.New("empty blockchain"))
+		mockReader.EXPECT().HeadsHeader().Return(nil, errors.New("empty blockchain"))
 
 		syncing, err := handler.Syncing()
 		assert.Nil(t, err)
@@ -42,7 +40,6 @@ func TestSyncing(t *testing.T) {
 
 	synchronizer.EXPECT().HighestBlockHeader().Return(nil).Times(2)
 	t.Run("undefined highest block", func(t *testing.T) {
-		mockReader.EXPECT().BlockHeaderHashByNumber(startingBlock).Return(&felt.Zero, nil)
 		mockReader.EXPECT().HeadsHeader().Return(&core.Header{}, nil)
 
 		syncing, err := handler.Syncing()
@@ -50,7 +47,6 @@ func TestSyncing(t *testing.T) {
 		assert.Equal(t, &rpc.Sync{Syncing: &defaultSyncState}, syncing)
 	})
 	t.Run("block height is greater than highest block", func(t *testing.T) {
-		mockReader.EXPECT().BlockHeaderHashByNumber(startingBlock).Return(&felt.Zero, nil)
 		mockReader.EXPECT().HeadsHeader().Return(&core.Header{Number: 1}, nil)
 
 		syncing, err := handler.Syncing()
@@ -63,9 +59,8 @@ func TestSyncing(t *testing.T) {
 			Number: 2,
 			Hash:   new(felt.Felt).SetUint64(2),
 		},
-	).Times(2)
+	).Times(3)
 	t.Run("block height is equal to highest block", func(t *testing.T) {
-		mockReader.EXPECT().BlockHeaderHashByNumber(startingBlock).Return(&felt.Zero, nil)
 		mockReader.EXPECT().HeadsHeader().Return(&core.Header{Number: 2}, nil)
 
 		syncing, err := handler.Syncing()
@@ -73,7 +68,6 @@ func TestSyncing(t *testing.T) {
 		assert.Equal(t, &rpc.Sync{Syncing: &defaultSyncState}, syncing)
 	})
 	t.Run("syncing", func(t *testing.T) {
-		mockReader.EXPECT().BlockHeaderHashByNumber(startingBlock).Return(&felt.Zero, nil)
 		mockReader.EXPECT().HeadsHeader().Return(
 			&core.Header{
 				Number: 1,
@@ -86,7 +80,30 @@ func TestSyncing(t *testing.T) {
 		highestBlockNumber := uint64(2)
 		expectedSyncing := &rpc.Sync{
 			StartingBlockHash:   &felt.Zero,
-			StartingBlockNumber: &startingBlock,
+			StartingBlockNumber: &startingBlockHeader.Number,
+			CurrentBlockHash:    new(felt.Felt).SetUint64(1),
+			CurrentBlockNumber:  &currentBlockNumber,
+			HighestBlockHash:    new(felt.Felt).SetUint64(2),
+			HighestBlockNumber:  &highestBlockNumber,
+		}
+		syncing, err := handler.Syncing()
+		assert.Nil(t, err)
+		assert.Equal(t, expectedSyncing, syncing)
+	})
+	t.Run("syncing with pruned starting block header", func(t *testing.T) {
+		mockReader.EXPECT().HeadsHeader().Return(
+			&core.Header{
+				Number: 1,
+				Hash:   new(felt.Felt).SetUint64(1),
+			},
+			nil,
+		)
+
+		currentBlockNumber := uint64(1)
+		highestBlockNumber := uint64(2)
+		expectedSyncing := &rpc.Sync{
+			StartingBlockHash:   &felt.Zero,
+			StartingBlockNumber: &startingBlockHeader.Number,
 			CurrentBlockHash:    new(felt.Felt).SetUint64(1),
 			CurrentBlockNumber:  &currentBlockNumber,
 			HighestBlockHash:    new(felt.Felt).SetUint64(2),

--- a/rpc/v9/sync_test.go
+++ b/rpc/v9/sync_test.go
@@ -22,29 +22,30 @@ func TestSyncing(t *testing.T) {
 	defaultSyncState := false
 
 	startingBlockHeader := &core.Header{Number: 0, Hash: &felt.Zero}
-	mockReader.EXPECT().HeadsHeader().Return(&core.Header{Number: 1}, nil)
-	synchronizer.EXPECT().HighestBlockHeader().Return(
-		&core.Header{Number: 2, Hash: new(felt.Felt).SetUint64(2)},
-	)
-	synchronizer.EXPECT().StartingBlockHeader().Return(nil, errors.New("nope"))
 	t.Run("undefined starting block header", func(t *testing.T) {
+		mockReader.EXPECT().HeadsHeader().Return(&core.Header{Number: 1}, nil)
+		synchronizer.EXPECT().HighestBlockHeader().Return(
+			&core.Header{Number: 2, Hash: new(felt.Felt).SetUint64(2)},
+		)
+		synchronizer.EXPECT().StartingBlockHeader().Return(nil, errors.New("nope"))
+
 		syncing, err := handler.Syncing()
 		assert.Nil(t, err)
 		assert.Equal(t, &rpc.Sync{Syncing: &defaultSyncState}, syncing)
 	})
 
-	mockReader.EXPECT().HeadsHeader().Return(&core.Header{Number: 1}, nil)
-	synchronizer.EXPECT().HighestBlockHeader().Return(
-		&core.Header{Number: 2, Hash: new(felt.Felt).SetUint64(2)},
-	)
-	synchronizer.EXPECT().StartingBlockHeader().Return(nil, nil)
 	t.Run("nil starting block header", func(t *testing.T) {
+		mockReader.EXPECT().HeadsHeader().Return(&core.Header{Number: 1}, nil)
+		synchronizer.EXPECT().HighestBlockHeader().Return(
+			&core.Header{Number: 2, Hash: new(felt.Felt).SetUint64(2)},
+		)
+		synchronizer.EXPECT().StartingBlockHeader().Return(nil, nil)
+
 		syncing, err := handler.Syncing()
 		assert.Nil(t, err)
 		assert.Equal(t, &rpc.Sync{Syncing: &defaultSyncState}, syncing)
 	})
 
-	synchronizer.EXPECT().StartingBlockHeader().Return(startingBlockHeader, nil).AnyTimes()
 	t.Run("empty blockchain", func(t *testing.T) {
 		mockReader.EXPECT().HeadsHeader().Return(nil, errors.New("empty blockchain"))
 
@@ -53,9 +54,9 @@ func TestSyncing(t *testing.T) {
 		assert.Equal(t, &rpc.Sync{Syncing: &defaultSyncState}, syncing)
 	})
 
-	synchronizer.EXPECT().HighestBlockHeader().Return(nil).Times(2)
 	t.Run("undefined highest block", func(t *testing.T) {
 		mockReader.EXPECT().HeadsHeader().Return(&core.Header{}, nil)
+		synchronizer.EXPECT().HighestBlockHeader().Return(nil)
 
 		syncing, err := handler.Syncing()
 		assert.Nil(t, err)
@@ -63,20 +64,21 @@ func TestSyncing(t *testing.T) {
 	})
 	t.Run("block height is greater than highest block", func(t *testing.T) {
 		mockReader.EXPECT().HeadsHeader().Return(&core.Header{Number: 1}, nil)
+		synchronizer.EXPECT().HighestBlockHeader().Return(nil)
 
 		syncing, err := handler.Syncing()
 		assert.Nil(t, err)
 		assert.Equal(t, &rpc.Sync{Syncing: &defaultSyncState}, syncing)
 	})
 
-	synchronizer.EXPECT().HighestBlockHeader().Return(
-		&core.Header{
-			Number: 2,
-			Hash:   new(felt.Felt).SetUint64(2),
-		},
-	).Times(2)
 	t.Run("block height is equal to highest block", func(t *testing.T) {
 		mockReader.EXPECT().HeadsHeader().Return(&core.Header{Number: 2}, nil)
+		synchronizer.EXPECT().HighestBlockHeader().Return(
+			&core.Header{
+				Number: 2,
+				Hash:   new(felt.Felt).SetUint64(2),
+			},
+		)
 
 		syncing, err := handler.Syncing()
 		assert.Nil(t, err)
@@ -90,6 +92,13 @@ func TestSyncing(t *testing.T) {
 			},
 			nil,
 		)
+		synchronizer.EXPECT().HighestBlockHeader().Return(
+			&core.Header{
+				Number: 2,
+				Hash:   new(felt.Felt).SetUint64(2),
+			},
+		)
+		synchronizer.EXPECT().StartingBlockHeader().Return(startingBlockHeader, nil)
 
 		currentBlockNumber := uint64(1)
 		highestBlockNumber := uint64(2)

--- a/rpc/v9/sync_test.go
+++ b/rpc/v9/sync_test.go
@@ -74,7 +74,7 @@ func TestSyncing(t *testing.T) {
 			Number: 2,
 			Hash:   new(felt.Felt).SetUint64(2),
 		},
-	).Times(3)
+	).Times(2)
 	t.Run("block height is equal to highest block", func(t *testing.T) {
 		mockReader.EXPECT().HeadsHeader().Return(&core.Header{Number: 2}, nil)
 
@@ -83,29 +83,6 @@ func TestSyncing(t *testing.T) {
 		assert.Equal(t, &rpc.Sync{Syncing: &defaultSyncState}, syncing)
 	})
 	t.Run("syncing", func(t *testing.T) {
-		mockReader.EXPECT().HeadsHeader().Return(
-			&core.Header{
-				Number: 1,
-				Hash:   new(felt.Felt).SetUint64(1),
-			},
-			nil,
-		)
-
-		currentBlockNumber := uint64(1)
-		highestBlockNumber := uint64(2)
-		expectedSyncing := &rpc.Sync{
-			StartingBlockHash:   &felt.Zero,
-			StartingBlockNumber: &startingBlockHeader.Number,
-			CurrentBlockHash:    new(felt.Felt).SetUint64(1),
-			CurrentBlockNumber:  &currentBlockNumber,
-			HighestBlockHash:    new(felt.Felt).SetUint64(2),
-			HighestBlockNumber:  &highestBlockNumber,
-		}
-		syncing, err := handler.Syncing()
-		assert.Nil(t, err)
-		assert.Equal(t, expectedSyncing, syncing)
-	})
-	t.Run("syncing with pruned starting block header", func(t *testing.T) {
 		mockReader.EXPECT().HeadsHeader().Return(
 			&core.Header{
 				Number: 1,

--- a/rpc/v9/sync_test.go
+++ b/rpc/v9/sync_test.go
@@ -34,18 +34,6 @@ func TestSyncing(t *testing.T) {
 		assert.Equal(t, &rpc.Sync{Syncing: &defaultSyncState}, syncing)
 	})
 
-	t.Run("nil starting block header", func(t *testing.T) {
-		mockReader.EXPECT().HeadsHeader().Return(&core.Header{Number: 1}, nil)
-		synchronizer.EXPECT().HighestBlockHeader().Return(
-			&core.Header{Number: 2, Hash: new(felt.Felt).SetUint64(2)},
-		)
-		synchronizer.EXPECT().StartingBlockHeader().Return(nil, nil)
-
-		syncing, err := handler.Syncing()
-		assert.Nil(t, err)
-		assert.Equal(t, &rpc.Sync{Syncing: &defaultSyncState}, syncing)
-	})
-
 	t.Run("empty blockchain", func(t *testing.T) {
 		mockReader.EXPECT().HeadsHeader().Return(nil, errors.New("empty blockchain"))
 

--- a/rpc/v9/sync_test.go
+++ b/rpc/v9/sync_test.go
@@ -22,8 +22,23 @@ func TestSyncing(t *testing.T) {
 	defaultSyncState := false
 
 	startingBlockHeader := &core.Header{Number: 0, Hash: &felt.Zero}
+	mockReader.EXPECT().HeadsHeader().Return(&core.Header{Number: 1}, nil)
+	synchronizer.EXPECT().HighestBlockHeader().Return(
+		&core.Header{Number: 2, Hash: new(felt.Felt).SetUint64(2)},
+	)
 	synchronizer.EXPECT().StartingBlockHeader().Return(nil, errors.New("nope"))
 	t.Run("undefined starting block header", func(t *testing.T) {
+		syncing, err := handler.Syncing()
+		assert.Nil(t, err)
+		assert.Equal(t, &rpc.Sync{Syncing: &defaultSyncState}, syncing)
+	})
+
+	mockReader.EXPECT().HeadsHeader().Return(&core.Header{Number: 1}, nil)
+	synchronizer.EXPECT().HighestBlockHeader().Return(
+		&core.Header{Number: 2, Hash: new(felt.Felt).SetUint64(2)},
+	)
+	synchronizer.EXPECT().StartingBlockHeader().Return(nil, nil)
+	t.Run("nil starting block header", func(t *testing.T) {
 		syncing, err := handler.Syncing()
 		assert.Nil(t, err)
 		assert.Equal(t, &rpc.Sync{Syncing: &defaultSyncState}, syncing)

--- a/sequencer/sequencer.go
+++ b/sequencer/sequencer.go
@@ -219,10 +219,6 @@ func (s *Sequencer) HighestBlockHeader() *core.Header {
 	return nil // Not relevant for Sequencer. Todo: clean Reader
 }
 
-func (s *Sequencer) StartingBlockNumber() (uint64, error) {
-	return 0, nil // Not relevant for Sequencer. Todo: clean Reader
-}
-
 func (s *Sequencer) StartingBlockHeader() (*core.Header, error) {
 	return nil, errors.New("StartingBlockHeader() not implemented") // Not relevant for Sequencer. Todo: clean Reader
 }

--- a/sequencer/sequencer.go
+++ b/sequencer/sequencer.go
@@ -224,7 +224,7 @@ func (s *Sequencer) StartingBlockNumber() (uint64, error) {
 }
 
 func (s *Sequencer) StartingBlockHeader() (*core.Header, error) {
-	return nil, nil // Not relevant for Sequencer. Todo: clean Reader
+	return nil, errors.New("StartingBlockHeader() not implemented") // Not relevant for Sequencer. Todo: clean Reader
 }
 
 // The builder has no reorg logic (centralised sequencer that can't reorg)

--- a/sequencer/sequencer.go
+++ b/sequencer/sequencer.go
@@ -220,7 +220,8 @@ func (s *Sequencer) HighestBlockHeader() *core.Header {
 }
 
 func (s *Sequencer) StartingBlockHeader() (*core.Header, error) {
-	return nil, errors.New("StartingBlockHeader() not implemented") // Not relevant for Sequencer. Todo: clean Reader
+	// Not relevant for Sequencer. Todo: clean Reader.
+	return nil, errors.New("StartingBlockHeader() not implemented")
 }
 
 // The builder has no reorg logic (centralised sequencer that can't reorg)

--- a/sequencer/sequencer.go
+++ b/sequencer/sequencer.go
@@ -223,6 +223,10 @@ func (s *Sequencer) StartingBlockNumber() (uint64, error) {
 	return 0, nil // Not relevant for Sequencer. Todo: clean Reader
 }
 
+func (s *Sequencer) StartingBlockHeader() (*core.Header, error) {
+	return nil, nil // Not relevant for Sequencer. Todo: clean Reader
+}
+
 // The builder has no reorg logic (centralised sequencer that can't reorg)
 func (s *Sequencer) SubscribeReorg() sync.ReorgSubscription {
 	return sync.ReorgSubscription{Subscription: s.subReorgFeed.Subscribe()}

--- a/sequencer/sequencer_test.go
+++ b/sequencer/sequencer_test.go
@@ -283,6 +283,10 @@ func TestHelpers(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, uint64(0), num)
 
+	header, err = seq.StartingBlockHeader()
+	require.Error(t, err)
+	require.Nil(t, header)
+
 	reorgSub := seq.SubscribeReorg()
 	require.NotNil(t, reorgSub)
 	require.NotNil(t, reorgSub.Subscription)

--- a/sequencer/sequencer_test.go
+++ b/sequencer/sequencer_test.go
@@ -279,10 +279,6 @@ func TestHelpers(t *testing.T) {
 	header := seq.HighestBlockHeader()
 	require.Nil(t, header)
 
-	num, err := seq.StartingBlockNumber()
-	require.NoError(t, err)
-	require.Equal(t, uint64(0), num)
-
 	header, err = seq.StartingBlockHeader()
 	require.Error(t, err)
 	require.Nil(t, header)

--- a/sync/sync.go
+++ b/sync/sync.go
@@ -3,6 +3,7 @@ package sync
 import (
 	"context"
 	"errors"
+	"fmt"
 	"runtime"
 	stdsync "sync"
 	"sync/atomic"
@@ -73,8 +74,6 @@ type ReorgBlockRange struct {
 //
 //go:generate mockgen -destination=../mocks/mock_synchronizer.go -package=mocks -mock_names Reader=MockSyncReader github.com/NethermindEth/juno/sync Reader
 type Reader interface {
-	// StartingBlockHeader returns the header for the first block of the current sync run.
-	// Implementations may return a partial header containing only Number and Hash.
 	StartingBlockHeader() (*core.Header, error)
 	HighestBlockHeader() *core.Header
 	SubscribeNewHeads() NewHeadSubscription
@@ -557,34 +556,30 @@ func (s *Synchronizer) revertHead(localHeader *core.Header) {
 }
 
 func (s *Synchronizer) StartingBlockHeader() (*core.Header, error) {
-	startingBlockNumber := s.startingBlockNumber.Load()
-	if startingBlockNumber == nil {
-		return nil, errors.New("not running")
-	}
-
 	header := s.startingBlockHeader.Load()
 	if header != nil {
 		return header, nil
 	}
 
-	hash, err := core.GetBlockHeaderHashByNumber(s.db, *startingBlockNumber)
-	if err != nil {
-		return nil, err
+	startingBlockNumber := s.startingBlockNumber.Load()
+	if startingBlockNumber == nil {
+		return nil, errors.New("starting block number is not set")
 	}
-	header = &core.Header{
-		Number: *startingBlockNumber,
-		Hash:   hash,
+
+	header, err := core.GetBlockHeaderByNumber(s.db, *startingBlockNumber)
+	if err != nil {
+		return nil, fmt.Errorf("getting header for block %d: %w", *startingBlockNumber, err)
 	}
 	// The sync loop may stop or restart while the fallback DB read is in flight.
 	// Only cache the fallback header if it still belongs to the same sync run.
 	if s.startingBlockNumber.Load() != startingBlockNumber {
-		return nil, errors.New("not running")
+		return nil, errors.New("starting block number changed")
 	}
 	// Avoid overwriting a full header cached by storeTask while this fallback was reading from DB.
 	if !s.startingBlockHeader.CompareAndSwap(nil, header) {
 		header = s.startingBlockHeader.Load()
 		if header == nil {
-			return nil, errors.New("not running")
+			return nil, errors.New("starting block header changed")
 		}
 	}
 	return header, nil

--- a/sync/sync.go
+++ b/sync/sync.go
@@ -567,9 +567,18 @@ func (s *Synchronizer) StartingBlockNumber() (uint64, error) {
 
 func (s *Synchronizer) StartingBlockHeader() (*core.Header, error) {
 	header := s.startingBlockHeader.Load()
-	if header == nil {
-		return nil, errors.New("starting block header not available")
+	if header != nil {
+		return header, nil
 	}
+	if s.startingBlockNumber == nil {
+		return nil, errors.New("not running")
+	}
+
+	header, err := s.blockchain.BlockHeaderByNumber(*s.startingBlockNumber)
+	if err != nil {
+		return nil, err
+	}
+	s.startingBlockHeader.Store(header)
 	return header, nil
 }
 

--- a/sync/sync.go
+++ b/sync/sync.go
@@ -74,6 +74,7 @@ type ReorgBlockRange struct {
 //go:generate mockgen -destination=../mocks/mock_synchronizer.go -package=mocks -mock_names Reader=MockSyncReader github.com/NethermindEth/juno/sync Reader
 type Reader interface {
 	StartingBlockNumber() (uint64, error)
+	StartingBlockHeader() (*core.Header, error)
 	HighestBlockHeader() *core.Header
 	SubscribeNewHeads() NewHeadSubscription
 	SubscribeReorg() ReorgSubscription
@@ -86,6 +87,10 @@ type NoopSynchronizer struct{}
 
 func (n *NoopSynchronizer) StartingBlockNumber() (uint64, error) {
 	return 0, errors.New("StartingBlockNumber() not implemented")
+}
+
+func (n *NoopSynchronizer) StartingBlockHeader() (*core.Header, error) {
+	return nil, errors.New("StartingBlockHeader() not implemented")
 }
 
 func (n *NoopSynchronizer) HighestBlockHeader() *core.Header {
@@ -115,6 +120,7 @@ type Synchronizer struct {
 	readOnlyBlockchain   bool
 	dataSource           DataSource
 	startingBlockNumber  *uint64
+	startingBlockHeader  atomic.Pointer[core.Header]
 	highestBlockHeader   atomic.Pointer[core.Header]
 	newHeads             *feed.Feed[*core.Block]
 	reorgFeed            *feed.Feed[*ReorgBlockRange]
@@ -372,6 +378,10 @@ func (s *Synchronizer) storeTask(
 	}
 	committedBlock.Persisted <- nil
 
+	if s.startingBlockNumber != nil && block.Number == *s.startingBlockNumber {
+		s.startingBlockHeader.Store(block.Header)
+	}
+
 	s.listener.OnSyncStepDone(OpStore, block.Number, time.Since(storeTimer))
 
 	highestBlockHeader := s.highestBlockHeader.Load()
@@ -455,6 +465,7 @@ func (s *Synchronizer) nextHeight() uint64 {
 func (s *Synchronizer) syncBlocks(syncCtx context.Context) {
 	defer func() {
 		s.startingBlockNumber = nil
+		s.startingBlockHeader.Store(nil)
 		s.highestBlockHeader.Store(nil)
 	}()
 
@@ -552,6 +563,14 @@ func (s *Synchronizer) StartingBlockNumber() (uint64, error) {
 		return 0, errors.New("not running")
 	}
 	return *s.startingBlockNumber, nil
+}
+
+func (s *Synchronizer) StartingBlockHeader() (*core.Header, error) {
+	header := s.startingBlockHeader.Load()
+	if header == nil {
+		return nil, errors.New("starting block header not available")
+	}
+	return header, nil
 }
 
 func (s *Synchronizer) HighestBlockHeader() *core.Header {

--- a/sync/sync.go
+++ b/sync/sync.go
@@ -114,7 +114,7 @@ type Synchronizer struct {
 	db                   db.KeyValueStore
 	readOnlyBlockchain   bool
 	dataSource           DataSource
-	startingBlockNumber  *uint64
+	startingBlockNumber  atomic.Pointer[uint64]
 	startingBlockHeader  atomic.Pointer[core.Header]
 	highestBlockHeader   atomic.Pointer[core.Header]
 	newHeads             *feed.Feed[*core.Block]
@@ -373,7 +373,8 @@ func (s *Synchronizer) storeTask(
 	}
 	committedBlock.Persisted <- nil
 
-	if s.startingBlockNumber != nil && block.Number == *s.startingBlockNumber {
+	startingBlockNumber := s.startingBlockNumber.Load()
+	if startingBlockNumber != nil && block.Number == *startingBlockNumber {
 		s.startingBlockHeader.Store(block.Header)
 	}
 
@@ -459,14 +460,14 @@ func (s *Synchronizer) nextHeight() uint64 {
 
 func (s *Synchronizer) syncBlocks(syncCtx context.Context) {
 	defer func() {
-		s.startingBlockNumber = nil
+		s.startingBlockNumber.Store(nil)
 		s.startingBlockHeader.Store(nil)
 		s.highestBlockHeader.Store(nil)
 	}()
 
 	nextHeight := s.nextHeight()
 	startingHeight := nextHeight
-	s.startingBlockNumber = &startingHeight
+	s.startingBlockNumber.Store(&startingHeight)
 
 	if s.readOnlyBlockchain {
 		s.pollLatest(syncCtx)
@@ -558,19 +559,31 @@ func (s *Synchronizer) StartingBlockHeader() (*core.Header, error) {
 	if header != nil {
 		return header, nil
 	}
-	if s.startingBlockNumber == nil {
+	startingBlockNumber := s.startingBlockNumber.Load()
+	if startingBlockNumber == nil {
 		return nil, errors.New("not running")
 	}
 
-	hash, err := core.GetBlockHeaderHashByNumber(s.db, *s.startingBlockNumber)
+	hash, err := core.GetBlockHeaderHashByNumber(s.db, *startingBlockNumber)
 	if err != nil {
 		return nil, err
 	}
 	header = &core.Header{
-		Number: *s.startingBlockNumber,
+		Number: *startingBlockNumber,
 		Hash:   hash,
 	}
-	s.startingBlockHeader.Store(header)
+	// The sync loop may stop or restart while the fallback DB read is in flight.
+	// Only cache the fallback header if it still belongs to the same sync run.
+	if s.startingBlockNumber.Load() != startingBlockNumber {
+		return nil, errors.New("not running")
+	}
+	// Avoid overwriting a full header cached by storeTask while this fallback was reading from DB.
+	if !s.startingBlockHeader.CompareAndSwap(nil, header) {
+		header = s.startingBlockHeader.Load()
+		if header == nil {
+			return nil, errors.New("not running")
+		}
+	}
 	return header, nil
 }
 

--- a/sync/sync.go
+++ b/sync/sync.go
@@ -73,6 +73,8 @@ type ReorgBlockRange struct {
 //
 //go:generate mockgen -destination=../mocks/mock_synchronizer.go -package=mocks -mock_names Reader=MockSyncReader github.com/NethermindEth/juno/sync Reader
 type Reader interface {
+	// StartingBlockHeader returns the header for the first block of the current sync run.
+	// Implementations may return a partial header containing only Number and Hash.
 	StartingBlockHeader() (*core.Header, error)
 	HighestBlockHeader() *core.Header
 	SubscribeNewHeads() NewHeadSubscription

--- a/sync/sync.go
+++ b/sync/sync.go
@@ -557,13 +557,14 @@ func (s *Synchronizer) revertHead(localHeader *core.Header) {
 }
 
 func (s *Synchronizer) StartingBlockHeader() (*core.Header, error) {
-	header := s.startingBlockHeader.Load()
-	if header != nil {
-		return header, nil
-	}
 	startingBlockNumber := s.startingBlockNumber.Load()
 	if startingBlockNumber == nil {
 		return nil, errors.New("not running")
+	}
+
+	header := s.startingBlockHeader.Load()
+	if header != nil {
+		return header, nil
 	}
 
 	hash, err := core.GetBlockHeaderHashByNumber(s.db, *startingBlockNumber)

--- a/sync/sync.go
+++ b/sync/sync.go
@@ -562,9 +562,13 @@ func (s *Synchronizer) StartingBlockHeader() (*core.Header, error) {
 		return nil, errors.New("not running")
 	}
 
-	header, err := s.blockchain.BlockHeaderByNumber(*s.startingBlockNumber)
+	hash, err := core.GetBlockHeaderHashByNumber(s.db, *s.startingBlockNumber)
 	if err != nil {
 		return nil, err
+	}
+	header = &core.Header{
+		Number: *s.startingBlockNumber,
+		Hash:   hash,
 	}
 	s.startingBlockHeader.Store(header)
 	return header, nil

--- a/sync/sync.go
+++ b/sync/sync.go
@@ -73,7 +73,6 @@ type ReorgBlockRange struct {
 //
 //go:generate mockgen -destination=../mocks/mock_synchronizer.go -package=mocks -mock_names Reader=MockSyncReader github.com/NethermindEth/juno/sync Reader
 type Reader interface {
-	StartingBlockNumber() (uint64, error)
 	StartingBlockHeader() (*core.Header, error)
 	HighestBlockHeader() *core.Header
 	SubscribeNewHeads() NewHeadSubscription
@@ -84,10 +83,6 @@ type Reader interface {
 
 // This is temporary and will be removed once the p2p synchronizer implements this interface.
 type NoopSynchronizer struct{}
-
-func (n *NoopSynchronizer) StartingBlockNumber() (uint64, error) {
-	return 0, errors.New("StartingBlockNumber() not implemented")
-}
 
 func (n *NoopSynchronizer) StartingBlockHeader() (*core.Header, error) {
 	return nil, errors.New("StartingBlockHeader() not implemented")
@@ -556,13 +551,6 @@ func (s *Synchronizer) revertHead(localHeader *core.Header) {
 	}
 
 	s.listener.OnReorg(localHeader.Number)
-}
-
-func (s *Synchronizer) StartingBlockNumber() (uint64, error) {
-	if s.startingBlockNumber == nil {
-		return 0, errors.New("not running")
-	}
-	return *s.startingBlockNumber, nil
 }
 
 func (s *Synchronizer) StartingBlockHeader() (*core.Header, error) {

--- a/sync/sync_test.go
+++ b/sync/sync_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/NethermindEth/juno/core"
 	"github.com/NethermindEth/juno/core/felt"
 	statetestutils "github.com/NethermindEth/juno/core/state/testutils"
+	"github.com/NethermindEth/juno/db"
 	"github.com/NethermindEth/juno/db/memory"
 	"github.com/NethermindEth/juno/mocks"
 	adaptfeeder "github.com/NethermindEth/juno/starknetdata/feeder"
@@ -272,6 +273,7 @@ func TestStartingBlockHeaderCachesStoredHeader(t *testing.T) {
 		t.Fatal("starting block was not stored")
 	}
 
+	// Delete before canceling because sync shutdown clears the cached starting header.
 	require.NoError(t, core.DeleteBlockHeaderByNumber(testDB, block0.Number))
 	header, err := synchronizer.StartingBlockHeader()
 	require.NoError(t, err)
@@ -332,7 +334,7 @@ func TestStartingBlockHeaderFallbackUnavailable(t *testing.T) {
 	}, timeout, 10*time.Millisecond)
 
 	header, err := synchronizer.StartingBlockHeader()
-	require.Error(t, err)
+	require.ErrorIs(t, err, db.ErrKeyNotFound)
 	require.Nil(t, header)
 
 	cancel()

--- a/sync/sync_test.go
+++ b/sync/sync_test.go
@@ -181,6 +181,49 @@ func TestSyncBlocks(t *testing.T) {
 	})
 }
 
+func TestStartingBlockHeaderFallsBackToBlockchain(t *testing.T) {
+	testDB := memory.New()
+	bc := blockchain.New(
+		testDB,
+		&networks.Mainnet,
+		blockchain.WithNewState(statetestutils.UseNewState()),
+	)
+
+	startingHeader := &core.Header{Number: 1, Hash: felt.NewFromUint64[felt.Felt](1)}
+	require.NoError(t, core.WriteChainHeight(testDB, 0))
+	require.NoError(t, core.WriteBlockHeaderByNumber(testDB, startingHeader))
+
+	dataSource := newTestBlockDataSource()
+	dataSource.setBlocks([]sync.CommittedBlock{
+		{Block: &core.Block{Header: &core.Header{Number: 0}}},
+		{Block: &core.Block{Header: startingHeader}},
+		{Block: &core.Block{Header: &core.Header{Number: 2, Hash: felt.NewFromUint64[felt.Felt](2)}}},
+	})
+
+	synchronizer := sync.New(
+		bc,
+		dataSource,
+		log.NewNopZapLogger(),
+		time.Duration(0),
+		true,
+		testDB,
+	)
+	ctx, cancel := context.WithCancel(t.Context())
+	done := make(chan error, 1)
+	go func() {
+		done <- synchronizer.Run(ctx)
+	}()
+
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		header, err := synchronizer.StartingBlockHeader()
+		assert.NoError(c, err)
+		assert.Equal(c, startingHeader, header)
+	}, timeout, 10*time.Millisecond)
+
+	cancel()
+	require.NoError(t, <-done)
+}
+
 func TestReorg(t *testing.T) {
 	mainClient := feeder.NewTestClient(t, &networks.Mainnet)
 	mainGw := adaptfeeder.New(mainClient)

--- a/sync/sync_test.go
+++ b/sync/sync_test.go
@@ -229,6 +229,58 @@ func TestStartingBlockHeaderFallsBackToBlockchain(t *testing.T) {
 	require.NoError(t, <-done)
 }
 
+func TestStartingBlockHeaderCachesStoredHeader(t *testing.T) {
+	client := feeder.NewTestClient(t, &networks.Mainnet)
+	gw := adaptfeeder.New(client)
+	block0, err := gw.BlockByNumber(t.Context(), 0)
+	require.NoError(t, err)
+
+	testDB := memory.New()
+	bc := blockchain.New(
+		testDB,
+		&networks.Mainnet,
+		blockchain.WithNewState(statetestutils.UseNewState()),
+	)
+	dataSource := sync.NewFeederGatewayDataSource(bc, gw)
+	synchronizer := sync.New(
+		bc,
+		dataSource,
+		log.NewNopZapLogger(),
+		time.Duration(0),
+		false,
+		testDB,
+	)
+
+	storedStartingBlock := make(chan struct{}, 1)
+	synchronizer.WithListener(&sync.SelectiveListener{
+		OnSyncStepDoneCb: func(op string, blockNum uint64, took time.Duration) {
+			if op == sync.OpStore && blockNum == 0 {
+				storedStartingBlock <- struct{}{}
+			}
+		},
+	})
+
+	ctx, cancel := context.WithCancel(t.Context())
+	done := make(chan error, 1)
+	go func() {
+		done <- synchronizer.Run(ctx)
+	}()
+
+	select {
+	case <-storedStartingBlock:
+	case <-time.After(timeout):
+		t.Fatal("starting block was not stored")
+	}
+
+	require.NoError(t, core.DeleteBlockHeaderByNumber(testDB, block0.Number))
+	header, err := synchronizer.StartingBlockHeader()
+	require.NoError(t, err)
+	require.Equal(t, block0.Header, header)
+
+	cancel()
+	require.NoError(t, <-done)
+}
+
 func TestStartingBlockHeaderNotRunning(t *testing.T) {
 	testDB := memory.New()
 	bc := blockchain.New(
@@ -257,9 +309,13 @@ func TestStartingBlockHeaderFallbackUnavailable(t *testing.T) {
 		&networks.Mainnet,
 		blockchain.WithNewState(statetestutils.UseNewState()),
 	)
+	dataSource := newTestBlockDataSource()
+	dataSource.setBlocks([]sync.CommittedBlock{
+		{Block: &core.Block{Header: &core.Header{Number: 0, Hash: felt.NewFromUint64[felt.Felt](0)}}},
+	})
 	synchronizer := sync.New(
 		bc,
-		newTestBlockDataSource(),
+		dataSource,
 		log.NewNopZapLogger(),
 		time.Duration(0),
 		true,
@@ -272,10 +328,12 @@ func TestStartingBlockHeaderFallbackUnavailable(t *testing.T) {
 	}()
 
 	require.EventuallyWithT(t, func(c *assert.CollectT) {
-		header, err := synchronizer.StartingBlockHeader()
-		assert.Error(c, err)
-		assert.Nil(c, header)
+		assert.NotNil(c, synchronizer.HighestBlockHeader())
 	}, timeout, 10*time.Millisecond)
+
+	header, err := synchronizer.StartingBlockHeader()
+	require.Error(t, err)
+	require.Nil(t, header)
 
 	cancel()
 	require.NoError(t, <-done)

--- a/sync/sync_test.go
+++ b/sync/sync_test.go
@@ -220,6 +220,63 @@ func TestStartingBlockHeaderFallsBackToBlockchain(t *testing.T) {
 		assert.Equal(c, startingHeader, header)
 	}, timeout, 10*time.Millisecond)
 
+	require.NoError(t, core.DeleteBlockHeaderByNumber(testDB, startingHeader.Number))
+	header, err := synchronizer.StartingBlockHeader()
+	require.NoError(t, err)
+	require.Equal(t, startingHeader, header)
+
+	cancel()
+	require.NoError(t, <-done)
+}
+
+func TestStartingBlockHeaderNotRunning(t *testing.T) {
+	testDB := memory.New()
+	bc := blockchain.New(
+		testDB,
+		&networks.Mainnet,
+		blockchain.WithNewState(statetestutils.UseNewState()),
+	)
+	synchronizer := sync.New(
+		bc,
+		newTestBlockDataSource(),
+		log.NewNopZapLogger(),
+		time.Duration(0),
+		true,
+		testDB,
+	)
+
+	header, err := synchronizer.StartingBlockHeader()
+	require.Error(t, err)
+	require.Nil(t, header)
+}
+
+func TestStartingBlockHeaderFallbackUnavailable(t *testing.T) {
+	testDB := memory.New()
+	bc := blockchain.New(
+		testDB,
+		&networks.Mainnet,
+		blockchain.WithNewState(statetestutils.UseNewState()),
+	)
+	synchronizer := sync.New(
+		bc,
+		newTestBlockDataSource(),
+		log.NewNopZapLogger(),
+		time.Duration(0),
+		true,
+		testDB,
+	)
+	ctx, cancel := context.WithCancel(t.Context())
+	done := make(chan error, 1)
+	go func() {
+		done <- synchronizer.Run(ctx)
+	}()
+
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		header, err := synchronizer.StartingBlockHeader()
+		assert.Error(c, err)
+		assert.Nil(c, header)
+	}, timeout, 10*time.Millisecond)
+
 	cancel()
 	require.NoError(t, <-done)
 }


### PR DESCRIPTION
Fixes #3791 

`starknet_syncing` previously read the starting block hash from blockchain storage using the sync start block number. In pruned mode, that starting block header may have already been removed, causing the RPC method to return `false` even while the node is still syncing.

This PR stores the starting block header in the synchronizer once the starting block is successfully stored, and updates RPC v8/v9/v10 to read the starting block metadata from the synchronizer instead of prunable chain history.

## Changes

- Add `StartingBlockHeader()` to the sync reader interface.
- Cache the starting block header in `Synchronizer` when the sync start block is stored.
- Clear the cached starting header when the sync loop exits.
- Update `starknet_syncing` in RPC v8/v9/v10 to use the synchronizer’s cached start header.
- Update mocks, fake syncers, sequencer implementation, and RPC sync tests.