### PR TITLE
feat(node): introduce disabling synchronization

### DIFF
--- a/cmd/juno/juno.go
+++ b/cmd/juno/juno.go
@@ -59,6 +59,7 @@ const (
 	pprofPortF                          = "pprof-port"
 	colourF                             = "colour"
 	preConfirmedPollIntervalF           = "preconfirmed-poll-interval"
+	disableSyncF                        = "disable-sync"
 	p2pF                                = "p2p"
 	p2pAddrF                            = "p2p-addr"
 	p2pPublicAddrF                      = "p2p-public-addr"
@@ -131,6 +132,7 @@ const (
 	defaultPprofPort                          = 6062
 	defaultColour                             = true
 	defaultPreConfirmedPollInterval           = 500 * time.Millisecond
+	defaultDisableSync                        = false
 	defaultP2p                                = false
 	defaultP2pAddr                            = ""
 	defaultP2pPublicAddr                      = ""
@@ -211,6 +213,7 @@ const (
 	disableL1VerificationUsage    = "Disables L1 verification since an Ethereum node is not provided."
 	preConfirmedPollIntervalUsage = "Sets how frequently pre_confirmed block will be updated" +
 		"(0s will disable fetching of pre_confirmed block)."
+	disableSyncUsage   = "Disables L2 synchronization."
 	p2pUsage           = "EXPERIMENTAL: Enables p2p server."
 	p2pAddrUsage       = "EXPERIMENTAL: Specify p2p listening source address as multiaddr.  Example: /ip4/0.0.0.0/tcp/7777"
 	p2pPublicAddrUsage = "EXPERIMENTAL: Specify p2p public address as multiaddr.  Example: /ip4/35.243.XXX.XXX/tcp/7777"
@@ -540,6 +543,7 @@ func NewCmd(config *node.Config, run func(*cobra.Command, []string) error) *cobr
 	setCategory(junoCmd, catNetwork, networkF, ethNodeF, disableL1VerificationF)
 
 	// --- Sync & Polling ---
+	junoCmd.Flags().Bool(disableSyncF, defaultDisableSync, disableSyncUsage)
 	junoCmd.Flags().Duration(
 		preConfirmedPollIntervalF, defaultPreConfirmedPollInterval, preConfirmedPollIntervalUsage,
 	)
@@ -548,7 +552,7 @@ func NewCmd(config *node.Config, run func(*cobra.Command, []string) error) *cobr
 		readinessBlockToleranceF, defaultReadinessBlockTolerance, readinessBlockToleranceUsage,
 	)
 	setCategory(junoCmd, catSyncPolling,
-		preConfirmedPollIntervalF, remoteDBF, readinessBlockToleranceF,
+		disableSyncF, preConfirmedPollIntervalF, remoteDBF, readinessBlockToleranceF,
 	)
 
 	// --- Gateway ---

--- a/cmd/juno/juno.go
+++ b/cmd/juno/juno.go
@@ -59,6 +59,7 @@ const (
 	pprofPortF                          = "pprof-port"
 	colourF                             = "colour"
 	preConfirmedPollIntervalF           = "preconfirmed-poll-interval"
+	syncF                               = "sync"
 	p2pF                                = "p2p"
 	p2pAddrF                            = "p2p-addr"
 	p2pPublicAddrF                      = "p2p-public-addr"
@@ -131,6 +132,7 @@ const (
 	defaultPprofPort                          = 6062
 	defaultColour                             = true
 	defaultPreConfirmedPollInterval           = 500 * time.Millisecond
+	defaultSync                               = true
 	defaultP2p                                = false
 	defaultP2pAddr                            = ""
 	defaultP2pPublicAddr                      = ""
@@ -211,6 +213,10 @@ const (
 	disableL1VerificationUsage    = "Disables L1 verification since an Ethereum node is not provided."
 	preConfirmedPollIntervalUsage = "Sets how frequently pre_confirmed block will be updated" +
 		"(0s will disable fetching of pre_confirmed block)."
+	syncUsage = "Enables L2 blockchain synchronization. " +
+		"L1 verification is controlled independently by --disable-l1-verification. " +
+		"Disabling synchronization is intended for tests or benchmarks using a preloaded database. " +
+		"Use /ready/rpc for readiness."
 	p2pUsage           = "EXPERIMENTAL: Enables p2p server."
 	p2pAddrUsage       = "EXPERIMENTAL: Specify p2p listening source address as multiaddr.  Example: /ip4/0.0.0.0/tcp/7777"
 	p2pPublicAddrUsage = "EXPERIMENTAL: Specify p2p public address as multiaddr.  Example: /ip4/35.243.XXX.XXX/tcp/7777"
@@ -404,6 +410,10 @@ func NewCmd(config *node.Config, run func(*cobra.Command, []string) error) *cobr
 			return err
 		}
 
+		// Keep the CLI option positive while storing its inverse so existing Config
+		// literals that omit this new field continue to enable synchronization.
+		config.DisableSync = !v.GetBool(syncF)
+
 		// Pruning is gated on the flag's *presence* (CLI, YAML, or env), not
 		// its numeric value — --prune-mode=0 is still "on, retain 0".
 		config.Prune = v.IsSet(pruneModeF)
@@ -540,6 +550,7 @@ func NewCmd(config *node.Config, run func(*cobra.Command, []string) error) *cobr
 	setCategory(junoCmd, catNetwork, networkF, ethNodeF, disableL1VerificationF)
 
 	// --- Sync & Polling ---
+	junoCmd.Flags().Bool(syncF, defaultSync, syncUsage)
 	junoCmd.Flags().Duration(
 		preConfirmedPollIntervalF, defaultPreConfirmedPollInterval, preConfirmedPollIntervalUsage,
 	)
@@ -548,7 +559,7 @@ func NewCmd(config *node.Config, run func(*cobra.Command, []string) error) *cobr
 		readinessBlockToleranceF, defaultReadinessBlockTolerance, readinessBlockToleranceUsage,
 	)
 	setCategory(junoCmd, catSyncPolling,
-		preConfirmedPollIntervalF, remoteDBF, readinessBlockToleranceF,
+		syncF, preConfirmedPollIntervalF, remoteDBF, readinessBlockToleranceF,
 	)
 
 	// --- Gateway ---

--- a/cmd/juno/juno_test.go
+++ b/cmd/juno/juno_test.go
@@ -206,6 +206,9 @@ func TestConfigPrecedence(t *testing.T) {
 	expectedNumericCompilationLimits.MaxCompilationQueue = 32
 	expectedNumericCompilationLimits.MaxCompilationQueueExplicit = true
 
+	expectedSyncDisabled := expectedConfig2
+	expectedSyncDisabled.DisableSync = true
+
 	tests := map[string]struct {
 		cfgFile         bool
 		cfgFileContents string
@@ -245,6 +248,19 @@ cn-unverifiable-range: [0,10]
 		"default config with no flags": {
 			inputArgs:      []string{""},
 			expectedConfig: &expectedConfig2,
+		},
+		"sync disabled": {
+			inputArgs:      []string{"--sync=false"},
+			expectedConfig: &expectedSyncDisabled,
+		},
+		"sync disabled in config file": {
+			cfgFile:         true,
+			cfgFileContents: "sync: false\n",
+			expectedConfig:  &expectedSyncDisabled,
+		},
+		"sync disabled in environment": {
+			env:            []string{"JUNO_SYNC", "false"},
+			expectedConfig: &expectedSyncDisabled,
 		},
 		"explicit compilation limits survive": {
 			inputArgs: []string{

--- a/cmd/juno/juno_test.go
+++ b/cmd/juno/juno_test.go
@@ -206,6 +206,9 @@ func TestConfigPrecedence(t *testing.T) {
 	expectedNumericCompilationLimits.MaxCompilationQueue = 32
 	expectedNumericCompilationLimits.MaxCompilationQueueExplicit = true
 
+	expectedSyncDisabled := expectedConfig2
+	expectedSyncDisabled.DisableSync = true
+
 	tests := map[string]struct {
 		cfgFile         bool
 		cfgFileContents string
@@ -245,6 +248,19 @@ cn-unverifiable-range: [0,10]
 		"default config with no flags": {
 			inputArgs:      []string{""},
 			expectedConfig: &expectedConfig2,
+		},
+		"sync disabled": {
+			inputArgs:      []string{"--disable-sync"},
+			expectedConfig: &expectedSyncDisabled,
+		},
+		"sync disabled in config file": {
+			cfgFile:         true,
+			cfgFileContents: "disable-sync: true\n",
+			expectedConfig:  &expectedSyncDisabled,
+		},
+		"sync disabled in environment": {
+			env:            []string{"JUNO_DISABLE_SYNC", "true"},
+			expectedConfig: &expectedSyncDisabled,
 		},
 		"explicit compilation limits survive": {
 			inputArgs: []string{
@@ -935,6 +951,24 @@ network: sepolia
 			require.NoError(t, err)
 
 			assert.Equal(t, tc.expectedConfig, config)
+		})
+	}
+}
+
+func TestDisableSyncFalseAllowsSyncDependentFlags(t *testing.T) {
+	tests := map[string][]string{
+		"sequencer":       {"--disable-sync=false", "--seq-enable"},
+		"p2p":             {"--disable-sync=false", "--p2p"},
+		"pruning":         {"--disable-sync=false", "--prune-mode"},
+		"remote database": {"--disable-sync=false", "--remote-db", "localhost:6064"},
+	}
+
+	for name, args := range tests {
+		t.Run(name, func(t *testing.T) {
+			cmd := juno.NewCmd(new(node.Config), func(*cobra.Command, []string) error { return nil })
+			cmd.SetArgs(args)
+
+			require.NoError(t, cmd.ExecuteContext(t.Context()))
 		})
 	}
 }

--- a/docs/docs/_config-options.md
+++ b/docs/docs/_config-options.md
@@ -40,6 +40,7 @@
 | `preconfirmed-poll-interval` | `500ms` | Sets how frequently pre_confirmed block will be updated(0s will disable fetching of pre_confirmed block) |
 | `readiness-block-tolerance` | `6` | Maximum blocks behind latest for /ready endpoints to return 200 OK |
 | `remote-db` |  | gRPC URL of a remote Juno node |
+| `sync` | `true` | Enables L2 blockchain synchronization. L1 verification is controlled independently by --disable-l1-verification. Disabling synchronization is intended for tests or benchmarks using a preloaded database. Use /ready/rpc for readiness |
 
 ### Gateway
 

--- a/docs/docs/_config-options.md
+++ b/docs/docs/_config-options.md
@@ -37,6 +37,7 @@
 
 | Config Option | Default Value | Description |
 | - | - | - |
+| `disable-sync` | `false` | Disables L2 synchronization |
 | `preconfirmed-poll-interval` | `500ms` | Sets how frequently pre_confirmed block will be updated(0s will disable fetching of pre_confirmed block) |
 | `readiness-block-tolerance` | `6` | Maximum blocks behind latest for /ready endpoints to return 200 OK |
 | `remote-db` |  | gRPC URL of a remote Juno node |

--- a/docs/docs/monitoring.md
+++ b/docs/docs/monitoring.md
@@ -138,6 +138,11 @@ readinessProbe:
   failureThreshold: 3
 ```
 
+### `/ready/rpc` endpoint
+
+The `/ready/rpc` endpoint returns `200 OK` once the database has a canonical head and RPC requests can be served.
+Use it as the readiness probe for tests or benchmarks started with `--disable-sync` and a preloaded database.
+
 ### Configuring readiness criteria
 
 You can configure what "synced" means for the `/ready` endpoint using the `readiness-block-tolerance` configuration option:

--- a/docs/docs/monitoring.md
+++ b/docs/docs/monitoring.md
@@ -127,6 +127,7 @@ The `/ready` endpoint returns:
 - `503 Service Unavailable` during migrations or when the node is not yet synced
 
 This endpoint is intended for use with Kubernetes `readinessProbe` to control traffic routing.
+When synchronization is disabled with `--sync=false`, use `/ready/rpc` instead.
 
 ```yaml title="Kubernetes readinessProbe example"
 readinessProbe:
@@ -137,6 +138,14 @@ readinessProbe:
   periodSeconds: 5
   failureThreshold: 3
 ```
+
+### `/ready/rpc` and `/ready/sync` endpoints
+
+The `/ready/rpc` endpoint returns `200 OK` once the database has a canonical head and RPC requests can be served.
+Use it as the readiness probe for tests or benchmarks started with `--sync=false` and a preloaded database.
+
+The `/ready/sync` endpoint always applies the synchronization check used by `/ready` on a synchronizing node.
+It returns `503 Service Unavailable` when synchronization is disabled or unavailable.
 
 ### Configuring readiness criteria
 

--- a/node/http.go
+++ b/node/http.go
@@ -311,3 +311,18 @@ func (h *readinessHandlers) isSynced() bool {
 func (h *readinessHandlers) HandleLive(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(http.StatusOK)
 }
+
+func (h *readinessHandlers) HandleReadyRPC(w http.ResponseWriter, r *http.Request) {
+	if _, err := h.bcReader.HeadsHeader(); err != nil {
+		w.WriteHeader(http.StatusServiceUnavailable)
+		if errors.Is(err, db.ErrKeyNotFound) {
+			emptyDatabaseMessage := []byte("RPC not ready: database contains no blocks.")
+			w.Write(emptyDatabaseMessage) //nolint:errcheck // best-effort body
+		} else {
+			w.Write([]byte("RPC not ready: database not serving.")) //nolint:errcheck // best-effort body
+		}
+		return
+	}
+
+	w.WriteHeader(http.StatusOK)
+}

--- a/node/http.go
+++ b/node/http.go
@@ -32,6 +32,7 @@ const (
 	defaultReadHeaderTimeout = 30 * time.Second
 	defaultWriteTimeout      = 30 * time.Second
 	defaultIdleTimeout       = 2 * time.Minute
+	rpcNotReadyMessage       = "RPC not ready: failed to read canonical head."
 )
 
 type httpService struct {
@@ -309,5 +310,15 @@ func (h *readinessHandlers) isSynced() bool {
 }
 
 func (h *readinessHandlers) HandleLive(w http.ResponseWriter, r *http.Request) {
+	w.WriteHeader(http.StatusOK)
+}
+
+func (h *readinessHandlers) HandleReadyRPC(w http.ResponseWriter, r *http.Request) {
+	if _, err := h.bcReader.HeadsHeader(); err != nil {
+		w.WriteHeader(http.StatusServiceUnavailable)
+		w.Write([]byte(rpcNotReadyMessage)) //nolint:errcheck // best-effort body
+		return
+	}
+
 	w.WriteHeader(http.StatusOK)
 }

--- a/node/http_test.go
+++ b/node/http_test.go
@@ -1,14 +1,17 @@
 package node_test
 
 import (
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"testing"
 
 	"github.com/NethermindEth/juno/core"
 	"github.com/NethermindEth/juno/core/felt"
+	"github.com/NethermindEth/juno/db"
 	"github.com/NethermindEth/juno/mocks"
 	"github.com/NethermindEth/juno/node"
+	junosync "github.com/NethermindEth/juno/sync"
 	"github.com/stretchr/testify/assert"
 	"go.uber.org/mock/gomock"
 )
@@ -71,5 +74,63 @@ func TestHandleReadySync(t *testing.T) {
 		readinessHandlers.HandleReadySync(rr, req)
 
 		assert.Equal(t, http.StatusOK, rr.Code)
+	})
+}
+
+func TestHandleReadySyncWithoutSynchronizer(t *testing.T) {
+	mockCtrl := gomock.NewController(t)
+	t.Cleanup(mockCtrl.Finish)
+
+	mockReader := mocks.NewMockReader(mockCtrl)
+	mockReader.EXPECT().HeadsHeader().Return(&core.Header{Number: 1}, nil)
+	readinessHandlers := node.NewReadinessHandlers(mockReader, &junosync.NoopSynchronizer{}, 6)
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/ready/sync", http.NoBody)
+	rr := httptest.NewRecorder()
+
+	readinessHandlers.HandleReadySync(rr, req)
+
+	assert.Equal(t, http.StatusServiceUnavailable, rr.Code)
+}
+
+func TestHandleReadyRPC(t *testing.T) {
+	mockCtrl := gomock.NewController(t)
+	t.Cleanup(mockCtrl.Finish)
+
+	t.Run("database serving returns 200", func(t *testing.T) {
+		mockReader := mocks.NewMockReader(mockCtrl)
+		mockReader.EXPECT().HeadsHeader().Return(&core.Header{Number: 1}, nil)
+		readinessHandlers := node.NewReadinessHandlers(mockReader, nil, 0)
+		req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/ready/rpc", http.NoBody)
+		rr := httptest.NewRecorder()
+
+		readinessHandlers.HandleReadyRPC(rr, req)
+
+		assert.Equal(t, http.StatusOK, rr.Code)
+	})
+
+	t.Run("missing canonical head returns 503", func(t *testing.T) {
+		mockReader := mocks.NewMockReader(mockCtrl)
+		mockReader.EXPECT().HeadsHeader().Return(nil, db.ErrKeyNotFound)
+		readinessHandlers := node.NewReadinessHandlers(mockReader, nil, 0)
+		req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/ready/rpc", http.NoBody)
+		rr := httptest.NewRecorder()
+
+		readinessHandlers.HandleReadyRPC(rr, req)
+
+		assert.Equal(t, http.StatusServiceUnavailable, rr.Code)
+		assert.Equal(t, "RPC not ready: failed to read canonical head.", rr.Body.String())
+	})
+
+	t.Run("database error returns 503", func(t *testing.T) {
+		mockReader := mocks.NewMockReader(mockCtrl)
+		mockReader.EXPECT().HeadsHeader().Return(nil, errors.New("database unavailable"))
+		readinessHandlers := node.NewReadinessHandlers(mockReader, nil, 0)
+		req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/ready/rpc", http.NoBody)
+		rr := httptest.NewRecorder()
+
+		readinessHandlers.HandleReadyRPC(rr, req)
+
+		assert.Equal(t, http.StatusServiceUnavailable, rr.Code)
+		assert.Equal(t, "RPC not ready: failed to read canonical head.", rr.Body.String())
 	})
 }

--- a/node/http_test.go
+++ b/node/http_test.go
@@ -7,8 +7,10 @@ import (
 
 	"github.com/NethermindEth/juno/core"
 	"github.com/NethermindEth/juno/core/felt"
+	"github.com/NethermindEth/juno/db"
 	"github.com/NethermindEth/juno/mocks"
 	"github.com/NethermindEth/juno/node"
+	junosync "github.com/NethermindEth/juno/sync"
 	"github.com/stretchr/testify/assert"
 	"go.uber.org/mock/gomock"
 )
@@ -71,5 +73,50 @@ func TestHandleReadySync(t *testing.T) {
 		readinessHandlers.HandleReadySync(rr, req)
 
 		assert.Equal(t, http.StatusOK, rr.Code)
+	})
+}
+
+func TestHandleReadySyncWithoutSynchronizer(t *testing.T) {
+	mockCtrl := gomock.NewController(t)
+	t.Cleanup(mockCtrl.Finish)
+
+	mockReader := mocks.NewMockReader(mockCtrl)
+	mockReader.EXPECT().HeadsHeader().Return(&core.Header{Number: 1}, nil)
+	readinessHandlers := node.NewReadinessHandlers(mockReader, &junosync.NoopSynchronizer{}, 6)
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/ready/sync", http.NoBody)
+	rr := httptest.NewRecorder()
+
+	readinessHandlers.HandleReadySync(rr, req)
+
+	assert.Equal(t, http.StatusServiceUnavailable, rr.Code)
+}
+
+func TestHandleReadyRPC(t *testing.T) {
+	mockCtrl := gomock.NewController(t)
+	t.Cleanup(mockCtrl.Finish)
+
+	t.Run("database serving returns 200", func(t *testing.T) {
+		mockReader := mocks.NewMockReader(mockCtrl)
+		mockReader.EXPECT().HeadsHeader().Return(&core.Header{Number: 1}, nil)
+		readinessHandlers := node.NewReadinessHandlers(mockReader, nil, 0)
+		req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/ready/rpc", http.NoBody)
+		rr := httptest.NewRecorder()
+
+		readinessHandlers.HandleReadyRPC(rr, req)
+
+		assert.Equal(t, http.StatusOK, rr.Code)
+	})
+
+	t.Run("empty database returns 503", func(t *testing.T) {
+		mockReader := mocks.NewMockReader(mockCtrl)
+		mockReader.EXPECT().HeadsHeader().Return(nil, db.ErrKeyNotFound)
+		readinessHandlers := node.NewReadinessHandlers(mockReader, nil, 0)
+		req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/ready/rpc", http.NoBody)
+		rr := httptest.NewRecorder()
+
+		readinessHandlers.HandleReadyRPC(rr, req)
+
+		assert.Equal(t, http.StatusServiceUnavailable, rr.Code)
+		assert.Equal(t, "RPC not ready: database contains no blocks.", rr.Body.String())
 	})
 }

--- a/node/node.go
+++ b/node/node.go
@@ -131,6 +131,7 @@ type Config struct {
 	ForbidRPCBatchRequests bool `mapstructure:"disable-rpc-batch-requests"`
 
 	DisableReceivedTxnStream bool `mapstructure:"disable-received-txn-stream"`
+	DisableSync              bool `mapstructure:"-"`
 
 	RPCRequestTimeout        time.Duration `mapstructure:"rpc-request-timeout"`
 	RPCMaxConcurrentRequests uint          `mapstructure:"rpc-max-concurrent-requests"`
@@ -184,6 +185,23 @@ func New(cfg *Config, version string, logLevel *log.Level) (*Node, error) {
 	)
 	if err != nil {
 		return nil, err
+	}
+
+	if cfg.DisableSync {
+		if cfg.Sequencer {
+			return nil, errors.New("--sync=false has no effect in sequencer mode; " +
+				"remove --seq-enable or --sync=false")
+		}
+		if cfg.P2P {
+			return nil, errors.New("--p2p requires synchronization; remove --p2p or --sync=false")
+		}
+		if cfg.Prune {
+			return nil, errors.New("--prune-mode requires synchronization; " +
+				"remove --prune-mode or --sync=false")
+		}
+
+		logger.Warn("L2 synchronization and plugin block events are disabled. " +
+			"Use /ready/rpc for readiness (/ready and /ready/sync will report 503).")
 	}
 
 	// History pruning needs an L1-finalised cutoff to know which blocks are
@@ -295,6 +313,7 @@ func New(cfg *Config, version string, logLevel *log.Level) (*Node, error) {
 	var client *feeder.Client
 	var gatewayClient *gateway.Client
 	var p2pService *p2p.Service
+	var syncReader sync.Reader = &sync.NoopSynchronizer{}
 
 	var junoPlugin plugin.JunoPlugin
 	if cfg.PluginPath != "" {
@@ -415,16 +434,18 @@ func New(cfg *Config, version string, logLevel *log.Level) (*Node, error) {
 		nodeVM = vm.New(&chainInfo, false, logger)
 		throttledVM = NewThrottledVM(nodeVM, cfg.MaxVMs, uint64(cfg.MaxVMQueue))
 
-		feederGatewayDataSource := sync.NewFeederGatewayDataSource(chain, adaptfeeder.New(client))
-		synchronizer = sync.New(
-			chain,
-			feederGatewayDataSource,
-			logger,
-			cfg.PreConfirmedPollInterval,
-			dbIsRemote,
-			database,
-		)
-		synchronizer.WithPlugin(junoPlugin)
+		if !cfg.DisableSync {
+			feederGatewayDataSource := sync.NewFeederGatewayDataSource(chain, adaptfeeder.New(client))
+			synchronizer = sync.New(
+				chain,
+				feederGatewayDataSource,
+				logger,
+				cfg.PreConfirmedPollInterval,
+				dbIsRemote,
+				database,
+			)
+			synchronizer.WithPlugin(junoPlugin)
+		}
 
 		gatewayClient = gateway.NewClient(cfg.Network.GatewayURL, logger).
 			WithUserAgent(ua).
@@ -459,8 +480,6 @@ func New(cfg *Config, version string, logLevel *log.Level) (*Node, error) {
 
 			services = append(services, p2pService)
 		}
-
-		var syncReader sync.Reader = &sync.NoopSynchronizer{}
 		if synchronizer != nil {
 			syncReader = synchronizer
 		}
@@ -555,10 +574,11 @@ func New(cfg *Config, version string, logLevel *log.Level) (*Node, error) {
 		"/rpc" + pathV08: jsonrpcServerV08,
 	}
 	if cfg.HTTP {
-		readinessHandlers := NewReadinessHandlers(chain, synchronizer, cfg.ReadinessBlockTolerance)
+		readinessHandlers := NewReadinessHandlers(chain, syncReader, cfg.ReadinessBlockTolerance)
 		httpHandlers := map[string]http.HandlerFunc{
 			"/live":       readinessHandlers.HandleLive,
 			"/ready":      readinessHandlers.HandleReadySync,
+			"/ready/rpc":  readinessHandlers.HandleReadyRPC,
 			"/ready/sync": readinessHandlers.HandleReadySync,
 		}
 		services = append(

--- a/node/node.go
+++ b/node/node.go
@@ -131,6 +131,7 @@ type Config struct {
 	ForbidRPCBatchRequests bool `mapstructure:"disable-rpc-batch-requests"`
 
 	DisableReceivedTxnStream bool `mapstructure:"disable-received-txn-stream"`
+	DisableSync              bool `mapstructure:"disable-sync"`
 
 	RPCRequestTimeout        time.Duration `mapstructure:"rpc-request-timeout"`
 	RPCMaxConcurrentRequests uint          `mapstructure:"rpc-max-concurrent-requests"`
@@ -184,6 +185,27 @@ func New(cfg *Config, version string, logLevel *log.Level) (*Node, error) {
 	)
 	if err != nil {
 		return nil, err
+	}
+
+	if cfg.DisableSync {
+		if cfg.Sequencer {
+			return nil, errors.New("--disable-sync has no effect in sequencer mode; " +
+				"remove --seq-enable or --disable-sync")
+		}
+		if cfg.P2P {
+			return nil, errors.New("--p2p requires synchronization; remove --p2p or --disable-sync")
+		}
+		if cfg.Prune {
+			return nil, errors.New("--prune-mode requires synchronization; " +
+				"remove --prune-mode or --disable-sync")
+		}
+		if cfg.RemoteDB != "" {
+			return nil, errors.New("--remote-db cannot be combined with --disable-sync; " +
+				"remove --remote-db or --disable-sync")
+		}
+
+		logger.Warn("L2 synchronization and plugin block events are disabled. " +
+			"Use /ready/rpc for readiness (/ready and /ready/sync will report 503).")
 	}
 
 	// History pruning needs an L1-finalised cutoff to know which blocks are
@@ -295,6 +317,7 @@ func New(cfg *Config, version string, logLevel *log.Level) (*Node, error) {
 	var client *feeder.Client
 	var gatewayClient *gateway.Client
 	var p2pService *p2p.Service
+	var syncReader sync.Reader = &sync.NoopSynchronizer{}
 
 	var junoPlugin plugin.JunoPlugin
 	if cfg.PluginPath != "" {
@@ -415,16 +438,18 @@ func New(cfg *Config, version string, logLevel *log.Level) (*Node, error) {
 		nodeVM = vm.New(&chainInfo, false, logger)
 		throttledVM = NewThrottledVM(nodeVM, cfg.MaxVMs, uint64(cfg.MaxVMQueue))
 
-		feederGatewayDataSource := sync.NewFeederGatewayDataSource(chain, adaptfeeder.New(client))
-		synchronizer = sync.New(
-			chain,
-			feederGatewayDataSource,
-			logger,
-			cfg.PreConfirmedPollInterval,
-			dbIsRemote,
-			database,
-		)
-		synchronizer.WithPlugin(junoPlugin)
+		if !cfg.DisableSync {
+			feederGatewayDataSource := sync.NewFeederGatewayDataSource(chain, adaptfeeder.New(client))
+			synchronizer = sync.New(
+				chain,
+				feederGatewayDataSource,
+				logger,
+				cfg.PreConfirmedPollInterval,
+				dbIsRemote,
+				database,
+			)
+			synchronizer.WithPlugin(junoPlugin)
+		}
 
 		gatewayClient = gateway.NewClient(cfg.Network.GatewayURL, logger).
 			WithUserAgent(ua).
@@ -459,8 +484,6 @@ func New(cfg *Config, version string, logLevel *log.Level) (*Node, error) {
 
 			services = append(services, p2pService)
 		}
-
-		var syncReader sync.Reader = &sync.NoopSynchronizer{}
 		if synchronizer != nil {
 			syncReader = synchronizer
 		}
@@ -555,10 +578,11 @@ func New(cfg *Config, version string, logLevel *log.Level) (*Node, error) {
 		"/rpc" + pathV08: jsonrpcServerV08,
 	}
 	if cfg.HTTP {
-		readinessHandlers := NewReadinessHandlers(chain, synchronizer, cfg.ReadinessBlockTolerance)
+		readinessHandlers := NewReadinessHandlers(chain, syncReader, cfg.ReadinessBlockTolerance)
 		httpHandlers := map[string]http.HandlerFunc{
 			"/live":       readinessHandlers.HandleLive,
 			"/ready":      readinessHandlers.HandleReadySync,
+			"/ready/rpc":  readinessHandlers.HandleReadyRPC,
 			"/ready/sync": readinessHandlers.HandleReadySync,
 		}
 		services = append(

--- a/node/node_test.go
+++ b/node/node_test.go
@@ -56,6 +56,27 @@ func TestNewNode(t *testing.T) {
 	n.Run(ctx)
 }
 
+func TestNewNodeWithSyncDisabled(t *testing.T) {
+	config := &node.Config{
+		LogLevel:                           "info",
+		HTTP:                               true,
+		HTTPPort:                           0,
+		DatabasePath:                       t.TempDir(),
+		DBCompression:                      "zstd",
+		Network:                            networks.Sepolia,
+		DisableL1Verification:              true,
+		DisableSync:                        true,
+		SubmittedTransactionsCacheEntryTTL: time.Second,
+	}
+
+	n, err := node.New(config, "v0.3", log.NewLevel(log.INFO))
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+	n.Run(ctx)
+}
+
 func TestNewNodeRunsOneAtATimeOnLowMemory(t *testing.T) {
 	config := &node.Config{
 		LogLevel:                           "info",
@@ -173,4 +194,36 @@ func TestNew_RejectsPruneWithoutL1Verification(t *testing.T) {
 		DisableL1Verification: true,
 	}, "test", log.NewLevel(log.INFO))
 	require.ErrorContains(t, err, "prune-mode requires L1 verification")
+}
+
+func TestNewRejectsModesThatRequireSynchronization(t *testing.T) {
+	tests := map[string]struct {
+		config    node.Config
+		errString string
+	}{
+		"sequencer": {
+			config:    node.Config{Sequencer: true},
+			errString: "disable-sync has no effect in sequencer mode",
+		},
+		"p2p": {
+			config:    node.Config{P2P: true},
+			errString: "p2p requires synchronization",
+		},
+		"pruning": {
+			config:    node.Config{Prune: true},
+			errString: "prune-mode requires synchronization",
+		},
+		"remote database": {
+			config:    node.Config{RemoteDB: "localhost:6064"},
+			errString: "remote-db cannot be combined with --disable-sync",
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			test.config.DisableSync = true
+			_, err := node.New(&test.config, "test", log.NewLevel(log.INFO))
+			require.ErrorContains(t, err, test.errString)
+		})
+	}
 }

--- a/node/node_test.go
+++ b/node/node_test.go
@@ -56,6 +56,27 @@ func TestNewNode(t *testing.T) {
 	n.Run(ctx)
 }
 
+func TestNewNodeWithSyncDisabled(t *testing.T) {
+	config := &node.Config{
+		LogLevel:                           "info",
+		HTTP:                               true,
+		HTTPPort:                           0,
+		DatabasePath:                       t.TempDir(),
+		DBCompression:                      "zstd",
+		Network:                            networks.Sepolia,
+		DisableL1Verification:              true,
+		DisableSync:                        true,
+		SubmittedTransactionsCacheEntryTTL: time.Second,
+	}
+
+	n, err := node.New(config, "v0.3", log.NewLevel(log.INFO))
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+	n.Run(ctx)
+}
+
 func TestNewNodeRunsOneAtATimeOnLowMemory(t *testing.T) {
 	config := &node.Config{
 		LogLevel:                           "info",
@@ -173,4 +194,32 @@ func TestNew_RejectsPruneWithoutL1Verification(t *testing.T) {
 		DisableL1Verification: true,
 	}, "test", log.NewLevel(log.INFO))
 	require.ErrorContains(t, err, "prune-mode requires L1 verification")
+}
+
+func TestNewRejectsModesThatRequireSynchronization(t *testing.T) {
+	tests := map[string]struct {
+		config    node.Config
+		errString string
+	}{
+		"sequencer": {
+			config:    node.Config{Sequencer: true},
+			errString: "sync=false has no effect in sequencer mode",
+		},
+		"p2p": {
+			config:    node.Config{P2P: true},
+			errString: "p2p requires synchronization",
+		},
+		"pruning": {
+			config:    node.Config{Prune: true},
+			errString: "prune-mode requires synchronization",
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			test.config.DisableSync = true
+			_, err := node.New(&test.config, "test", log.NewLevel(log.INFO))
+			require.ErrorContains(t, err, test.errString)
+		})
+	}
 }

--- a/rpc/v10/block_test.go
+++ b/rpc/v10/block_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/NethermindEth/juno/rpc/rpccore"
 	rpc "github.com/NethermindEth/juno/rpc/v10"
 	adaptfeeder "github.com/NethermindEth/juno/starknetdata/feeder"
+	junosync "github.com/NethermindEth/juno/sync"
 	"github.com/NethermindEth/juno/sync/preconfirmed"
 	"github.com/NethermindEth/juno/utils/log"
 	"github.com/stretchr/testify/assert"
@@ -723,6 +724,17 @@ func TestBlockWithTxHashes_ErrorCases(t *testing.T) {
 			assert.Equal(t, rpccore.ErrBlockNotFound, rpcErr)
 		})
 	}
+
+	t.Run("pre_confirmed with no-op synchronizer", func(t *testing.T) {
+		chain := blockchain.New(memory.New(), &networks.Mainnet)
+		handler := rpc.New(chain, new(junosync.NoopSynchronizer), nil, log.NewNopZapLogger())
+		id := rpc.BlockIDPreConfirmed()
+
+		block, rpcErr := handler.BlockWithTxHashes(&id)
+
+		assert.Nil(t, block)
+		assert.Equal(t, rpccore.ErrBlockNotFound, rpcErr)
+	})
 
 	t.Run("l1head failure", func(t *testing.T) {
 		mockCtrl := gomock.NewController(t)

--- a/sync/sync.go
+++ b/sync/sync.go
@@ -105,7 +105,7 @@ func (n *NoopSynchronizer) SubscribePreConfirmed() PreConfirmedDataSubscription 
 }
 
 func (n *NoopSynchronizer) PreConfirmedChain() (preconfirmed.ChainReader, error) {
-	return preconfirmed.ChainReader{}, errors.New("PreConfirmedChain() is not implemented")
+	return preconfirmed.ChainReader{}, pending.ErrPreConfirmedNotFound
 }
 
 // Synchronizer manages a list of StarknetData to fetch the latest blockchain updates

--- a/sync/sync_test.go
+++ b/sync/sync_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/NethermindEth/juno/clients/feeder"
 	"github.com/NethermindEth/juno/core"
 	"github.com/NethermindEth/juno/core/felt"
+	"github.com/NethermindEth/juno/core/pending"
 	statetestutils "github.com/NethermindEth/juno/core/state/testutils"
 	"github.com/NethermindEth/juno/db/memory"
 	"github.com/NethermindEth/juno/mocks"
@@ -24,6 +25,11 @@ import (
 )
 
 const timeout = time.Second
+
+func TestNoopSynchronizerPreConfirmedChain(t *testing.T) {
+	_, err := new(sync.NoopSynchronizer).PreConfirmedChain()
+	require.ErrorIs(t, err, pending.ErrPreConfirmedNotFound)
+}
 
 func TestSyncBlocks(t *testing.T) {
 	mockCtrl := gomock.NewController(t)


### PR DESCRIPTION
Allow disabling L2 sync so a node can serve RPC from an existing DB snapshot. 

Gates synchronizer/P2P creation behind `!DisableSync,` defaults `syncReader` to `NoopSynchronizer` (also fixing a latent /ready nil-deref in sequencer mode), and adds a sync-independent `/ready/rpc` endpoint that reports 200 when the local DB head is readable. `NoopSynchronizer.PreConfirmedChain()` now returns the `ErrPreConfirmedNotFound` sentinel so RPC callers map it to `ErrBlockNotFound`.