### PR TITLE
perf(felt): encode felt.Slice as a single JSON value under json/v2

### DIFF
--- a/.github/workflows/juno-test.yml
+++ b/.github/workflows/juno-test.yml
@@ -7,6 +7,10 @@ on:
   pull_request:
   workflow_dispatch:
 
+permissions:
+  contents: read
+  pull-requests: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
@@ -88,3 +92,42 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
           fail_ci_if_error: true
           files: coverage/coverage.old.out,coverage/coverage.new.out
+
+  # TODO(granza): Delete this job and move slice_jsonv2.go into slice.go once jsonv2 is default
+  test-jsonv2:
+    name: Run Tests (jsonv2)
+    runs-on: ubuntu-latest
+    env:
+      GOEXPERIMENT: jsonv2
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Set up go
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v6.0.0
+        with:
+          go-version-file: go.mod
+
+      - name: Fail once jsonv2 is no longer an experiment
+        run: |
+          if GOEXPERIMENT= go list encoding/json/v2 >/dev/null 2>&1; then
+            echo "::error::json/v2 builds without GOEXPERIMENT now, so this job is a"
+            echo "::error::duplicate of Run Tests. Delete it and move the body of"
+            echo "::error::core/felt/slice_jsonv2.go into core/felt/slice.go."
+            exit 1
+          fi
+
+      - name: Verify the build tag is applied
+        run: go list -f '{{join .GoFiles "\n"}}' ./core/felt | grep -qx slice_jsonv2.go
+
+      # Scoped to core/felt: jsonrpc fails under the experiment on Go 1.26 because it
+      # shifts the offset reported for a JSON parse error.
+      # It is a toolchain bug, fixed in Go 1.27 (go.dev/issue/79659).
+      - name: Tests
+        run: go test -short -count=1 -coverprofile=coverage.out -covermode=atomic ./core/felt/...
+
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: coverage.out
+          flags: jsonv2

--- a/.github/workflows/juno-test.yml
+++ b/.github/workflows/juno-test.yml
@@ -7,6 +7,10 @@ on:
   pull_request:
   workflow_dispatch:
 
+permissions:
+  contents: read
+  pull-requests: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
@@ -88,3 +92,61 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
           fail_ci_if_error: true
           files: coverage/coverage.old.out,coverage/coverage.new.out
+
+  # TODO(granza): Delete this job and move slice_jsonv2.go into slice.go once jsonv2 is default
+  test-jsonv2:
+    name: Run Tests (jsonv2)
+    runs-on: ubuntu-latest
+    env:
+      GOEXPERIMENT: jsonv2
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Set up go
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v6.0.0
+        with:
+          go-version-file: go.mod
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+        with:
+          toolchain: "1.94.1"
+
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2.8.1
+        with:
+          workspaces: |
+            vm/rust
+            starknet/compiler/rust
+
+      # vm links against -lbz2, and the rpc tests import node, which links jemalloc
+      - name: Install bzip2 and Jemalloc
+        run: sudo apt-get update -qq && sudo apt-get install -y libbz2-dev libjemalloc-dev libjemalloc2
+
+      - name: Fail once jsonv2 is no longer an experiment
+        run: |
+          if GOEXPERIMENT= go list encoding/json/v2 >/dev/null 2>&1; then
+            echo "::error::json/v2 builds without GOEXPERIMENT now, so this job is a"
+            echo "::error::duplicate of Run Tests. Delete it and move the body of"
+            echo "::error::core/felt/slice_jsonv2.go into core/felt/slice.go."
+            exit 1
+          fi
+
+      - name: Verify the build tag is applied
+        run: go list -f '{{join .GoFiles "\n"}}' ./core/felt | grep -qx slice_jsonv2.go
+
+      - name: Build the Rust libraries that rpc links against
+        run: make rustdeps
+
+      # jsonrpc is left out: it fails under the experiment on Go 1.26 because the
+      # offset reported for a JSON parse error shifts.
+      # It is a toolchain bug, fixed in Go 1.27 (go.dev/issue/79659).
+      - name: Tests
+        env:
+          CGO_LDFLAGS: -ldl -lm
+        run: go test -short -count=1 -coverpkg=./core/...,./rpc/... -coverprofile=coverage.out -covermode=atomic ./core/... ./rpc/...
+
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          fail_ci_if_error: true
+          files: coverage.out
+          flags: jsonv2

--- a/core/felt/felt.go
+++ b/core/felt/felt.go
@@ -63,15 +63,19 @@ func (z *Felt) UnmarshalJSON(data []byte) error {
 	if dataSize < len(`"0x0"`) || data[0] != '"' || data[dataSize-1] != '"' {
 		return errors.New("felt: expected a quoted 0x hex string")
 	}
+	return z.setHex(data[1 : dataSize-1])
+}
 
-	digits := data[1 : dataSize-1]
-	if digits[0] != '0' || (digits[1] != 'x' && digits[1] != 'X') {
+// setHex parses a 0x-prefixed hex string (without surrounding quotes) into z.
+// It is the decode counterpart of AppendText.
+func (z *Felt) setHex(data []byte) error {
+	if len(data) < len("0x0") || data[0] != '0' || (data[1] != 'x' && data[1] != 'X') {
 		return errors.New("felt: expected hex string starting with 0x")
 	}
-	if len(digits) > MaxFeltAsHexSize {
+	if len(data) > MaxFeltAsHexSize {
 		return errors.New("felt: value exceeds field size")
 	}
-	digits = digits[2:]
+	digits := data[2:]
 
 	// hex.Decode consumes digits in pairs, so an odd number means a leading zero.
 	if len(digits)%2 == 1 {

--- a/core/felt/slice_bench_test.go
+++ b/core/felt/slice_bench_test.go
@@ -1,6 +1,7 @@
 package felt_test
 
 import (
+	"encoding/json"
 	"fmt"
 	"testing"
 
@@ -8,7 +9,7 @@ import (
 	"github.com/NethermindEth/juno/encoder"
 )
 
-func BenchmarkSliceVsFeltArray(b *testing.B) {
+func BenchmarkSliceVsFeltArrayCBOR(b *testing.B) {
 	for _, n := range []int{1000, 5000} {
 		slice := randomSlice[feltoid](n)
 		feltArray := []feltoid(slice)
@@ -43,5 +44,68 @@ func BenchmarkSliceVsFeltArray(b *testing.B) {
 				_ = encoder.Unmarshal(encoded, &out)
 			}
 		})
+	}
+}
+
+func shortSlice(size int) felt.Slice[felt.Felt] {
+	slice := make(felt.Slice[felt.Felt], size)
+	for idx := range slice {
+		slice[idx] = felt.FromUint64[felt.Felt](uint64(idx) % 4096)
+	}
+
+	return slice
+}
+
+func BenchmarkSliceVsFeltArrayJSON(b *testing.B) {
+	cases := map[string]func(int) felt.Slice[felt.Felt]{
+		"short": shortSlice,
+		"long":  randomSlice[felt.Felt],
+	}
+
+	for _, name := range []string{"short", "long"} {
+		for _, n := range []int{1000, 5000} {
+			slice := cases[name](n)
+			feltArray := []felt.Felt(slice)
+
+			encoded, err := json.Marshal(slice)
+			if err != nil {
+				b.Fatal(err)
+			}
+
+			b.Run(fmt.Sprintf("marshal/Slice/%s/n=%d", name, n), func(b *testing.B) {
+				b.ReportAllocs()
+				for b.Loop() {
+					if _, err := json.Marshal(slice); err != nil {
+						b.Fatal(err)
+					}
+				}
+			})
+			b.Run(fmt.Sprintf("marshal/FeltArray/%s/n=%d", name, n), func(b *testing.B) {
+				b.ReportAllocs()
+				for b.Loop() {
+					if _, err := json.Marshal(feltArray); err != nil {
+						b.Fatal(err)
+					}
+				}
+			})
+			b.Run(fmt.Sprintf("unmarshal/Slice/%s/n=%d", name, n), func(b *testing.B) {
+				b.ReportAllocs()
+				for b.Loop() {
+					var out felt.Slice[felt.Felt]
+					if err := json.Unmarshal(encoded, &out); err != nil {
+						b.Fatal(err)
+					}
+				}
+			})
+			b.Run(fmt.Sprintf("unmarshal/FeltArray/%s/n=%d", name, n), func(b *testing.B) {
+				b.ReportAllocs()
+				for b.Loop() {
+					var out []felt.Felt
+					if err := json.Unmarshal(encoded, &out); err != nil {
+						b.Fatal(err)
+					}
+				}
+			})
+		}
 	}
 }

--- a/core/felt/slice_jsonv2.go
+++ b/core/felt/slice_jsonv2.go
@@ -1,0 +1,101 @@
+//go:build goexperiment.jsonv2
+
+// TODO(granza): Move this to slice.go after jsonv2 is no longer experimental
+package felt
+
+import (
+	"bytes"
+	"encoding/json/jsontext"
+	"errors"
+	"fmt"
+)
+
+// MarshalJSONTo serialises the slice as a JSON array of 0x-hex strings.
+func (s Slice[F]) MarshalJSONTo(enc *jsontext.Encoder) error {
+	if s == nil {
+		return enc.WriteToken(jsontext.Null)
+	}
+
+	// account for quotes and commas per felt + '[' and ']' at the ends.
+	maxSize := len(s)*(MaxFeltAsHexSize+len(`"",`)) + len("[]")
+	data := make([]byte, 1, maxSize)
+
+	data[0] = '['
+	for index := range s {
+		if index > 0 {
+			data = append(data, ',')
+		}
+		data = append(data, '"')
+		data, _ = Felt(s[index]).AppendText(data)
+		data = append(data, '"')
+	}
+	data = append(data, ']')
+
+	return enc.WriteValue(jsontext.Value(data))
+}
+
+// UnmarshalJSONFrom reads a JSON array of 0x-hex strings into the slice.
+func (s *Slice[F]) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
+	kind := dec.PeekKind()
+	if kind == 'n' { // null -> nil slice
+		_, tokErr := dec.ReadToken()
+		if tokErr != nil {
+			return tokErr
+		}
+		*s = nil
+		return nil
+	}
+
+	if kind != '[' {
+		return fmt.Errorf("felt: cannot unmarshal %s into Slice", kind)
+	}
+
+	val, valErr := dec.ReadValue()
+	if valErr != nil {
+		return valErr
+	}
+
+	newSlice := (*s)[:0]
+	if newSlice == nil {
+		newSlice = Slice[F]{}
+	}
+
+	for index := 1; index < len(val)-1; {
+		switch val[index] {
+		case ' ', '\t', '\n', '\r', ',':
+			index++
+			continue
+		case '"':
+		default:
+			return fmt.Errorf("felt: cannot unmarshal %s element into Slice", kindOf(val[index]))
+		}
+
+		relativeEnd := bytes.IndexByte(val[index+1:], '"')
+		if relativeEnd < 0 {
+			return errors.New("felt: unterminated string in Slice")
+		}
+		end := index + 1 + relativeEnd
+
+		var newFelt F
+		hexErr := asFeltPtr(&newFelt).setHex(val[index+1 : end])
+		if hexErr != nil {
+			return hexErr
+		}
+
+		newSlice = append(newSlice, newFelt)
+
+		index = end + 1
+	}
+
+	*s = newSlice
+	return nil
+}
+
+func kindOf(char byte) jsontext.Kind {
+	switch char {
+	case 'n', 't', 'f', '"', '{', '[':
+		return jsontext.Kind(char)
+	default:
+		return '0'
+	}
+}

--- a/core/felt/slice_jsonv2.go
+++ b/core/felt/slice_jsonv2.go
@@ -10,23 +10,25 @@ import (
 	"fmt"
 )
 
-// MarshalJSONTo serialises the slice as a JSON array of 0x-hex strings.
 func (s Slice[F]) MarshalJSONTo(enc *jsontext.Encoder) error {
 	if s == nil {
 		return enc.WriteToken(jsontext.Null)
 	}
 
-	// account for quotes and commas per felt + '[' and ']' at the ends.
-	maxSize := len(s)*(MaxFeltAsHexSize+len(`"",`)) + len("[]")
+	// account for quotes and commas per felt + '[' and ']' at the ends - the last comma.
+	maxSize := len(s)*(MaxFeltAsHexSize+len(`"",`)) + len("[]") - len(",")
 	data := make([]byte, 1, maxSize)
 
+	var err error
 	data[0] = '['
 	for index := range s {
 		if index > 0 {
 			data = append(data, ',')
 		}
 		data = append(data, '"')
-		data, _ = Felt(s[index]).AppendText(data)
+		if data, err = Felt(s[index]).AppendText(data); err != nil {
+			return err
+		}
 		data = append(data, '"')
 	}
 	data = append(data, ']')

--- a/core/felt/slice_jsonv2.go
+++ b/core/felt/slice_jsonv2.go
@@ -10,14 +10,13 @@ import (
 	"fmt"
 )
 
-// MarshalJSONTo serialises the slice as a JSON array of 0x-hex strings.
 func (s Slice[F]) MarshalJSONTo(enc *jsontext.Encoder) error {
 	if s == nil {
 		return enc.WriteToken(jsontext.Null)
 	}
 
-	// account for quotes and commas per felt + '[' and ']' at the ends.
-	maxSize := len(s)*(MaxFeltAsHexSize+len(`"",`)) + len("[]")
+	// account for quotes and commas per felt + '[' and ']' at the ends - the last comma.
+	maxSize := len(s)*(MaxFeltAsHexSize+len(`"",`)) + len("[]") - len(",")
 	data := make([]byte, 1, maxSize)
 
 	data[0] = '['

--- a/core/felt/slice_test.go
+++ b/core/felt/slice_test.go
@@ -2,6 +2,7 @@ package felt_test
 
 import (
 	"encoding/binary"
+	"encoding/json"
 	"math"
 	"math/rand"
 	"slices"
@@ -44,7 +45,7 @@ func encodeFeltCBOR(t *testing.T, value felt.Felt) []byte {
 
 // requireSliceDecodeEquivalent decodes data with both the fast and generic
 // paths and asserts they agree, either on the decoded felts or on the error.
-func requireSliceDecodeEquivalent[F felt.FeltLike](t *testing.T, data []byte) {
+func requireSliceDecodeCBOREquivalent[F felt.FeltLike](t *testing.T, data []byte) {
 	t.Helper()
 
 	var fast felt.Slice[F]
@@ -85,7 +86,7 @@ func requireSliceDecodeEquivalent[F felt.FeltLike](t *testing.T, data []byte) {
 	}
 }
 
-func TestSliceRoundTripBoundarySizes(t *testing.T) {
+func TestSliceRoundTripCBORBoundarySizes(t *testing.T) {
 	sizes := []struct {
 		name string
 		size int
@@ -115,15 +116,15 @@ func TestSliceRoundTripBoundarySizes(t *testing.T) {
 				tc.size,
 			)
 
-			requireSliceDecodeEquivalent[felt.Felt](t, fast)
-			requireSliceDecodeEquivalent[feltoid](t, fast)
+			requireSliceDecodeCBOREquivalent[felt.Felt](t, fast)
+			requireSliceDecodeCBOREquivalent[feltoid](t, fast)
 		})
 	}
 }
 
 // A nil slice must marshal like the generic encoder (null, not an empty array)
 // and round-trip back to nil rather than an empty slice.
-func TestSliceMarshalNil(t *testing.T) {
+func TestSliceMarshalCBORNil(t *testing.T) {
 	var s felt.Slice[felt.Felt] // nil
 
 	fast, err := s.MarshalCBOR()
@@ -137,7 +138,7 @@ func TestSliceMarshalNil(t *testing.T) {
 	require.Nil(t, back, "nil slice must round-trip back to nil, not empty")
 }
 
-func TestSliceDecodeCornerCases(t *testing.T) {
+func TestSliceDecodeCBORCornerCases(t *testing.T) {
 	feltBytes1 := encodeFeltCBOR(t, fromLimbs[felt.Felt](1))
 	feltBytes2 := encodeFeltCBOR(t, fromLimbs[felt.Felt](2))
 
@@ -174,13 +175,13 @@ func TestSliceDecodeCornerCases(t *testing.T) {
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			requireSliceDecodeEquivalent[felt.Felt](t, tc.data)
-			requireSliceDecodeEquivalent[feltoid](t, tc.data)
+			requireSliceDecodeCBOREquivalent[felt.Felt](t, tc.data)
+			requireSliceDecodeCBOREquivalent[feltoid](t, tc.data)
 		})
 	}
 }
 
-func TestSliceDecodeRejectsOversizedHeader(t *testing.T) {
+func TestSliceDecodeCBORRejectsOversizedHeader(t *testing.T) {
 	feltBytes := encodeFeltCBOR(t, fromLimbs[felt.Felt](1))
 
 	// cborArrayUint32 reads the element count
@@ -188,13 +189,13 @@ func TestSliceDecodeRejectsOversizedHeader(t *testing.T) {
 	header := binary.BigEndian.AppendUint32([]byte{cborArrayUint32}, math.MaxUint32)
 	data := slices.Concat(header, feltBytes)
 
-	requireSliceDecodeEquivalent[felt.Felt](t, data)
-	requireSliceDecodeEquivalent[feltoid](t, data)
+	requireSliceDecodeCBOREquivalent[felt.Felt](t, data)
+	requireSliceDecodeCBOREquivalent[feltoid](t, data)
 }
 
 // FuzzSliceDecodeEquivalence fuzzes the decode path, the one that can receive
 // arbitrary bytes, to ensure it stays equivalent to the generic decoder and never panics.
-func FuzzSliceDecodeEquivalence(fz *testing.F) {
+func FuzzSliceDecodeCBOREquivalence(fz *testing.F) {
 	for _, n := range []int{0, 1, 2, 23, 24, 255, 256} {
 		encoded, err := randomSlice[felt.Felt](n).MarshalCBOR()
 		require.NoError(fz, err)
@@ -207,7 +208,165 @@ func FuzzSliceDecodeEquivalence(fz *testing.F) {
 	}
 
 	fz.Fuzz(func(t *testing.T, data []byte) {
-		requireSliceDecodeEquivalent[felt.Felt](t, data)
-		requireSliceDecodeEquivalent[feltoid](t, data)
+		requireSliceDecodeCBOREquivalent[felt.Felt](t, data)
+		requireSliceDecodeCBOREquivalent[feltoid](t, data)
+	})
+}
+
+func TestSliceJSON(t *testing.T) {
+	// One below the field modulus, so it exercises the widest hex a felt can print.
+	const maxFelt = "0x800000000000011000000000000000000000000000000000000000000000000"
+
+	cases := []struct {
+		name string
+		in   felt.Slice[felt.Felt]
+		want string
+	}{
+		{"nil", nil, `null`},
+		{"empty", felt.Slice[felt.Felt]{}, `[]`},
+		{"one", felt.Slice[felt.Felt]{felt.UnsafeFromString[felt.Felt]("0xdeadbeef")}, `["0xdeadbeef"]`},
+		{
+			"many",
+			felt.Slice[felt.Felt]{
+				felt.Zero,
+				felt.UnsafeFromString[felt.Felt]("0x1"),
+				felt.UnsafeFromString[felt.Felt](maxFelt),
+			},
+			`["0x0","0x1","` + maxFelt + `"]`,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			encoded, err := json.Marshal(tc.in)
+			require.NoError(t, err)
+			require.Equal(t, tc.want, string(encoded))
+
+			// Must match the generic encoder byte for byte.
+			generic, err := json.Marshal([]felt.Felt(tc.in))
+			require.NoError(t, err)
+			require.Equal(t, string(generic), string(encoded))
+
+			// nil and empty have to stay distinct across the round trip.
+			var roundTrip felt.Slice[felt.Felt]
+			require.NoError(t, json.Unmarshal(encoded, &roundTrip))
+			require.Equal(t, tc.in, roundTrip)
+
+			requireSliceDecodeJSONEquivalent(t, encoded)
+		})
+	}
+}
+
+func TestSliceJSONAccepts(t *testing.T) {
+	cases := map[string]string{
+		"interior whitespace": `[ "0x1" , "0x2" ]`,
+		"newlines":            "[\n\t\"0x1\",\n\t\"0x2\"\n]",
+		"leading zeros":       `["0x0001","0x02"]`,
+		"uppercase prefix":    `["0X1","0X2"]`,
+		"mixed case digits":   `["0xAbCd","0xabcd"]`,
+	}
+
+	for name, input := range cases {
+		t.Run(name, func(t *testing.T) {
+			var decoded felt.Slice[felt.Felt]
+			require.NoError(t, json.Unmarshal([]byte(input), &decoded))
+			require.Len(t, decoded, 2)
+
+			requireSliceDecodeJSONEquivalent(t, []byte(input))
+		})
+	}
+}
+
+func TestSliceJSONReusesDestination(t *testing.T) {
+	var slice felt.Slice[felt.Felt]
+	require.NoError(t, json.Unmarshal([]byte(`["0x1","0x2","0x3","0x4","0x5"]`), &slice))
+	require.Len(t, slice, 5)
+
+	require.NoError(t, json.Unmarshal([]byte(`["0xa","0xb"]`), &slice))
+	require.Len(t, slice, 2)
+
+	encoded, err := json.Marshal(slice)
+	require.NoError(t, err)
+	require.Equal(t, `["0xa","0xb"]`, string(encoded))
+
+	// And down to nothing.
+	require.NoError(t, json.Unmarshal([]byte(`[]`), &slice))
+	require.Empty(t, slice)
+	require.NotNil(t, slice)
+}
+
+func requireSliceDecodeJSONEquivalent(t *testing.T, data []byte) {
+	t.Helper()
+
+	var fast felt.Slice[felt.Felt]
+	errFast := json.Unmarshal(data, &fast)
+
+	var generic []felt.Felt
+	errGeneric := json.Unmarshal(data, &generic)
+
+	if errGeneric != nil {
+		require.Error(
+			t,
+			errFast,
+			"fast decoder accepted input the generic decoder rejected (%v): %s",
+			errGeneric,
+			data,
+		)
+
+		return
+	}
+
+	require.NoError(
+		t,
+		errFast,
+		"fast decoder rejected input the generic decoder accepted: %s",
+		data,
+	)
+
+	require.Equal(t, len(generic), len(fast), "length mismatch for %s", data)
+	for idx := range generic {
+		require.True(
+			t,
+			felt.Equal(&generic[idx], &fast[idx]),
+			"element %d mismatch for %s: generic=%v fast=%v",
+			idx,
+			data,
+			generic[idx],
+			fast[idx],
+		)
+	}
+}
+
+func TestSliceJSONRejects(t *testing.T) {
+	for _, input := range []string{
+		`{}`, `[1]`, `[null]`, `[true]`, `[[]]`,
+		`["notahex"]`, `["0x"]`, `["0xzz"]`, `["0x1"}`,
+		`["0xa\"b"]`, `["0x1\n"]`, `["\u00300x1"]`,
+	} {
+		t.Run(input, func(t *testing.T) {
+			var out felt.Slice[felt.Felt]
+			require.Error(t, json.Unmarshal([]byte(input), &out))
+
+			requireSliceDecodeJSONEquivalent(t, []byte(input))
+		})
+	}
+}
+
+func FuzzSliceDecodeJSONEquivalence(fz *testing.F) {
+	for _, n := range []int{0, 1, 2, 17, 256} {
+		encoded, err := json.Marshal(randomSlice[felt.Felt](n))
+		require.NoError(fz, err)
+		fz.Add(encoded)
+	}
+
+	for _, seed := range []string{
+		`null`, `[]`, `[ ]`, `["0x0"]`, `[ "0x1" , "0x2" ]`, `["0X1"]`,
+		`["0xa\"b"]`, `[1]`, `[null]`, `{}`, `[`, `["0x1"`, ``,
+	} {
+		fz.Add([]byte(seed))
+	}
+
+	fz.Fuzz(func(t *testing.T, data []byte) {
+		requireSliceDecodeJSONEquivalent(t, data)
 	})
 }

--- a/jsonrpc/pretty_error_test.go
+++ b/jsonrpc/pretty_error_test.go
@@ -10,6 +10,9 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// These assert exact error positions, which fail under the experiment on Go 1.26
+// because it shifts the offset reported for a JSON parse error.
+// It is a toolchain bug, fixed in Go 1.27 (go.dev/issue/79659).
 var parseErrorTests = map[string]struct {
 	req string
 	res string

--- a/rpc/v10/class.go
+++ b/rpc/v10/class.go
@@ -10,7 +10,7 @@ import (
 
 // https://github.com/starkware-libs/starknet-specs/blob/v0.10.3/api/starknet_api_openrpc.json#L506-L522
 type Class struct {
-	SierraProgram        []felt.Felt            `json:"sierra_program,omitempty"`
+	SierraProgram        felt.Slice[felt.Felt]  `json:"sierra_program,omitempty"`
 	Program              string                 `json:"program,omitempty"`
 	ContractClassVersion string                 `json:"contract_class_version,omitempty"`
 	EntryPoints          ClassEntryPointsByType `json:"entry_points_by_type"`

--- a/rpc/v10/class_test.go
+++ b/rpc/v10/class_test.go
@@ -420,7 +420,7 @@ func assertEqualDeprecatedCairoClass(
 }
 
 func assertEqualSierraClass(t *testing.T, sierraClass *core.SierraClass, class *rpc.Class) {
-	assert.Equal(t, []felt.Felt(sierraClass.Program), class.SierraProgram)
+	assert.Equal(t, sierraClass.Program, class.SierraProgram)
 	assert.Equal(t, sierraClass.Abi, class.Abi.(string))
 	assert.Equal(t, sierraClass.SemanticVersion, class.ContractClassVersion)
 

--- a/rpc/v10/compiled_casm.go
+++ b/rpc/v10/compiled_casm.go
@@ -29,11 +29,11 @@ type EntryPointsByType struct {
 type CompiledCasmResponse struct {
 	EntryPointsByType EntryPointsByType `json:"entry_points_by_type"`
 	// can't use felt.Felt here because prime is larger than felt
-	Prime                  string          `json:"prime"`
-	CompilerVersion        string          `json:"compiler_version"`
-	Bytecode               []felt.Felt     `json:"bytecode"`
-	Hints                  json.RawMessage `json:"hints"`
-	BytecodeSegmentLengths []int           `json:"bytecode_segment_lengths,omitempty"`
+	Prime                  string                `json:"prime"`
+	CompilerVersion        string                `json:"compiler_version"`
+	Bytecode               felt.Slice[felt.Felt] `json:"bytecode"`
+	Hints                  json.RawMessage       `json:"hints"`
+	BytecodeSegmentLengths []int                 `json:"bytecode_segment_lengths,omitempty"`
 }
 
 // CompiledCasm receives a class hash and returns the compiled cairo assembly (CASM)

--- a/rpc/v8/class.go
+++ b/rpc/v8/class.go
@@ -18,11 +18,11 @@ import (
 
 // https://github.com/starkware-libs/starknet-specs/blob/v0.8.1/api/starknet_api_openrpc.json#L3159
 type Class struct {
-	SierraProgram        []felt.Felt `json:"sierra_program,omitempty"`
-	Program              string      `json:"program,omitempty"`
-	ContractClassVersion string      `json:"contract_class_version,omitempty"`
-	EntryPoints          EntryPoints `json:"entry_points_by_type"`
-	Abi                  any         `json:"abi"`
+	SierraProgram        felt.Slice[felt.Felt] `json:"sierra_program,omitempty"`
+	Program              string                `json:"program,omitempty"`
+	ContractClassVersion string                `json:"contract_class_version,omitempty"`
+	EntryPoints          EntryPoints           `json:"entry_points_by_type"`
+	Abi                  any                   `json:"abi"`
 }
 
 type EntryPoints struct {

--- a/rpc/v8/class_test.go
+++ b/rpc/v8/class_test.go
@@ -360,7 +360,7 @@ func assertEqualDeprecatedCairoClass(
 }
 
 func assertEqualSierraClass(t *testing.T, sierraClass *core.SierraClass, class *rpc.Class) {
-	assert.Equal(t, []felt.Felt(sierraClass.Program), class.SierraProgram)
+	assert.Equal(t, sierraClass.Program, class.SierraProgram)
 	assert.Equal(t, sierraClass.Abi, class.Abi.(string))
 	assert.Equal(t, sierraClass.SemanticVersion, class.ContractClassVersion)
 

--- a/rpc/v8/compiled_casm.go
+++ b/rpc/v8/compiled_casm.go
@@ -30,11 +30,11 @@ type EntryPointsByType struct {
 type CasmCompiledContractClass struct {
 	EntryPointsByType EntryPointsByType `json:"entry_points_by_type"`
 	// can't use felt.Felt here because prime is larger than felt
-	Prime                  string          `json:"prime"`
-	CompilerVersion        string          `json:"compiler_version"`
-	Bytecode               []felt.Felt     `json:"bytecode"`
-	Hints                  json.RawMessage `json:"hints"`
-	BytecodeSegmentLengths []int           `json:"bytecode_segment_lengths,omitempty"`
+	Prime                  string                `json:"prime"`
+	CompilerVersion        string                `json:"compiler_version"`
+	Bytecode               felt.Slice[felt.Felt] `json:"bytecode"`
+	Hints                  json.RawMessage       `json:"hints"`
+	BytecodeSegmentLengths []int                 `json:"bytecode_segment_lengths,omitempty"`
 }
 
 func (h *Handler) CompiledCasm(

--- a/rpc/v9/class.go
+++ b/rpc/v9/class.go
@@ -20,7 +20,7 @@ type CalldataInputs = rpccore.LimitSlice[felt.Felt, rpccore.FunctionCalldataLimi
 
 // https://github.com/starkware-libs/starknet-specs/blob/e0b76ed0d8d8eba405e182371f9edac8b2bcbc5a/api/starknet_api_openrpc.json#L268-L280
 type Class struct {
-	SierraProgram        []felt.Felt            `json:"sierra_program,omitempty"`
+	SierraProgram        felt.Slice[felt.Felt]  `json:"sierra_program,omitempty"`
 	Program              string                 `json:"program,omitempty"`
 	ContractClassVersion string                 `json:"contract_class_version,omitempty"`
 	EntryPoints          ClassEntryPointsByType `json:"entry_points_by_type"`

--- a/rpc/v9/class_test.go
+++ b/rpc/v9/class_test.go
@@ -420,7 +420,7 @@ func assertEqualDeprecatedCairoClass(
 }
 
 func assertEqualSierraClass(t *testing.T, sierraClass *core.SierraClass, class *rpcv9.Class) {
-	assert.Equal(t, []felt.Felt(sierraClass.Program), class.SierraProgram)
+	assert.Equal(t, sierraClass.Program, class.SierraProgram)
 	assert.Equal(t, sierraClass.Abi, class.Abi.(string))
 	assert.Equal(t, sierraClass.SemanticVersion, class.ContractClassVersion)
 

--- a/rpc/v9/compiled_casm.go
+++ b/rpc/v9/compiled_casm.go
@@ -29,11 +29,11 @@ type EntryPointsByType struct {
 type CompiledCasmResponse struct {
 	EntryPointsByType EntryPointsByType `json:"entry_points_by_type"`
 	// can't use felt.Felt here because prime is larger than felt
-	Prime                  string          `json:"prime"`
-	CompilerVersion        string          `json:"compiler_version"`
-	Bytecode               []felt.Felt     `json:"bytecode"`
-	Hints                  json.RawMessage `json:"hints"`
-	BytecodeSegmentLengths []int           `json:"bytecode_segment_lengths,omitempty"`
+	Prime                  string                `json:"prime"`
+	CompilerVersion        string                `json:"compiler_version"`
+	Bytecode               felt.Slice[felt.Felt] `json:"bytecode"`
+	Hints                  json.RawMessage       `json:"hints"`
+	BytecodeSegmentLengths []int                 `json:"bytecode_segment_lengths,omitempty"`
 }
 
 // CompiledCasm receives a class hash and returns the compiled cairo assembly (CASM)


### PR DESCRIPTION
**TL;DR: WE DO NOT NEED AN EXTENSIVE MIGRATION TO JSON V2.** It is just a matter of allowing jsonv2.

This PR was supposed to be a preparation for moving the RPC method `getClass` to json/v2. It would allow the method to use the v2 engine when using Golang experimental mode (`GOEXPERIMENT=jsonv2`).

It turns out, once the experiment becomes the default, our json/v1 call will use the v2 engine underneath, with 100% compatibility. ([ref](https://github.com/golang/go/blob/master/src/encoding/json/v2_options.go))

> "The entirety of v1 is implemented in terms of v2, where options are implicitly specified to opt into legacy behavior. For example, `Marshal` directly calls `jsonv2.Marshal` with `DefaultOptionsV1`".

### Proving json/v2 does not degrades

Same code, two binaries: one built normally, one with `GOEXPERIMENT=jsonv2`. 

| payload | op | json/v1 | v2 engine | speedup | B/op | allocs |
|---|---|---|---|---|---|---|
| `getClass` (sierra) | marshal | 2.80 ms | 1.34 ms | **2.09x** | 2593 -> 2216 KiB | 29964 -> 4 |
| `getClass` (sierra) | unmarshal | 4.46 ms | 2.39 ms | **1.87x** | 4828 KiB | 67 -> 59 |
| traces (30) | marshal | 461 us | 407 us | 1.13x | 342 -> 138 KiB | 2642 -> 33 |
| transactions (180) | marshal | 648 us | 585 us | 1.11x | 466 -> 155 KiB | 4163 -> 182 |
| transactions (180) | unmarshal | 1.43 ms | 882 us | **1.62x** | 314 KiB | 2677 -> 2671 |
| receipts (180) | marshal | 1.02 ms | 987 us | 1.04x | 720 -> 308 KiB | 6015 -> 724 |

Nothing regresses. Also, allocation counts drop by 60% to 99.99% across the board

### What actually is in this PR

A `felt.Slice` optimization that is only unlocked if v2.
`getClass` is mostly a "get `felt.Slice`", and it got 2x faster (see the table).
`felt.Slice` is a replacer for `[]felt.Felt`, so we can replace it in other places to optimize other RPC methods.

