### PR TITLE
feat(cborlite): add the CBOR decoder primitives

### DIFF
--- a/encoder/cborlite/fuzz_test.go
+++ b/encoder/cborlite/fuzz_test.go
@@ -1,0 +1,123 @@
+package cborlite_test
+
+import (
+	"math"
+	"testing"
+
+	"github.com/NethermindEth/juno/encoder/cborlite"
+	"github.com/stretchr/testify/require"
+)
+
+type reader struct {
+	name string
+	read func(data []byte) (int, bool)
+}
+
+func readers() []reader {
+	return []reader{
+		{"Head", func(data []byte) (int, bool) {
+			_, _, consumed, ok := cborlite.Head(data)
+			return consumed, ok
+		}},
+		{"Skip", cborlite.Skip},
+		{"BytesNoCopy", func(data []byte) (int, bool) {
+			_, consumed, ok := cborlite.BytesNoCopy(data)
+			return consumed, ok
+		}},
+		{"Bytes", func(data []byte) (int, bool) {
+			_, consumed, ok := cborlite.Bytes(data)
+			return consumed, ok
+		}},
+		{"StringNoCopy", func(data []byte) (int, bool) {
+			_, consumed, ok := cborlite.StringNoCopy(data)
+			return consumed, ok
+		}},
+		{"String", func(data []byte) (int, bool) {
+			_, consumed, ok := cborlite.String(data)
+			return consumed, ok
+		}},
+		{"Uint64", func(data []byte) (int, bool) {
+			_, consumed, ok := cborlite.Uint64(data)
+			return consumed, ok
+		}},
+		{"Int64", func(data []byte) (int, bool) {
+			_, consumed, ok := cborlite.Int64(data)
+			return consumed, ok
+		}},
+		{"BigInt", func(data []byte) (int, bool) {
+			_, consumed, ok := cborlite.BigInt(data)
+			return consumed, ok
+		}},
+		{"Bool", func(data []byte) (int, bool) {
+			_, consumed, ok := cborlite.Bool(data)
+			return consumed, ok
+		}},
+		{"Tag", func(data []byte) (int, bool) {
+			_, consumed, ok := cborlite.Tag(data)
+			return consumed, ok
+		}},
+		{"ArrayHeader", func(data []byte) (int, bool) {
+			_, consumed, ok := cborlite.ArrayHeader(data)
+			return consumed, ok
+		}},
+		{"MapHeader", func(data []byte) (int, bool) {
+			_, consumed, ok := cborlite.MapHeader(data)
+			return consumed, ok
+		}},
+		{"ReadNull", cborlite.ReadNull},
+	}
+}
+
+func FuzzReadersStayInBounds(f *testing.F) {
+	f.Add([]byte{})
+	f.Add(head(uintMajor, 0))
+	f.Add([]byte{null})
+	f.Add([]byte{simpleFalse})
+	f.Add([]byte{simpleTrue})
+	f.Add(head(simpleMajor, 23)) // undefined, which is neither null nor a boolean
+	f.Add(head(simpleMajor, 32))
+	f.Add(head(uintMajor, 255))
+	f.Add(head(uintMajor, math.MaxUint64))
+	f.Add(cborBytes(0xaa, 0xbb, 0xcc))
+	f.Add(cborText("abc"))
+	f.Add(cborArray(head(uintMajor, 1), head(uintMajor, 2)))
+	f.Add(cborMap(cborText("k"), head(uintMajor, 1)))
+	f.Add(cborTagged(tagPositiveBignum, cborBytes(beyondUint64.Bytes()...)))
+	f.Add(cborArray(
+		cborArray(head(uintMajor, 1), head(uintMajor, 2)),
+		cborMap(head(uintMajor, 3), head(uintMajor, 4)),
+	))
+	f.Add([]byte{initialByte(arrayMajor, 31), 1, 0xff})          // Indefinite length.
+	f.Add([]byte{initialByte(arrayMajor, info1Byte), 255, 0x01}) // Too little bytes.
+
+	all := readers()
+
+	f.Fuzz(func(t *testing.T, data []byte) {
+		if len(data) > 1024 {
+			return
+		}
+
+		points := []int{0, 1, len(data) / 2, len(data)}
+
+		for _, r := range all {
+			for _, at := range points {
+				if at > len(data) {
+					continue
+				}
+
+				window := data[at:]
+				consumed, ok := r.read(window)
+				if !ok {
+					continue
+				}
+
+				require.Positivef(t, consumed,
+					"%s reported success without making progress on %d bytes",
+					r.name, len(window))
+				require.LessOrEqualf(t, consumed, len(window),
+					"%s reported consuming %d of %d bytes",
+					r.name, consumed, len(window))
+			}
+		}
+	})
+}

--- a/encoder/cborlite/headers.go
+++ b/encoder/cborlite/headers.go
@@ -1,0 +1,98 @@
+package cborlite
+
+import "encoding/binary"
+
+const (
+	// MajorMask and InfoMask split a header byte into
+	// major type (top 3 bits) and additional info (low 5 bits).
+	MajorMask = 0b1110_0000
+	InfoMask  = 0b0001_1111
+
+	// Major types. They define the object type.
+	// See https://www.rfc-editor.org/rfc/rfc8949.html#section-3.1
+	UintMajor   = 0 << 5
+	NegIntMajor = 1 << 5
+	BytesMajor  = 2 << 5
+	StringMajor = 3 << 5
+	ArrayMajor  = 4 << 5
+	MapMajor    = 5 << 5
+	TagMajor    = 6 << 5
+	SimpleMajor = 7 << 5
+
+	// bool values and nil pointers.
+	SimpleFalse = SimpleMajor | 20
+	SimpleTrue  = SimpleMajor | 21
+	Null        = SimpleMajor | 22
+
+	// Tag types to define Big Numbers
+	// https://www.rfc-editor.org/rfc/rfc8949.html#section-3.4.3
+	TagPositiveBignum = 2
+	TagNegativeBignum = 3
+
+	// Additional info values that say how many bytes follow the argument.
+	Info1Byte = 24
+	Info2Byte = 25
+	Info4Byte = 26
+	Info8Byte = 27
+
+	// Always one byte.
+	headerSize = 1
+)
+
+// Head reads the header at the start of data.
+// argument is a value for a scalar, the length for a string, or an item count for an array/map.
+func Head(data []byte) (major byte, argument uint64, consumed int, ok bool) {
+	if len(data) == 0 {
+		return 0, 0, 0, false
+	}
+
+	header := data[0]
+	major = header & MajorMask
+	info := header & InfoMask
+
+	// The argument is so small it fits inside info.
+	if info < Info1Byte {
+		return major, uint64(info), headerSize, true
+	}
+
+	// info says the number of bytes that follow, max 8.
+	if info > Info8Byte {
+		return 0, 0, 0, false
+	}
+	infoByteSize := 1 << (info - Info1Byte)
+	if len(data) < headerSize+infoByteSize {
+		return 0, 0, 0, false
+	}
+
+	switch infoByteSize {
+	case 1:
+		argument = uint64(data[headerSize])
+	case 2:
+		argument = uint64(binary.BigEndian.Uint16(data[headerSize:]))
+	case 4:
+		argument = uint64(binary.BigEndian.Uint32(data[headerSize:]))
+	default:
+		argument = binary.BigEndian.Uint64(data[headerSize:])
+	}
+	return major, argument, headerSize + infoByteSize, true
+}
+
+// ArrayHeader reads an array header and its element count.
+func ArrayHeader(data []byte) (length, consumed int, ok bool) {
+	major, count, consumed, ok := Head(data)
+	// An element takes at least one byte, data must have space for it.
+	if !ok || major != ArrayMajor || count > uint64(len(data)-consumed) {
+		return 0, 0, false
+	}
+	return int(count), consumed, true
+}
+
+// MapHeader reads a map header and its pair count.
+func MapHeader(data []byte) (pairsCount, consumed int, ok bool) {
+	major, count, consumed, ok := Head(data)
+	// A pair takes at least two bytes, data must have space for it.
+	if !ok || major != MapMajor || count > uint64(len(data)-consumed)/2 {
+		return 0, 0, false
+	}
+	return int(count), consumed, true
+}

--- a/encoder/cborlite/headers_test.go
+++ b/encoder/cborlite/headers_test.go
@@ -1,0 +1,167 @@
+package cborlite_test
+
+import (
+	"math"
+	"testing"
+
+	"github.com/NethermindEth/juno/encoder/cborlite"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestHead(t *testing.T) {
+	tests := []struct {
+		name     string
+		data     []byte
+		major    byte
+		argument uint64
+		consumed int
+		ok       bool
+	}{
+		{
+			name:  "argument inside the header byte",
+			data:  head(uintMajor, 23),
+			major: uintMajor, argument: 23, consumed: 1, ok: true,
+		},
+		{
+			name:  "one byte argument",
+			data:  head(uintMajor, 255),
+			major: uintMajor, argument: 255, consumed: 2, ok: true,
+		},
+		{
+			name:  "two byte argument",
+			data:  head(uintMajor, 256),
+			major: uintMajor, argument: 256, consumed: 3, ok: true,
+		},
+		{
+			name:  "four byte argument",
+			data:  head(uintMajor, 65536),
+			major: uintMajor, argument: 65536, consumed: 5, ok: true,
+		},
+		{
+			name:  "eight byte argument",
+			data:  head(uintMajor, 1<<32),
+			major: uintMajor, argument: 1 << 32, consumed: 9, ok: true,
+		},
+		{
+			// The reader stops at the end of the header and never looks at what follows
+			name:  "reads only the header, whatever trails it",
+			data:  cborText("abc"),
+			major: stringMajor, argument: 3, consumed: 1, ok: true,
+		},
+		{
+			name: "major type is decoded independently of the argument",
+			data: []byte{initialByte(mapMajor, 1)}, major: mapMajor, argument: 1, consumed: 1, ok: true,
+		},
+		{name: "empty buffer", data: []byte{}},
+		{name: "one byte argument truncated", data: []byte{initialByte(uintMajor, info1Byte)}},
+		{name: "two byte argument truncated", data: []byte{initialByte(uintMajor, info2Byte), 0x01}},
+		{
+			name: "four byte argument truncated",
+			data: []byte{initialByte(uintMajor, info4Byte), 0x00, 0x01},
+		},
+		{
+			name: "eight byte argument truncated",
+			data: []byte{initialByte(uintMajor, info8Byte), 0, 0, 0, 1},
+		},
+		{name: "reserved additional info 28", data: headerFollowedBy(initialByte(uintMajor, 28), 16)},
+		{name: "reserved additional info 29", data: headerFollowedBy(initialByte(uintMajor, 29), 32)},
+		{name: "reserved additional info 30", data: headerFollowedBy(initialByte(uintMajor, 30), 64)},
+		{name: "indefinite length", data: headerFollowedBy(initialByte(uintMajor, 31), 128)},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			major, argument, consumed, ok := cborlite.Head(test.data)
+
+			require.Equal(t, test.ok, ok)
+			if !test.ok {
+				return
+			}
+			assert.Equal(t, test.major, major)
+			assert.Equal(t, test.argument, argument)
+			assert.Equal(t, test.consumed, consumed)
+		})
+	}
+}
+
+func TestArrayHeader(t *testing.T) {
+	tests := []struct {
+		name     string
+		data     []byte
+		length   int
+		consumed int
+		ok       bool
+	}{
+		{
+			name:   "count and header width",
+			data:   cborArray(head(uintMajor, 1), head(uintMajor, 2)),
+			length: 2, consumed: 1, ok: true,
+		},
+		{name: "empty array is zero", data: cborArray(), consumed: 1, ok: true},
+		// Null is a different item, not an array of no elements.
+		{name: "declines null", data: []byte{null}},
+		// Guards the allocation: every element needs at least one byte.
+		{
+			name: "rejects a count past the remaining bytes",
+			data: []byte{initialByte(arrayMajor, 5), 0x01, 0x02},
+		},
+		// The count is returned as an int, so this one is the case that would come back
+		// negative and make every length check downstream read backwards.
+		{name: "rejects a count of all ones", data: head(arrayMajor, math.MaxUint64)},
+		{
+			name: "rejects another major type",
+			data: cborMap(head(uintMajor, 1), head(uintMajor, 2)),
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			length, consumed, ok := cborlite.ArrayHeader(test.data)
+
+			require.Equal(t, test.ok, ok)
+			if !test.ok {
+				return
+			}
+			assert.Equal(t, test.length, length)
+			assert.Equal(t, test.consumed, consumed)
+		})
+	}
+}
+
+func TestMapHeader(t *testing.T) {
+	tests := []struct {
+		name     string
+		data     []byte
+		pairs    int
+		consumed int
+		ok       bool
+	}{
+		{
+			name:  "pair count and header width",
+			data:  cborMap(head(uintMajor, 1), head(uintMajor, 2)),
+			pairs: 1, consumed: 1, ok: true,
+		},
+		{name: "empty map is zero", data: cborMap(), consumed: 1, ok: true},
+		{name: "declines null", data: []byte{null}},
+		// A pair takes two bytes at the very least, so this count cannot be honoured.
+		{name: "rejects a count past the remaining bytes", data: []byte{initialByte(mapMajor, 5), 0x01}},
+		{
+			name: "rejects an array",
+			data: cborArray(head(uintMajor, 1), head(uintMajor, 2)),
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			pairs, consumed, ok := cborlite.MapHeader(test.data)
+
+			require.Equal(t, test.ok, ok)
+			if !test.ok {
+				return
+			}
+			assert.Equal(t, test.pairs, pairs)
+			assert.Equal(t, test.consumed, consumed)
+		})
+	}
+}

--- a/encoder/cborlite/helpers_test.go
+++ b/encoder/cborlite/helpers_test.go
@@ -1,0 +1,101 @@
+package cborlite_test
+
+import (
+	"encoding/binary"
+	"math"
+	"math/big"
+	"slices"
+
+	"github.com/NethermindEth/juno/encoder/cborlite"
+)
+
+// Short names for the constants
+const (
+	uintMajor   = cborlite.UintMajor
+	negIntMajor = cborlite.NegIntMajor
+	bytesMajor  = cborlite.BytesMajor
+	stringMajor = cborlite.StringMajor
+	arrayMajor  = cborlite.ArrayMajor
+	mapMajor    = cborlite.MapMajor
+	tagMajor    = cborlite.TagMajor
+	simpleMajor = cborlite.SimpleMajor
+
+	info1Byte = cborlite.Info1Byte
+	info2Byte = cborlite.Info2Byte
+	info4Byte = cborlite.Info4Byte
+	info8Byte = cborlite.Info8Byte
+
+	simpleFalse = cborlite.SimpleFalse
+	simpleTrue  = cborlite.SimpleTrue
+	null        = cborlite.Null
+
+	tagPositiveBignum = cborlite.TagPositiveBignum
+	tagNegativeBignum = cborlite.TagNegativeBignum
+)
+
+// The smallest whole number bigger than UInt64
+var beyondUint64 = new(big.Int).Lsh(big.NewInt(1), 64)
+
+// initialByte packs a major type with its additional info.
+func initialByte(major, info byte) byte {
+	return major | info
+}
+
+// head writes the initial byte plus the argument, in the narrowest width that holds it.
+func head(major byte, argument uint64) []byte {
+	switch {
+	case argument < info1Byte:
+		return []byte{initialByte(major, byte(argument))}
+	case argument <= math.MaxUint8:
+		return []byte{initialByte(major, info1Byte), byte(argument)}
+	case argument <= math.MaxUint16:
+		return binary.BigEndian.AppendUint16([]byte{initialByte(major, info2Byte)}, uint16(argument))
+	case argument <= math.MaxUint32:
+		return binary.BigEndian.AppendUint32([]byte{initialByte(major, info4Byte)}, uint32(argument))
+	default:
+		return binary.BigEndian.AppendUint64([]byte{initialByte(major, info8Byte)}, argument)
+	}
+}
+
+func trailByJunk(item []byte) []byte {
+	return slices.Concat(item, []byte{0xff, 0xff})
+}
+
+// headerFollowedBy writes a header byte and argumentSize zero bytes after it.
+func headerFollowedBy(header byte, argumentSize int) []byte {
+	return append([]byte{header}, make([]byte, argumentSize)...)
+}
+
+/*
+	Well-formed items.
+*/
+
+func cborBytes(payload ...byte) []byte {
+	return append(head(bytesMajor, uint64(len(payload))), payload...)
+}
+
+func cborText(text string) []byte {
+	return append(head(stringMajor, uint64(len(text))), text...)
+}
+
+func cborArray(items ...[]byte) []byte {
+	out := head(arrayMajor, uint64(len(items)))
+	for _, element := range items {
+		out = append(out, element...)
+	}
+	return out
+}
+
+// cborMap takes its pairs flattened, a key followed by its value.
+func cborMap(pairs ...[]byte) []byte {
+	out := head(mapMajor, uint64(len(pairs)/2))
+	for _, half := range pairs {
+		out = append(out, half...)
+	}
+	return out
+}
+
+// cborTagged wraps an item in a tag.
+func cborTagged(number uint64, tagged []byte) []byte {
+	return append(head(tagMajor, number), tagged...)
+}

--- a/encoder/cborlite/values.go
+++ b/encoder/cborlite/values.go
@@ -1,0 +1,216 @@
+package cborlite
+
+import (
+	"math"
+	"math/big"
+)
+
+// bytesPayload returns the payload of bytes after the header.
+func bytesPayload(data []byte, expectedMajor byte) (value []byte, consumed int, ok bool) {
+	major, length, header, ok := Head(data)
+	if !ok || major != expectedMajor || length > uint64(len(data)-header) {
+		return nil, 0, false
+	}
+	end := header + int(length)
+	return data[header:end], end, true
+}
+
+// BytesNoCopy returns a sub-slice of data, valid only while data is. [Bytes] copies.
+func BytesNoCopy(data []byte) (value []byte, consumed int, ok bool) {
+	return bytesPayload(data, BytesMajor)
+}
+
+// Bytes copies and returns the payload of bytes after the header.
+func Bytes(data []byte) (value []byte, consumed int, ok bool) {
+	borrowed, consumed, ok := bytesPayload(data, BytesMajor)
+	if !ok {
+		return nil, 0, false
+	}
+
+	out := make([]byte, len(borrowed))
+	copy(out, borrowed)
+
+	return out, consumed, true
+}
+
+// StringNoCopy returns a sub-slice of data, valid only while data is. [String] copies.
+func StringNoCopy(data []byte) (value []byte, consumed int, ok bool) {
+	return bytesPayload(data, StringMajor)
+}
+
+// String copies the string out of data.
+func String(data []byte) (value string, consumed int, ok bool) {
+	borrowed, consumed, ok := bytesPayload(data, StringMajor)
+	if !ok {
+		return "", 0, false
+	}
+	return string(borrowed), consumed, true
+}
+
+// Uint64 reads an unsigned integer. A negative one is rejected.
+func Uint64(data []byte) (value uint64, consumed int, ok bool) {
+	major, value, consumed, ok := Head(data)
+	if !ok || major != UintMajor {
+		return 0, 0, false
+	}
+	return value, consumed, true
+}
+
+// Bool reads a boolean.
+func Bool(data []byte) (value bool, consumed int, ok bool) {
+	if len(data) == 0 {
+		return false, 0, false
+	}
+
+	switch data[0] {
+	case SimpleFalse:
+		return false, 1, true
+	case SimpleTrue:
+		return true, 1, true
+	default:
+		return false, 0, false
+	}
+}
+
+// Tag reads a tag number. The encoder writes one to record which concrete type went
+// into an interface field.
+func Tag(data []byte) (value uint64, consumed int, ok bool) {
+	major, tag, consumed, ok := Head(data)
+	if !ok || major != TagMajor {
+		return 0, 0, false
+	}
+	return tag, consumed, true
+}
+
+// ReadNull reports whether the item is null.
+// It does not consume the bytes when it is not null.
+// No other reader checks null, so call this first wherever null is a possibility.
+func ReadNull(data []byte) (consumed int, isNull bool) {
+	if len(data) > 0 && data[0] == Null {
+		return 1, true
+	}
+	return 0, false
+}
+
+// Avoid deeply malformed structures
+const maxSkipDepth = 1024
+
+// Skip reports how many bytes the next items take.
+func Skip(data []byte) (consumed int, ok bool) {
+	return skip(data, maxSkipDepth)
+}
+
+func skip(data []byte, depth int) (consumed int, ok bool) {
+	if depth <= 0 {
+		return 0, false
+	}
+
+	major, argument, consumed, ok := Head(data)
+	if !ok {
+		return 0, false
+	}
+
+	switch major {
+	case UintMajor, NegIntMajor, SimpleMajor:
+		return consumed, true
+
+	case BytesMajor, StringMajor:
+		if argument > uint64(len(data)-consumed) {
+			return 0, false
+		}
+		return consumed + int(argument), true
+
+	case TagMajor:
+		tagged, ok := skip(data[consumed:], depth-1)
+		if !ok {
+			return 0, false
+		}
+		return consumed + tagged, true
+
+	case ArrayMajor, MapMajor:
+		// TODO(granza): the first byte already tells the size of most items.
+		// Add that size and move on, instead of calling Skip for every element.
+		remainingBytes := uint64(len(data) - consumed)
+		itemsCount := argument
+
+		if major == MapMajor {
+			// avoid overflows
+			if itemsCount > remainingBytes/2 {
+				return 0, false
+			}
+			itemsCount *= 2
+		} else if itemsCount > remainingBytes {
+			return 0, false
+		}
+
+		for range itemsCount {
+			element, ok := skip(data[consumed:], depth-1)
+			if !ok {
+				return 0, false
+			}
+			consumed += element
+		}
+		return consumed, true
+
+	default:
+		// Unreachable. A major is three bits and the cases above name all eight.
+		return 0, false
+	}
+}
+
+// BigInt reads an integer of any width.
+func BigInt(data []byte) (value *big.Int, consumed int, ok bool) {
+	major, argument, consumed, ok := Head(data)
+	if !ok {
+		return nil, 0, false
+	}
+
+	switch major {
+	case UintMajor, NegIntMajor:
+		out := new(big.Int).SetUint64(argument)
+		if major == NegIntMajor {
+			out.Not(out)
+		}
+		return out, consumed, true
+
+	case TagMajor:
+		if argument != TagPositiveBignum && argument != TagNegativeBignum {
+			return nil, 0, false
+		}
+
+		bignum, used, ok := bytesPayload(data[consumed:], BytesMajor)
+		if !ok {
+			return nil, 0, false
+		}
+		consumed += used
+
+		out := new(big.Int).SetBytes(bignum)
+		if argument == TagNegativeBignum {
+			out.Not(out)
+		}
+		return out, consumed, true
+
+	default:
+		return nil, 0, false
+	}
+}
+
+// Int64 reads a signed integer.
+func Int64(data []byte) (value int64, consumed int, ok bool) {
+	major, argument, consumed, ok := Head(data)
+	if !ok || argument > math.MaxInt64 {
+		return 0, 0, false
+	}
+
+	switch major {
+	case UintMajor, NegIntMajor:
+		out := int64(argument)
+		if major == NegIntMajor {
+			out = ^out
+		}
+		return out, consumed, true
+
+	default:
+		return 0, 0, false
+	}
+}

--- a/encoder/cborlite/values_test.go
+++ b/encoder/cborlite/values_test.go
@@ -1,0 +1,438 @@
+package cborlite_test
+
+import (
+	"fmt"
+	"math"
+	"math/big"
+	"testing"
+
+	"github.com/NethermindEth/juno/encoder/cborlite"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBytesNoCopy(t *testing.T) {
+	data := cborBytes(0xaa, 0xbb, 0xcc)
+
+	got, next, ok := cborlite.BytesNoCopy(data)
+	require.True(t, ok)
+	assert.Equal(t, []byte{0xaa, 0xbb, 0xcc}, got)
+	assert.Equal(t, 4, next)
+
+	t.Run("aliases the buffer", func(t *testing.T) {
+		got, _, ok := cborlite.BytesNoCopy(data)
+		require.True(t, ok)
+
+		data[1] = 0x11
+		assert.Equal(t, byte(0x11), got[0])
+		data[1] = 0xaa
+	})
+
+	t.Run("rejects a length past the buffer", func(t *testing.T) {
+		_, _, ok := cborlite.BytesNoCopy([]byte{initialByte(bytesMajor, 3), 0xaa})
+		assert.False(t, ok)
+	})
+
+	t.Run("rejects another major type", func(t *testing.T) {
+		_, _, ok := cborlite.BytesNoCopy(cborText("abc"))
+		assert.False(t, ok)
+	})
+
+	t.Run("does not read null", func(t *testing.T) {
+		_, _, ok := cborlite.BytesNoCopy([]byte{null})
+		assert.False(t, ok)
+	})
+}
+
+func TestBytes(t *testing.T) {
+	data := cborBytes(0xaa, 0xbb, 0xcc)
+
+	got, next, ok := cborlite.Bytes(data)
+	require.True(t, ok)
+	assert.Equal(t, []byte{0xaa, 0xbb, 0xcc}, got)
+	assert.Equal(t, 4, next)
+
+	t.Run("does not alias the buffer", func(t *testing.T) {
+		data[1] = 0x11
+		assert.Equal(t, byte(0xaa), got[0], "the copy must survive the buffer changing")
+		data[1] = 0xaa
+	})
+
+	// Null is another shape, and no reader here takes it.
+	t.Run("does not read null", func(t *testing.T) {
+		_, _, ok := cborlite.Bytes([]byte{null})
+		assert.False(t, ok)
+	})
+
+	t.Run("empty byte string is not nil", func(t *testing.T) {
+		got, _, ok := cborlite.Bytes(cborBytes())
+		require.True(t, ok)
+		assert.NotNil(t, got)
+		assert.Empty(t, got)
+	})
+}
+
+func TestStringNoCopyAndString(t *testing.T) {
+	data := trailByJunk(cborText("abc"))
+
+	raw, consumed, ok := cborlite.StringNoCopy(data)
+	require.True(t, ok)
+	assert.Equal(t, []byte("abc"), raw)
+	assert.Equal(t, 4, consumed)
+
+	str, consumed, ok := cborlite.String(data)
+	require.True(t, ok)
+	assert.Equal(t, "abc", str)
+	assert.Equal(t, 4, consumed)
+
+	t.Run("String copies out of the buffer", func(t *testing.T) {
+		buffer := cborText("abc")
+		str, _, ok := cborlite.String(buffer)
+		require.True(t, ok)
+
+		buffer[1] = 'z'
+		assert.Equal(t, "abc", str)
+	})
+
+	t.Run("reject a byte string", func(t *testing.T) {
+		_, _, ok := cborlite.StringNoCopy(cborBytes(0xaa, 0xbb, 0xcc))
+		assert.False(t, ok)
+
+		_, _, ok = cborlite.String(cborBytes(0xaa, 0xbb, 0xcc))
+		assert.False(t, ok)
+	})
+
+	t.Run("reject a truncated length", func(t *testing.T) {
+		_, _, ok := cborlite.StringNoCopy([]byte{initialByte(stringMajor, 3), 'a'})
+		assert.False(t, ok)
+	})
+}
+
+func TestUint64(t *testing.T) {
+	got, next, ok := cborlite.Uint64(head(uintMajor, 42))
+	require.True(t, ok)
+	assert.Equal(t, uint64(42), got)
+	assert.Equal(t, 2, next)
+
+	t.Run("rejects a negative integer instead of wrapping it", func(t *testing.T) {
+		_, _, ok := cborlite.Uint64(head(negIntMajor, 0))
+		assert.False(t, ok)
+	})
+
+	t.Run("rejects another major type", func(t *testing.T) {
+		_, _, ok := cborlite.Uint64(cborText("abc"))
+		assert.False(t, ok)
+	})
+}
+
+func TestBool(t *testing.T) {
+	tests := []struct {
+		name     string
+		data     []byte
+		value    bool
+		consumed int
+		ok       bool
+	}{
+		{name: "false", data: []byte{simpleFalse}, value: false, consumed: 1, ok: true},
+		{name: "true", data: []byte{simpleTrue}, value: true, consumed: 1, ok: true},
+		{
+			name:  "reads one byte and leaves the rest",
+			data:  trailByJunk([]byte{simpleTrue}),
+			value: true, consumed: 1, ok: true,
+		},
+		// All the following return ok as false
+		{name: "null is not false", data: []byte{null}},
+		{name: "undefined is not false", data: head(simpleMajor, 23)},
+		{name: "a simple value with a following byte", data: head(simpleMajor, 32)},
+		{name: "zero is not false", data: head(uintMajor, 0)},
+		{name: "empty text string is not false", data: cborText("")},
+		{name: "empty", data: []byte{}},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			value, consumed, ok := cborlite.Bool(test.data)
+
+			require.Equal(t, test.ok, ok)
+			if !test.ok {
+				return
+			}
+			assert.Equal(t, test.value, value)
+			assert.Equal(t, test.consumed, consumed)
+		})
+	}
+}
+
+func TestTag(t *testing.T) {
+	tests := []struct {
+		name     string
+		data     []byte
+		value    uint64
+		consumed int
+		ok       bool
+	}{
+		{
+			name:  "small enough for the header",
+			data:  head(tagMajor, tagPositiveBignum),
+			value: 2, consumed: 1, ok: true,
+		},
+		{
+			name:  "the first tag the encoder registers",
+			data:  head(tagMajor, 65536),
+			value: 65536, consumed: 5, ok: true,
+		},
+		{name: "an unsigned integer", data: head(uintMajor, 1)},
+		{name: "a truncated argument", data: []byte{initialByte(tagMajor, info4Byte), 0x00}},
+		{name: "empty", data: []byte{}},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			value, consumed, ok := cborlite.Tag(test.data)
+
+			require.Equal(t, test.ok, ok)
+			if !test.ok {
+				return
+			}
+			assert.Equal(t, test.value, value)
+			assert.Equal(t, test.consumed, consumed)
+		})
+	}
+}
+
+func TestReadNull(t *testing.T) {
+	consumed, isNull := cborlite.ReadNull([]byte{null})
+	assert.True(t, isNull)
+	assert.Equal(t, 1, consumed)
+
+	t.Run("consumes nothing when the item is not null", func(t *testing.T) {
+		// A caller that goes on to read the item for real has to start where it was.
+		consumed, isNull := cborlite.ReadNull(head(uintMajor, 1))
+		assert.False(t, isNull)
+		assert.Zero(t, consumed)
+	})
+
+	t.Run("an empty buffer is not null", func(t *testing.T) {
+		consumed, isNull := cborlite.ReadNull([]byte{})
+		assert.False(t, isNull)
+		assert.Zero(t, consumed)
+	})
+}
+
+func TestSkip(t *testing.T) {
+	tests := []struct {
+		name     string
+		data     []byte
+		consumed int
+		ok       bool
+	}{
+		{name: "unsigned in the header", data: head(uintMajor, 5), consumed: 1, ok: true},
+		{name: "unsigned with an argument", data: head(uintMajor, 256), consumed: 3, ok: true},
+		{name: "negative", data: head(negIntMajor, 99), consumed: 2, ok: true},
+		{name: "null", data: []byte{null}, consumed: 1, ok: true},
+		{name: "boolean", data: []byte{simpleTrue}, consumed: 1, ok: true},
+		{name: "byte string", data: cborBytes(0xaa, 0xbb, 0xcc), consumed: 4, ok: true},
+		{name: "text string", data: cborText("abc"), consumed: 4, ok: true},
+		{name: "empty array", data: cborArray(), consumed: 1, ok: true},
+		{
+			name: "array of scalars", data: cborArray(head(uintMajor, 1), head(uintMajor, 2)),
+			consumed: 3, ok: true,
+		},
+		{
+			name: "map of one pair", data: cborMap(head(uintMajor, 1), head(uintMajor, 2)),
+			consumed: 3, ok: true,
+		},
+		{
+			name:     "tag wrapping a byte string",
+			data:     cborTagged(tagPositiveBignum, cborBytes(0x01)),
+			consumed: 3, ok: true,
+		},
+		{
+			name: "array holding an array and a map",
+			data: cborArray(
+				cborArray(head(uintMajor, 1), head(uintMajor, 2)),
+				cborMap(head(uintMajor, 3), head(uintMajor, 4)),
+			),
+			consumed: 7, ok: true,
+		},
+		{
+			name: "stops at the end of the item, leaving the rest",
+			data: trailByJunk(cborArray(head(uintMajor, 1), head(uintMajor, 2))), consumed: 3, ok: true,
+		},
+		{name: "empty", data: []byte{}},
+		{name: "truncated byte string", data: []byte{initialByte(bytesMajor, 3), 0xaa}},
+		{name: "array with fewer elements than promised", data: []byte{initialByte(arrayMajor, 2), 0x01}},
+		{name: "map with fewer pairs than promised", data: []byte{initialByte(mapMajor, 2), 0x01, 0x02}},
+		// Doubling a pair count to compare it against the remaining bytes overflows
+		// here, and the wrapped value used to pass, reading this as an empty map.
+		{name: "map claiming 2^63 pairs", data: head(mapMajor, 1<<63)},
+		{
+			name: "map claiming a count near the uint64 top",
+			data: head(mapMajor, math.MaxUint64),
+		},
+		{
+			name: "array claiming a count near the uint64 top",
+			data: head(arrayMajor, math.MaxUint64),
+		},
+		{name: "tag with nothing after it", data: []byte{initialByte(tagMajor, tagPositiveBignum)}},
+		{name: "indefinite length", data: []byte{initialByte(arrayMajor, 31), 0x01, 0xff}},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			consumed, ok := cborlite.Skip(test.data)
+
+			require.Equal(t, test.ok, ok)
+			if test.ok {
+				assert.Equal(t, test.consumed, consumed)
+			}
+		})
+	}
+}
+
+func TestSkipStopsBeforeTheStackOverflows(t *testing.T) {
+	nested := func(depth int) []byte {
+		data := make([]byte, 0, depth+1)
+		for range depth {
+			data = append(data, initialByte(arrayMajor, 1))
+		}
+		return append(data, initialByte(uintMajor, 0))
+	}
+
+	t.Run("nesting a real value reaches is still read", func(t *testing.T) {
+		consumed, ok := cborlite.Skip(nested(8))
+
+		require.True(t, ok)
+		require.Equal(t, 9, consumed)
+	})
+
+	for _, depth := range []int{10_000, 5_000_000} {
+		t.Run(fmt.Sprintf("declines %d levels instead of crashing", depth), func(t *testing.T) {
+			consumed, ok := cborlite.Skip(nested(depth))
+
+			require.False(t, ok)
+			require.Zero(t, consumed)
+		})
+	}
+}
+
+func TestBigInt(t *testing.T) {
+	bignumPayload := cborBytes(beyondUint64.Bytes()...)
+
+	tests := []struct {
+		name     string
+		data     []byte
+		value    *big.Int
+		consumed int
+		ok       bool
+	}{
+		{name: "does not read null", data: []byte{null}},
+		{
+			name: "positive in the header", data: head(uintMajor, 5),
+			value: big.NewInt(5), consumed: 1, ok: true,
+		},
+		{
+			name: "positive with an argument", data: head(uintMajor, 42),
+			value: big.NewInt(42), consumed: 2, ok: true,
+		},
+		// A negative integer's argument is the magnitude minus one, so 0x20 is -1.
+		{name: "minus one", data: head(negIntMajor, 0), value: big.NewInt(-1), consumed: 1, ok: true},
+		{
+			name: "minus one hundred", data: head(negIntMajor, 99),
+			value: big.NewInt(-100), consumed: 2, ok: true,
+		},
+		{
+			name:  "positive bignum",
+			data:  cborTagged(tagPositiveBignum, bignumPayload),
+			value: beyondUint64, consumed: 11, ok: true,
+		},
+		{
+			name:  "negative bignum",
+			data:  cborTagged(tagNegativeBignum, bignumPayload),
+			value: new(big.Int).Not(beyondUint64), consumed: 11, ok: true,
+		},
+		{
+			name: "a tag that is not a bignum",
+			data: cborTagged(4, bignumPayload),
+		},
+		{
+			name: "a bignum wrapping something other than bytes",
+			data: cborTagged(tagPositiveBignum, head(uintMajor, 1)),
+		},
+		{
+			name: "a bignum with a truncated payload",
+			data: append(head(tagMajor, tagPositiveBignum), initialByte(bytesMajor, 9), 0x01),
+		},
+		{name: "a text string", data: cborText("abc")},
+		{name: "empty", data: []byte{}},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			value, consumed, ok := cborlite.BigInt(test.data)
+
+			require.Equal(t, test.ok, ok)
+			if !test.ok {
+				return
+			}
+			assert.Equal(t, test.consumed, consumed)
+			// Comparing with Cmp, since two equal big.Ints can hold different internals.
+			assert.Zerof(t, test.value.Cmp(value), "want %s, got %s", test.value, value)
+		})
+	}
+}
+
+func TestInt64(t *testing.T) {
+	tests := []struct {
+		name     string
+		data     []byte
+		value    int64
+		consumed int
+		ok       bool
+	}{
+		{name: "zero", data: head(uintMajor, 0), consumed: 1, ok: true},
+		{
+			name: "positive with an argument", data: head(uintMajor, 42),
+			value: 42, consumed: 2, ok: true,
+		},
+		{name: "minus one", data: head(negIntMajor, 0), value: -1, consumed: 1, ok: true},
+		{
+			name: "minus one hundred", data: head(negIntMajor, 99),
+			value: -100, consumed: 2, ok: true,
+		},
+		{
+			name:  "the largest int64",
+			data:  head(uintMajor, math.MaxInt64),
+			value: math.MaxInt64, consumed: 9, ok: true,
+		},
+		{
+			name:  "the most negative int64",
+			data:  head(negIntMajor, math.MaxInt64),
+			value: math.MinInt64, consumed: 9, ok: true,
+		},
+		{
+			name: "past int64 going up",
+			data: head(uintMajor, math.MaxUint64),
+		},
+		{
+			name: "past int64 going down",
+			data: head(negIntMajor, math.MaxUint64),
+		},
+		{name: "a text string", data: cborText("abc")},
+		{name: "a bignum", data: cborTagged(tagPositiveBignum, cborBytes(0x01))},
+		{name: "empty", data: []byte{}},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			value, consumed, ok := cborlite.Int64(test.data)
+
+			require.Equal(t, test.ok, ok)
+			if !test.ok {
+				return
+			}
+			assert.Equal(t, test.value, value)
+			assert.Equal(t, test.consumed, consumed)
+		})
+	}
+}


### PR DESCRIPTION
Header and value decoders that take bytes, unmarshal them and report how many they used, so a caller can keep reading where one left off. 

These are the building blocks for faster CBOR unmarshalings. See [CBORlite](https://github.com/NethermindEth/juno/pull/3935).

We only cover types in use for juno.