### PR TITLE
fix(rpcv10): bump spec version 

### DIFF
--- a/rpc/v10/block.go
+++ b/rpc/v10/block.go
@@ -88,7 +88,7 @@ type BlockWithReceipts struct {
 	Transactions []TransactionWithReceipt `json:"transactions"`
 }
 
-// https://github.com/starkware-libs/starknet-specs/blob/release/v0.10.2/api/starknet_api_openrpc.json#L830-L848
+// https://github.com/starkware-libs/starknet-specs/blob/v0.10.3/api/starknet_api_openrpc.json#L830-L848
 type BlockHashAndNumber struct {
 	Hash   *felt.Felt `json:"block_hash"`
 	Number uint64     `json:"block_number"`
@@ -101,7 +101,7 @@ type BlockHashAndNumber struct {
 // BlockNumber returns the latest synced block number.
 //
 // It follows the specification defined here:
-// https://github.com/starkware-libs/starknet-specs/blob/release/v0.10.2/api/starknet_api_openrpc.json#L809
+// https://github.com/starkware-libs/starknet-specs/blob/v0.10.3/api/starknet_api_openrpc.json#L809
 func (h *Handler) BlockNumber() (uint64, *jsonrpc.Error) {
 	num, err := h.bcReader.Height()
 	if err != nil {
@@ -114,7 +114,7 @@ func (h *Handler) BlockNumber() (uint64, *jsonrpc.Error) {
 // BlockHashAndNumber returns the block hash and number of the latest synced block.
 //
 // It follows the specification defined here:
-// https://github.com/starkware-libs/starknet-specs/blob/release/v0.10.2/api/starknet_api_openrpc.json#L827
+// https://github.com/starkware-libs/starknet-specs/blob/v0.10.3/api/starknet_api_openrpc.json#L827
 func (h *Handler) BlockHashAndNumber() (*BlockHashAndNumber, *jsonrpc.Error) {
 	block, err := h.bcReader.Head()
 	if err != nil {
@@ -127,7 +127,7 @@ func (h *Handler) BlockHashAndNumber() (*BlockHashAndNumber, *jsonrpc.Error) {
 // identified by the given BlockID.
 //
 // It follows the specification defined here:
-// https://github.com/starkware-libs/starknet-specs/blob/release/v0.10.2/api/starknet_api_openrpc.json#L622
+// https://github.com/starkware-libs/starknet-specs/blob/v0.10.3/api/starknet_api_openrpc.json#L622
 func (h *Handler) BlockTransactionCount(id *BlockID) (uint64, *jsonrpc.Error) {
 	var count uint64
 	var err error

--- a/rpc/v10/chain.go
+++ b/rpc/v10/chain.go
@@ -12,7 +12,7 @@ import (
 // ChainID returns the chain ID of the currently configured network.
 //
 // It follows the specification defined here:
-// https://github.com/starkware-libs/starknet-specs/blob/release/v0.10.2/api/starknet_api_openrpc.json#L856
+// https://github.com/starkware-libs/starknet-specs/blob/v0.10.3/api/starknet_api_openrpc.json#L856
 func (h *Handler) ChainID() (*felt.Felt, *jsonrpc.Error) {
 	return h.bcReader.Network().L2ChainIDFelt(), nil
 }

--- a/rpc/v10/class.go
+++ b/rpc/v10/class.go
@@ -8,7 +8,7 @@ import (
 	"github.com/NethermindEth/juno/rpc/rpccore"
 )
 
-// https://github.com/starkware-libs/starknet-specs/blob/release/v0.10.2/api/starknet_api_openrpc.json#L506-L522
+// https://github.com/starkware-libs/starknet-specs/blob/v0.10.3/api/starknet_api_openrpc.json#L506-L522
 type Class struct {
 	SierraProgram        []felt.Felt            `json:"sierra_program,omitempty"`
 	Program              string                 `json:"program,omitempty"`
@@ -36,7 +36,7 @@ type ClassEntryPoint struct {
 // Class gets the contract class definition in the given block associated with the given hash
 //
 // It follows the specification defined here:
-// https://github.com/starkware-libs/starknet-specs/blob/release/v0.10.2/api/starknet_api_openrpc.json#L484
+// https://github.com/starkware-libs/starknet-specs/blob/v0.10.3/api/starknet_api_openrpc.json#L484
 func (h *Handler) Class(id *BlockID, classHash *felt.Felt) (*Class, *jsonrpc.Error) {
 	state, stateCloser, rpcErr := h.stateByBlockID(id)
 	if rpcErr != nil {
@@ -83,7 +83,7 @@ func (h *Handler) Class(id *BlockID, classHash *felt.Felt) (*Class, *jsonrpc.Err
 // given contract address
 //
 // It follows the specification defined here:
-// https://github.com/starkware-libs/starknet-specs/blob/release/v0.10.2/api/starknet_api_openrpc.json#L573
+// https://github.com/starkware-libs/starknet-specs/blob/v0.10.3/api/starknet_api_openrpc.json#L573
 func (h *Handler) ClassAt(id *BlockID, address *felt.Felt) (*Class, *jsonrpc.Error) {
 	classHash, err := h.ClassHashAt(id, address)
 	if err != nil {
@@ -106,7 +106,7 @@ func (h *Handler) ClassAt(id *BlockID, address *felt.Felt) (*Class, *jsonrpc.Err
 // in the given block.
 //
 // It follows the specification defined here:
-// https://github.com/starkware-libs/starknet-specs/blob/release/v0.10.2/api/starknet_api_openrpc.json#L533
+// https://github.com/starkware-libs/starknet-specs/blob/v0.10.3/api/starknet_api_openrpc.json#L533
 func (h *Handler) ClassHashAt(id *BlockID, address *felt.Felt) (*felt.Felt, *jsonrpc.Error) {
 	stateReader, stateCloser, rpcErr := h.stateByBlockID(id)
 	if rpcErr != nil {

--- a/rpc/v10/compiled_casm.go
+++ b/rpc/v10/compiled_casm.go
@@ -25,7 +25,7 @@ type EntryPointsByType struct {
 }
 
 // CompiledCasmResponse represents a compiled Cairo class. It follows this specification:
-// https://github.com/starkware-libs/starknet-specs/blob/release/v0.10.2/api/starknet_executables.json#L45
+// https://github.com/starkware-libs/starknet-specs/blob/v0.10.3/api/starknet_executables.json#L45
 type CompiledCasmResponse struct {
 	EntryPointsByType EntryPointsByType `json:"entry_points_by_type"`
 	// can't use felt.Felt here because prime is larger than felt

--- a/rpc/v10/handlers.go
+++ b/rpc/v10/handlers.go
@@ -174,5 +174,5 @@ func (h *Handler) Run(ctx context.Context) error {
 }
 
 func (h *Handler) SpecVersion() (string, *jsonrpc.Error) {
-	return "0.10.2", nil
+	return "0.10.3", nil
 }

--- a/rpc/v10/handlers_test.go
+++ b/rpc/v10/handlers_test.go
@@ -20,7 +20,7 @@ func TestSpecVersion(t *testing.T) {
 	handler := rpcv10.New(nil, nil, nil, nil)
 	version, rpcErr := handler.SpecVersion()
 	require.Nil(t, rpcErr)
-	require.Equal(t, "0.10.2", version)
+	require.Equal(t, "0.10.3", version)
 }
 
 func TestThrottledVMError(t *testing.T) {

--- a/rpc/v10/l1.go
+++ b/rpc/v10/l1.go
@@ -88,7 +88,7 @@ func (h *Handler) GetMessageStatus(
 
 		// Skip if execution status is not present since it is required by the spec, thus
 		// finality status cannot be RECEIVED or CANDIDATE
-		// https://github.com/starkware-libs/starknet-specs/blob/release/v0.10.2/api/starknet_api_openrpc.json#L3325
+		// https://github.com/starkware-libs/starknet-specs/blob/v0.10.3/api/starknet_api_openrpc.json#L3327
 		if status.Execution == UnknownExecution {
 			continue
 		}

--- a/rpc/v10/nonce.go
+++ b/rpc/v10/nonce.go
@@ -14,7 +14,7 @@ import (
 // Nonce returns the nonce associated with the given address in the given block number
 //
 // It follows the specification defined here:
-// https://github.com/starkware-libs/starknet-specs/blob/release/v0.10.2/api/starknet_api_openrpc.json#L940
+// https://github.com/starkware-libs/starknet-specs/blob/v0.10.3/api/starknet_api_openrpc.json#L940
 func (h *Handler) Nonce(id *BlockID, address *felt.Felt) (*felt.Felt, *jsonrpc.Error) {
 	stateReader, stateCloser, rpcErr := h.stateByBlockID(id)
 	if rpcErr != nil {

--- a/rpc/v10/storage.go
+++ b/rpc/v10/storage.go
@@ -174,7 +174,7 @@ type StorageProofResult struct {
 // of storage proofs (classes, contracts, and storage).
 //
 // It follows the specification defined here:
-// https://github.com/starkware-libs/starknet-specs/blob/release/v0.10.2/api/starknet_api_openrpc.json#L980
+// https://github.com/starkware-libs/starknet-specs/blob/v0.10.3/api/starknet_api_openrpc.json#L980
 func (h *Handler) StorageProof(
 	id *BlockID, classes, contracts []felt.Felt, storageKeys []StorageKeys,
 ) (*StorageProofResult, *jsonrpc.Error) {

--- a/rpc/v10/sync.go
+++ b/rpc/v10/sync.go
@@ -7,7 +7,7 @@ import (
 	"github.com/NethermindEth/juno/jsonrpc"
 )
 
-// https://github.com/starkware-libs/starknet-specs/blob/release/v0.10.2/api/starknet_api_openrpc.json#L1350
+// https://github.com/starkware-libs/starknet-specs/blob/v0.10.3/api/starknet_api_openrpc.json#L1350
 type Sync struct {
 	Syncing             *bool      `json:"-"`
 	StartingBlockHash   *felt.Felt `json:"starting_block_hash,omitempty"`
@@ -34,7 +34,7 @@ func (s Sync) MarshalJSON() ([]byte, error) {
 // Syncing returns the syncing status of the node.
 //
 // It follows the specification defined here:
-// https://github.com/starkware-libs/starknet-specs/blob/release/v0.10.2/api/starknet_api_openrpc.json#L869
+// https://github.com/starkware-libs/starknet-specs/blob/v0.10.3/api/starknet_api_openrpc.json#L869
 func (h *Handler) Syncing() (*Sync, *jsonrpc.Error) {
 	defaultSyncState := &Sync{Syncing: new(bool)}
 

--- a/rpc/v10/transaction_types.go
+++ b/rpc/v10/transaction_types.go
@@ -420,7 +420,7 @@ type Transaction struct {
 }
 
 // ContractClass represents a contract class to be declared in the DECLARE broadcast transaction.
-// https://github.com/starkware-libs/starknet-specs/blob/release/v0.10.2/api/starknet_api_openrpc.json#L3373
+// https://github.com/starkware-libs/starknet-specs/blob/v0.10.3/api/starknet_api_openrpc.json#L3369
 type ContractClass struct {
 	SierraProgram        []felt.Felt              `json:"sierra_program" validate:"required"`
 	ContractClassVersion string                   `json:"contract_class_version" validate:"required"`


### PR DESCRIPTION
We already support `0.10.3`, hardcoded value was stale