### PR TITLE
feat(pruner): Add retention floor tracking

### DIFF
--- a/blockchain/blockchain.go
+++ b/blockchain/blockchain.go
@@ -12,6 +12,7 @@ import (
 	"github.com/NethermindEth/juno/db"
 	"github.com/NethermindEth/juno/feed"
 	"github.com/NethermindEth/juno/l1/eth"
+	"github.com/NethermindEth/juno/pruner"
 )
 
 type L1HeadSubscription struct {
@@ -107,6 +108,7 @@ type options struct {
 	listener                EventListener
 	stateVersion            bool
 	runningFilterInitialize core.RunningEventFilterInitializer
+	retentionFloor          *pruner.RetentionFloor
 }
 
 // Option is a functional option for configuring Blockchain options.
@@ -134,11 +136,21 @@ func WithRunningEventFilterInitializer(initialize core.RunningEventFilterInitial
 	}
 }
 
+// WithRetentionFloor shares a seeded retention floor (see
+// [pruner.NewRetentionFloor]) with the state backend, so retention checks
+// skip the database. The default unseeded floor probes the database instead.
+func WithRetentionFloor(floor *pruner.RetentionFloor) Option {
+	return func(o *options) {
+		o.retentionFloor = floor
+	}
+}
+
 func New(database db.KeyValueStore, network *networks.Network, opts ...Option) *Blockchain {
 	o := options{
 		listener:                &SelectiveListener{},
 		stateVersion:            false,
 		runningFilterInitialize: core.InitializeRunningEventFilter,
+		retentionFloor:          &pruner.RetentionFloor{},
 	}
 	for _, opt := range opts {
 		opt(&o)
@@ -163,6 +175,7 @@ func New(database db.KeyValueStore, network *networks.Network, opts ...Option) *
 			database,
 			runningFilter,
 			network,
+			o.retentionFloor,
 			o.stateVersion,
 		),
 	}

--- a/blockchain/blockchain_test.go
+++ b/blockchain/blockchain_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/NethermindEth/juno/db"
 	"github.com/NethermindEth/juno/db/memory"
 	"github.com/NethermindEth/juno/l1/eth"
+	"github.com/NethermindEth/juno/pruner"
 	adaptfeeder "github.com/NethermindEth/juno/starknetdata/feeder"
 	"github.com/NethermindEth/juno/sync/preconfirmed"
 	"github.com/stretchr/testify/assert"
@@ -444,6 +445,40 @@ func TestTransactionAndReceipt(t *testing.T) {
 			})
 		}
 	})
+}
+
+func TestStateAtBlockNumberWithRetentionFloor(t *testing.T) {
+	testDB := memory.New()
+	floor, err := pruner.NewRetentionFloor(testDB)
+	require.NoError(t, err)
+
+	chain := blockchain.New(
+		testDB,
+		&networks.Mainnet,
+		blockchain.WithNewState(statetestutils.UseNewState()),
+		blockchain.WithRetentionFloor(floor),
+	)
+
+	client := feeder.NewTestClient(t, &networks.Mainnet)
+	gw := adaptfeeder.New(client)
+
+	var lastHash *felt.Felt
+	for i := range uint64(2) {
+		block, err := gw.BlockByNumber(t.Context(), i)
+		require.NoError(t, err)
+		su, err := gw.StateUpdate(t.Context(), i)
+		require.NoError(t, err)
+		require.NoError(t, chain.Store(block, &emptyCommitments, su, nil))
+		lastHash = block.Hash
+	}
+
+	// Drop the hash → number index for block 1: the header-probe retention
+	// check would reject it, so only the floor fast path can accept it.
+	require.NoError(t, testDB.Delete(db.BlockHeaderNumbersByHashKey(lastHash)))
+
+	_, closer, err := chain.StateAtBlockNumber(1)
+	require.NoError(t, err)
+	require.NoError(t, closer())
 }
 
 func TestState(t *testing.T) {

--- a/blockchain/blockchain_test.go
+++ b/blockchain/blockchain_test.go
@@ -448,37 +448,53 @@ func TestTransactionAndReceipt(t *testing.T) {
 }
 
 func TestStateAtBlockNumberWithRetentionFloor(t *testing.T) {
-	testDB := memory.New()
-	floor, err := pruner.NewRetentionFloor(testDB)
-	require.NoError(t, err)
+	for _, newState := range []bool{false, true} {
+		t.Run(fmt.Sprintf("newState=%t", newState), func(t *testing.T) {
+			testDB := memory.New()
+			floor := &pruner.RetentionFloor{}
 
-	chain := blockchain.New(
-		testDB,
-		&networks.Mainnet,
-		blockchain.WithNewState(statetestutils.UseNewState()),
-		blockchain.WithRetentionFloor(floor),
-	)
+			chain := blockchain.New(
+				testDB,
+				&networks.Mainnet,
+				blockchain.WithNewState(newState),
+				blockchain.WithRetentionFloor(floor),
+			)
 
-	client := feeder.NewTestClient(t, &networks.Mainnet)
-	gw := adaptfeeder.New(client)
+			client := feeder.NewTestClient(t, &networks.Mainnet)
+			gw := adaptfeeder.New(client)
 
-	var lastHash *felt.Felt
-	for i := range uint64(2) {
-		block, err := gw.BlockByNumber(t.Context(), i)
-		require.NoError(t, err)
-		su, err := gw.StateUpdate(t.Context(), i)
-		require.NoError(t, err)
-		require.NoError(t, chain.Store(block, &emptyCommitments, su, nil))
-		lastHash = block.Hash
+			var lastHash *felt.Felt
+			for i := range uint64(3) {
+				block, err := gw.BlockByNumber(t.Context(), i)
+				require.NoError(t, err)
+				su, err := gw.StateUpdate(t.Context(), i)
+				require.NoError(t, err)
+				require.NoError(t, chain.Store(block, &emptyCommitments, su, nil))
+				lastHash = block.Hash
+			}
+
+			require.NoError(t, testDB.Delete(db.BlockCommitmentsKey(0)))
+			require.NoError(t, testDB.Delete(db.BlockCommitmentsKey(1)))
+			require.NoError(t, floor.Seed(testDB))
+
+			_, _, err := chain.StateAtBlockNumber(0)
+			require.ErrorIs(t, err, db.ErrKeyNotFound)
+
+			for blockNumber := uint64(1); blockNumber <= 2; blockNumber++ {
+				_, closer, err := chain.StateAtBlockNumber(blockNumber)
+				require.NoError(t, err)
+				require.NoError(t, closer())
+			}
+
+			_, _, err = chain.StateAtBlockNumber(3)
+			require.ErrorIs(t, err, db.ErrKeyNotFound)
+
+			require.NoError(t, testDB.Delete(db.BlockHeaderNumbersByHashKey(lastHash)))
+			_, closer, err := chain.StateAtBlockNumber(2)
+			require.NoError(t, err)
+			require.NoError(t, closer())
+		})
 	}
-
-	// Drop the hash → number index for block 1: the header-probe retention
-	// check would reject it, so only the floor fast path can accept it.
-	require.NoError(t, testDB.Delete(db.BlockHeaderNumbersByHashKey(lastHash)))
-
-	_, closer, err := chain.StateAtBlockNumber(1)
-	require.NoError(t, err)
-	require.NoError(t, closer())
 }
 
 func TestState(t *testing.T) {

--- a/blockchain/statebackend/deprecated.go
+++ b/blockchain/statebackend/deprecated.go
@@ -29,7 +29,8 @@ func (b *deprecatedStateBackend) HeadState() (core.StateReader, StateCloser, err
 func (b *deprecatedStateBackend) StateAtBlockNumber(
 	blockNumber uint64,
 ) (core.StateReader, StateCloser, error) {
-	if err := pruner.RequireStateRetainedByBlockNumber(b.database, blockNumber); err != nil {
+	err := pruner.RequireStateRetainedByBlockNumber(b.database, b.retentionFloor, blockNumber)
+	if err != nil {
 		return nil, nil, err
 	}
 	//nolint:staticcheck,nolintlint // used by old state

--- a/blockchain/statebackend/statebackend.go
+++ b/blockchain/statebackend/statebackend.go
@@ -34,7 +34,11 @@ func (b *stateBackend) HeadState() (core.StateReader, StateCloser, error) {
 func (b *stateBackend) StateAtBlockNumber(
 	blockNumber uint64,
 ) (core.StateReader, StateCloser, error) {
-	stateRoot, err := pruner.StateRootIfStateRetainedByBlockNumber(b.database, blockNumber)
+	stateRoot, err := pruner.StateRootIfStateRetainedByBlockNumber(
+		b.database,
+		b.retentionFloor,
+		blockNumber,
+	)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/blockchain/statebackend/types.go
+++ b/blockchain/statebackend/types.go
@@ -7,6 +7,7 @@ import (
 	"github.com/NethermindEth/juno/core/state"
 	"github.com/NethermindEth/juno/core/trie2/triedb"
 	"github.com/NethermindEth/juno/db"
+	"github.com/NethermindEth/juno/pruner"
 )
 
 // StateBackend is the interface for state operations in blockchain.
@@ -52,21 +53,24 @@ type SimulateResult struct {
 }
 
 type baseState struct {
-	database      db.KeyValueStore
-	runningFilter *core.RunningEventFilter
-	network       *networks.Network
+	database       db.KeyValueStore
+	runningFilter  *core.RunningEventFilter
+	network        *networks.Network
+	retentionFloor *pruner.RetentionFloor
 }
 
 func New(
 	database db.KeyValueStore,
 	runningFilter *core.RunningEventFilter,
 	network *networks.Network,
+	retentionFloor *pruner.RetentionFloor,
 	stateVersion bool,
 ) StateBackend {
 	base := baseState{
-		database:      database,
-		runningFilter: runningFilter,
-		network:       network,
+		database:       database,
+		runningFilter:  runningFilter,
+		network:        network,
+		retentionFloor: retentionFloor,
 	}
 
 	if stateVersion {

--- a/blockchain/statebackend/types_test.go
+++ b/blockchain/statebackend/types_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/NethermindEth/juno/blockchain/networks"
 	"github.com/NethermindEth/juno/core"
 	"github.com/NethermindEth/juno/db/memory"
+	"github.com/NethermindEth/juno/pruner"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -16,7 +17,7 @@ func TestNew(t *testing.T) {
 		filter := core.NewRunningEventFilterLazy(memDB, core.InitializeRunningEventFilter)
 		network := &networks.Mainnet
 
-		backend := New(memDB, filter, network, true)
+		backend := New(memDB, filter, network, &pruner.RetentionFloor{}, true)
 
 		sb, ok := backend.(*stateBackend)
 		require.True(t, ok, "expected *stateBackend, got %T", backend)
@@ -31,7 +32,7 @@ func TestNew(t *testing.T) {
 		filter := core.NewRunningEventFilterLazy(memDB, core.InitializeRunningEventFilter)
 		network := &networks.Mainnet
 
-		backend := New(memDB, filter, network, false)
+		backend := New(memDB, filter, network, &pruner.RetentionFloor{}, false)
 
 		dsb, ok := backend.(*deprecatedStateBackend)
 		require.True(t, ok, "expected *deprecatedStateBackend, got %T", backend)

--- a/node/node.go
+++ b/node/node.go
@@ -160,6 +160,9 @@ type Node struct {
 	db         db.KeyValueStore
 	blockchain *blockchain.Blockchain
 	compiler   compiler.Compiler
+	// retentionFloor is shared with the blockchain and pruner; seeded in
+	// Run after migrations.
+	retentionFloor *pruner.RetentionFloor
 
 	earlyServices []service.Service // Services that needs to start before than other services and before migration.
 	services      []service.Service
@@ -233,10 +236,9 @@ func New(cfg *Config, version string, logLevel *log.Level) (*Node, error) {
 	services := make([]service.Service, 0)
 	earlyServices := make([]service.Service, 0)
 
-	retentionFloor, err := pruner.NewRetentionFloor(database)
-	if err != nil {
-		return nil, fmt.Errorf("seeding retention floor: %w", err)
-	}
+	// Unseeded until Run: the historyprunner migration prunes blocks before
+	// services start, and a floor seeded now would go stale.
+	retentionFloor := &pruner.RetentionFloor{}
 
 	opts := make([]blockchain.Option, 0, 4)
 	if cfg.Metrics {
@@ -626,14 +628,15 @@ func New(cfg *Config, version string, logLevel *log.Level) (*Node, error) {
 	}
 
 	n := &Node{
-		cfg:           cfg,
-		logger:        logger,
-		version:       version,
-		db:            database,
-		blockchain:    chain,
-		compiler:      throttledCompiler,
-		services:      services,
-		earlyServices: earlyServices,
+		cfg:            cfg,
+		logger:         logger,
+		version:        version,
+		db:             database,
+		blockchain:     chain,
+		compiler:       throttledCompiler,
+		services:       services,
+		earlyServices:  earlyServices,
+		retentionFloor: retentionFloor,
 	}
 
 	if !n.cfg.DisableL1Verification {
@@ -769,6 +772,13 @@ func (n *Node) Run(ctx context.Context) {
 			return
 		}
 		n.logger.Error("Error while running migrations", zap.Error(err))
+		return
+	}
+
+	// Seed only after migrations: the historyprunner migration prunes
+	// blocks without going through the pruner service.
+	if err := n.retentionFloor.Seed(n.db); err != nil {
+		n.logger.Error("Error while seeding retention floor", zap.Error(err))
 		return
 	}
 

--- a/node/node.go
+++ b/node/node.go
@@ -233,13 +233,20 @@ func New(cfg *Config, version string, logLevel *log.Level) (*Node, error) {
 	services := make([]service.Service, 0)
 	earlyServices := make([]service.Service, 0)
 
-	opts := make([]blockchain.Option, 0, 3)
+	retentionFloor, err := pruner.NewRetentionFloor(database)
+	if err != nil {
+		return nil, fmt.Errorf("seeding retention floor: %w", err)
+	}
+
+	opts := make([]blockchain.Option, 0, 4)
 	if cfg.Metrics {
 		opts = append(opts, blockchain.WithListener(makeBlockchainMetrics()))
 	}
-	opts = append(opts, blockchain.WithNewState(
-		cfg.NewState,
-	))
+	opts = append(
+		opts,
+		blockchain.WithNewState(cfg.NewState),
+		blockchain.WithRetentionFloor(retentionFloor),
+	)
 	if cfg.Prune {
 		opts = append(
 			opts,
@@ -352,6 +359,7 @@ func New(cfg *Config, version string, logLevel *log.Level) (*Node, error) {
 			prunerOpts = append(prunerOpts, pruner.WithMinAge(cfg.PruneMinAge))
 			p := pruner.New(
 				database,
+				retentionFloor,
 				cfg.RetainedBlocks,
 				seq.SubscribeNewHeads().Subscription,
 				chain.SubscribeL1Head().Subscription,
@@ -484,6 +492,7 @@ func New(cfg *Config, version string, logLevel *log.Level) (*Node, error) {
 				prunerOpts = append(prunerOpts, pruner.WithMinAge(cfg.PruneMinAge))
 				p := pruner.New(
 					database,
+					retentionFloor,
 					cfg.RetainedBlocks,
 					synchronizer.SubscribeNewHeads().Subscription,
 					chain.SubscribeL1Head().Subscription,

--- a/pruner/pruner.go
+++ b/pruner/pruner.go
@@ -84,8 +84,8 @@ type Pruner struct {
 	// latestSampledHeight is the lowest block with Timestamp >= now-minAge,
 	// re-derived each floorTickInterval tick.
 	latestSampledHeight uint64
-	// retentionFloor is raised after each prune so state readers can check
-	// retention without probing the database. Shared with the state backend.
+	// retentionFloor is shared with the state backend and raised before
+	// each prune.
 	retentionFloor *RetentionFloor
 	database       db.KeyValueStore
 	// newHeadSub fires on each new L2 head. During catch-up (L2 < L1) it
@@ -405,6 +405,10 @@ func (p *Pruner) onNewL1Head(ctx context.Context, l1Head *core.L1Head) error {
 func (p *Pruner) pruneUpto(ctx context.Context, oldestBlockToKeep uint64) error {
 	start := time.Now()
 
+	if oldestBlockToKeep > 0 {
+		p.retentionFloor.raiseTo(oldestBlockToKeep - 1)
+	}
+
 	blocksPruned, oldestKept, err := PruneUpto(
 		ctx,
 		p.database,
@@ -418,12 +422,6 @@ func (p *Pruner) pruneUpto(ctx context.Context, oldestBlockToKeep uint64) error 
 	// Keep latestSampledHeight at or above the retention floor so the next
 	// sampleHeight binary search never starts from a pruned block.
 	p.latestSampledHeight = max(p.latestSampledHeight, oldestKept)
-
-	// State at oldestKept-1 stays reconstructible: history entries record
-	// pre-block values, so entries at or above oldestKept cover it.
-	if oldestKept > 0 {
-		p.retentionFloor.raiseTo(oldestKept - 1)
-	}
 
 	elapsed := time.Since(start)
 	p.listener.OnPrune(oldestKept, blocksPruned, elapsed)

--- a/pruner/pruner.go
+++ b/pruner/pruner.go
@@ -84,7 +84,10 @@ type Pruner struct {
 	// latestSampledHeight is the lowest block with Timestamp >= now-minAge,
 	// re-derived each floorTickInterval tick.
 	latestSampledHeight uint64
-	database            db.KeyValueStore
+	// retentionFloor is raised after each prune so state readers can check
+	// retention without probing the database. Shared with the state backend.
+	retentionFloor *RetentionFloor
+	database       db.KeyValueStore
 	// newHeadSub fires on each new L2 head. During catch-up (L2 < L1) it
 	// drives the floor from this event's block number; otherwise the L1
 	// path drives the floor and this event acts only as a trigger.
@@ -146,15 +149,17 @@ func WithFloorTickInterval(duration time.Duration) Option {
 	}
 }
 
-// New constructs a Pruner. retainedBlocks is the number of blocks
-// retained below the retention pivot (= min(l1Head, l2Head); the pivot
-// itself is always retained), so the pruner keeps blocks in
-// [pivot - retainedBlocks, l2Head] and deletes everything below.
-// newHeadSub and l1HeadSub are the two trigger feeds (see [Pruner]).
-// Subscriptions are [feed.Subscription.Unsubscribe]'d when [Pruner.Run]
-// returns.
+// New constructs a Pruner. retentionFloor is raised after each prune and
+// must be the same instance the state backend reads (see [NewRetentionFloor]).
+// retainedBlocks is the number of blocks retained below the retention pivot
+// (= min(l1Head, l2Head); the pivot itself is always retained), so the
+// pruner keeps blocks in [pivot - retainedBlocks, l2Head] and deletes
+// everything below. newHeadSub and l1HeadSub are the two trigger feeds (see
+// [Pruner]). Subscriptions are [feed.Subscription.Unsubscribe]'d when
+// [Pruner.Run] returns.
 func New(
 	database db.KeyValueStore,
+	retentionFloor *RetentionFloor,
 	retainedBlocks uint64,
 	newHeadSub *feed.Subscription[*core.Block],
 	l1HeadSub *feed.Subscription[*core.L1Head],
@@ -171,6 +176,7 @@ func New(
 		opt(&o)
 	}
 	return &Pruner{
+		retentionFloor:      retentionFloor,
 		numRetainedBlocks:   retainedBlocks,
 		targetBatchByteSize: o.targetBatchByteSize,
 		l2HeadsPerPrune:     o.l2HeadsPerPrune,
@@ -218,7 +224,8 @@ func (p *Pruner) Run(ctx context.Context) error {
 		case block := <-p.newHeadSub.Recv():
 			if err := p.onNewBlock(ctx, block); err != nil {
 				p.listener.OnPruneError(err)
-				p.logger.Error("on new L2 block",
+				p.logger.Error(
+					"on new L2 block",
 					zap.Uint64("num", block.Number),
 					zap.Error(err),
 				)
@@ -227,7 +234,8 @@ func (p *Pruner) Run(ctx context.Context) error {
 		case l1Head := <-p.l1HeadSub.Recv():
 			if err := p.onNewL1Head(ctx, l1Head); err != nil {
 				p.listener.OnPruneError(err)
-				p.logger.Error("on new L1 Head",
+				p.logger.Error(
+					"on new L1 Head",
 					zap.Uint64("num", l1Head.BlockNumber),
 					zap.Error(err),
 				)
@@ -245,9 +253,10 @@ func (p *Pruner) Run(ctx context.Context) error {
 
 		case <-staleTicker.C:
 			p.listener.OnL1Stale()
-			p.logger.Warn("no L1 head received in more than 24 hours. " +
-				"Pruning is paused and disk usage will slowly grow until L1 head delivery resumes" +
-				". Verify that the L1 client connected is live and synced.",
+			p.logger.Warn(
+				"no L1 head received in more than 24 hours. " +
+					"Pruning is paused and disk usage will slowly grow until L1 head delivery resumes" +
+					". Verify that the L1 client connected is live and synced.",
 			)
 			staleTicker.Reset(periodicStalenessTick)
 		}
@@ -410,9 +419,16 @@ func (p *Pruner) pruneUpto(ctx context.Context, oldestBlockToKeep uint64) error 
 	// sampleHeight binary search never starts from a pruned block.
 	p.latestSampledHeight = max(p.latestSampledHeight, oldestKept)
 
+	// State at oldestKept-1 stays reconstructible: history entries record
+	// pre-block values, so entries at or above oldestKept cover it.
+	if oldestKept > 0 {
+		p.retentionFloor.raiseTo(oldestKept - 1)
+	}
+
 	elapsed := time.Since(start)
 	p.listener.OnPrune(oldestKept, blocksPruned, elapsed)
-	p.logger.Info("Pruned Blocks",
+	p.logger.Info(
+		"Pruned Blocks",
 		zap.Uint64("prunedBelow", oldestKept),
 		zap.Uint64("blocksPruned", blocksPruned),
 		zap.Duration("duration", elapsed),

--- a/pruner/pruner_test.go
+++ b/pruner/pruner_test.go
@@ -60,6 +60,7 @@ func startPrunerService(
 
 	p := pruner.New(
 		database,
+		&pruner.RetentionFloor{},
 		retention,
 		l2Feed.Subscribe(),
 		l1Feed.Subscribe(),

--- a/pruner/pruner_test.go
+++ b/pruner/pruner_test.go
@@ -31,6 +31,7 @@ type servicePruner struct {
 	l1Feed *feed.Feed[*core.L1Head]
 	l2Feed *feed.Feed[*core.Block]
 	pruned chan pruneEvent
+	floor  *pruner.RetentionFloor
 }
 
 func startPrunerService(
@@ -58,9 +59,10 @@ func startPrunerService(
 		}),
 	}, extraOpts...)
 
+	floor := &pruner.RetentionFloor{}
 	p := pruner.New(
 		database,
-		&pruner.RetentionFloor{},
+		floor,
 		retention,
 		l2Feed.Subscribe(),
 		l1Feed.Subscribe(),
@@ -79,7 +81,7 @@ func startPrunerService(
 		}
 	})
 
-	return &servicePruner{l1Feed: l1Feed, l2Feed: l2Feed, pruned: pruned}
+	return &servicePruner{l1Feed: l1Feed, l2Feed: l2Feed, pruned: pruned, floor: floor}
 }
 
 // sendL1AndAwait broadcasts an L1 head to the pruner and waits for the
@@ -182,6 +184,27 @@ func TestPruner_L1Path(t *testing.T) {
 		for i := range uint64(85) - core.BlockHashLag {
 			testutils.AssertBlockPruned(t, database, blocks[i])
 		}
+	})
+
+	t.Run("prune raises the shared retention floor for readers", func(t *testing.T) {
+		database := testutils.NewPebbleTestDB(t)
+		for i := range totalBlocks {
+			testutils.StoreBlock(t, database, i)
+		}
+		require.NoError(t, core.WriteChainHeight(database, totalBlocks))
+
+		sp := startPrunerService(t, database, 10)
+		require.NoError(t, sp.floor.Seed(database))
+
+		ev := sp.sendL1AndAwait(t, 95)
+		require.Equal(t, uint64(85), ev.oldest)
+
+		require.NoError(t, pruner.RequireStateRetainedByBlockNumber(database, sp.floor, 84))
+		err := pruner.RequireStateRetainedByBlockNumber(database, sp.floor, 83)
+		require.ErrorIs(t, err, db.ErrKeyNotFound)
+
+		_, err = pruner.StateRootIfStateRetainedByBlockNumber(database, sp.floor, 83)
+		require.ErrorIs(t, err, db.ErrKeyNotFound)
 	})
 
 	t.Run("L1 head at or beyond chainHeight is a no-op", func(t *testing.T) {

--- a/pruner/retention.go
+++ b/pruner/retention.go
@@ -57,36 +57,38 @@ func RequireRetained(r db.KeyValueReader, blockNumber uint64) error {
 }
 
 // RetentionFloor publishes the lowest block number whose historical state is
-// still queryable. The pruner raises it after each prune and readers consult
-// it instead reaching to DB. The zero value is unseeded: readers fall back to
-// the database probe, preserving correctness for standalone tools that never
-// wire a floor. Seed via [NewRetentionFloor].
+// still queryable, letting readers check retention without reaching for the
+// database. The zero value is unseeded: readers fall back to the database
+// probe.
 type RetentionFloor struct {
 	// state holds floor+1 so the zero value reads as unseeded.
 	state atomic.Uint64
 }
 
-// NewRetentionFloor derives the floor from the database: state at
-// oldestRetained-1 is still reconstructible from the retained history
-// entries (they record pre-block values), matching the hash → number
-// carve-out left by [PruneUpto]. An empty database floors at zero.
+// NewRetentionFloor returns a floor seeded from the database.
 func NewRetentionFloor(r db.KeyValueReader) (*RetentionFloor, error) {
-	oldest, err := OldestRetainedBlock(r)
-	if err != nil && !errors.Is(err, db.ErrKeyNotFound) {
-		return nil, err
-	}
-
 	f := &RetentionFloor{}
-	if oldest > 0 {
-		f.raiseTo(oldest - 1)
-	} else {
-		f.raiseTo(0)
+	if err := f.Seed(r); err != nil {
+		return nil, err
 	}
 	return f, nil
 }
 
-// raiseTo raises the floor to the given value; lower values are ignored so
-// concurrent readers never observe the floor moving down.
+// Seed derives the floor from the database. The floor is oldestRetained-1:
+// history entries record pre-block values, so state one block below the
+// oldest retained block stays reconstructible. An empty database seeds a
+// floor of zero that counts as seeded. Seeding never lowers the floor.
+func (f *RetentionFloor) Seed(r db.KeyValueReader) error {
+	oldest, err := OldestRetainedBlock(r)
+	if err != nil && !errors.Is(err, db.ErrKeyNotFound) {
+		return err
+	}
+	f.raiseTo(max(oldest, 1) - 1)
+	return nil
+}
+
+// raiseTo raises the floor; lower values are ignored so concurrent readers
+// never observe it moving down.
 func (f *RetentionFloor) raiseTo(floor uint64) {
 	for {
 		cur := f.state.Load()
@@ -102,10 +104,16 @@ func (f *RetentionFloor) raiseTo(floor uint64) {
 // floor returns the current floor and whether it has been seeded.
 func (f *RetentionFloor) floor() (uint64, bool) {
 	s := f.state.Load()
-	return s - 1, s > 0
+	if s == 0 {
+		return 0, false
+	}
+	return s - 1, true
 }
 
 // RequireStateRetainedByBlockNumber checks state retention by number.
+// The upper bound is the chain height, while
+// [StateRootIfStateRetainedByBlockNumber] uses header existence — equivalent
+// only because headers and the chain height are written in the same batch.
 func RequireStateRetainedByBlockNumber(
 	r db.KeyValueReader,
 	floor *RetentionFloor,
@@ -144,9 +152,7 @@ func StateRootIfStateRetainedByBlockNumber(
 		if blockNumber < f {
 			return nil, db.ErrKeyNotFound
 		}
-		// The header read doubles as the upper-bound check: headers above
-		// the chain height don't exist, and retained headers below the
-		// floor (the BlockHashLag carve-out) are already rejected above.
+		// The header read doubles as the upper-bound check.
 		return core.GetGlobalStateRootByBlockNumber(r, blockNumber)
 	}
 

--- a/pruner/retention.go
+++ b/pruner/retention.go
@@ -4,6 +4,7 @@ import (
 	"encoding/binary"
 	"errors"
 	"fmt"
+	"sync/atomic"
 
 	"github.com/NethermindEth/juno/core"
 	"github.com/NethermindEth/juno/core/felt"
@@ -27,7 +28,8 @@ func (e *BlockPrunedError) Error() string {
 	if e.OldestRetained == 0 {
 		return fmt.Sprintf("block %d is below the node's retention floor", e.BlockNumber)
 	}
-	return fmt.Sprintf("block %d has been pruned; oldest retained block is %d",
+	return fmt.Sprintf(
+		"block %d has been pruned; oldest retained block is %d",
 		e.BlockNumber,
 		e.OldestRetained,
 	)
@@ -54,9 +56,75 @@ func RequireRetained(r db.KeyValueReader, blockNumber uint64) error {
 	return &BlockPrunedError{BlockNumber: blockNumber, OldestRetained: oldest}
 }
 
-// RequireStateRetainedByBlockNumber checks state retention by number, avoiding the full
-// header decode (and its heavy fields like EventsBloom) when only the hash is needed.
-func RequireStateRetainedByBlockNumber(r db.KeyValueReader, blockNumber uint64) error {
+// RetentionFloor publishes the lowest block number whose historical state is
+// still queryable. The pruner raises it after each prune and readers consult
+// it instead reaching to DB. The zero value is unseeded: readers fall back to
+// the database probe, preserving correctness for standalone tools that never
+// wire a floor. Seed via [NewRetentionFloor].
+type RetentionFloor struct {
+	// state holds floor+1 so the zero value reads as unseeded.
+	state atomic.Uint64
+}
+
+// NewRetentionFloor derives the floor from the database: state at
+// oldestRetained-1 is still reconstructible from the retained history
+// entries (they record pre-block values), matching the hash → number
+// carve-out left by [PruneUpto]. An empty database floors at zero.
+func NewRetentionFloor(r db.KeyValueReader) (*RetentionFloor, error) {
+	oldest, err := OldestRetainedBlock(r)
+	if err != nil && !errors.Is(err, db.ErrKeyNotFound) {
+		return nil, err
+	}
+
+	f := &RetentionFloor{}
+	if oldest > 0 {
+		f.raiseTo(oldest - 1)
+	} else {
+		f.raiseTo(0)
+	}
+	return f, nil
+}
+
+// raiseTo raises the floor to the given value; lower values are ignored so
+// concurrent readers never observe the floor moving down.
+func (f *RetentionFloor) raiseTo(floor uint64) {
+	for {
+		cur := f.state.Load()
+		if floor+1 <= cur {
+			return
+		}
+		if f.state.CompareAndSwap(cur, floor+1) {
+			return
+		}
+	}
+}
+
+// floor returns the current floor and whether it has been seeded.
+func (f *RetentionFloor) floor() (uint64, bool) {
+	s := f.state.Load()
+	return s - 1, s > 0
+}
+
+// RequireStateRetainedByBlockNumber checks state retention by number.
+func RequireStateRetainedByBlockNumber(
+	r db.KeyValueReader,
+	floor *RetentionFloor,
+	blockNumber uint64,
+) error {
+	if f, seeded := floor.floor(); seeded {
+		if blockNumber < f {
+			return db.ErrKeyNotFound
+		}
+		height, err := core.GetChainHeight(r)
+		if err != nil {
+			return err
+		}
+		if blockNumber > height {
+			return db.ErrKeyNotFound
+		}
+		return nil
+	}
+
 	hash, err := core.GetBlockHeaderHashByNumber(r, blockNumber)
 	if err != nil {
 		return err
@@ -65,12 +133,23 @@ func RequireStateRetainedByBlockNumber(r db.KeyValueReader, blockNumber uint64) 
 	return err
 }
 
-// StateRootIfStateRetainedByBlockNumber returns the global state root for blockNumber
-// only if state at that block is queryable, decoding hash and state root in a single header read.
+// StateRootIfStateRetainedByBlockNumber returns the global state root for
+// blockNumber only if state at that block is queryable.
 func StateRootIfStateRetainedByBlockNumber(
 	r db.KeyValueReader,
+	floor *RetentionFloor,
 	blockNumber uint64,
 ) (*felt.Felt, error) {
+	if f, seeded := floor.floor(); seeded {
+		if blockNumber < f {
+			return nil, db.ErrKeyNotFound
+		}
+		// The header read doubles as the upper-bound check: headers above
+		// the chain height don't exist, and retained headers below the
+		// floor (the BlockHashLag carve-out) are already rejected above.
+		return core.GetGlobalStateRootByBlockNumber(r, blockNumber)
+	}
+
 	hash, stateRoot, err := core.GetBlockHeaderHashAndStateRootByNumber(r, blockNumber)
 	if err != nil {
 		return nil, err

--- a/pruner/retention_test.go
+++ b/pruner/retention_test.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"testing"
 
+	"github.com/NethermindEth/juno/core"
 	"github.com/NethermindEth/juno/db"
 	"github.com/NethermindEth/juno/db/memory"
 	_ "github.com/NethermindEth/juno/encoder/registry"
@@ -85,17 +86,18 @@ func TestRequireRetained(t *testing.T) {
 }
 
 func TestRequireStateRetainedByBlockNumber(t *testing.T) {
-	t.Run("allows retained state", func(t *testing.T) {
+	t.Run("unseeded floor allows retained state", func(t *testing.T) {
 		const blockNumber = uint64(3)
 
 		database := memory.New()
 		for i := range uint64(5) {
 			testutils.StoreBlock(t, database, i)
 		}
-		require.NoError(t, pruner.RequireStateRetainedByBlockNumber(database, blockNumber))
+		floor := &pruner.RetentionFloor{}
+		require.NoError(t, pruner.RequireStateRetainedByBlockNumber(database, floor, blockNumber))
 	})
 
-	t.Run("rejects pruned state when header remains", func(t *testing.T) {
+	t.Run("unseeded floor rejects pruned state when header remains", func(t *testing.T) {
 		const blockNumber = uint64(1)
 
 		database := memory.New()
@@ -106,7 +108,80 @@ func TestRequireStateRetainedByBlockNumber(t *testing.T) {
 		prunedHash := blocks[blockNumber].Header.Hash
 		require.NoError(t, database.Delete(db.BlockHeaderNumbersByHashKey(prunedHash)))
 
-		err := pruner.RequireStateRetainedByBlockNumber(database, blockNumber)
+		floor := &pruner.RetentionFloor{}
+		err := pruner.RequireStateRetainedByBlockNumber(database, floor, blockNumber)
+		require.ErrorIs(t, err, db.ErrKeyNotFound)
+	})
+
+	t.Run("seeded floor skips the header probe", func(t *testing.T) {
+		const blockNumber = uint64(1)
+
+		database := memory.New()
+		blocks := make([]*testutils.StoredBlock, 5)
+		for i := range uint64(5) {
+			blocks[i] = testutils.StoreBlock(t, database, i)
+		}
+		require.NoError(t, core.WriteChainHeight(database, 4))
+
+		floor, err := pruner.NewRetentionFloor(database)
+		require.NoError(t, err)
+
+		// Drop the hash → number index: the probe path would reject this
+		// block, so only the floor fast path can accept it.
+		require.NoError(t,
+			database.Delete(db.BlockHeaderNumbersByHashKey(blocks[blockNumber].Header.Hash)))
+		require.NoError(t, pruner.RequireStateRetainedByBlockNumber(database, floor, blockNumber))
+	})
+
+	t.Run("seeded floor rejects blocks below the floor", func(t *testing.T) {
+		database := memory.New()
+		for i := uint64(5); i <= 7; i++ {
+			testutils.StoreBlock(t, database, i)
+		}
+		require.NoError(t, core.WriteChainHeight(database, 7))
+
+		floor, err := pruner.NewRetentionFloor(database)
+		require.NoError(t, err)
+
+		err = pruner.RequireStateRetainedByBlockNumber(database, floor, 3)
+		require.ErrorIs(t, err, db.ErrKeyNotFound)
+
+		// State at oldestRetained-1 is still reconstructible from the
+		// retained history entries, matching the hash carve-out semantics.
+		require.NoError(t, pruner.RequireStateRetainedByBlockNumber(database, floor, 4))
+		require.NoError(t, pruner.RequireStateRetainedByBlockNumber(database, floor, 5))
+		require.NoError(t, pruner.RequireStateRetainedByBlockNumber(database, floor, 7))
+	})
+
+	t.Run("seeded floor rejects blocks above the chain height", func(t *testing.T) {
+		database := memory.New()
+		for i := range uint64(5) {
+			testutils.StoreBlock(t, database, i)
+		}
+		require.NoError(t, core.WriteChainHeight(database, 4))
+
+		floor, err := pruner.NewRetentionFloor(database)
+		require.NoError(t, err)
+
+		err = pruner.RequireStateRetainedByBlockNumber(database, floor, 5)
+		require.ErrorIs(t, err, db.ErrKeyNotFound)
+	})
+}
+
+func TestNewRetentionFloor(t *testing.T) {
+	t.Run("empty database retains every block stored later", func(t *testing.T) {
+		database := memory.New()
+		floor, err := pruner.NewRetentionFloor(database)
+		require.NoError(t, err)
+
+		for i := range uint64(3) {
+			testutils.StoreBlock(t, database, i)
+		}
+		require.NoError(t, core.WriteChainHeight(database, 2))
+
+		require.NoError(t, pruner.RequireStateRetainedByBlockNumber(database, floor, 0))
+		require.NoError(t, pruner.RequireStateRetainedByBlockNumber(database, floor, 2))
+		err = pruner.RequireStateRetainedByBlockNumber(database, floor, 3)
 		require.ErrorIs(t, err, db.ErrKeyNotFound)
 	})
 }
@@ -121,12 +196,13 @@ func TestStateRootIfStateRetainedByBlockNumber(t *testing.T) {
 			blocks[i] = testutils.StoreBlock(t, database, i)
 		}
 
-		stateRoot, err := pruner.StateRootIfStateRetainedByBlockNumber(database, blockNumber)
+		floor := &pruner.RetentionFloor{}
+		stateRoot, err := pruner.StateRootIfStateRetainedByBlockNumber(database, floor, blockNumber)
 		require.NoError(t, err)
 		assert.Equal(t, blocks[blockNumber].Header.GlobalStateRoot, stateRoot)
 	})
 
-	t.Run("rejects pruned state when header remains", func(t *testing.T) {
+	t.Run("unseeded floor rejects pruned state when header remains", func(t *testing.T) {
 		const blockNumber = uint64(1)
 
 		database := memory.New()
@@ -137,13 +213,49 @@ func TestStateRootIfStateRetainedByBlockNumber(t *testing.T) {
 		prunedHash := blocks[blockNumber].Header.Hash
 		require.NoError(t, database.Delete(db.BlockHeaderNumbersByHashKey(prunedHash)))
 
-		_, err := pruner.StateRootIfStateRetainedByBlockNumber(database, blockNumber)
+		floor := &pruner.RetentionFloor{}
+		_, err := pruner.StateRootIfStateRetainedByBlockNumber(database, floor, blockNumber)
+		require.ErrorIs(t, err, db.ErrKeyNotFound)
+	})
+
+	t.Run("seeded floor skips the hash probe", func(t *testing.T) {
+		const blockNumber = uint64(1)
+
+		database := memory.New()
+		blocks := make([]*testutils.StoredBlock, 5)
+		for i := range uint64(5) {
+			blocks[i] = testutils.StoreBlock(t, database, i)
+		}
+
+		floor, err := pruner.NewRetentionFloor(database)
+		require.NoError(t, err)
+
+		// Drop the hash → number index: the probe path would reject this
+		// block, so only the floor fast path can accept it.
+		require.NoError(t,
+			database.Delete(db.BlockHeaderNumbersByHashKey(blocks[blockNumber].Header.Hash)))
+		stateRoot, err := pruner.StateRootIfStateRetainedByBlockNumber(database, floor, blockNumber)
+		require.NoError(t, err)
+		assert.Equal(t, blocks[blockNumber].Header.GlobalStateRoot, stateRoot)
+	})
+
+	t.Run("seeded floor rejects blocks below the floor", func(t *testing.T) {
+		database := memory.New()
+		for i := uint64(5); i <= 7; i++ {
+			testutils.StoreBlock(t, database, i)
+		}
+
+		floor, err := pruner.NewRetentionFloor(database)
+		require.NoError(t, err)
+
+		_, err = pruner.StateRootIfStateRetainedByBlockNumber(database, floor, 3)
 		require.ErrorIs(t, err, db.ErrKeyNotFound)
 	})
 
 	t.Run("missing block returns ErrKeyNotFound", func(t *testing.T) {
 		database := memory.New()
-		_, err := pruner.StateRootIfStateRetainedByBlockNumber(database, 0)
+		floor := &pruner.RetentionFloor{}
+		_, err := pruner.StateRootIfStateRetainedByBlockNumber(database, floor, 0)
 		require.ErrorIs(t, err, db.ErrKeyNotFound)
 	})
 }

--- a/pruner/retention_test.go
+++ b/pruner/retention_test.go
@@ -126,8 +126,6 @@ func TestRequireStateRetainedByBlockNumber(t *testing.T) {
 		floor, err := pruner.NewRetentionFloor(database)
 		require.NoError(t, err)
 
-		// Drop the hash → number index: the probe path would reject this
-		// block, so only the floor fast path can accept it.
 		require.NoError(t,
 			database.Delete(db.BlockHeaderNumbersByHashKey(blocks[blockNumber].Header.Hash)))
 		require.NoError(t, pruner.RequireStateRetainedByBlockNumber(database, floor, blockNumber))
@@ -146,8 +144,6 @@ func TestRequireStateRetainedByBlockNumber(t *testing.T) {
 		err = pruner.RequireStateRetainedByBlockNumber(database, floor, 3)
 		require.ErrorIs(t, err, db.ErrKeyNotFound)
 
-		// State at oldestRetained-1 is still reconstructible from the
-		// retained history entries, matching the hash carve-out semantics.
 		require.NoError(t, pruner.RequireStateRetainedByBlockNumber(database, floor, 4))
 		require.NoError(t, pruner.RequireStateRetainedByBlockNumber(database, floor, 5))
 		require.NoError(t, pruner.RequireStateRetainedByBlockNumber(database, floor, 7))
@@ -165,6 +161,41 @@ func TestRequireStateRetainedByBlockNumber(t *testing.T) {
 
 		err = pruner.RequireStateRetainedByBlockNumber(database, floor, 5)
 		require.ErrorIs(t, err, db.ErrKeyNotFound)
+	})
+}
+
+func TestRetentionFloorSeed(t *testing.T) {
+	t.Run("reseeding after out-of-band pruning raises the floor", func(t *testing.T) {
+		database := testutils.NewPebbleTestDB(t)
+		for i := range uint64(10) {
+			testutils.StoreBlock(t, database, i)
+		}
+		require.NoError(t, core.WriteChainHeight(database, 9))
+
+		floor, err := pruner.NewRetentionFloor(database)
+		require.NoError(t, err)
+
+		batch := database.NewBatch()
+		require.NoError(t, pruner.PruneBlockDataUpto(batch, 5))
+		require.NoError(t, batch.Write())
+
+		require.NoError(t, floor.Seed(database))
+
+		err = pruner.RequireStateRetainedByBlockNumber(database, floor, 3)
+		require.ErrorIs(t, err, db.ErrKeyNotFound)
+		require.NoError(t, pruner.RequireStateRetainedByBlockNumber(database, floor, 4))
+	})
+
+	t.Run("seeding an empty database leaves nothing rejected", func(t *testing.T) {
+		database := testutils.NewPebbleTestDB(t)
+		floor := &pruner.RetentionFloor{}
+		require.NoError(t, floor.Seed(database))
+
+		for i := range uint64(3) {
+			testutils.StoreBlock(t, database, i)
+		}
+		require.NoError(t, core.WriteChainHeight(database, 2))
+		require.NoError(t, pruner.RequireStateRetainedByBlockNumber(database, floor, 0))
 	})
 }
 
@@ -230,8 +261,6 @@ func TestStateRootIfStateRetainedByBlockNumber(t *testing.T) {
 		floor, err := pruner.NewRetentionFloor(database)
 		require.NoError(t, err)
 
-		// Drop the hash → number index: the probe path would reject this
-		// block, so only the floor fast path can accept it.
 		require.NoError(t,
 			database.Delete(db.BlockHeaderNumbersByHashKey(blocks[blockNumber].Header.Hash)))
 		stateRoot, err := pruner.StateRootIfStateRetainedByBlockNumber(database, floor, blockNumber)

--- a/pruner/staleness_test.go
+++ b/pruner/staleness_test.go
@@ -33,6 +33,7 @@ func startStalenessPruner(t *testing.T) (*atomic.Int64, *feed.Feed[*core.L1Head]
 	staleCount := &atomic.Int64{}
 	p := pruner.New(
 		database,
+		&pruner.RetentionFloor{},
 		64,
 		l2Feed.Subscribe(),
 		l1Feed.Subscribe(),


### PR DESCRIPTION
For both pruned and non-pruned nodes, `StateAtBlockNumber` reads go through `pruner` wiring. Importantly, it checks the presense of the block in the DB, which results in 2 DB reads to verify something that we should know already. 

This PR introduces a concept of `RetentionFloor` which basically tracks the `oldestRetained-1` in the atomic value, efectively reducing DB look-ups. 


Microbench on Sepolia (pruned) snapshot:

| benchmark (n=6) | probe (old) | floor (new) | speedup |
|---|---|---|---|
| `RequireStateRetainedByBlockNumber` | 36.3µs ± 1% | 828ns ± 2% | ~44× |
| `StateAtBlockNumber`  | 37.4µs ± 1% | 994ns ± 4% | ~38× |