### PR TITLE
build(lint): install golangci-lint v2 to match v2 config

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -104,7 +104,7 @@ install-mockgen:
 	go install go.uber.org/mock/mockgen@latest
 
 install-golangci-lint:
-	@which golangci-lint || go install github.com/golangci/golangci-lint/cmd/golangci-lint@latest
+	@which golangci-lint || go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@latest
 
 lint: install-golangci-lint lint-diff
 	golangci-lint run


### PR DESCRIPTION
## Summary
- Update Makefile to install golangci-lint v2, matching the existing v2 config