### PR TITLE
perf(blockchain): decode only the events subset of receipts in getEvents

### DIFF
--- a/blockchain/blockchain_test.go
+++ b/blockchain/blockchain_test.go
@@ -1,6 +1,7 @@
 package blockchain_test
 
 import (
+	"bytes"
 	"fmt"
 	"testing"
 
@@ -936,10 +937,10 @@ func TestEventsMultiPreConfirmed(t *testing.T) {
 		gotPerBlock := map[uint64]int{}
 		for i, e := range events {
 			require.NotNil(t, e.BlockNumber)
-			gotPerBlock[*e.BlockNumber]++
+			gotPerBlock[e.BlockNumber]++
 			// Events must be yielded oldest-first across canonical + pre_confirmed.
 			if i > 0 {
-				require.LessOrEqual(t, *events[i-1].BlockNumber, *e.BlockNumber,
+				require.LessOrEqual(t, events[i-1].BlockNumber, e.BlockNumber,
 					"events must be returned oldest-first by block number")
 			}
 		}
@@ -1013,7 +1014,7 @@ func TestEventsMultiPreConfirmed(t *testing.T) {
 		require.NotEmpty(t, events)
 		for _, e := range events {
 			require.NotNil(t, e.BlockNumber)
-			require.Equal(t, lastPreConfirmedBlockNum, *e.BlockNumber,
+			require.Equal(t, lastPreConfirmedBlockNum, e.BlockNumber,
 				"pre_confirmed tag should return only the tip block")
 		}
 	})
@@ -1041,7 +1042,7 @@ func TestEventsMultiPreConfirmed(t *testing.T) {
 			require.NotNil(t, e.From)
 			require.Equal(t, from[0], felt.Address(*e.From))
 			require.NotNil(t, e.BlockNumber)
-			require.Equal(t, lastPreConfirmedBlockNum, *e.BlockNumber)
+			require.Equal(t, lastPreConfirmedBlockNum, e.BlockNumber)
 		}
 	})
 
@@ -1104,23 +1105,98 @@ func TestEventsMultiPreConfirmed(t *testing.T) {
 	})
 }
 
-// TestEventsPreConfirmedProjectionReuse tests the pre_confirmed receipt projection,
-// which uses one buffer again for each chain entry. The first entry has more
-// transactions than the second entry. If the buffer keeps the data of the first
-// entry, the second entry shows the transactions of the first entry. The test sets
-// the number of transactions directly, because the fixtures do not control it.
-func TestEventsPreConfirmedProjectionReuse(t *testing.T) {
+func TestEventsHeadAdvancesDuringQuery(t *testing.T) {
 	const (
-		canonicalHead  = uint64(0)
-		wideBlockNum   = canonicalHead + 1
-		narrowBlockNum = wideBlockNum + 1
-		wideTxCount    = 5
-		narrowTxCount  = 2
+		headAtStart       = uint64(3) // blocks 0..3 are stored before the query
+		committedMidQuery = headAtStart + 1
+		preConfirmedNum   = committedMidQuery + 1
 	)
 
 	testDB := memory.New()
 	chain := blockchain.New(
 		testDB,
+		&networks.Sepolia,
+		blockchain.WithNewState(statetestutils.UseNewState()),
+	)
+
+	gw := adaptfeeder.New(feeder.NewTestClient(t, &networks.Sepolia))
+	store := func(t *testing.T, blockNum uint64) {
+		t.Helper()
+		block, err := gw.BlockByNumber(t.Context(), blockNum)
+		require.NoError(t, err)
+		stateUpdate, err := gw.StateUpdate(t.Context(), blockNum)
+		require.NoError(t, err)
+		require.NoError(t, chain.Store(block, &emptyCommitments, stateUpdate, nil))
+	}
+	for blockNum := range headAtStart + 1 {
+		store(t, blockNum)
+	}
+
+	// The fetch acts as the poller: it commits the next block and returns a chain
+	// above it.
+	preConfirmedFn := func() (blockchain.PreConfirmedReader, error) {
+		store(t, committedMidQuery)
+
+		block, err := gw.BlockByNumber(t.Context(), preConfirmedNum)
+		require.NoError(t, err)
+		block.Hash = nil // a pre-confirmed block has no hash
+		entry := pending.NewPreConfirmed(block, nil, nil, "")
+		preConfChain, err := preconfirmed.NewChain(&entry)
+		require.NoError(t, err)
+		return &preConfChain, nil
+	}
+
+	filter, err := chain.EventFilter(nil, nil, preConfirmedFn)
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, filter.Close()) })
+
+	require.NoError(t, filter.SetRangeEndBlockByNumber(blockchain.EventFilterFrom, 0))
+	require.NoError(t, filter.SetRangeEndBlockByNumber(
+		blockchain.EventFilterTo, blockchain.PreConfirmedFilterSentinel,
+	))
+
+	events, cToken, err := filter.Events(nil, 1024)
+	require.NoError(t, err)
+	require.True(t, cToken.IsEmpty())
+
+	perBlock := map[uint64]int{}
+	for _, event := range events {
+		perBlock[event.BlockNumber]++
+	}
+	require.Equal(t, map[uint64]int{0: 4, committedMidQuery: 4, preConfirmedNum: 2}, perBlock)
+
+	for _, event := range events {
+		if event.BlockNumber == preConfirmedNum {
+			require.Nil(t, event.BlockHash)
+			continue
+		}
+		require.NotNil(t, event.BlockHash,
+			"block %d must be served from the canonical range", event.BlockNumber)
+	}
+}
+
+// chainHeightCounter counts the reads of the chain height key.
+type chainHeightCounter struct {
+	db.KeyValueStore
+	reads int
+}
+
+func (c *chainHeightCounter) Get(key []byte, cb func([]byte) error) error {
+	if bytes.Equal(key, db.ChainHeight.Key()) {
+		c.reads++
+	}
+	return c.KeyValueStore.Get(key, cb)
+}
+
+func TestEventsChainHeightReads(t *testing.T) {
+	const (
+		canonicalHead   = uint64(0)
+		preConfirmedNum = canonicalHead + 1
+	)
+
+	counter := &chainHeightCounter{KeyValueStore: memory.New()}
+	chain := blockchain.New(
+		counter,
 		&networks.Sepolia,
 		blockchain.WithNewState(statetestutils.UseNewState()),
 	)
@@ -1132,76 +1208,39 @@ func TestEventsPreConfirmedProjectionReuse(t *testing.T) {
 	require.NoError(t, err)
 	require.NoError(t, chain.Store(block, &emptyCommitments, stateUpdate, nil))
 
-	eventFrom := felt.UnsafeFromString[felt.Felt]("0xdeadbeef")
-	txHash := func(blockNum uint64, txIndex uint) *felt.Felt {
-		return new(felt.Felt).SetUint64(blockNum*100 + uint64(txIndex))
-	}
-	makeEntry := func(blockNum uint64, txCount int) *pending.PreConfirmed {
-		receipts := make([]*core.TransactionReceipt, txCount)
-		for i := range receipts {
-			receipts[i] = &core.TransactionReceipt{
-				TransactionHash: txHash(blockNum, uint(i)),
-				Events: []*core.Event{{
-					From: &eventFrom,
-					Keys: []felt.Felt{felt.One},
-					Data: []felt.Felt{felt.One},
-				}},
-			}
-		}
-		entry := pending.NewPreConfirmed(&core.Block{
-			Header: &core.Header{
-				Number:      blockNum,
-				EventsBloom: core.EventsBloom(receipts),
-			},
-			Receipts: receipts,
-		}, nil, nil, "")
-		return &entry
-	}
-
-	preConfChain, err := preconfirmed.NewChain(
-		makeEntry(wideBlockNum, wideTxCount),
-		makeEntry(narrowBlockNum, narrowTxCount),
-	)
+	preConfirmedBlock, err := gw.BlockByNumber(t.Context(), preConfirmedNum)
+	require.NoError(t, err)
+	preConfirmedBlock.Hash = nil
+	entry := pending.NewPreConfirmed(preConfirmedBlock, nil, nil, "")
+	preConfChain, err := preconfirmed.NewChain(&entry)
 	require.NoError(t, err)
 
-	filter, err := chain.EventFilter(
-		nil,
-		nil,
-		func() (blockchain.PreConfirmedReader, error) { return &preConfChain, nil },
-	)
-	require.NoError(t, err)
-	t.Cleanup(func() { require.NoError(t, filter.Close()) })
+	for _, test := range []struct {
+		name    string
+		toBlock uint64
+		reads   int
+	}{
+		{"canonical range", canonicalHead, 1},
+		{"range past the head", preConfirmedNum, 1},
+		{"pre_confirmed tag", blockchain.PreConfirmedFilterSentinel, 0},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			filter, err := chain.EventFilter(
+				nil,
+				nil,
+				func() (blockchain.PreConfirmedReader, error) { return &preConfChain, nil },
+			)
+			require.NoError(t, err)
+			t.Cleanup(func() { require.NoError(t, filter.Close()) })
+			require.NoError(t, filter.SetRangeEndBlockByNumber(blockchain.EventFilterFrom, 0))
+			require.NoError(t, filter.SetRangeEndBlockByNumber(blockchain.EventFilterTo, test.toBlock))
 
-	require.NoError(t, filter.SetRangeEndBlockByNumber(blockchain.EventFilterFrom, wideBlockNum))
-	require.NoError(t, filter.SetRangeEndBlockByNumber(
-		blockchain.EventFilterTo, blockchain.PreConfirmedFilterSentinel,
-	))
-
-	events, cToken, err := filter.Events(nil, 1024)
-	require.NoError(t, err)
-	require.True(t, cToken.IsEmpty())
-
-	// Each transaction has one event. Therefore the second entry must give exactly
-	// narrowTxCount events. If the buffer keeps old data, it gives wideTxCount events.
-	type want struct {
-		blockNum uint64
-		txIndex  uint
-	}
-	wants := make([]want, 0, wideTxCount+narrowTxCount)
-	for i := range uint(wideTxCount) {
-		wants = append(wants, want{wideBlockNum, i})
-	}
-	for i := range uint(narrowTxCount) {
-		wants = append(wants, want{narrowBlockNum, i})
-	}
-
-	require.Len(t, events, len(wants))
-	for i, e := range events {
-		require.NotNil(t, e.BlockNumber)
-		require.Equal(t, wants[i].blockNum, *e.BlockNumber)
-		require.Equal(t, wants[i].txIndex, e.TransactionIndex)
-		require.Zero(t, e.EventIndex)
-		require.Equal(t, txHash(wants[i].blockNum, wants[i].txIndex), e.TransactionHash)
+			counter.reads = 0
+			_, _, err = filter.Events(nil, 1024)
+			require.NoError(t, err)
+			// Blockchain.EventFilter also reads the height, so count only the query.
+			require.Equal(t, test.reads, counter.reads)
+		})
 	}
 }
 

--- a/blockchain/blockchain_test.go
+++ b/blockchain/blockchain_test.go
@@ -1104,6 +1104,107 @@ func TestEventsMultiPreConfirmed(t *testing.T) {
 	})
 }
 
+// TestEventsPreConfirmedProjectionReuse tests the pre_confirmed receipt projection,
+// which uses one buffer again for each chain entry. The first entry has more
+// transactions than the second entry. If the buffer keeps the data of the first
+// entry, the second entry shows the transactions of the first entry. The test sets
+// the number of transactions directly, because the fixtures do not control it.
+func TestEventsPreConfirmedProjectionReuse(t *testing.T) {
+	const (
+		canonicalHead  = uint64(0)
+		wideBlockNum   = canonicalHead + 1
+		narrowBlockNum = wideBlockNum + 1
+		wideTxCount    = 5
+		narrowTxCount  = 2
+	)
+
+	testDB := memory.New()
+	chain := blockchain.New(
+		testDB,
+		&networks.Sepolia,
+		blockchain.WithNewState(statetestutils.UseNewState()),
+	)
+
+	gw := adaptfeeder.New(feeder.NewTestClient(t, &networks.Sepolia))
+	block, err := gw.BlockByNumber(t.Context(), canonicalHead)
+	require.NoError(t, err)
+	stateUpdate, err := gw.StateUpdate(t.Context(), canonicalHead)
+	require.NoError(t, err)
+	require.NoError(t, chain.Store(block, &emptyCommitments, stateUpdate, nil))
+
+	eventFrom := felt.UnsafeFromString[felt.Felt]("0xdeadbeef")
+	txHash := func(blockNum uint64, txIndex uint) *felt.Felt {
+		return new(felt.Felt).SetUint64(blockNum*100 + uint64(txIndex))
+	}
+	makeEntry := func(blockNum uint64, txCount int) *pending.PreConfirmed {
+		receipts := make([]*core.TransactionReceipt, txCount)
+		for i := range receipts {
+			receipts[i] = &core.TransactionReceipt{
+				TransactionHash: txHash(blockNum, uint(i)),
+				Events: []*core.Event{{
+					From: &eventFrom,
+					Keys: []felt.Felt{felt.One},
+					Data: []felt.Felt{felt.One},
+				}},
+			}
+		}
+		entry := pending.NewPreConfirmed(&core.Block{
+			Header: &core.Header{
+				Number:      blockNum,
+				EventsBloom: core.EventsBloom(receipts),
+			},
+			Receipts: receipts,
+		}, nil, nil, "")
+		return &entry
+	}
+
+	preConfChain, err := preconfirmed.NewChain(
+		makeEntry(wideBlockNum, wideTxCount),
+		makeEntry(narrowBlockNum, narrowTxCount),
+	)
+	require.NoError(t, err)
+
+	filter, err := chain.EventFilter(
+		nil,
+		nil,
+		func() (blockchain.PreConfirmedReader, error) { return &preConfChain, nil },
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, filter.Close()) })
+
+	require.NoError(t, filter.SetRangeEndBlockByNumber(blockchain.EventFilterFrom, wideBlockNum))
+	require.NoError(t, filter.SetRangeEndBlockByNumber(
+		blockchain.EventFilterTo, blockchain.PreConfirmedFilterSentinel,
+	))
+
+	events, cToken, err := filter.Events(nil, 1024)
+	require.NoError(t, err)
+	require.True(t, cToken.IsEmpty())
+
+	// Each transaction has one event. Therefore the second entry must give exactly
+	// narrowTxCount events. If the buffer keeps old data, it gives wideTxCount events.
+	type want struct {
+		blockNum uint64
+		txIndex  uint
+	}
+	wants := make([]want, 0, wideTxCount+narrowTxCount)
+	for i := range uint(wideTxCount) {
+		wants = append(wants, want{wideBlockNum, i})
+	}
+	for i := range uint(narrowTxCount) {
+		wants = append(wants, want{narrowBlockNum, i})
+	}
+
+	require.Len(t, events, len(wants))
+	for i, e := range events {
+		require.NotNil(t, e.BlockNumber)
+		require.Equal(t, wants[i].blockNum, *e.BlockNumber)
+		require.Equal(t, wants[i].txIndex, e.TransactionIndex)
+		require.Zero(t, e.EventIndex)
+		require.Equal(t, txHash(wants[i].blockNum, wants[i].txIndex), e.TransactionHash)
+	}
+}
+
 func TestRevert(t *testing.T) {
 	testDB := memory.New()
 	chain := blockchain.New(

--- a/blockchain/blockchain_test.go
+++ b/blockchain/blockchain_test.go
@@ -784,6 +784,36 @@ func TestEvents(t *testing.T) {
 			})
 		}
 	})
+
+	t.Run("pre-confirmed fetch is gated on the range", func(t *testing.T) {
+		fetches := 0
+		countingFn := func() (blockchain.PreConfirmedReader, error) {
+			fetches++
+			return preConfirmedFunc()
+		}
+		runQuery := func(t *testing.T, toBlock uint64) {
+			t.Helper()
+			filter, err := chain.EventFilter(nil, nil, countingFn)
+			require.NoError(t, err)
+			require.NoError(t, filter.SetRangeEndBlockByNumber(blockchain.EventFilterFrom, 0))
+			require.NoError(t, filter.SetRangeEndBlockByNumber(blockchain.EventFilterTo, toBlock))
+			_, _, err = filter.Events(nil, 10)
+			require.NoError(t, err)
+			require.NoError(t, filter.Close())
+		}
+
+		t.Run("historical range never fetches", func(t *testing.T) {
+			fetches = 0
+			runQuery(t, firstPendingBlockNum-1) // toBlock == canonical head
+			require.Zero(t, fetches)
+		})
+
+		t.Run("range past head fetches once", func(t *testing.T) {
+			fetches = 0
+			runQuery(t, firstPendingBlockNum)
+			require.Equal(t, 1, fetches)
+		})
+	})
 }
 
 // TestEventsMultiPreConfirmed covers the blockchain event filter against a

--- a/blockchain/blockchain_test.go
+++ b/blockchain/blockchain_test.go
@@ -815,6 +815,36 @@ func TestEvents(t *testing.T) {
 			})
 		}
 	})
+
+	t.Run("pre-confirmed fetch is gated on the range", func(t *testing.T) {
+		fetches := 0
+		countingFn := func() (blockchain.PreConfirmedReader, error) {
+			fetches++
+			return preConfirmedFunc()
+		}
+		runQuery := func(t *testing.T, toBlock uint64) {
+			t.Helper()
+			filter, err := chain.EventFilter(nil, nil, countingFn)
+			require.NoError(t, err)
+			require.NoError(t, filter.SetRangeEndBlockByNumber(blockchain.EventFilterFrom, 0))
+			require.NoError(t, filter.SetRangeEndBlockByNumber(blockchain.EventFilterTo, toBlock))
+			_, _, err = filter.Events(nil, 10)
+			require.NoError(t, err)
+			require.NoError(t, filter.Close())
+		}
+
+		t.Run("historical range never fetches", func(t *testing.T) {
+			fetches = 0
+			runQuery(t, firstPendingBlockNum-1) // toBlock == canonical head
+			require.Zero(t, fetches)
+		})
+
+		t.Run("range past head fetches once", func(t *testing.T) {
+			fetches = 0
+			runQuery(t, firstPendingBlockNum)
+			require.Equal(t, 1, fetches)
+		})
+	})
 }
 
 // TestEventsMultiPreConfirmed covers the blockchain event filter against a

--- a/blockchain/event_filter.go
+++ b/blockchain/event_filter.go
@@ -34,6 +34,11 @@ type EventFilter struct {
 	preConfirmedFn func() (PreConfirmedReader, error)
 	cachedFilters  *AggregatedBloomFilterCache
 	runningFilter  *core.RunningEventFilter
+	// txEventsBuf holds the pre-confirmed receipt projection. One filter serves one
+	// request from one goroutine. Therefore the code can fill this buffer again for
+	// each chain entry and each call. The projection then makes one allocation for
+	// each filter, and not one allocation for each pre-confirmed block.
+	txEventsBuf []core.TransactionEvents
 }
 
 type EventFilterRange uint
@@ -151,15 +156,14 @@ func (e *EventFilter) Events(
 		return nil, ContinuationToken{}, err
 	}
 
-	// Fetch pre_confirmed only when the range can reach past the canonical head; a
-	// purely historical query never consults it. When fetched, re-read latest
-	// afterwards: with the pre-head latest, the head could advance between the two
-	// reads, leaving blocks committed in between scanned by neither the canonical
-	// range (stopped at the stale latest) nor pre_confirmed (based above them), a
-	// gap. Re-reading makes latest >= the snapshot's base, so the ranges overlap
-	// instead. Pinning a fixed head wouldn't help: once a block commits,
-	// SnapshotForBlock trims it, so a stale head yields an empty view. On error,
-	// drop it and serve canonical only.
+	// Get pre_confirmed only if the range includes blocks above the canonical head.
+	// Then read latest a second time. The first value can be too old, because the
+	// node can commit blocks between the two reads. The canonical range stops at the
+	// old value, and the pre_confirmed snapshot starts above those blocks, so no
+	// range includes them. The second read prevents this. It also keeps those blocks
+	// in the canonical range, which is the only range that has a block hash. A fixed
+	// head is not a solution, because SnapshotForBlock removes committed blocks and
+	// an old head gives an empty view. If the fetch fails, use the canonical range.
 	var preConfirmed PreConfirmedReader
 	if e.toBlock > latest {
 		if fetched, err := e.preConfirmedFn(); err == nil {
@@ -311,18 +315,21 @@ func (e *EventFilter) canonicalEvents(
 	return matchedEvents, ContinuationToken{}, nil
 }
 
-// transactionEventsFromReceipts projects in-memory receipts down to the events
-// subset the matcher consumes, so both event sources feed it one shape. The call
-// inlines and the slice does not escape, making the projection stack-only.
-func transactionEventsFromReceipts(receipts []*core.TransactionReceipt) []core.TransactionEvents {
-	events := make([]core.TransactionEvents, len(receipts))
-	for i, receipt := range receipts {
-		events[i] = core.TransactionEvents{
+// appendTransactionEvents adds the events subset of each receipt to dst. Both event
+// sources then give the matcher the same type. The caller can use dst again for each
+// block. This is safe, because the function copies only slice headers and pointers,
+// and the matcher keeps no reference to dst.
+func appendTransactionEvents(
+	dst []core.TransactionEvents,
+	receipts []*core.TransactionReceipt,
+) []core.TransactionEvents {
+	for _, receipt := range receipts {
+		dst = append(dst, core.TransactionEvents{
 			Events:          receipt.Events,
 			TransactionHash: receipt.TransactionHash,
-		}
+		})
 	}
-	return events
+	return dst
 }
 
 // preConfirmedEvents processes pending events across every pre-confirmed block in
@@ -370,12 +377,14 @@ func (e *EventFilter) preConfirmedEvents(
 			continue
 		}
 
+		e.txEventsBuf = appendTransactionEvents(e.txEventsBuf[:0], entry.Block.Receipts)
+
 		var processedEvents uint64
 		matchedEvents, processedEvents, err = e.matcher.AppendBlockEvents(
 			matchedEvents,
 			blockNumber,
 			func() (*felt.Felt, error) { return header.Hash, nil },
-			transactionEventsFromReceipts(entry.Block.Receipts),
+			e.txEventsBuf,
 			skippedEvents,
 			chunkSize,
 		)

--- a/blockchain/event_filter.go
+++ b/blockchain/event_filter.go
@@ -135,7 +135,7 @@ func (c *ContinuationToken) FromString(str string) error {
 
 type FilteredEvent struct {
 	*core.Event
-	BlockNumber      *uint64
+	BlockNumber      uint64
 	BlockHash        *felt.Felt
 	TransactionHash  *felt.Felt
 	TransactionIndex uint
@@ -146,29 +146,9 @@ func (e *EventFilter) Events(
 	cToken *ContinuationToken,
 	chunkSize uint64,
 ) ([]FilteredEvent, ContinuationToken, error) {
-	latest, err := core.GetChainHeight(e.database)
+	latest, preConfirmed, err := e.headAndPreConfirmed()
 	if err != nil {
 		return nil, ContinuationToken{}, err
-	}
-
-	// Get pre_confirmed only if the range includes blocks above the canonical head.
-	// Then read latest a second time. The first value can be too old, because the
-	// node can commit blocks between the two reads. The canonical range stops at the
-	// old value, and the pre_confirmed snapshot starts above those blocks, so no
-	// range includes them. The second read prevents this. It also keeps those blocks
-	// in the canonical range, which is the only range that has a block hash. A fixed
-	// head is not a solution, because SnapshotForBlock removes committed blocks and
-	// an old head gives an empty view. If the fetch fails, use the canonical range.
-	var preConfirmed PreConfirmedReader
-	if e.toBlock > latest {
-		if fetched, err := e.preConfirmedFn(); err == nil {
-			preConfirmed = fetched
-		}
-
-		latest, err = core.GetChainHeight(e.database)
-		if err != nil {
-			return nil, ContinuationToken{}, err
-		}
 	}
 
 	var skippedEvents uint64
@@ -226,10 +206,41 @@ func (e *EventFilter) Events(
 		matchedEvents,
 		preConfirmed,
 		startBlock,
-		latest,
 		skippedEvents,
 		chunkSize,
 	)
+}
+
+// headAndPreConfirmed returns the canonical head that divides the query, and the
+// pre-confirmed chain if the range goes above that head.
+//
+// The head comes from the chain: its oldest entry is one block above the head the
+// chain was built on. A head read before the fetch can be too old, and blocks
+// committed in between then fall between the two ranges.
+func (e *EventFilter) headAndPreConfirmed() (uint64, PreConfirmedReader, error) {
+	// PreConfirmedFilterSentinel is above every block, so the read changes nothing.
+	var latest uint64
+	if e.toBlock != PreConfirmedFilterSentinel {
+		var err error
+		if latest, err = core.GetChainHeight(e.database); err != nil {
+			return 0, nil, err
+		}
+		if e.toBlock <= latest {
+			return latest, nil, nil
+		}
+	}
+
+	preConfirmed, err := e.preConfirmedFn()
+	if err != nil || preConfirmed == nil || preConfirmed.Length() == 0 {
+		// No chain to derive from. This read also covers the sentinel case above.
+		latest, err = core.GetChainHeight(e.database)
+		if err != nil {
+			return 0, nil, err
+		}
+		return latest, nil, nil
+	}
+
+	return preConfirmed.Head().Block.Number - uint64(preConfirmed.Length()), preConfirmed, nil
 }
 
 func (e *EventFilter) canonicalEvents(
@@ -318,7 +329,6 @@ func (e *EventFilter) preConfirmedEvents(
 	matchedEvents []FilteredEvent,
 	preConfirmed PreConfirmedReader,
 	fromBlock,
-	latest,
 	skippedEvents,
 	chunkSize uint64,
 ) ([]FilteredEvent, ContinuationToken, error) {
@@ -337,10 +347,9 @@ func (e *EventFilter) preConfirmedEvents(
 	var err error
 	for entry := range preConfirmed.OldestFirst() {
 		blockNumber := entry.Block.Number
-		// Skip blocks the canonical scan already covered (numbers <= latest, an
-		// overlap opened by a head advance mid-query) and blocks below the resume
-		// point.
-		if blockNumber <= latest || blockNumber < fromBlock {
+		// Skip blocks below the resume point. The canonical scan stops at the head
+		// this chain was built on, so the ranges cannot overlap.
+		if blockNumber < fromBlock {
 			continue
 		}
 		if blockNumber > e.toBlock {
@@ -359,7 +368,7 @@ func (e *EventFilter) preConfirmedEvents(
 		matchedEvents, processedEvents, err = e.matcher.AppendBlockEventsFromReceipts(
 			matchedEvents,
 			blockNumber,
-			func() (*felt.Felt, error) { return header.Hash, nil },
+			header.Hash,
 			entry.Block.Receipts,
 			skippedEvents,
 			chunkSize,

--- a/blockchain/event_filter.go
+++ b/blockchain/event_filter.go
@@ -146,21 +146,30 @@ func (e *EventFilter) Events(
 	cToken *ContinuationToken,
 	chunkSize uint64,
 ) ([]FilteredEvent, ContinuationToken, error) {
-	// Read pre_confirmed before latest. If latest were read first, the head could
-	// advance before this fetch, leaving blocks committed in between scanned by
-	// neither the canonical range (stopped at the stale latest) nor pre_confirmed
-	// (based above them), a gap. This order makes latest >= the snapshot's base,
-	// so the ranges overlap instead. Pinning a fixed head wouldn't help: once a
-	// block commits, SnapshotForBlock trims it, so a stale head yields an empty
-	// view. On error, drop it and serve canonical only.
-	preConfirmed, err := e.preConfirmedFn()
-	if err != nil {
-		preConfirmed = nil
-	}
-
 	latest, err := core.GetChainHeight(e.database)
 	if err != nil {
 		return nil, ContinuationToken{}, err
+	}
+
+	// Fetch pre_confirmed only when the range can reach past the canonical head; a
+	// purely historical query never consults it. When fetched, re-read latest
+	// afterwards: with the pre-head latest, the head could advance between the two
+	// reads, leaving blocks committed in between scanned by neither the canonical
+	// range (stopped at the stale latest) nor pre_confirmed (based above them), a
+	// gap. Re-reading makes latest >= the snapshot's base, so the ranges overlap
+	// instead. Pinning a fixed head wouldn't help: once a block commits,
+	// SnapshotForBlock trims it, so a stale head yields an empty view. On error,
+	// drop it and serve canonical only.
+	var preConfirmed PreConfirmedReader
+	if e.toBlock > latest {
+		if fetched, err := e.preConfirmedFn(); err == nil {
+			preConfirmed = fetched
+		}
+
+		latest, err = core.GetChainHeight(e.database)
+		if err != nil {
+			return nil, ContinuationToken{}, err
+		}
 	}
 
 	var skippedEvents uint64
@@ -262,13 +271,7 @@ func (e *EventFilter) canonicalEvents(
 
 		lastProccessedBlock = curBlockNum
 
-		curBlockHash, err := core.GetBlockHeaderHashByNumber(e.database, curBlockNum)
-		if err != nil {
-			return nil, ContinuationToken{}, err
-		}
-
-		var receipts []*core.TransactionReceipt
-		receipts, err = core.GetReceiptsByBlockNumber(e.database, curBlockNum)
+		receipts, err := core.GetTransactionEventsByBlockNumber(e.database, curBlockNum)
 		if err != nil {
 			return nil, ContinuationToken{}, err
 		}
@@ -277,7 +280,9 @@ func (e *EventFilter) canonicalEvents(
 		matchedEvents, processedEvents, err = e.matcher.AppendBlockEvents(
 			matchedEvents,
 			curBlockNum,
-			curBlockHash,
+			func() (*felt.Felt, error) {
+				return core.GetBlockHeaderHashByNumber(e.database, curBlockNum)
+			},
 			receipts,
 			skippedEvents,
 			chunkSize,
@@ -304,6 +309,21 @@ func (e *EventFilter) canonicalEvents(
 	}
 
 	return matchedEvents, ContinuationToken{}, nil
+}
+
+// transactionEventsFromReceipts projects in-memory receipts down to the events
+// subset the matcher consumes. The adapter slice is one small allocation per
+// pre-confirmed block; an iterator would instead cost several heap escapes per
+// canonical candidate block (range-over-func closure), measured strictly worse.
+func transactionEventsFromReceipts(receipts []*core.TransactionReceipt) []core.TransactionEvents {
+	events := make([]core.TransactionEvents, len(receipts))
+	for i, receipt := range receipts {
+		events[i] = core.TransactionEvents{
+			Events:          receipt.Events,
+			TransactionHash: receipt.TransactionHash,
+		}
+	}
+	return events
 }
 
 // preConfirmedEvents processes pending events across every pre-confirmed block in
@@ -355,8 +375,8 @@ func (e *EventFilter) preConfirmedEvents(
 		matchedEvents, processedEvents, err = e.matcher.AppendBlockEvents(
 			matchedEvents,
 			blockNumber,
-			header.Hash,
-			entry.Block.Receipts,
+			func() (*felt.Felt, error) { return header.Hash, nil },
+			transactionEventsFromReceipts(entry.Block.Receipts),
 			skippedEvents,
 			chunkSize,
 		)

--- a/blockchain/event_filter.go
+++ b/blockchain/event_filter.go
@@ -271,7 +271,7 @@ func (e *EventFilter) canonicalEvents(
 
 		lastProccessedBlock = curBlockNum
 
-		receipts, err := core.GetTransactionEventsByBlockNumber(e.database, curBlockNum)
+		blockEvents, err := core.GetTransactionEventsByBlockNumber(e.database, curBlockNum)
 		if err != nil {
 			return nil, ContinuationToken{}, err
 		}
@@ -283,7 +283,7 @@ func (e *EventFilter) canonicalEvents(
 			func() (*felt.Felt, error) {
 				return core.GetBlockHeaderHashByNumber(e.database, curBlockNum)
 			},
-			receipts,
+			blockEvents,
 			skippedEvents,
 			chunkSize,
 		)
@@ -312,9 +312,8 @@ func (e *EventFilter) canonicalEvents(
 }
 
 // transactionEventsFromReceipts projects in-memory receipts down to the events
-// subset the matcher consumes. The adapter slice is one small allocation per
-// pre-confirmed block; an iterator would instead cost several heap escapes per
-// canonical candidate block (range-over-func closure), measured strictly worse.
+// subset the matcher consumes, so both event sources feed it one shape. The call
+// inlines and the slice does not escape, making the projection stack-only.
 func transactionEventsFromReceipts(receipts []*core.TransactionReceipt) []core.TransactionEvents {
 	events := make([]core.TransactionEvents, len(receipts))
 	for i, receipt := range receipts {

--- a/blockchain/event_filter.go
+++ b/blockchain/event_filter.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	"math"
+	"slices"
 
 	"github.com/NethermindEth/juno/core"
 	"github.com/NethermindEth/juno/core/felt"
@@ -34,10 +35,11 @@ type EventFilter struct {
 	preConfirmedFn func() (PreConfirmedReader, error)
 	cachedFilters  *AggregatedBloomFilterCache
 	runningFilter  *core.RunningEventFilter
-	// txEventsBuf holds the pre-confirmed receipt projection. One filter serves one
-	// request from one goroutine. Therefore the code can fill this buffer again for
-	// each chain entry and each call. The projection then makes one allocation for
-	// each filter, and not one allocation for each pre-confirmed block.
+	// txEventsBuf holds the pre-confirmed receipt projection. One goroutine uses a
+	// filter, never two at the same time, and no caller keeps the returned slice.
+	// Therefore the code can fill this buffer again for each chain entry and each
+	// call. The projection then makes one allocation for each filter, and not one
+	// allocation for each pre-confirmed block.
 	txEventsBuf []core.TransactionEvents
 }
 
@@ -323,6 +325,7 @@ func appendTransactionEvents(
 	dst []core.TransactionEvents,
 	receipts []*core.TransactionReceipt,
 ) []core.TransactionEvents {
+	dst = slices.Grow(dst, len(receipts))
 	for _, receipt := range receipts {
 		dst = append(dst, core.TransactionEvents{
 			Events:          receipt.Events,

--- a/blockchain/event_filter.go
+++ b/blockchain/event_filter.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"io"
 	"math"
-	"slices"
 
 	"github.com/NethermindEth/juno/core"
 	"github.com/NethermindEth/juno/core/felt"
@@ -35,12 +34,6 @@ type EventFilter struct {
 	preConfirmedFn func() (PreConfirmedReader, error)
 	cachedFilters  *AggregatedBloomFilterCache
 	runningFilter  *core.RunningEventFilter
-	// txEventsBuf holds the pre-confirmed receipt projection. One goroutine uses a
-	// filter, never two at the same time, and no caller keeps the returned slice.
-	// Therefore the code can fill this buffer again for each chain entry and each
-	// call. The projection then makes one allocation for each filter, and not one
-	// allocation for each pre-confirmed block.
-	txEventsBuf []core.TransactionEvents
 }
 
 type EventFilterRange uint
@@ -283,7 +276,7 @@ func (e *EventFilter) canonicalEvents(
 		}
 
 		var processedEvents uint64
-		matchedEvents, processedEvents, err = e.matcher.AppendBlockEvents(
+		matchedEvents, processedEvents, err = e.matcher.AppendBlockEventsFromTransactionEvents(
 			matchedEvents,
 			curBlockNum,
 			func() (*felt.Felt, error) {
@@ -315,24 +308,6 @@ func (e *EventFilter) canonicalEvents(
 	}
 
 	return matchedEvents, ContinuationToken{}, nil
-}
-
-// appendTransactionEvents adds the events subset of each receipt to dst. Both event
-// sources then give the matcher the same type. The caller can use dst again for each
-// block. This is safe, because the function copies only slice headers and pointers,
-// and the matcher keeps no reference to dst.
-func appendTransactionEvents(
-	dst []core.TransactionEvents,
-	receipts []*core.TransactionReceipt,
-) []core.TransactionEvents {
-	dst = slices.Grow(dst, len(receipts))
-	for _, receipt := range receipts {
-		dst = append(dst, core.TransactionEvents{
-			Events:          receipt.Events,
-			TransactionHash: receipt.TransactionHash,
-		})
-	}
-	return dst
 }
 
 // preConfirmedEvents processes pending events across every pre-confirmed block in
@@ -380,14 +355,12 @@ func (e *EventFilter) preConfirmedEvents(
 			continue
 		}
 
-		e.txEventsBuf = appendTransactionEvents(e.txEventsBuf[:0], entry.Block.Receipts)
-
 		var processedEvents uint64
-		matchedEvents, processedEvents, err = e.matcher.AppendBlockEvents(
+		matchedEvents, processedEvents, err = e.matcher.AppendBlockEventsFromReceipts(
 			matchedEvents,
 			blockNumber,
 			func() (*felt.Felt, error) { return header.Hash, nil },
-			e.txEventsBuf,
+			entry.Block.Receipts,
 			skippedEvents,
 			chunkSize,
 		)

--- a/blockchain/event_matcher.go
+++ b/blockchain/event_matcher.go
@@ -150,10 +150,18 @@ func (e *EventMatcher) getCandidateBlocksForFilterInto(filter *core.AggregatedBl
 	return nil
 }
 
-// AppendBlockEvents appends the block's events matching the filter to matchedEventsSofar.
-// blockHashFn resolves the block hash and is called on the first match only, so blocks a
-// bloom false positive let through never pay the header read.
-func (e *EventMatcher) AppendBlockEvents(
+// AppendBlockEventsFromTransactionEvents appends the events of a canonical block that
+// match the filter to matchedEventsSofar. Canonical receipts decode to the events subset
+// only. blockHashFn gets the block hash. The code calls it on the first match only, so a
+// block with no match reads no header.
+//
+// AppendBlockEventsFromReceipts holds the same loop for pre-confirmed blocks. Change both
+// functions together. One shared loop needs a call for each transaction, and the compiler
+// cannot inline that call. This costs 8-15% on both paths.
+// TestEventMatcher_BothSourcesAgree compares the two functions.
+//
+//nolint:dupl // The two sources keep separate loops on purpose. See above.
+func (e *EventMatcher) AppendBlockEventsFromTransactionEvents(
 	matchedEventsSofar []FilteredEvent,
 	blockNum uint64,
 	blockHashFn func() (*felt.Felt, error),
@@ -161,11 +169,14 @@ func (e *EventMatcher) AppendBlockEvents(
 	skippedEvents uint64,
 	chunkSize uint64,
 ) ([]FilteredEvent, uint64, error) {
-	var blockHash *felt.Felt
-	blockHashResolved := false
+	var (
+		blockHash   *felt.Felt
+		blockNumPtr *uint64
+	)
 	processedEvents := uint64(0)
 	for txIndex, txEvents := range blockEvents {
-		for i, event := range txEvents.Events {
+		txHash, events := txEvents.TransactionHash, txEvents.Events
+		for i, event := range events {
 			// if last request was interrupted mid-block, and we are still processing that block, skip events
 			// that were already processed
 			if processedEvents < skippedEvents {
@@ -188,17 +199,89 @@ func (e *EventMatcher) AppendBlockEvents(
 			}
 
 			if uint64(len(matchedEventsSofar)) < chunkSize {
-				if !blockHashResolved {
+				if blockNumPtr == nil {
 					var err error
 					if blockHash, err = blockHashFn(); err != nil {
 						return nil, 0, err
 					}
-					blockHashResolved = true
+					// Copy the block number. The address of a parameter moves the
+					// parameter to the heap at function entry, also for a block
+					// with no match.
+					num := blockNum
+					blockNumPtr = &num
 				}
 				matchedEventsSofar = append(matchedEventsSofar, FilteredEvent{
-					BlockNumber:      &blockNum,
+					BlockNumber:      blockNumPtr,
 					BlockHash:        blockHash,
-					TransactionHash:  txEvents.TransactionHash,
+					TransactionHash:  txHash,
+					TransactionIndex: uint(txIndex),
+					EventIndex:       uint(i),
+					Event:            event,
+				})
+			} else {
+				// we are at the capacity, return what we have accumulated so far and a continuation token
+				return matchedEventsSofar, processedEvents, errChunkSizeReached
+			}
+			// count the events we processed for this block to include in the continuation token
+			processedEvents++
+		}
+	}
+	return matchedEventsSofar, processedEvents, nil
+}
+
+// AppendBlockEventsFromReceipts appends the events of a pre-confirmed block that match
+// the filter to matchedEventsSofar. A pre-confirmed block holds full receipts in memory.
+// This function reads the events from the receipts, so the path needs no projection.
+// See AppendBlockEventsFromTransactionEvents for the reason the loops stay separate.
+//
+//nolint:dupl // The other source keeps its own loop on purpose. See above.
+func (e *EventMatcher) AppendBlockEventsFromReceipts(
+	matchedEventsSofar []FilteredEvent,
+	blockNum uint64,
+	blockHashFn func() (*felt.Felt, error),
+	receipts []*core.TransactionReceipt,
+	skippedEvents uint64,
+	chunkSize uint64,
+) ([]FilteredEvent, uint64, error) {
+	var (
+		blockHash   *felt.Felt
+		blockNumPtr *uint64
+	)
+	processedEvents := uint64(0)
+	for txIndex, receipt := range receipts {
+		txHash, events := receipt.TransactionHash, receipt.Events
+		for i, event := range events {
+			if processedEvents < skippedEvents {
+				processedEvents++
+				continue
+			}
+
+			if len(e.contractAddresses) > 0 {
+				contains := slices.Contains(e.contractAddresses, felt.Address(*event.From))
+				if !contains {
+					processedEvents++
+					continue
+				}
+			}
+
+			if !e.MatchesEventKeys(event.Keys) {
+				processedEvents++
+				continue
+			}
+
+			if uint64(len(matchedEventsSofar)) < chunkSize {
+				if blockNumPtr == nil {
+					var err error
+					if blockHash, err = blockHashFn(); err != nil {
+						return nil, 0, err
+					}
+					num := blockNum
+					blockNumPtr = &num
+				}
+				matchedEventsSofar = append(matchedEventsSofar, FilteredEvent{
+					BlockNumber:      blockNumPtr,
+					BlockHash:        blockHash,
+					TransactionHash:  txHash,
 					TransactionIndex: uint(txIndex),
 					EventIndex:       uint(i),
 					Event:            event,

--- a/blockchain/event_matcher.go
+++ b/blockchain/event_matcher.go
@@ -10,6 +10,9 @@ import (
 	"github.com/bits-and-blooms/bloom/v3"
 )
 
+// maxPreallocatedEvents caps the matched-events preallocation for one Events call.
+const maxPreallocatedEvents = 1024
+
 type EventMatcher struct {
 	contractAddresses    []felt.Address
 	contractAddressBytes [][]byte
@@ -150,14 +153,19 @@ func (e *EventMatcher) getCandidateBlocksForFilterInto(filter *core.AggregatedBl
 	return nil
 }
 
+// AppendBlockEvents appends the block's events matching the filter to matchedEventsSofar.
+// blockHashFn resolves the block hash and is called on the first match only, so blocks a
+// bloom false positive let through never pay the header read.
 func (e *EventMatcher) AppendBlockEvents(
 	matchedEventsSofar []FilteredEvent,
 	blockNum uint64,
-	blockHash *felt.Felt,
-	receipts []*core.TransactionReceipt,
+	blockHashFn func() (*felt.Felt, error),
+	receipts []core.TransactionEvents,
 	skippedEvents uint64,
 	chunkSize uint64,
 ) ([]FilteredEvent, uint64, error) {
+	var blockHash *felt.Felt
+	blockHashResolved := false
 	processedEvents := uint64(0)
 	for txIndex, receipt := range receipts {
 		for i, event := range receipt.Events {
@@ -183,6 +191,19 @@ func (e *EventMatcher) AppendBlockEvents(
 			}
 
 			if uint64(len(matchedEventsSofar)) < chunkSize {
+				// Preallocate for the chunk on the first match, so growth never
+				// reallocates and no-match queries never pay for it. The cap keeps
+				// an oversized chunk request from ballooning the allocation.
+				if matchedEventsSofar == nil {
+					matchedEventsSofar = make([]FilteredEvent, 0, min(chunkSize, maxPreallocatedEvents))
+				}
+				if !blockHashResolved {
+					var err error
+					if blockHash, err = blockHashFn(); err != nil {
+						return nil, 0, err
+					}
+					blockHashResolved = true
+				}
 				matchedEventsSofar = append(matchedEventsSofar, FilteredEvent{
 					BlockNumber:      &blockNum,
 					BlockHash:        blockHash,

--- a/blockchain/event_matcher.go
+++ b/blockchain/event_matcher.go
@@ -150,17 +150,13 @@ func (e *EventMatcher) getCandidateBlocksForFilterInto(filter *core.AggregatedBl
 	return nil
 }
 
-// AppendBlockEventsFromTransactionEvents appends the events of a canonical block that
-// match the filter to matchedEventsSofar. Canonical receipts decode to the events subset
-// only. blockHashFn gets the block hash. The code calls it on the first match only, so a
+// AppendBlockEventsFromTransactionEvents appends the events of one block that match
+// the filter to matchedEventsSofar. blockEvents holds the events-only projection of
+// the block's receipts. blockHashFn gets the block hash on the first match, so a
 // block with no match reads no header.
 //
-// AppendBlockEventsFromReceipts holds the same loop for pre-confirmed blocks. Change both
-// functions together. One shared loop needs a call for each transaction, and the compiler
-// cannot inline that call. This costs 8-15% on both paths.
-// TestEventMatcher_BothSourcesAgree compares the two functions.
-//
-//nolint:dupl // The two sources keep separate loops on purpose. See above.
+// AppendBlockEventsFromReceipts holds the same loop for full receipts. Change both
+// together: a shared loop needs a per-transaction call the compiler cannot inline.
 func (e *EventMatcher) AppendBlockEventsFromTransactionEvents(
 	matchedEventsSofar []FilteredEvent,
 	blockNum uint64,
@@ -170,8 +166,8 @@ func (e *EventMatcher) AppendBlockEventsFromTransactionEvents(
 	chunkSize uint64,
 ) ([]FilteredEvent, uint64, error) {
 	var (
-		blockHash   *felt.Felt
-		blockNumPtr *uint64
+		blockHash    *felt.Felt
+		hashResolved bool
 	)
 	processedEvents := uint64(0)
 	for txIndex, txEvents := range blockEvents {
@@ -199,19 +195,15 @@ func (e *EventMatcher) AppendBlockEventsFromTransactionEvents(
 			}
 
 			if uint64(len(matchedEventsSofar)) < chunkSize {
-				if blockNumPtr == nil {
+				if !hashResolved {
 					var err error
 					if blockHash, err = blockHashFn(); err != nil {
 						return nil, 0, err
 					}
-					// Copy the block number. The address of a parameter moves the
-					// parameter to the heap at function entry, also for a block
-					// with no match.
-					num := blockNum
-					blockNumPtr = &num
+					hashResolved = true
 				}
 				matchedEventsSofar = append(matchedEventsSofar, FilteredEvent{
-					BlockNumber:      blockNumPtr,
+					BlockNumber:      blockNum,
 					BlockHash:        blockHash,
 					TransactionHash:  txHash,
 					TransactionIndex: uint(txIndex),
@@ -229,24 +221,18 @@ func (e *EventMatcher) AppendBlockEventsFromTransactionEvents(
 	return matchedEventsSofar, processedEvents, nil
 }
 
-// AppendBlockEventsFromReceipts appends the events of a pre-confirmed block that match
-// the filter to matchedEventsSofar. A pre-confirmed block holds full receipts in memory.
-// This function reads the events from the receipts, so the path needs no projection.
-// See AppendBlockEventsFromTransactionEvents for the reason the loops stay separate.
-//
-//nolint:dupl // The other source keeps its own loop on purpose. See above.
+// AppendBlockEventsFromReceipts appends the events of one block that match the filter
+// to matchedEventsSofar, read from full receipts of any source. The caller holds the
+// block hash, which is nil for a source that has none, so this loop takes it directly.
+// See AppendBlockEventsFromTransactionEvents for why the loops stay separate.
 func (e *EventMatcher) AppendBlockEventsFromReceipts(
 	matchedEventsSofar []FilteredEvent,
 	blockNum uint64,
-	blockHashFn func() (*felt.Felt, error),
+	blockHash *felt.Felt,
 	receipts []*core.TransactionReceipt,
 	skippedEvents uint64,
 	chunkSize uint64,
 ) ([]FilteredEvent, uint64, error) {
-	var (
-		blockHash   *felt.Felt
-		blockNumPtr *uint64
-	)
 	processedEvents := uint64(0)
 	for txIndex, receipt := range receipts {
 		txHash, events := receipt.TransactionHash, receipt.Events
@@ -270,16 +256,8 @@ func (e *EventMatcher) AppendBlockEventsFromReceipts(
 			}
 
 			if uint64(len(matchedEventsSofar)) < chunkSize {
-				if blockNumPtr == nil {
-					var err error
-					if blockHash, err = blockHashFn(); err != nil {
-						return nil, 0, err
-					}
-					num := blockNum
-					blockNumPtr = &num
-				}
 				matchedEventsSofar = append(matchedEventsSofar, FilteredEvent{
-					BlockNumber:      blockNumPtr,
+					BlockNumber:      blockNum,
 					BlockHash:        blockHash,
 					TransactionHash:  txHash,
 					TransactionIndex: uint(txIndex),

--- a/blockchain/event_matcher.go
+++ b/blockchain/event_matcher.go
@@ -10,9 +10,6 @@ import (
 	"github.com/bits-and-blooms/bloom/v3"
 )
 
-// maxPreallocatedEvents caps the matched-events preallocation for one Events call.
-const maxPreallocatedEvents = 1024
-
 type EventMatcher struct {
 	contractAddresses    []felt.Address
 	contractAddressBytes [][]byte
@@ -160,15 +157,15 @@ func (e *EventMatcher) AppendBlockEvents(
 	matchedEventsSofar []FilteredEvent,
 	blockNum uint64,
 	blockHashFn func() (*felt.Felt, error),
-	receipts []core.TransactionEvents,
+	blockEvents []core.TransactionEvents,
 	skippedEvents uint64,
 	chunkSize uint64,
 ) ([]FilteredEvent, uint64, error) {
 	var blockHash *felt.Felt
 	blockHashResolved := false
 	processedEvents := uint64(0)
-	for txIndex, receipt := range receipts {
-		for i, event := range receipt.Events {
+	for txIndex, txEvents := range blockEvents {
+		for i, event := range txEvents.Events {
 			// if last request was interrupted mid-block, and we are still processing that block, skip events
 			// that were already processed
 			if processedEvents < skippedEvents {
@@ -191,12 +188,6 @@ func (e *EventMatcher) AppendBlockEvents(
 			}
 
 			if uint64(len(matchedEventsSofar)) < chunkSize {
-				// Preallocate for the chunk on the first match, so growth never
-				// reallocates and no-match queries never pay for it. The cap keeps
-				// an oversized chunk request from ballooning the allocation.
-				if matchedEventsSofar == nil {
-					matchedEventsSofar = make([]FilteredEvent, 0, min(chunkSize, maxPreallocatedEvents))
-				}
 				if !blockHashResolved {
 					var err error
 					if blockHash, err = blockHashFn(); err != nil {
@@ -207,7 +198,7 @@ func (e *EventMatcher) AppendBlockEvents(
 				matchedEventsSofar = append(matchedEventsSofar, FilteredEvent{
 					BlockNumber:      &blockNum,
 					BlockHash:        blockHash,
-					TransactionHash:  receipt.TransactionHash,
+					TransactionHash:  txEvents.TransactionHash,
 					TransactionIndex: uint(txIndex),
 					EventIndex:       uint(i),
 					Event:            event,

--- a/blockchain/event_matcher_test.go
+++ b/blockchain/event_matcher_test.go
@@ -1,9 +1,11 @@
 package blockchain_test
 
 import (
+	"errors"
 	"testing"
 
 	"github.com/NethermindEth/juno/blockchain"
+	"github.com/NethermindEth/juno/core"
 	"github.com/NethermindEth/juno/core/felt"
 	"github.com/stretchr/testify/require"
 )
@@ -238,4 +240,98 @@ func TestEventMatcher_MatchesEventKeys(t *testing.T) {
 			require.Equal(t, tc.expected, result)
 		})
 	}
+}
+
+func TestEventMatcher_AppendBlockEvents(t *testing.T) {
+	emitter := felt.NewFromUint64[felt.Felt](0xa)
+	otherEmitter := felt.NewFromUint64[felt.Felt](0xb)
+	blockHash := felt.NewFromUint64[felt.Felt](0xc0ffee)
+
+	// Two transactions, two events each; all four from emitter.
+	blockEvents := []core.TransactionEvents{
+		{
+			TransactionHash: felt.NewFromUint64[felt.Felt](0x1),
+			Events: []*core.Event{
+				{From: emitter, Keys: []felt.Felt{felt.FromUint64[felt.Felt](0x11)}},
+				{From: emitter, Keys: []felt.Felt{felt.FromUint64[felt.Felt](0x12)}},
+			},
+		},
+		{
+			TransactionHash: felt.NewFromUint64[felt.Felt](0x2),
+			Events: []*core.Event{
+				{From: emitter, Keys: []felt.Felt{felt.FromUint64[felt.Felt](0x21)}},
+				{From: emitter, Keys: []felt.Felt{felt.FromUint64[felt.Felt](0x22)}},
+			},
+		},
+	}
+
+	countingHashFn := func(calls *int) func() (*felt.Felt, error) {
+		return func() (*felt.Felt, error) {
+			*calls++
+			return blockHash, nil
+		}
+	}
+
+	t.Run("no match resolves no hash", func(t *testing.T) {
+		matcher := blockchain.NewEventMatcher([]felt.Address{felt.Address(*otherEmitter)}, nil)
+		calls := 0
+		matched, processed, err := matcher.AppendBlockEvents(
+			nil, 1, countingHashFn(&calls), blockEvents, 0, 10,
+		)
+		require.NoError(t, err)
+		require.Empty(t, matched)
+		require.Equal(t, uint64(4), processed)
+		require.Zero(t, calls, "block hash must not be resolved when nothing matches")
+	})
+
+	t.Run("matches resolve the hash once and stamp every event", func(t *testing.T) {
+		matcher := blockchain.NewEventMatcher(nil, nil)
+		calls := 0
+		matched, processed, err := matcher.AppendBlockEvents(
+			nil, 1, countingHashFn(&calls), blockEvents, 0, 10,
+		)
+		require.NoError(t, err)
+		require.Len(t, matched, 4)
+		require.Equal(t, uint64(4), processed)
+		require.Equal(t, 1, calls, "block hash must be resolved exactly once per block")
+		for i, event := range matched {
+			require.Equal(t, blockHash, event.BlockHash)
+			require.Equal(t, blockEvents[i/2].TransactionHash, event.TransactionHash)
+			require.Equal(t, uint(i/2), event.TransactionIndex)
+			require.Equal(t, uint(i%2), event.EventIndex)
+		}
+	})
+
+	t.Run("hash resolution failure surfaces", func(t *testing.T) {
+		matcher := blockchain.NewEventMatcher(nil, nil)
+		hashErr := errors.New("header gone")
+		matched, processed, err := matcher.AppendBlockEvents(
+			nil, 1, func() (*felt.Felt, error) { return nil, hashErr }, blockEvents, 0, 10,
+		)
+		require.ErrorIs(t, err, hashErr)
+		require.Nil(t, matched)
+		require.Zero(t, processed)
+	})
+
+	t.Run("chunk limit stops mid-block and resumes via skipped events", func(t *testing.T) {
+		matcher := blockchain.NewEventMatcher(nil, nil)
+		calls := 0
+		firstPage, processed, err := matcher.AppendBlockEvents(
+			nil, 1, countingHashFn(&calls), blockEvents, 0, 2,
+		)
+		require.Error(t, err, "hitting the chunk limit must signal a continuation")
+		require.Len(t, firstPage, 2)
+		require.Equal(t, uint64(2), processed)
+
+		calls = 0
+		secondPage, processed, err := matcher.AppendBlockEvents(
+			nil, 1, countingHashFn(&calls), blockEvents, processed, 10,
+		)
+		require.NoError(t, err)
+		require.Len(t, secondPage, 2)
+		require.Equal(t, uint64(4), processed)
+		require.Equal(t, 1, calls)
+		require.Equal(t, uint(1), secondPage[0].TransactionIndex)
+		require.Equal(t, uint(0), secondPage[0].EventIndex)
+	})
 }

--- a/blockchain/event_matcher_test.go
+++ b/blockchain/event_matcher_test.go
@@ -275,7 +275,7 @@ func TestEventMatcher_AppendBlockEvents(t *testing.T) {
 	t.Run("no match resolves no hash", func(t *testing.T) {
 		matcher := blockchain.NewEventMatcher([]felt.Address{felt.Address(*otherEmitter)}, nil)
 		calls := 0
-		matched, processed, err := matcher.AppendBlockEvents(
+		matched, processed, err := matcher.AppendBlockEventsFromTransactionEvents(
 			nil, 1, countingHashFn(&calls), blockEvents, 0, 10,
 		)
 		require.NoError(t, err)
@@ -287,7 +287,7 @@ func TestEventMatcher_AppendBlockEvents(t *testing.T) {
 	t.Run("matches resolve the hash once and stamp every event", func(t *testing.T) {
 		matcher := blockchain.NewEventMatcher(nil, nil)
 		calls := 0
-		matched, processed, err := matcher.AppendBlockEvents(
+		matched, processed, err := matcher.AppendBlockEventsFromTransactionEvents(
 			nil, 1, countingHashFn(&calls), blockEvents, 0, 10,
 		)
 		require.NoError(t, err)
@@ -305,7 +305,7 @@ func TestEventMatcher_AppendBlockEvents(t *testing.T) {
 	t.Run("hash resolution failure surfaces", func(t *testing.T) {
 		matcher := blockchain.NewEventMatcher(nil, nil)
 		hashErr := errors.New("header gone")
-		matched, processed, err := matcher.AppendBlockEvents(
+		matched, processed, err := matcher.AppendBlockEventsFromTransactionEvents(
 			nil, 1, func() (*felt.Felt, error) { return nil, hashErr }, blockEvents, 0, 10,
 		)
 		require.ErrorIs(t, err, hashErr)
@@ -316,7 +316,7 @@ func TestEventMatcher_AppendBlockEvents(t *testing.T) {
 	t.Run("chunk limit stops mid-block and resumes via skipped events", func(t *testing.T) {
 		matcher := blockchain.NewEventMatcher(nil, nil)
 		calls := 0
-		firstPage, processed, err := matcher.AppendBlockEvents(
+		firstPage, processed, err := matcher.AppendBlockEventsFromTransactionEvents(
 			nil, 1, countingHashFn(&calls), blockEvents, 0, 2,
 		)
 		// errChunkSizeReached is not exported. Therefore compare the message and do
@@ -326,7 +326,7 @@ func TestEventMatcher_AppendBlockEvents(t *testing.T) {
 		require.Equal(t, uint64(2), processed)
 
 		calls = 0
-		secondPage, processed, err := matcher.AppendBlockEvents(
+		secondPage, processed, err := matcher.AppendBlockEventsFromTransactionEvents(
 			nil, 1, countingHashFn(&calls), blockEvents, processed, 10,
 		)
 		require.NoError(t, err)
@@ -335,5 +335,107 @@ func TestEventMatcher_AppendBlockEvents(t *testing.T) {
 		require.Equal(t, 1, calls)
 		require.Equal(t, uint(1), secondPage[0].TransactionIndex)
 		require.Equal(t, uint(0), secondPage[0].EventIndex)
+	})
+
+	t.Run("a block with no match allocates nothing", func(t *testing.T) {
+		matcher := blockchain.NewEventMatcher([]felt.Address{felt.Address(*otherEmitter)}, nil)
+		// Build the hash function outside the measured body. A closure that captures a
+		// variable is one allocation of the test.
+		calls := 0
+		hashFn := countingHashFn(&calls)
+		allocs := testing.AllocsPerRun(100, func() {
+			_, _, err := matcher.AppendBlockEventsFromTransactionEvents(nil, 1, hashFn, blockEvents, 0, 10)
+			require.NoError(t, err)
+		})
+		require.Zero(t, allocs)
+		require.Zero(t, calls)
+	})
+}
+
+func constHashFn(hash *felt.Felt) func() (*felt.Felt, error) {
+	return func() (*felt.Felt, error) {
+		return hash, nil
+	}
+}
+
+// TestEventMatcher_BothSourcesAgree compares the two loops of event_matcher.go. The loops
+// hold the same logic for two event sources. Therefore they must give the same result for
+// each filter, resume point and chunk size.
+func TestEventMatcher_BothSourcesAgree(t *testing.T) {
+	emitters := []*felt.Felt{
+		felt.NewFromUint64[felt.Felt](0xa),
+		felt.NewFromUint64[felt.Felt](0xb),
+		felt.NewFromUint64[felt.Felt](0xc),
+	}
+	blockHash := felt.NewFromUint64[felt.Felt](0xc0ffee)
+	hashFn := constHashFn(blockHash)
+	absent := felt.Address(*felt.NewFromUint64[felt.Felt](0xdead))
+
+	// Five transactions, three events each. The emitters and the keys repeat in a cycle.
+	// An address filter and a key filter then each select a subset.
+	const txCount, eventsPerTx = 5, 3
+	txEvents := make([]core.TransactionEvents, txCount)
+	receipts := make([]*core.TransactionReceipt, txCount)
+	for i := range txCount {
+		events := make([]*core.Event, eventsPerTx)
+		for j := range eventsPerTx {
+			events[j] = &core.Event{
+				From: emitters[(i*eventsPerTx+j)%len(emitters)],
+				Keys: []felt.Felt{felt.FromUint64[felt.Felt](uint64(j))},
+			}
+		}
+		hash := felt.NewFromUint64[felt.Felt](uint64(i))
+		txEvents[i] = core.TransactionEvents{TransactionHash: hash, Events: events}
+		receipts[i] = &core.TransactionReceipt{TransactionHash: hash, Events: events}
+	}
+
+	testCases := []struct {
+		name      string
+		addresses []felt.Address
+		keys      [][]felt.Felt
+	}{
+		{name: "no filter"},
+		{name: "address filter", addresses: []felt.Address{felt.Address(*emitters[1])}},
+		{name: "absent address", addresses: []felt.Address{absent}},
+		{name: "key filter", keys: [][]felt.Felt{{felt.FromUint64[felt.Felt](1)}}},
+		{
+			name:      "address and key filter",
+			addresses: []felt.Address{felt.Address(*emitters[0])},
+			keys:      [][]felt.Felt{{felt.FromUint64[felt.Felt](0)}},
+		},
+	}
+
+	// Full pages, chunk limits that stop inside the block, and resume points.
+	chunkSizes := []uint64{0, 1, 4, 15, 100}
+	skips := []uint64{0, 1, 7, 15}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			matcher := blockchain.NewEventMatcher(tc.addresses, tc.keys)
+			for _, chunkSize := range chunkSizes {
+				for _, skipped := range skips {
+					wantEvents, wantProcessed, wantErr := matcher.AppendBlockEventsFromTransactionEvents(
+						nil, 7, hashFn, txEvents, skipped, chunkSize,
+					)
+					gotEvents, gotProcessed, gotErr := matcher.AppendBlockEventsFromReceipts(
+						nil, 7, hashFn, receipts, skipped, chunkSize,
+					)
+
+					msg := "chunkSize=%d skipped=%d"
+					require.Equal(t, wantErr, gotErr, msg, chunkSize, skipped)
+					require.Equal(t, wantProcessed, gotProcessed, msg, chunkSize, skipped)
+					require.Equal(t, wantEvents, gotEvents, msg, chunkSize, skipped)
+				}
+			}
+		})
+	}
+
+	t.Run("a pre-confirmed block with no match allocates nothing", func(t *testing.T) {
+		matcher := blockchain.NewEventMatcher([]felt.Address{absent}, nil)
+		allocs := testing.AllocsPerRun(100, func() {
+			_, _, err := matcher.AppendBlockEventsFromReceipts(nil, 7, hashFn, receipts, 0, 100)
+			require.NoError(t, err)
+		})
+		require.Zero(t, allocs)
 	})
 }

--- a/blockchain/event_matcher_test.go
+++ b/blockchain/event_matcher_test.go
@@ -319,7 +319,9 @@ func TestEventMatcher_AppendBlockEvents(t *testing.T) {
 		firstPage, processed, err := matcher.AppendBlockEvents(
 			nil, 1, countingHashFn(&calls), blockEvents, 0, 2,
 		)
-		require.Error(t, err, "hitting the chunk limit must signal a continuation")
+		// errChunkSizeReached is not exported. Therefore compare the message and do
+		// not use ErrorIs.
+		require.EqualError(t, err, "chunk size reached")
 		require.Len(t, firstPage, 2)
 		require.Equal(t, uint64(2), processed)
 

--- a/blockchain/event_matcher_test.go
+++ b/blockchain/event_matcher_test.go
@@ -319,8 +319,6 @@ func TestEventMatcher_AppendBlockEvents(t *testing.T) {
 		firstPage, processed, err := matcher.AppendBlockEventsFromTransactionEvents(
 			nil, 1, countingHashFn(&calls), blockEvents, 0, 2,
 		)
-		// errChunkSizeReached is not exported. Therefore compare the message and do
-		// not use ErrorIs.
 		require.EqualError(t, err, "chunk size reached")
 		require.Len(t, firstPage, 2)
 		require.Equal(t, uint64(2), processed)
@@ -339,8 +337,6 @@ func TestEventMatcher_AppendBlockEvents(t *testing.T) {
 
 	t.Run("a block with no match allocates nothing", func(t *testing.T) {
 		matcher := blockchain.NewEventMatcher([]felt.Address{felt.Address(*otherEmitter)}, nil)
-		// Build the hash function outside the measured body. A closure that captures a
-		// variable is one allocation of the test.
 		calls := 0
 		hashFn := countingHashFn(&calls)
 		allocs := testing.AllocsPerRun(100, func() {
@@ -358,9 +354,6 @@ func constHashFn(hash *felt.Felt) func() (*felt.Felt, error) {
 	}
 }
 
-// TestEventMatcher_BothSourcesAgree compares the two loops of event_matcher.go. The loops
-// hold the same logic for two event sources. Therefore they must give the same result for
-// each filter, resume point and chunk size.
 func TestEventMatcher_BothSourcesAgree(t *testing.T) {
 	emitters := []*felt.Felt{
 		felt.NewFromUint64[felt.Felt](0xa),
@@ -371,8 +364,6 @@ func TestEventMatcher_BothSourcesAgree(t *testing.T) {
 	hashFn := constHashFn(blockHash)
 	absent := felt.Address(*felt.NewFromUint64[felt.Felt](0xdead))
 
-	// Five transactions, three events each. The emitters and the keys repeat in a cycle.
-	// An address filter and a key filter then each select a subset.
 	const txCount, eventsPerTx = 5, 3
 	txEvents := make([]core.TransactionEvents, txCount)
 	receipts := make([]*core.TransactionReceipt, txCount)
@@ -418,7 +409,7 @@ func TestEventMatcher_BothSourcesAgree(t *testing.T) {
 						nil, 7, hashFn, txEvents, skipped, chunkSize,
 					)
 					gotEvents, gotProcessed, gotErr := matcher.AppendBlockEventsFromReceipts(
-						nil, 7, hashFn, receipts, skipped, chunkSize,
+						nil, 7, blockHash, receipts, skipped, chunkSize,
 					)
 
 					msg := "chunkSize=%d skipped=%d"
@@ -433,7 +424,7 @@ func TestEventMatcher_BothSourcesAgree(t *testing.T) {
 	t.Run("a pre-confirmed block with no match allocates nothing", func(t *testing.T) {
 		matcher := blockchain.NewEventMatcher([]felt.Address{absent}, nil)
 		allocs := testing.AllocsPerRun(100, func() {
-			_, _, err := matcher.AppendBlockEventsFromReceipts(nil, 7, hashFn, receipts, 0, 100)
+			_, _, err := matcher.AppendBlockEventsFromReceipts(nil, 7, blockHash, receipts, 0, 100)
 			require.NoError(t, err)
 		})
 		require.Zero(t, allocs)

--- a/core/accessors.go
+++ b/core/accessors.go
@@ -496,6 +496,15 @@ func GetReceiptsByBlockNumber(
 	return BlockTransactionsAllReceiptsPartialBucket.Get(r, blockNumber, struct{}{})
 }
 
+// GetTransactionEventsByBlockNumber returns only the events subset of every receipt
+// in a given block, skipping the heavier receipt fields.
+func GetTransactionEventsByBlockNumber(
+	r db.KeyValueReader,
+	blockNumber uint64,
+) ([]TransactionEvents, error) {
+	return BlockTransactionsAllTransactionEventsPartialBucket.Get(r, blockNumber, struct{}{})
+}
+
 // GetReceiptByBlockAndIndex returns a receipt by block number and transaction index
 func GetReceiptByBlockAndIndex(
 	r db.KeyValueReader,

--- a/core/accessors.go
+++ b/core/accessors.go
@@ -496,8 +496,8 @@ func GetReceiptsByBlockNumber(
 	return BlockTransactionsAllReceiptsPartialBucket.Get(r, blockNumber, struct{}{})
 }
 
-// GetTransactionEventsByBlockNumber returns only the events subset of every receipt
-// in a given block, skipping the heavier receipt fields.
+// GetTransactionEventsByBlockNumber returns the events subset of every receipt in the
+// block. It skips the heavier receipt fields.
 func GetTransactionEventsByBlockNumber(
 	r db.KeyValueReader,
 	blockNumber uint64,

--- a/core/accessors_test.go
+++ b/core/accessors_test.go
@@ -211,6 +211,35 @@ func TestGetReceiptByBlockAndIndex(t *testing.T) {
 	})
 }
 
+func TestGetTransactionEventsByBlockNumber(t *testing.T) {
+	t.Parallel()
+	memDB, block := setupForTxsAndReceiptsTests(t)
+
+	t.Run("valid block", func(t *testing.T) {
+		t.Parallel()
+		require.NotEmpty(t, block.Receipts)
+		events, err := core.GetTransactionEventsByBlockNumber(memDB, block.Number)
+		require.NoError(t, err)
+
+		// The partial decode must recover the same events the full receipts carry.
+		full, err := core.GetReceiptsByBlockNumber(memDB, block.Number)
+		require.NoError(t, err)
+		require.Len(t, events, len(full))
+		for i, receipt := range full {
+			assert.Equal(t, core.TransactionEvents{
+				Events:          receipt.Events,
+				TransactionHash: receipt.TransactionHash,
+			}, events[i])
+		}
+	})
+
+	t.Run("non-existent block", func(t *testing.T) {
+		t.Parallel()
+		_, err := core.GetTransactionEventsByBlockNumber(memDB, nonexistentBlockNumber)
+		require.ErrorIs(t, err, db.ErrKeyNotFound)
+	})
+}
+
 func TestGetTransactionExecutionStatusByBlockAndIndex(t *testing.T) {
 	t.Parallel()
 	memDB, block := setupForTxsAndReceiptsTests(t)

--- a/core/accessors_test.go
+++ b/core/accessors_test.go
@@ -256,6 +256,35 @@ func TestGetTransactionAndReceiptByBlockAndIndex(t *testing.T) {
 	})
 }
 
+func TestGetTransactionEventsByBlockNumber(t *testing.T) {
+	t.Parallel()
+	memDB, block := setupForTxsAndReceiptsTests(t)
+
+	t.Run("valid block", func(t *testing.T) {
+		t.Parallel()
+		require.NotEmpty(t, block.Receipts)
+		events, err := core.GetTransactionEventsByBlockNumber(memDB, block.Number)
+		require.NoError(t, err)
+
+		// The partial decode must recover the same events the full receipts carry.
+		full, err := core.GetReceiptsByBlockNumber(memDB, block.Number)
+		require.NoError(t, err)
+		require.Len(t, events, len(full))
+		for i, receipt := range full {
+			assert.Equal(t, core.TransactionEvents{
+				Events:          receipt.Events,
+				TransactionHash: receipt.TransactionHash,
+			}, events[i])
+		}
+	})
+
+	t.Run("non-existent block", func(t *testing.T) {
+		t.Parallel()
+		_, err := core.GetTransactionEventsByBlockNumber(memDB, nonexistentBlockNumber)
+		require.ErrorIs(t, err, db.ErrKeyNotFound)
+	})
+}
+
 func TestGetTransactionExecutionStatusByBlockAndIndex(t *testing.T) {
 	t.Parallel()
 	memDB, block := setupForTxsAndReceiptsTests(t)

--- a/core/block_transaction.go
+++ b/core/block_transaction.go
@@ -100,3 +100,12 @@ type executionStatusProjectionSlice = indexed.LazySlice[receiptExecutionStatusPr
 func (b *BlockTransactions) executionStatusProjections() executionStatusProjectionSlice {
 	return indexed.NewLazySlice[receiptExecutionStatusProjection](b.Indexes.Receipts, b.Data)
 }
+
+// transactionEventsProjectionSlice is the lazily-decoded slice of events projections.
+type transactionEventsProjectionSlice = indexed.LazySlice[receiptEventsProjection]
+
+// transactionEventsProjections decodes receipts into the events subset, skipping the
+// heavier receipt fields.
+func (b *BlockTransactions) transactionEventsProjections() transactionEventsProjectionSlice {
+	return indexed.NewLazySlice[receiptEventsProjection](b.Indexes.Receipts, b.Data)
+}

--- a/core/block_transaction.go
+++ b/core/block_transaction.go
@@ -106,3 +106,12 @@ type executionStatusProjectionSlice = indexed.LazySlice[receiptExecutionStatusPr
 func (b *BlockTransactions) executionStatusProjections() executionStatusProjectionSlice {
 	return indexed.NewLazySlice[receiptExecutionStatusProjection](b.Indexes.Receipts, b.Data)
 }
+
+// transactionEventsProjectionSlice is the lazily-decoded slice of events projections.
+type transactionEventsProjectionSlice = indexed.LazySlice[receiptEventsProjection]
+
+// transactionEventsProjections decodes receipts into the events subset, skipping the
+// heavier receipt fields.
+func (b *BlockTransactions) transactionEventsProjections() transactionEventsProjectionSlice {
+	return indexed.NewLazySlice[receiptEventsProjection](b.Indexes.Receipts, b.Data)
+}

--- a/core/block_transaction.go
+++ b/core/block_transaction.go
@@ -110,8 +110,7 @@ func (b *BlockTransactions) executionStatusProjections() executionStatusProjecti
 // transactionEventsProjectionSlice is the lazily-decoded slice of events projections.
 type transactionEventsProjectionSlice = indexed.LazySlice[receiptEventsProjection]
 
-// transactionEventsProjections decodes receipts into the events subset, skipping the
-// heavier receipt fields.
+// transactionEventsProjections decodes receipts into the events subset only.
 func (b *BlockTransactions) transactionEventsProjections() transactionEventsProjectionSlice {
 	return indexed.NewLazySlice[receiptEventsProjection](b.Indexes.Receipts, b.Data)
 }

--- a/core/block_transaction_serializer.go
+++ b/core/block_transaction_serializer.go
@@ -97,16 +97,15 @@ func (extractAllTransactionEvents) extract(
 	_ struct{},
 ) ([]TransactionEvents, error) {
 	projections := b.transactionEventsProjections()
-	events := make([]TransactionEvents, len(b.Indexes.Receipts))
-	for i := range events {
-		projection, err := projections.Get(i)
+	events := make([]TransactionEvents, 0, len(b.Indexes.Receipts))
+	for projection, err := range projections.Iter() {
 		if err != nil {
 			return nil, err
 		}
-		events[i] = TransactionEvents{
+		events = append(events, TransactionEvents{
 			Events:          projection.Events,
 			TransactionHash: projection.TransactionHash,
-		}
+		})
 	}
 	return events, nil
 }

--- a/core/block_transaction_serializer.go
+++ b/core/block_transaction_serializer.go
@@ -70,6 +70,27 @@ func (extractAllReceipts) extract(b *BlockTransactions, _ struct{}) ([]*Transact
 	return b.Receipts().All()
 }
 
+type extractAllTransactionEvents struct{}
+
+func (extractAllTransactionEvents) extract(
+	b *BlockTransactions,
+	_ struct{},
+) ([]TransactionEvents, error) {
+	projections := b.transactionEventsProjections()
+	events := make([]TransactionEvents, len(b.Indexes.Receipts))
+	for i := range events {
+		projection, err := projections.Get(i)
+		if err != nil {
+			return nil, err
+		}
+		events[i] = TransactionEvents{
+			Events:          projection.Events,
+			TransactionHash: projection.TransactionHash,
+		}
+	}
+	return events, nil
+}
+
 type extractAll struct{}
 
 func (extractAll) extract(b *BlockTransactions, _ struct{}) (BlockTransactions, error) {
@@ -121,5 +142,10 @@ var (
 		extractAllReceipts,
 		struct{},
 		[]*TransactionReceipt,
+	]{}
+	BlockTransactionsAllTransactionEventsPartialSerializer = blockTransactionsPartialSerializer[
+		extractAllTransactionEvents,
+		struct{},
+		[]TransactionEvents,
 	]{}
 )

--- a/core/block_transaction_serializer.go
+++ b/core/block_transaction_serializer.go
@@ -90,6 +90,27 @@ func (extractAllReceipts) extract(b *BlockTransactions, _ struct{}) ([]*Transact
 	return b.Receipts().All()
 }
 
+type extractAllTransactionEvents struct{}
+
+func (extractAllTransactionEvents) extract(
+	b *BlockTransactions,
+	_ struct{},
+) ([]TransactionEvents, error) {
+	projections := b.transactionEventsProjections()
+	events := make([]TransactionEvents, len(b.Indexes.Receipts))
+	for i := range events {
+		projection, err := projections.Get(i)
+		if err != nil {
+			return nil, err
+		}
+		events[i] = TransactionEvents{
+			Events:          projection.Events,
+			TransactionHash: projection.TransactionHash,
+		}
+	}
+	return events, nil
+}
+
 type extractAll struct{}
 
 func (extractAll) extract(b *BlockTransactions, _ struct{}) (BlockTransactions, error) {
@@ -146,5 +167,10 @@ var (
 		extractAllReceipts,
 		struct{},
 		[]*TransactionReceipt,
+	]{}
+	BlockTransactionsAllTransactionEventsPartialSerializer = blockTransactionsPartialSerializer[
+		extractAllTransactionEvents,
+		struct{},
+		[]TransactionEvents,
 	]{}
 )

--- a/core/block_transaction_test.go
+++ b/core/block_transaction_test.go
@@ -149,6 +149,23 @@ func TestBlockTransactionsSerializer(t *testing.T) {
 		)
 	})
 
+	t.Run("BlockTransactionsAllTransactionEventsPartialSerializer", func(t *testing.T) {
+		expected := make([]core.TransactionEvents, len(receipts))
+		for i, receipt := range receipts {
+			expected[i] = core.TransactionEvents{
+				Events:          receipt.Events,
+				TransactionHash: receipt.TransactionHash,
+			}
+		}
+		assertPartialSerializer(
+			t,
+			core.BlockTransactionsAllTransactionEventsPartialSerializer,
+			struct{}{},
+			expected,
+			serialised,
+		)
+	})
+
 	t.Run("BlockTransactionsExecutionStatusPartialSerializer", func(t *testing.T) {
 		for i := range transactionCount {
 			assertPartialSerializer(

--- a/core/partial_cbor.go
+++ b/core/partial_cbor.go
@@ -104,3 +104,9 @@ type receiptExecutionStatusProjection struct {
 	Reverted     bool
 	RevertReason string
 }
+
+type receiptEventsProjection struct {
+	discardedReceiptSkeleton
+	Events          []*Event
+	TransactionHash *felt.Felt
+}

--- a/core/partial_cbor_test.go
+++ b/core/partial_cbor_test.go
@@ -329,8 +329,9 @@ func TestProjectionsAreDecodeOnly(t *testing.T) {
 
 // --- Receipt projections ---
 
-// sampleReceipt is a reverted receipt with distinct values, so its encoding exercises every
-// TransactionReceipt key and the projection assertions can check their shadowed fields.
+// sampleReceipt is a reverted receipt with every field populated with distinct values, so its
+// encoding exercises every TransactionReceipt key with realistic nested payloads and the
+// projection assertions can check their shadowed fields.
 func sampleReceipt() *TransactionReceipt {
 	return &TransactionReceipt{
 		Fee:             felt.NewFromUint64[felt.Felt](1),
@@ -342,6 +343,17 @@ func sampleReceipt() *TransactionReceipt {
 			Keys: []felt.Felt{felt.FromUint64[felt.Felt](4)},
 			Data: []felt.Felt{felt.FromUint64[felt.Felt](5)},
 		}},
+		ExecutionResources: &ExecutionResources{
+			BuiltinInstanceCounter: BuiltinInstanceCounter{
+				Pedersen:   6,
+				RangeCheck: 7,
+				Poseidon:   8,
+			},
+			MemoryHoles:      9,
+			Steps:            10,
+			DataAvailability: &DataAvailability{L1Gas: 11, L1DataGas: 12},
+			TotalGasConsumed: &GasConsumed{L1Gas: 13, L1DataGas: 14, L2Gas: 15},
+		},
 	}
 }
 
@@ -424,6 +436,26 @@ func BenchmarkPartialHeaderProjections(b *testing.B) {
 			})
 		})
 	}
+}
+
+// BenchmarkTransactionEventsProjection compares decoding a receipt in full against decoding
+// only the events subset getEvents filtering needs, via the discard projection.
+func BenchmarkTransactionEventsProjection(b *testing.B) {
+	data := sampleReceiptBytes(b)
+	b.Run("full_receipt", func(b *testing.B) {
+		b.ReportAllocs()
+		for b.Loop() {
+			var r TransactionReceipt
+			_ = encoder.Unmarshal(data, &r)
+		}
+	})
+	b.Run("events_projection", func(b *testing.B) {
+		b.ReportAllocs()
+		for b.Loop() {
+			var r receiptEventsProjection
+			_ = encoder.Unmarshal(data, &r)
+		}
+	})
 }
 
 // BenchmarkExecutionStatusProjection compares decoding the execution-status subset via the naive

--- a/core/partial_cbor_test.go
+++ b/core/partial_cbor_test.go
@@ -329,9 +329,8 @@ func TestProjectionsAreDecodeOnly(t *testing.T) {
 
 // --- Receipt projections ---
 
-// sampleReceipt is a reverted receipt with every field populated with distinct values, so its
-// encoding exercises every TransactionReceipt key with realistic nested payloads and the
-// projection assertions can check their shadowed fields.
+// sampleReceipt is a reverted receipt with a distinct value in every field, so its encoding
+// holds every TransactionReceipt key, nested payloads included.
 func sampleReceipt() *TransactionReceipt {
 	return &TransactionReceipt{
 		Fee:             felt.NewFromUint64[felt.Felt](1),
@@ -405,8 +404,8 @@ func TestExecutionStatusProjectionDecodesShadowedFields(t *testing.T) {
 		"RevertReason must receive the wire value, not discardedCBOR")
 }
 
-// TestEventsProjectionDecodesShadowedFields proves the shadowing fields receive the wire values,
-// not discardedCBOR — a change in cbor's embed precedence would slip past the key guards.
+// TestEventsProjectionDecodesShadowedFields checks the shadowing fields get the wire values,
+// not discardedCBOR. A change in cbor's embed precedence passes the key guards.
 func TestEventsProjectionDecodesShadowedFields(t *testing.T) {
 	receipt := sampleReceipt()
 	var projection receiptEventsProjection
@@ -438,8 +437,8 @@ func BenchmarkPartialHeaderProjections(b *testing.B) {
 	}
 }
 
-// BenchmarkTransactionEventsProjection compares decoding a receipt in full against decoding
-// only the events subset getEvents filtering needs, via the discard projection.
+// BenchmarkTransactionEventsProjection compares a full receipt decode against the
+// events-subset decode.
 func BenchmarkTransactionEventsProjection(b *testing.B) {
 	data := sampleReceiptBytes(b)
 	b.Run("full_receipt", func(b *testing.B) {

--- a/core/partial_cbor_test.go
+++ b/core/partial_cbor_test.go
@@ -330,13 +330,18 @@ func TestProjectionsAreDecodeOnly(t *testing.T) {
 // --- Receipt projections ---
 
 // sampleReceipt is a reverted receipt with distinct values, so its encoding exercises every
-// TransactionReceipt key and the execution-status assertions can check Reverted and RevertReason.
+// TransactionReceipt key and the projection assertions can check their shadowed fields.
 func sampleReceipt() *TransactionReceipt {
 	return &TransactionReceipt{
 		Fee:             felt.NewFromUint64[felt.Felt](1),
 		TransactionHash: felt.NewFromUint64[felt.Felt](2),
 		Reverted:        true,
 		RevertReason:    "sample revert reason",
+		Events: []*Event{{
+			From: felt.NewFromUint64[felt.Felt](3),
+			Keys: []felt.Felt{felt.FromUint64[felt.Felt](4)},
+			Data: []felt.Felt{felt.FromUint64[felt.Felt](5)},
+		}},
 	}
 }
 
@@ -357,11 +362,13 @@ func TestPartialSkeletonMatchesReceipt(t *testing.T) {
 	)
 }
 
-// TestReceiptProjectionCoversEveryKey asserts the execution-status projection covers every
+// TestReceiptProjectionCoversEveryKey asserts each receipt projection covers every
 // TransactionReceipt wire key.
 func TestReceiptProjectionCoversEveryKey(t *testing.T) {
 	assertProjectionsCoverSource(t, reflect.TypeFor[TransactionReceipt](),
-		reflect.TypeFor[receiptExecutionStatusProjection]())
+		reflect.TypeFor[receiptExecutionStatusProjection](),
+		reflect.TypeFor[receiptEventsProjection](),
+	)
 }
 
 // TestReceiptProjectionCoversEveryWireKey guards against tag-option drift that cborKeys
@@ -370,6 +377,7 @@ func TestReceiptProjectionCoversEveryWireKey(t *testing.T) {
 	assertProjectionsCoverEveryWireKey(t, sampleReceiptBytes(t),
 		&discardedReceiptSkeleton{},
 		&receiptExecutionStatusProjection{},
+		&receiptEventsProjection{},
 	)
 }
 
@@ -383,6 +391,18 @@ func TestExecutionStatusProjectionDecodesShadowedFields(t *testing.T) {
 		"Reverted must receive the wire value, not discardedCBOR")
 	require.Equal(t, receipt.RevertReason, projection.RevertReason,
 		"RevertReason must receive the wire value, not discardedCBOR")
+}
+
+// TestEventsProjectionDecodesShadowedFields proves the shadowing fields receive the wire values,
+// not discardedCBOR — a change in cbor's embed precedence would slip past the key guards.
+func TestEventsProjectionDecodesShadowedFields(t *testing.T) {
+	receipt := sampleReceipt()
+	var projection receiptEventsProjection
+	require.NoError(t, encoder.Unmarshal(sampleReceiptBytes(t), &projection))
+	require.Equal(t, receipt.Events, projection.Events,
+		"Events must receive the wire value, not discardedCBOR")
+	require.Equal(t, receipt.TransactionHash, projection.TransactionHash,
+		"TransactionHash must receive the wire value, not discardedCBOR")
 }
 
 // BenchmarkPartialHeaderProjections benchmarks each header projection, field_omitting vs discard.

--- a/core/receipt.go
+++ b/core/receipt.go
@@ -33,6 +33,13 @@ type TransactionExecutionStatus struct {
 	RevertReason string
 }
 
+// TransactionEvents is the events subset of a TransactionReceipt: the emitted events
+// and the hash of the transaction that emitted them.
+type TransactionEvents struct {
+	Events          []*Event
+	TransactionHash *felt.Felt
+}
+
 func (r *TransactionReceipt) hash() felt.Felt {
 	revertReasonHash := &felt.Zero
 	if r.Reverted {

--- a/core/receipt.go
+++ b/core/receipt.go
@@ -33,8 +33,8 @@ type TransactionExecutionStatus struct {
 	RevertReason string
 }
 
-// TransactionEvents is the events subset of a TransactionReceipt: the emitted events
-// and the hash of the transaction that emitted them.
+// TransactionEvents is the events subset of a TransactionReceipt: the events and the
+// hash of the transaction that emitted them.
 type TransactionEvents struct {
 	Events          []*Event
 	TransactionHash *felt.Felt

--- a/core/typed_buckets.go
+++ b/core/typed_buckets.go
@@ -196,3 +196,8 @@ var BlockTransactionsAllReceiptsPartialBucket = partial.NewPartialBucket(
 	BlockTransactionsBucket.Bucket,
 	BlockTransactionsAllReceiptsPartialSerializer,
 )
+
+var BlockTransactionsAllTransactionEventsPartialBucket = partial.NewPartialBucket(
+	BlockTransactionsBucket.Bucket,
+	BlockTransactionsAllTransactionEventsPartialSerializer,
+)

--- a/core/typed_buckets.go
+++ b/core/typed_buckets.go
@@ -191,3 +191,8 @@ var BlockTransactionsAllReceiptsPartialBucket = partial.NewPartialBucket(
 	BlockTransactionsBucket.Bucket,
 	BlockTransactionsAllReceiptsPartialSerializer,
 )
+
+var BlockTransactionsAllTransactionEventsPartialBucket = partial.NewPartialBucket(
+	BlockTransactionsBucket.Bucket,
+	BlockTransactionsAllTransactionEventsPartialSerializer,
+)

--- a/rpc/v10/events.go
+++ b/rpc/v10/events.go
@@ -186,9 +186,10 @@ func (h *Handler) Events(args *EventArgs) (EventsChunk, *jsonrpc.Error) {
 	}
 
 	emittedEvents := make([]EmittedEvent, len(filteredEvents))
-	for i, fEvent := range filteredEvents {
+	for i := range filteredEvents {
+		fEvent := &filteredEvents[i]
 		emittedEvents[i] = EmittedEvent{
-			BlockNumber:      fEvent.BlockNumber,
+			BlockNumber:      &fEvent.BlockNumber,
 			BlockHash:        fEvent.BlockHash,
 			TransactionHash:  fEvent.TransactionHash,
 			TransactionIndex: fEvent.TransactionIndex,

--- a/rpc/v10/events.go
+++ b/rpc/v10/events.go
@@ -72,7 +72,7 @@ func (a AddressList) Contains(addr *felt.Address) bool {
 
 type EmittedEvent struct {
 	*Event
-	BlockNumber      *uint64    `json:"block_number,omitempty"`
+	BlockNumber      uint64     `json:"block_number"`
 	BlockHash        *felt.Felt `json:"block_hash,omitempty"`
 	TransactionHash  *felt.Felt `json:"transaction_hash"`
 	TransactionIndex uint       `json:"transaction_index"`
@@ -189,7 +189,7 @@ func (h *Handler) Events(args *EventArgs) (EventsChunk, *jsonrpc.Error) {
 	for i := range filteredEvents {
 		fEvent := &filteredEvents[i]
 		emittedEvents[i] = EmittedEvent{
-			BlockNumber:      &fEvent.BlockNumber,
+			BlockNumber:      fEvent.BlockNumber,
 			BlockHash:        fEvent.BlockHash,
 			TransactionHash:  fEvent.TransactionHash,
 			TransactionIndex: fEvent.TransactionIndex,

--- a/rpc/v10/events_test.go
+++ b/rpc/v10/events_test.go
@@ -54,8 +54,8 @@ func createEventPreConfirmedFromBlock(
 					Keys: event.Keys,
 					Data: event.Data,
 				},
-				BlockNumber:      &preConfirmedBlock.Number, // Pre-confirmed events have block number
-				BlockHash:        nil,                       // Pre-confirmed events have no block hash
+				BlockNumber:      preConfirmedBlock.Number, // Pre-confirmed events have block number
+				BlockHash:        nil,                      // Pre-confirmed events have no block hash
 				TransactionHash:  receipt.TransactionHash,
 				TransactionIndex: uint(txIndex),
 				EventIndex:       uint(eventIndex),
@@ -87,7 +87,7 @@ func extractCanonicalEvents(
 						Keys: event.Keys,
 						Data: event.Data,
 					},
-					BlockNumber:      &block.Number,
+					BlockNumber:      block.Number,
 					BlockHash:        block.Hash,
 					TransactionHash:  receipt.TransactionHash,
 					TransactionIndex: uint(txIndex),

--- a/rpc/v10/subscription_events.go
+++ b/rpc/v10/subscription_events.go
@@ -307,7 +307,7 @@ func (s *eventSubscriberState) sendFilteredEvent(
 	finalityStatus TxnFinalityStatus,
 ) error {
 	emittedEvent := EmittedEvent{
-		BlockNumber:      &event.BlockNumber,
+		BlockNumber:      event.BlockNumber,
 		BlockHash:        event.BlockHash,
 		TransactionHash:  event.TransactionHash,
 		TransactionIndex: event.TransactionIndex,

--- a/rpc/v10/subscription_events.go
+++ b/rpc/v10/subscription_events.go
@@ -202,7 +202,7 @@ func matchingEvents(
 				}
 
 				filtered := &blockchain.FilteredEvent{
-					BlockNumber:      &block.Number,
+					BlockNumber:      block.Number,
 					BlockHash:        block.Hash,
 					TransactionHash:  receipt.TransactionHash,
 					TransactionIndex: uint(txIndex),
@@ -278,7 +278,7 @@ func (s *eventSubscriberState) sendHistoricalEvents(
 	id string,
 	events []blockchain.FilteredEvent,
 ) error {
-	for _, event := range events {
+	for i := range events {
 		select {
 		case <-ctx.Done():
 			return ctx.Err()
@@ -288,13 +288,13 @@ func (s *eventSubscriberState) sendHistoricalEvents(
 		// Historical replay is bounded to the canonical tip, so every event
 		// here is canonical: L1-finalised at or below the L1 head, else L2.
 		finalityStatus := TxnAcceptedOnL2
-		if *event.BlockNumber <= s.l1HeadNumber {
+		if events[i].BlockNumber <= s.l1HeadNumber {
 			finalityStatus = TxnAcceptedOnL1
 		}
 
 		// Historical replay is a one-shot bootstrap with no internal
 		// duplicates, so it sends directly without the deduper.
-		if err := s.sendFilteredEvent(id, &event, finalityStatus); err != nil {
+		if err := s.sendFilteredEvent(id, &events[i], finalityStatus); err != nil {
 			return err
 		}
 	}
@@ -307,7 +307,7 @@ func (s *eventSubscriberState) sendFilteredEvent(
 	finalityStatus TxnFinalityStatus,
 ) error {
 	emittedEvent := EmittedEvent{
-		BlockNumber:      event.BlockNumber,
+		BlockNumber:      &event.BlockNumber,
 		BlockHash:        event.BlockHash,
 		TransactionHash:  event.TransactionHash,
 		TransactionIndex: event.TransactionIndex,

--- a/rpc/v10/subscriptions_test.go
+++ b/rpc/v10/subscriptions_test.go
@@ -2724,7 +2724,6 @@ func createTestEvents(
 	finalityStatus TxnFinalityStatus,
 ) ([]blockchain.FilteredEvent, []SubscriptionEmittedEvent) {
 	t.Helper()
-	blockNumber := &b.Number
 	eventMatcher := blockchain.NewEventMatcher(fromAddresses, keys)
 	var filtered []blockchain.FilteredEvent
 	var responses []SubscriptionEmittedEvent
@@ -2754,7 +2753,7 @@ func createTestEvents(
 						Keys: event.Keys,
 						Data: event.Data,
 					},
-					BlockNumber:      blockNumber,
+					BlockNumber:      b.Number,
 					BlockHash:        b.Hash,
 					TransactionHash:  receipt.TransactionHash,
 					TransactionIndex: uint(txIndex),

--- a/rpc/v10/subscriptions_test.go
+++ b/rpc/v10/subscriptions_test.go
@@ -2741,7 +2741,7 @@ func createTestEvents(
 
 			filtered = append(filtered, blockchain.FilteredEvent{
 				Event:            event,
-				BlockNumber:      blockNumber,
+				BlockNumber:      b.Number,
 				BlockHash:        b.Hash,
 				TransactionHash:  receipt.TransactionHash,
 				TransactionIndex: uint(txIndex),

--- a/rpc/v8/events.go
+++ b/rpc/v8/events.go
@@ -111,9 +111,11 @@ func (h *Handler) Events(args EventsArg) (*EventsChunk, *jsonrpc.Error) {
 
 	emittedEvents := make([]EmittedEvent, len(filteredEvents))
 	for i, fEvent := range filteredEvents {
+		// v8 omits both fields for a pending event. Point into the slice: &fEvent
+		// allocates a copy for each event.
 		var blockNumber *uint64
 		if fEvent.BlockHash != nil {
-			blockNumber = fEvent.BlockNumber
+			blockNumber = &filteredEvents[i].BlockNumber
 		}
 		emittedEvents[i] = EmittedEvent{
 			BlockNumber:     blockNumber,

--- a/rpc/v8/subscriptions.go
+++ b/rpc/v8/subscriptions.go
@@ -395,13 +395,14 @@ func sendEvents(
 	events []blockchain.FilteredEvent,
 	id string,
 ) error {
-	for _, event := range events {
+	for i := range events {
 		select {
 		case <-ctx.Done():
 			return ctx.Err()
 		default:
+			event := &events[i]
 			emittedEvent := &EmittedEvent{
-				BlockNumber:     event.BlockNumber,
+				BlockNumber:     &event.BlockNumber,
 				BlockHash:       event.BlockHash,
 				TransactionHash: event.TransactionHash,
 				Event: &Event{

--- a/rpc/v8/subscriptions_test.go
+++ b/rpc/v8/subscriptions_test.go
@@ -1191,7 +1191,7 @@ func createTestEvents(
 		for i, event := range receipt.Events {
 			filtered = append(filtered, blockchain.FilteredEvent{
 				Event:           event,
-				BlockNumber:     &b.Number,
+				BlockNumber:     b.Number,
 				BlockHash:       b.Hash,
 				TransactionHash: receipt.TransactionHash,
 				EventIndex:      uint(i),

--- a/rpc/v9/events.go
+++ b/rpc/v9/events.go
@@ -32,7 +32,7 @@ type EventsChunk struct {
 
 type EmittedEvent struct {
 	*Event
-	BlockNumber     *uint64    `json:"block_number,omitempty"`
+	BlockNumber     uint64     `json:"block_number"`
 	BlockHash       *felt.Felt `json:"block_hash,omitempty"`
 	TransactionHash *felt.Felt `json:"transaction_hash"`
 }
@@ -152,7 +152,7 @@ func (h *Handler) Events(args EventArgs) (EventsChunk, *jsonrpc.Error) {
 	for i := range filteredEvents {
 		fEvent := &filteredEvents[i]
 		emittedEvents[i] = EmittedEvent{
-			BlockNumber:     &fEvent.BlockNumber,
+			BlockNumber:     fEvent.BlockNumber,
 			BlockHash:       fEvent.BlockHash,
 			TransactionHash: fEvent.TransactionHash,
 			// rpc.Event is field-identical to core.Event (guarded in this file), so alias the

--- a/rpc/v9/events.go
+++ b/rpc/v9/events.go
@@ -149,9 +149,10 @@ func (h *Handler) Events(args EventArgs) (EventsChunk, *jsonrpc.Error) {
 	}
 
 	emittedEvents := make([]EmittedEvent, len(filteredEvents))
-	for i, fEvent := range filteredEvents {
+	for i := range filteredEvents {
+		fEvent := &filteredEvents[i]
 		emittedEvents[i] = EmittedEvent{
-			BlockNumber:     fEvent.BlockNumber,
+			BlockNumber:     &fEvent.BlockNumber,
 			BlockHash:       fEvent.BlockHash,
 			TransactionHash: fEvent.TransactionHash,
 			// rpc.Event is field-identical to core.Event (guarded in this file), so alias the

--- a/rpc/v9/events_test.go
+++ b/rpc/v9/events_test.go
@@ -52,8 +52,8 @@ func createEventPreConfirmedFromBlock(block *core.Block) (
 					Keys: event.Keys,
 					Data: event.Data,
 				},
-				BlockNumber:     &preConfirmedBlock.Number, // Pre-confirmed events have block number
-				BlockHash:       nil,                       // Pre-confirmed events have no block hash
+				BlockNumber:     preConfirmedBlock.Number, // Pre-confirmed events have block number
+				BlockHash:       nil,                      // Pre-confirmed events have no block hash
 				TransactionHash: receipt.TransactionHash,
 			})
 		}
@@ -83,7 +83,7 @@ func extractCanonicalEvents(
 						Keys: event.Keys,
 						Data: event.Data,
 					},
-					BlockNumber:     &block.Number,
+					BlockNumber:     block.Number,
 					BlockHash:       block.Hash,
 					TransactionHash: receipt.TransactionHash,
 				})

--- a/rpc/v9/subscription_events.go
+++ b/rpc/v9/subscription_events.go
@@ -218,7 +218,7 @@ func matchingEvents(
 				}
 
 				filtered := &blockchain.FilteredEvent{
-					BlockNumber:      &block.Number,
+					BlockNumber:      block.Number,
 					BlockHash:        block.Hash,
 					TransactionHash:  receipt.TransactionHash,
 					TransactionIndex: uint(txIndex),
@@ -299,7 +299,7 @@ func (s *eventSubscriberState) sendHistoricalEvents(
 	id string,
 	events []blockchain.FilteredEvent,
 ) error {
-	for _, event := range events {
+	for i := range events {
 		select {
 		case <-ctx.Done():
 			return ctx.Err()
@@ -307,13 +307,13 @@ func (s *eventSubscriberState) sendHistoricalEvents(
 			// Historical replay is bounded to the canonical tip, so every event
 			// here is canonical: L1-finalised at or below the L1 head, else L2.
 			finalityStatus := TxnAcceptedOnL2
-			if *event.BlockNumber <= s.l1HeadNumber {
+			if events[i].BlockNumber <= s.l1HeadNumber {
 				finalityStatus = TxnAcceptedOnL1
 			}
 
 			// Historical replay is a one-shot bootstrap with no internal
 			// duplicates, so it sends directly without the deduper.
-			if err := s.sendFilteredEvent(id, &event, finalityStatus); err != nil {
+			if err := s.sendFilteredEvent(id, &events[i], finalityStatus); err != nil {
 				return err
 			}
 		}
@@ -327,7 +327,7 @@ func (s *eventSubscriberState) sendFilteredEvent(
 	finalityStatus TxnFinalityStatus,
 ) error {
 	emittedEvent := EmittedEvent{
-		BlockNumber:     event.BlockNumber,
+		BlockNumber:     &event.BlockNumber,
 		BlockHash:       event.BlockHash,
 		TransactionHash: event.TransactionHash,
 		Event: &Event{

--- a/rpc/v9/subscription_events.go
+++ b/rpc/v9/subscription_events.go
@@ -327,7 +327,7 @@ func (s *eventSubscriberState) sendFilteredEvent(
 	finalityStatus TxnFinalityStatus,
 ) error {
 	emittedEvent := EmittedEvent{
-		BlockNumber:     &event.BlockNumber,
+		BlockNumber:     event.BlockNumber,
 		BlockHash:       event.BlockHash,
 		TransactionHash: event.TransactionHash,
 		Event: &Event{

--- a/rpc/v9/subscriptions_test.go
+++ b/rpc/v9/subscriptions_test.go
@@ -2387,7 +2387,6 @@ func createTestEvents(
 ) ([]blockchain.FilteredEvent, []SubscriptionEmittedEvent) {
 	t.Helper()
 
-	blockNumber := &b.Number
 	var addresses []felt.Address
 	if fromAddress != nil {
 		addresses = []felt.Address{*fromAddress}
@@ -2421,7 +2420,7 @@ func createTestEvents(
 						Keys: event.Keys,
 						Data: event.Data,
 					},
-					BlockNumber:     blockNumber,
+					BlockNumber:     b.Number,
 					BlockHash:       b.Hash,
 					TransactionHash: receipt.TransactionHash,
 				},

--- a/rpc/v9/subscriptions_test.go
+++ b/rpc/v9/subscriptions_test.go
@@ -2408,7 +2408,7 @@ func createTestEvents(
 
 			filtered = append(filtered, blockchain.FilteredEvent{
 				Event:            event,
-				BlockNumber:      blockNumber,
+				BlockNumber:      b.Number,
 				BlockHash:        b.Hash,
 				TransactionHash:  receipt.TransactionHash,
 				TransactionIndex: uint(txIndex),


### PR DESCRIPTION
Bench results for various test cases using sepolia snapshot:

| Scenario | Query shape | Latency | Allocs/op | Bytes/op |
|---|---|---|---|---|
| addr+key / 8k blocks | busiest contract + one event type (indexer paging Transfers) | 13.34 ms → 11.34 ms (**−15.0%**) | 23,720 → 17,900 (**−24.5%**) | 1,245 KiB → 972 KiB (**−21.9%**) |
| addr-only / 8k blocks | all events of the busiest contract | 13.33 ms → 11.40 ms (**−14.5%**) | 23,710 → 17,890 (**−24.5%**) | 1,243 KiB → 971 KiB (**−21.9%**) |
| match-all / 64 blocks | no filter, "all recent events" (explorer feed) | 1.45 ms → 1.10 ms (**−24.3%**) | 5,204 → 3,933 (**−24.4%**) | 264 KiB → 205 KiB (**−22.5%**) |
| sparse-addr / 8k blocks | rarely-active contract, 35 results | 2.11 ms → 1.82 ms (**−13.8%**) | 5,659 → 4,711 (**−16.8%**) | 281 KiB → 236 KiB (**−15.9%**) |
| rare-key / 8k blocks | key matching nothing, 0 results | 18.3 µs → 17.7 µs (−3.3%, p=0.009) | 39 → 39 (±0%) | 7.1 KiB → 7.1 KiB (±0%) |