### PR TITLE
feat(jsonrpc): add request timeout for websocket RPC requests

### DIFF
--- a/jsonrpc/server.go
+++ b/jsonrpc/server.go
@@ -248,11 +248,13 @@ func (s *Server) registerMethod(method Method) error {
 type Conn interface {
 	io.Writer
 	Equal(Conn) bool
+	Context() context.Context
 }
 
 type connection struct {
 	w         io.Writer
 	activated <-chan struct{}
+	ctx       context.Context
 
 	// initialErr is not thread-safe. It must be set to its final value before the connection is activated.
 	initialErr error
@@ -276,6 +278,10 @@ func (c *connection) Equal(other Conn) bool {
 	return c.w == c2.w
 }
 
+func (c *connection) Context() context.Context {
+	return c.ctx
+}
+
 // ConnKey the key used to retrieve the connection from the context passed to a handler.
 // It is exported to allow transports to set it manually if they decide not to use HandleReadWriter, which sets it automatically.
 // Manually setting the connection can be especially useful when testing handlers.
@@ -296,14 +302,31 @@ func ConnFromContext(ctx context.Context) (Conn, bool) {
 // HandleReadWriter permits methods to send messages on the connection after the server sends the initial response.
 // rw must permit concurrent writes.
 // A non-nil error indicates the initial response could not be sent, and that no method will be able to write the connection.
-func (s *Server) HandleReadWriter(ctx context.Context, rw io.ReadWriter) error {
+func (s *Server) HandleReadWriter(
+	connCtx context.Context,
+	requestTimeout time.Duration,
+	rw io.ReadWriter,
+) error {
 	activated := make(chan struct{})
 	defer close(activated)
 	conn := &connection{
 		w:         rw.(io.Writer),
 		activated: activated,
+		ctx:       connCtx,
 	}
-	msgCtx := context.WithValue(ctx, ConnKey{}, conn)
+
+	var (
+		requestCtx context.Context
+		cancel     context.CancelFunc
+	)
+	if requestTimeout > 0 {
+		requestCtx, cancel = context.WithTimeout(connCtx, requestTimeout)
+	} else {
+		requestCtx, cancel = context.WithCancel(connCtx)
+	}
+	defer cancel()
+
+	msgCtx := context.WithValue(requestCtx, ConnKey{}, conn)
 	// header is unnecessary for read-writer(websocket)
 	resp, _, err := s.HandleReader(msgCtx, rw)
 	if err != nil {

--- a/jsonrpc/server_test.go
+++ b/jsonrpc/server_test.go
@@ -707,7 +707,9 @@ func TestCannotWriteToConnInHandler(t *testing.T) {
 	require.NotNil(t, header)
 }
 
-type fakeConn struct{}
+type fakeConn struct {
+	ctx context.Context
+}
 
 func (fc *fakeConn) Write(p []byte) (int, error) {
 	return 0, nil
@@ -715,6 +717,10 @@ func (fc *fakeConn) Write(p []byte) (int, error) {
 
 func (fc *fakeConn) Equal(other jsonrpc.Conn) bool {
 	return false
+}
+
+func (fc *fakeConn) Context() context.Context {
+	return fc.ctx
 }
 
 func TestWriteToConnInHandler(t *testing.T) {
@@ -745,7 +751,7 @@ func TestWriteToConnInHandler(t *testing.T) {
 	})
 
 	wg.Go(func() {
-		err := server.HandleReadWriter(t.Context(), serverConn)
+		err := server.HandleReadWriter(t.Context(), 0, serverConn)
 		require.NoError(t, err)
 	})
 
@@ -782,7 +788,7 @@ func TestWriteToClosedConnInHandler(t *testing.T) {
 	})
 
 	wg.Go(func() {
-		err := server.HandleReadWriter(t.Context(), serverConn)
+		err := server.HandleReadWriter(t.Context(), 0, serverConn)
 		require.ErrorIs(t, err, io.ErrClosedPipe)
 	})
 

--- a/jsonrpc/websocket.go
+++ b/jsonrpc/websocket.go
@@ -21,11 +21,12 @@ const (
 )
 
 type Websocket struct {
-	rpc        *Server
-	logger     log.StructuredLogger
-	connParams *WebsocketConnParams
-	listener   NewRequestListener
-	shutdown   <-chan struct{}
+	rpc            *Server
+	logger         log.StructuredLogger
+	connParams     *WebsocketConnParams
+	listener       NewRequestListener
+	shutdown       <-chan struct{}
+	requestTimeout time.Duration
 
 	// Add connection tracking
 	connSem *semaphore.Weighted
@@ -53,6 +54,11 @@ func (ws *Websocket) WithMaxConnections(maxConns int64) *Websocket {
 // WithConnParams sanity checks and applies the provided params.
 func (ws *Websocket) WithConnParams(p *WebsocketConnParams) *Websocket {
 	ws.connParams = p
+	return ws
+}
+
+func (ws *Websocket) WithRequestTimeout(d time.Duration) *Websocket {
+	ws.requestTimeout = d
 	return ws
 }
 
@@ -110,7 +116,7 @@ func (ws *Websocket) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			break
 		}
 		ws.listener.OnNewRequest("any")
-		if err = ws.rpc.HandleReadWriter(wsc.ctx, wsc); err != nil {
+		if err = ws.rpc.HandleReadWriter(wsc.ctx, ws.requestTimeout, wsc); err != nil {
 			break
 		}
 		// From websocket docs: "Read to EOF otherwise connection will hang."

--- a/jsonrpc/websocket_test.go
+++ b/jsonrpc/websocket_test.go
@@ -2,6 +2,7 @@ package jsonrpc_test
 
 import (
 	"context"
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -91,6 +92,172 @@ func TestSendFromHandler(t *testing.T) {
 	_, resp1, err := conn.Read(ctx)
 	require.NoError(t, err)
 	require.Equal(t, msg, string(resp1))
+
+	require.NoError(t, conn.Close(websocket.StatusNormalClosure, ""))
+}
+
+func TestWebsocketRequestTimeout(t *testing.T) {
+	t.Parallel()
+
+	echo := jsonrpc.Method{
+		Name:   "test_echo",
+		Params: []jsonrpc.Parameter{{Name: "msg"}},
+		Handler: func(msg string) (string, *jsonrpc.Error) {
+			return msg, nil
+		},
+	}
+	block := jsonrpc.Method{
+		Name: "test_block",
+		Handler: func(ctx context.Context) (string, *jsonrpc.Error) {
+			<-ctx.Done()
+			return "", jsonrpc.Err(jsonrpc.InternalError, ctx.Err().Error())
+		},
+	}
+
+	rpc := jsonrpc.NewServer(1, log.NewNopZapLogger())
+	require.NoError(t, rpc.RegisterMethods(echo, block))
+	ws := jsonrpc.NewWebsocket(rpc, nil, log.NewNopZapLogger()).
+		WithRequestTimeout(50 * time.Millisecond)
+	srv := httptest.NewServer(ws)
+	t.Cleanup(srv.Close)
+
+	conn, resp, err := websocket.Dial(t.Context(), srv.URL, nil) //nolint:bodyclose // lib closes Body
+	require.NoError(t, err)
+	require.Equal(t, http.StatusSwitchingProtocols, resp.StatusCode)
+
+	req := `{"jsonrpc" : "2.0", "method" : "test_block", "params":[], "id" : 1}`
+	require.NoError(t, conn.Write(t.Context(), websocket.MessageText, []byte(req)))
+	_, got, err := conn.Read(t.Context())
+	require.NoError(t, err)
+	assert.Contains(t, string(got), "context deadline exceeded")
+
+	req = `{"jsonrpc" : "2.0", "method" : "test_echo", "params" : [ "abc123" ], "id" : 2}`
+	require.NoError(t, conn.Write(t.Context(), websocket.MessageText, []byte(req)))
+	_, got, err = conn.Read(t.Context())
+	require.NoError(t, err)
+	assert.Equal(t, `{"jsonrpc":"2.0","result":"abc123","id":2}`, string(got))
+
+	require.NoError(t, conn.Close(websocket.StatusNormalClosure, ""))
+}
+
+func TestWebsocketBatchRequestSharesDeadline(t *testing.T) {
+	t.Parallel()
+
+	echo := jsonrpc.Method{
+		Name:   "test_echo",
+		Params: []jsonrpc.Parameter{{Name: "msg"}},
+		Handler: func(msg string) (string, *jsonrpc.Error) {
+			return msg, nil
+		},
+	}
+	block := jsonrpc.Method{
+		Name: "test_block",
+		Handler: func(ctx context.Context) (string, *jsonrpc.Error) {
+			<-ctx.Done()
+			return "", jsonrpc.Err(jsonrpc.InternalError, ctx.Err().Error())
+		},
+	}
+
+	rpc := jsonrpc.NewServer(2, log.NewNopZapLogger())
+	require.NoError(t, rpc.RegisterMethods(echo, block))
+	ws := jsonrpc.NewWebsocket(rpc, nil, log.NewNopZapLogger()).
+		WithRequestTimeout(50 * time.Millisecond)
+	srv := httptest.NewServer(ws)
+	t.Cleanup(srv.Close)
+
+	conn, resp, err := websocket.Dial(t.Context(), srv.URL, nil) //nolint:bodyclose // lib closes Body
+	require.NoError(t, err)
+	require.Equal(t, http.StatusSwitchingProtocols, resp.StatusCode)
+
+	req := `[{"jsonrpc":"2.0","method":"test_block","params":[],"id":1},` +
+		`{"jsonrpc":"2.0","method":"test_echo","params":["abc123"],"id":2}]`
+	require.NoError(t, conn.Write(t.Context(), websocket.MessageText, []byte(req)))
+	_, got, err := conn.Read(t.Context())
+	require.NoError(t, err)
+
+	var batch []json.RawMessage
+	require.NoError(t, json.Unmarshal(got, &batch))
+	require.Len(t, batch, 2)
+	assert.Contains(t, string(got), "context deadline exceeded")
+	assert.Contains(t, string(got), `"result":"abc123"`)
+
+	require.NoError(t, conn.Close(websocket.StatusNormalClosure, ""))
+}
+
+func TestWebsocketRequestTimeoutDisabled(t *testing.T) {
+	t.Parallel()
+
+	hasDeadline := jsonrpc.Method{
+		Name: "test_deadline",
+		Handler: func(ctx context.Context) (bool, *jsonrpc.Error) {
+			_, ok := ctx.Deadline()
+			return ok, nil
+		},
+	}
+
+	rpc := jsonrpc.NewServer(1, log.NewNopZapLogger())
+	require.NoError(t, rpc.RegisterMethods(hasDeadline))
+	ws := jsonrpc.NewWebsocket(rpc, nil, log.NewNopZapLogger()).WithRequestTimeout(0)
+	srv := httptest.NewServer(ws)
+	t.Cleanup(srv.Close)
+
+	conn, resp, err := websocket.Dial(t.Context(), srv.URL, nil) //nolint:bodyclose // lib closes Body
+	require.NoError(t, err)
+	require.Equal(t, http.StatusSwitchingProtocols, resp.StatusCode)
+
+	req := `{"jsonrpc" : "2.0", "method" : "test_deadline", "params":[], "id" : 1}`
+	require.NoError(t, conn.Write(t.Context(), websocket.MessageText, []byte(req)))
+	_, got, err := conn.Read(t.Context())
+	require.NoError(t, err)
+	assert.Equal(t, `{"jsonrpc":"2.0","result":false,"id":1}`, string(got))
+
+	require.NoError(t, conn.Close(websocket.StatusNormalClosure, ""))
+}
+
+func TestWebsocketConnOutlivesRequest(t *testing.T) {
+	t.Parallel()
+
+	wg := conc.NewWaitGroup()
+	t.Cleanup(wg.Wait)
+
+	method := jsonrpc.Method{
+		Name: "test_sub",
+		Handler: func(ctx context.Context) (int, *jsonrpc.Error) {
+			conn, ok := jsonrpc.ConnFromContext(ctx)
+			if !assert.True(t, ok) {
+				return 0, jsonrpc.Err(jsonrpc.InternalError, "no conn in context")
+			}
+			wg.Go(func() {
+				<-ctx.Done()
+				assert.NoError(t, conn.Context().Err())
+				_, werr := conn.Write([]byte("alive"))
+				assert.NoError(t, werr)
+			})
+			return 0, nil
+		},
+	}
+
+	rpc := jsonrpc.NewServer(1, log.NewNopZapLogger())
+	require.NoError(t, rpc.RegisterMethods(method))
+	ws := jsonrpc.NewWebsocket(rpc, nil, log.NewNopZapLogger()).
+		WithRequestTimeout(50 * time.Millisecond)
+	srv := httptest.NewServer(ws)
+	t.Cleanup(srv.Close)
+
+	conn, resp, err := websocket.Dial(t.Context(), srv.URL, nil) //nolint:bodyclose // lib closes Body
+	require.NoError(t, err)
+	require.Equal(t, http.StatusSwitchingProtocols, resp.StatusCode)
+
+	req := `{"jsonrpc" : "2.0", "method" : "test_sub", "params":[], "id" : 1}`
+	require.NoError(t, conn.Write(t.Context(), websocket.MessageText, []byte(req)))
+
+	_, got, err := conn.Read(t.Context())
+	require.NoError(t, err)
+	assert.Equal(t, `{"jsonrpc":"2.0","result":0,"id":1}`, string(got))
+
+	_, alive, err := conn.Read(t.Context())
+	require.NoError(t, err)
+	assert.Equal(t, "alive", string(alive))
 
 	require.NoError(t, conn.Close(websocket.StatusNormalClosure, ""))
 }

--- a/node/http.go
+++ b/node/http.go
@@ -147,8 +147,14 @@ func makeRPCOverHTTP(
 	return svc
 }
 
-func makeRPCOverWebsocket(host string, port uint16, servers map[string]*jsonrpc.Server,
-	logger log.StructuredLogger, metricsEnabled bool, corsEnabled bool,
+func makeRPCOverWebsocket(
+	host string,
+	port uint16,
+	servers map[string]*jsonrpc.Server,
+	logger log.StructuredLogger,
+	metricsEnabled bool,
+	corsEnabled bool,
+	rpcRequestTimeout time.Duration,
 ) *httpService {
 	var listener jsonrpc.NewRequestListener
 	if metricsEnabled {
@@ -159,7 +165,8 @@ func makeRPCOverWebsocket(host string, port uint16, servers map[string]*jsonrpc.
 
 	mux := http.NewServeMux()
 	for path, server := range servers {
-		wsHandler := jsonrpc.NewWebsocket(server, shutdown, logger)
+		wsHandler := jsonrpc.NewWebsocket(server, shutdown, logger).
+			WithRequestTimeout(rpcRequestTimeout)
 		if listener != nil {
 			wsHandler = wsHandler.WithListener(listener)
 		}

--- a/node/node.go
+++ b/node/node.go
@@ -576,6 +576,7 @@ func New(cfg *Config, version string, logLevel *log.Level) (*Node, error) {
 				logger,
 				cfg.Metrics,
 				cfg.RPCCorsEnable,
+				cfg.RPCRequestTimeout,
 			),
 		)
 	}

--- a/rpc/v10/subscription_events.go
+++ b/rpc/v10/subscription_events.go
@@ -29,17 +29,17 @@ func (h *Handler) SubscribeEvents(
 	blockID *SubscriptionBlockID,
 	finalityStatus *TxnFinalityStatusWithoutL1,
 ) (SubscriptionID, *jsonrpc.Error) {
-	w, ok := jsonrpc.ConnFromContext(ctx)
+	wsConn, ok := jsonrpc.ConnFromContext(ctx)
 	if !ok {
 		return "", jsonrpc.Err(jsonrpc.MethodNotFound, nil)
 	}
 
-	sub, rpcErr := newEventSubscriber(h, w, fromAddrs, keys, blockID, finalityStatus)
+	sub, rpcErr := newEventSubscriber(h, wsConn, fromAddrs, keys, blockID, finalityStatus)
 	if rpcErr != nil {
 		return "", rpcErr
 	}
 
-	return h.subscribe(ctx, w, sub)
+	return h.subscribe(wsConn, sub)
 }
 
 type SubscriptionEmittedEvent struct {
@@ -327,6 +327,6 @@ func (s *eventSubscriberState) sendFilteredEvent(
 	return sendEvent(s.conn, response, id)
 }
 
-func sendEvent(w jsonrpc.Conn, event *SubscriptionEmittedEvent, id string) error {
-	return sendResponse("starknet_subscriptionEvents", w, id, event)
+func sendEvent(wsConn jsonrpc.Conn, event *SubscriptionEmittedEvent, id string) error {
+	return sendResponse("starknet_subscriptionEvents", wsConn, id, event)
 }

--- a/rpc/v10/subscription_heads.go
+++ b/rpc/v10/subscription_heads.go
@@ -19,7 +19,7 @@ func (h *Handler) SubscribeNewHeads(
 	ctx context.Context,
 	blockID *SubscriptionBlockID,
 ) (SubscriptionID, *jsonrpc.Error) {
-	w, ok := jsonrpc.ConnFromContext(ctx)
+	wsConn, ok := jsonrpc.ConnFromContext(ctx)
 	if !ok {
 		return "", jsonrpc.Err(jsonrpc.MethodNotFound, nil)
 	}
@@ -29,7 +29,7 @@ func (h *Handler) SubscribeNewHeads(
 		return "", rpcErr
 	}
 
-	return h.subscribe(ctx, w, newHeadsSubscriber(h, w, startBlock, latestBlock))
+	return h.subscribe(wsConn, newHeadsSubscriber(h, wsConn, startBlock, latestBlock))
 }
 
 type headsSubscriberState struct {
@@ -109,6 +109,6 @@ func (s *headsSubscriberState) sendHistoricalHeaders(
 	return nil
 }
 
-func sendHeader(w jsonrpc.Conn, header *BlockHeader, id string) error {
-	return sendResponse("starknet_subscriptionNewHeads", w, id, header)
+func sendHeader(wsConn jsonrpc.Conn, header *BlockHeader, id string) error {
+	return sendResponse("starknet_subscriptionNewHeads", wsConn, id, header)
 }

--- a/rpc/v10/subscription_receipts.go
+++ b/rpc/v10/subscription_receipts.go
@@ -31,17 +31,17 @@ func (h *Handler) SubscribeNewTransactionReceipts(
 	senderAddress []felt.Address,
 	finalityStatuses []TxnFinalityStatusWithoutL1,
 ) (SubscriptionID, *jsonrpc.Error) {
-	w, ok := jsonrpc.ConnFromContext(ctx)
+	wsConn, ok := jsonrpc.ConnFromContext(ctx)
 	if !ok {
 		return "", jsonrpc.Err(jsonrpc.MethodNotFound, nil)
 	}
 
-	sub, rpcErr := newReceiptsSubscriber(w, senderAddress, finalityStatuses)
+	sub, rpcErr := newReceiptsSubscriber(wsConn, senderAddress, finalityStatuses)
 	if rpcErr != nil {
 		return "", rpcErr
 	}
 
-	return h.subscribe(ctx, w, sub)
+	return h.subscribe(wsConn, sub)
 }
 
 // receiptsSubscriberState is touched only by its single subscription dispatch
@@ -169,6 +169,6 @@ func receiptsOf(
 	}
 }
 
-func sendTransactionReceipt(w jsonrpc.Conn, receipt *TransactionReceipt, id string) error {
-	return sendResponse("starknet_subscriptionNewTransactionReceipts", w, id, receipt)
+func sendTransactionReceipt(wsConn jsonrpc.Conn, receipt *TransactionReceipt, id string) error {
+	return sendResponse("starknet_subscriptionNewTransactionReceipts", wsConn, id, receipt)
 }

--- a/rpc/v10/subscription_status.go
+++ b/rpc/v10/subscription_status.go
@@ -44,12 +44,12 @@ func (h *Handler) SubscribeTransactionStatus(
 	ctx context.Context,
 	txHash *felt.Felt,
 ) (SubscriptionID, *jsonrpc.Error) {
-	w, ok := jsonrpc.ConnFromContext(ctx)
+	wsConn, ok := jsonrpc.ConnFromContext(ctx)
 	if !ok {
 		return "", jsonrpc.Err(jsonrpc.MethodNotFound, nil)
 	}
 
-	return h.subscribe(ctx, w, newTxStatusSubscriber(h, w, txHash))
+	return h.subscribe(wsConn, newTxStatusSubscriber(h, wsConn, txHash))
 }
 
 type txStatusSubscriberState struct {
@@ -59,10 +59,10 @@ type txStatusSubscriberState struct {
 	lastStatus TxnStatus
 }
 
-func newTxStatusSubscriber(h *Handler, w jsonrpc.Conn, txHash *felt.Felt) subscriber {
+func newTxStatusSubscriber(h *Handler, wsConn jsonrpc.Conn, txHash *felt.Felt) subscriber {
 	state := &txStatusSubscriberState{
 		handler: h,
-		conn:    w,
+		conn:    wsConn,
 		txHash:  txHash,
 	}
 
@@ -209,6 +209,6 @@ func (s *txStatusSubscriberState) checkTxStatus(
 	return nil
 }
 
-func sendTxnStatus(w jsonrpc.Conn, status SubscriptionTransactionStatus, id string) error {
-	return sendResponse("starknet_subscriptionTransactionStatus", w, id, status)
+func sendTxnStatus(wsConn jsonrpc.Conn, status SubscriptionTransactionStatus, id string) error {
+	return sendResponse("starknet_subscriptionTransactionStatus", wsConn, id, status)
 }

--- a/rpc/v10/subscription_transactions.go
+++ b/rpc/v10/subscription_transactions.go
@@ -32,17 +32,17 @@ func (h *Handler) SubscribeNewTransactions(
 	senderAddr []felt.Address,
 	tags SubscriptionTags,
 ) (SubscriptionID, *jsonrpc.Error) {
-	w, ok := jsonrpc.ConnFromContext(ctx)
+	wsConn, ok := jsonrpc.ConnFromContext(ctx)
 	if !ok {
 		return "", jsonrpc.Err(jsonrpc.MethodNotFound, nil)
 	}
 
-	sub, rpcErr := newTransactionsSubscriber(w, finalityStatus, senderAddr, tags)
+	sub, rpcErr := newTransactionsSubscriber(wsConn, finalityStatus, senderAddr, tags)
 	if rpcErr != nil {
 		return "", rpcErr
 	}
 
-	return h.subscribe(ctx, w, sub)
+	return h.subscribe(wsConn, sub)
 }
 
 type SubscriptionNewTransaction struct {
@@ -203,6 +203,6 @@ func (s *transactionsSubscriberState) onReceivedTransaction(
 	return sendTransaction(s.conn, &response, id)
 }
 
-func sendTransaction(w jsonrpc.Conn, result *SubscriptionNewTransaction, id string) error {
-	return sendResponse("starknet_subscriptionNewTransaction", w, id, result)
+func sendTransaction(wsConn jsonrpc.Conn, result *SubscriptionNewTransaction, id string) error {
+	return sendResponse("starknet_subscriptionNewTransaction", wsConn, id, result)
 }

--- a/rpc/v10/subscriptions.go
+++ b/rpc/v10/subscriptions.go
@@ -51,16 +51,15 @@ func unsubscribeFeedSubscription[T any](sub *feed.Subscription[T]) {
 
 //nolint:gocyclo // select statement with multiple subscription cases
 func (h *Handler) subscribe(
-	ctx context.Context,
-	w jsonrpc.Conn,
+	wsConn jsonrpc.Conn,
 	subscriber subscriber,
 ) (SubscriptionID, *jsonrpc.Error) {
 	id := h.idgen()
 	//nolint:gosec // G118: cancel called in unsubscribe()
-	subscriptionCtx, subscriptionCtxCancel := context.WithCancel(ctx)
+	subscriptionCtx, subscriptionCtxCancel := context.WithCancel(wsConn.Context())
 	sub := &subscription{
 		cancel: subscriptionCtxCancel,
-		conn:   w,
+		conn:   wsConn,
 	}
 	h.subscriptions.Store(id, sub)
 
@@ -207,7 +206,7 @@ func (h *Handler) resolveBlockRange(
 }
 
 func (h *Handler) Unsubscribe(ctx context.Context, id string) (bool, *jsonrpc.Error) {
-	w, ok := jsonrpc.ConnFromContext(ctx)
+	wsConn, ok := jsonrpc.ConnFromContext(ctx)
 	if !ok {
 		return false, jsonrpc.Err(jsonrpc.MethodNotFound, nil)
 	}
@@ -217,7 +216,7 @@ func (h *Handler) Unsubscribe(ctx context.Context, id string) (bool, *jsonrpc.Er
 	}
 
 	subs := sub.(*subscription)
-	if !subs.conn.Equal(w) {
+	if !subs.conn.Equal(wsConn) {
 		return false, rpccore.ErrInvalidSubscriptionID
 	}
 
@@ -227,8 +226,8 @@ func (h *Handler) Unsubscribe(ctx context.Context, id string) (bool, *jsonrpc.Er
 	return true, nil
 }
 
-func sendReorg(w jsonrpc.Conn, reorg *sync.ReorgBlockRange, id string) error {
-	return sendResponse("starknet_subscriptionReorg", w, id, &ReorgEvent{
+func sendReorg(wsConn jsonrpc.Conn, reorg *sync.ReorgBlockRange, id string) error {
+	return sendResponse("starknet_subscriptionReorg", wsConn, id, &ReorgEvent{
 		StartBlockHash: reorg.StartBlockHash,
 		StartBlockNum:  reorg.StartBlockNum,
 		EndBlockHash:   reorg.EndBlockHash,
@@ -236,7 +235,7 @@ func sendReorg(w jsonrpc.Conn, reorg *sync.ReorgBlockRange, id string) error {
 	})
 }
 
-func sendResponse(method string, w jsonrpc.Conn, id string, result any) error {
+func sendResponse(method string, wsConn jsonrpc.Conn, id string, result any) error {
 	resp, err := json.Marshal(SubscriptionResponse{
 		Version: "2.0",
 		Method:  method,
@@ -248,6 +247,6 @@ func sendResponse(method string, w jsonrpc.Conn, id string, result any) error {
 	if err != nil {
 		return err
 	}
-	_, err = w.Write(resp)
+	_, err = wsConn.Write(resp)
 	return err
 }

--- a/rpc/v10/subscriptions_test.go
+++ b/rpc/v10/subscriptions_test.go
@@ -45,7 +45,8 @@ func mustNewChain(t *testing.T, entries ...*pending.PreConfirmed) preconfirmed.C
 
 type fakeConn struct {
 	net.Conn
-	w io.Writer
+	w   io.Writer
+	ctx context.Context
 }
 
 func (fc *fakeConn) Write(p []byte) (int, error) {
@@ -58,6 +59,10 @@ func (fc *fakeConn) Equal(other jsonrpc.Conn) bool {
 		return false
 	}
 	return fc.w == fc2.w
+}
+
+func (fc *fakeConn) Context() context.Context {
+	return fc.ctx
 }
 
 type fakeSyncer struct {
@@ -2848,9 +2853,11 @@ func createTestWebsocket(
 
 	ctx, cancel := context.WithCancel(t.Context())
 	// Create fakeConn embedding clientConn for net.Conn methods, using serverConn for writing
-	fakeConn := &fakeConn{Conn: clientConn, w: serverConn}
-	subCtx := context.WithValue(ctx, jsonrpc.ConnKey{}, fakeConn)
+	fakeConn := &fakeConn{Conn: clientConn, w: serverConn, ctx: ctx}
+	reqCtx, reqCancel := context.WithCancel(ctx)
+	subCtx := context.WithValue(reqCtx, jsonrpc.ConnKey{}, fakeConn)
 	id, rpcErr := subscribe(subCtx)
+	reqCancel()
 	require.Nil(t, rpcErr)
 
 	t.Cleanup(func() {

--- a/rpc/v8/subscriptions.go
+++ b/rpc/v8/subscriptions.go
@@ -115,16 +115,15 @@ func (h *Handler) unsubscribe(sub *subscription, id string) {
 }
 
 func (h *Handler) subscribe(
-	ctx context.Context,
-	w jsonrpc.Conn,
+	wsConn jsonrpc.Conn,
 	subscriber subscriber,
 ) (SubscriptionID, *jsonrpc.Error) {
 	id := h.idgen()
 	//nolint:gosec // G118: cancel called in unsubscribe()
-	subscriptionCtx, subscriptionCtxCancel := context.WithCancel(ctx)
+	subscriptionCtx, subscriptionCtxCancel := context.WithCancel(wsConn.Context())
 	sub := &subscription{
 		cancel: subscriptionCtxCancel,
-		conn:   w,
+		conn:   wsConn,
 	}
 	h.subscriptions.Store(id, sub)
 
@@ -180,7 +179,7 @@ func (h *Handler) SubscribeEvents(
 	keys [][]felt.Felt,
 	blockID *SubscriptionBlockID,
 ) (SubscriptionID, *jsonrpc.Error) {
-	w, ok := jsonrpc.ConnFromContext(ctx)
+	wsConn, ok := jsonrpc.ConnFromContext(ctx)
 	if !ok {
 		return "", jsonrpc.Err(jsonrpc.MethodNotFound, nil)
 	}
@@ -206,13 +205,13 @@ func (h *Handler) SubscribeEvents(
 			fromB := BlockIDFromNumber(requestedHeader.Number)
 			toB := BlockIDFromNumber(headHeader.Number)
 			return h.processEvents(
-				ctx, w, id, &fromB, &toB, fromAddr, keys, headHeader.Number,
+				ctx, wsConn, id, &fromB, &toB, fromAddr, keys, headHeader.Number,
 			)
 		},
 		onReorg: func(
 			ctx context.Context, id string, _ *subscription, reorg *sync.ReorgBlockRange,
 		) error {
-			if err := sendReorg(w, reorg, id); err != nil {
+			if err := sendReorg(wsConn, reorg, id); err != nil {
 				return err
 			}
 			nextBlock = reorg.StartBlockNum
@@ -222,7 +221,7 @@ func (h *Handler) SubscribeEvents(
 			fromB := BlockIDFromNumber(nextBlock)
 			toB := BlockIDFromNumber(head.Number)
 			err := h.processEvents(
-				ctx, w, id, &fromB, &toB, fromAddr, keys, head.Number,
+				ctx, wsConn, id, &fromB, &toB, fromAddr, keys, head.Number,
 			)
 			if err != nil {
 				return err
@@ -231,14 +230,14 @@ func (h *Handler) SubscribeEvents(
 			return nil
 		},
 	}
-	return h.subscribe(ctx, w, subscriber)
+	return h.subscribe(wsConn, subscriber)
 }
 
 // SubscribeTransactionStatus subscribes to status changes of a transaction. It checks for updates each time a new block is added.
 // Later updates are sent only when the transaction status changes.
 // The optional block_id parameter is ignored, as status changes are not stored and historical data cannot be sent.
 func (h *Handler) SubscribeTransactionStatus(ctx context.Context, txHash *felt.Felt) (SubscriptionID, *jsonrpc.Error) {
-	w, ok := jsonrpc.ConnFromContext(ctx)
+	wsConn, ok := jsonrpc.ConnFromContext(ctx)
 	if !ok {
 		return "", jsonrpc.Err(jsonrpc.MethodNotFound, nil)
 	}
@@ -254,7 +253,7 @@ func (h *Handler) SubscribeTransactionStatus(ctx context.Context, txHash *felt.F
 			return nil
 		},
 		onReorg: func(ctx context.Context, id string, _ *subscription, reorg *sync.ReorgBlockRange) error {
-			return sendReorg(w, reorg, id)
+			return sendReorg(wsConn, reorg, id)
 		},
 		onNewHead: func(ctx context.Context, id string, sub *subscription, head *core.Block) error {
 			if lastStatus < TxnStatusAcceptedOnL2 {
@@ -271,7 +270,7 @@ func (h *Handler) SubscribeTransactionStatus(ctx context.Context, txHash *felt.F
 			return nil
 		},
 	}
-	return h.subscribe(ctx, w, subscriber)
+	return h.subscribe(wsConn, subscriber)
 }
 
 // If the error is transaction not found that means the transaction has not been submitted to the feeder gateway,
@@ -334,7 +333,7 @@ func (h *Handler) checkTxStatus(
 // processEvents queries database for events and stream filtered events.
 func (h *Handler) processEvents(
 	ctx context.Context,
-	w jsonrpc.Conn,
+	wsConn jsonrpc.Conn,
 	id string,
 	from, to *BlockID,
 	fromAddr *felt.Address,
@@ -371,7 +370,7 @@ func (h *Handler) processEvents(
 		return err
 	}
 
-	err = sendEvents(ctx, w, filteredEvents, id)
+	err = sendEvents(ctx, wsConn, filteredEvents, id)
 	if err != nil {
 		return err
 	}
@@ -382,7 +381,7 @@ func (h *Handler) processEvents(
 			return err
 		}
 
-		err = sendEvents(ctx, w, filteredEvents, id)
+		err = sendEvents(ctx, wsConn, filteredEvents, id)
 		if err != nil {
 			return err
 		}
@@ -392,7 +391,7 @@ func (h *Handler) processEvents(
 
 func sendEvents(
 	ctx context.Context,
-	w jsonrpc.Conn,
+	wsConn jsonrpc.Conn,
 	events []blockchain.FilteredEvent,
 	id string,
 ) error {
@@ -412,7 +411,7 @@ func sendEvents(
 				},
 			}
 
-			if err := sendResponse("starknet_subscriptionEvents", w, id, emittedEvent); err != nil {
+			if err := sendResponse("starknet_subscriptionEvents", wsConn, id, emittedEvent); err != nil {
 				return err
 			}
 		}
@@ -422,7 +421,7 @@ func sendEvents(
 
 // SubscribeNewHeads creates a WebSocket stream which will fire events when a new block header is added.
 func (h *Handler) SubscribeNewHeads(ctx context.Context, blockID *SubscriptionBlockID) (SubscriptionID, *jsonrpc.Error) {
-	w, ok := jsonrpc.ConnFromContext(ctx)
+	wsConn, ok := jsonrpc.ConnFromContext(ctx)
 	if !ok {
 		return "", jsonrpc.Err(jsonrpc.MethodNotFound, nil)
 	}
@@ -434,23 +433,23 @@ func (h *Handler) SubscribeNewHeads(ctx context.Context, blockID *SubscriptionBl
 
 	subscriber := subscriber{
 		onStart: func(ctx context.Context, id string, _ *subscription, _ any) error {
-			return h.sendHistoricalHeaders(ctx, startHeader, latestHeader, w, id)
+			return h.sendHistoricalHeaders(ctx, startHeader, latestHeader, wsConn, id)
 		},
 		onReorg: func(ctx context.Context, id string, _ *subscription, reorg *sync.ReorgBlockRange) error {
-			return sendReorg(w, reorg, id)
+			return sendReorg(wsConn, reorg, id)
 		},
 		onNewHead: func(ctx context.Context, id string, _ *subscription, head *core.Block) error {
-			return sendHeader(w, head.Header, id)
+			return sendHeader(wsConn, head.Header, id)
 		},
 	}
-	return h.subscribe(ctx, w, subscriber)
+	return h.subscribe(wsConn, subscriber)
 }
 
 // SubscribePendingTxs creates a WebSocket stream which will fire events when a new pending transaction is added.
 // The getDetails flag controls if the response will contain the transaction details or just the transaction hashes.
 // The senderAddr flag is used to filter the transactions by sender address.
 func (h *Handler) SubscribePendingTxs(ctx context.Context, getDetails *bool, senderAddr []felt.Felt) (SubscriptionID, *jsonrpc.Error) {
-	w, ok := jsonrpc.ConnFromContext(ctx)
+	wsConn, ok := jsonrpc.ConnFromContext(ctx)
 	if !ok {
 		return "", jsonrpc.Err(jsonrpc.MethodNotFound, nil)
 	}
@@ -465,19 +464,21 @@ func (h *Handler) SubscribePendingTxs(ctx context.Context, getDetails *bool, sen
 	subscriber := subscriber{
 		onStart: func(ctx context.Context, id string, _ *subscription, _ any) error {
 			if pending := h.PendingBlock(); pending != nil {
-				return h.onPendingBlock(id, w, getDetails, senderAddr, pending, &lastParentHash, sentTxHashes)
+				return h.onPendingBlock(
+					id, wsConn, getDetails, senderAddr, pending, &lastParentHash, sentTxHashes,
+				)
 			}
 			return nil
 		},
 	}
-	return h.subscribe(ctx, w, subscriber)
+	return h.subscribe(wsConn, subscriber)
 }
 
 // If getDetails is true, response will contain the transaction details.
 // If getDetails is false, response will only contain the transaction hashes.
 func (h *Handler) onPendingBlock(
 	id string,
-	w jsonrpc.Conn,
+	wsConn jsonrpc.Conn,
 	getDetails *bool,
 	senderAddr []felt.Felt,
 	pending *core.Block,
@@ -499,7 +500,7 @@ func (h *Handler) onPendingBlock(
 	for _, txn := range pending.Transactions {
 		if _, exist := sentTxHashes[*txn.Hash()]; !exist {
 			if h.filterTxBySender(txn, senderAddr) {
-				if err := sendPendingTxs(w, toResult(txn), id); err != nil {
+				if err := sendPendingTxs(wsConn, toResult(txn), id); err != nil {
 					return err
 				}
 			}
@@ -544,8 +545,8 @@ func (h *Handler) filterTxBySender(txn core.Transaction, senderAddr []felt.Felt)
 	return false
 }
 
-func sendPendingTxs(w jsonrpc.Conn, result any, id string) error {
-	return sendResponse("starknet_subscriptionPendingTransactions", w, id, result)
+func sendPendingTxs(wsConn jsonrpc.Conn, result any, id string) error {
+	return sendResponse("starknet_subscriptionPendingTransactions", wsConn, id, result)
 }
 
 // resolveBlockRange returns the start and latest headers based on the blockID.
@@ -579,7 +580,7 @@ func (h *Handler) resolveBlockRange(
 func (h *Handler) sendHistoricalHeaders(
 	ctx context.Context,
 	startHeader, latestHeader *core.Header,
-	w jsonrpc.Conn,
+	wsConn jsonrpc.Conn,
 	id string,
 ) error {
 	var (
@@ -592,7 +593,7 @@ func (h *Handler) sendHistoricalHeaders(
 		case <-ctx.Done():
 			return ctx.Err()
 		default:
-			if err := sendHeader(w, curHeader, id); err != nil {
+			if err := sendHeader(wsConn, curHeader, id); err != nil {
 				return err
 			}
 
@@ -609,8 +610,8 @@ func (h *Handler) sendHistoricalHeaders(
 }
 
 // sendHeader creates a request and sends it to the client
-func sendHeader(w jsonrpc.Conn, header *core.Header, id string) error {
-	return sendResponse("starknet_subscriptionNewHeads", w, id, adaptBlockHeader(header))
+func sendHeader(wsConn jsonrpc.Conn, header *core.Header, id string) error {
+	return sendResponse("starknet_subscriptionNewHeads", wsConn, id, adaptBlockHeader(header))
 }
 
 type ReorgEvent struct {
@@ -620,8 +621,8 @@ type ReorgEvent struct {
 	EndBlockNum    uint64     `json:"ending_block_number"`
 }
 
-func sendReorg(w jsonrpc.Conn, reorg *sync.ReorgBlockRange, id string) error {
-	return sendResponse("starknet_subscriptionReorg", w, id, &ReorgEvent{
+func sendReorg(wsConn jsonrpc.Conn, reorg *sync.ReorgBlockRange, id string) error {
+	return sendResponse("starknet_subscriptionReorg", wsConn, id, &ReorgEvent{
 		StartBlockHash: reorg.StartBlockHash,
 		StartBlockNum:  reorg.StartBlockNum,
 		EndBlockHash:   reorg.EndBlockHash,
@@ -630,7 +631,7 @@ func sendReorg(w jsonrpc.Conn, reorg *sync.ReorgBlockRange, id string) error {
 }
 
 func (h *Handler) Unsubscribe(ctx context.Context, id string) (bool, *jsonrpc.Error) {
-	w, ok := jsonrpc.ConnFromContext(ctx)
+	wsConn, ok := jsonrpc.ConnFromContext(ctx)
 	if !ok {
 		return false, jsonrpc.Err(jsonrpc.MethodNotFound, nil)
 	}
@@ -640,7 +641,7 @@ func (h *Handler) Unsubscribe(ctx context.Context, id string) (bool, *jsonrpc.Er
 	}
 
 	subs := sub.(*subscription)
-	if !subs.conn.Equal(w) {
+	if !subs.conn.Equal(wsConn) {
 		return false, rpccore.ErrInvalidSubscriptionID
 	}
 
@@ -656,11 +657,11 @@ type SubscriptionTransactionStatus struct {
 }
 
 // sendTxnStatus creates a response and sends it to the client
-func sendTxnStatus(w jsonrpc.Conn, status SubscriptionTransactionStatus, id string) error {
-	return sendResponse("starknet_subscriptionTransactionStatus", w, id, status)
+func sendTxnStatus(wsConn jsonrpc.Conn, status SubscriptionTransactionStatus, id string) error {
+	return sendResponse("starknet_subscriptionTransactionStatus", wsConn, id, status)
 }
 
-func sendResponse(method string, w jsonrpc.Conn, id string, result any) error {
+func sendResponse(method string, wsConn jsonrpc.Conn, id string, result any) error {
 	resp, err := json.Marshal(SubscriptionResponse{
 		Version: "2.0",
 		Method:  method,
@@ -672,6 +673,6 @@ func sendResponse(method string, w jsonrpc.Conn, id string, result any) error {
 	if err != nil {
 		return err
 	}
-	_, err = w.Write(resp)
+	_, err = wsConn.Write(resp)
 	return err
 }

--- a/rpc/v8/subscriptions_test.go
+++ b/rpc/v8/subscriptions_test.go
@@ -37,7 +37,8 @@ import (
 var emptyCommitments = core.BlockCommitments{}
 
 type fakeConn struct {
-	w io.Writer
+	w   io.Writer
+	ctx context.Context
 }
 
 func (fc *fakeConn) Write(p []byte) (int, error) {
@@ -50,6 +51,10 @@ func (fc *fakeConn) Equal(other jsonrpc.Conn) bool {
 		return false
 	}
 	return fc.w == fc2.w
+}
+
+func (fc *fakeConn) Context() context.Context {
+	return fc.ctx
 }
 
 func TestSubscribeEvents(t *testing.T) {
@@ -1237,8 +1242,10 @@ func createTestWebsocket(t *testing.T, subscribe func(context.Context) (Subscrip
 	serverConn, clientConn := net.Pipe()
 
 	ctx, cancel := context.WithCancel(t.Context())
-	subCtx := context.WithValue(ctx, jsonrpc.ConnKey{}, &fakeConn{w: serverConn})
+	reqCtx, reqCancel := context.WithCancel(ctx)
+	subCtx := context.WithValue(reqCtx, jsonrpc.ConnKey{}, &fakeConn{w: serverConn, ctx: ctx})
 	id, rpcErr := subscribe(subCtx)
+	reqCancel()
 	require.Nil(t, rpcErr)
 
 	t.Cleanup(func() {

--- a/rpc/v9/subscription_events.go
+++ b/rpc/v9/subscription_events.go
@@ -29,17 +29,17 @@ func (h *Handler) SubscribeEvents(
 	blockID *SubscriptionBlockID,
 	finalityStatus *TxnFinalityStatusWithoutL1,
 ) (SubscriptionID, *jsonrpc.Error) {
-	w, ok := jsonrpc.ConnFromContext(ctx)
+	wsConn, ok := jsonrpc.ConnFromContext(ctx)
 	if !ok {
 		return "", jsonrpc.Err(jsonrpc.MethodNotFound, nil)
 	}
 
-	sub, rpcErr := newEventSubscriber(h, w, fromAddr, keys, blockID, finalityStatus)
+	sub, rpcErr := newEventSubscriber(h, wsConn, fromAddr, keys, blockID, finalityStatus)
 	if rpcErr != nil {
 		return "", rpcErr
 	}
 
-	return h.subscribe(ctx, w, sub)
+	return h.subscribe(wsConn, sub)
 }
 
 type SubscriptionEmittedEvent struct {
@@ -345,6 +345,6 @@ func (s *eventSubscriberState) sendFilteredEvent(
 	return sendEvent(s.conn, response, id)
 }
 
-func sendEvent(w jsonrpc.Conn, event *SubscriptionEmittedEvent, id string) error {
-	return sendResponse("starknet_subscriptionEvents", w, id, event)
+func sendEvent(wsConn jsonrpc.Conn, event *SubscriptionEmittedEvent, id string) error {
+	return sendResponse("starknet_subscriptionEvents", wsConn, id, event)
 }

--- a/rpc/v9/subscription_heads.go
+++ b/rpc/v9/subscription_heads.go
@@ -19,7 +19,7 @@ func (h *Handler) SubscribeNewHeads(
 	ctx context.Context,
 	blockID *SubscriptionBlockID,
 ) (SubscriptionID, *jsonrpc.Error) {
-	w, ok := jsonrpc.ConnFromContext(ctx)
+	wsConn, ok := jsonrpc.ConnFromContext(ctx)
 	if !ok {
 		return "", jsonrpc.Err(jsonrpc.MethodNotFound, nil)
 	}
@@ -29,7 +29,7 @@ func (h *Handler) SubscribeNewHeads(
 		return "", rpcErr
 	}
 
-	return h.subscribe(ctx, w, newHeadsSubscriber(h, w, startBlock, latestBlock))
+	return h.subscribe(wsConn, newHeadsSubscriber(h, wsConn, startBlock, latestBlock))
 }
 
 type headsSubscriberState struct {
@@ -97,6 +97,6 @@ func (s *headsSubscriberState) sendHistoricalHeaders(
 	return nil
 }
 
-func sendHeader(w jsonrpc.Conn, header *core.Header, id string) error {
-	return sendResponse("starknet_subscriptionNewHeads", w, id, AdaptBlockHeader(header))
+func sendHeader(wsConn jsonrpc.Conn, header *core.Header, id string) error {
+	return sendResponse("starknet_subscriptionNewHeads", wsConn, id, AdaptBlockHeader(header))
 }

--- a/rpc/v9/subscription_receipts.go
+++ b/rpc/v9/subscription_receipts.go
@@ -30,17 +30,17 @@ func (h *Handler) SubscribeNewTransactionReceipts(
 	senderAddress []felt.Felt,
 	finalityStatuses []TxnFinalityStatusWithoutL1,
 ) (SubscriptionID, *jsonrpc.Error) {
-	w, ok := jsonrpc.ConnFromContext(ctx)
+	wsConn, ok := jsonrpc.ConnFromContext(ctx)
 	if !ok {
 		return "", jsonrpc.Err(jsonrpc.MethodNotFound, nil)
 	}
 
-	sub, rpcErr := newReceiptsSubscriber(w, senderAddress, finalityStatuses)
+	sub, rpcErr := newReceiptsSubscriber(wsConn, senderAddress, finalityStatuses)
 	if rpcErr != nil {
 		return "", rpcErr
 	}
 
-	return h.subscribe(ctx, w, sub)
+	return h.subscribe(wsConn, sub)
 }
 
 // receiptsSubscriberState is touched only by its single subscription dispatch
@@ -168,6 +168,6 @@ func receiptsOf(
 	}
 }
 
-func sendTransactionReceipt(w jsonrpc.Conn, receipt *TransactionReceipt, id string) error {
-	return sendResponse("starknet_subscriptionNewTransactionReceipts", w, id, receipt)
+func sendTransactionReceipt(wsConn jsonrpc.Conn, receipt *TransactionReceipt, id string) error {
+	return sendResponse("starknet_subscriptionNewTransactionReceipts", wsConn, id, receipt)
 }

--- a/rpc/v9/subscription_status.go
+++ b/rpc/v9/subscription_status.go
@@ -44,12 +44,12 @@ func (h *Handler) SubscribeTransactionStatus(
 	ctx context.Context,
 	txHash *felt.Felt,
 ) (SubscriptionID, *jsonrpc.Error) {
-	w, ok := jsonrpc.ConnFromContext(ctx)
+	wsConn, ok := jsonrpc.ConnFromContext(ctx)
 	if !ok {
 		return "", jsonrpc.Err(jsonrpc.MethodNotFound, nil)
 	}
 
-	return h.subscribe(ctx, w, newTxStatusSubscriber(h, w, txHash))
+	return h.subscribe(wsConn, newTxStatusSubscriber(h, wsConn, txHash))
 }
 
 type SubscriptionTransactionStatus struct {
@@ -64,10 +64,10 @@ type txStatusSubscriberState struct {
 	lastStatus TxnStatus
 }
 
-func newTxStatusSubscriber(h *Handler, w jsonrpc.Conn, txHash *felt.Felt) subscriber {
+func newTxStatusSubscriber(h *Handler, wsConn jsonrpc.Conn, txHash *felt.Felt) subscriber {
 	state := &txStatusSubscriberState{
 		handler: h,
-		conn:    w,
+		conn:    wsConn,
 		txHash:  txHash,
 	}
 
@@ -214,6 +214,6 @@ func (s *txStatusSubscriberState) checkTxStatus(
 	return nil
 }
 
-func sendTxnStatus(w jsonrpc.Conn, status SubscriptionTransactionStatus, id string) error {
-	return sendResponse("starknet_subscriptionTransactionStatus", w, id, status)
+func sendTxnStatus(wsConn jsonrpc.Conn, status SubscriptionTransactionStatus, id string) error {
+	return sendResponse("starknet_subscriptionTransactionStatus", wsConn, id, status)
 }

--- a/rpc/v9/subscription_transactions.go
+++ b/rpc/v9/subscription_transactions.go
@@ -31,17 +31,17 @@ func (h *Handler) SubscribeNewTransactions(
 	finalityStatus []TxnStatusWithoutL1,
 	senderAddr []felt.Felt,
 ) (SubscriptionID, *jsonrpc.Error) {
-	w, ok := jsonrpc.ConnFromContext(ctx)
+	wsConn, ok := jsonrpc.ConnFromContext(ctx)
 	if !ok {
 		return "", jsonrpc.Err(jsonrpc.MethodNotFound, nil)
 	}
 
-	sub, rpcErr := newTransactionsSubscriber(w, finalityStatus, senderAddr)
+	sub, rpcErr := newTransactionsSubscriber(wsConn, finalityStatus, senderAddr)
 	if rpcErr != nil {
 		return "", rpcErr
 	}
 
-	return h.subscribe(ctx, w, sub)
+	return h.subscribe(wsConn, sub)
 }
 
 type SubscriptionNewTransaction struct {
@@ -196,6 +196,6 @@ func (s *transactionsSubscriberState) onReceivedTransaction(
 	return sendTransaction(s.conn, &response, id)
 }
 
-func sendTransaction(w jsonrpc.Conn, result *SubscriptionNewTransaction, id string) error {
-	return sendResponse("starknet_subscriptionNewTransaction", w, id, result)
+func sendTransaction(wsConn jsonrpc.Conn, result *SubscriptionNewTransaction, id string) error {
+	return sendResponse("starknet_subscriptionNewTransaction", wsConn, id, result)
 }

--- a/rpc/v9/subscriptions.go
+++ b/rpc/v9/subscriptions.go
@@ -103,16 +103,15 @@ func unsubscribeFeedSubscription[T any](sub *feed.Subscription[T]) {
 
 //nolint:gocyclo // select statement with multiple subscription cases
 func (h *Handler) subscribe(
-	ctx context.Context,
-	w jsonrpc.Conn,
+	wsConn jsonrpc.Conn,
 	subscriber subscriber,
 ) (SubscriptionID, *jsonrpc.Error) {
 	id := h.idgen()
 	//nolint:gosec // G118: cancel called in unsubscribe()
-	subscriptionCtx, subscriptionCtxCancel := context.WithCancel(ctx)
+	subscriptionCtx, subscriptionCtxCancel := context.WithCancel(wsConn.Context())
 	sub := &subscription{
 		cancel: subscriptionCtxCancel,
-		conn:   w,
+		conn:   wsConn,
 	}
 	h.subscriptions.Store(id, sub)
 
@@ -256,7 +255,7 @@ type ReorgEvent struct {
 }
 
 func (h *Handler) Unsubscribe(ctx context.Context, id string) (bool, *jsonrpc.Error) {
-	w, ok := jsonrpc.ConnFromContext(ctx)
+	wsConn, ok := jsonrpc.ConnFromContext(ctx)
 	if !ok {
 		return false, jsonrpc.Err(jsonrpc.MethodNotFound, nil)
 	}
@@ -266,7 +265,7 @@ func (h *Handler) Unsubscribe(ctx context.Context, id string) (bool, *jsonrpc.Er
 	}
 
 	subs := sub.(*subscription)
-	if !subs.conn.Equal(w) {
+	if !subs.conn.Equal(wsConn) {
 		return false, rpccore.ErrInvalidSubscriptionID
 	}
 
@@ -338,8 +337,8 @@ func (s TxnStatusWithoutL1) MarshalText() ([]byte, error) {
 	}
 }
 
-func sendReorg(w jsonrpc.Conn, reorg *sync.ReorgBlockRange, id string) error {
-	return sendResponse("starknet_subscriptionReorg", w, id, &ReorgEvent{
+func sendReorg(wsConn jsonrpc.Conn, reorg *sync.ReorgBlockRange, id string) error {
+	return sendResponse("starknet_subscriptionReorg", wsConn, id, &ReorgEvent{
 		StartBlockHash: reorg.StartBlockHash,
 		StartBlockNum:  reorg.StartBlockNum,
 		EndBlockHash:   reorg.EndBlockHash,
@@ -347,7 +346,7 @@ func sendReorg(w jsonrpc.Conn, reorg *sync.ReorgBlockRange, id string) error {
 	})
 }
 
-func sendResponse(method string, w jsonrpc.Conn, id string, result any) error {
+func sendResponse(method string, wsConn jsonrpc.Conn, id string, result any) error {
 	resp, err := json.Marshal(SubscriptionResponse{
 		Version: "2.0",
 		Method:  method,
@@ -359,6 +358,6 @@ func sendResponse(method string, w jsonrpc.Conn, id string, result any) error {
 	if err != nil {
 		return err
 	}
-	_, err = w.Write(resp)
+	_, err = wsConn.Write(resp)
 	return err
 }

--- a/rpc/v9/subscriptions_test.go
+++ b/rpc/v9/subscriptions_test.go
@@ -46,7 +46,8 @@ func mustNewChain(t *testing.T, entries ...*pending.PreConfirmed) preconfirmed.C
 }
 
 type fakeConn struct {
-	w io.Writer
+	w   io.Writer
+	ctx context.Context
 }
 
 func (fc *fakeConn) Write(p []byte) (int, error) {
@@ -59,6 +60,10 @@ func (fc *fakeConn) Equal(other jsonrpc.Conn) bool {
 		return false
 	}
 	return fc.w == fc2.w
+}
+
+func (fc *fakeConn) Context() context.Context {
+	return fc.ctx
 }
 
 type fakeSyncer struct {
@@ -2477,8 +2482,10 @@ func createTestWebsocket(t *testing.T, subscribe func(context.Context) (Subscrip
 	serverConn, clientConn := net.Pipe()
 
 	ctx, cancel := context.WithCancel(t.Context())
-	subCtx := context.WithValue(ctx, jsonrpc.ConnKey{}, &fakeConn{w: serverConn})
+	reqCtx, reqCancel := context.WithCancel(ctx)
+	subCtx := context.WithValue(reqCtx, jsonrpc.ConnKey{}, &fakeConn{w: serverConn, ctx: ctx})
 	id, rpcErr := subscribe(subCtx)
+	reqCancel()
 	require.Nil(t, rpcErr)
 
 	t.Cleanup(func() {


### PR DESCRIPTION
## Summary
- Add a configurable request timeout for websocket RPC requests
- Wire the timeout through node startup and HTTP/WS server setup
- Update v8/v9/v10 subscription handlers accordingly
- Add tests covering the new websocket timeout behavior