### PR TITLE
perf(rpc): read a transaction and its receipt in one DB lookup

### DIFF
--- a/bench/rpc/README.md
+++ b/bench/rpc/README.md
@@ -6,6 +6,7 @@ Sample a Starknet node into a seeded JSON-RPC corpus, then replay it with
 ## Methods
 
 - `starknet_getTransactionByHash`
+- `starknet_getTransactionReceipt`
 
 ## Use
 

--- a/bench/rpc/cmd/corpus-gen/get_transaction_receipt.go
+++ b/bench/rpc/cmd/corpus-gen/get_transaction_receipt.go
@@ -1,0 +1,41 @@
+package main
+
+import (
+	"fmt"
+	"math/rand/v2"
+
+	"github.com/spf13/cobra"
+)
+
+const methodGetTransactionReceipt = "starknet_getTransactionReceipt"
+
+// newGetTxReceiptCmd reuses getTransactionByHash's sampler: both are keyed by a
+// transaction hash.
+func newGetTxReceiptCmd(cfg *rootConfig) *cobra.Command {
+	var blockStart, blockEnd uint64
+
+	cmd := &cobra.Command{
+		Use:   "getTransactionReceipt",
+		Short: "Sample random transaction hashes and emit starknet_getTransactionReceipt requests.",
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			if blockEnd <= blockStart {
+				return fmt.Errorf("--block-end (%d) must be > --block-start (%d)", blockEnd, blockStart)
+			}
+			meta := blockRange{Start: blockStart, End: blockEnd}
+			makeGen := func(client *rpcClient, rng *rand.Rand) func() (any, error) {
+				return func() (any, error) {
+					return sampleTxHash(cmd.Context(), client, rng, blockStart, blockEnd)
+				}
+			}
+			return runCorpus(cmd, cfg, methodGetTransactionReceipt, meta, makeGen)
+		},
+	}
+
+	cmd.Flags().Uint64Var(&blockStart, "block-start", 0,
+		"Start block number to sample from (inclusive).")
+	cmd.Flags().Uint64Var(&blockEnd, "block-end", 0,
+		"End block number to sample from (exclusive).")
+	_ = cmd.MarkFlagRequired("block-start")
+	_ = cmd.MarkFlagRequired("block-end")
+	return cmd
+}

--- a/bench/rpc/cmd/corpus-gen/main.go
+++ b/bench/rpc/cmd/corpus-gen/main.go
@@ -52,6 +52,7 @@ func newRootCmd() *cobra.Command {
 		"Batch size per entry; omit for plain request objects, N for JSON-RPC arrays of N.")
 
 	cmd.AddCommand(newGetTxByHashCmd(cfg))
+	cmd.AddCommand(newGetTxReceiptCmd(cfg))
 	return cmd
 }
 

--- a/blockchain/blockchain.go
+++ b/blockchain/blockchain.go
@@ -59,9 +59,9 @@ type Reader interface {
 	Receipt(
 		hash *felt.Felt,
 	) (receipt *core.TransactionReceipt, blockHash *felt.Felt, blockNumber uint64, err error)
-	ReceiptByBlockNumberAndIndex(
+	TransactionAndReceiptByBlockNumberAndIndex(
 		blockNumber, index uint64,
-	) (receipt core.TransactionReceipt, blockHash *felt.Felt, err error)
+	) (pair core.TransactionAndReceipt, blockHash *felt.Felt, err error)
 	TransactionExecutionStatusByBlockNumberAndIndex(
 		blockNumber, index uint64,
 	) (status core.TransactionExecutionStatus, err error)
@@ -328,22 +328,23 @@ func (b *Blockchain) Receipt(hash *felt.Felt) (*core.TransactionReceipt, *felt.F
 	return receipt, header.Hash, header.Number, nil
 }
 
-func (b *Blockchain) ReceiptByBlockNumberAndIndex(
+// TransactionAndReceiptByBlockNumberAndIndex returns a transaction and its receipt
+func (b *Blockchain) TransactionAndReceiptByBlockNumberAndIndex(
 	blockNumber, index uint64,
-) (core.TransactionReceipt, *felt.Felt, error) {
-	b.listener.OnRead("ReceiptByBlockNumberAndIndex")
+) (core.TransactionAndReceipt, *felt.Felt, error) {
+	b.listener.OnRead("TransactionAndReceiptByBlockNumberAndIndex")
 
-	receipt, err := core.GetReceiptByBlockAndIndex(b.database, blockNumber, index)
+	pair, err := core.GetTransactionAndReceiptByBlockAndIndex(b.database, blockNumber, index)
 	if err != nil {
-		return core.TransactionReceipt{}, nil, err
+		return core.TransactionAndReceipt{}, nil, err
 	}
 
-	header, err := core.GetBlockHeaderByNumber(b.database, blockNumber)
+	blockHash, err := core.GetBlockHeaderHashByNumber(b.database, blockNumber)
 	if err != nil {
-		return core.TransactionReceipt{}, nil, err
+		return core.TransactionAndReceipt{}, nil, err
 	}
 
-	return *receipt, header.Hash, nil
+	return pair, blockHash, nil
 }
 
 // TransactionExecutionStatusByBlockNumberAndIndex returns only the status subset of a receipt.

--- a/core/accessors.go
+++ b/core/accessors.go
@@ -505,6 +505,15 @@ func GetReceiptByBlockAndIndex(
 	return BlockTransactionsReceiptPartialBucket.Get(r, blockNumber, int(index))
 }
 
+// GetTransactionAndReceiptByBlockAndIndex returns a transaction with its receipt
+func GetTransactionAndReceiptByBlockAndIndex(
+	r db.KeyValueReader,
+	blockNumber uint64,
+	index uint64,
+) (TransactionAndReceipt, error) {
+	return BlockTransactionsTransactionAndReceiptPartialBucket.Get(r, blockNumber, int(index))
+}
+
 // GetTransactionExecutionStatusByBlockAndIndex returns only the status subset of a
 // receipt, skipping its heavier fields.
 func GetTransactionExecutionStatusByBlockAndIndex(

--- a/core/block_transaction.go
+++ b/core/block_transaction.go
@@ -35,6 +35,11 @@ type BlockTransactions struct {
 	Data    []byte
 }
 
+type TransactionAndReceipt struct {
+	Transaction Transaction
+	Receipt     *TransactionReceipt
+}
+
 func NewBlockTransactionsFromIterators[T, R any](
 	transactions iter.Seq2[T, error],
 	receipts iter.Seq2[R, error],

--- a/core/block_transaction_serializer.go
+++ b/core/block_transaction_serializer.go
@@ -42,6 +42,23 @@ func (extractReceipt) extract(b *BlockTransactions, subKey int) (*TransactionRec
 	return b.Receipts().Get(subKey)
 }
 
+type extractTransactionAndReceipt struct{}
+
+func (extractTransactionAndReceipt) extract(
+	b *BlockTransactions,
+	subKey int,
+) (TransactionAndReceipt, error) {
+	txn, err := b.Transactions().Get(subKey)
+	if err != nil {
+		return TransactionAndReceipt{}, err
+	}
+	receipt, err := b.Receipts().Get(subKey)
+	if err != nil {
+		return TransactionAndReceipt{}, err
+	}
+	return TransactionAndReceipt{Transaction: txn, Receipt: receipt}, nil
+}
+
 type extractExecutionStatus struct{}
 
 func (extractExecutionStatus) extract(
@@ -106,6 +123,11 @@ var (
 		extractReceipt,
 		int,
 		*TransactionReceipt,
+	]{}
+	BlockTransactionsTransactionAndReceiptPartialSerializer = blockTransactionsPartialSerializer[
+		extractTransactionAndReceipt,
+		int,
+		TransactionAndReceipt,
 	]{}
 	BlockTransactionsExecutionStatusPartialSerializer = blockTransactionsPartialSerializer[
 		extractExecutionStatus,

--- a/core/typed_buckets.go
+++ b/core/typed_buckets.go
@@ -177,6 +177,11 @@ var BlockTransactionsReceiptPartialBucket = partial.NewPartialBucket(
 	BlockTransactionsReceiptPartialSerializer,
 )
 
+var BlockTransactionsTransactionAndReceiptPartialBucket = partial.NewPartialBucket(
+	BlockTransactionsBucket.Bucket,
+	BlockTransactionsTransactionAndReceiptPartialSerializer,
+)
+
 var BlockTransactionsExecutionStatusPartialBucket = partial.NewPartialBucket(
 	BlockTransactionsBucket.Bucket,
 	BlockTransactionsExecutionStatusPartialSerializer,

--- a/mocks/mock_blockchain.go
+++ b/mocks/mock_blockchain.go
@@ -317,22 +317,6 @@ func (mr *MockReaderMockRecorder) Receipt(hash any) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Receipt", reflect.TypeOf((*MockReader)(nil).Receipt), hash)
 }
 
-// ReceiptByBlockNumberAndIndex mocks base method.
-func (m *MockReader) ReceiptByBlockNumberAndIndex(blockNumber, index uint64) (core.TransactionReceipt, *felt.Felt, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ReceiptByBlockNumberAndIndex", blockNumber, index)
-	ret0, _ := ret[0].(core.TransactionReceipt)
-	ret1, _ := ret[1].(*felt.Felt)
-	ret2, _ := ret[2].(error)
-	return ret0, ret1, ret2
-}
-
-// ReceiptByBlockNumberAndIndex indicates an expected call of ReceiptByBlockNumberAndIndex.
-func (mr *MockReaderMockRecorder) ReceiptByBlockNumberAndIndex(blockNumber, index any) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReceiptByBlockNumberAndIndex", reflect.TypeOf((*MockReader)(nil).ReceiptByBlockNumberAndIndex), blockNumber, index)
-}
-
 // StateAtBlockHash mocks base method.
 func (m *MockReader) StateAtBlockHash(blockHash *felt.Felt) (core.StateReader, blockchain.StateCloser, error) {
 	m.ctrl.T.Helper()
@@ -407,6 +391,22 @@ func (m *MockReader) SubscribeL1Head() blockchain.L1HeadSubscription {
 func (mr *MockReaderMockRecorder) SubscribeL1Head() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SubscribeL1Head", reflect.TypeOf((*MockReader)(nil).SubscribeL1Head))
+}
+
+// TransactionAndReceiptByBlockNumberAndIndex mocks base method.
+func (m *MockReader) TransactionAndReceiptByBlockNumberAndIndex(blockNumber, index uint64) (core.TransactionAndReceipt, *felt.Felt, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "TransactionAndReceiptByBlockNumberAndIndex", blockNumber, index)
+	ret0, _ := ret[0].(core.TransactionAndReceipt)
+	ret1, _ := ret[1].(*felt.Felt)
+	ret2, _ := ret[2].(error)
+	return ret0, ret1, ret2
+}
+
+// TransactionAndReceiptByBlockNumberAndIndex indicates an expected call of TransactionAndReceiptByBlockNumberAndIndex.
+func (mr *MockReaderMockRecorder) TransactionAndReceiptByBlockNumberAndIndex(blockNumber, index any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "TransactionAndReceiptByBlockNumberAndIndex", reflect.TypeOf((*MockReader)(nil).TransactionAndReceiptByBlockNumberAndIndex), blockNumber, index)
 }
 
 // TransactionByBlockNumberAndIndex mocks base method.

--- a/rpc/v10/transaction.go
+++ b/rpc/v10/transaction.go
@@ -493,15 +493,7 @@ func (h *Handler) TransactionReceiptByHash(
 		return nil, rpccore.ErrTxnHashNotFound
 	}
 
-	txn, err := h.bcReader.TransactionByBlockNumberAndIndex(blockNumber, idx)
-	if err != nil {
-		if !errors.Is(err, db.ErrKeyNotFound) {
-			return nil, rpccore.ErrInternal.CloneWithData(err)
-		}
-		return nil, rpccore.ErrTxnHashNotFound
-	}
-
-	receipt, blockHash, err := h.bcReader.ReceiptByBlockNumberAndIndex(blockNumber, idx)
+	pair, blockHash, err := h.bcReader.TransactionAndReceiptByBlockNumberAndIndex(blockNumber, idx)
 	if err != nil {
 		if !errors.Is(err, db.ErrKeyNotFound) {
 			return nil, rpccore.ErrInternal.CloneWithData(err)
@@ -520,8 +512,8 @@ func (h *Handler) TransactionReceiptByHash(
 	}
 
 	return AdaptReceiptWithBlockInfo(
-		&receipt,
-		txn,
+		pair.Receipt,
+		pair.Transaction,
 		status,
 		blockHash,
 		blockNumber,

--- a/rpc/v10/transaction_test.go
+++ b/rpc/v10/transaction_test.go
@@ -1140,12 +1140,12 @@ func TestTransactionReceiptByHash(t *testing.T) {
 				mockReader.EXPECT().BlockNumberAndIndexByTxHash(
 					(*felt.TransactionHash)(expected.Hash),
 				).Return(*expected.BlockNumber, uint64(transactionIndex), nil)
-				mockReader.EXPECT().TransactionByBlockNumberAndIndex(
+				mockReader.EXPECT().TransactionAndReceiptByBlockNumberAndIndex(
 					*expected.BlockNumber, uint64(transactionIndex),
-				).Return(transaction, nil)
-				mockReader.EXPECT().ReceiptByBlockNumberAndIndex(
-					*expected.BlockNumber, uint64(transactionIndex),
-				).Return(*loadedBlock.Receipts[transactionIndex], expected.BlockHash, nil)
+				).Return(core.TransactionAndReceipt{
+					Transaction: transaction,
+					Receipt:     loadedBlock.Receipts[transactionIndex],
+				}, expected.BlockHash, nil)
 				mockReader.EXPECT().L1Head().Return(test.l1Head, nil)
 			}
 

--- a/rpc/v8/l1_test.go
+++ b/rpc/v8/l1_test.go
@@ -103,12 +103,12 @@ func TestGetMessageStatus(t *testing.T) {
 				mockReader.EXPECT().BlockNumberAndIndexByTxHash(
 					(*felt.TransactionHash)(msg.L1HandlerHash),
 				).Return(block.Number, uint64(0), nil)
-				mockReader.EXPECT().TransactionByBlockNumberAndIndex(
+				mockReader.EXPECT().TransactionAndReceiptByBlockNumberAndIndex(
 					block.Number, uint64(0),
-				).Return(l1handlerTxns[i], nil)
-				mockReader.EXPECT().ReceiptByBlockNumberAndIndex(
-					block.Number, uint64(0),
-				).Return(*block.Receipts[0], block.Hash, nil)
+				).Return(core.TransactionAndReceipt{
+					Transaction: l1handlerTxns[i],
+					Receipt:     block.Receipts[0],
+				}, block.Hash, nil)
 				mockReader.EXPECT().L1Head().Return(core.L1Head{BlockNumber: uint64(test.l1HeadBlockNum)}, nil)
 			}
 			msgStatuses, rpcErr := handler.GetMessageStatus(t.Context(), &test.l1TxnHash)

--- a/rpc/v8/subscriptions_test.go
+++ b/rpc/v8/subscriptions_test.go
@@ -395,12 +395,12 @@ func TestSubscribeTxnStatus(t *testing.T) {
 		mockChain.EXPECT().BlockNumberAndIndexByTxHash(
 			(*felt.TransactionHash)(txHash),
 		).Return(block.Number, uint64(0), nil)
-		mockChain.EXPECT().TransactionByBlockNumberAndIndex(
+		mockChain.EXPECT().TransactionAndReceiptByBlockNumberAndIndex(
 			block.Number, uint64(0),
-		).Return(block.Transactions[0], nil)
-		mockChain.EXPECT().ReceiptByBlockNumberAndIndex(
-			block.Number, uint64(0),
-		).Return(*block.Receipts[0], block.Hash, nil)
+		).Return(core.TransactionAndReceipt{
+			Transaction: block.Transactions[0],
+			Receipt:     block.Receipts[0],
+		}, block.Hash, nil)
 		mockChain.EXPECT().L1Head().Return(core.L1Head{}, db.ErrKeyNotFound)
 		for i := range 3 {
 			handler.preConfirmedFeed.Send(
@@ -417,12 +417,12 @@ func TestSubscribeTxnStatus(t *testing.T) {
 		mockChain.EXPECT().BlockNumberAndIndexByTxHash(
 			(*felt.TransactionHash)(txHash),
 		).Return(block.Number, uint64(0), nil)
-		mockChain.EXPECT().TransactionByBlockNumberAndIndex(
+		mockChain.EXPECT().TransactionAndReceiptByBlockNumberAndIndex(
 			block.Number, uint64(0),
-		).Return(block.Transactions[0], nil)
-		mockChain.EXPECT().ReceiptByBlockNumberAndIndex(
-			block.Number, uint64(0),
-		).Return(*block.Receipts[0], block.Hash, nil)
+		).Return(core.TransactionAndReceipt{
+			Transaction: block.Transactions[0],
+			Receipt:     block.Receipts[0],
+		}, block.Hash, nil)
 		mockChain.EXPECT().L1Head().Return(l1Head, nil)
 		handler.l1Heads.Send(&l1Head)
 		assertNextTxnStatus(t, conn, id, txHash, TxnStatusAcceptedOnL1, TxnSuccess, "")

--- a/rpc/v8/transaction.go
+++ b/rpc/v8/transaction.go
@@ -600,15 +600,7 @@ func (h *Handler) TransactionReceiptByHash(hash felt.Felt) (*TransactionReceipt,
 		return AdaptReceipt(receipt, txn, TxnPending, nil, 0), nil
 	}
 
-	txn, err := h.bcReader.TransactionByBlockNumberAndIndex(blockNumber, idx)
-	if err != nil {
-		if !errors.Is(err, db.ErrKeyNotFound) {
-			return nil, rpccore.ErrInternal.CloneWithData(err)
-		}
-		return nil, rpccore.ErrTxnHashNotFound
-	}
-
-	receipt, blockHash, err := h.bcReader.ReceiptByBlockNumberAndIndex(blockNumber, idx)
+	pair, blockHash, err := h.bcReader.TransactionAndReceiptByBlockNumberAndIndex(blockNumber, idx)
 	if err != nil {
 		return nil, rpccore.ErrTxnHashNotFound
 	}
@@ -624,7 +616,7 @@ func (h *Handler) TransactionReceiptByHash(hash felt.Felt) (*TransactionReceipt,
 		}
 	}
 
-	return AdaptReceipt(&receipt, txn, status, blockHash, blockNumber), nil
+	return AdaptReceipt(pair.Receipt, pair.Transaction, status, blockHash, blockNumber), nil
 }
 
 // AddTransaction relays a transaction to the gateway, or to the sequencer if enabled

--- a/rpc/v8/transaction_test.go
+++ b/rpc/v8/transaction_test.go
@@ -680,12 +680,12 @@ func TestTransactionReceiptByHash(t *testing.T) {
 			mockReader.EXPECT().BlockNumberAndIndexByTxHash(
 				gomock.Any(),
 			).Return(block0.Number, uint64(test.index), nil)
-			mockReader.EXPECT().TransactionByBlockNumberAndIndex(
+			mockReader.EXPECT().TransactionAndReceiptByBlockNumberAndIndex(
 				block0.Number, uint64(test.index),
-			).Return(block0.Transactions[test.index], nil)
-			mockReader.EXPECT().ReceiptByBlockNumberAndIndex(
-				block0.Number, uint64(test.index),
-			).Return(*block0.Receipts[test.index], block0.Hash, nil)
+			).Return(core.TransactionAndReceipt{
+				Transaction: block0.Transactions[test.index],
+				Receipt:     block0.Receipts[test.index],
+			}, block0.Hash, nil)
 			mockReader.EXPECT().L1Head().Return(core.L1Head{}, db.ErrKeyNotFound)
 
 			checkTxReceipt(t, txHash, test.expected)
@@ -738,12 +738,12 @@ func TestTransactionReceiptByHash(t *testing.T) {
 		mockReader.EXPECT().BlockNumberAndIndexByTxHash(
 			(*felt.TransactionHash)(txHash),
 		).Return(block0.Number, uint64(i), nil)
-		mockReader.EXPECT().TransactionByBlockNumberAndIndex(
+		mockReader.EXPECT().TransactionAndReceiptByBlockNumberAndIndex(
 			block0.Number, uint64(i),
-		).Return(block0.Transactions[i], nil)
-		mockReader.EXPECT().ReceiptByBlockNumberAndIndex(
-			block0.Number, uint64(i),
-		).Return(*block0.Receipts[i], block0.Hash, nil)
+		).Return(core.TransactionAndReceipt{
+			Transaction: block0.Transactions[i],
+			Receipt:     block0.Receipts[i],
+		}, block0.Hash, nil)
 		mockReader.EXPECT().L1Head().Return(core.L1Head{
 			BlockNumber: block0.Number,
 			BlockHash:   block0.Hash,
@@ -783,12 +783,12 @@ func TestTransactionReceiptByHash(t *testing.T) {
 		mockReader.EXPECT().BlockNumberAndIndexByTxHash(
 			(*felt.TransactionHash)(revertedTxnHash),
 		).Return(blockWithRevertedTxn.Number, uint64(revertedTxnIdx), nil)
-		mockReader.EXPECT().TransactionByBlockNumberAndIndex(
+		mockReader.EXPECT().TransactionAndReceiptByBlockNumberAndIndex(
 			blockWithRevertedTxn.Number, uint64(revertedTxnIdx),
-		).Return(blockWithRevertedTxn.Transactions[revertedTxnIdx], nil)
-		mockReader.EXPECT().ReceiptByBlockNumberAndIndex(
-			blockWithRevertedTxn.Number, uint64(revertedTxnIdx),
-		).Return(*blockWithRevertedTxn.Receipts[revertedTxnIdx], blockWithRevertedTxn.Hash, nil)
+		).Return(core.TransactionAndReceipt{
+			Transaction: blockWithRevertedTxn.Transactions[revertedTxnIdx],
+			Receipt:     blockWithRevertedTxn.Receipts[revertedTxnIdx],
+		}, blockWithRevertedTxn.Hash, nil)
 		mockReader.EXPECT().L1Head().Return(core.L1Head{}, db.ErrKeyNotFound)
 
 		checkTxReceipt(t, revertedTxnHash, expected)
@@ -853,12 +853,12 @@ func TestTransactionReceiptByHash(t *testing.T) {
 		mockReader.EXPECT().BlockNumberAndIndexByTxHash(
 			(*felt.TransactionHash)(txnHash),
 		).Return(block.Number, uint64(index), nil)
-		mockReader.EXPECT().TransactionByBlockNumberAndIndex(
+		mockReader.EXPECT().TransactionAndReceiptByBlockNumberAndIndex(
 			block.Number, uint64(index),
-		).Return(block.Transactions[index], nil)
-		mockReader.EXPECT().ReceiptByBlockNumberAndIndex(
-			block.Number, uint64(index),
-		).Return(*block.Receipts[index], block.Hash, nil)
+		).Return(core.TransactionAndReceipt{
+			Transaction: block.Transactions[index],
+			Receipt:     block.Receipts[index],
+		}, block.Hash, nil)
 		mockReader.EXPECT().L1Head().Return(core.L1Head{}, db.ErrKeyNotFound)
 
 		checkTxReceipt(t, txnHash, expected)
@@ -909,12 +909,12 @@ func TestTransactionReceiptByHash(t *testing.T) {
 		mockReader.EXPECT().BlockNumberAndIndexByTxHash(
 			(*felt.TransactionHash)(txnHash),
 		).Return(block.Number, uint64(index), nil)
-		mockReader.EXPECT().TransactionByBlockNumberAndIndex(
+		mockReader.EXPECT().TransactionAndReceiptByBlockNumberAndIndex(
 			block.Number, uint64(index),
-		).Return(block.Transactions[index], nil)
-		mockReader.EXPECT().ReceiptByBlockNumberAndIndex(
-			block.Number, uint64(index),
-		).Return(*block.Receipts[index], block.Hash, nil)
+		).Return(core.TransactionAndReceipt{
+			Transaction: block.Transactions[index],
+			Receipt:     block.Receipts[index],
+		}, block.Hash, nil)
 		mockReader.EXPECT().L1Head().Return(core.L1Head{}, db.ErrKeyNotFound)
 
 		checkTxReceipt(t, txnHash, expected)
@@ -1399,12 +1399,12 @@ func TestTransactionStatus(t *testing.T) {
 					mockReader.EXPECT().BlockNumberAndIndexByTxHash(
 						(*felt.TransactionHash)(tx.Hash()),
 					).Return(block.Number, uint64(0), nil)
-					mockReader.EXPECT().TransactionByBlockNumberAndIndex(
+					mockReader.EXPECT().TransactionAndReceiptByBlockNumberAndIndex(
 						block.Number, uint64(0),
-					).Return(tx, nil)
-					mockReader.EXPECT().ReceiptByBlockNumberAndIndex(
-						block.Number, uint64(0),
-					).Return(*block.Receipts[0], block.Hash, nil)
+					).Return(core.TransactionAndReceipt{
+						Transaction: tx,
+						Receipt:     block.Receipts[0],
+					}, block.Hash, nil)
 					mockReader.EXPECT().L1Head().Return(core.L1Head{}, nil)
 
 					handler := rpc.New(mockReader, nil, nil, nil)
@@ -1422,12 +1422,12 @@ func TestTransactionStatus(t *testing.T) {
 					mockReader.EXPECT().BlockNumberAndIndexByTxHash(
 						(*felt.TransactionHash)(tx.Hash()),
 					).Return(block.Number, uint64(0), nil)
-					mockReader.EXPECT().TransactionByBlockNumberAndIndex(
+					mockReader.EXPECT().TransactionAndReceiptByBlockNumberAndIndex(
 						block.Number, uint64(0),
-					).Return(tx, nil)
-					mockReader.EXPECT().ReceiptByBlockNumberAndIndex(
-						block.Number, uint64(0),
-					).Return(*block.Receipts[0], block.Hash, nil)
+					).Return(core.TransactionAndReceipt{
+						Transaction: tx,
+						Receipt:     block.Receipts[0],
+					}, block.Hash, nil)
 					mockReader.EXPECT().L1Head().Return(core.L1Head{
 						BlockNumber: block.Number + 1,
 					}, nil)
@@ -1447,12 +1447,12 @@ func TestTransactionStatus(t *testing.T) {
 					mockReader.EXPECT().BlockNumberAndIndexByTxHash(
 						(*felt.TransactionHash)(tx.Hash()),
 					).Return(block.Number, uint64(0), nil)
-					mockReader.EXPECT().TransactionByBlockNumberAndIndex(
+					mockReader.EXPECT().TransactionAndReceiptByBlockNumberAndIndex(
 						block.Number, uint64(0),
-					).Return(tx, nil)
-					mockReader.EXPECT().ReceiptByBlockNumberAndIndex(
-						block.Number, uint64(0),
-					).Return(*block.Receipts[0], block.Hash, nil)
+					).Return(core.TransactionAndReceipt{
+						Transaction: tx,
+						Receipt:     block.Receipts[0],
+					}, block.Hash, nil)
 					mockReader.EXPECT().L1Head().Return(core.L1Head{
 						BlockNumber: block.Number + 1,
 					}, nil)

--- a/rpc/v9/transaction.go
+++ b/rpc/v9/transaction.go
@@ -656,15 +656,7 @@ func (h *Handler) TransactionReceiptByHash(hash *felt.Felt) (*TransactionReceipt
 		return nil, rpccore.ErrTxnHashNotFound
 	}
 
-	txn, err := h.bcReader.TransactionByBlockNumberAndIndex(blockNumber, idx)
-	if err != nil {
-		if !errors.Is(err, db.ErrKeyNotFound) {
-			return nil, rpccore.ErrInternal.CloneWithData(err)
-		}
-		return nil, rpccore.ErrTxnHashNotFound
-	}
-
-	receipt, blockHash, err := h.bcReader.ReceiptByBlockNumberAndIndex(blockNumber, idx)
+	pair, blockHash, err := h.bcReader.TransactionAndReceiptByBlockNumberAndIndex(blockNumber, idx)
 	if err != nil {
 		return nil, rpccore.ErrTxnHashNotFound
 	}
@@ -680,8 +672,8 @@ func (h *Handler) TransactionReceiptByHash(hash *felt.Felt) (*TransactionReceipt
 	}
 
 	return AdaptReceiptWithBlockInfo(
-		&receipt,
-		txn,
+		pair.Receipt,
+		pair.Transaction,
 		status,
 		blockHash,
 		blockNumber,

--- a/rpc/v9/transaction_test.go
+++ b/rpc/v9/transaction_test.go
@@ -914,12 +914,12 @@ func TestTransactionReceiptByHash(t *testing.T) {
 			mockReader.EXPECT().BlockNumberAndIndexByTxHash(
 				(*felt.TransactionHash)(txHash),
 			).Return(block0.Number, uint64(test.index), nil)
-			mockReader.EXPECT().TransactionByBlockNumberAndIndex(
+			mockReader.EXPECT().TransactionAndReceiptByBlockNumberAndIndex(
 				block0.Number, uint64(test.index),
-			).Return(block0.Transactions[test.index], nil)
-			mockReader.EXPECT().ReceiptByBlockNumberAndIndex(
-				block0.Number, uint64(test.index),
-			).Return(*block0.Receipts[test.index], block0.Hash, nil)
+			).Return(core.TransactionAndReceipt{
+				Transaction: block0.Transactions[test.index],
+				Receipt:     block0.Receipts[test.index],
+			}, block0.Hash, nil)
 			mockReader.EXPECT().L1Head().Return(core.L1Head{}, db.ErrKeyNotFound)
 
 			checkTxReceipt(t, txHash, test.expected)
@@ -1012,12 +1012,12 @@ func TestTransactionReceiptByHash(t *testing.T) {
 		mockReader.EXPECT().BlockNumberAndIndexByTxHash(
 			(*felt.TransactionHash)(txHash),
 		).Return(block0.Number, uint64(i), nil)
-		mockReader.EXPECT().TransactionByBlockNumberAndIndex(
+		mockReader.EXPECT().TransactionAndReceiptByBlockNumberAndIndex(
 			block0.Number, uint64(i),
-		).Return(block0.Transactions[i], nil)
-		mockReader.EXPECT().ReceiptByBlockNumberAndIndex(
-			block0.Number, uint64(i),
-		).Return(*block0.Receipts[i], block0.Hash, nil)
+		).Return(core.TransactionAndReceipt{
+			Transaction: block0.Transactions[i],
+			Receipt:     block0.Receipts[i],
+		}, block0.Hash, nil)
 		mockReader.EXPECT().L1Head().Return(core.L1Head{
 			BlockNumber: block0.Number,
 			BlockHash:   block0.Hash,
@@ -1066,12 +1066,12 @@ func TestTransactionReceiptByHash(t *testing.T) {
 		mockReader.EXPECT().BlockNumberAndIndexByTxHash(
 			(*felt.TransactionHash)(revertedTxnHash),
 		).Return(blockWithRevertedTxn.Number, uint64(revertedTxnIdx), nil)
-		mockReader.EXPECT().TransactionByBlockNumberAndIndex(
+		mockReader.EXPECT().TransactionAndReceiptByBlockNumberAndIndex(
 			blockWithRevertedTxn.Number, uint64(revertedTxnIdx),
-		).Return(blockWithRevertedTxn.Transactions[revertedTxnIdx], nil)
-		mockReader.EXPECT().ReceiptByBlockNumberAndIndex(
-			blockWithRevertedTxn.Number, uint64(revertedTxnIdx),
-		).Return(*blockWithRevertedTxn.Receipts[revertedTxnIdx], blockWithRevertedTxn.Hash, nil)
+		).Return(core.TransactionAndReceipt{
+			Transaction: blockWithRevertedTxn.Transactions[revertedTxnIdx],
+			Receipt:     blockWithRevertedTxn.Receipts[revertedTxnIdx],
+		}, blockWithRevertedTxn.Hash, nil)
 		mockReader.EXPECT().L1Head().Return(core.L1Head{}, db.ErrKeyNotFound)
 
 		checkTxReceipt(t, revertedTxnHash, expected)
@@ -1144,12 +1144,12 @@ func TestTransactionReceiptByHash(t *testing.T) {
 		mockReader.EXPECT().BlockNumberAndIndexByTxHash(
 			(*felt.TransactionHash)(txnHash),
 		).Return(block.Number, uint64(index), nil)
-		mockReader.EXPECT().TransactionByBlockNumberAndIndex(
+		mockReader.EXPECT().TransactionAndReceiptByBlockNumberAndIndex(
 			block.Number, uint64(index),
-		).Return(block.Transactions[index], nil)
-		mockReader.EXPECT().ReceiptByBlockNumberAndIndex(
-			block.Number, uint64(index),
-		).Return(*block.Receipts[index], block.Hash, nil)
+		).Return(core.TransactionAndReceipt{
+			Transaction: block.Transactions[index],
+			Receipt:     block.Receipts[index],
+		}, block.Hash, nil)
 		mockReader.EXPECT().L1Head().Return(core.L1Head{}, db.ErrKeyNotFound)
 
 		checkTxReceipt(t, txnHash, expected)
@@ -1209,12 +1209,12 @@ func TestTransactionReceiptByHash(t *testing.T) {
 		mockReader.EXPECT().BlockNumberAndIndexByTxHash(
 			(*felt.TransactionHash)(txnHash),
 		).Return(block.Number, uint64(index), nil)
-		mockReader.EXPECT().TransactionByBlockNumberAndIndex(
+		mockReader.EXPECT().TransactionAndReceiptByBlockNumberAndIndex(
 			block.Number, uint64(index),
-		).Return(block.Transactions[index], nil)
-		mockReader.EXPECT().ReceiptByBlockNumberAndIndex(
-			block.Number, uint64(index),
-		).Return(*block.Receipts[index], block.Hash, nil)
+		).Return(core.TransactionAndReceipt{
+			Transaction: block.Transactions[index],
+			Receipt:     block.Receipts[index],
+		}, block.Hash, nil)
 		mockReader.EXPECT().L1Head().Return(core.L1Head{}, db.ErrKeyNotFound)
 
 		checkTxReceipt(t, txnHash, expected)


### PR DESCRIPTION
`starknet_getTransactionReceipt` did two DB lookups where one suffices, and
decoded a whole block header to read a single field.

**One record, two lookups.** A block's transactions and receipts live in a single
record (`db.BlockTransactions`), addressed by offsets into one byte slice. The
handler fetched the transaction through `TransactionByBlockNumberAndIndex` and
then the receipt through `ReceiptByBlockNumberAndIndex` - two point lookups on
the same key, the second re-reading a record that had just been decoded.
`GetTransactionAndReceiptByBlockAndIndex` extracts both halves inside one read,
following the partial-bucket pattern the neighbouring accessors already use.

**A whole header for one felt.** `ReceiptByBlockNumberAndIndex` decoded the full
header to read `header.Hash`. 60% of that record is a 1 KB events bloom filter
that no part of the receipt response touches. `GetBlockHeaderHashByNumber`
already existed for exactly this and decodes only the hash.

All three RPC versions move to the new method, so `ReceiptByBlockNumberAndIndex`
has no callers left and is removed.

## Measurements

Real Sepolia database (91 GB, height 13.2M), synchronization disabled,
corpus of 100 000 transaction hashes

**Sequential - 1 VU, one full pass over the corpus:**

| | throughput | avg | med | p90 | p99 |
  | --- | --- | --- | --- | --- | --- |
  | before | 5 330 rps | 151 µs | 143 µs | 188 µs | 338 µs |
  | after | 6 260 rps | 124 µs | 118 µs | 148 µs | 272 µs |
  | | **+17%** | **−18%** | **−17%** | **−21%** | **−20%** |

**Concurrency - 50 VUs, 30 s:**

| | throughput | avg | med | p90 | p99 |
| --- | --- | --- | --- | --- | --- |
| before | 44 800 rps | 1.04 ms | 909 µs | 1.82 ms | 3.42 ms |
| after | 54 300 rps | 849 µs | 719 µs | 1.51 ms | 3.09 ms |
| | **+21%** | **−18%** | **−21%** | **−17%** | **−10%** |