### PR TITLE
 perf(core): decode execution status via partial-CBOR projection

### DIFF
--- a/blockchain/blockchain.go
+++ b/blockchain/blockchain.go
@@ -63,7 +63,7 @@ type Reader interface {
 	) (receipt core.TransactionReceipt, blockHash *felt.Felt, err error)
 	TransactionExecutionStatusByBlockNumberAndIndex(
 		blockNumber, index uint64,
-	) (status core.ExecutionStatus, err error)
+	) (status core.TransactionExecutionStatus, err error)
 
 	StateUpdateByNumber(number uint64) (update *core.StateUpdate, err error)
 	StateUpdateByHash(hash *felt.Felt) (update *core.StateUpdate, err error)
@@ -336,9 +336,9 @@ func (b *Blockchain) ReceiptByBlockNumberAndIndex(
 // TransactionExecutionStatusByBlockNumberAndIndex returns only the status subset of a receipt.
 func (b *Blockchain) TransactionExecutionStatusByBlockNumberAndIndex(
 	blockNumber, index uint64,
-) (core.ExecutionStatus, error) {
+) (core.TransactionExecutionStatus, error) {
 	b.listener.OnRead("TransactionExecutionStatusByBlockNumberAndIndex")
-	return core.GetExecutionStatusByBlockAndIndex(b.database, blockNumber, index)
+	return core.GetTransactionExecutionStatusByBlockAndIndex(b.database, blockNumber, index)
 }
 
 func (b *Blockchain) SubscribeL1Head() L1HeadSubscription {

--- a/core/accessors.go
+++ b/core/accessors.go
@@ -505,13 +505,13 @@ func GetReceiptByBlockAndIndex(
 	return BlockTransactionsReceiptPartialBucket.Get(r, blockNumber, int(index))
 }
 
-// GetExecutionStatusByBlockAndIndex returns only the status subset of a receipt,
-// skipping its heavier fields.
-func GetExecutionStatusByBlockAndIndex(
+// GetTransactionExecutionStatusByBlockAndIndex returns only the status subset of a
+// receipt, skipping its heavier fields.
+func GetTransactionExecutionStatusByBlockAndIndex(
 	r db.KeyValueReader,
 	blockNumber uint64,
 	index uint64,
-) (ExecutionStatus, error) {
+) (TransactionExecutionStatus, error) {
 	return BlockTransactionsExecutionStatusPartialBucket.Get(r, blockNumber, int(index))
 }
 

--- a/core/accessors_test.go
+++ b/core/accessors_test.go
@@ -211,7 +211,7 @@ func TestGetReceiptByBlockAndIndex(t *testing.T) {
 	})
 }
 
-func TestGetExecutionStatusByBlockAndIndex(t *testing.T) {
+func TestGetTransactionExecutionStatusByBlockAndIndex(t *testing.T) {
 	t.Parallel()
 	memDB, block := setupForTxsAndReceiptsTests(t)
 
@@ -219,13 +219,13 @@ func TestGetExecutionStatusByBlockAndIndex(t *testing.T) {
 		t.Parallel()
 		require.NotEmpty(t, block.Receipts)
 		for i := range block.Receipts {
-			status, err := core.GetExecutionStatusByBlockAndIndex(memDB, block.Number, uint64(i))
+			status, err := core.GetTransactionExecutionStatusByBlockAndIndex(memDB, block.Number, uint64(i))
 			require.NoError(t, err)
 
 			// The partial decode must recover the same status the full receipt carries.
 			full, err := core.GetReceiptByBlockAndIndex(memDB, block.Number, uint64(i))
 			require.NoError(t, err)
-			assert.Equal(t, core.ExecutionStatus{
+			assert.Equal(t, core.TransactionExecutionStatus{
 				Reverted:     full.Reverted,
 				RevertReason: full.RevertReason,
 			}, status)
@@ -233,14 +233,18 @@ func TestGetExecutionStatusByBlockAndIndex(t *testing.T) {
 	})
 	t.Run("non-existent block", func(t *testing.T) {
 		t.Parallel()
-		_, err := core.GetExecutionStatusByBlockAndIndex(memDB, nonexistentBlockNumber, 0)
+		_, err := core.GetTransactionExecutionStatusByBlockAndIndex(memDB, nonexistentBlockNumber, 0)
 		require.ErrorIs(t, err, db.ErrKeyNotFound)
 	})
 
 	t.Run("non-existent index", func(t *testing.T) {
 		t.Parallel()
 		// one past the last index should return ErrKeyNotFound
-		_, err := core.GetExecutionStatusByBlockAndIndex(memDB, block.Number, uint64(len(block.Receipts)))
+		_, err := core.GetTransactionExecutionStatusByBlockAndIndex(
+			memDB,
+			block.Number,
+			uint64(len(block.Receipts)),
+		)
 		require.ErrorIs(t, err, db.ErrKeyNotFound)
 	})
 
@@ -268,12 +272,16 @@ func TestGetExecutionStatusByBlockAndIndex(t *testing.T) {
 			[]*core.TransactionReceipt{reverted},
 		))
 
-		status, err := core.GetExecutionStatusByBlockAndIndex(revertedDB, revertedBlockNumber, 0)
+		status, err := core.GetTransactionExecutionStatusByBlockAndIndex(
+			revertedDB,
+			revertedBlockNumber,
+			0,
+		)
 		require.NoError(t, err)
 
 		full, err := core.GetReceiptByBlockAndIndex(revertedDB, revertedBlockNumber, 0)
 		require.NoError(t, err)
-		assert.Equal(t, core.ExecutionStatus{
+		assert.Equal(t, core.TransactionExecutionStatus{
 			Reverted:     full.Reverted,
 			RevertReason: full.RevertReason,
 		}, status)

--- a/core/block_transaction.go
+++ b/core/block_transaction.go
@@ -92,8 +92,8 @@ func (b *BlockTransactions) Receipts() indexed.LazySlice[*TransactionReceipt] {
 	return indexed.NewLazySlice[*TransactionReceipt](b.Indexes.Receipts, b.Data)
 }
 
-// ExecutionStatuses decodes receipts into the ExecutionStatus subset, skipping the
+// executionStatusProjections decodes receipts into the execution-status subset, skipping the
 // heavier receipt fields.
-func (b *BlockTransactions) ExecutionStatuses() indexed.LazySlice[ExecutionStatus] {
-	return indexed.NewLazySlice[ExecutionStatus](b.Indexes.Receipts, b.Data)
+func (b *BlockTransactions) executionStatusProjections() indexed.LazySlice[receiptExecutionStatus] {
+	return indexed.NewLazySlice[receiptExecutionStatus](b.Indexes.Receipts, b.Data)
 }

--- a/core/block_transaction.go
+++ b/core/block_transaction.go
@@ -92,8 +92,11 @@ func (b *BlockTransactions) Receipts() indexed.LazySlice[*TransactionReceipt] {
 	return indexed.NewLazySlice[*TransactionReceipt](b.Indexes.Receipts, b.Data)
 }
 
+// executionStatusProjectionSlice is the lazily-decoded slice of execution-status projections.
+type executionStatusProjectionSlice = indexed.LazySlice[receiptExecutionStatusProjection]
+
 // executionStatusProjections decodes receipts into the execution-status subset, skipping the
 // heavier receipt fields.
-func (b *BlockTransactions) executionStatusProjections() indexed.LazySlice[receiptExecutionStatus] {
-	return indexed.NewLazySlice[receiptExecutionStatus](b.Indexes.Receipts, b.Data)
+func (b *BlockTransactions) executionStatusProjections() executionStatusProjectionSlice {
+	return indexed.NewLazySlice[receiptExecutionStatusProjection](b.Indexes.Receipts, b.Data)
 }

--- a/core/block_transaction_serializer.go
+++ b/core/block_transaction_serializer.go
@@ -45,7 +45,11 @@ func (extractReceipt) extract(b *BlockTransactions, subKey int) (*TransactionRec
 type extractExecutionStatus struct{}
 
 func (extractExecutionStatus) extract(b *BlockTransactions, subKey int) (ExecutionStatus, error) {
-	return b.ExecutionStatuses().Get(subKey)
+	projection, err := b.executionStatusProjections().Get(subKey)
+	if err != nil {
+		return ExecutionStatus{}, err
+	}
+	return ExecutionStatus{Reverted: projection.Reverted, RevertReason: projection.RevertReason}, nil
 }
 
 type extractAllTransactions struct{}

--- a/core/block_transaction_serializer.go
+++ b/core/block_transaction_serializer.go
@@ -44,12 +44,18 @@ func (extractReceipt) extract(b *BlockTransactions, subKey int) (*TransactionRec
 
 type extractExecutionStatus struct{}
 
-func (extractExecutionStatus) extract(b *BlockTransactions, subKey int) (ExecutionStatus, error) {
+func (extractExecutionStatus) extract(
+	b *BlockTransactions,
+	subKey int,
+) (TransactionExecutionStatus, error) {
 	projection, err := b.executionStatusProjections().Get(subKey)
 	if err != nil {
-		return ExecutionStatus{}, err
+		return TransactionExecutionStatus{}, err
 	}
-	return ExecutionStatus{Reverted: projection.Reverted, RevertReason: projection.RevertReason}, nil
+	return TransactionExecutionStatus{
+		Reverted:     projection.Reverted,
+		RevertReason: projection.RevertReason,
+	}, nil
 }
 
 type extractAllTransactions struct{}
@@ -104,7 +110,7 @@ var (
 	BlockTransactionsExecutionStatusPartialSerializer = blockTransactionsPartialSerializer[
 		extractExecutionStatus,
 		int,
-		ExecutionStatus,
+		TransactionExecutionStatus,
 	]{}
 	BlockTransactionsAllTransactionsPartialSerializer = blockTransactionsPartialSerializer[
 		extractAllTransactions,

--- a/core/block_transaction_test.go
+++ b/core/block_transaction_test.go
@@ -155,7 +155,7 @@ func TestBlockTransactionsSerializer(t *testing.T) {
 				t,
 				core.BlockTransactionsExecutionStatusPartialSerializer,
 				i,
-				core.ExecutionStatus{
+				core.TransactionExecutionStatus{
 					Reverted:     receipts[i].Reverted,
 					RevertReason: receipts[i].RevertReason,
 				},

--- a/core/partial_cbor.go
+++ b/core/partial_cbor.go
@@ -99,7 +99,7 @@ type discardedReceiptSkeleton struct {
 	RevertReason       discardedCBOR
 }
 
-type receiptExecutionStatus struct {
+type receiptExecutionStatusProjection struct {
 	discardedReceiptSkeleton
 	Reverted     bool
 	RevertReason string

--- a/core/partial_cbor.go
+++ b/core/partial_cbor.go
@@ -82,3 +82,25 @@ type headerHashAndStateRootProjection struct {
 	Hash            *felt.Felt
 	GlobalStateRoot *felt.Felt
 }
+
+// discardedReceiptSkeleton names every field of TransactionReceipt as discarded. Receipt
+// projections embed it and shadow the fields they want with typed fields of the same name (see
+// [discardedCBOR] for why every field must be named). A reflection test asserts this skeleton's
+// field set stays identical to TransactionReceipt's.
+type discardedReceiptSkeleton struct {
+	Fee                discardedCBOR
+	FeeUnit            discardedCBOR
+	Events             discardedCBOR
+	ExecutionResources discardedCBOR
+	L1ToL2Message      discardedCBOR
+	L2ToL1Message      discardedCBOR
+	TransactionHash    discardedCBOR
+	Reverted           discardedCBOR
+	RevertReason       discardedCBOR
+}
+
+type receiptExecutionStatus struct {
+	discardedReceiptSkeleton
+	Reverted     bool
+	RevertReason string
+}

--- a/core/partial_cbor_test.go
+++ b/core/partial_cbor_test.go
@@ -359,7 +359,7 @@ func TestPartialSkeletonMatchesReceipt(t *testing.T) {
 // TransactionReceipt wire key.
 func TestReceiptProjectionCoversEveryKey(t *testing.T) {
 	assertProjectionsCoverSource(t, reflect.TypeFor[TransactionReceipt](),
-		reflect.TypeFor[receiptExecutionStatus]())
+		reflect.TypeFor[receiptExecutionStatusProjection]())
 }
 
 // TestReceiptProjectionCoversEveryWireKey guards against tag-option drift that cborKeys
@@ -367,7 +367,7 @@ func TestReceiptProjectionCoversEveryKey(t *testing.T) {
 func TestReceiptProjectionCoversEveryWireKey(t *testing.T) {
 	assertProjectionsCoverEveryWireKey(t, sampleReceiptBytes(t),
 		&discardedReceiptSkeleton{},
-		&receiptExecutionStatus{},
+		&receiptExecutionStatusProjection{},
 	)
 }
 
@@ -375,7 +375,7 @@ func TestReceiptProjectionCoversEveryWireKey(t *testing.T) {
 // values, not discardedCBOR — a change in cbor's embed precedence would slip past the key guards.
 func TestExecutionStatusProjectionDecodesShadowedFields(t *testing.T) {
 	receipt := sampleReceipt()
-	var projection receiptExecutionStatus
+	var projection receiptExecutionStatusProjection
 	require.NoError(t, encoder.Unmarshal(sampleReceiptBytes(t), &projection))
 	require.Equal(t, receipt.Reverted, projection.Reverted,
 		"Reverted must receive the wire value, not discardedCBOR")
@@ -422,7 +422,7 @@ func BenchmarkExecutionStatusProjection(b *testing.B) {
 	b.Run("discard", func(b *testing.B) {
 		b.ReportAllocs()
 		for b.Loop() {
-			var r receiptExecutionStatus
+			var r receiptExecutionStatusProjection
 			_ = encoder.Unmarshal(data, &r)
 		}
 	})

--- a/core/partial_cbor_test.go
+++ b/core/partial_cbor_test.go
@@ -63,6 +63,8 @@ func assertProjectionsCoverSource(t *testing.T, source reflect.Type, projections
 // decoder flags any unmatched key, catching top-level tag-option drift (keyasint, toarray) that
 // cborKeys can't. Only top-level keys matter: discarded fields throw their nested value away, so
 // the projection is only responsible for lining up the keys it names.
+//
+// Non-vacuous: see TestStrictGuardCatchesKeyAsIntDrift.
 func assertProjectionsCoverEveryWireKey(t *testing.T, data []byte, projections ...any) {
 	t.Helper()
 	strict, err := cbor.DecOptions{ExtraReturnErrors: cbor.ExtraDecErrorUnknownField}.DecMode()

--- a/core/partial_cbor_test.go
+++ b/core/partial_cbor_test.go
@@ -41,24 +41,50 @@ func cborKeys(t reflect.Type) map[string]struct{} {
 	return keys
 }
 
+// assertSkeletonNamesAllFields fails if the skeleton's CBOR key set differs from its source's — a
+// dropped or renamed field would send that key back to the allocating unmatched-key path.
+func assertSkeletonNamesAllFields(t *testing.T, source, skeleton reflect.Type) {
+	t.Helper()
+	require.Equalf(t, cborKeys(source), cborKeys(skeleton),
+		"%s must name every %s field (fix discardedCBOR fields to match)", skeleton, source)
+}
+
+// assertProjectionsCoverSource fails if any projection's CBOR key set differs from its source's.
+func assertProjectionsCoverSource(t *testing.T, source reflect.Type, projections ...reflect.Type) {
+	t.Helper()
+	sourceKeys := cborKeys(source)
+	for _, projection := range projections {
+		require.Equalf(t, sourceKeys, cborKeys(projection),
+			"%s must cover exactly the %s keys", projection, source)
+	}
+}
+
+// assertProjectionsCoverEveryWireKey strict-decodes real wire bytes into each projection so the
+// decoder flags any unmatched key, catching top-level tag-option drift (keyasint, toarray) that
+// cborKeys can't. Only top-level keys matter: discarded fields throw their nested value away, so
+// the projection is only responsible for lining up the keys it names.
+func assertProjectionsCoverEveryWireKey(t *testing.T, data []byte, projections ...any) {
+	t.Helper()
+	strict, err := cbor.DecOptions{ExtraReturnErrors: cbor.ExtraDecErrorUnknownField}.DecMode()
+	require.NoError(t, err)
+	for _, projection := range projections {
+		require.NoErrorf(t, strict.Unmarshal(data, projection),
+			"%T leaves a wire key unmatched (field added, or a tag name/option changed)", projection)
+	}
+}
+
 // TestPartialSkeletonMatchesHeader fails if the skeleton omits a Header field (its key would then
 // hit the allocating unmatched-key path).
 func TestPartialSkeletonMatchesHeader(t *testing.T) {
-	headerKeys := cborKeys(reflect.TypeFor[Header]())
-	skeletonKeys := cborKeys(reflect.TypeFor[discardedHeaderSkeleton]())
-	require.Equal(t, headerKeys, skeletonKeys,
-		"discardedHeaderSkeleton must name every Header field (fix discardedCBOR fields to match)")
+	assertSkeletonNamesAllFields(t,
+		reflect.TypeFor[Header](),
+		reflect.TypeFor[discardedHeaderSkeleton](),
+	)
 }
 
-// TestHeaderProjectionsCoverEveryWireKey decodes with unknown-field errors on, so the real decoder
-// flags any unmatched wire key — catching tag-option drift (keyasint, toarray) that cborKeys can't.
-// The strict DecMode lacks the encoder's tag set; valid only because Header has no tagged types.
+// TestHeaderProjectionsCoverEveryWireKey guards against tag-option drift that cborKeys is blind to.
 func TestHeaderProjectionsCoverEveryWireKey(t *testing.T) {
-	strict, err := cbor.DecOptions{ExtraReturnErrors: cbor.ExtraDecErrorUnknownField}.DecMode()
-	require.NoError(t, err)
-
-	data := sampleHeaderBytes(t)
-	for _, target := range []any{
+	assertProjectionsCoverEveryWireKey(t, sampleHeaderBytes(t),
 		&discardedHeaderSkeleton{},
 		&headerHashProjection{},
 		&headerGlobalStateRootProjection{},
@@ -66,31 +92,19 @@ func TestHeaderProjectionsCoverEveryWireKey(t *testing.T) {
 		&headerTimestampProjection{},
 		&headerEventsBloomProjection{},
 		&headerHashAndStateRootProjection{},
-	} {
-		require.NoErrorf(t, strict.Unmarshal(data, target),
-			"%T leaves a Header wire key unmatched (field added, or a tag name/option changed)", target)
-	}
-
-	// The guard is not vacuous: a projection that omits fields (the pre-fix shape) must be rejected.
-	var omitting struct{ Hash *felt.Felt }
-	require.Error(t, strict.Unmarshal(data, &omitting),
-		"strict mode must reject a projection that does not cover every Header wire key")
+	)
 }
 
 // TestHeaderProjectionsCoverEveryKey asserts each projection covers every Header wire key.
 func TestHeaderProjectionsCoverEveryKey(t *testing.T) {
-	headerKeys := cborKeys(reflect.TypeFor[Header]())
-	for _, projection := range []reflect.Type{
+	assertProjectionsCoverSource(t, reflect.TypeFor[Header](),
 		reflect.TypeFor[headerHashProjection](),
 		reflect.TypeFor[headerGlobalStateRootProjection](),
 		reflect.TypeFor[headerTransactionCountProjection](),
 		reflect.TypeFor[headerTimestampProjection](),
 		reflect.TypeFor[headerEventsBloomProjection](),
 		reflect.TypeFor[headerHashAndStateRootProjection](),
-	} {
-		require.Equal(t, headerKeys, cborKeys(projection),
-			"%s must cover exactly the Header keys", projection)
-	}
+	)
 }
 
 // Stand-in source/projection pairs used to prove the guards above actually fail on drift.
@@ -311,6 +325,64 @@ func TestProjectionsAreDecodeOnly(t *testing.T) {
 	require.ErrorIs(t, err, errDiscardedCBORMarshal)
 }
 
+// --- Receipt projections ---
+
+// sampleReceipt is a reverted receipt with distinct values, so its encoding exercises every
+// TransactionReceipt key and the execution-status assertions can check Reverted and RevertReason.
+func sampleReceipt() *TransactionReceipt {
+	return &TransactionReceipt{
+		Fee:             felt.NewFromUint64[felt.Felt](1),
+		TransactionHash: felt.NewFromUint64[felt.Felt](2),
+		Reverted:        true,
+		RevertReason:    "sample revert reason",
+	}
+}
+
+// sampleReceiptBytes marshals a live TransactionReceipt, so the wire key set tracks the struct.
+func sampleReceiptBytes(tb testing.TB) []byte {
+	tb.Helper()
+	data, err := encoder.Marshal(sampleReceipt())
+	require.NoError(tb, err)
+	return data
+}
+
+// TestPartialSkeletonMatchesReceipt fails if the skeleton omits a TransactionReceipt field (its key
+// would then hit the allocating unmatched-key path).
+func TestPartialSkeletonMatchesReceipt(t *testing.T) {
+	assertSkeletonNamesAllFields(t,
+		reflect.TypeFor[TransactionReceipt](),
+		reflect.TypeFor[discardedReceiptSkeleton](),
+	)
+}
+
+// TestReceiptProjectionCoversEveryKey asserts the execution-status projection covers every
+// TransactionReceipt wire key.
+func TestReceiptProjectionCoversEveryKey(t *testing.T) {
+	assertProjectionsCoverSource(t, reflect.TypeFor[TransactionReceipt](),
+		reflect.TypeFor[receiptExecutionStatus]())
+}
+
+// TestReceiptProjectionCoversEveryWireKey guards against tag-option drift that cborKeys
+// is blind to.
+func TestReceiptProjectionCoversEveryWireKey(t *testing.T) {
+	assertProjectionsCoverEveryWireKey(t, sampleReceiptBytes(t),
+		&discardedReceiptSkeleton{},
+		&receiptExecutionStatus{},
+	)
+}
+
+// TestExecutionStatusProjectionDecodesShadowedFields proves the shadowing fields receive the wire
+// values, not discardedCBOR — a change in cbor's embed precedence would slip past the key guards.
+func TestExecutionStatusProjectionDecodesShadowedFields(t *testing.T) {
+	receipt := sampleReceipt()
+	var projection receiptExecutionStatus
+	require.NoError(t, encoder.Unmarshal(sampleReceiptBytes(t), &projection))
+	require.Equal(t, receipt.Reverted, projection.Reverted,
+		"Reverted must receive the wire value, not discardedCBOR")
+	require.Equal(t, receipt.RevertReason, projection.RevertReason,
+		"RevertReason must receive the wire value, not discardedCBOR")
+}
+
 // BenchmarkPartialHeaderProjections benchmarks each header projection, field_omitting vs discard.
 func BenchmarkPartialHeaderProjections(b *testing.B) {
 	data := sampleHeaderBytes(b)
@@ -330,4 +402,28 @@ func BenchmarkPartialHeaderProjections(b *testing.B) {
 			})
 		})
 	}
+}
+
+// BenchmarkExecutionStatusProjection compares decoding the execution-status subset via the naive
+// field-omitting struct (every unwanted key hits the allocating unmatched-key path) against the
+// discard projection (every key named, unwanted ones discarded without allocation).
+func BenchmarkExecutionStatusProjection(b *testing.B) {
+	data := sampleReceiptBytes(b)
+	b.Run("field_omitting", func(b *testing.B) {
+		b.ReportAllocs()
+		for b.Loop() {
+			var r struct {
+				Reverted     bool
+				RevertReason string
+			}
+			_ = encoder.Unmarshal(data, &r)
+		}
+	})
+	b.Run("discard", func(b *testing.B) {
+		b.ReportAllocs()
+		for b.Loop() {
+			var r receiptExecutionStatus
+			_ = encoder.Unmarshal(data, &r)
+		}
+	})
 }

--- a/core/receipt.go
+++ b/core/receipt.go
@@ -26,10 +26,9 @@ type TransactionReceipt struct {
 	RevertReason       string
 }
 
-// ExecutionStatus is the status subset of TransactionReceipt, decoded on its own to
-// skip the heavier fields. Field names must match TransactionReceipt so the CBOR
-// decoder can pick them out by key.
-type ExecutionStatus struct {
+// TransactionExecutionStatus is the execution-status subset of a TransactionReceipt:
+// whether the transaction reverted, and the revert reason if it did.
+type TransactionExecutionStatus struct {
 	Reverted     bool
 	RevertReason string
 }

--- a/core/receipt_test.go
+++ b/core/receipt_test.go
@@ -5,32 +5,8 @@ import (
 	"testing"
 
 	"github.com/NethermindEth/juno/core/felt"
-	"github.com/NethermindEth/juno/encoder"
 	"github.com/stretchr/testify/require"
 )
-
-// TestExecutionStatusDecodesFromReceipt ensures TransactionExecutionStatus decodes from
-// an encoded TransactionReceipt so the status is read correctly.
-func TestExecutionStatusDecodesFromReceipt(t *testing.T) {
-	receipt := TransactionReceipt{
-		Reverted:     true,
-		RevertReason: "some revert reason",
-		// Heavy fields the subset is meant to skip, populated to prove it does.
-		Fee:             new(felt.Felt).SetUint64(7),
-		TransactionHash: new(felt.Felt).SetUint64(9),
-		Events:          []*Event{{}},
-	}
-
-	data, err := encoder.Marshal(&receipt)
-	require.NoError(t, err)
-
-	var status TransactionExecutionStatus
-	require.NoError(t, encoder.Unmarshal(data, &status))
-	require.Equal(t, TransactionExecutionStatus{
-		Reverted:     receipt.Reverted,
-		RevertReason: receipt.RevertReason,
-	}, status)
-}
 
 // note(rdr): based on git blame, it seems this global var is here to avoid certain compiler optimizations.
 //			  it would be nice to have extra clarity

--- a/core/receipt_test.go
+++ b/core/receipt_test.go
@@ -9,8 +9,8 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// TestExecutionStatusDecodesFromReceipt ensures ExecutionStatus decodes from an
-// encoded TransactionReceipt so the status is read correctly.
+// TestExecutionStatusDecodesFromReceipt ensures TransactionExecutionStatus decodes from
+// an encoded TransactionReceipt so the status is read correctly.
 func TestExecutionStatusDecodesFromReceipt(t *testing.T) {
 	receipt := TransactionReceipt{
 		Reverted:     true,
@@ -24,9 +24,9 @@ func TestExecutionStatusDecodesFromReceipt(t *testing.T) {
 	data, err := encoder.Marshal(&receipt)
 	require.NoError(t, err)
 
-	var status ExecutionStatus
+	var status TransactionExecutionStatus
 	require.NoError(t, encoder.Unmarshal(data, &status))
-	require.Equal(t, ExecutionStatus{
+	require.Equal(t, TransactionExecutionStatus{
 		Reverted:     receipt.Reverted,
 		RevertReason: receipt.RevertReason,
 	}, status)

--- a/mocks/mock_blockchain.go
+++ b/mocks/mock_blockchain.go
@@ -440,10 +440,10 @@ func (mr *MockReaderMockRecorder) TransactionByHash(hash any) *gomock.Call {
 }
 
 // TransactionExecutionStatusByBlockNumberAndIndex mocks base method.
-func (m *MockReader) TransactionExecutionStatusByBlockNumberAndIndex(blockNumber, index uint64) (core.ExecutionStatus, error) {
+func (m *MockReader) TransactionExecutionStatusByBlockNumberAndIndex(blockNumber, index uint64) (core.TransactionExecutionStatus, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "TransactionExecutionStatusByBlockNumberAndIndex", blockNumber, index)
-	ret0, _ := ret[0].(core.ExecutionStatus)
+	ret0, _ := ret[0].(core.TransactionExecutionStatus)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }

--- a/rpc/v10/l1_test.go
+++ b/rpc/v10/l1_test.go
@@ -128,7 +128,7 @@ func TestGetMessageStatus(t *testing.T) {
 				).Return(block.Number, uint64(i), nil)
 				mockReader.EXPECT().TransactionExecutionStatusByBlockNumberAndIndex(
 					block.Number, uint64(i),
-				).Return(core.ExecutionStatus{
+				).Return(core.TransactionExecutionStatus{
 					Reverted:     block.Receipts[i].Reverted,
 					RevertReason: block.Receipts[i].RevertReason,
 				}, nil)

--- a/rpc/v10/subscriptions_test.go
+++ b/rpc/v10/subscriptions_test.go
@@ -986,7 +986,7 @@ func TestSubscribeTxnStatus(t *testing.T) {
 		).Return(block.Number, uint64(0), nil)
 		mockChain.EXPECT().TransactionExecutionStatusByBlockNumberAndIndex(
 			block.Number, uint64(0),
-		).Return(core.ExecutionStatus{
+		).Return(core.TransactionExecutionStatus{
 			Reverted:     block.Receipts[0].Reverted,
 			RevertReason: block.Receipts[0].RevertReason,
 		}, nil)
@@ -1011,7 +1011,7 @@ func TestSubscribeTxnStatus(t *testing.T) {
 		).Return(block.Number, uint64(0), nil)
 		mockChain.EXPECT().TransactionExecutionStatusByBlockNumberAndIndex(
 			block.Number, uint64(0),
-		).Return(core.ExecutionStatus{
+		).Return(core.TransactionExecutionStatus{
 			Reverted:     block.Receipts[0].Reverted,
 			RevertReason: block.Receipts[0].RevertReason,
 		}, nil)

--- a/rpc/v10/transaction_test.go
+++ b/rpc/v10/transaction_test.go
@@ -1610,7 +1610,7 @@ func TestTransactionStatus(t *testing.T) {
 		).Return(block.Number, uint64(0), nil)
 		mockReader.EXPECT().TransactionExecutionStatusByBlockNumberAndIndex(
 			block.Number, uint64(0),
-		).Return(core.ExecutionStatus{
+		).Return(core.TransactionExecutionStatus{
 			Reverted:     block.Receipts[0].Reverted,
 			RevertReason: block.Receipts[0].RevertReason,
 		}, nil)
@@ -1639,7 +1639,7 @@ func TestTransactionStatus(t *testing.T) {
 		).Return(block.Number, uint64(0), nil)
 		mockReader.EXPECT().TransactionExecutionStatusByBlockNumberAndIndex(
 			block.Number, uint64(0),
-		).Return(core.ExecutionStatus{
+		).Return(core.TransactionExecutionStatus{
 			Reverted:     true,
 			RevertReason: "some revert reason",
 		}, nil)

--- a/rpc/v9/l1_test.go
+++ b/rpc/v9/l1_test.go
@@ -112,7 +112,7 @@ func TestGetMessageStatus(t *testing.T) {
 				).Return(block.Number, uint64(i), nil)
 				mockReader.EXPECT().TransactionExecutionStatusByBlockNumberAndIndex(
 					block.Number, uint64(i),
-				).Return(core.ExecutionStatus{
+				).Return(core.TransactionExecutionStatus{
 					Reverted:     block.Receipts[i].Reverted,
 					RevertReason: block.Receipts[i].RevertReason,
 				}, nil)

--- a/rpc/v9/subscriptions_test.go
+++ b/rpc/v9/subscriptions_test.go
@@ -886,7 +886,7 @@ func TestSubscribeTxnStatus(t *testing.T) {
 		).Return(block.Number, uint64(0), nil)
 		mockChain.EXPECT().TransactionExecutionStatusByBlockNumberAndIndex(
 			block.Number, uint64(0),
-		).Return(core.ExecutionStatus{
+		).Return(core.TransactionExecutionStatus{
 			Reverted:     block.Receipts[0].Reverted,
 			RevertReason: block.Receipts[0].RevertReason,
 		}, nil)
@@ -903,7 +903,7 @@ func TestSubscribeTxnStatus(t *testing.T) {
 		).Return(block.Number, uint64(0), nil)
 		mockChain.EXPECT().TransactionExecutionStatusByBlockNumberAndIndex(
 			block.Number, uint64(0),
-		).Return(core.ExecutionStatus{
+		).Return(core.TransactionExecutionStatus{
 			Reverted:     block.Receipts[0].Reverted,
 			RevertReason: block.Receipts[0].RevertReason,
 		}, nil)

--- a/rpc/v9/transaction_test.go
+++ b/rpc/v9/transaction_test.go
@@ -1755,7 +1755,7 @@ func TestTransactionStatus(t *testing.T) {
 					).Return(block.Number, uint64(0), nil)
 					mockReader.EXPECT().TransactionExecutionStatusByBlockNumberAndIndex(
 						block.Number, uint64(0),
-					).Return(core.ExecutionStatus{
+					).Return(core.TransactionExecutionStatus{
 						Reverted:     block.Receipts[0].Reverted,
 						RevertReason: block.Receipts[0].RevertReason,
 					}, nil)
@@ -1786,7 +1786,7 @@ func TestTransactionStatus(t *testing.T) {
 					).Return(block.Number, uint64(0), nil)
 					mockReader.EXPECT().TransactionExecutionStatusByBlockNumberAndIndex(
 						block.Number, uint64(0),
-					).Return(core.ExecutionStatus{
+					).Return(core.TransactionExecutionStatus{
 						Reverted:     block.Receipts[0].Reverted,
 						RevertReason: block.Receipts[0].RevertReason,
 					}, nil)
@@ -1819,7 +1819,7 @@ func TestTransactionStatus(t *testing.T) {
 					).Return(block.Number, uint64(0), nil)
 					mockReader.EXPECT().TransactionExecutionStatusByBlockNumberAndIndex(
 						block.Number, uint64(0),
-					).Return(core.ExecutionStatus{
+					).Return(core.TransactionExecutionStatus{
 						Reverted:     true,
 						RevertReason: "some revert reason",
 					}, nil)


### PR DESCRIPTION
Same CBOR discard trick applied to `ExecutionStatus` reads. Saves 2 alloc per skipped key, for status 7 of them are skipped thus saves 14 alloc on execution status read.

## Block 0 — genesis-era (all 0-event receipts)

| tx | events | time old→new | Δ time | mem old→new | Δ mem | allocs old→new | Δ allocs |
|----|-------:|--------------|-------:|-------------|------:|----------------|---------:|
| 00 | 0 | 3.27 → 3.29 µs | +0.7% | 880 → 676 B | −23.2% | 32 → 18 | −43.8% |
| 01 | 0 | 3.25 → 3.34 µs | +2.9% | 880 → 676 B | −23.2% | 32 → 18 | −43.8% |
| 02 | 0 | 3.42 → 3.62 µs | +5.8% | 880 → 676 B | −23.2% | 32 → 18 | −43.8% |
| 03 | 0 | 3.26 → 3.34 µs | +2.6% | 880 → 676 B | −23.2% | 32 → 18 | −43.8% |
| 04 | 0 | 3.24 → 3.40 µs | +4.7% | 880 → 676 B | −23.2% | 32 → 18 | −43.8% |
| 05 | 0 | 3.28 → 3.41 µs | +3.9% | 880 → 676 B | −23.2% | 32 → 18 | −43.8% |
| 06 | 0 | 3.47 → 3.58 µs | +3.4% | 880 → 676 B | −23.2% | 32 → 18 | −43.8% |
| 07 | 0 | 3.28 → 3.36 µs | +2.3% | 880 → 676 B | −23.2% | 32 → 18 | −43.8% |
| 08 | 0 | 3.28 → 3.35 µs | +2.1% | 880 → 676 B | −23.2% | 32 → 18 | −43.8% |
| 09 | 0 | 3.27 → 3.36 µs | +2.6% | 880 → 676 B | −23.2% | 32 → 18 | −43.8% |
| 10 | 0 | 3.27 → 3.32 µs | +1.4% | 880 → 676 B | −23.2% | 32 → 18 | −43.8% |
| 11 | 0 | 3.34 → 3.31 µs | −0.7% | 880 → 676 B | −23.2% | 32 → 18 | −43.8% |
| 12 | 0 | 3.53 → 3.55 µs | +0.4% | 880 → 676 B | −23.2% | 32 → 18 | −43.8% |
| 13 | 0 | 3.33 → 3.35 µs | +0.4% | 880 → 676 B | −23.2% | 32 → 18 | −43.8% |
| 14 | 0 | 3.27 → 3.30 µs | +1.1% | 880 → 676 B | −23.2% | 32 → 18 | −43.8% |
| 15 | 0 | 3.29 → 3.27 µs | −0.4% | 880 → 676 B | −23.2% | 32 → 18 | −43.8% |
| 16 | 0 | 3.28 → 3.30 µs | +0.4% | 880 → 676 B | −23.2% | 32 → 18 | −43.8% |
| 17 | 0 | 3.26 → 3.28 µs | +0.5% | 880 → 676 B | −23.2% | 32 → 18 | −43.8% |

## Block 763497 — mainnet (sorted by event count)

| tx | events | time old→new | Δ time | mem old→new | Δ mem | allocs old→new | Δ allocs |
|----|-------:|--------------|-------:|-------------|------:|----------------|---------:|
| 16 | 2  | 4.01 → 4.10 µs   | +2.4% | 896 → 696 B | −22.3% | 33 → 19 | −42.4% |
| 01 | 3  | 4.27 → 4.27 µs   | −0.1% | 896 → 696 B | −22.3% | 33 → 19 | −42.4% |
| 08 | 3  | 4.72 → 4.81 µs   | +2.0% | 896 → 696 B | −22.3% | 33 → 19 | −42.4% |
| 13 | 3  | 4.37 → 4.36 µs   | −0.1% | 896 → 696 B | −22.3% | 33 → 19 | −42.4% |
| 14 | 7  | 22.40 → 22.38 µs | −0.1% | 896 → 696 B | −22.3% | 33 → 19 | −42.4% |
| 10 | 8  | 9.20 → 9.12 µs   | −0.9% | 896 → 696 B | −22.3% | 33 → 19 | −42.4% |
| 06 | 9  | 10.99 → 10.83 µs | −1.4% | 896 → 696 B | −22.3% | 33 → 19 | −42.4% |
| 11 | 11 | 8.99 → 8.85 µs   | −1.6% | 896 → 696 B | −22.3% | 33 → 19 | −42.4% |
| 12 | 14 | 16.92 → 16.86 µs | −0.4% | 896 → 696 B | −22.3% | 33 → 19 | −42.4% |
| 09 | 15 | 8.44 → 8.42 µs   | −0.2% | 896 → 696 B | −22.3% | 33 → 19 | −42.4% |
| 05 | 23 | 13.76 → 13.65 µs | −0.8% | 896 → 696 B | −22.3% | 33 → 19 | −42.4% |
| 04 | 26 | 14.14 → 13.98 µs | −1.2% | 896 → 696 B | −22.3% | 33 → 19 | −42.4% |
| 15 | 32 | 14.56 → 14.77 µs | +1.4% | 896 → 696 B | −22.3% | 33 → 19 | −42.4% |
| 00 | 42 | 20.99 → 20.76 µs | −1.1% | 896 → 696 B | −22.3% | 33 → 19 | −42.4% |
| 02 | 42 | 20.62 → 20.59 µs | −0.1% | 896 → 696 B | −22.3% | 33 → 19 | −42.4% |
| 07 | 45 | 16.36 → 16.23 µs | −0.8% | 896 → 696 B | −22.3% | 33 → 19 | −42.4% |
| 03 | 52 | 36.69 → 36.78 µs | +0.2% | 896 → 696 B | −22.3% | 33 → 19 | −42.4% |