### PR TITLE
perf(rpc): resolve transaction status by reading only the execution status

### DIFF
--- a/blockchain/blockchain.go
+++ b/blockchain/blockchain.go
@@ -61,6 +61,9 @@ type Reader interface {
 	ReceiptByBlockNumberAndIndex(
 		blockNumber, index uint64,
 	) (receipt core.TransactionReceipt, blockHash *felt.Felt, err error)
+	TransactionExecutionStatusByBlockNumberAndIndex(
+		blockNumber, index uint64,
+	) (status core.ExecutionStatus, err error)
 
 	StateUpdateByNumber(number uint64) (update *core.StateUpdate, err error)
 	StateUpdateByHash(hash *felt.Felt) (update *core.StateUpdate, err error)
@@ -328,6 +331,14 @@ func (b *Blockchain) ReceiptByBlockNumberAndIndex(
 	}
 
 	return *receipt, header.Hash, nil
+}
+
+// TransactionExecutionStatusByBlockNumberAndIndex returns only the status subset of a receipt.
+func (b *Blockchain) TransactionExecutionStatusByBlockNumberAndIndex(
+	blockNumber, index uint64,
+) (core.ExecutionStatus, error) {
+	b.listener.OnRead("TransactionExecutionStatusByBlockNumberAndIndex")
+	return core.GetExecutionStatusByBlockAndIndex(b.database, blockNumber, index)
 }
 
 func (b *Blockchain) SubscribeL1Head() L1HeadSubscription {

--- a/core/accessors.go
+++ b/core/accessors.go
@@ -518,6 +518,16 @@ func GetReceiptByBlockAndIndex(
 	return BlockTransactionsReceiptPartialBucket.Get(r, blockNumber, int(index))
 }
 
+// GetExecutionStatusByBlockAndIndex returns only the status subset of a receipt,
+// skipping its heavier fields.
+func GetExecutionStatusByBlockAndIndex(
+	r db.KeyValueReader,
+	blockNumber uint64,
+	index uint64,
+) (ExecutionStatus, error) {
+	return BlockTransactionsExecutionStatusPartialBucket.Get(r, blockNumber, int(index))
+}
+
 // GetBlockByNumber returns a full block by number
 func GetBlockByNumber(r db.KeyValueReader, blockNumber uint64) (*Block, error) {
 	header, err := GetBlockHeaderByNumber(r, blockNumber)

--- a/core/accessors_test.go
+++ b/core/accessors_test.go
@@ -211,6 +211,77 @@ func TestGetReceiptByBlockAndIndex(t *testing.T) {
 	})
 }
 
+func TestGetExecutionStatusByBlockAndIndex(t *testing.T) {
+	t.Parallel()
+	memDB, block := setupForTxsAndReceiptsTests(t)
+
+	t.Run("valid block", func(t *testing.T) {
+		t.Parallel()
+		require.NotEmpty(t, block.Receipts)
+		for i := range block.Receipts {
+			status, err := core.GetExecutionStatusByBlockAndIndex(memDB, block.Number, uint64(i))
+			require.NoError(t, err)
+
+			// The partial decode must recover the same status the full receipt carries.
+			full, err := core.GetReceiptByBlockAndIndex(memDB, block.Number, uint64(i))
+			require.NoError(t, err)
+			assert.Equal(t, core.ExecutionStatus{
+				Reverted:     full.Reverted,
+				RevertReason: full.RevertReason,
+			}, status)
+		}
+	})
+	t.Run("non-existent block", func(t *testing.T) {
+		t.Parallel()
+		_, err := core.GetExecutionStatusByBlockAndIndex(memDB, nonexistentBlockNumber, 0)
+		require.ErrorIs(t, err, db.ErrKeyNotFound)
+	})
+
+	t.Run("non-existent index", func(t *testing.T) {
+		t.Parallel()
+		// one past the last index should return ErrKeyNotFound
+		_, err := core.GetExecutionStatusByBlockAndIndex(memDB, block.Number, uint64(len(block.Receipts)))
+		require.ErrorIs(t, err, db.ErrKeyNotFound)
+	})
+
+	// The fixture block only carries SUCCEEDED receipts, so seed a reverted one with
+	// heavy fields populated to prove the partial decode recovers the revert status
+	// while skipping the fields it is meant to ignore.
+	t.Run("reverted receipt with heavy fields", func(t *testing.T) {
+		t.Parallel()
+		revertedDB := memory.New()
+
+		tx := block.Transactions[0]
+		reverted := &core.TransactionReceipt{
+			TransactionHash:    tx.Hash(),
+			Reverted:           true,
+			RevertReason:       "some revert reason",
+			Events:             block.Receipts[0].Events,
+			L2ToL1Message:      block.Receipts[0].L2ToL1Message,
+			ExecutionResources: block.Receipts[0].ExecutionResources,
+		}
+		const revertedBlockNumber = 999
+		require.NoError(t, core.WriteTransactionsAndReceipts(
+			revertedDB,
+			revertedBlockNumber,
+			[]core.Transaction{tx},
+			[]*core.TransactionReceipt{reverted},
+		))
+
+		status, err := core.GetExecutionStatusByBlockAndIndex(revertedDB, revertedBlockNumber, 0)
+		require.NoError(t, err)
+
+		full, err := core.GetReceiptByBlockAndIndex(revertedDB, revertedBlockNumber, 0)
+		require.NoError(t, err)
+		assert.Equal(t, core.ExecutionStatus{
+			Reverted:     full.Reverted,
+			RevertReason: full.RevertReason,
+		}, status)
+		assert.True(t, status.Reverted)
+		assert.Equal(t, "some revert reason", status.RevertReason)
+	})
+}
+
 func TestGetBlockByNumber(t *testing.T) {
 	t.Parallel()
 	memDB, block := setupForTxsAndReceiptsTests(t)

--- a/core/block_transaction.go
+++ b/core/block_transaction.go
@@ -91,3 +91,9 @@ func (b *BlockTransactions) Transactions() indexed.LazySlice[Transaction] {
 func (b *BlockTransactions) Receipts() indexed.LazySlice[*TransactionReceipt] {
 	return indexed.NewLazySlice[*TransactionReceipt](b.Indexes.Receipts, b.Data)
 }
+
+// ExecutionStatuses decodes receipts into the ExecutionStatus subset, skipping the
+// heavier receipt fields.
+func (b *BlockTransactions) ExecutionStatuses() indexed.LazySlice[ExecutionStatus] {
+	return indexed.NewLazySlice[ExecutionStatus](b.Indexes.Receipts, b.Data)
+}

--- a/core/block_transaction_serializer.go
+++ b/core/block_transaction_serializer.go
@@ -42,6 +42,12 @@ func (extractReceipt) extract(b *BlockTransactions, subKey int) (*TransactionRec
 	return b.Receipts().Get(subKey)
 }
 
+type extractExecutionStatus struct{}
+
+func (extractExecutionStatus) extract(b *BlockTransactions, subKey int) (ExecutionStatus, error) {
+	return b.ExecutionStatuses().Get(subKey)
+}
+
 type extractAllTransactions struct{}
 
 func (extractAllTransactions) extract(b *BlockTransactions, _ struct{}) ([]Transaction, error) {
@@ -90,6 +96,11 @@ var (
 		extractReceipt,
 		int,
 		*TransactionReceipt,
+	]{}
+	BlockTransactionsExecutionStatusPartialSerializer = blockTransactionsPartialSerializer[
+		extractExecutionStatus,
+		int,
+		ExecutionStatus,
 	]{}
 	BlockTransactionsAllTransactionsPartialSerializer = blockTransactionsPartialSerializer[
 		extractAllTransactions,

--- a/core/block_transaction_test.go
+++ b/core/block_transaction_test.go
@@ -148,4 +148,19 @@ func TestBlockTransactionsSerializer(t *testing.T) {
 			serialised,
 		)
 	})
+
+	t.Run("BlockTransactionsExecutionStatusPartialSerializer", func(t *testing.T) {
+		for i := range transactionCount {
+			assertPartialSerializer(
+				t,
+				core.BlockTransactionsExecutionStatusPartialSerializer,
+				i,
+				core.ExecutionStatus{
+					Reverted:     receipts[i].Reverted,
+					RevertReason: receipts[i].RevertReason,
+				},
+				serialised,
+			)
+		}
+	})
 }

--- a/core/receipt.go
+++ b/core/receipt.go
@@ -26,6 +26,14 @@ type TransactionReceipt struct {
 	RevertReason       string
 }
 
+// ExecutionStatus is the status subset of TransactionReceipt, decoded on its own to
+// skip the heavier fields. Field names must match TransactionReceipt so the CBOR
+// decoder can pick them out by key.
+type ExecutionStatus struct {
+	Reverted     bool
+	RevertReason string
+}
+
 func (r *TransactionReceipt) hash() felt.Felt {
 	revertReasonHash := &felt.Zero
 	if r.Reverted {

--- a/core/receipt_test.go
+++ b/core/receipt_test.go
@@ -5,8 +5,32 @@ import (
 	"testing"
 
 	"github.com/NethermindEth/juno/core/felt"
+	"github.com/NethermindEth/juno/encoder"
 	"github.com/stretchr/testify/require"
 )
+
+// TestExecutionStatusDecodesFromReceipt ensures ExecutionStatus decodes from an
+// encoded TransactionReceipt so the status is read correctly.
+func TestExecutionStatusDecodesFromReceipt(t *testing.T) {
+	receipt := TransactionReceipt{
+		Reverted:     true,
+		RevertReason: "some revert reason",
+		// Heavy fields the subset is meant to skip, populated to prove it does.
+		Fee:             new(felt.Felt).SetUint64(7),
+		TransactionHash: new(felt.Felt).SetUint64(9),
+		Events:          []*Event{{}},
+	}
+
+	data, err := encoder.Marshal(&receipt)
+	require.NoError(t, err)
+
+	var status ExecutionStatus
+	require.NoError(t, encoder.Unmarshal(data, &status))
+	require.Equal(t, ExecutionStatus{
+		Reverted:     receipt.Reverted,
+		RevertReason: receipt.RevertReason,
+	}, status)
+}
 
 // note(rdr): based on git blame, it seems this global var is here to avoid certain compiler optimizations.
 //			  it would be nice to have extra clarity

--- a/core/typed_buckets.go
+++ b/core/typed_buckets.go
@@ -177,6 +177,11 @@ var BlockTransactionsReceiptPartialBucket = partial.NewPartialBucket(
 	BlockTransactionsReceiptPartialSerializer,
 )
 
+var BlockTransactionsExecutionStatusPartialBucket = partial.NewPartialBucket(
+	BlockTransactionsBucket.Bucket,
+	BlockTransactionsExecutionStatusPartialSerializer,
+)
+
 var BlockTransactionsAllTransactionsPartialBucket = partial.NewPartialBucket(
 	BlockTransactionsBucket.Bucket,
 	BlockTransactionsAllTransactionsPartialSerializer,

--- a/mocks/mock_blockchain.go
+++ b/mocks/mock_blockchain.go
@@ -333,6 +333,21 @@ func (mr *MockReaderMockRecorder) ReceiptByBlockNumberAndIndex(blockNumber, inde
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReceiptByBlockNumberAndIndex", reflect.TypeOf((*MockReader)(nil).ReceiptByBlockNumberAndIndex), blockNumber, index)
 }
 
+// TransactionExecutionStatusByBlockNumberAndIndex mocks base method.
+func (m *MockReader) TransactionExecutionStatusByBlockNumberAndIndex(blockNumber, index uint64) (core.ExecutionStatus, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "TransactionExecutionStatusByBlockNumberAndIndex", blockNumber, index)
+	ret0, _ := ret[0].(core.ExecutionStatus)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// TransactionExecutionStatusByBlockNumberAndIndex indicates an expected call of TransactionExecutionStatusByBlockNumberAndIndex.
+func (mr *MockReaderMockRecorder) TransactionExecutionStatusByBlockNumberAndIndex(blockNumber, index any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "TransactionExecutionStatusByBlockNumberAndIndex", reflect.TypeOf((*MockReader)(nil).TransactionExecutionStatusByBlockNumberAndIndex), blockNumber, index)
+}
+
 // StateAtBlockHash mocks base method.
 func (m *MockReader) StateAtBlockHash(blockHash *felt.Felt) (core.StateReader, blockchain.StateCloser, error) {
 	m.ctrl.T.Helper()

--- a/mocks/mock_blockchain.go
+++ b/mocks/mock_blockchain.go
@@ -333,21 +333,6 @@ func (mr *MockReaderMockRecorder) ReceiptByBlockNumberAndIndex(blockNumber, inde
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReceiptByBlockNumberAndIndex", reflect.TypeOf((*MockReader)(nil).ReceiptByBlockNumberAndIndex), blockNumber, index)
 }
 
-// TransactionExecutionStatusByBlockNumberAndIndex mocks base method.
-func (m *MockReader) TransactionExecutionStatusByBlockNumberAndIndex(blockNumber, index uint64) (core.ExecutionStatus, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "TransactionExecutionStatusByBlockNumberAndIndex", blockNumber, index)
-	ret0, _ := ret[0].(core.ExecutionStatus)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// TransactionExecutionStatusByBlockNumberAndIndex indicates an expected call of TransactionExecutionStatusByBlockNumberAndIndex.
-func (mr *MockReaderMockRecorder) TransactionExecutionStatusByBlockNumberAndIndex(blockNumber, index any) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "TransactionExecutionStatusByBlockNumberAndIndex", reflect.TypeOf((*MockReader)(nil).TransactionExecutionStatusByBlockNumberAndIndex), blockNumber, index)
-}
-
 // StateAtBlockHash mocks base method.
 func (m *MockReader) StateAtBlockHash(blockHash *felt.Felt) (core.StateReader, blockchain.StateCloser, error) {
 	m.ctrl.T.Helper()
@@ -452,6 +437,21 @@ func (m *MockReader) TransactionByHash(hash *felt.Felt) (core.Transaction, error
 func (mr *MockReaderMockRecorder) TransactionByHash(hash any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "TransactionByHash", reflect.TypeOf((*MockReader)(nil).TransactionByHash), hash)
+}
+
+// TransactionExecutionStatusByBlockNumberAndIndex mocks base method.
+func (m *MockReader) TransactionExecutionStatusByBlockNumberAndIndex(blockNumber, index uint64) (core.ExecutionStatus, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "TransactionExecutionStatusByBlockNumberAndIndex", blockNumber, index)
+	ret0, _ := ret[0].(core.ExecutionStatus)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// TransactionExecutionStatusByBlockNumberAndIndex indicates an expected call of TransactionExecutionStatusByBlockNumberAndIndex.
+func (mr *MockReaderMockRecorder) TransactionExecutionStatusByBlockNumberAndIndex(blockNumber, index any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "TransactionExecutionStatusByBlockNumberAndIndex", reflect.TypeOf((*MockReader)(nil).TransactionExecutionStatusByBlockNumberAndIndex), blockNumber, index)
 }
 
 // TransactionsByBlockNumber mocks base method.

--- a/rpc/v10/l1_test.go
+++ b/rpc/v10/l1_test.go
@@ -112,13 +112,6 @@ func TestGetMessageStatus(t *testing.T) {
 				},
 			}
 			mockSyncReader.EXPECT().PreConfirmedChain().Return(mustNewChain(t, preConfirmed), nil).AnyTimes()
-			l1handlerTxns := make([]core.Transaction, len(test.msgs))
-			for i := range len(test.msgs) {
-				//nolint:staticcheck //SA1019: used here to get the stored txs in testdata feeder
-				txn, err := gw.Transaction(t.Context(), test.msgs[i].L1HandlerHash)
-				require.NoError(t, err)
-				l1handlerTxns[i] = txn
-			}
 
 			mockL1Client.EXPECT().TransactionReceipt(
 				gomock.Any(),
@@ -133,12 +126,12 @@ func TestGetMessageStatus(t *testing.T) {
 				mockReader.EXPECT().BlockNumberAndIndexByTxHash(
 					(*felt.TransactionHash)(msg.L1HandlerHash),
 				).Return(block.Number, uint64(i), nil)
-				mockReader.EXPECT().TransactionByBlockNumberAndIndex(
+				mockReader.EXPECT().TransactionExecutionStatusByBlockNumberAndIndex(
 					block.Number, uint64(i),
-				).Return(l1handlerTxns[i], nil)
-				mockReader.EXPECT().ReceiptByBlockNumberAndIndex(
-					block.Number, uint64(i),
-				).Return(*block.Receipts[i], block.Hash, nil)
+				).Return(core.ExecutionStatus{
+					Reverted:     block.Receipts[i].Reverted,
+					RevertReason: block.Receipts[i].RevertReason,
+				}, nil)
 				mockReader.EXPECT().L1Head().Return(core.L1Head{BlockNumber: test.l1HeadBlockNum}, nil)
 			}
 			msgStatuses, rpcErr := handler.GetMessageStatus(t.Context(), &test.l1TxnHash)

--- a/rpc/v10/subscriptions_test.go
+++ b/rpc/v10/subscriptions_test.go
@@ -984,12 +984,12 @@ func TestSubscribeTxnStatus(t *testing.T) {
 		mockChain.EXPECT().BlockNumberAndIndexByTxHash(
 			&txHash,
 		).Return(block.Number, uint64(0), nil)
-		mockChain.EXPECT().TransactionByBlockNumberAndIndex(
+		mockChain.EXPECT().TransactionExecutionStatusByBlockNumberAndIndex(
 			block.Number, uint64(0),
-		).Return(block.Transactions[0], nil)
-		mockChain.EXPECT().ReceiptByBlockNumberAndIndex(
-			block.Number, uint64(0),
-		).Return(*block.Receipts[0], block.Hash, nil)
+		).Return(core.ExecutionStatus{
+			Reverted:     block.Receipts[0].Reverted,
+			RevertReason: block.Receipts[0].RevertReason,
+		}, nil)
 		mockChain.EXPECT().L1Head().Return(core.L1Head{}, db.ErrKeyNotFound)
 
 		handler.newHeads.Send(block)
@@ -1009,12 +1009,12 @@ func TestSubscribeTxnStatus(t *testing.T) {
 		mockChain.EXPECT().BlockNumberAndIndexByTxHash(
 			&txHash,
 		).Return(block.Number, uint64(0), nil)
-		mockChain.EXPECT().TransactionByBlockNumberAndIndex(
+		mockChain.EXPECT().TransactionExecutionStatusByBlockNumberAndIndex(
 			block.Number, uint64(0),
-		).Return(block.Transactions[0], nil)
-		mockChain.EXPECT().ReceiptByBlockNumberAndIndex(
-			block.Number, uint64(0),
-		).Return(*block.Receipts[0], block.Hash, nil)
+		).Return(core.ExecutionStatus{
+			Reverted:     block.Receipts[0].Reverted,
+			RevertReason: block.Receipts[0].RevertReason,
+		}, nil)
 		mockChain.EXPECT().L1Head().Return(l1Head, nil)
 		handler.l1Heads.Send(&l1Head)
 		assertNextTxnStatus(

--- a/rpc/v10/transaction.go
+++ b/rpc/v10/transaction.go
@@ -278,14 +278,10 @@ func (h *Handler) TransactionStatus(
 	ctx context.Context,
 	hash *felt.Felt,
 ) (TransactionStatus, *jsonrpc.Error) {
-	receipt, txErr := h.TransactionReceiptByHash(hash)
+	status, txErr := h.transactionStatusFromStore(hash)
 	switch txErr {
 	case nil:
-		return TransactionStatus{
-			Finality:      TxnStatus(receipt.FinalityStatus),
-			Execution:     receipt.ExecutionStatus,
-			FailureReason: receipt.RevertReason,
-		}, nil
+		return status, nil
 	case rpccore.ErrTxnHashNotFound:
 		if h.feederClient == nil {
 			break
@@ -312,6 +308,75 @@ func (h *Handler) TransactionStatus(
 		return status, nil
 	}
 	return TransactionStatus{}, txErr
+}
+
+// transactionStatusFromStore resolves a transaction's status from the
+// pre_confirmed chain or the committed store, decoding only the receipt fields
+// the status needs instead of adapting the whole receipt. Returns
+// rpccore.ErrTxnHashNotFound if the transaction is not found locally.
+func (h *Handler) transactionStatusFromStore(
+	hash *felt.Felt,
+) (TransactionStatus, *jsonrpc.Error) {
+	if chain, err := h.syncReader.PreConfirmedChain(); err == nil {
+		if receipt, _, err := chain.ReceiptByHash(hash); err == nil {
+			return newTransactionStatus(
+				TxnStatusPreConfirmed, receipt.Reverted, receipt.RevertReason,
+			), nil
+		}
+	}
+
+	blockNumber, index, err := h.bcReader.BlockNumberAndIndexByTxHash(
+		(*felt.TransactionHash)(hash),
+	)
+	if err != nil {
+		if !errors.Is(err, db.ErrKeyNotFound) {
+			return TransactionStatus{}, rpccore.ErrInternal.CloneWithData(err)
+		}
+		return TransactionStatus{}, rpccore.ErrTxnHashNotFound
+	}
+
+	executionStatus, err := h.bcReader.TransactionExecutionStatusByBlockNumberAndIndex(
+		blockNumber,
+		index,
+	)
+	if err != nil {
+		if !errors.Is(err, db.ErrKeyNotFound) {
+			return TransactionStatus{}, rpccore.ErrInternal.CloneWithData(err)
+		}
+		return TransactionStatus{}, rpccore.ErrTxnHashNotFound
+	}
+
+	l1H, jsonErr := h.l1Head()
+	if jsonErr != nil {
+		return TransactionStatus{}, jsonErr
+	}
+
+	finality := TxnStatusAcceptedOnL2
+	if isL1Verified(blockNumber, l1H) {
+		finality = TxnStatusAcceptedOnL1
+	}
+
+	return newTransactionStatus(
+		finality, executionStatus.Reverted, executionStatus.RevertReason,
+	), nil
+}
+
+// newTransactionStatus builds a TransactionStatus from a finality status and the
+// receipt's execution outcome.
+func newTransactionStatus(
+	finality TxnStatus,
+	reverted bool,
+	revertReason string,
+) TransactionStatus {
+	execution := TxnSuccess
+	if reverted {
+		execution = TxnFailure
+	}
+	return TransactionStatus{
+		Finality:      finality,
+		Execution:     execution,
+		FailureReason: revertReason,
+	}
 }
 
 /****************************************************

--- a/rpc/v10/transaction_test.go
+++ b/rpc/v10/transaction_test.go
@@ -1608,12 +1608,12 @@ func TestTransactionStatus(t *testing.T) {
 		mockReader.EXPECT().BlockNumberAndIndexByTxHash(
 			(*felt.TransactionHash)(tx.Hash()),
 		).Return(block.Number, uint64(0), nil)
-		mockReader.EXPECT().TransactionByBlockNumberAndIndex(
+		mockReader.EXPECT().TransactionExecutionStatusByBlockNumberAndIndex(
 			block.Number, uint64(0),
-		).Return(tx, nil)
-		mockReader.EXPECT().ReceiptByBlockNumberAndIndex(
-			block.Number, uint64(0),
-		).Return(*block.Receipts[0], block.Hash, nil)
+		).Return(core.ExecutionStatus{
+			Reverted:     block.Receipts[0].Reverted,
+			RevertReason: block.Receipts[0].RevertReason,
+		}, nil)
 		mockSyncReader.EXPECT().PreConfirmedChain().Return(mustNewChain(t, &preConfirmedPlaceHolder), nil)
 	}
 

--- a/rpc/v10/transaction_test.go
+++ b/rpc/v10/transaction_test.go
@@ -1630,7 +1630,22 @@ func TestTransactionStatus(t *testing.T) {
 			Times(1)
 	}
 
-	// TODO(Ege): Add test with failure reason REVERTED
+	mockFoundInDBReverted := func(
+		mockReader *mocks.MockReader,
+		mockSyncReader *mocks.MockSyncReader,
+	) {
+		mockReader.EXPECT().BlockNumberAndIndexByTxHash(
+			(*felt.TransactionHash)(tx.Hash()),
+		).Return(block.Number, uint64(0), nil)
+		mockReader.EXPECT().TransactionExecutionStatusByBlockNumberAndIndex(
+			block.Number, uint64(0),
+		).Return(core.ExecutionStatus{
+			Reverted:     true,
+			RevertReason: "some revert reason",
+		}, nil)
+		mockSyncReader.EXPECT().PreConfirmedChain().Return(mustNewChain(t, &preConfirmedPlaceHolder), nil)
+	}
+
 	testCases := []testCase{
 		{
 			description: "status ACCEPTED_ON_L2",
@@ -1642,6 +1657,20 @@ func TestTransactionStatus(t *testing.T) {
 			},
 			setupMocks: func(mockReader *mocks.MockReader, mockSyncReader *mocks.MockSyncReader) {
 				mockFoundInDB(mockReader, mockSyncReader)
+				mockReader.EXPECT().L1Head().Return(core.L1Head{BlockNumber: 0}, nil)
+			},
+		},
+		{
+			description: "status ACCEPTED_ON_L2 REVERTED",
+			network:     &networks.Mainnet,
+			txHash:      targetTxnHash,
+			expectedStatus: rpc.TransactionStatus{
+				Finality:      rpc.TxnStatusAcceptedOnL2,
+				Execution:     rpc.TxnFailure,
+				FailureReason: "some revert reason",
+			},
+			setupMocks: func(mockReader *mocks.MockReader, mockSyncReader *mocks.MockSyncReader) {
+				mockFoundInDBReverted(mockReader, mockSyncReader)
 				mockReader.EXPECT().L1Head().Return(core.L1Head{BlockNumber: 0}, nil)
 			},
 		},

--- a/rpc/v9/l1_test.go
+++ b/rpc/v9/l1_test.go
@@ -97,12 +97,6 @@ func TestGetMessageStatus(t *testing.T) {
 				},
 			}
 			mockSyncReader.EXPECT().PreConfirmedChain().Return(mustNewChain(t, preConfirmed), nil).AnyTimes()
-			l1handlerTxns := make([]core.Transaction, len(test.msgs))
-			for i := range len(test.msgs) {
-				txn, err := gw.Transaction(t.Context(), test.msgs[i].L1HandlerHash)
-				require.NoError(t, err)
-				l1handlerTxns[i] = txn
-			}
 
 			mockL1Client.EXPECT().TransactionReceipt(
 				gomock.Any(), gomock.Any(),
@@ -116,12 +110,12 @@ func TestGetMessageStatus(t *testing.T) {
 				mockReader.EXPECT().BlockNumberAndIndexByTxHash(
 					(*felt.TransactionHash)(msg.L1HandlerHash),
 				).Return(block.Number, uint64(i), nil)
-				mockReader.EXPECT().TransactionByBlockNumberAndIndex(
+				mockReader.EXPECT().TransactionExecutionStatusByBlockNumberAndIndex(
 					block.Number, uint64(i),
-				).Return(l1handlerTxns[i], nil)
-				mockReader.EXPECT().ReceiptByBlockNumberAndIndex(
-					block.Number, uint64(i),
-				).Return(*block.Receipts[i], block.Hash, nil)
+				).Return(core.ExecutionStatus{
+					Reverted:     block.Receipts[i].Reverted,
+					RevertReason: block.Receipts[i].RevertReason,
+				}, nil)
 				mockReader.EXPECT().L1Head().Return(core.L1Head{BlockNumber: test.l1HeadBlockNum}, nil)
 			}
 			msgStatuses, rpcErr := handler.GetMessageStatus(t.Context(), &test.l1TxnHash)

--- a/rpc/v9/subscriptions_test.go
+++ b/rpc/v9/subscriptions_test.go
@@ -884,12 +884,12 @@ func TestSubscribeTxnStatus(t *testing.T) {
 		mockChain.EXPECT().BlockNumberAndIndexByTxHash(
 			(*felt.TransactionHash)(txHash),
 		).Return(block.Number, uint64(0), nil)
-		mockChain.EXPECT().TransactionByBlockNumberAndIndex(
+		mockChain.EXPECT().TransactionExecutionStatusByBlockNumberAndIndex(
 			block.Number, uint64(0),
-		).Return(block.Transactions[0], nil)
-		mockChain.EXPECT().ReceiptByBlockNumberAndIndex(
-			block.Number, uint64(0),
-		).Return(*block.Receipts[0], block.Hash, nil)
+		).Return(core.ExecutionStatus{
+			Reverted:     block.Receipts[0].Reverted,
+			RevertReason: block.Receipts[0].RevertReason,
+		}, nil)
 		mockChain.EXPECT().L1Head().Return(core.L1Head{}, db.ErrKeyNotFound)
 
 		handler.newHeads.Send(block)
@@ -901,11 +901,12 @@ func TestSubscribeTxnStatus(t *testing.T) {
 		mockChain.EXPECT().BlockNumberAndIndexByTxHash(
 			(*felt.TransactionHash)(txHash),
 		).Return(block.Number, uint64(0), nil)
-		mockChain.EXPECT().TransactionByBlockNumberAndIndex(
-			block.Number, uint64(0)).Return(block.Transactions[0], nil)
-		mockChain.EXPECT().ReceiptByBlockNumberAndIndex(
+		mockChain.EXPECT().TransactionExecutionStatusByBlockNumberAndIndex(
 			block.Number, uint64(0),
-		).Return(*block.Receipts[0], block.Hash, nil)
+		).Return(core.ExecutionStatus{
+			Reverted:     block.Receipts[0].Reverted,
+			RevertReason: block.Receipts[0].RevertReason,
+		}, nil)
 		mockChain.EXPECT().L1Head().Return(l1Head, nil)
 		handler.l1Heads.Send(&l1Head)
 		assertNextTxnStatus(t, conn, id, txHash, TxnStatusAcceptedOnL1, TxnSuccess, "")

--- a/rpc/v9/transaction.go
+++ b/rpc/v9/transaction.go
@@ -842,14 +842,10 @@ func (h *Handler) TransactionStatus(
 	ctx context.Context,
 	hash *felt.Felt,
 ) (TransactionStatus, *jsonrpc.Error) {
-	receipt, txErr := h.TransactionReceiptByHash(hash)
+	status, txErr := h.transactionStatusFromStore(hash)
 	switch txErr {
 	case nil:
-		return TransactionStatus{
-			Finality:      TxnStatus(receipt.FinalityStatus),
-			Execution:     receipt.ExecutionStatus,
-			FailureReason: receipt.RevertReason,
-		}, nil
+		return status, nil
 	case rpccore.ErrTxnHashNotFound:
 		if h.feederClient == nil {
 			break
@@ -876,6 +872,75 @@ func (h *Handler) TransactionStatus(
 		return status, nil
 	}
 	return TransactionStatus{}, txErr
+}
+
+// transactionStatusFromStore resolves a transaction's status from the
+// pre_confirmed chain or the committed store, decoding only the receipt fields
+// the status needs instead of adapting the whole receipt. Returns
+// rpccore.ErrTxnHashNotFound if the transaction is not found locally.
+func (h *Handler) transactionStatusFromStore(
+	hash *felt.Felt,
+) (TransactionStatus, *jsonrpc.Error) {
+	if chain, err := h.syncReader.PreConfirmedChain(); err == nil {
+		if receipt, _, err := chain.ReceiptByHash(hash); err == nil {
+			return newTransactionStatus(
+				TxnStatusPreConfirmed, receipt.Reverted, receipt.RevertReason,
+			), nil
+		}
+	}
+
+	blockNumber, index, err := h.bcReader.BlockNumberAndIndexByTxHash(
+		(*felt.TransactionHash)(hash),
+	)
+	if err != nil {
+		if !errors.Is(err, db.ErrKeyNotFound) {
+			return TransactionStatus{}, rpccore.ErrInternal.CloneWithData(err)
+		}
+		return TransactionStatus{}, rpccore.ErrTxnHashNotFound
+	}
+
+	executionStatus, err := h.bcReader.TransactionExecutionStatusByBlockNumberAndIndex(
+		blockNumber,
+		index,
+	)
+	if err != nil {
+		if !errors.Is(err, db.ErrKeyNotFound) {
+			return TransactionStatus{}, rpccore.ErrInternal.CloneWithData(err)
+		}
+		return TransactionStatus{}, rpccore.ErrTxnHashNotFound
+	}
+
+	l1H, jsonErr := h.l1Head()
+	if jsonErr != nil {
+		return TransactionStatus{}, jsonErr
+	}
+
+	finality := TxnStatusAcceptedOnL2
+	if isL1Verified(blockNumber, l1H) {
+		finality = TxnStatusAcceptedOnL1
+	}
+
+	return newTransactionStatus(
+		finality, executionStatus.Reverted, executionStatus.RevertReason,
+	), nil
+}
+
+// newTransactionStatus builds a TransactionStatus from a finality status and the
+// receipt's execution outcome.
+func newTransactionStatus(
+	finality TxnStatus,
+	reverted bool,
+	revertReason string,
+) TransactionStatus {
+	execution := TxnSuccess
+	if reverted {
+		execution = TxnFailure
+	}
+	return TransactionStatus{
+		Finality:      finality,
+		Execution:     execution,
+		FailureReason: revertReason,
+	}
 }
 
 //nolint:gocyclo // maps gateway error codes to RPC errors

--- a/rpc/v9/transaction_test.go
+++ b/rpc/v9/transaction_test.go
@@ -1753,12 +1753,12 @@ func TestTransactionStatus(t *testing.T) {
 					mockReader.EXPECT().BlockNumberAndIndexByTxHash(
 						(*felt.TransactionHash)(tx.Hash()),
 					).Return(block.Number, uint64(0), nil)
-					mockReader.EXPECT().TransactionByBlockNumberAndIndex(
+					mockReader.EXPECT().TransactionExecutionStatusByBlockNumberAndIndex(
 						block.Number, uint64(0),
-					).Return(tx, nil)
-					mockReader.EXPECT().ReceiptByBlockNumberAndIndex(
-						block.Number, uint64(0),
-					).Return(*block.Receipts[0], block.Hash, nil)
+					).Return(core.ExecutionStatus{
+						Reverted:     block.Receipts[0].Reverted,
+						RevertReason: block.Receipts[0].RevertReason,
+					}, nil)
 					mockReader.EXPECT().L1Head().Return(core.L1Head{}, nil)
 
 					handler := rpc.New(mockReader, mockSyncReader, nil, nil)
@@ -1784,12 +1784,12 @@ func TestTransactionStatus(t *testing.T) {
 					mockReader.EXPECT().BlockNumberAndIndexByTxHash(
 						(*felt.TransactionHash)(tx.Hash()),
 					).Return(block.Number, uint64(0), nil)
-					mockReader.EXPECT().TransactionByBlockNumberAndIndex(
+					mockReader.EXPECT().TransactionExecutionStatusByBlockNumberAndIndex(
 						block.Number, uint64(0),
-					).Return(tx, nil)
-					mockReader.EXPECT().ReceiptByBlockNumberAndIndex(
-						block.Number, uint64(0),
-					).Return(*block.Receipts[0], block.Hash, nil)
+					).Return(core.ExecutionStatus{
+						Reverted:     block.Receipts[0].Reverted,
+						RevertReason: block.Receipts[0].RevertReason,
+					}, nil)
 					mockReader.EXPECT().L1Head().Return(core.L1Head{
 						BlockNumber: block.Number + 1,
 					}, nil)

--- a/rpc/v9/transaction_test.go
+++ b/rpc/v9/transaction_test.go
@@ -1804,6 +1804,38 @@ func TestTransactionStatus(t *testing.T) {
 					require.Nil(t, rpcErr)
 					require.Equal(t, *want, status)
 				})
+				t.Run("reverted", func(t *testing.T) {
+					mockReader := mocks.NewMockReader(mockCtrl)
+					mockSyncReader := mocks.NewMockSyncReader(mockCtrl)
+					mockSyncReader.EXPECT().PreConfirmedChain().Return(mustNewChain(t, &pending.PreConfirmed{
+						Block: &core.Block{
+							Header: &core.Header{
+								Number: block.Number + 1,
+							},
+						},
+					}), nil)
+					mockReader.EXPECT().BlockNumberAndIndexByTxHash(
+						(*felt.TransactionHash)(tx.Hash()),
+					).Return(block.Number, uint64(0), nil)
+					mockReader.EXPECT().TransactionExecutionStatusByBlockNumberAndIndex(
+						block.Number, uint64(0),
+					).Return(core.ExecutionStatus{
+						Reverted:     true,
+						RevertReason: "some revert reason",
+					}, nil)
+					mockReader.EXPECT().L1Head().Return(core.L1Head{}, nil)
+
+					handler := rpc.New(mockReader, mockSyncReader, nil, logger)
+
+					want := &rpc.TransactionStatus{
+						Finality:      rpc.TxnStatusAcceptedOnL2,
+						Execution:     rpc.TxnFailure,
+						FailureReason: "some revert reason",
+					}
+					status, rpcErr := handler.TransactionStatus(ctx, tx.Hash())
+					require.Nil(t, rpcErr)
+					require.Equal(t, *want, status)
+				})
 			})
 			t.Run("transaction not found in db", func(t *testing.T) {
 				notFoundTests := map[string]struct {


### PR DESCRIPTION
`starknet_getTransactionStatus` previously went through `TransactionReceiptByHash`, adapting the entire receipt (events, execution resources, fees, messages) just to read finality, execution status, and revert reason. 

This PR resolves status by decoding only a minimal `ExecutionStatus` subset (Reverted, RevertReason) straight from the stored receipt bytes, so we no longer decode the transaction and no longer materialize the full receipt. Adds `core.ExecutionStatus` plus its partial serializer/bucket/accessor and `TransactionExecutionStatusByBlockNumberAndIndex` reader, wires them into `TransactionStatus` for both v9 and v10 (pre_confirmed chain first, then a subset read by block number and index), and leaves the feeder-gateway fallback unchanged.