### PR TITLE
fix(jsonrpc): drop the caret when the offending bytes left the window

### DIFF
--- a/jsonrpc/pretty_error.go
+++ b/jsonrpc/pretty_error.go
@@ -54,7 +54,6 @@ func errorOffset(inputLength int, err error) (offset int, ok bool) {
 	case errors.Is(err, io.ErrUnexpectedEOF), errors.Is(err, io.EOF):
 		return inputLength, true
 	default:
-		// TODO(granza): when we add SONIC, the errors will be already pretty.
 		return 0, false
 	}
 }
@@ -199,7 +198,12 @@ func prettyParseError(c *windowBuffer, err error) string {
 	}
 
 	windowStart := c.consumedBytes - len(c.window)
-	markerPos := max(0, absOffset-windowStart)
+	if absOffset < windowStart {
+		// Do not show the caret if the error is no longer inside the message
+		return describeError(nil, 0, err)
+	}
+
+	markerPos := absOffset - windowStart
 	line, col := lineAndColumn(c, markerPos)
 	msg := fmt.Sprintf("%s [line %d, position %d]", describeError(c.window, markerPos, err), line, col)
 

--- a/jsonrpc/pretty_error_test.go
+++ b/jsonrpc/pretty_error_test.go
@@ -86,6 +86,21 @@ var parseErrorTests = map[string]struct {
 		res: `{"jsonrpc":"2.0","error":{"code":-32700,"message":"Parse error","data":"{\"jsonrpc\": 5, \"method\": \"x\", \"id\": 1}\n            ^\nfield \"jsonrpc\" should be string, got number [line 1, position 13]"},"id":null}`,
 	},
 
+	"type mismatch behind the captured window drops the position and marker": {
+		req: `{"jsonrpc": 5, "method": "x", "params": [` + strings.Repeat(`"0x1", `, 80) + `"0x2"], "id": 1}`,
+		res: `{"jsonrpc":"2.0","error":{"code":-32700,"message":"Parse error","data":"field \"jsonrpc\" should be string, got number"},"id":null}`,
+	},
+
+	"syntax error behind the captured window drops the position and marker": {
+		req: `{"jsonrpc": "2.0", "params": [` + strings.Repeat(`"0x1", `, 400) + ` @ ` + strings.Repeat(`"0x1", `, 400) + `"0x2"]}`,
+		res: `{"jsonrpc":"2.0","error":{"code":-32700,"message":"Parse error","data":"invalid character '@' looking for beginning of value"},"id":null}`,
+	},
+
+	"error exactly at the window start still draws the marker": {
+		req: `{"jsonrpc": 5, "method": "x", "params": [` + strings.Repeat(`"0x1", `, 66) + strings.Repeat(" ", 5) + `"0x2"], "id": 1}`,
+		res: `{"jsonrpc":"2.0","error":{"code":-32700,"message":"Parse error","data":"5, \"method\": \"x\", \"params\": [\"0x1\", \"0x1\", \"0x1\", \"0x1\", \"0x1\", \"0x1\", \"0x...\n^\nfield \"jsonrpc\" should be string, got number [line 1, position 1]"},"id":null}`,
+	},
+
 	"long line is windowed": {
 		req: `{
   "jsonrpc": "2.0",


### PR DESCRIPTION
The pretty json was pointing at the worng place when the error was no longer inside the error buffer.