### PR TITLE
perf(history): Check contract deployment only for slots with zero values

### DIFF
--- a/core/deprecatedstate/history.go
+++ b/core/deprecatedstate/history.go
@@ -2,6 +2,7 @@ package deprecatedstate
 
 import (
 	"errors"
+	"fmt"
 
 	"github.com/NethermindEth/juno/core"
 	"github.com/NethermindEth/juno/core/felt"
@@ -63,10 +64,10 @@ func (s *stateHistory) ContractStorage(addr, key *felt.Felt) (felt.Felt, error) 
 	val, err := s.state.ContractStorageAt(addr, key, s.blockNumber)
 	if err != nil {
 		if !errors.Is(err, ErrCheckHeadState) {
-			return felt.Felt{}, err
+			return felt.Felt{}, fmt.Errorf("reading storage history: %w", err)
 		}
 		if val, err = s.state.ContractStorage(addr, key); err != nil {
-			return felt.Felt{}, err
+			return felt.Felt{}, fmt.Errorf("reading head storage: %w", err)
 		}
 	}
 

--- a/core/deprecatedstate/history.go
+++ b/core/deprecatedstate/history.go
@@ -60,15 +60,23 @@ func (s *stateHistory) ContractNonce(addr *felt.Felt) (felt.Felt, error) {
 }
 
 func (s *stateHistory) ContractStorage(addr, key *felt.Felt) (felt.Felt, error) {
-	if err := s.checkDeployed(addr); err != nil {
-		return felt.Felt{}, err
-	}
-
 	val, err := s.state.ContractStorageAt(addr, key, s.blockNumber)
 	if err != nil {
-		if errors.Is(err, ErrCheckHeadState) {
-			return s.state.ContractStorage(addr, key)
+		if !errors.Is(err, ErrCheckHeadState) {
+			return felt.Felt{}, err
 		}
+		if val, err = s.state.ContractStorage(addr, key); err != nil {
+			return felt.Felt{}, err
+		}
+	}
+
+	// A non-zero value proves a write at or before blockNumber, and only
+	// deployed contracts are written to - skip the deployment probe.
+	if !val.IsZero() {
+		return val, nil
+	}
+
+	if err := s.checkDeployed(addr); err != nil {
 		return felt.Felt{}, err
 	}
 	return val, nil

--- a/core/deprecatedstate/history_test.go
+++ b/core/deprecatedstate/history_test.go
@@ -194,6 +194,13 @@ func TestStateHistory(t *testing.T) {
 		})
 	})
 
+	t.Run("unset slot on deployed contract returns zero", func(t *testing.T) {
+		unsetKey := felt.NewFromUint64[felt.Felt](999)
+		storage, err := snapshotAtDeployment.ContractStorage(&addrFelt, unsetKey)
+		require.NoError(t, err)
+		require.Equal(t, felt.Zero, storage)
+	})
+
 	t.Run(
 		"deprecated state history trie methods return ErrHistoricalTrieNotSupported",
 		func(t *testing.T) {
@@ -205,5 +212,61 @@ func TestStateHistory(t *testing.T) {
 
 			_, err = snapshotAtDeployment.ContractStorageTrie(&addrFelt)
 			require.ErrorIs(t, err, deprecatedstate.ErrHistoricalTrieNotSupported)
-		})
+		},
+	)
+}
+
+func TestContractStorageSkipsDeploymentProbeForNonZeroValue(t *testing.T) {
+	testDB := memory.New()
+	txn := testDB.NewIndexedBatch()
+	state := deprecatedstate.New(txn)
+
+	addr := felt.NewFromUint64[felt.Felt](1)
+	storageKey := felt.NewFromUint64[felt.Felt](2)
+	classHash := felt.NewFromUint64[felt.Felt](10)
+	initialValue := felt.NewFromUint64[felt.Felt](100)
+	updatedValue := felt.NewFromUint64[felt.Felt](200)
+
+	deployedHeight := uint64(3)
+	changeHeight := uint64(10)
+
+	require.NoError(t, state.Update(&core.Header{Number: deployedHeight}, &core.StateUpdate{
+		OldRoot: &felt.Zero,
+		NewRoot: &felt.Zero,
+		StateDiff: &core.StateDiff{
+			DeployedContracts: map[felt.Felt]*felt.Felt{*addr: classHash},
+			StorageDiffs: map[felt.Felt]map[felt.Felt]*felt.Felt{
+				*addr: {*storageKey: initialValue},
+			},
+		},
+	}, nil, true))
+
+	root, err := state.Commitment("")
+	require.NoError(t, err)
+
+	require.NoError(t, state.Update(&core.Header{Number: changeHeight}, &core.StateUpdate{
+		OldRoot: &root,
+		NewRoot: &felt.Zero,
+		StateDiff: &core.StateDiff{
+			StorageDiffs: map[felt.Felt]map[felt.Felt]*felt.Felt{
+				*addr: {*storageKey: updatedValue},
+			},
+		},
+	}, nil, true))
+
+	require.NoError(t, txn.Delete(db.ContractDeploymentHeightKey(addr)))
+
+	t.Run("value from history entry", func(t *testing.T) {
+		snapshot := deprecatedstate.NewHistory(state, deployedHeight)
+		storage, err := snapshot.ContractStorage(addr, storageKey)
+		require.NoError(t, err)
+		require.Equal(t, *initialValue, storage)
+	})
+
+	t.Run("value from head fallback", func(t *testing.T) {
+		snapshot := deprecatedstate.NewHistory(state, changeHeight)
+		storage, err := snapshot.ContractStorage(addr, storageKey)
+		require.NoError(t, err)
+		require.Equal(t, *updatedValue, storage)
+	})
 }

--- a/core/deprecatedstate/history_test.go
+++ b/core/deprecatedstate/history_test.go
@@ -269,4 +269,13 @@ func TestContractStorageSkipsDeploymentProbeForNonZeroValue(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, *updatedValue, storage)
 	})
+
+	// The zero branch must still probe, otherwise the two sub-tests above would
+	// pass with the probe removed altogether rather than skipped for non-zero values.
+	t.Run("zero value still probes deployment", func(t *testing.T) {
+		unsetKey := felt.NewFromUint64[felt.Felt](999)
+		snapshot := deprecatedstate.NewHistory(state, changeHeight)
+		_, err := snapshot.ContractStorage(addr, unsetKey)
+		require.ErrorIs(t, err, db.ErrKeyNotFound)
+	})
 }

--- a/core/deprecatedstate/history_test.go
+++ b/core/deprecatedstate/history_test.go
@@ -1,6 +1,7 @@
 package deprecatedstate_test
 
 import (
+	"errors"
 	"testing"
 
 	"github.com/NethermindEth/juno/core"
@@ -278,4 +279,59 @@ func TestContractStorageSkipsDeploymentProbeForNonZeroValue(t *testing.T) {
 		_, err := snapshot.ContractStorage(addr, unsetKey)
 		require.ErrorIs(t, err, db.ErrKeyNotFound)
 	})
+}
+
+// errInjected is the failure the batch wrappers below inject.
+var errInjected = errors.New("injected db failure")
+
+// iterFailBatch fails the storage history lookup, which reads through an iterator.
+type iterFailBatch struct {
+	db.IndexedBatch
+}
+
+func (iterFailBatch) NewIterator([]byte, bool) (db.Iterator, error) {
+	return nil, errInjected
+}
+
+// getFailBatch fails the head state read, which reads trie nodes through Get.
+type getFailBatch struct {
+	db.IndexedBatch
+}
+
+func (getFailBatch) Get([]byte, func([]byte) error) error {
+	return errInjected
+}
+
+func TestContractStorageWrapsDBFailures(t *testing.T) {
+	testDB := memory.New()
+
+	addr := felt.NewFromUint64[felt.Felt](1)
+	storageKey := felt.NewFromUint64[felt.Felt](2)
+
+	tests := []struct {
+		name    string
+		state   *deprecatedstate.State
+		wantMsg string
+	}{
+		{
+			name:    "history lookup",
+			state:   deprecatedstate.New(iterFailBatch{testDB.NewIndexedBatch()}),
+			wantMsg: "reading storage history",
+		},
+		{
+			// An empty state holds no history entry, so the lookup falls back to the
+			// head state and reaches the failing Get.
+			name:    "head state fallback",
+			state:   deprecatedstate.New(getFailBatch{testDB.NewIndexedBatch()}),
+			wantMsg: "reading head storage",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			_, err := deprecatedstate.NewHistory(test.state, 1).ContractStorage(addr, storageKey)
+			require.ErrorIs(t, err, errInjected)
+			require.ErrorContains(t, err, test.wantMsg)
+		})
+	}
 }


### PR DESCRIPTION
This PR prioritizes "happy" path over a missing storage slot. This means it speeds up reads for existing slots, but degrades the case of a missing contract - check `notfound` results below.

Non-zero values are unambiguously clear - we have the slot and the contract is deployed. For zero values, we need to check if that's an actual value or a missing contract.


I've run some tests against both pruned and non-pruned Sepolia snapshots, and got an exact match over ~12k lookups.

Bench results:

| case             | ns/op old | ns/op new | Δ ns/op | B/op old | B/op new | Δ B/op | allocs old | allocs new | Δ allocs |
|------------------|----------:|----------:|--------:|---------:|---------:|-------:|-----------:|-----------:|---------:|
| nonzero          |   279,511 |   189,680 |  −32.1% |    5,246 |    4,386 | −16.4% |         33 |         21 |   −36.4% |
| zero             |   288,086 |   286,786 |   −0.5% |    5,139 |    5,168 |  +0.6% |         32 |         32 |       0% |
| notfound         |    81,931 |   285,621 | +248.6% |      830 |    5,161 |  +522% |         12 |         32 |    +167% |