### PR TITLE
perf(rpc): reduce allocations in adapt block header

### DIFF
--- a/rpc/v10/block.go
+++ b/rpc/v10/block.go
@@ -41,24 +41,24 @@ func (l L1DAMode) MarshalText() ([]byte, error) {
 // PRE_CONFIRMED_BLOCK_HEADER
 // https://github.com/starkware-libs/starknet-specs/blob/cce1563eff702c87590bad3a48382d2febf1f7d9/api/starknet_api_openrpc.json#L1711
 type BlockHeader struct {
-	Hash                  *felt.Felt     `json:"block_hash,omitempty"`
-	ParentHash            *felt.Felt     `json:"parent_hash,omitempty"`
-	Number                *uint64        `json:"block_number,omitempty"`
-	NewRoot               *felt.Felt     `json:"new_root,omitempty"`
-	Timestamp             uint64         `json:"timestamp"`
-	SequencerAddress      *felt.Felt     `json:"sequencer_address,omitempty"`
-	L1GasPrice            *ResourcePrice `json:"l1_gas_price"`
-	L1DataGasPrice        *ResourcePrice `json:"l1_data_gas_price,omitempty"`
-	L1DAMode              *L1DAMode      `json:"l1_da_mode,omitempty"`
-	StarknetVersion       string         `json:"starknet_version"`
-	L2GasPrice            *ResourcePrice `json:"l2_gas_price"`
-	TransactionCommitment *felt.Hash     `json:"transaction_commitment,omitempty"`
-	EventCommitment       *felt.Hash     `json:"event_commitment,omitempty"`
-	ReceiptCommitment     *felt.Hash     `json:"receipt_commitment,omitempty"`
-	StateDiffCommitment   *felt.Hash     `json:"state_diff_commitment,omitempty"`
-	EventCount            *uint64        `json:"event_count,omitempty"`
-	TransactionCount      *uint64        `json:"transaction_count,omitempty"`
-	StateDiffLength       *uint64        `json:"state_diff_length,omitempty"`
+	Hash                  *felt.Felt    `json:"block_hash,omitempty"`
+	ParentHash            *felt.Felt    `json:"parent_hash,omitempty"`
+	Number                *uint64       `json:"block_number,omitempty"`
+	NewRoot               *felt.Felt    `json:"new_root,omitempty"`
+	Timestamp             uint64        `json:"timestamp"`
+	SequencerAddress      *felt.Felt    `json:"sequencer_address,omitempty"`
+	L1GasPrice            ResourcePrice `json:"l1_gas_price"`
+	L1DataGasPrice        ResourcePrice `json:"l1_data_gas_price"`
+	L1DAMode              L1DAMode      `json:"l1_da_mode"`
+	StarknetVersion       string        `json:"starknet_version"`
+	L2GasPrice            ResourcePrice `json:"l2_gas_price"`
+	TransactionCommitment *felt.Hash    `json:"transaction_commitment,omitempty"`
+	EventCommitment       *felt.Hash    `json:"event_commitment,omitempty"`
+	ReceiptCommitment     *felt.Hash    `json:"receipt_commitment,omitempty"`
+	StateDiffCommitment   *felt.Hash    `json:"state_diff_commitment,omitempty"`
+	EventCount            *uint64       `json:"event_count,omitempty"`
+	TransactionCount      *uint64       `json:"transaction_count,omitempty"`
+	StateDiffLength       *uint64       `json:"state_diff_length,omitempty"`
 }
 
 // https://github.com/starkware-libs/starknet-specs/blob/cce1563eff702c87590bad3a48382d2febf1f7d9/api/starknet_api_openrpc.json#L1794
@@ -405,14 +405,14 @@ func AdaptBlockHeader(
 		NewRoot:          header.GlobalStateRoot,
 		Timestamp:        header.Timestamp,
 		SequencerAddress: sequencerAddress,
-		L1GasPrice: &ResourcePrice{
+		L1GasPrice: ResourcePrice{
 			InWei: nilToOne(header.L1GasPriceETH),
 			InFri: nilToOne(header.L1GasPriceSTRK),
 		},
-		L1DataGasPrice:  &l1DataGasPrice,
-		L1DAMode:        &l1DAMode,
+		L1DataGasPrice:  l1DataGasPrice,
+		L1DAMode:        l1DAMode,
 		StarknetVersion: header.ProtocolVersion,
-		L2GasPrice:      &l2GasPrice,
+		L2GasPrice:      l2GasPrice,
 	}
 
 	// Only populate commitment fields for blocks with commitments

--- a/rpc/v10/block_test.go
+++ b/rpc/v10/block_test.go
@@ -208,7 +208,7 @@ func assertCommittedBlockHeader(
 	case core.Calldata:
 		expectedl1DAMode = rpc.Calldata
 	}
-	assert.Equal(t, expectedl1DAMode, *actual.L1DAMode)
+	assert.Equal(t, expectedl1DAMode, actual.L1DAMode)
 	assert.Equal(t, expectedBlock.ProtocolVersion, actual.StarknetVersion)
 	assert.Equal(
 		t,
@@ -261,7 +261,7 @@ func assertPreConfirmedBlockHeader(
 	case core.Calldata:
 		expectedl1DAMode = rpc.Calldata
 	}
-	assert.Equal(t, expectedl1DAMode, *actual.L1DAMode)
+	assert.Equal(t, expectedl1DAMode, actual.L1DAMode)
 
 	assert.Nil(t, actual.Hash)
 	assert.Nil(t, actual.ParentHash)
@@ -1168,18 +1168,18 @@ func TestBlockWithTxHashesV013(t *testing.T) {
 			NewRoot:         block.GlobalStateRoot,
 			Number:          &block.Number,
 			ParentHash:      block.ParentHash,
-			L1DAMode:        new(rpc.Blob),
-			L1GasPrice: &rpc.ResourcePrice{
+			L1DAMode:        rpc.Blob,
+			L1GasPrice: rpc.ResourcePrice{
 				InFri: felt.NewUnsafeFromString[felt.Felt]("0x17882b6aa74"),
 				InWei: felt.NewUnsafeFromString[felt.Felt]("0x3b9aca10"),
 			},
-			L1DataGasPrice: &rpc.ResourcePrice{
+			L1DataGasPrice: rpc.ResourcePrice{
 				InFri: felt.NewUnsafeFromString[felt.Felt]("0x2cc6d7f596e1"),
 				InWei: felt.NewUnsafeFromString[felt.Felt]("0x716a8f6dd"),
 			},
 			SequencerAddress: block.SequencerAddress,
 			Timestamp:        block.Timestamp,
-			L2GasPrice: &rpc.ResourcePrice{
+			L2GasPrice: rpc.ResourcePrice{
 				InFri: &felt.One,
 				InWei: &felt.One,
 			},

--- a/rpc/v9/block.go
+++ b/rpc/v9/block.go
@@ -513,7 +513,7 @@ func AdaptBlockHeader(header *core.Header) BlockHeader {
 		Timestamp:        header.Timestamp,
 		SequencerAddress: sequencerAddress,
 		L1GasPrice: ResourcePrice{
-			InWei: header.L1GasPriceETH,
+			InWei: nilToZero(header.L1GasPriceETH),
 			InFri: nilToZero(header.L1GasPriceSTRK),
 		},
 		L1DataGasPrice:  l1DataGasPrice,

--- a/rpc/v9/block.go
+++ b/rpc/v9/block.go
@@ -189,17 +189,17 @@ func (b *BlockID) UnmarshalJSON(data []byte) error {
 // PRE_CONFIRMED_BLOCK_HEADER
 // https://github.com/starkware-libs/starknet-specs/blob/0bf403bfafbfbe0eaa52103a9c7df545bec8f73b/api/starknet_api_openrpc.json#L1636
 type BlockHeader struct {
-	Hash             *felt.Felt     `json:"block_hash,omitempty"`
-	ParentHash       *felt.Felt     `json:"parent_hash,omitempty"`
-	Number           *uint64        `json:"block_number,omitempty"`
-	NewRoot          *felt.Felt     `json:"new_root,omitempty"`
-	Timestamp        uint64         `json:"timestamp"`
-	SequencerAddress *felt.Felt     `json:"sequencer_address,omitempty"`
-	L1GasPrice       *ResourcePrice `json:"l1_gas_price"`
-	L1DataGasPrice   *ResourcePrice `json:"l1_data_gas_price,omitempty"`
-	L1DAMode         *L1DAMode      `json:"l1_da_mode,omitempty"`
-	StarknetVersion  string         `json:"starknet_version"`
-	L2GasPrice       *ResourcePrice `json:"l2_gas_price"`
+	Hash             *felt.Felt    `json:"block_hash,omitempty"`
+	ParentHash       *felt.Felt    `json:"parent_hash,omitempty"`
+	Number           *uint64       `json:"block_number,omitempty"`
+	NewRoot          *felt.Felt    `json:"new_root,omitempty"`
+	Timestamp        uint64        `json:"timestamp"`
+	SequencerAddress *felt.Felt    `json:"sequencer_address,omitempty"`
+	L1GasPrice       ResourcePrice `json:"l1_gas_price"`
+	L1DataGasPrice   ResourcePrice `json:"l1_data_gas_price"`
+	L1DAMode         L1DAMode      `json:"l1_da_mode"`
+	StarknetVersion  string        `json:"starknet_version"`
+	L2GasPrice       ResourcePrice `json:"l2_gas_price"`
 }
 
 type ResourcePrice struct {
@@ -466,8 +466,6 @@ func (h *Handler) blockStatus(id *BlockID, blockNumber uint64) (BlockStatus, *js
 }
 
 func AdaptBlockHeader(header *core.Header) BlockHeader {
-	blockNumber := &header.Number
-
 	sequencerAddress := header.SequencerAddress
 	if sequencerAddress == nil {
 		sequencerAddress = &felt.Zero
@@ -510,18 +508,18 @@ func AdaptBlockHeader(header *core.Header) BlockHeader {
 	return BlockHeader{
 		Hash:             header.Hash,
 		ParentHash:       header.ParentHash,
-		Number:           blockNumber,
+		Number:           &header.Number,
 		NewRoot:          header.GlobalStateRoot,
 		Timestamp:        header.Timestamp,
 		SequencerAddress: sequencerAddress,
-		L1GasPrice: &ResourcePrice{
+		L1GasPrice: ResourcePrice{
 			InWei: header.L1GasPriceETH,
 			InFri: nilToZero(header.L1GasPriceSTRK),
 		},
-		L1DataGasPrice:  &l1DataGasPrice,
-		L1DAMode:        &l1DAMode,
+		L1DataGasPrice:  l1DataGasPrice,
+		L1DAMode:        l1DAMode,
 		StarknetVersion: header.ProtocolVersion,
-		L2GasPrice:      &l2GasPrice,
+		L2GasPrice:      l2GasPrice,
 	}
 }
 

--- a/rpc/v9/block_test.go
+++ b/rpc/v9/block_test.go
@@ -859,18 +859,18 @@ func TestBlockWithTxHashesV013(t *testing.T) {
 			NewRoot:         coreBlock.GlobalStateRoot,
 			Number:          &coreBlock.Number,
 			ParentHash:      coreBlock.ParentHash,
-			L1DAMode:        new(rpc.Blob),
-			L1GasPrice: &rpc.ResourcePrice{
+			L1DAMode:        rpc.Blob,
+			L1GasPrice: rpc.ResourcePrice{
 				InFri: felt.NewUnsafeFromString[felt.Felt]("0x17882b6aa74"),
 				InWei: felt.NewUnsafeFromString[felt.Felt]("0x3b9aca10"),
 			},
-			L1DataGasPrice: &rpc.ResourcePrice{
+			L1DataGasPrice: rpc.ResourcePrice{
 				InFri: felt.NewUnsafeFromString[felt.Felt]("0x2cc6d7f596e1"),
 				InWei: felt.NewUnsafeFromString[felt.Felt]("0x716a8f6dd"),
 			},
 			SequencerAddress: coreBlock.SequencerAddress,
 			Timestamp:        coreBlock.Timestamp,
-			L2GasPrice: &rpc.ResourcePrice{
+			L2GasPrice: rpc.ResourcePrice{
 				InFri: &felt.One,
 				InWei: &felt.One,
 			},


### PR DESCRIPTION
`l1_gas_price`, `l1_data_gas_price`, `l2_gas_price` and `l1_da_mode` are
  required fields of the RPC block header, and `AdaptBlockHeader` has always
  assigned all four — the nil core-header cases fall back to a felt (`felt.One`
  in v10, `felt.Zero` in v9) and the zero DA mode rather than being left unset.
  Holding them as pointers therefore only added a heap allocation per header,
  so this switches them to values in both `rpcv9` and `rpcv10`.

  The `omitempty` on `l1_data_gas_price` and `l1_da_mode` is dropped along
  with the pointers. It never fired, since the pointers were never nil, so
  the serialised output is unchanged. Dropping it is required rather than
  cosmetic: `Blob == 0`, so on a value `L1DAMode` the `omitempty` would have
  silently omitted `l1_da_mode` for every BLOB block. The `newHeads` golden
  JSON in `rpc/v9/subscriptions_test.go` covers exactly that case.

  ## Allocations removed

  **rpcv9 — now allocation-free.** `AdaptBlockHeader` takes only the header,
  with no commitment path, so these four were its only allocations:

  | Allocation | Before | After |
  | --- | --- | --- |
  | `&ResourcePrice{...}` × 3 (l1 / l1_data / l2 gas price) | 48 B | – |
  | `&l1DAMode` | 1 B | – |
  | **total** | **49 B, 4 allocs/op** | **0 B, 0 allocs/op** |


  **rpcv10 — four of five allocations per committed header.** It also takes
  commitments and a state diff, and the commitment branch keeps one allocation:

  | Allocation | Before | After |
  | --- | --- | --- |
  | `&ResourcePrice{...}` × 3 (l1 / l1_data / l2 gas price) | 48 B | – |
  | `&l1DAMode` | 8 B | – |
  | `&stateDiffLength` | 8 B | 8 B |
  | **total** | **64 B, 5 allocs/op** | **8 B, 1 alloc/op** |

  `TransactionCount` and `EventCount` cost nothing either way, they are
  interior pointers into the caller's `*core.Header`.

  The pre-confirmed path (`header.Hash == nil`) skips the commitment block
  entirely, so v10 is fully allocation-free there too: 4 → 0 allocs/op.

  ## Follow-up

  The one remaining allocation is v10's `&stateDiffLength`, which exists only
  because the length is computed on the fly from the state diff. #3904 will
  store it alongside the block commitments, making it an interior pointer like
  the other counts — that takes `AdaptBlockHeader` to zero allocations on every
  path in both versions.