### PR TITLE
perf(core): bound valueAt history iterator to the key prefix

### DIFF
--- a/core/deprecatedstate/state.go
+++ b/core/deprecatedstate/state.go
@@ -853,7 +853,7 @@ func (s *State) performStateDeletions(blockNumber uint64, diff *core.StateDiff) 
 }
 
 func (s *State) valueAt(key []byte, height uint64) ([]byte, error) {
-	it, err := s.txn.NewIterator(nil, false)
+	it, err := s.txn.NewIterator(key, true)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Adds bounds to contract related DB iterators.

Benchmark data against sepolia snapshot:

| benchmark  | unbounded (main) | bounded (branch) | delta |
|---|---|---|---|
| `ContractStorageAtSepolia` (sequential) | 43.2µs | 32.6µs | **−24.5%** (p=0.029) |
| `ContractStorageAtSepoliaParallel` (10 goroutines) | 19.5µs ± 8% | 16.0µs ± 13% | **−18.4%** (p=0.002) |