### PR TITLE
Remove dead deprecated get_transaction code path

### DIFF
--- a/adapters/sn2core/sn2core_test.go
+++ b/adapters/sn2core/sn2core_test.go
@@ -296,15 +296,9 @@ func TestClassV0(t *testing.T) {
 }
 
 func TestTransaction(t *testing.T) {
-	clientGoerli := feeder.NewTestClient(t, &networks.Goerli)
-	clientMainnet := feeder.NewTestClient(t, &networks.Mainnet)
-	ctx := t.Context()
-
 	t.Run("invoke transaction", func(t *testing.T) {
 		hash := felt.NewUnsafeFromString[felt.Felt]("0x7e3a229febf47c6edfd96582d9476dd91a58a5ba3df4553ae448a14a2f132d9")
-		response, err := clientGoerli.Transaction(ctx, hash)
-		require.NoError(t, err)
-		responseTx := response.Transaction
+		responseTx := feeder.TransactionFromTestData(t, &networks.Goerli, hash)
 
 		txn, err := sn2core.AdaptTransaction(responseTx)
 		require.NoError(t, err)
@@ -324,9 +318,7 @@ func TestTransaction(t *testing.T) {
 
 	t.Run("deploy transaction", func(t *testing.T) {
 		hash := felt.NewUnsafeFromString[felt.Felt]("0x15b51c2f4880b1e7492d30ada7254fc59c09adde636f37eb08cdadbd9dabebb")
-		response, err := clientGoerli.Transaction(ctx, hash)
-		require.NoError(t, err)
-		responseTx := response.Transaction
+		responseTx := feeder.TransactionFromTestData(t, &networks.Goerli, hash)
 
 		txn, err := sn2core.AdaptTransaction(responseTx)
 		require.NoError(t, err)
@@ -344,9 +336,7 @@ func TestTransaction(t *testing.T) {
 
 	t.Run("deploy account transaction", func(t *testing.T) {
 		hash := felt.NewUnsafeFromString[felt.Felt]("0xd61fc89f4d1dc4dc90a014957d655d38abffd47ecea8e3fa762e3160f155f2")
-		response, err := clientMainnet.Transaction(ctx, hash)
-		require.NoError(t, err)
-		responseTx := response.Transaction
+		responseTx := feeder.TransactionFromTestData(t, &networks.Mainnet, hash)
 
 		txn, err := sn2core.AdaptTransaction(responseTx)
 		require.NoError(t, err)
@@ -367,9 +357,7 @@ func TestTransaction(t *testing.T) {
 
 	t.Run("declare transaction", func(t *testing.T) {
 		hash := felt.NewUnsafeFromString[felt.Felt]("0x6eab8252abfc9bbfd72c8d592dde4018d07ce467c5ce922519d7142fcab203f")
-		response, err := clientGoerli.Transaction(ctx, hash)
-		require.NoError(t, err)
-		responseTx := response.Transaction
+		responseTx := feeder.TransactionFromTestData(t, &networks.Goerli, hash)
 
 		txn, err := sn2core.AdaptTransaction(responseTx)
 		require.NoError(t, err)
@@ -388,9 +376,7 @@ func TestTransaction(t *testing.T) {
 
 	t.Run("l1handler transaction", func(t *testing.T) {
 		hash := felt.NewUnsafeFromString[felt.Felt]("0x537eacfd3c49166eec905daff61ff7feef9c133a049ea2135cb94eec840a4a8")
-		response, err := clientMainnet.Transaction(ctx, hash)
-		require.NoError(t, err)
-		responseTx := response.Transaction
+		responseTx := feeder.TransactionFromTestData(t, &networks.Mainnet, hash)
 
 		txn, err := sn2core.AdaptTransaction(responseTx)
 		require.NoError(t, err)
@@ -408,9 +394,6 @@ func TestTransaction(t *testing.T) {
 }
 
 func TestTransactionV3(t *testing.T) {
-	client := feeder.NewTestClient(t, &networks.Integration)
-	ctx := t.Context()
-
 	tests := map[string]core.Transaction{
 		// https://external.integration.starknet.io/feeder_gateway/get_transaction?transactionHash=0x49728601e0bb2f48ce506b0cbd9c0e2a9e50d95858aa41463f46386dca489fd
 		"invoke": &core.InvokeTransaction{
@@ -561,9 +544,8 @@ func TestTransactionV3(t *testing.T) {
 
 	for description, want := range tests {
 		t.Run(description, func(t *testing.T) {
-			status, err := client.Transaction(ctx, want.Hash())
-			require.NoError(t, err)
-			tx, err := sn2core.AdaptTransaction(status.Transaction)
+			responseTx := feeder.TransactionFromTestData(t, &networks.Integration, want.Hash())
+			tx, err := sn2core.AdaptTransaction(responseTx)
 			require.NoError(t, err)
 			require.Equal(t, want, tx)
 		})

--- a/clients/feeder/feeder.go
+++ b/clients/feeder/feeder.go
@@ -45,7 +45,6 @@ type Client struct {
 }
 
 //go:generate mockgen -destination=../../mocks/mock_feeder.go -mock_names Reader=MockFeederReader -package=mocks github.com/NethermindEth/juno/clients/feeder Reader
-//nolint:staticcheck // Transaction() returns the deprecated DeprecatedTransactionStatus type.
 type Reader interface {
 	Block(ctx context.Context, blockID string) (starknet.Block, error)
 	BlockHeader(ctx context.Context, blockID string) (starknet.BlockHeader, error)
@@ -71,11 +70,6 @@ type Reader interface {
 		ctx context.Context,
 		blockID string,
 	) (starknet.StateUpdateWithBlockAndSignature, error)
-	// Deprecated: Use TransactionStatus() instead.
-	Transaction(
-		ctx context.Context,
-		transactionHash *felt.Felt,
-	) (starknet.DeprecatedTransactionStatus, error)
 	TransactionStatus(
 		ctx context.Context,
 		transactionHash *felt.Felt,
@@ -414,18 +408,6 @@ func (c *Client) fetchPreConfirmedUpdate(
 		)
 	}
 	return &env, nil
-}
-
-// Deprecated: Transaction calls the get_transaction endpoint which returns
-// the full transaction body. Use TransactionStatus() instead.
-func (c *Client) Transaction(
-	ctx context.Context, transactionHash *felt.Felt,
-) (starknet.DeprecatedTransactionStatus, error) {
-	queryURL := buildQueryString(c.url, "get_transaction", map[string]string{
-		"transactionHash": transactionHash.String(),
-	})
-
-	return doRequest[starknet.DeprecatedTransactionStatus](ctx, c, queryURL)
 }
 
 // TransactionStatus calls the get_transaction_status endpoint which returns only status fields

--- a/clients/feeder/feeder_test.go
+++ b/clients/feeder/feeder_test.go
@@ -22,14 +22,10 @@ const (
 
 func TestDeclareTransactionUnmarshal(t *testing.T) {
 	t.Run("pre-v0.3", func(t *testing.T) {
-		client := feeder.NewTestClient(t, &networks.Mainnet)
 		txnHash := felt.NewUnsafeFromString[felt.Felt](
 			"0x93f542728e403f1edcea4a41f1509a39be35ebcad7d4b5aa77623e5e6480d",
 		)
-		status, err := client.Transaction(t.Context(), txnHash)
-		require.NoError(t, err)
-
-		declareTx := status.Transaction
+		declareTx := feeder.TransactionFromTestData(t, &networks.Mainnet, txnHash)
 		assert.Equal(
 			t,
 			"0x93f542728e403f1edcea4a41f1509a39be35ebcad7d4b5aa77623e5e6480d",
@@ -63,12 +59,10 @@ func TestDeclareTransactionUnmarshal(t *testing.T) {
 	})
 
 	t.Run("v0.3", func(t *testing.T) {
-		client := feeder.NewTestClient(t, &networks.Integration)
 		txnHash := felt.NewUnsafeFromString[felt.Felt](
 			"0x41d1f5206ef58a443e7d3d1ca073171ec25fa75313394318fc83a074a6631c3",
 		)
-		status, err := client.Transaction(t.Context(), txnHash)
-		require.NoError(t, err)
+		declareTx := feeder.TransactionFromTestData(t, &networks.Integration, txnHash)
 
 		require.Equal(t, &starknet.Transaction{
 			Hash: felt.NewUnsafeFromString[felt.Felt](
@@ -113,21 +107,16 @@ func TestDeclareTransactionUnmarshal(t *testing.T) {
 			),
 			AccountDeploymentData: &[]felt.Felt{},
 			Type:                  starknet.TxnDeclare,
-		}, status.Transaction)
+		}, declareTx)
 	})
 }
 
 func TestInvokeTransactionUnmarshal(t *testing.T) {
 	t.Run("pre-v0.3", func(t *testing.T) {
-		client := feeder.NewTestClient(t, &networks.Mainnet)
-
 		txnHash := felt.NewUnsafeFromString[felt.Felt](
 			"0x631333277e88053336d8c302630b4420dc3ff24018a1c464da37d5e36ea19df",
 		)
-		status, err := client.Transaction(t.Context(), txnHash)
-		require.NoError(t, err)
-
-		invokeTx := status.Transaction
+		invokeTx := feeder.TransactionFromTestData(t, &networks.Mainnet, txnHash)
 		assert.Equal(
 			t,
 			"0x631333277e88053336d8c302630b4420dc3ff24018a1c464da37d5e36ea19df",
@@ -157,12 +146,10 @@ func TestInvokeTransactionUnmarshal(t *testing.T) {
 	})
 
 	t.Run("v0.3", func(t *testing.T) {
-		client := feeder.NewTestClient(t, &networks.Integration)
 		txnHash := felt.NewUnsafeFromString[felt.Felt](
 			"0x49728601e0bb2f48ce506b0cbd9c0e2a9e50d95858aa41463f46386dca489fd",
 		)
-		status, err := client.Transaction(t.Context(), txnHash)
-		require.NoError(t, err)
+		invokeTx := feeder.TransactionFromTestData(t, &networks.Integration, txnHash)
 
 		require.Equal(t, &starknet.Transaction{
 			Hash: felt.NewUnsafeFromString[felt.Felt](
@@ -234,21 +221,16 @@ func TestInvokeTransactionUnmarshal(t *testing.T) {
 			},
 			AccountDeploymentData: &[]felt.Felt{},
 			Type:                  starknet.TxnInvoke,
-		}, status.Transaction)
+		}, invokeTx)
 	})
 }
 
 //nolint:dupl
 func TestDeployTransactionUnmarshal(t *testing.T) {
-	client := feeder.NewTestClient(t, &networks.Mainnet)
-
 	txnHash := felt.NewUnsafeFromString[felt.Felt](
 		"0x6d3e06989ee2245139cd677f59b4da7f360a27b2b614a4eb088fdf5862d23ee",
 	)
-	status, err := client.Transaction(t.Context(), txnHash)
-	require.NoError(t, err)
-
-	deployTx := status.Transaction
+	deployTx := feeder.TransactionFromTestData(t, &networks.Mainnet, txnHash)
 	assert.Equal(
 		t,
 		"0x6d3e06989ee2245139cd677f59b4da7f360a27b2b614a4eb088fdf5862d23ee",
@@ -292,15 +274,10 @@ func TestDeployTransactionUnmarshal(t *testing.T) {
 
 func TestDeployAccountTransactionUnmarshal(t *testing.T) {
 	t.Run("pre-v0.3", func(t *testing.T) {
-		client := feeder.NewTestClient(t, &networks.Mainnet)
-
 		txnHash := felt.NewUnsafeFromString[felt.Felt](
 			"0x32b272b6d0d584305a460197aa849b5c7a9a85903b66e9d3e1afa2427ef093e",
 		)
-		status, err := client.Transaction(t.Context(), txnHash)
-		require.NoError(t, err)
-
-		deployTx := status.Transaction
+		deployTx := feeder.TransactionFromTestData(t, &networks.Mainnet, txnHash)
 		assert.Equal(
 			t,
 			"0x32b272b6d0d584305a460197aa849b5c7a9a85903b66e9d3e1afa2427ef093e",
@@ -358,12 +335,10 @@ func TestDeployAccountTransactionUnmarshal(t *testing.T) {
 	})
 
 	t.Run("v0.3", func(t *testing.T) {
-		client := feeder.NewTestClient(t, &networks.Integration)
 		txnHash := felt.NewUnsafeFromString[felt.Felt](
 			"0x29fd7881f14380842414cdfdd8d6c0b1f2174f8916edcfeb1ede1eb26ac3ef0",
 		)
-		status, err := client.Transaction(t.Context(), txnHash)
-		require.NoError(t, err)
+		deployTx := feeder.TransactionFromTestData(t, &networks.Integration, txnHash)
 
 		require.Equal(t, &starknet.Transaction{
 			Hash: felt.NewUnsafeFromString[felt.Felt](
@@ -410,21 +385,16 @@ func TestDeployAccountTransactionUnmarshal(t *testing.T) {
 				),
 			},
 			Type: starknet.TxnDeployAccount,
-		}, status.Transaction)
+		}, deployTx)
 	})
 }
 
 //nolint:dupl
 func TestL1HandlerTransactionUnmarshal(t *testing.T) {
-	client := feeder.NewTestClient(t, &networks.Mainnet)
-
 	txnHash := felt.NewUnsafeFromString[felt.Felt](
 		"0x218adbb5aea7985d67fe49b45d44a991380b63db41622f9f4adc36274d02190",
 	)
-	status, err := client.Transaction(t.Context(), txnHash)
-	require.NoError(t, err)
-
-	handlerTx := status.Transaction
+	handlerTx := feeder.TransactionFromTestData(t, &networks.Mainnet, txnHash)
 	assert.Equal(
 		t,
 		"0x218adbb5aea7985d67fe49b45d44a991380b63db41622f9f4adc36274d02190",
@@ -926,29 +896,6 @@ func TestCompiledClassDefinition(t *testing.T) {
 		"0x3604cea1cdb094a73a31144f14a3e5861613c008e1e879939ebc4827d10cd50",
 		class.EntryPoints.External[9].Selector.String(),
 	)
-}
-
-func TestTransactionStatusRevertError(t *testing.T) {
-	client := feeder.NewTestClient(t, &networks.Integration)
-
-	txnHash := felt.NewUnsafeFromString[felt.Felt](
-		"0x19abec18bbacec23c2eee160c70190a48e4b41dd5ff98ad8f247f9393559998",
-	)
-	status, err := client.Transaction(t.Context(), txnHash)
-	require.NoError(t, err)
-	require.NotEmpty(t, status.RevertError)
-}
-
-func TestTransactionStatusTransactionFailureReason(t *testing.T) {
-	client := feeder.NewTestClient(t, &networks.SepoliaIntegration)
-
-	txnHash := felt.NewUnsafeFromString[felt.Felt]("0x1111")
-	expectedMessage := "some error"
-	expectedErrorCode := "SOME_ERROR_CODE"
-	status, err := client.Transaction(t.Context(), txnHash)
-	require.NoError(t, err)
-	require.Equal(t, expectedMessage, status.FailureReason.Message)
-	require.Equal(t, expectedErrorCode, status.FailureReason.Code)
 }
 
 func TestPublicKey(t *testing.T) {

--- a/clients/feeder/test_feeder.go
+++ b/clients/feeder/test_feeder.go
@@ -1,6 +1,7 @@
 package feeder
 
 import (
+	"encoding/json"
 	"errors"
 	"net/http"
 	"net/http/httptest"
@@ -11,6 +12,8 @@ import (
 	"testing"
 
 	"github.com/NethermindEth/juno/blockchain/networks"
+	"github.com/NethermindEth/juno/core/felt"
+	"github.com/NethermindEth/juno/starknet"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -55,6 +58,33 @@ func NewTestClient(t testing.TB, network *networks.Network, opts ...Option) *Cli
 	clientOpts = append(clientOpts, opts...)
 
 	return NewClient(feederURL, clientOpts...)
+}
+
+// TransactionFromTestData loads a transaction fixture captured from the legacy
+// get_transaction endpoint and returns the transaction body it contains.
+func TransactionFromTestData(
+	t testing.TB,
+	network *networks.Network,
+	transactionHash *felt.Felt,
+) *starknet.Transaction {
+	t.Helper()
+
+	dataPath, err := findTargetDirectory("clients/feeder/testdata")
+	require.NoError(t, err)
+
+	fixturePath := filepath.Join(
+		dataPath, network.String(), "transaction", transactionHash.String()+".json",
+	)
+	raw, err := os.ReadFile(fixturePath)
+	require.NoError(t, err)
+
+	var fixture struct {
+		Transaction *starknet.Transaction `json:"transaction"`
+	}
+	require.NoError(t, json.Unmarshal(raw, &fixture))
+	require.NotNil(t, fixture.Transaction)
+
+	return fixture.Transaction
 }
 
 func newTestServer(t testing.TB, network *networks.Network) *httptest.Server {
@@ -138,10 +168,6 @@ func resolveDirAndQueryArg(t testing.TB, path string, queryMap url.Values) (stri
 		dir = "transaction_status"
 		queryArg = transactionHashArg
 
-	case strings.HasSuffix(path, "get_transaction"):
-		dir = "transaction"
-		queryArg = transactionHashArg
-
 	case strings.HasSuffix(path, "get_class_by_hash"):
 		dir = "class"
 		queryArg = classHashArg
@@ -182,9 +208,6 @@ func resolveDirAndQueryArg(t testing.TB, path string, queryMap url.Values) (stri
 
 func handleNotFound(dir, queryArg string, w http.ResponseWriter) {
 	switch {
-	case dir == "transaction" && queryArg == transactionHashArg:
-		// get_transaction not-found response
-		w.Write([]byte("{\"finality_status\": \"NOT_RECEIVED\", \"status\": \"NOT_RECEIVED\"}")) //nolint:errcheck
 	case dir == "transaction_status" && queryArg == transactionHashArg:
 		// get_transaction_status not-found response
 		resp := `{"tx_status":"NOT_RECEIVED","finality_status":"NOT_RECEIVED","execution_status":null}`

--- a/clients/feeder/test_feeder.go
+++ b/clients/feeder/test_feeder.go
@@ -69,6 +69,9 @@ func TransactionFromTestData(
 ) *starknet.Transaction {
 	t.Helper()
 
+	require.NotNil(t, network)
+	require.NotNil(t, transactionHash)
+
 	dataPath, err := findTargetDirectory("clients/feeder/testdata")
 	require.NoError(t, err)
 

--- a/core/transaction_test.go
+++ b/core/transaction_test.go
@@ -149,28 +149,20 @@ func checkTransactionSymmetry(t *testing.T, input core.Transaction) {
 }
 
 func TestVerifyTransactionHash(t *testing.T) {
-	client := feeder.NewTestClient(t, &networks.Mainnet)
-	gw := adaptfeeder.New(client)
-
 	txnHash0 := felt.NewUnsafeFromString[felt.Felt]("0x1b4d9f09276629d496af1af8ff00173c11ff146affacb1b5c858d7aa89001ae")
-	txn0, err := gw.Transaction(t.Context(), txnHash0)
-	require.NoError(t, err)
+	txn0 := adaptfeeder.TransactionFromTestData(t, &networks.Mainnet, txnHash0)
 
 	txnHash1 := felt.NewUnsafeFromString[felt.Felt]("0x6d3e06989ee2245139cd677f59b4da7f360a27b2b614a4eb088fdf5862d23ee")
-	txn1, err := gw.Transaction(t.Context(), txnHash1)
-	require.NoError(t, err)
+	txn1 := adaptfeeder.TransactionFromTestData(t, &networks.Mainnet, txnHash1)
 
 	txnHash2 := felt.NewUnsafeFromString[felt.Felt]("0x32b272b6d0d584305a460197aa849b5c7a9a85903b66e9d3e1afa2427ef093e")
-	txn2, err := gw.Transaction(t.Context(), txnHash2)
-	require.NoError(t, err)
+	txn2 := adaptfeeder.TransactionFromTestData(t, &networks.Mainnet, txnHash2)
 
 	txnHash3 := felt.NewUnsafeFromString[felt.Felt]("0x218adbb5aea7985d67fe49b45d44a991380b63db41622f9f4adc36274d02190")
-	txn3, err := gw.Transaction(t.Context(), txnHash3)
-	require.NoError(t, err)
+	txn3 := adaptfeeder.TransactionFromTestData(t, &networks.Mainnet, txnHash3)
 
 	txnHash4 := felt.NewUnsafeFromString[felt.Felt]("0x2897e3cec3e24e4d341df26b8cf1ab84ea1c01a051021836b36c6639145b497")
-	txn4, err := gw.Transaction(t.Context(), txnHash4)
-	require.NoError(t, err)
+	txn4 := adaptfeeder.TransactionFromTestData(t, &networks.Mainnet, txnHash4)
 
 	t.Run("contains bad transaction", func(t *testing.T) {
 		badTxn0 := new(core.DeclareTransaction)
@@ -219,8 +211,6 @@ func TestVerifyTransactionHash(t *testing.T) {
 
 func TestTransactionV3Hash(t *testing.T) {
 	network := networks.Sepolia
-	gw := adaptfeeder.New(feeder.NewTestClient(t, &network))
-	ctx := t.Context()
 
 	tests := map[string]struct {
 		tx   func(hash *felt.Felt) core.Transaction
@@ -229,8 +219,7 @@ func TestTransactionV3Hash(t *testing.T) {
 		"invoke": {
 			// https://alpha-sepolia.starknet.io/feeder_gateway/get_transaction?transactionHash=0x76b52e17bc09064bd986ead34263e6305ef3cecfb3ae9e19b86bf4f1a1a20ea
 			tx: func(hash *felt.Felt) core.Transaction {
-				tx, err := gw.Transaction(ctx, hash)
-				require.NoError(t, err)
+				tx := adaptfeeder.TransactionFromTestData(t, &network, hash)
 				invoke, ok := tx.(*core.InvokeTransaction)
 				require.True(t, ok)
 				invoke.TransactionHash = nil
@@ -243,8 +232,7 @@ func TestTransactionV3Hash(t *testing.T) {
 		// https://alpha-sepolia.starknet.io/feeder_gateway/get_transaction?transactionHash=0x30c852c522274765e1d681bc8a84ce7c41118370ef2ba7d18a427ed29f5b155
 		"declare": {
 			tx: func(hash *felt.Felt) core.Transaction {
-				tx, err := gw.Transaction(ctx, hash)
-				require.NoError(t, err)
+				tx := adaptfeeder.TransactionFromTestData(t, &network, hash)
 				declare, ok := tx.(*core.DeclareTransaction)
 				require.True(t, ok)
 				declare.TransactionHash = nil
@@ -257,8 +245,7 @@ func TestTransactionV3Hash(t *testing.T) {
 		// https://alpha-sepolia.starknet.io/feeder_gateway/get_transaction?transactionHash=0x32413f8cee053089d6d7026a72e4108262ca3cfe868dd9159bc1dd160aec975
 		"deployAccount": {
 			tx: func(hash *felt.Felt) core.Transaction {
-				tx, err := gw.Transaction(ctx, hash)
-				require.NoError(t, err)
+				tx := adaptfeeder.TransactionFromTestData(t, &network, hash)
 				deployAccount, ok := tx.(*core.DeployAccountTransaction)
 				require.True(t, ok)
 				deployAccount.TransactionHash = nil
@@ -282,13 +269,10 @@ func TestTransactionV3Hash(t *testing.T) {
 // BenchmarkTransactionV3Hash measures the Poseidon-based v3 invoke transaction hash.
 func BenchmarkTransactionV3Hash(b *testing.B) {
 	network := networks.Sepolia
-	gw := adaptfeeder.New(feeder.NewTestClient(b, &network))
 
 	key := "0x76b52e17bc09064bd986ead34263e6305ef3cecfb3ae9e19b86bf4f1a1a20ea"
 	hash := felt.UnsafeFromString[felt.Felt](key)
-	//nolint:staticcheck // need the full transaction to hash it; the status endpoint won't do
-	tx, err := gw.Transaction(b.Context(), &hash)
-	require.NoError(b, err)
+	tx := adaptfeeder.TransactionFromTestData(b, &network, &hash)
 	invoke, ok := tx.(*core.InvokeTransaction)
 	require.True(b, ok)
 	invoke.TransactionHash = nil

--- a/mocks/mock_feeder.go
+++ b/mocks/mock_feeder.go
@@ -223,21 +223,6 @@ func (mr *MockFeederReaderMockRecorder) StateUpdateWithBlockAndSignature(ctx, bl
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StateUpdateWithBlockAndSignature", reflect.TypeOf((*MockFeederReader)(nil).StateUpdateWithBlockAndSignature), ctx, blockID)
 }
 
-// Transaction mocks base method.
-func (m *MockFeederReader) Transaction(ctx context.Context, transactionHash *felt.Felt) (starknet.DeprecatedTransactionStatus, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Transaction", ctx, transactionHash)
-	ret0, _ := ret[0].(starknet.DeprecatedTransactionStatus)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// Transaction indicates an expected call of Transaction.
-func (mr *MockFeederReaderMockRecorder) Transaction(ctx, transactionHash any) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Transaction", reflect.TypeOf((*MockFeederReader)(nil).Transaction), ctx, transactionHash)
-}
-
 // TransactionStatus mocks base method.
 func (m *MockFeederReader) TransactionStatus(ctx context.Context, transactionHash *felt.Felt) (starknet.TransactionStatus, error) {
 	m.ctrl.T.Helper()

--- a/mocks/mock_starknetdata.go
+++ b/mocks/mock_starknetdata.go
@@ -164,18 +164,3 @@ func (mr *MockStarknetDataMockRecorder) StateUpdateWithBlock(ctx, blockNumber an
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StateUpdateWithBlock", reflect.TypeOf((*MockStarknetData)(nil).StateUpdateWithBlock), ctx, blockNumber)
 }
-
-// Transaction mocks base method.
-func (m *MockStarknetData) Transaction(ctx context.Context, transactionHash *felt.Felt) (core.Transaction, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Transaction", ctx, transactionHash)
-	ret0, _ := ret[0].(core.Transaction)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// Transaction indicates an expected call of Transaction.
-func (mr *MockStarknetDataMockRecorder) Transaction(ctx, transactionHash any) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Transaction", reflect.TypeOf((*MockStarknetData)(nil).Transaction), ctx, transactionHash)
-}

--- a/rpc/v10/l1_test.go
+++ b/rpc/v10/l1_test.go
@@ -114,10 +114,9 @@ func TestGetMessageStatus(t *testing.T) {
 			mockSyncReader.EXPECT().PreConfirmedChain().Return(mustNewChain(t, preConfirmed), nil).AnyTimes()
 			l1handlerTxns := make([]core.Transaction, len(test.msgs))
 			for i := range len(test.msgs) {
-				//nolint:staticcheck //SA1019: used here to get the stored txs in testdata feeder
-				txn, err := gw.Transaction(t.Context(), test.msgs[i].L1HandlerHash)
-				require.NoError(t, err)
-				l1handlerTxns[i] = txn
+				l1handlerTxns[i] = adaptfeeder.TransactionFromTestData(
+					t, &test.network, test.msgs[i].L1HandlerHash,
+				)
 			}
 
 			mockL1Client.EXPECT().TransactionReceipt(

--- a/rpc/v10/transaction_test.go
+++ b/rpc/v10/transaction_test.go
@@ -549,17 +549,13 @@ func TestTransactionByHash(t *testing.T) {
 
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
-			gw := adaptfeeder.New(feeder.NewTestClient(t, test.network))
 			mockCtrl := gomock.NewController(t)
 			t.Cleanup(mockCtrl.Finish)
 			mockReader := mocks.NewMockReader(mockCtrl)
 			mockSyncReader := mocks.NewMockSyncReader(mockCtrl)
 			mockReader.EXPECT().TransactionByHash(
 				gomock.Any()).DoAndReturn(func(hash *felt.Felt) (core.Transaction, error) {
-				tx, err := gw.Transaction(t.Context(), hash)
-				if err != nil {
-					return nil, err
-				}
+				tx := adaptfeeder.TransactionFromTestData(t, test.network, hash)
 				// Mock the gateway to include proof_facts for "INVOKE v3 with response flags" test
 				invokeTx, ok := tx.(*core.InvokeTransaction)
 				if ok && test.withProofFacts {
@@ -924,13 +920,10 @@ func TestTransactionByBlockIdAndIndex(t *testing.T) {
 
 	t.Run("response flags", func(t *testing.T) {
 		network := &networks.Sepolia
-		client := feeder.NewTestClient(t, network)
-		gw := adaptfeeder.New(client)
 		txnHash := felt.NewUnsafeFromString[felt.Felt](
 			"0x435f87f1eecd5968ba8190744fee1f3ef69f17471f8902ce1e7d444c4e0c8cb",
 		)
-		invokeTx, err := gw.Transaction(t.Context(), txnHash)
-		require.NoError(t, err)
+		invokeTx := adaptfeeder.TransactionFromTestData(t, network, txnHash)
 		require.IsType(t, &core.InvokeTransaction{}, invokeTx)
 		invokeTxCore := invokeTx.(*core.InvokeTransaction)
 		require.NotNil(t, invokeTxCore.ProofFacts)
@@ -1199,10 +1192,8 @@ func TestAddTransactionUnmarshal(t *testing.T) {
 
 func TestAddTransaction(t *testing.T) {
 	n := &networks.Integration
-	gw := adaptfeeder.New(feeder.NewTestClient(t, n))
 	txWithoutClass := func(hash string) rpc.BroadcastedTransaction {
-		tx, err := gw.Transaction(t.Context(), felt.NewUnsafeFromString[felt.Felt](hash))
-		require.NoError(t, err)
+		tx := adaptfeeder.TransactionFromTestData(t, n, felt.NewUnsafeFromString[felt.Felt](hash))
 		return rpc.BroadcastedTransaction{
 			Transaction: *rpc.AdaptCoreTransaction(tx),
 		}
@@ -1534,15 +1525,13 @@ func TestAddTransaction(t *testing.T) {
 		defer sub.Unsubscribe()
 		recv := sub.Recv()
 
-		gw := adaptfeeder.New(feeder.NewTestClient(t, n))
-		//nolint:staticcheck // Intention here is reading the transaction, not its status
-		tx, err := gw.Transaction(
-			t.Context(),
+		tx := adaptfeeder.TransactionFromTestData(
+			t,
+			n,
 			felt.NewUnsafeFromString[felt.Felt](
 				"0x435f87f1eecd5968ba8190744fee1f3ef69f17471f8902ce1e7d444c4e0c8cb",
 			),
 		)
-		require.NoError(t, err)
 
 		broadcastedTxn := rpc.BroadcastedTransaction{
 			Transaction: rpc.AdaptTransaction(tx, false),

--- a/rpc/v8/l1_test.go
+++ b/rpc/v8/l1_test.go
@@ -86,9 +86,9 @@ func TestGetMessageStatus(t *testing.T) {
 
 			l1handlerTxns := make([]core.Transaction, len(test.msgs))
 			for i := range len(test.msgs) {
-				txn, err := gw.Transaction(t.Context(), test.msgs[i].L1HandlerHash)
-				require.NoError(t, err)
-				l1handlerTxns[i] = txn
+				l1handlerTxns[i] = adaptfeeder.TransactionFromTestData(
+					t, &test.network, test.msgs[i].L1HandlerHash,
+				)
 			}
 
 			mockL1Client.EXPECT().TransactionReceipt(

--- a/rpc/v8/transaction_test.go
+++ b/rpc/v8/transaction_test.go
@@ -409,12 +409,11 @@ func TestTransactionByHash(t *testing.T) {
 
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
-			gw := adaptfeeder.New(feeder.NewTestClient(t, test.network))
 			mockCtrl := gomock.NewController(t)
 			t.Cleanup(mockCtrl.Finish)
 			mockReader := mocks.NewMockReader(mockCtrl)
 			mockReader.EXPECT().TransactionByHash(gomock.Any()).DoAndReturn(func(hash *felt.Felt) (core.Transaction, error) {
-				return gw.Transaction(t.Context(), hash)
+				return adaptfeeder.TransactionFromTestData(t, test.network, hash), nil
 			}).Times(1)
 			handler := rpc.New(mockReader, nil, nil, nil)
 
@@ -967,10 +966,8 @@ func TestAddTransactionUnmarshal(t *testing.T) {
 
 func TestAddTransaction(t *testing.T) {
 	n := &networks.Integration
-	gw := adaptfeeder.New(feeder.NewTestClient(t, n))
 	txWithoutClass := func(hash string) rpc.BroadcastedTransaction {
-		tx, err := gw.Transaction(t.Context(), felt.NewUnsafeFromString[felt.Felt](hash))
-		require.NoError(t, err)
+		tx := adaptfeeder.TransactionFromTestData(t, n, felt.NewUnsafeFromString[felt.Felt](hash))
 		return rpc.BroadcastedTransaction{
 			Transaction: *rpc.AdaptTransaction(tx),
 		}
@@ -1311,15 +1308,13 @@ func TestAddTransaction(t *testing.T) {
 			sub := receivedTxFeed.SubscribeKeepLast()
 			defer sub.Unsubscribe()
 
-			gw := adaptfeeder.New(feeder.NewTestClient(t, n))
-			//nolint:staticcheck // Intention here is reading the transaction, not its status
-			tx, err := gw.Transaction(
-				t.Context(),
+			tx := adaptfeeder.TransactionFromTestData(
+				t,
+				n,
 				felt.NewUnsafeFromString[felt.Felt](
 					"0x435f87f1eecd5968ba8190744fee1f3ef69f17471f8902ce1e7d444c4e0c8cb",
 				),
 			)
-			require.NoError(t, err)
 
 			broadcastedTxn := rpc.BroadcastedTransaction{
 				Transaction: *rpc.AdaptTransaction(tx),

--- a/rpc/v9/l1_test.go
+++ b/rpc/v9/l1_test.go
@@ -99,9 +99,9 @@ func TestGetMessageStatus(t *testing.T) {
 			mockSyncReader.EXPECT().PreConfirmedChain().Return(mustNewChain(t, preConfirmed), nil).AnyTimes()
 			l1handlerTxns := make([]core.Transaction, len(test.msgs))
 			for i := range len(test.msgs) {
-				txn, err := gw.Transaction(t.Context(), test.msgs[i].L1HandlerHash)
-				require.NoError(t, err)
-				l1handlerTxns[i] = txn
+				l1handlerTxns[i] = adaptfeeder.TransactionFromTestData(
+					t, &test.network, test.msgs[i].L1HandlerHash,
+				)
 			}
 
 			mockL1Client.EXPECT().TransactionReceipt(

--- a/rpc/v9/transaction_test.go
+++ b/rpc/v9/transaction_test.go
@@ -435,13 +435,12 @@ func TestTransactionByHash(t *testing.T) {
 
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
-			gw := adaptfeeder.New(feeder.NewTestClient(t, test.network))
 			mockCtrl := gomock.NewController(t)
 			t.Cleanup(mockCtrl.Finish)
 			mockReader := mocks.NewMockReader(mockCtrl)
 			mockSyncReader := mocks.NewMockSyncReader(mockCtrl)
 			mockReader.EXPECT().TransactionByHash(gomock.Any()).DoAndReturn(func(hash *felt.Felt) (core.Transaction, error) {
-				return gw.Transaction(t.Context(), hash)
+				return adaptfeeder.TransactionFromTestData(t, test.network, hash), nil
 			}).Times(1)
 			mockSyncReader.EXPECT().PreConfirmedChain().Return(mustNewChain(t, &pending.PreConfirmed{
 				Block: &core.Block{
@@ -1245,10 +1244,8 @@ func TestAddTransactionUnmarshal(t *testing.T) {
 
 func TestAddTransaction(t *testing.T) {
 	n := &networks.Integration
-	gw := adaptfeeder.New(feeder.NewTestClient(t, n))
 	txWithoutClass := func(hash string) rpc.BroadcastedTransaction {
-		tx, err := gw.Transaction(t.Context(), felt.NewUnsafeFromString[felt.Felt](hash))
-		require.NoError(t, err)
+		tx := adaptfeeder.TransactionFromTestData(t, n, felt.NewUnsafeFromString[felt.Felt](hash))
 		return rpc.BroadcastedTransaction{
 			Transaction: *rpc.AdaptTransaction(tx),
 		}
@@ -1622,15 +1619,13 @@ func TestAddTransaction(t *testing.T) {
 		sub := receivedTxFeed.SubscribeKeepLast()
 		defer sub.Unsubscribe()
 
-		gw := adaptfeeder.New(feeder.NewTestClient(t, n))
-		//nolint:staticcheck // Intention here is reading the transaction, not its status
-		tx, err := gw.Transaction(
-			t.Context(),
+		tx := adaptfeeder.TransactionFromTestData(
+			t,
+			n,
 			felt.NewUnsafeFromString[felt.Felt](
 				"0x435f87f1eecd5968ba8190744fee1f3ef69f17471f8902ce1e7d444c4e0c8cb",
 			),
 		)
-		require.NoError(t, err)
 
 		broadcastedTxn := rpc.BroadcastedTransaction{
 			Transaction: *rpc.AdaptTransaction(tx),

--- a/starknet/transaction.go
+++ b/starknet/transaction.go
@@ -187,25 +187,6 @@ type Transaction struct {
 	ProofFacts            *[]felt.Felt                 `json:"proof_facts,omitempty"`
 }
 
-// Deprecated: Use TransactionStatus with Client.DeprecatedTransactionStatus() instead.
-type DeprecatedTransactionStatus struct {
-	Status           string                    `json:"status"`
-	FinalityStatus   FinalityStatus            `json:"finality_status"`
-	ExecutionStatus  ExecutionStatus           `json:"execution_status"`
-	BlockHash        *felt.Felt                `json:"block_hash"`
-	BlockNumber      uint64                    `json:"block_number"`
-	TransactionIndex uint64                    `json:"transaction_index"`
-	Transaction      *Transaction              `json:"transaction"`
-	RevertError      string                    `json:"revert_error"`
-	FailureReason    *TransactionFailureReason `json:"transaction_failure_reason,omitempty"`
-}
-
-// TODO: placeholder for now to avoid compiler errors. A proper validation
-// should be implemented in a follow-up PR.
-func (val *DeprecatedTransactionStatus) Validate() error {
-	return nil
-}
-
 // TransactionStatus represents the response from the get_transaction_status endpoint.
 type TransactionStatus struct {
 	TxStatus        string                   `json:"tx_status"`

--- a/starknetdata/feeder/feeder.go
+++ b/starknetdata/feeder/feeder.go
@@ -67,22 +67,6 @@ func (f *Feeder) block(ctx context.Context, blockID string) (*core.Block, error)
 	return sn2core.AdaptBlock(&response, sig.Signature)
 }
 
-// Deprecated: Transaction gets the transaction for a given transaction hash from the feeder,
-// then adapts it to the appropriate core.Transaction types.
-// Uses the old get_transaction endpoint; prefer get_transaction_status for status-only queries.
-func (f *Feeder) Transaction(ctx context.Context, transactionHash *felt.Felt) (core.Transaction, error) {
-	response, err := f.client.Transaction(ctx, transactionHash)
-	if err != nil {
-		return nil, err
-	}
-	tx, err := sn2core.AdaptTransaction(response.Transaction)
-	if err != nil {
-		return nil, err
-	}
-
-	return tx, nil
-}
-
 // Class gets the class for a given class hash from the feeder,
 // then adapts it to the core.Class type.
 func (f *Feeder) Class(ctx context.Context, classHash *felt.Felt) (core.ClassDefinition, error) {

--- a/starknetdata/feeder/feeder_test.go
+++ b/starknetdata/feeder/feeder_test.go
@@ -10,7 +10,6 @@ import (
 	"github.com/NethermindEth/juno/adapters/sn2core"
 	"github.com/NethermindEth/juno/blockchain/networks"
 	"github.com/NethermindEth/juno/clients/feeder"
-	"github.com/NethermindEth/juno/core"
 	"github.com/NethermindEth/juno/core/felt"
 	"github.com/NethermindEth/juno/starknet"
 	adaptfeeder "github.com/NethermindEth/juno/starknetdata/feeder"
@@ -119,81 +118,6 @@ func TestClassV0(t *testing.T) {
 			require.Equal(t, adaptedResponse, classGeneric)
 		})
 	}
-}
-
-func TestTransaction(t *testing.T) {
-	clientGoerli := feeder.NewTestClient(t, &networks.Goerli)
-	adapterGoerli := adaptfeeder.New(clientGoerli)
-
-	clientMainnet := feeder.NewTestClient(t, &networks.Mainnet)
-	adapterMainnet := adaptfeeder.New(clientMainnet)
-
-	ctx := t.Context()
-
-	t.Run("invoke transaction", func(t *testing.T) {
-		hash := felt.NewUnsafeFromString[felt.Felt]("0x7e3a229febf47c6edfd96582d9476dd91a58a5ba3df4553ae448a14a2f132d9")
-		response, err := clientGoerli.Transaction(ctx, hash)
-		require.NoError(t, err)
-		responseTx := response.Transaction
-
-		txn, err := adapterGoerli.Transaction(ctx, hash)
-		require.NoError(t, err)
-		invokeTx, ok := txn.(*core.InvokeTransaction)
-		require.True(t, ok)
-		assert.Equal(t, sn2core.AdaptInvokeTransaction(responseTx), invokeTx)
-	})
-
-	t.Run("deploy transaction", func(t *testing.T) {
-		hash := felt.NewUnsafeFromString[felt.Felt]("0x15b51c2f4880b1e7492d30ada7254fc59c09adde636f37eb08cdadbd9dabebb")
-		response, err := clientGoerli.Transaction(ctx, hash)
-		require.NoError(t, err)
-		responseTx := response.Transaction
-
-		txn, err := adapterGoerli.Transaction(ctx, hash)
-		require.NoError(t, err)
-		deployTx, ok := txn.(*core.DeployTransaction)
-		require.True(t, ok)
-		assert.Equal(t, sn2core.AdaptDeployTransaction(responseTx), deployTx)
-	})
-
-	t.Run("deploy account transaction", func(t *testing.T) {
-		hash := felt.NewUnsafeFromString[felt.Felt]("0xd61fc89f4d1dc4dc90a014957d655d38abffd47ecea8e3fa762e3160f155f2")
-		response, err := clientMainnet.Transaction(ctx, hash)
-		require.NoError(t, err)
-		responseTx := response.Transaction
-
-		txn, err := adapterMainnet.Transaction(ctx, hash)
-		require.NoError(t, err)
-		deployAccountTx, ok := txn.(*core.DeployAccountTransaction)
-		require.True(t, ok)
-		assert.Equal(t, sn2core.AdaptDeployAccountTransaction(responseTx), deployAccountTx)
-	})
-
-	t.Run("declare transaction", func(t *testing.T) {
-		hash := felt.NewUnsafeFromString[felt.Felt]("0x6eab8252abfc9bbfd72c8d592dde4018d07ce467c5ce922519d7142fcab203f")
-		response, err := clientGoerli.Transaction(ctx, hash)
-		require.NoError(t, err)
-		responseTx := response.Transaction
-
-		txn, err := adapterGoerli.Transaction(ctx, hash)
-		require.NoError(t, err)
-		declareTx, ok := txn.(*core.DeclareTransaction)
-		require.True(t, ok)
-		assert.Equal(t, sn2core.AdaptDeclareTransaction(responseTx), declareTx)
-	})
-
-	t.Run("l1handler transaction", func(t *testing.T) {
-		hash := felt.NewUnsafeFromString[felt.Felt]("0x537eacfd3c49166eec905daff61ff7feef9c133a049ea2135cb94eec840a4a8")
-		response, err := clientMainnet.Transaction(ctx, hash)
-		require.NoError(t, err)
-		responseTx := response.Transaction
-
-		txn, err := adapterMainnet.Transaction(ctx, hash)
-		require.NoError(t, err)
-		l1HandlerTx, ok := txn.(*core.L1HandlerTransaction)
-		require.True(t, ok)
-		assert.Equal(t, sn2core.AdaptL1HandlerTransaction(responseTx), l1HandlerTx)
-	})
 }
 
 func TestClassV1(t *testing.T) {

--- a/starknetdata/feeder/testdata.go
+++ b/starknetdata/feeder/testdata.go
@@ -20,8 +20,12 @@ func TransactionFromTestData(
 ) core.Transaction {
 	t.Helper()
 
+	require.NotNil(t, network)
+	require.NotNil(t, transactionHash)
+
 	tx, err := sn2core.AdaptTransaction(feeder.TransactionFromTestData(t, network, transactionHash))
 	require.NoError(t, err)
+	require.NotNil(t, tx)
 
 	return tx
 }

--- a/starknetdata/feeder/testdata.go
+++ b/starknetdata/feeder/testdata.go
@@ -1,0 +1,27 @@
+package feeder
+
+import (
+	"testing"
+
+	"github.com/NethermindEth/juno/adapters/sn2core"
+	"github.com/NethermindEth/juno/blockchain/networks"
+	"github.com/NethermindEth/juno/clients/feeder"
+	"github.com/NethermindEth/juno/core"
+	"github.com/NethermindEth/juno/core/felt"
+	"github.com/stretchr/testify/require"
+)
+
+// TransactionFromTestData loads a transaction fixture captured from the legacy
+// get_transaction endpoint and adapts it to a core.Transaction.
+func TransactionFromTestData(
+	t testing.TB,
+	network *networks.Network,
+	transactionHash *felt.Felt,
+) core.Transaction {
+	t.Helper()
+
+	tx, err := sn2core.AdaptTransaction(feeder.TransactionFromTestData(t, network, transactionHash))
+	require.NoError(t, err)
+
+	return tx
+}

--- a/starknetdata/starknetdata.go
+++ b/starknetdata/starknetdata.go
@@ -15,8 +15,6 @@ type StarknetData interface {
 	BlockByNumber(ctx context.Context, blockNumber uint64) (*core.Block, error)
 	BlockLatest(ctx context.Context) (*core.Block, error)
 	BlockHeaderLatest(ctx context.Context) (core.Header, error)
-	// Deprecated: uses the old get_transaction feeder gateway endpoint.
-	Transaction(ctx context.Context, transactionHash *felt.Felt) (core.Transaction, error)
 	Class(ctx context.Context, classHash *felt.Felt) (core.ClassDefinition, error)
 	StateUpdate(ctx context.Context, blockNumber uint64) (*core.StateUpdate, error)
 	StateUpdateWithBlock(ctx context.Context, blockNumber uint64) (*core.StateUpdate, *core.Block, error)

--- a/vm/transaction_pkg_test.go
+++ b/vm/transaction_pkg_test.go
@@ -5,7 +5,6 @@ import (
 	"testing"
 
 	"github.com/NethermindEth/juno/blockchain/networks"
-	"github.com/NethermindEth/juno/clients/feeder"
 	"github.com/NethermindEth/juno/core/felt"
 	"github.com/NethermindEth/juno/starknet"
 	adaptfeeder "github.com/NethermindEth/juno/starknetdata/feeder"
@@ -14,9 +13,6 @@ import (
 )
 
 func TestTransactionMarshal(t *testing.T) {
-	client := feeder.NewTestClient(t, &networks.Integration)
-	gw := adaptfeeder.New(client)
-
 	tests := map[string]struct {
 		Hash     *felt.Felt
 		Expected string
@@ -362,8 +358,7 @@ func TestTransactionMarshal(t *testing.T) {
 
 	for description, test := range tests {
 		t.Run(description, func(t *testing.T) {
-			txn, err := gw.Transaction(t.Context(), test.Hash)
-			require.NoError(t, err)
+			txn := adaptfeeder.TransactionFromTestData(t, &networks.Integration, test.Hash)
 
 			jsonB, err := marshalTxn(txn)
 			require.NoError(t, err)


### PR DESCRIPTION
Closes #3871

The deprecated `get_transaction` chain had no production callers left, so this removes it end to end:

- `StarknetData.Transaction()` and its `Feeder` adapter implementation
- `Client.Transaction()` in the feeder client — the last code path hitting the legacy `get_transaction` gateway endpoint
- the `starknet.DeprecatedTransactionStatus` type and the test server's `get_transaction` route
- three `//nolint:staticcheck` escapes that only existed for this chain (mocks regenerated)

A bunch of tests used the endpoint purely as a fixture loader, so those keep working through two small helpers that read the same testdata JSON directly from disk: `feeder.TransactionFromTestData` (raw `starknet.Transaction`) and `adaptfeeder.TransactionFromTestData` (adapted `core.Transaction`). Tests that only exercised the removed code itself are deleted.

No behaviour change for the node — it's dead code removal plus test plumbing.
