### PR TITLE
feat(bench): add seeded RPC benchmark harness

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,8 @@ OPTIONS-*
 CURRENT
 LOCK
 
+# RPC benchmark harness: generated corpora and run results (keep the dir).
+bench/rpc/corpus/*
+!bench/rpc/corpus/.gitkeep
+bench/rpc/results/
+

--- a/Makefile
+++ b/Makefile
@@ -43,6 +43,9 @@ juno-cached: ## Cached Juno compilation
 	@mkdir -p build
 	@go build $(GO_TAGS) -ldflags="-X main.Version=$(shell git describe --tags)" -o build/juno ./cmd/juno/
 
+corpus-gen: ## Build the corpus generator
+	@mkdir -p build
+	@go build -o build/corpus-gen ./bench/rpc/cmd/corpus-gen
 
 MINIMUM_RUST_VERSION = 1.94.1
 CURR_RUST_VERSION = $(shell rustc --version | grep -o '[0-9.]\+' | head -n1)
@@ -105,6 +108,9 @@ install-mockgen:
 
 install-golangci-lint:
 	@which golangci-lint || go install github.com/golangci/golangci-lint/cmd/golangci-lint@latest
+
+install-k6: ## Install the k6 load generator used by the RPC benchmark harness
+	go install go.k6.io/k6@latest
 
 lint: install-golangci-lint lint-diff
 	golangci-lint run

--- a/bench/rpc/README.md
+++ b/bench/rpc/README.md
@@ -1,0 +1,45 @@
+# RPC benchmark harness (`bench/rpc`)
+
+Sample a Starknet node into a seeded JSON-RPC corpus, then replay it with
+[k6](https://k6.io) to measure latency and throughput.
+
+## Methods
+
+- `starknet_getTransactionByHash`
+
+## Use
+
+```
+make install-k6
+make corpus-gen
+mkdir -p bench/rpc/corpus/v0_10
+./build/corpus-gen getTransactionByHash \
+    --count 1000 --block-start 0 --block-end 800000 --seed 1 \
+    > bench/rpc/corpus/v0_10/getTransactionByHash.json
+k6 run bench/rpc/single.js -e NODE_URL=http://localhost:6060/v0_10 \
+    < bench/rpc/corpus/v0_10/getTransactionByHash.json > result.json
+```
+
+Scenarios: `single.js`, `concurrency.js`, `throughput.js` (share `common.js`).
+Corpus must be redirected in (`<`), not piped. Summary → stdout, table → stderr.
+
+## corpus-gen flags
+
+| Flag            | Meaning                                        |
+| --------------- | ---------------------------------------------- |
+| `--count`       | corpus entries                                 |
+| `--block-start` | sample range low (inclusive)                   |
+| `--block-end`   | sample range high (exclusive)                  |
+| `--seed`        | reproducible corpus                            |
+| `--batch N`     | N requests per entry                           |
+| `--source-url`  | node to sample (`http://localhost:6060/v0_10`) |
+
+## k6 env
+
+| Env          | Meaning                                       |
+| ------------ | --------------------------------------------- |
+| `NODE_URL`   | endpoint under test (required)                |
+| `VUS`        | concurrent VUs (`50`)                         |
+| `ITERATIONS` | requests, single scenario (`200`)             |
+| `RATES`      | throughput ramp targets, req/s (`50,100,200`) |
+| `DURATION`   | run length / per-stage ramp time (`30s`)      |

--- a/bench/rpc/cmd/corpus-gen/client.go
+++ b/bench/rpc/cmd/corpus-gen/client.go
@@ -1,0 +1,76 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"time"
+)
+
+type rpcClient struct {
+	url    string
+	client *http.Client
+}
+
+func newRPCClient(url string) *rpcClient {
+	return &rpcClient{
+		url:    url,
+		client: &http.Client{Timeout: time.Minute},
+	}
+}
+
+type rpcError struct {
+	Code    int    `json:"code"`
+	Message string `json:"message"`
+}
+
+func (e *rpcError) Error() string {
+	return fmt.Sprintf("json-rpc error %d: %s", e.Code, e.Message)
+}
+
+type rpcEnvelope[T any] struct {
+	Result T         `json:"result"`
+	Error  *rpcError `json:"error"`
+}
+
+func rpcCall[T any](ctx context.Context, c *rpcClient, method string, params any) (T, error) {
+	var zero T
+	reqBody, err := json.Marshal(jsonRPCRequest{JSONRPC: "2.0", ID: 1, Method: method, Params: params})
+	if err != nil {
+		return zero, err
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.url, bytes.NewReader(reqBody))
+	if err != nil {
+		return zero, err
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := c.client.Do(req)
+	if err != nil {
+		return zero, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		return zero, fmt.Errorf("%s: unexpected status %s: %s",
+			method, resp.Status, bytes.TrimSpace(body))
+	}
+
+	var env rpcEnvelope[T]
+	if err := json.NewDecoder(resp.Body).Decode(&env); err != nil {
+		return zero, fmt.Errorf("%s: decode response: %w", method, err)
+	}
+	if env.Error != nil {
+		return zero, fmt.Errorf("%s: %w", method, env.Error)
+	}
+	return env.Result, nil
+}
+
+func (c *rpcClient) specVersion(ctx context.Context) (string, error) {
+	return rpcCall[string](ctx, c, "starknet_specVersion", nil)
+}

--- a/bench/rpc/cmd/corpus-gen/get_transaction_by_hash.go
+++ b/bench/rpc/cmd/corpus-gen/get_transaction_by_hash.go
@@ -1,0 +1,81 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"math/rand/v2"
+
+	"github.com/spf13/cobra"
+)
+
+const (
+	methodGetTransactionByHash = "starknet_getTransactionByHash"
+	maxResampleAttempts        = 10000
+)
+
+type getTxByHashParams struct {
+	TransactionHash string `json:"transaction_hash"`
+}
+
+func newGetTxByHashCmd(cfg *rootConfig) *cobra.Command {
+	var blockStart, blockEnd uint64
+
+	cmd := &cobra.Command{
+		Use:   "getTransactionByHash",
+		Short: "Sample random transaction hashes and emit starknet_getTransactionByHash requests.",
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			if blockEnd <= blockStart {
+				return fmt.Errorf("--block-end (%d) must be > --block-start (%d)", blockEnd, blockStart)
+			}
+			meta := blockRange{Start: blockStart, End: blockEnd}
+			makeGen := func(client *rpcClient, rng *rand.Rand) func() (any, error) {
+				return func() (any, error) {
+					return sampleTxHash(cmd.Context(), client, rng, blockStart, blockEnd)
+				}
+			}
+			return runCorpus(cmd, cfg, methodGetTransactionByHash, meta, makeGen)
+		},
+	}
+
+	cmd.Flags().Uint64Var(&blockStart, "block-start", 0,
+		"Start block number to sample from (inclusive).")
+	cmd.Flags().Uint64Var(&blockEnd, "block-end", 0,
+		"End block number to sample from (exclusive).")
+	_ = cmd.MarkFlagRequired("block-start")
+	_ = cmd.MarkFlagRequired("block-end")
+	return cmd
+}
+
+func sampleTxHash(
+	ctx context.Context,
+	client *rpcClient,
+	rng *rand.Rand,
+	start, end uint64,
+) (getTxByHashParams, error) {
+	span := end - start
+	for range maxResampleAttempts {
+		blockNumber := start + rng.Uint64N(span)
+		hashes, err := txHashesInBlock(ctx, client, blockNumber)
+		if err != nil {
+			return getTxByHashParams{}, fmt.Errorf("get block %d: %w", blockNumber, err)
+		}
+		if len(hashes) == 0 {
+			continue
+		}
+		return getTxByHashParams{TransactionHash: hashes[rng.Uint64N(uint64(len(hashes)))]}, nil
+	}
+	return getTxByHashParams{}, fmt.Errorf(
+		"no non-empty block found in [%d, %d) after %d attempts", start, end, maxResampleAttempts)
+}
+
+func txHashesInBlock(ctx context.Context, client *rpcClient, blockNumber uint64) ([]string, error) {
+	type block struct {
+		Transactions []string `json:"transactions"`
+	}
+	params := map[string]any{"block_id": map[string]any{"block_number": blockNumber}}
+	result, err := rpcCall[block](ctx, client, "starknet_getBlockWithTxHashes", params)
+	if err != nil {
+		return nil, err
+	}
+	return result.Transactions, nil
+}

--- a/bench/rpc/cmd/corpus-gen/main.go
+++ b/bench/rpc/cmd/corpus-gen/main.go
@@ -1,0 +1,180 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"math/rand/v2"
+	"os"
+	"time"
+
+	"github.com/spf13/cobra"
+)
+
+const (
+	defaultCount     = 1000
+	defaultSeed      = 1
+	defaultSourceURL = "http://localhost:6060/v0_10"
+)
+
+type rootConfig struct {
+	count     int
+	seed      uint64
+	sourceURL string
+	batch     int
+}
+
+func newRootCmd() *cobra.Command {
+	cfg := &rootConfig{}
+
+	cmd := &cobra.Command{
+		Use:          "corpus-gen",
+		Short:        "Generate seeded, RPC-version-agnostic JSON-RPC benchmark corpora.",
+		SilenceUsage: true,
+		PersistentPreRunE: func(*cobra.Command, []string) error {
+			if cfg.count < 1 {
+				return fmt.Errorf("--count must be >= 1 (got %d)", cfg.count)
+			}
+			if cfg.batch < 0 {
+				return fmt.Errorf("--batch must be >= 0 (got %d)", cfg.batch)
+			}
+			return nil
+		},
+	}
+
+	pf := cmd.PersistentFlags()
+	pf.IntVar(&cfg.count, "count", defaultCount, "Number of corpus entries to generate.")
+	pf.Uint64Var(&cfg.seed, "seed", defaultSeed, "Numeric seed for deterministic sampling.")
+	pf.StringVar(&cfg.sourceURL, "source-url", defaultSourceURL,
+		"JSON-RPC URL of the source node to sample.")
+	pf.IntVar(&cfg.batch, "batch", 0,
+		"Batch size per entry; omit for plain request objects, N for JSON-RPC arrays of N.")
+
+	cmd.AddCommand(newGetTxByHashCmd(cfg))
+	return cmd
+}
+
+func main() {
+	if err := newRootCmd().Execute(); err != nil {
+		os.Exit(1)
+	}
+}
+
+type blockRange struct {
+	Start uint64 `json:"start"`
+	End   uint64 `json:"end"`
+}
+
+type corpusMeta[T any] struct {
+	Method      string `json:"method"`
+	RPCVersion  string `json:"rpcVersion"`
+	Seed        uint64 `json:"seed"`
+	Count       int    `json:"count"`
+	Batch       int    `json:"batch"`
+	GeneratedAt string `json:"generatedAt"`
+	Sampling    T      `json:"sampling"`
+}
+
+type corpus[T any] struct {
+	Meta     corpusMeta[T] `json:"meta"`
+	Requests []any         `json:"requests"`
+}
+
+type jsonRPCRequest struct {
+	JSONRPC string `json:"jsonrpc"`
+	ID      int    `json:"id"`
+	Method  string `json:"method"`
+	Params  any    `json:"params"`
+}
+
+func writeCorpus[T any](w io.Writer, c *corpus[T]) error {
+	data, err := json.MarshalIndent(c, "", "  ")
+	if err != nil {
+		return err
+	}
+	data = append(data, '\n')
+
+	_, err = w.Write(data)
+	return err
+}
+
+func runCorpus[T any](
+	cmd *cobra.Command, cfg *rootConfig, method string, meta T,
+	makeGen func(*rpcClient, *rand.Rand) func() (any, error),
+) error {
+	generatedAt := time.Now().UTC().Format(time.RFC3339)
+	client := newRPCClient(cfg.sourceURL)
+	rng := newSeededRand(cfg.seed)
+
+	c, err := buildCorpus(cmd.Context(), cfg, client, method, meta, generatedAt, makeGen(client, rng))
+	if err != nil {
+		return err
+	}
+
+	if err := writeCorpus(cmd.OutOrStdout(), c); err != nil {
+		return err
+	}
+
+	_, err = fmt.Fprintf(cmd.ErrOrStderr(), "wrote %d entries\n", cfg.count)
+	return err
+}
+
+func buildCorpus[T any](
+	ctx context.Context, cfg *rootConfig, client *rpcClient,
+	method string, meta T, generatedAt string, nextParams func() (any, error),
+) (*corpus[T], error) {
+	version, err := client.specVersion(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("fetch spec version: %w", err)
+	}
+
+	id := 0
+	nextRequest := func() (jsonRPCRequest, error) {
+		params, paramsErr := nextParams()
+		if paramsErr != nil {
+			return jsonRPCRequest{}, paramsErr
+		}
+		id++
+		return jsonRPCRequest{JSONRPC: "2.0", ID: id, Method: method, Params: params}, nil
+	}
+
+	requests := make([]any, 0, cfg.count)
+	for range cfg.count {
+		if cfg.batch < 1 {
+			req, reqErr := nextRequest()
+			if reqErr != nil {
+				return nil, reqErr
+			}
+			requests = append(requests, req)
+			continue
+		}
+		entry := make([]jsonRPCRequest, 0, cfg.batch)
+		for range cfg.batch {
+			req, reqErr := nextRequest()
+			if reqErr != nil {
+				return nil, reqErr
+			}
+			entry = append(entry, req)
+		}
+		requests = append(requests, entry)
+	}
+
+	return &corpus[T]{
+		Meta: corpusMeta[T]{
+			Method:      method,
+			RPCVersion:  version,
+			Seed:        cfg.seed,
+			Count:       cfg.count,
+			Batch:       cfg.batch,
+			GeneratedAt: generatedAt,
+			Sampling:    meta,
+		},
+		Requests: requests,
+	}, nil
+}
+
+func newSeededRand(seed uint64) *rand.Rand {
+	//nolint:gosec // G404: deterministic corpus needs a seeded PRNG, not crypto randomness
+	return rand.New(rand.NewPCG(seed, 0))
+}

--- a/bench/rpc/common.js
+++ b/bench/rpc/common.js
@@ -1,0 +1,133 @@
+import http from 'k6/http';
+import { check } from 'k6';
+import { SharedArray } from 'k6/data';
+import exec from 'k6/execution';
+
+function requiredEnv(name) {
+  const v = __ENV[name];
+  if (v === undefined || v === '') {
+    throw new Error(`${name} is required (pass with -e ${name}=...)`);
+  }
+  return v;
+}
+
+export function parseIntStrict(raw, label) {
+  const n = parseInt(raw, 10);
+  if (Number.isNaN(n)) {
+    throw new Error(`${label} must be an integer (got "${raw}")`);
+  }
+  return n;
+}
+
+export function intEnv(name, def) {
+  return parseIntStrict(__ENV[name] || String(def), name);
+}
+
+export const NODE_URL = requiredEnv('NODE_URL');
+
+// k6 open() cannot seek a pipe, so the corpus must be redirected in (`< file`), not piped.
+let parsed;
+const load = () => (parsed ??= JSON.parse(open('/dev/stdin')));
+const corpus = new SharedArray('corpus', () => load().requests);
+const meta = new SharedArray('meta', () => [load().meta]);
+
+export function buildOptions(measured) {
+  return {
+    scenarios: { measure: { exec: 'measure', ...measured } },
+    summaryTrendStats: ['avg', 'min', 'med', 'p(50)', 'p(90)', 'p(99)', 'max'],
+  };
+}
+
+// JSON-RPC errors still return HTTP 200, so success is defined by the presence of a `result`.
+function isSuccess(res) {
+  if (res.status !== 200) {
+    return false;
+  }
+  let body;
+  try {
+    body = res.json();
+  } catch (_e) {
+    return false;
+  }
+  const hasResult = (r) => r !== null && typeof r === 'object' && 'result' in r;
+  return Array.isArray(body) ? body.every(hasResult) : hasResult(body);
+}
+
+export function measure() {
+  const entry = corpus[exec.scenario.iterationInTest % corpus.length];
+  const res = http.post(NODE_URL, JSON.stringify(entry), {
+    headers: { 'Content-Type': 'application/json' },
+  });
+  check(res, { 'rpc call ok': isSuccess });
+}
+
+function stat(data, metric, key) {
+  const m = data.metrics[metric];
+  if (!m || !m.values || m.values[key] === undefined) {
+    return null;
+  }
+  return m.values[key];
+}
+
+function fmt(n) {
+  return n === null ? 'n/a' : n.toFixed(2);
+}
+
+function buildMarkdown(summary) {
+  const m = summary.metrics;
+  const knobs = Object.entries(summary.knobs)
+    .map(([k, v]) => `${k}=${Array.isArray(v) ? v.join(',') : v}`)
+    .join(' ');
+  return [
+    `# RPC benchmark — ${summary.method}`,
+    '',
+    `- **Node:** ${summary.node}`,
+    `- **Scenario:** ${summary.scenario}`,
+    `- **Knobs:** ${knobs}`,
+    '',
+    '| Metric | Value |',
+    '| --- | --- |',
+    `| p50 latency (ms) | ${fmt(m.latency_ms.p50)} |`,
+    `| p90 latency (ms) | ${fmt(m.latency_ms.p90)} |`,
+    `| p99 latency (ms) | ${fmt(m.latency_ms.p99)} |`,
+    `| avg latency (ms) | ${fmt(m.latency_ms.avg)} |`,
+    `| max latency (ms) | ${fmt(m.latency_ms.max)} |`,
+    `| throughput (rpc/s) | ${fmt(m.throughput_rps)} |`,
+    `| requests (measured) | ${fmt(m.requests)} |`,
+    `| dropped iterations | ${fmt(m.dropped_iterations)} |`,
+    `| pass rate | ${fmt(m.pass_rate)} |`,
+    '',
+  ].join('\n');
+}
+
+export function summarize(scenario, knobs) {
+  return (data) => {
+    const durationMetric = 'http_req_duration';
+    const httpReqRate = stat(data, 'http_reqs', 'rate');
+    const rpcPerReq = Math.max(1, meta[0].batch);
+    const summary = {
+      node: NODE_URL,
+      method: meta[0].method,
+      scenario,
+      knobs,
+      metrics: {
+        latency_ms: {
+          p50: stat(data, durationMetric, 'p(50)'),
+          p90: stat(data, durationMetric, 'p(90)'),
+          p99: stat(data, durationMetric, 'p(99)'),
+          avg: stat(data, durationMetric, 'avg'),
+          max: stat(data, durationMetric, 'max'),
+        },
+        throughput_rps: httpReqRate === null ? null : httpReqRate * rpcPerReq,
+        requests: stat(data, 'http_reqs', 'count'),
+        dropped_iterations: stat(data, 'dropped_iterations', 'count'),
+        pass_rate: stat(data, 'checks', 'rate'),
+      },
+    };
+    const markdown = buildMarkdown(summary);
+    return {
+      stdout: `${JSON.stringify(summary, null, 2)}\n`,
+      stderr: `\n${markdown}\n`,
+    };
+  };
+}

--- a/bench/rpc/concurrency.js
+++ b/bench/rpc/concurrency.js
@@ -1,0 +1,13 @@
+import { buildOptions, summarize, measure, intEnv } from './common.js';
+
+const VUS = intEnv('VUS', 50);
+const DURATION = __ENV.DURATION || '30s';
+
+export const options = buildOptions({
+  executor: 'constant-vus',
+  vus: VUS,
+  duration: DURATION,
+});
+
+export { measure };
+export const handleSummary = summarize('concurrency', { VUS, DURATION });

--- a/bench/rpc/single.js
+++ b/bench/rpc/single.js
@@ -1,0 +1,12 @@
+import { buildOptions, summarize, measure, intEnv } from './common.js';
+
+const ITERATIONS = intEnv('ITERATIONS', 200);
+
+export const options = buildOptions({
+  executor: 'shared-iterations',
+  vus: 1,
+  iterations: ITERATIONS,
+});
+
+export { measure };
+export const handleSummary = summarize('single', { ITERATIONS });

--- a/bench/rpc/throughput.js
+++ b/bench/rpc/throughput.js
@@ -1,0 +1,17 @@
+import { buildOptions, summarize, measure, intEnv, parseIntStrict } from './common.js';
+
+const VUS = intEnv('VUS', 50);
+const DURATION = __ENV.DURATION || '30s';
+const RATES = (__ENV.RATES || '50,100,200').split(',').map((r) => parseIntStrict(r.trim(), 'RATES'));
+
+export const options = buildOptions({
+  executor: 'ramping-arrival-rate',
+  startRate: 0,
+  timeUnit: '1s',
+  preAllocatedVUs: VUS,
+  maxVUs: Math.max(VUS, ...RATES),
+  stages: RATES.map((target) => ({ target, duration: DURATION })),
+});
+
+export { measure };
+export const handleSummary = summarize('throughput', { VUS, RATES, DURATION });


### PR DESCRIPTION
## Summary
- Adds a corpus-gen tool (`bench/rpc`) that queries a Juno node to build a seeded corpus of real request params (e.g. transaction hashes) for RPC load testing
- Adds k6 scripts (`single.js`, `concurrency.js`, `throughput.js`, `common.js`) for single-request, concurrency, and throughput benchmarking against the RPC endpoint
- Adds Makefile targets and a README documenting usage