### PR TITLE
perf(rpc): receipt adapt

### DIFF
--- a/core/receipt.go
+++ b/core/receipt.go
@@ -15,12 +15,12 @@ type GasConsumed struct {
 }
 
 type TransactionReceipt struct {
-	Fee                *felt.Felt
+	Fee                *felt.Felt // Note(Ege): check if ever nil
 	FeeUnit            FeeUnit
-	Events             []*Event
+	Events             []*Event // Note(Ege): check if ever nil
 	ExecutionResources *ExecutionResources
 	L1ToL2Message      *L1ToL2Message
-	L2ToL1Message      []*L2ToL1Message
+	L2ToL1Message      []*L2ToL1Message // Note(Ege): check if ever nil
 	TransactionHash    *felt.Felt
 	Reverted           bool
 	RevertReason       string

--- a/core/receipt.go
+++ b/core/receipt.go
@@ -15,12 +15,12 @@ type GasConsumed struct {
 }
 
 type TransactionReceipt struct {
-	Fee                *felt.Felt // Note(Ege): check if ever nil
+	Fee                *felt.Felt
 	FeeUnit            FeeUnit
-	Events             []*Event // Note(Ege): check if ever nil
+	Events             []*Event
 	ExecutionResources *ExecutionResources
 	L1ToL2Message      *L1ToL2Message
-	L2ToL1Message      []*L2ToL1Message // Note(Ege): check if ever nil
+	L2ToL1Message      []*L2ToL1Message
 	TransactionHash    *felt.Felt
 	Reverted           bool
 	RevertReason       string

--- a/core/transaction.go
+++ b/core/transaction.go
@@ -81,9 +81,9 @@ func (rb ResourceBounds) IsZero() bool {
 }
 
 type Event struct {
-	Data []felt.Felt
-	From *felt.Felt
+	From *felt.Felt // Note(Ege): can ever be nil
 	Keys []felt.Felt
+	Data []felt.Felt
 }
 
 type L1ToL2Message struct {

--- a/core/transaction.go
+++ b/core/transaction.go
@@ -90,14 +90,14 @@ type L1ToL2Message struct {
 	// todo(rdr): Starknet from 0.14.1 has dropped the assumption that we use an EthAddress
 	//            here. We should change this to felt.Address
 	From     eth.Address
-	Nonce    *felt.Felt
+	Nonce    *felt.Felt // Note(Ege): can ever be nil
 	Payload  []felt.Felt
-	Selector *felt.Felt
-	To       *felt.Felt
+	Selector *felt.Felt // Note(Ege): can ever be nil
+	To       *felt.Felt // Note(Ege): can ever be nil
 }
 
 type L2ToL1Message struct {
-	From    *felt.Felt
+	From    *felt.Felt // Note(Ege): can ever be nil
 	Payload []felt.Felt
 	// todo(rdr): Starknet from 0.14.1 has dropped the assumption that we use an EthAddress
 	//            here. We should change this to felt.Address

--- a/core/transaction.go
+++ b/core/transaction.go
@@ -81,7 +81,7 @@ func (rb ResourceBounds) IsZero() bool {
 }
 
 type Event struct {
-	From *felt.Felt // Note(Ege): can ever be nil
+	From *felt.Felt
 	Keys []felt.Felt
 	Data []felt.Felt
 }
@@ -90,14 +90,14 @@ type L1ToL2Message struct {
 	// todo(rdr): Starknet from 0.14.1 has dropped the assumption that we use an EthAddress
 	//            here. We should change this to felt.Address
 	From     eth.Address
-	Nonce    *felt.Felt // Note(Ege): can ever be nil
+	Nonce    *felt.Felt
 	Payload  []felt.Felt
-	Selector *felt.Felt // Note(Ege): can ever be nil
-	To       *felt.Felt // Note(Ege): can ever be nil
+	Selector *felt.Felt
+	To       *felt.Felt
 }
 
 type L2ToL1Message struct {
-	From    *felt.Felt // Note(Ege): can ever be nil
+	From    *felt.Felt
 	Payload []felt.Felt
 	// todo(rdr): Starknet from 0.14.1 has dropped the assumption that we use an EthAddress
 	//            here. We should change this to felt.Address

--- a/rpc/v10/adapt_transaction.go
+++ b/rpc/v10/adapt_transaction.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"strings"
+	"unsafe"
 
 	"github.com/NethermindEth/juno/blockchain/networks"
 	"github.com/NethermindEth/juno/clients/gateway"
@@ -145,21 +146,12 @@ func AdaptReceipt(
 	txn core.Transaction,
 	finalityStatus TxnFinalityStatus,
 ) *TransactionReceipt {
-	messages := make([]*MsgToL1, len(receipt.L2ToL1Message))
+	messages := make([]MsgToL1, len(receipt.L2ToL1Message))
 	for idx, msg := range receipt.L2ToL1Message {
-		messages[idx] = &MsgToL1{
+		messages[idx] = MsgToL1{
 			To:      msg.To,
 			Payload: msg.Payload,
 			From:    msg.From,
-		}
-	}
-
-	events := make([]*Event, len(receipt.Events))
-	for idx, event := range receipt.Events {
-		events[idx] = &Event{
-			From: event.From,
-			Keys: event.Keys,
-			Data: event.Data,
 		}
 	}
 
@@ -186,12 +178,14 @@ func AdaptReceipt(
 		ExecutionStatus: es,
 		Type:            transactionTypeFrom(txn),
 		Hash:            txn.Hash(),
-		ActualFee: &FeePayment{
+		ActualFee: FeePayment{
 			Amount: receipt.Fee,
 			Unit:   feeUnitFromTransactionVersion(txn.TxVersion()),
 		},
-		MessagesSent:       messages,
-		Events:             events,
+		MessagesSent: messages,
+		// Zero-copy: rpc.Event has the same layout as core.Event (guarded in events.go), so the
+		// decoded []*core.Event is reinterpreted as []*Event without a per-element copy.
+		Events:             *(*[]*Event)(unsafe.Pointer(&receipt.Events)),
 		ContractAddress:    contractAddress,
 		RevertReason:       receipt.RevertReason,
 		ExecutionResources: adaptExecutionResources(receipt.ExecutionResources),

--- a/rpc/v10/adapt_transaction.go
+++ b/rpc/v10/adapt_transaction.go
@@ -173,6 +173,12 @@ func AdaptReceipt(
 		es = TxnSuccess
 	}
 
+	// Zero-copy: rpc.Event is field-identical to core.Event (guarded in events.go), so the decoded
+	// []*core.Event is reinterpreted as []*Event reusing the same backing array (no copy).
+	events := *(*[]*Event)(unsafe.Pointer(&receipt.Events))
+	if events == nil {
+		events = []*Event{}
+	}
 	return &TransactionReceipt{
 		FinalityStatus:  finalityStatus,
 		ExecutionStatus: es,
@@ -182,10 +188,8 @@ func AdaptReceipt(
 			Amount: receipt.Fee,
 			Unit:   feeUnitFromTransactionVersion(txn.TxVersion()),
 		},
-		MessagesSent: messages,
-		// Zero-copy: rpc.Event has the same layout as core.Event (guarded in events.go), so the
-		// decoded []*core.Event is reinterpreted as []*Event without a per-element copy.
-		Events:             *(*[]*Event)(unsafe.Pointer(&receipt.Events)),
+		MessagesSent:       messages,
+		Events:             events,
 		ContractAddress:    contractAddress,
 		RevertReason:       receipt.RevertReason,
 		ExecutionResources: adaptExecutionResources(receipt.ExecutionResources),

--- a/rpc/v10/events.go
+++ b/rpc/v10/events.go
@@ -193,11 +193,9 @@ func (h *Handler) Events(args *EventArgs) (EventsChunk, *jsonrpc.Error) {
 			TransactionHash:  fEvent.TransactionHash,
 			TransactionIndex: fEvent.TransactionIndex,
 			EventIndex:       fEvent.EventIndex,
-			Event: &Event{
-				From: fEvent.From,
-				Keys: fEvent.Keys,
-				Data: fEvent.Data,
-			},
+			// rpc.Event is field-identical to core.Event (guarded in this file), so alias the
+			// filtered *core.Event instead of allocating a fresh Event per emitted event.
+			Event: (*Event)(fEvent.Event),
 		}
 	}
 

--- a/rpc/v10/events.go
+++ b/rpc/v10/events.go
@@ -3,19 +3,35 @@ package rpcv10
 import (
 	"encoding/json"
 	"slices"
+	"unsafe"
 
 	"github.com/NethermindEth/juno/blockchain"
+	"github.com/NethermindEth/juno/core"
 	"github.com/NethermindEth/juno/core/felt"
 	"github.com/NethermindEth/juno/jsonrpc"
 	"github.com/NethermindEth/juno/rpc/rpccore"
 	"github.com/NethermindEth/juno/utils"
 )
 
+// Event is the RPC wire type for an event. It has the SAME memory layout as core.Event (identical
+// fields, order, and types, only the json tags differ), which lets `AdaptReceipt` reinterpret a
+// receipt's []*core.Event as []*Event with zero copies. The layout guards below make a divergence a
+// compile error.
 type Event struct {
 	From *felt.Felt  `json:"from_address,omitempty"`
 	Keys []felt.Felt `json:"keys"`
 	Data []felt.Felt `json:"data"`
 }
+
+// Compile-time layout guards: rpc.Event must stay byte-identical to core.Event for the unsafe
+// reinterpret in AdaptReceipt to be sound. Any size/offset drift fails the build (index out of
+// range).
+var (
+	_ = [1]struct{}{}[unsafe.Sizeof(Event{})-unsafe.Sizeof(core.Event{})]
+	_ = [1]struct{}{}[unsafe.Offsetof(Event{}.Data)-unsafe.Offsetof(core.Event{}.Data)]
+	_ = [1]struct{}{}[unsafe.Offsetof(Event{}.From)-unsafe.Offsetof(core.Event{}.From)]
+	_ = [1]struct{}{}[unsafe.Offsetof(Event{}.Keys)-unsafe.Offsetof(core.Event{}.Keys)]
+)
 
 type ResultPageRequest struct {
 	ContinuationToken string `json:"continuation_token"`

--- a/rpc/v10/events.go
+++ b/rpc/v10/events.go
@@ -3,7 +3,6 @@ package rpcv10
 import (
 	"encoding/json"
 	"slices"
-	"unsafe"
 
 	"github.com/NethermindEth/juno/blockchain"
 	"github.com/NethermindEth/juno/core"
@@ -13,25 +12,16 @@ import (
 	"github.com/NethermindEth/juno/utils"
 )
 
-// Event is the RPC wire type for an event. It has the SAME memory layout as core.Event (identical
-// fields, order, and types, only the json tags differ), which lets `AdaptReceipt` reinterpret a
-// receipt's []*core.Event as []*Event with zero copies. The layout guards below make a divergence a
-// compile error.
+// Event is the RPC wire type for an event. It is field-for-field identical to core.Event (only the
+// json tags differ), which lets `AdaptReceipt` reinterpret a receipt's []*core.Event as []*Event
+// with zero copies. The conversion guard below makes any divergence a compile error.
 type Event struct {
 	From *felt.Felt  `json:"from_address,omitempty"`
 	Keys []felt.Felt `json:"keys"`
 	Data []felt.Felt `json:"data"`
 }
 
-// Compile-time layout guards: rpc.Event must stay byte-identical to core.Event for the unsafe
-// reinterpret in AdaptReceipt to be sound. Any size/offset drift fails the build (index out of
-// range).
-var (
-	_ = [1]struct{}{}[unsafe.Sizeof(Event{})-unsafe.Sizeof(core.Event{})]
-	_ = [1]struct{}{}[unsafe.Offsetof(Event{}.Data)-unsafe.Offsetof(core.Event{}.Data)]
-	_ = [1]struct{}{}[unsafe.Offsetof(Event{}.From)-unsafe.Offsetof(core.Event{}.From)]
-	_ = [1]struct{}{}[unsafe.Offsetof(Event{}.Keys)-unsafe.Offsetof(core.Event{}.Keys)]
-)
+var _ = Event(core.Event{})
 
 type ResultPageRequest struct {
 	ContinuationToken string `json:"continuation_token"`

--- a/rpc/v10/transaction_test.go
+++ b/rpc/v10/transaction_test.go
@@ -978,6 +978,28 @@ func TestTransactionByBlockIdAndIndex(t *testing.T) {
 	})
 }
 
+// A receipt with no events must marshal "events" as an empty JSON array, not null.
+// AdaptReceipt reinterprets receipt.Events ([]*core.Event) as []*rpc.Event via unsafe
+// pointer aliasing, so a nil slice would marshal to `null` without the nil -> []*Event{}
+// guard. Fixtures built through adaptfeeder/sn2core always wrap events in a non-nil slice
+// (utils.NonNilSlice), so no other test exercises this branch.
+func TestAdaptReceiptNilEventsMarshalsAsEmptyArray(t *testing.T) {
+	txn := &core.InvokeTransaction{
+		TransactionHash: new(felt.Felt),
+		Version:         new(core.TransactionVersion).SetUint64(1),
+	}
+	receipt := &core.TransactionReceipt{
+		Fee:             new(felt.Felt),
+		Events:          nil,
+		TransactionHash: txn.TransactionHash,
+	}
+
+	got, err := json.Marshal(rpc.AdaptReceipt(receipt, txn, rpc.TxnAcceptedOnL2))
+	require.NoError(t, err)
+	assert.Contains(t, string(got), `"events":[]`)
+	assert.NotContains(t, string(got), `"events":null`)
+}
+
 func TestTransactionReceiptByHash(t *testing.T) {
 	type testCase struct {
 		description    string

--- a/rpc/v10/transaction_types.go
+++ b/rpc/v10/transaction_types.go
@@ -290,19 +290,19 @@ type ExecutionResources struct {
 
 // https://github.com/starkware-libs/starknet-specs/blob/master/api/starknet_api_openrpc.json#L1871
 type TransactionReceipt struct {
-	Type               TransactionType     `json:"type"`
-	Hash               *felt.Felt          `json:"transaction_hash"`
-	ActualFee          *FeePayment         `json:"actual_fee"`
-	ExecutionStatus    TxnExecutionStatus  `json:"execution_status"`
-	FinalityStatus     TxnFinalityStatus   `json:"finality_status"`
-	BlockHash          *felt.Felt          `json:"block_hash,omitempty"`
-	BlockNumber        *uint64             `json:"block_number,omitempty"`
-	MessagesSent       []*MsgToL1          `json:"messages_sent"`
-	Events             []*Event            `json:"events"`
-	ContractAddress    *felt.Felt          `json:"contract_address,omitempty"`
-	RevertReason       string              `json:"revert_reason,omitempty"`
-	ExecutionResources *ExecutionResources `json:"execution_resources,omitempty"`
-	MessageHash        string              `json:"message_hash,omitempty"`
+	Type               TransactionType    `json:"type"`
+	Hash               *felt.Felt         `json:"transaction_hash"`
+	ActualFee          FeePayment         `json:"actual_fee"`
+	ExecutionStatus    TxnExecutionStatus `json:"execution_status"`
+	FinalityStatus     TxnFinalityStatus  `json:"finality_status"`
+	BlockHash          *felt.Felt         `json:"block_hash,omitempty"`
+	BlockNumber        *uint64            `json:"block_number,omitempty"`
+	MessagesSent       []MsgToL1          `json:"messages_sent"`
+	Events             []*Event           `json:"events"`
+	ContractAddress    *felt.Felt         `json:"contract_address,omitempty"`
+	RevertReason       string             `json:"revert_reason,omitempty"`
+	ExecutionResources ExecutionResources `json:"execution_resources"`
+	MessageHash        string             `json:"message_hash,omitempty"`
 }
 
 type CalldataInputs = rpccore.LimitSlice[felt.Felt, rpccore.FunctionCalldataLimit]
@@ -378,12 +378,12 @@ func MakeTransactionExecutionError(err *vm.TransactionExecutionError) *jsonrpc.E
 	})
 }
 
-func adaptExecutionResources(resources *core.ExecutionResources) *ExecutionResources {
+func adaptExecutionResources(resources *core.ExecutionResources) ExecutionResources {
 	if resources == nil {
-		return &ExecutionResources{}
+		return ExecutionResources{}
 	}
 
-	res := &ExecutionResources{}
+	res := ExecutionResources{}
 	if tgc := resources.TotalGasConsumed; tgc != nil {
 		res.L1Gas = tgc.L1Gas
 		res.L2Gas = tgc.L2Gas

--- a/rpc/v9/events.go
+++ b/rpc/v9/events.go
@@ -1,7 +1,10 @@
 package rpcv9
 
 import (
+	"unsafe"
+
 	"github.com/NethermindEth/juno/blockchain"
+	"github.com/NethermindEth/juno/core"
 	"github.com/NethermindEth/juno/core/felt"
 	"github.com/NethermindEth/juno/jsonrpc"
 	"github.com/NethermindEth/juno/rpc/rpccore"
@@ -36,11 +39,25 @@ type EmittedEvent struct {
 	TransactionHash *felt.Felt `json:"transaction_hash"`
 }
 
+// Event is the RPC wire type for an event. It has the SAME memory layout as core.Event (identical
+// fields, order, and types, only the json tags differ), which lets AdaptReceipt reinterpret a
+// receipt's []*core.Event as []*Event with zero copies. The layout guards below make a divergence a
+// compile error.
 type Event struct {
 	From *felt.Felt  `json:"from_address,omitempty"`
 	Keys []felt.Felt `json:"keys"`
 	Data []felt.Felt `json:"data"`
 }
+
+// Compile-time layout guards: rpc.Event must stay byte-identical to core.Event for the unsafe
+// reinterpret in AdaptReceipt to be sound. Any size/offset drift fails the build (index out of
+// range).
+var (
+	_ = [1]struct{}{}[unsafe.Sizeof(Event{})-unsafe.Sizeof(core.Event{})]
+	_ = [1]struct{}{}[unsafe.Offsetof(Event{}.Data)-unsafe.Offsetof(core.Event{}.Data)]
+	_ = [1]struct{}{}[unsafe.Offsetof(Event{}.From)-unsafe.Offsetof(core.Event{}.From)]
+	_ = [1]struct{}{}[unsafe.Offsetof(Event{}.Keys)-unsafe.Offsetof(core.Event{}.Keys)]
+)
 
 func setEventFilterRange(filter blockchain.EventFilterer, from, to *BlockID, latestHeight uint64) error {
 	set := func(filterRange blockchain.EventFilterRange, blockID *BlockID) error {

--- a/rpc/v9/events.go
+++ b/rpc/v9/events.go
@@ -1,8 +1,6 @@
 package rpcv9
 
 import (
-	"unsafe"
-
 	"github.com/NethermindEth/juno/blockchain"
 	"github.com/NethermindEth/juno/core"
 	"github.com/NethermindEth/juno/core/felt"
@@ -39,25 +37,16 @@ type EmittedEvent struct {
 	TransactionHash *felt.Felt `json:"transaction_hash"`
 }
 
-// Event is the RPC wire type for an event. It has the SAME memory layout as core.Event (identical
-// fields, order, and types, only the json tags differ), which lets AdaptReceipt reinterpret a
-// receipt's []*core.Event as []*Event with zero copies. The layout guards below make a divergence a
-// compile error.
+// Event is the RPC wire type for an event. It is field-for-field identical to core.Event (only the
+// json tags differ), which lets AdaptReceipt reinterpret a receipt's []*core.Event as []*Event with
+// zero copies. The conversion guard below makes any divergence a compile error.
 type Event struct {
 	From *felt.Felt  `json:"from_address,omitempty"`
 	Keys []felt.Felt `json:"keys"`
 	Data []felt.Felt `json:"data"`
 }
 
-// Compile-time layout guards: rpc.Event must stay byte-identical to core.Event for the unsafe
-// reinterpret in AdaptReceipt to be sound. Any size/offset drift fails the build (index out of
-// range).
-var (
-	_ = [1]struct{}{}[unsafe.Sizeof(Event{})-unsafe.Sizeof(core.Event{})]
-	_ = [1]struct{}{}[unsafe.Offsetof(Event{}.Data)-unsafe.Offsetof(core.Event{}.Data)]
-	_ = [1]struct{}{}[unsafe.Offsetof(Event{}.From)-unsafe.Offsetof(core.Event{}.From)]
-	_ = [1]struct{}{}[unsafe.Offsetof(Event{}.Keys)-unsafe.Offsetof(core.Event{}.Keys)]
-)
+var _ = Event(core.Event{})
 
 func setEventFilterRange(filter blockchain.EventFilterer, from, to *BlockID, latestHeight uint64) error {
 	set := func(filterRange blockchain.EventFilterRange, blockID *BlockID) error {

--- a/rpc/v9/events.go
+++ b/rpc/v9/events.go
@@ -154,11 +154,9 @@ func (h *Handler) Events(args EventArgs) (EventsChunk, *jsonrpc.Error) {
 			BlockNumber:     fEvent.BlockNumber,
 			BlockHash:       fEvent.BlockHash,
 			TransactionHash: fEvent.TransactionHash,
-			Event: &Event{
-				From: fEvent.From,
-				Keys: fEvent.Keys,
-				Data: fEvent.Data,
-			},
+			// rpc.Event is field-identical to core.Event (guarded in this file), so alias the
+			// filtered *core.Event instead of allocating a fresh Event per emitted event.
+			Event: (*Event)(fEvent.Event),
 		}
 	}
 

--- a/rpc/v9/helpers.go
+++ b/rpc/v9/helpers.go
@@ -149,12 +149,12 @@ func (h *Handler) blockHeaderByID(blockID *BlockID) (*core.Header, *jsonrpc.Erro
 	return header, nil
 }
 
-func adaptExecutionResources(resources *core.ExecutionResources) *ExecutionResources {
+func adaptExecutionResources(resources *core.ExecutionResources) ExecutionResources {
 	if resources == nil {
-		return &ExecutionResources{}
+		return ExecutionResources{}
 	}
 
-	res := &ExecutionResources{}
+	res := ExecutionResources{}
 	if tgc := resources.TotalGasConsumed; tgc != nil {
 		res.L1Gas = tgc.L1Gas
 		res.L2Gas = tgc.L2Gas

--- a/rpc/v9/transaction.go
+++ b/rpc/v9/transaction.go
@@ -1071,6 +1071,9 @@ func AdaptReceipt(
 	// Zero-copy: rpc.Event has the same layout as core.Event (guarded in events.go), so the decoded
 	// []*core.Event is reinterpreted as []*Event without a per-element copy.
 	events := *(*[]*Event)(unsafe.Pointer(&receipt.Events))
+	if events == nil {
+		events = []*Event{}
+	}
 
 	var messageHash string
 	var contractAddress *felt.Felt

--- a/rpc/v9/transaction.go
+++ b/rpc/v9/transaction.go
@@ -1068,7 +1068,7 @@ func AdaptReceipt(
 		}
 	}
 
-	// Zero-copy: rpc.Event has the same layout as core.Event (guarded in events.go), so the decoded
+	// Zero-copy: rpc.Event is field-identical to core.Event (guarded in events.go), so the decoded
 	// []*core.Event is reinterpreted as []*Event without a per-element copy.
 	events := *(*[]*Event)(unsafe.Pointer(&receipt.Events))
 	if events == nil {

--- a/rpc/v9/transaction.go
+++ b/rpc/v9/transaction.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"strings"
+	"unsafe"
 
 	"github.com/NethermindEth/juno/adapters/sn2core"
 	"github.com/NethermindEth/juno/blockchain/networks"
@@ -332,19 +333,19 @@ type InnerExecutionResources struct {
 
 // https://github.com/starkware-libs/starknet-specs/blob/master/api/starknet_api_openrpc.json#L1871
 type TransactionReceipt struct {
-	Type               TransactionType     `json:"type"`
-	Hash               *felt.Felt          `json:"transaction_hash"`
-	ActualFee          *FeePayment         `json:"actual_fee"`
-	ExecutionStatus    TxnExecutionStatus  `json:"execution_status"`
-	FinalityStatus     TxnFinalityStatus   `json:"finality_status"`
-	BlockHash          *felt.Felt          `json:"block_hash,omitempty"`
-	BlockNumber        *uint64             `json:"block_number,omitempty"`
-	MessagesSent       []*MsgToL1          `json:"messages_sent"`
-	Events             []*Event            `json:"events"`
-	ContractAddress    *felt.Felt          `json:"contract_address,omitempty"`
-	RevertReason       string              `json:"revert_reason,omitempty"`
-	ExecutionResources *ExecutionResources `json:"execution_resources,omitempty"`
-	MessageHash        string              `json:"message_hash,omitempty"`
+	Type               TransactionType    `json:"type"`
+	Hash               *felt.Felt         `json:"transaction_hash"`
+	ActualFee          FeePayment         `json:"actual_fee"`
+	ExecutionStatus    TxnExecutionStatus `json:"execution_status"`
+	FinalityStatus     TxnFinalityStatus  `json:"finality_status"`
+	BlockHash          *felt.Felt         `json:"block_hash,omitempty"`
+	BlockNumber        *uint64            `json:"block_number,omitempty"`
+	MessagesSent       []MsgToL1          `json:"messages_sent"`
+	Events             []*Event           `json:"events"`
+	ContractAddress    *felt.Felt         `json:"contract_address,omitempty"`
+	RevertReason       string             `json:"revert_reason,omitempty"`
+	ExecutionResources ExecutionResources `json:"execution_resources"`
+	MessageHash        string             `json:"message_hash,omitempty"`
 }
 
 type FeePayment struct {
@@ -1058,23 +1059,18 @@ func AdaptReceipt(
 	txn core.Transaction,
 	finalityStatus TxnFinalityStatus,
 ) *TransactionReceipt {
-	messages := make([]*MsgToL1, len(receipt.L2ToL1Message))
+	messages := make([]MsgToL1, len(receipt.L2ToL1Message))
 	for idx, msg := range receipt.L2ToL1Message {
-		messages[idx] = &MsgToL1{
+		messages[idx] = MsgToL1{
 			To:      msg.To,
 			Payload: msg.Payload,
 			From:    msg.From,
 		}
 	}
 
-	events := make([]*Event, len(receipt.Events))
-	for idx, event := range receipt.Events {
-		events[idx] = &Event{
-			From: event.From,
-			Keys: event.Keys,
-			Data: event.Data,
-		}
-	}
+	// Zero-copy: rpc.Event has the same layout as core.Event (guarded in events.go), so the decoded
+	// []*core.Event is reinterpreted as []*Event without a per-element copy.
+	events := *(*[]*Event)(unsafe.Pointer(&receipt.Events))
 
 	var messageHash string
 	var contractAddress *felt.Felt
@@ -1099,7 +1095,7 @@ func AdaptReceipt(
 		ExecutionStatus: es,
 		Type:            transactionTypeFrom(txn),
 		Hash:            txn.Hash(),
-		ActualFee: &FeePayment{
+		ActualFee: FeePayment{
 			Amount: receipt.Fee,
 			Unit:   feeUnitFromTransactionVersion(txn.TxVersion()),
 		},

--- a/rpc/v9/transaction_test.go
+++ b/rpc/v9/transaction_test.go
@@ -782,6 +782,28 @@ func TestTransactionByBlockIdAndIndex(t *testing.T) {
 	})
 }
 
+// A receipt with no events must marshal "events" as an empty JSON array, not null.
+// AdaptReceipt reinterprets receipt.Events ([]*core.Event) as []*rpc.Event via unsafe
+// pointer aliasing, so a nil slice would marshal to `null` without the nil -> []*Event{}
+// guard. Fixtures built through adaptfeeder/sn2core always wrap events in a non-nil slice
+// (utils.NonNilSlice), so no other test exercises this branch.
+func TestAdaptReceiptNilEventsMarshalsAsEmptyArray(t *testing.T) {
+	txn := &core.InvokeTransaction{
+		TransactionHash: new(felt.Felt),
+		Version:         new(core.TransactionVersion).SetUint64(1),
+	}
+	receipt := &core.TransactionReceipt{
+		Fee:             new(felt.Felt),
+		Events:          nil,
+		TransactionHash: txn.TransactionHash,
+	}
+
+	got, err := json.Marshal(rpc.AdaptReceipt(receipt, txn, rpc.TxnAcceptedOnL2))
+	require.NoError(t, err)
+	assert.Contains(t, string(got), `"events":[]`)
+	assert.NotContains(t, string(got), `"events":null`)
+}
+
 //nolint:dupl
 func TestTransactionReceiptByHash(t *testing.T) {
 	mockCtrl := gomock.NewController(t)


### PR DESCRIPTION
## Summary

Reduces per-receipt allocations in the RPC receipt-adapt path (`AdaptReceipt`, `v9` and `v10`) with no change to the JSON wire output. Also reduces 1 alloc per event in `get_events`.

## Changes
- Value fields instead of pointers on TransactionReceipt:
    - ActualFee: `*FeePayment` → `FeePayment`
    - ExecutionResources: `*ExecutionResources` → `ExecutionResources` (drop omitempty)
    - MessagesSent: `[]*MsgToL1` → `[]MsgToL1`
    - adaptExecutionResources now returns a value.
  - Zero-copy events: reinterpret the decoded `[]*core.Event` as `[]*rpc.Event` via unsafe instead of copying each event into a freshly-allocated struct. This turns N+1 allocations (new backing array + one *Event
  per event) into zero. `rpc.Event` is a distinct wire type kept byte-identical to `core.Event`; compile-time guards (Sizeof/Offsetof) fail the build on any layout drift.
    - Events deliberately stays `[]*Event` (not `[]Event`) because the upstream `core.TransactionReceipt.Events` is still `[]*core.Event`. The zero-copy reinterpret requires the two slice element types to match, so `rpc.Event` mirrors the pointer shape. Once `core.Event` is switched to a value slice (`[]core.Event`) upstream, this becomes `[]Event` and drops the pointer indirection for free.
  - Reorder `core.Event` fields to {From, Keys, Data} so the two layouts match and the JSON output stays byte-identical (CBOR is canonical / order-independent, so persistence is unaffected — no migration).

## Correctness / safety

  - `actual_fee` and `execution_resources` are mandatory in the spec and were never `nil` in practice. `adaptExecutionResources` always returned a non-nil value and `ActualFee` was always constructed, so the old
  `omitempty` on `execution_resources` never actually fired. Switching these to value types emits the exact same bytes — verified byte-for-byte against the previous output.
  - `[]*T` → `[]T` is safe: MessagesSent/events are only produced and serialized on a read-only path; nothing mutates elements through the pointer indirection, so dropping it changes nothing observable.
  - The zero-copy events slice aliases the core receipt's backing array (shared, not copied) — sound because the adapt→serialize path never writes through it. Any future layout divergence between `rpc.Event` and `core.Event` is a compile error, not a runtime bug.