### PR TITLE
feat(cborlite): a light CBOR reader.

### DIFF
--- a/core/felt/cbor.go
+++ b/core/felt/cbor.go
@@ -2,10 +2,18 @@ package felt
 
 import (
 	"encoding/binary"
+	"errors"
 	"math"
 
+	"github.com/NethermindEth/juno/encoder/cborlite"
 	"github.com/consensys/gnark-crypto/ecc/stark-curve/fp"
 	"github.com/fxamacker/cbor/v2"
+)
+
+var (
+	_ cborlite.PrefixUnmarshaler = (*Felt)(nil)
+	_ cbor.Marshaler             = (*Felt)(nil)
+	_ cbor.Unmarshaler           = (*Felt)(nil)
 )
 
 // Fast, felt-specialized CBOR marshaling.
@@ -22,6 +30,14 @@ func (z *Felt) UnmarshalCBOR(data []byte) error {
 		return nil
 	}
 	return cbor.Unmarshal(data, (*fp.Element)(z))
+}
+
+func (z *Felt) UnmarshalCBORPrefix(data []byte) (int, error) {
+	consumed, ok := decodeLimbs(data, z)
+	if !ok {
+		return 0, errors.New("felt: not limb-encoded")
+	}
+	return consumed, nil
 }
 
 const (

--- a/core/felt/cbor_fastpath_test.go
+++ b/core/felt/cbor_fastpath_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/NethermindEth/juno/core/felt"
 	"github.com/consensys/gnark-crypto/ecc/stark-curve/fp"
 	"github.com/fxamacker/cbor/v2"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -236,4 +237,67 @@ func FuzzCBORFastPathMarshalEquivalence(f *testing.F) {
 		value := fromLimbs[felt.Felt](l0, l1, l2, l3)
 		requireMarshalEquivalent(t, &value)
 	})
+}
+
+func TestFeltUnmarshalCBORPrefix(t *testing.T) {
+	want := felt.FromUint64[felt.Felt](0xdeadbeef)
+	encoded, err := want.MarshalCBOR()
+	require.NoError(t, err)
+
+	t.Run("reads the felt and reports the count", func(t *testing.T) {
+		var got felt.Felt
+		consumed, err := got.UnmarshalCBORPrefix(encoded)
+
+		require.NoError(t, err)
+		assert.Equal(t, len(encoded), consumed)
+		assert.Equal(t, want, got)
+	})
+
+	t.Run("trailing bytes are allowed, and not counted", func(t *testing.T) {
+		var got felt.Felt
+		consumed, err := got.UnmarshalCBORPrefix(append(append([]byte{}, encoded...), 0xff, 0xff))
+
+		require.NoError(t, err)
+		assert.Equal(t, len(encoded), consumed, "counting the trailer would misread the next field")
+		assert.Equal(t, want, got)
+	})
+
+	t.Run("rejects what is not a limb-encoded felt", func(t *testing.T) {
+		for name, data := range map[string][]byte{
+			"empty":                  {},
+			"truncated":              encoded[:len(encoded)-1],
+			"not an array":           {0x18, 0x2a},
+			"array of the wrong len": {0x83, 0x01, 0x02, 0x03},
+			"null":                   {0xf6},
+			"a limb that is signed":  {0x84, 0x20, 0x01, 0x02, 0x03},
+		} {
+			t.Run(name, func(t *testing.T) {
+				got := felt.FromUint64[felt.Felt](7)
+				consumed, err := got.UnmarshalCBORPrefix(data)
+
+				assert.Error(t, err)
+				assert.Zero(t, consumed)
+				assert.Equal(t, felt.FromUint64[felt.Felt](7), got,
+					"a rejected input must not touch the destination")
+			})
+		}
+	})
+}
+
+// TestTrailingBytesLeaveTheReceiverAlone covers what the fastpath table cannot: its
+// fixtures decode to the zero felt, so a receiver written by a rejected parse looks
+// exactly like one that was never touched.
+func TestTrailingBytesLeaveTheReceiverAlone(t *testing.T) {
+	var value felt.Felt
+	value.SetUint64(0xdeadbeef)
+
+	encoded, err := value.MarshalCBOR()
+	require.NoError(t, err)
+
+	withTrailing := append(append([]byte{}, encoded...), 0x00)
+
+	var got felt.Felt
+	err = got.UnmarshalCBOR(withTrailing)
+	require.Error(t, err, "trailing bytes must not decode")
+	require.True(t, got.IsZero(), "a failed decode must not write the receiver")
 }

--- a/core/felt/slice.go
+++ b/core/felt/slice.go
@@ -2,12 +2,20 @@ package felt
 
 import (
 	"encoding/binary"
+	"errors"
 	"math"
 
+	"github.com/NethermindEth/juno/encoder/cborlite"
 	"github.com/fxamacker/cbor/v2"
 )
 
 type Slice[F FeltLike] []F
+
+var (
+	_ cborlite.PrefixUnmarshaler = (*Slice[Felt])(nil)
+	_ cbor.Marshaler             = (*Slice[Felt])(nil)
+	_ cbor.Unmarshaler           = (*Slice[Felt])(nil)
+)
 
 const (
 	// maxCBORArrayHeaderLen: 1 major/info byte + 4 length bytes (uint32)
@@ -33,36 +41,55 @@ func (s Slice[F]) MarshalCBOR() ([]byte, error) {
 }
 
 func (s *Slice[F]) UnmarshalCBOR(data []byte) error {
+	var out Slice[F]
+	consumed, ok := decodeSlicePrefix(data, &out)
+	if ok && consumed == len(data) {
+		*s = out
+		return nil
+	}
+	return s.unmarshalCBORGeneric(data)
+}
+
+func (s *Slice[F]) UnmarshalCBORPrefix(data []byte) (int, error) {
+	consumed, ok := decodeSlicePrefix(data, s)
+	if !ok {
+		return 0, errors.New("felt: not a limb-encoded array")
+	}
+	return consumed, nil
+}
+
+func decodeSlicePrefix[F FeltLike](data []byte, out *Slice[F]) (int, bool) {
+	if consumed, isNull := cborlite.ReadNull(data); isNull {
+		*out = nil
+		return consumed, true
+	}
+
 	size, offset, ok := decodeCBORArrayHeader(data)
 	if !ok {
-		return s.unmarshalGeneric(data)
+		return 0, false
 	}
 
 	// Checking if size was corrupted to avoid allocating a malicious amount of data
 	maxPossibleFelts := (len(data) - offset) / minCBORFeltLen
 	if size < 0 || size > maxPossibleFelts {
-		return s.unmarshalGeneric(data)
+		return 0, false
 	}
 
 	buffer := make([]F, size)
 	for i := range buffer {
 		consumed, ok := decodeLimbs(data[offset:], &buffer[i])
 		if !ok {
-			return s.unmarshalGeneric(data)
+			return 0, false
 		}
 		offset += consumed
 	}
 
-	if offset != len(data) {
-		return s.unmarshalGeneric(data)
-	}
-
-	*s = buffer
-	return nil
+	*out = buffer
+	return offset, true
 }
 
-// unmarshalGeneric handles any shape the fast path does not recognise.
-func (s *Slice[F]) unmarshalGeneric(data []byte) error {
+// unmarshalCBORGeneric handles any shape the fast path does not recognise.
+func (s *Slice[F]) unmarshalCBORGeneric(data []byte) error {
 	var buffer []F
 	if err := cbor.Unmarshal(data, &buffer); err != nil {
 		return err

--- a/core/felt/slice_test.go
+++ b/core/felt/slice_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/NethermindEth/juno/core/felt"
 	"github.com/fxamacker/cbor/v2"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -368,5 +369,75 @@ func FuzzSliceDecodeJSONEquivalence(fz *testing.F) {
 
 	fz.Fuzz(func(t *testing.T, data []byte) {
 		requireSliceDecodeJSONEquivalent(t, data)
+	})
+}
+
+func TestFeltSliceUnmarshalCBORPrefix(t *testing.T) {
+	want := felt.Slice[felt.Felt]{
+		felt.FromUint64[felt.Felt](1),
+		felt.FromUint64[felt.Felt](0xffffffffffffffff),
+	}
+	encoded, err := want.MarshalCBOR()
+	require.NoError(t, err)
+
+	t.Run("reads the slice and reports the count", func(t *testing.T) {
+		var got felt.Slice[felt.Felt]
+		consumed, err := got.UnmarshalCBORPrefix(encoded)
+
+		require.NoError(t, err)
+		assert.Equal(t, len(encoded), consumed)
+		assert.Equal(t, want, got)
+	})
+
+	t.Run("trailing bytes are allowed, and not counted", func(t *testing.T) {
+		var got felt.Slice[felt.Felt]
+		consumed, err := got.UnmarshalCBORPrefix(append(append([]byte{}, encoded...), 0xff))
+
+		require.NoError(t, err)
+		assert.Equal(t, len(encoded), consumed)
+	})
+
+	t.Run("an empty slice is empty, not nil", func(t *testing.T) {
+		empty, err := felt.Slice[felt.Felt]{}.MarshalCBOR()
+		require.NoError(t, err)
+
+		var got felt.Slice[felt.Felt]
+		consumed, err := got.UnmarshalCBORPrefix(empty)
+
+		require.NoError(t, err)
+		assert.Equal(t, len(empty), consumed)
+		assert.NotNil(t, got)
+		assert.Empty(t, got)
+	})
+
+	// A nil slice goes on the wire as null, so declining it would send every value
+	// holding one back to the generic decoder over an empty field.
+	t.Run("null reads as a nil slice", func(t *testing.T) {
+		got := felt.Slice[felt.Felt]{felt.FromUint64[felt.Felt](7)}
+		consumed, err := got.UnmarshalCBORPrefix([]byte{0xf6})
+
+		require.NoError(t, err)
+		assert.Equal(t, 1, consumed)
+		assert.Nil(t, got)
+	})
+
+	t.Run("rejects what is not a felt array", func(t *testing.T) {
+		for name, data := range map[string][]byte{
+			"empty":                         {},
+			"truncated":                     encoded[:len(encoded)-1],
+			"not an array":                  {0x18, 0x2a},
+			"an element that is not a felt": {0x82, 0x01, 0x02},
+			// A count far past the buffer would size an allocation if it were trusted.
+			"count past the buffer": {0x98, 0xff, 0x01},
+		} {
+			t.Run(name, func(t *testing.T) {
+				var got felt.Slice[felt.Felt]
+				consumed, err := got.UnmarshalCBORPrefix(data)
+
+				assert.Error(t, err)
+				assert.Zero(t, consumed)
+				assert.Nil(t, got)
+			})
+		}
 	})
 }

--- a/encoder/cborlite/cache.go
+++ b/encoder/cborlite/cache.go
@@ -1,0 +1,67 @@
+package cborlite
+
+import (
+	"reflect"
+	"sync"
+)
+
+type reader func(target reflect.Value, data []byte) (consumed int, err error)
+
+// builtReader is what a build produced, including an error.
+type builtReader struct {
+	reader
+	err error
+}
+
+// cacheKey identifies a reader by type and strictness.
+type cacheKey struct {
+	valueType reflect.Type
+	strict    bool
+}
+
+var (
+	// Finished readers
+	readers sync.Map // cacheKey -> builtReader
+
+	// buildMutex serialises building.
+	buildMutex sync.Mutex
+
+	// Finished plans.
+	plans = map[cacheKey]*plan{}
+
+	// Holds plans still under construction.
+	buildingPlans = map[cacheKey]*plan{}
+)
+
+// cachedReader builds a reader and cache it so it only builds once.
+func cachedReader(valueType reflect.Type, strict bool) (reader, error) {
+	key := cacheKey{valueType: valueType, strict: strict}
+
+	cached, ok := readers.Load(key)
+	if ok {
+		built := cached.(builtReader)
+		return built.reader, built.err
+	}
+
+	buildMutex.Lock()
+	defer buildMutex.Unlock()
+
+	// Another goroutine may have finished while this one waited.
+	cached, ok = readers.Load(key)
+	if ok {
+		built := cached.(builtReader)
+		return built.reader, built.err
+	}
+
+	built, err := buildReader(valueType, strict)
+	readers.Store(key, builtReader{reader: built, err: err})
+	return built, err
+}
+
+func buildReader(valueType reflect.Type, strict bool) (reader, error) {
+	// If the type reads itself (e.g. implements UnmarshalCBORPrefix), it takes priority
+	if read, ok := specialTypeReader(valueType); ok {
+		return read, nil
+	}
+	return kindReader(valueType, strict)
+}

--- a/encoder/cborlite/cache.go
+++ b/encoder/cborlite/cache.go
@@ -5,6 +5,8 @@ import (
 	"sync"
 )
 
+const maxNestedPlans = 32
+
 type reader func(target reflect.Value, data []byte) (consumed int, err error)
 
 // builtReader is what a build produced, including an error.
@@ -25,12 +27,10 @@ var (
 
 	// buildMutex serialises building.
 	buildMutex sync.Mutex
+	buildDepth int
 
 	// Finished plans.
 	plans = map[cacheKey]*plan{}
-
-	// Holds plans still under construction.
-	buildingPlans = map[cacheKey]*plan{}
 )
 
 // cachedReader builds a reader and cache it so it only builds once.

--- a/encoder/cborlite/cache_test.go
+++ b/encoder/cborlite/cache_test.go
@@ -1,0 +1,53 @@
+package cborlite_test
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/NethermindEth/juno/encoder/cborlite"
+	"github.com/stretchr/testify/assert"
+)
+
+// Eight types, so the goroutines below build eight plans at once rather than queueing on
+// one. Nothing else names them, so each is built for the first time inside the test.
+type (
+	raced1 struct{ Value uint64 }
+	raced2 struct{ Value uint64 }
+	raced3 struct{ Value uint64 }
+	raced4 struct{ Value uint64 }
+	raced5 struct{ Value uint64 }
+	raced6 struct{ Value uint64 }
+	raced7 struct{ Value uint64 }
+	raced8 struct{ Value uint64 }
+)
+
+// TestConcurrentFirstBuildsAreSafe guards the plan caches, which are plain maps behind
+// buildMutex rather than sync.Map. Run under -race, this reports a data race, or panics
+// with a concurrent map write, if a build path ever stops taking the lock.
+func TestConcurrentFirstBuildsAreSafe(t *testing.T) {
+	data := cborMap(cborText("Value"), []byte{0x07})
+
+	// Half strict, so the strict caches are built concurrently too.
+	decodes := []func() error{
+		func() error { var v raced1; return cborlite.Unmarshal(data, &v) },
+		func() error { var v raced2; return cborlite.Unmarshal(data, &v) },
+		func() error { var v raced3; return cborlite.Unmarshal(data, &v) },
+		func() error { var v raced4; return cborlite.Unmarshal(data, &v) },
+		func() error { var v raced5; return cborlite.UnmarshalStrict(data, &v) },
+		func() error { var v raced6; return cborlite.UnmarshalStrict(data, &v) },
+		func() error { var v raced7; return cborlite.UnmarshalStrict(data, &v) },
+		func() error { var v raced8; return cborlite.UnmarshalStrict(data, &v) },
+	}
+
+	var group sync.WaitGroup
+	for range 4 {
+		for _, decode := range decodes {
+			group.Add(1)
+			go func() {
+				defer group.Done()
+				assert.NoError(t, decode())
+			}()
+		}
+	}
+	group.Wait()
+}

--- a/encoder/cborlite/cache_test.go
+++ b/encoder/cborlite/cache_test.go
@@ -8,8 +8,6 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-// Eight types, so the goroutines below build eight plans at once rather than queueing on
-// one. Nothing else names them, so each is built for the first time inside the test.
 type (
 	raced1 struct{ Value uint64 }
 	raced2 struct{ Value uint64 }
@@ -25,9 +23,9 @@ type (
 // buildMutex rather than sync.Map. Run under -race, this reports a data race, or panics
 // with a concurrent map write, if a build path ever stops taking the lock.
 func TestConcurrentFirstBuildsAreSafe(t *testing.T) {
-	data := cborMap(cborText("Value"), []byte{0x07})
+	data := cborMap(cborText("Value"), head(uintMajor, 7))
 
-	// Half strict, so the strict caches are built concurrently too.
+	// Test both strict and not strict.
 	decodes := []func() error{
 		func() error { var v raced1; return cborlite.Unmarshal(data, &v) },
 		func() error { var v raced2; return cborlite.Unmarshal(data, &v) },

--- a/encoder/cborlite/decode.go
+++ b/encoder/cborlite/decode.go
@@ -9,10 +9,9 @@
 // that can meet null calls [ReadNull] first.
 //
 // This unmarshaler is not exhaustive. It declines a shape it does not know.
+// It throws [ErrShape] and [ErrUnsupportedType], anything else is a defect.
 // A caller can fall back to the generic decoder. Add support when a shape needs it.
-//
-// It does not check that the bytes are well formed, so it is for bytes this node wrote
-// and read back. Do not use it for external inputs.
+// Do not use it for external inputs.
 //
 // To unmarshal a new type, implement [PrefixUnmarshaler].
 // Use the readers in headers.go and values.go to help.
@@ -30,7 +29,11 @@ type PrefixUnmarshaler interface {
 	UnmarshalCBORPrefix(data []byte) (consumed int, err error)
 }
 
-var errShape = errors.New("shape does not match")
+// ErrShape means these bytes are not wellformed.
+var ErrShape = errors.New("shape does not match")
+
+// ErrUnsupportedType means this Go type is not supported by cborlite.
+var ErrUnsupportedType = errors.New("unsupported type")
 
 // Unmarshal decodes data into target.
 func Unmarshal(data []byte, target any) error {

--- a/encoder/cborlite/decode.go
+++ b/encoder/cborlite/decode.go
@@ -1,0 +1,81 @@
+// Package cborlite is a CBOR unmarshaler. It has two main goals:
+//
+//   - To only see a byte once. No revisiting.
+//   - To fill the fields you ask for and skip the rest.
+//
+// Skipping is cheap. No hidden byte checks. Less CPU usage.
+//
+// No reader checks null, since that would be a hidden byte check on every call. A caller
+// that can meet null calls [ReadNull] first.
+//
+// This unmarshaler is not exhaustive. It declines a shape it does not know.
+// A caller can fall back to the generic decoder. Add support when a shape needs it.
+//
+// It does not check that the bytes are well formed, so it is for bytes this node wrote
+// and read back. Do not use it for external inputs.
+//
+// To unmarshal a new type, implement [PrefixUnmarshaler].
+// Use the readers in headers.go and values.go to help.
+package cborlite
+
+import (
+	"errors"
+	"fmt"
+	"reflect"
+)
+
+// PrefixUnmarshaler is the interface a type uses to unmarshal itself from a buffer front.
+// It must copy what it keeps, since data is freed after reading.
+type PrefixUnmarshaler interface {
+	UnmarshalCBORPrefix(data []byte) (consumed int, err error)
+}
+
+var errShape = errors.New("shape does not match")
+
+// Unmarshal decodes data into target.
+func Unmarshal(data []byte, target any) error {
+	return unmarshalAll(data, target, false)
+}
+
+// UnmarshalPrefix decodes the value at the start of data and reports its length.
+func UnmarshalPrefix(data []byte, target any) (consumed int, err error) {
+	return unmarshalPrefix(data, target, false)
+}
+
+// UnmarshalStrict decodes like [Unmarshal] but fails if any key would be skipped.
+func UnmarshalStrict(data []byte, target any) error {
+	return unmarshalAll(data, target, true)
+}
+
+func unmarshalAll(data []byte, target any, strict bool) error {
+	consumed, err := unmarshalPrefix(data, target, strict)
+	if err != nil {
+		return err
+	}
+	if consumed != len(data) {
+		return fmt.Errorf("cborlite: %T: %d bytes left over", target, len(data)-consumed)
+	}
+
+	return nil
+}
+
+func unmarshalPrefix(data []byte, target any, strict bool) (consumed int, err error) {
+	value := reflect.ValueOf(target)
+	if value.Kind() != reflect.Pointer || value.IsNil() {
+		return 0, fmt.Errorf("cborlite: needs a non-nil pointer, got %T", target)
+	}
+
+	valueType := value.Type().Elem()
+
+	reader, err := cachedReader(valueType, strict)
+	if err != nil {
+		return 0, err
+	}
+
+	consumed, err = reader(value.Elem(), data)
+	if err != nil {
+		return 0, fmt.Errorf("cborlite: %w", err)
+	}
+
+	return consumed, nil
+}

--- a/encoder/cborlite/decode_test.go
+++ b/encoder/cborlite/decode_test.go
@@ -8,19 +8,19 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// TestUnmarshalPrefix covers the entry point a self-reading type is built on: it stops at
-// the end of the value and reports where that was, instead of demanding the whole buffer.
 func TestUnmarshalPrefix(t *testing.T) {
 	type holder struct{ Value uint64 }
 
-	value := cborMap(cborText("Value"), []byte{0x07})
-	data := append(append([]byte{}, value...), 0xff, 0xff)
+	value := cborMap(cborText("Value"), head(uintMajor, 7))
+	data := trailByJunk(value)
 
-	var got holder
-	consumed, err := cborlite.UnmarshalPrefix(data, &got)
-	require.NoError(t, err)
-	assert.Equal(t, len(value), consumed)
-	assert.Equal(t, uint64(7), got.Value)
+	t.Run("extra fields don't fail", func(t *testing.T) {
+		var got holder
+		consumed, err := cborlite.UnmarshalPrefix(data, &got)
+		require.NoError(t, err)
+		assert.Equal(t, len(value), consumed)
+		assert.Equal(t, uint64(7), got.Value)
+	})
 
 	t.Run("the same bytes fail Unmarshal, which wants all of them", func(t *testing.T) {
 		var got holder
@@ -29,8 +29,6 @@ func TestUnmarshalPrefix(t *testing.T) {
 	})
 }
 
-// TestUnmarshalStrict covers the difference from [cborlite.Unmarshal]: a key no field
-// reads is an error rather than something to skip.
 func TestUnmarshalStrict(t *testing.T) {
 	type both struct {
 		First  uint64
@@ -38,11 +36,13 @@ func TestUnmarshalStrict(t *testing.T) {
 	}
 	type onlyFirst struct{ First uint64 }
 
-	data := cborMap(cborText("First"), []byte{0x01}, cborText("Second"), []byte{0x02})
+	data := cborMap(cborText("First"), head(uintMajor, 1), cborText("Second"), head(uintMajor, 2))
 
-	var complete both
-	require.NoError(t, cborlite.UnmarshalStrict(data, &complete))
-	assert.Equal(t, both{First: 1, Second: 2}, complete)
+	t.Run("a struct with all the fields must work", func(t *testing.T) {
+		var complete both
+		require.NoError(t, cborlite.UnmarshalStrict(data, &complete))
+		assert.Equal(t, both{First: 1, Second: 2}, complete)
+	})
 
 	t.Run("a struct that leaves a field out fails, and names the key", func(t *testing.T) {
 		var got onlyFirst

--- a/encoder/cborlite/decode_test.go
+++ b/encoder/cborlite/decode_test.go
@@ -1,0 +1,59 @@
+package cborlite_test
+
+import (
+	"testing"
+
+	"github.com/NethermindEth/juno/encoder/cborlite"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestUnmarshalPrefix covers the entry point a self-reading type is built on: it stops at
+// the end of the value and reports where that was, instead of demanding the whole buffer.
+func TestUnmarshalPrefix(t *testing.T) {
+	type holder struct{ Value uint64 }
+
+	value := cborMap(cborText("Value"), []byte{0x07})
+	data := append(append([]byte{}, value...), 0xff, 0xff)
+
+	var got holder
+	consumed, err := cborlite.UnmarshalPrefix(data, &got)
+	require.NoError(t, err)
+	assert.Equal(t, len(value), consumed)
+	assert.Equal(t, uint64(7), got.Value)
+
+	t.Run("the same bytes fail Unmarshal, which wants all of them", func(t *testing.T) {
+		var got holder
+		err := cborlite.Unmarshal(data, &got)
+		assert.ErrorContains(t, err, "left over")
+	})
+}
+
+// TestUnmarshalStrict covers the difference from [cborlite.Unmarshal]: a key no field
+// reads is an error rather than something to skip.
+func TestUnmarshalStrict(t *testing.T) {
+	type both struct {
+		First  uint64
+		Second uint64
+	}
+	type onlyFirst struct{ First uint64 }
+
+	data := cborMap(cborText("First"), []byte{0x01}, cborText("Second"), []byte{0x02})
+
+	var complete both
+	require.NoError(t, cborlite.UnmarshalStrict(data, &complete))
+	assert.Equal(t, both{First: 1, Second: 2}, complete)
+
+	t.Run("a struct that leaves a field out fails, and names the key", func(t *testing.T) {
+		var got onlyFirst
+		err := cborlite.UnmarshalStrict(data, &got)
+		require.Error(t, err)
+		assert.ErrorContains(t, err, "Second")
+	})
+
+	t.Run("the same struct passes without strict", func(t *testing.T) {
+		var got onlyFirst
+		require.NoError(t, cborlite.Unmarshal(data, &got))
+		assert.Equal(t, uint64(1), got.First)
+	})
+}

--- a/encoder/cborlite/plan.go
+++ b/encoder/cborlite/plan.go
@@ -1,0 +1,150 @@
+package cborlite
+
+import (
+	"fmt"
+	"reflect"
+	"strings"
+)
+
+type planField struct {
+	index int
+	reader
+}
+
+// A plan is what a struct type becomes: its fields, keyed by the name they have on the
+// wire, each with the reader that fills it.
+type plan struct {
+	fields            map[string]planField
+	rejectUnknownKeys bool
+	name              string
+}
+
+func planFor(structType reflect.Type, strict bool) (*plan, error) {
+	key := cacheKey{valueType: structType, strict: strict}
+
+	if cached, ok := plans[key]; ok {
+		return cached, nil
+	}
+	if buildingPlan, ok := buildingPlans[key]; ok {
+		return buildingPlan, nil
+	}
+
+	built := &plan{
+		fields:            make(map[string]planField, structType.NumField()),
+		name:              structType.String(),
+		rejectUnknownKeys: strict,
+	}
+	buildingPlans[key] = built
+	defer delete(buildingPlans, key)
+
+	// A non-empty type without exported fields is not valid.
+	if structType.NumField() > 0 && !hasExportedField(structType) {
+		return nil, fmt.Errorf("%s: no exported fields to read", structType)
+	}
+
+	for index := range structType.NumField() {
+		field := structType.Field(index)
+
+		if field.Anonymous {
+			return nil, fmt.Errorf("%s.%s: embedded fields are not supported",
+				structType, field.Name)
+		}
+
+		if !field.IsExported() {
+			continue
+		}
+
+		// check for unsupported CBOR keys
+		name, supported := cborKey(&field)
+		if !supported {
+			return nil, fmt.Errorf("%s.%s: unsupported cbor tag %q",
+				structType, field.Name, field.Tag.Get("cbor"))
+		}
+
+		reader, err := buildReader(field.Type, strict)
+		if err != nil {
+			return nil, fmt.Errorf("%s.%s: %w", structType, field.Name, err)
+		}
+
+		built.fields[name] = planField{index: index, reader: reader}
+	}
+
+	plans[key] = built
+	return built, nil
+}
+
+func hasExportedField(structType reflect.Type) bool {
+	for index := range structType.NumField() {
+		if structType.Field(index).IsExported() {
+			return true
+		}
+	}
+	return false
+}
+
+// cborKey gets name of a field, the CBOR tag name when it has one, else the Go field name.
+// Fails if a CBOR tag is not supported.
+func cborKey(field *reflect.StructField) (name string, supported bool) {
+	tag, ok := field.Tag.Lookup("cbor")
+	if !ok {
+		// Fields without tags return the Go name.
+		return field.Name, true
+	}
+
+	tagName, options, _ := strings.Cut(tag, ",")
+	// The tag says the field is not on the wire, which this package does not implement.
+	if tagName == "-" {
+		return "", false
+	}
+
+	for option := range strings.SplitSeq(options, ",") {
+		// The only options we support at the moment.
+		if option != "" && option != "omitempty" {
+			return "", false
+		}
+	}
+
+	if tagName == "" {
+		return field.Name, true
+	}
+
+	return tagName, true
+}
+
+// reader uses the plan to find the field each key goes to.
+func (p *plan) reader(target reflect.Value, data []byte) (consumed int, err error) {
+	pairsCount, offset, ok := MapHeader(data)
+	if !ok {
+		return 0, fmt.Errorf("%s: %w", p.name, errShape)
+	}
+
+	for range pairsCount {
+		key, keyLength, ok := StringNoCopy(data[offset:])
+		if !ok {
+			return 0, fmt.Errorf("%s: reading a key: %w", p.name, errShape)
+		}
+		offset += keyLength
+
+		field, known := p.fields[string(key)]
+		if !known {
+			if p.rejectUnknownKeys {
+				return 0, fmt.Errorf("%s: unknown field %q: %w", p.name, key, errShape)
+			}
+
+			skippedBytes, ok := Skip(data[offset:])
+			if !ok {
+				return 0, fmt.Errorf("%s: skipping unknown field %q: %w",
+					p.name, key, errShape)
+			}
+			offset += skippedBytes
+			continue
+		}
+
+		usedBytes, err := field.reader(target.Field(field.index), data[offset:])
+		if err != nil {
+			return 0, fmt.Errorf("%s.%s: %w", p.name, key, err)
+		}
+		offset += usedBytes
+	}
+	return offset, nil
+}

--- a/encoder/cborlite/plan.go
+++ b/encoder/cborlite/plan.go
@@ -19,14 +19,24 @@ type plan struct {
 	name              string
 }
 
-func planFor(structType reflect.Type, strict bool) (*plan, error) {
-	key := cacheKey{valueType: structType, strict: strict}
+// planFor builds the reader for a struct.
+func planFor(structType reflect.Type, strict bool) (reader, error) {
+	buildDepth++
+	defer func() { buildDepth-- }()
+	surface := buildDepth == 1
 
-	if cached, ok := plans[key]; ok {
-		return cached, nil
+	key := cacheKey{valueType: structType, strict: strict}
+	if surface {
+		if cached, ok := plans[key]; ok {
+			return cached.reader, nil
+		}
 	}
-	if buildingPlan, ok := buildingPlans[key]; ok {
-		return buildingPlan, nil
+
+	if buildDepth > maxNestedPlans {
+		name := structType.String()
+		return func(reflect.Value, []byte) (int, error) {
+			return 0, fmt.Errorf("%s: nested past %d: %w", name, maxNestedPlans, ErrShape)
+		}, nil
 	}
 
 	built := &plan{
@@ -34,20 +44,18 @@ func planFor(structType reflect.Type, strict bool) (*plan, error) {
 		name:              structType.String(),
 		rejectUnknownKeys: strict,
 	}
-	buildingPlans[key] = built
-	defer delete(buildingPlans, key)
 
 	// A non-empty type without exported fields is not valid.
 	if structType.NumField() > 0 && !hasExportedField(structType) {
-		return nil, fmt.Errorf("%s: no exported fields to read", structType)
+		return nil, fmt.Errorf("%s: no exported fields to read: %w", structType, ErrUnsupportedType)
 	}
 
 	for index := range structType.NumField() {
 		field := structType.Field(index)
 
 		if field.Anonymous {
-			return nil, fmt.Errorf("%s.%s: embedded fields are not supported",
-				structType, field.Name)
+			return nil, fmt.Errorf("%s.%s: embedded fields are not supported: %w",
+				structType, field.Name, ErrUnsupportedType)
 		}
 
 		if !field.IsExported() {
@@ -57,8 +65,8 @@ func planFor(structType reflect.Type, strict bool) (*plan, error) {
 		// check for unsupported CBOR keys
 		name, supported := cborKey(&field)
 		if !supported {
-			return nil, fmt.Errorf("%s.%s: unsupported cbor tag %q",
-				structType, field.Name, field.Tag.Get("cbor"))
+			return nil, fmt.Errorf("%s.%s: unsupported cbor tag %q: %w",
+				structType, field.Name, field.Tag.Get("cbor"), ErrUnsupportedType)
 		}
 
 		reader, err := buildReader(field.Type, strict)
@@ -69,8 +77,10 @@ func planFor(structType reflect.Type, strict bool) (*plan, error) {
 		built.fields[name] = planField{index: index, reader: reader}
 	}
 
-	plans[key] = built
-	return built, nil
+	if surface {
+		plans[key] = built
+	}
+	return built.reader, nil
 }
 
 func hasExportedField(structType reflect.Type) bool {
@@ -115,26 +125,31 @@ func cborKey(field *reflect.StructField) (name string, supported bool) {
 func (p *plan) reader(target reflect.Value, data []byte) (consumed int, err error) {
 	pairsCount, offset, ok := MapHeader(data)
 	if !ok {
-		return 0, fmt.Errorf("%s: %w", p.name, errShape)
+		// Structs holding null are accepted and its bytes are zeroed.
+		// Compatibility with the generic decoder.
+		if consumed, isNull := readNullInto(target, data); isNull {
+			return consumed, nil
+		}
+		return 0, fmt.Errorf("%s: %w", p.name, ErrShape)
 	}
 
 	for range pairsCount {
 		key, keyLength, ok := StringNoCopy(data[offset:])
 		if !ok {
-			return 0, fmt.Errorf("%s: reading a key: %w", p.name, errShape)
+			return 0, fmt.Errorf("%s: reading a key: %w", p.name, ErrShape)
 		}
 		offset += keyLength
 
 		field, known := p.fields[string(key)]
 		if !known {
 			if p.rejectUnknownKeys {
-				return 0, fmt.Errorf("%s: unknown field %q: %w", p.name, key, errShape)
+				return 0, fmt.Errorf("%s: unknown field %q: %w", p.name, key, ErrShape)
 			}
 
 			skippedBytes, ok := Skip(data[offset:])
 			if !ok {
 				return 0, fmt.Errorf("%s: skipping unknown field %q: %w",
-					p.name, key, errShape)
+					p.name, key, ErrShape)
 			}
 			offset += skippedBytes
 			continue

--- a/encoder/cborlite/plan_test.go
+++ b/encoder/cborlite/plan_test.go
@@ -1,6 +1,7 @@
 package cborlite_test
 
 import (
+	"fmt"
 	"math/big"
 	"testing"
 
@@ -16,7 +17,7 @@ func TestUnmarshalHonoursCBORTags(t *testing.T) {
 		}
 
 		// Keyed on the tag name, which is what the encoder writes.
-		data := cborMap(cborText("gasprice"), []byte{0x07})
+		data := cborMap(cborText("gasprice"), head(uintMajor, 7))
 
 		var got tagged
 		require.NoError(t, cborlite.Unmarshal(data, &got))
@@ -30,7 +31,7 @@ func TestUnmarshalHonoursCBORTags(t *testing.T) {
 		}
 
 		// Keyed on the Go name: unknown to the plan, so skipped, and the field stays nil.
-		data := cborMap(cborText("Price"), []byte{0x07})
+		data := cborMap(cborText("Price"), head(uintMajor, 7))
 
 		var got tagged
 		require.NoError(t, cborlite.Unmarshal(data, &got))
@@ -43,7 +44,7 @@ func TestUnmarshalHonoursCBORTags(t *testing.T) {
 		}
 
 		var got tagged
-		require.NoError(t, cborlite.Unmarshal(cborMap(cborText("Value"), []byte{0x07}), &got))
+		require.NoError(t, cborlite.Unmarshal(cborMap(cborText("Value"), head(uintMajor, 7)), &got))
 		assert.Equal(t, uint64(7), got.Value)
 	})
 
@@ -74,29 +75,29 @@ func TestUnmarshalEmbeddedFieldIsRefused(t *testing.T) {
 	}
 
 	var got outer
-	err := cborlite.Unmarshal(cborMap(cborText("Low"), []byte{0x01}), &got)
+	err := cborlite.Unmarshal(cborMap(cborText("Low"), head(uintMajor, 1)), &got)
 	assert.ErrorContains(t, err, "embedded")
 }
 
-// A pair of types that reach each other, so two plans are under construction at once and
-// the cache has to hand back the right one. Local types cannot do this: a type declared in
-// a function body cannot name one declared after it.
+// cycleOuter cannot be built: float64 has no reader. cycleInner takes part in the cycle.
+type (
+	cycleOuter struct {
+		Inner cycleInner
+		Good  uint64
+		Bad   float64
+	}
+	cycleInner struct{ Outer *cycleOuter }
+)
+
+// Local types cannot do cross reference
 type (
 	outerCycle struct{ Inner []innerCycle }
 	innerCycle struct {
-		Back  []outerCycle
+		Outer []outerCycle
 		Value uint64
 	}
 )
 
-// TestUnmarshalSelfReferentialStruct covers the cycle guard in the plan cache. Building a
-// plan descends into every field, and a field of the type being built descends into it
-// again, so without the half-built plan being handed back the build never returns and the
-// process dies on a full stack rather than reporting anything.
-//
-// core.SegmentLengths is this shape and it is read on the getClass path, so the guard runs
-// in production. Nothing else here would notice it going: every other test names a type
-// that terminates.
 func TestUnmarshalSelfReferentialStruct(t *testing.T) {
 	t.Run("through a slice of itself", func(t *testing.T) {
 		type node struct {
@@ -105,12 +106,12 @@ func TestUnmarshalSelfReferentialStruct(t *testing.T) {
 		}
 
 		data := cborMap(
-			cborText("Length"), []byte{0x01},
+			cborText("Length"), head(uintMajor, 1),
 			cborText("Children"), cborArray(
-				cborMap(cborText("Length"), []byte{0x02}),
+				cborMap(cborText("Length"), head(uintMajor, 2)),
 				cborMap(
-					cborText("Length"), []byte{0x03},
-					cborText("Children"), cborArray(cborMap(cborText("Length"), []byte{0x04})),
+					cborText("Length"), head(uintMajor, 3),
+					cborText("Children"), cborArray(cborMap(cborText("Length"), head(uintMajor, 4))),
 				),
 			),
 		)
@@ -126,7 +127,6 @@ func TestUnmarshalSelfReferentialStruct(t *testing.T) {
 		}, got)
 	})
 
-	// A pointer field descends eagerly too, so it reaches the guard by its own route.
 	t.Run("through a pointer to itself", func(t *testing.T) {
 		type node struct {
 			Next  *node
@@ -134,10 +134,10 @@ func TestUnmarshalSelfReferentialStruct(t *testing.T) {
 		}
 
 		data := cborMap(
-			cborText("Value"), []byte{0x01},
+			cborText("Value"), head(uintMajor, 1),
 			cborText("Next"), cborMap(
-				cborText("Value"), []byte{0x02},
-				cborText("Next"), []byte{cborlite.Null},
+				cborText("Value"), head(uintMajor, 2),
+				cborText("Next"), []byte{null},
 			),
 		)
 
@@ -149,8 +149,8 @@ func TestUnmarshalSelfReferentialStruct(t *testing.T) {
 	t.Run("through another type that points back", func(t *testing.T) {
 		data := cborMap(cborText("Inner"), cborArray(
 			cborMap(
-				cborText("Value"), []byte{0x07},
-				cborText("Back"), cborArray(cborMap(cborText("Inner"), cborArray())),
+				cborText("Value"), head(uintMajor, 7),
+				cborText("Outer"), cborArray(cborMap(cborText("Inner"), cborArray())),
 			),
 		))
 
@@ -158,14 +158,13 @@ func TestUnmarshalSelfReferentialStruct(t *testing.T) {
 		require.NoError(t, cborlite.Unmarshal(data, &got))
 		assert.Equal(t, outerCycle{Inner: []innerCycle{{
 			Value: 7,
-			Back:  []outerCycle{{Inner: []innerCycle{}}},
+			Outer: []outerCycle{{Inner: []innerCycle{}}},
 		}}}, got)
 	})
 }
 
-// TestNullWhereAStructIsExpected covers the one kind that cannot be absent. A pointer, a
-// slice, a map and an interface field all read null as their zero value, and a struct
-// field refuses it instead of coming back silently empty.
+// A struct by value has no nil to hold, so null zeroes it.
+// Compatibility with the generic decoder
 func TestNullWhereAStructIsExpected(t *testing.T) {
 	type inner struct{ Value uint64 }
 	type outer struct {
@@ -174,10 +173,69 @@ func TestNullWhereAStructIsExpected(t *testing.T) {
 	}
 
 	data := cborMap(
-		cborText("Nested"), []byte{cborlite.Null},
-		cborText("After"), []byte{0x07},
+		cborText("Nested"), []byte{null},
+		cborText("After"), head(uintMajor, 7),
 	)
 
 	var got outer
-	require.ErrorContains(t, cborlite.Unmarshal(data, &got), "Nested")
+	require.NoError(t, cborlite.Unmarshal(data, &got))
+	assert.Zero(t, got.Nested)
+	assert.Equal(t, uint64(7), got.After)
+}
+
+func TestReadingStopsBeforeTheStackOverflows(t *testing.T) {
+	type node struct{ Children []node }
+
+	build := func(depth int) []byte {
+		out := make([]byte, 0, depth*12+1)
+		for range depth {
+			out = append(out, initialByte(mapMajor, 1))
+			out = append(out, cborText("Children")...)
+			out = append(out, initialByte(arrayMajor, 1))
+		}
+		return append(out, initialByte(mapMajor, 0))
+	}
+
+	t.Run("nesting within the bound is read", func(t *testing.T) {
+		var got node
+		require.NoError(t, cborlite.Unmarshal(build(8), &got))
+	})
+
+	for _, depth := range []int{100, 1_000_000} {
+		t.Run(fmt.Sprintf("declines %d levels instead of crashing", depth), func(t *testing.T) {
+			var got node
+			require.ErrorContains(t, cborlite.Unmarshal(build(depth), &got), "nested past")
+		})
+	}
+}
+
+func TestAFailedBuildInACycleLeavesNothingUsable(t *testing.T) {
+	data := cborMap(cborText("Good"), head(uintMajor, 7), cborText("Bad"), head(uintMajor, 1))
+
+	var outer cycleOuter
+	require.Error(t, cborlite.Unmarshal(data, &outer))
+
+	// cycleInner points back at cycleOuter, so its build saw the outer one half-built.
+	var inner cycleInner
+	require.Error(t, cborlite.Unmarshal(cborMap(cborText("Outer"), []byte{null}), &inner))
+}
+
+func TestDeclinesAreTellableApart(t *testing.T) {
+	t.Run("bytes that do not match the target", func(t *testing.T) {
+		type holder struct{ Value uint64 }
+
+		err := cborlite.Unmarshal(cborMap(cborText("Value"), cborText("no")), &holder{})
+		require.ErrorIs(t, err, cborlite.ErrShape)
+		assert.NotErrorIs(t, err, cborlite.ErrUnsupportedType)
+	})
+
+	t.Run("a tag this package does not support", func(t *testing.T) {
+		type holder struct {
+			Value uint64 `cbor:",not_an_option"`
+		}
+
+		err := cborlite.Unmarshal(cborMap(), &holder{})
+		require.ErrorIs(t, err, cborlite.ErrUnsupportedType)
+		assert.NotErrorIs(t, err, cborlite.ErrShape)
+	})
 }

--- a/encoder/cborlite/plan_test.go
+++ b/encoder/cborlite/plan_test.go
@@ -1,0 +1,183 @@
+package cborlite_test
+
+import (
+	"math/big"
+	"testing"
+
+	"github.com/NethermindEth/juno/encoder/cborlite"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestUnmarshalHonoursCBORTags(t *testing.T) {
+	t.Run("a tag name is the wire key, not the Go field name", func(t *testing.T) {
+		type tagged struct {
+			Price *big.Int `cbor:"gasprice"`
+		}
+
+		// Keyed on the tag name, which is what the encoder writes.
+		data := cborMap(cborText("gasprice"), []byte{0x07})
+
+		var got tagged
+		require.NoError(t, cborlite.Unmarshal(data, &got))
+		require.NotNil(t, got.Price)
+		assert.Equal(t, int64(7), got.Price.Int64())
+	})
+
+	t.Run("the Go name is not accepted when a tag renames the field", func(t *testing.T) {
+		type tagged struct {
+			Price *big.Int `cbor:"gasprice"`
+		}
+
+		// Keyed on the Go name: unknown to the plan, so skipped, and the field stays nil.
+		data := cborMap(cborText("Price"), []byte{0x07})
+
+		var got tagged
+		require.NoError(t, cborlite.Unmarshal(data, &got))
+		assert.Nil(t, got.Price, "an unknown key is skipped, which is how a typo goes quiet")
+	})
+
+	t.Run("an empty tag name keeps the Go field name", func(t *testing.T) {
+		type tagged struct {
+			Value uint64 `cbor:",omitempty"`
+		}
+
+		var got tagged
+		require.NoError(t, cborlite.Unmarshal(cborMap(cborText("Value"), []byte{0x07}), &got))
+		assert.Equal(t, uint64(7), got.Value)
+	})
+
+	t.Run("a dash means the field is not on the wire, so the build fails", func(t *testing.T) {
+		type tagged struct {
+			Value uint64 `cbor:"-"`
+		}
+
+		var got tagged
+		assert.ErrorContains(t, cborlite.Unmarshal(cborMap(), &got), "unsupported cbor tag")
+	})
+
+	t.Run("keyasint is not implemented, and says so", func(t *testing.T) {
+		type tagged struct {
+			Value uint64 `cbor:"1,keyasint"`
+		}
+
+		var got tagged
+		assert.ErrorContains(t, cborlite.Unmarshal(cborMap(), &got), "unsupported cbor tag")
+	})
+}
+
+func TestUnmarshalEmbeddedFieldIsRefused(t *testing.T) {
+	type inner struct{ Low uint64 }
+	type outer struct {
+		inner
+		High uint64
+	}
+
+	var got outer
+	err := cborlite.Unmarshal(cborMap(cborText("Low"), []byte{0x01}), &got)
+	assert.ErrorContains(t, err, "embedded")
+}
+
+// A pair of types that reach each other, so two plans are under construction at once and
+// the cache has to hand back the right one. Local types cannot do this: a type declared in
+// a function body cannot name one declared after it.
+type (
+	outerCycle struct{ Inner []innerCycle }
+	innerCycle struct {
+		Back  []outerCycle
+		Value uint64
+	}
+)
+
+// TestUnmarshalSelfReferentialStruct covers the cycle guard in the plan cache. Building a
+// plan descends into every field, and a field of the type being built descends into it
+// again, so without the half-built plan being handed back the build never returns and the
+// process dies on a full stack rather than reporting anything.
+//
+// core.SegmentLengths is this shape and it is read on the getClass path, so the guard runs
+// in production. Nothing else here would notice it going: every other test names a type
+// that terminates.
+func TestUnmarshalSelfReferentialStruct(t *testing.T) {
+	t.Run("through a slice of itself", func(t *testing.T) {
+		type node struct {
+			Children []node
+			Length   uint64
+		}
+
+		data := cborMap(
+			cborText("Length"), []byte{0x01},
+			cborText("Children"), cborArray(
+				cborMap(cborText("Length"), []byte{0x02}),
+				cborMap(
+					cborText("Length"), []byte{0x03},
+					cborText("Children"), cborArray(cborMap(cborText("Length"), []byte{0x04})),
+				),
+			),
+		)
+
+		var got node
+		require.NoError(t, cborlite.Unmarshal(data, &got))
+		assert.Equal(t, node{
+			Length: 1,
+			Children: []node{
+				{Length: 2},
+				{Length: 3, Children: []node{{Length: 4}}},
+			},
+		}, got)
+	})
+
+	// A pointer field descends eagerly too, so it reaches the guard by its own route.
+	t.Run("through a pointer to itself", func(t *testing.T) {
+		type node struct {
+			Next  *node
+			Value uint64
+		}
+
+		data := cborMap(
+			cborText("Value"), []byte{0x01},
+			cborText("Next"), cborMap(
+				cborText("Value"), []byte{0x02},
+				cborText("Next"), []byte{cborlite.Null},
+			),
+		)
+
+		var got node
+		require.NoError(t, cborlite.Unmarshal(data, &got))
+		assert.Equal(t, node{Value: 1, Next: &node{Value: 2}}, got)
+	})
+
+	t.Run("through another type that points back", func(t *testing.T) {
+		data := cborMap(cborText("Inner"), cborArray(
+			cborMap(
+				cborText("Value"), []byte{0x07},
+				cborText("Back"), cborArray(cborMap(cborText("Inner"), cborArray())),
+			),
+		))
+
+		var got outerCycle
+		require.NoError(t, cborlite.Unmarshal(data, &got))
+		assert.Equal(t, outerCycle{Inner: []innerCycle{{
+			Value: 7,
+			Back:  []outerCycle{{Inner: []innerCycle{}}},
+		}}}, got)
+	})
+}
+
+// TestNullWhereAStructIsExpected covers the one kind that cannot be absent. A pointer, a
+// slice, a map and an interface field all read null as their zero value, and a struct
+// field refuses it instead of coming back silently empty.
+func TestNullWhereAStructIsExpected(t *testing.T) {
+	type inner struct{ Value uint64 }
+	type outer struct {
+		Nested inner
+		After  uint64
+	}
+
+	data := cborMap(
+		cborText("Nested"), []byte{cborlite.Null},
+		cborText("After"), []byte{0x07},
+	)
+
+	var got outer
+	require.ErrorContains(t, cborlite.Unmarshal(data, &got), "Nested")
+}

--- a/encoder/cborlite/readers.go
+++ b/encoder/cborlite/readers.go
@@ -1,0 +1,85 @@
+package cborlite
+
+import (
+	"encoding"
+	"fmt"
+	"math/big"
+	"reflect"
+)
+
+var (
+	prefixUnmarshalerType = reflect.TypeFor[PrefixUnmarshaler]()
+	binaryUnmarshalerType = reflect.TypeFor[encoding.BinaryUnmarshaler]()
+
+	// A *big.Int looks like a normal number until it outgrows a uint64.
+	// We need to check the type explicitly to match it to the correct reader.
+	bigIntType = reflect.TypeFor[*big.Int]()
+)
+
+// specialTypeReader covers everything that can't be resolved through its kind.
+func specialTypeReader(valueType reflect.Type) (reader, bool) {
+	// Implements UnmarshalCBORPrefix
+	if reflect.PointerTo(valueType).Implements(prefixUnmarshalerType) {
+		return readPrefixUnmarshaler, true
+	}
+
+	// Implements UnmarshalBinary
+	if reflect.PointerTo(valueType).Implements(binaryUnmarshalerType) {
+		return readBinaryUnmarshaler, true
+	}
+
+	if valueType == bigIntType {
+		return readBigInt, true
+	}
+
+	return nil, false
+}
+
+func readPrefixUnmarshaler(target reflect.Value, data []byte) (consumed int, err error) {
+	unmarshaler, ok := target.Addr().Interface().(PrefixUnmarshaler)
+	if !ok {
+		return 0, errShape
+	}
+
+	consumed, err = unmarshaler.UnmarshalCBORPrefix(data)
+	if err != nil {
+		return 0, err
+	}
+
+	if consumed <= 0 || consumed > len(data) {
+		return 0, fmt.Errorf("%T reported consuming %d of %d bytes",
+			unmarshaler, consumed, len(data))
+	}
+	return consumed, nil
+}
+
+func readBinaryUnmarshaler(target reflect.Value, data []byte) (consumed int, err error) {
+	bytes, consumed, ok := BytesNoCopy(data)
+	if !ok {
+		return 0, errShape
+	}
+
+	unmarshaler, ok := target.Addr().Interface().(encoding.BinaryUnmarshaler)
+	if !ok {
+		return 0, errShape
+	}
+	if err := unmarshaler.UnmarshalBinary(bytes); err != nil {
+		return 0, fmt.Errorf("%T: %w", unmarshaler, err)
+	}
+
+	return consumed, nil
+}
+
+func readBigInt(target reflect.Value, data []byte) (consumed int, err error) {
+	if consumed, isNull := readNullInto(target, data); isNull {
+		return consumed, nil
+	}
+
+	value, consumed, ok := BigInt(data)
+	if !ok {
+		return 0, errShape
+	}
+
+	target.Set(reflect.ValueOf(value))
+	return consumed, nil
+}

--- a/encoder/cborlite/readers.go
+++ b/encoder/cborlite/readers.go
@@ -38,7 +38,7 @@ func specialTypeReader(valueType reflect.Type) (reader, bool) {
 func readPrefixUnmarshaler(target reflect.Value, data []byte) (consumed int, err error) {
 	unmarshaler, ok := target.Addr().Interface().(PrefixUnmarshaler)
 	if !ok {
-		return 0, errShape
+		return 0, ErrShape
 	}
 
 	consumed, err = unmarshaler.UnmarshalCBORPrefix(data)
@@ -56,12 +56,12 @@ func readPrefixUnmarshaler(target reflect.Value, data []byte) (consumed int, err
 func readBinaryUnmarshaler(target reflect.Value, data []byte) (consumed int, err error) {
 	bytes, consumed, ok := BytesNoCopy(data)
 	if !ok {
-		return 0, errShape
+		return 0, ErrShape
 	}
 
 	unmarshaler, ok := target.Addr().Interface().(encoding.BinaryUnmarshaler)
 	if !ok {
-		return 0, errShape
+		return 0, ErrShape
 	}
 	if err := unmarshaler.UnmarshalBinary(bytes); err != nil {
 		return 0, fmt.Errorf("%T: %w", unmarshaler, err)
@@ -77,7 +77,7 @@ func readBigInt(target reflect.Value, data []byte) (consumed int, err error) {
 
 	value, consumed, ok := BigInt(data)
 	if !ok {
-		return 0, errShape
+		return 0, ErrShape
 	}
 
 	target.Set(reflect.ValueOf(value))

--- a/encoder/cborlite/readers_kind.go
+++ b/encoder/cborlite/readers_kind.go
@@ -8,8 +8,6 @@ import (
 // maxPresizedBytes caps the allocation a count is trusted for up front.
 const maxPresizedBytes = 1 << 20
 
-var byteType = reflect.TypeFor[byte]()
-
 // kindReader maps a Go kind onto a reader, for what specialTypeReader did not claim.
 func kindReader(valueType reflect.Type, strict bool) (reader, error) {
 	if scalar := scalarReader(valueType.Kind()); scalar != nil {
@@ -18,11 +16,7 @@ func kindReader(valueType reflect.Type, strict bool) (reader, error) {
 
 	switch valueType.Kind() {
 	case reflect.Struct:
-		structPlan, err := planFor(valueType, strict)
-		if err != nil {
-			return nil, err
-		}
-		return structPlan.reader, nil
+		return planFor(valueType, strict)
 
 	case reflect.Pointer:
 		return pointerReader(valueType, strict)
@@ -40,7 +34,8 @@ func kindReader(valueType reflect.Type, strict bool) (reader, error) {
 		return interfaceReader(valueType, strict), nil
 
 	default:
-		return nil, fmt.Errorf("no reader for %s (kind %s)", valueType, valueType.Kind())
+		return nil, fmt.Errorf("no reader for %s (kind %s): %w",
+			valueType, valueType.Kind(), ErrUnsupportedType)
 	}
 }
 
@@ -52,7 +47,7 @@ func scalarReader(kind reflect.Kind) reader {
 		return func(target reflect.Value, data []byte) (int, error) {
 			value, consumed, ok := Int64(data)
 			if !ok || target.OverflowInt(value) {
-				return 0, errShape
+				return 0, ErrShape
 			}
 			target.SetInt(value)
 			return consumed, nil
@@ -62,7 +57,7 @@ func scalarReader(kind reflect.Kind) reader {
 		return func(target reflect.Value, data []byte) (int, error) {
 			value, consumed, ok := Uint64(data)
 			if !ok || target.OverflowUint(value) {
-				return 0, errShape
+				return 0, ErrShape
 			}
 			target.SetUint(value)
 			return consumed, nil
@@ -72,7 +67,7 @@ func scalarReader(kind reflect.Kind) reader {
 		return func(target reflect.Value, data []byte) (int, error) {
 			value, consumed, ok := String(data)
 			if !ok {
-				return 0, errShape
+				return 0, ErrShape
 			}
 			target.SetString(value)
 			return consumed, nil
@@ -82,7 +77,7 @@ func scalarReader(kind reflect.Kind) reader {
 		return func(target reflect.Value, data []byte) (int, error) {
 			value, consumed, ok := Bool(data)
 			if !ok {
-				return 0, errShape
+				return 0, ErrShape
 			}
 			target.SetBool(value)
 			return consumed, nil
@@ -131,7 +126,7 @@ func readByteSlice(target reflect.Value, data []byte) (consumed int, err error) 
 
 	value, consumed, ok := Bytes(data)
 	if !ok {
-		return 0, errShape
+		return 0, ErrShape
 	}
 
 	target.SetBytes(value)
@@ -142,24 +137,17 @@ func readByteSlice(target reflect.Value, data []byte) (consumed int, err error) 
 // The length has to match exactly, since an array cannot grow or shrink to fit.
 func readByteArray(arrayType reflect.Type) reader {
 	length := arrayType.Len()
-	elemIsByte := arrayType.Elem() == byteType
 
 	return func(target reflect.Value, data []byte) (int, error) {
 		value, consumed, ok := BytesNoCopy(data)
 		if !ok || len(value) != length {
-			return 0, errShape
+			if consumed, isNull := readNullInto(target, data); isNull {
+				return consumed, nil
+			}
+			return 0, ErrShape
 		}
 
-		if elemIsByte {
-			reflect.Copy(target, reflect.ValueOf(value))
-			return consumed, nil
-		}
-
-		// reflect.Copy needs the element types to be the same. Same kind is not enough.
-		// So setting one by one
-		for index, b := range value {
-			target.Index(index).SetUint(uint64(b))
-		}
+		copy(target.Bytes(), value)
 		return consumed, nil
 	}
 }
@@ -187,7 +175,7 @@ func sliceReader(sliceType reflect.Type, strict bool) (reader, error) {
 
 		length, consumed, ok := ArrayHeader(data)
 		if !ok {
-			return 0, errShape
+			return 0, ErrShape
 		}
 
 		presized := min(length, maxElements)
@@ -227,9 +215,13 @@ func arrayReader(arrayType reflect.Type, strict bool) (reader, error) {
 		count, consumed, ok := ArrayHeader(data)
 		// A fixed-size array has to match exactly
 		if !ok || count != length {
-			return 0, errShape
+			if consumed, isNull := readNullInto(target, data); isNull {
+				return consumed, nil
+			}
+			return 0, ErrShape
 		}
 
+		// Written in place for performance.
 		for index := range length {
 			used, err := elemReader(target.Index(index), data[consumed:])
 			if err != nil {
@@ -260,7 +252,7 @@ func mapReader(mapType reflect.Type, strict bool) (reader, error) {
 
 		pairs, consumed, ok := MapHeader(data)
 		if !ok {
-			return 0, errShape
+			return 0, ErrShape
 		}
 
 		out := reflect.MakeMapWithSize(mapType, min(pairs, maxEntries))
@@ -289,7 +281,7 @@ func mapReader(mapType reflect.Type, strict bool) (reader, error) {
 
 		// A repeated key means the map holds fewer entries than the header counted.
 		if out.Len() != pairs {
-			return 0, errShape
+			return 0, ErrShape
 		}
 
 		target.Set(out)
@@ -305,16 +297,16 @@ func interfaceReader(interfaceType reflect.Type, strict bool) reader {
 
 		tag, consumed, ok := Tag(data)
 		if !ok {
-			return 0, errShape
+			return 0, ErrShape
 		}
 
 		concrete, known := tagTypes.Load(tag)
 		if !known {
-			return 0, errShape
+			return 0, ErrShape
 		}
 		concreteType := concrete.(reflect.Type)
 		if !reflect.PointerTo(concreteType).Implements(interfaceType) {
-			return 0, errShape
+			return 0, ErrShape
 		}
 
 		read, err := cachedReader(concreteType, strict)

--- a/encoder/cborlite/readers_kind.go
+++ b/encoder/cborlite/readers_kind.go
@@ -1,0 +1,334 @@
+package cborlite
+
+import (
+	"fmt"
+	"reflect"
+)
+
+// maxPresizedBytes caps the allocation a count is trusted for up front.
+const maxPresizedBytes = 1 << 20
+
+var byteType = reflect.TypeFor[byte]()
+
+// kindReader maps a Go kind onto a reader, for what specialTypeReader did not claim.
+func kindReader(valueType reflect.Type, strict bool) (reader, error) {
+	if scalar := scalarReader(valueType.Kind()); scalar != nil {
+		return scalar, nil
+	}
+
+	switch valueType.Kind() {
+	case reflect.Struct:
+		structPlan, err := planFor(valueType, strict)
+		if err != nil {
+			return nil, err
+		}
+		return structPlan.reader, nil
+
+	case reflect.Pointer:
+		return pointerReader(valueType, strict)
+
+	case reflect.Slice:
+		return sliceReader(valueType, strict)
+
+	case reflect.Array:
+		return arrayReader(valueType, strict)
+
+	case reflect.Map:
+		return mapReader(valueType, strict)
+
+	case reflect.Interface:
+		return interfaceReader(valueType, strict), nil
+
+	default:
+		return nil, fmt.Errorf("no reader for %s (kind %s)", valueType, valueType.Kind())
+	}
+}
+
+// scalarReader covers the kinds that need nothing but the kind itself.
+// Keeping them inlined for performance reasons.
+func scalarReader(kind reflect.Kind) reader {
+	switch kind {
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+		return func(target reflect.Value, data []byte) (int, error) {
+			value, consumed, ok := Int64(data)
+			if !ok || target.OverflowInt(value) {
+				return 0, errShape
+			}
+			target.SetInt(value)
+			return consumed, nil
+		}
+
+	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
+		return func(target reflect.Value, data []byte) (int, error) {
+			value, consumed, ok := Uint64(data)
+			if !ok || target.OverflowUint(value) {
+				return 0, errShape
+			}
+			target.SetUint(value)
+			return consumed, nil
+		}
+
+	case reflect.String:
+		return func(target reflect.Value, data []byte) (int, error) {
+			value, consumed, ok := String(data)
+			if !ok {
+				return 0, errShape
+			}
+			target.SetString(value)
+			return consumed, nil
+		}
+
+	case reflect.Bool:
+		return func(target reflect.Value, data []byte) (int, error) {
+			value, consumed, ok := Bool(data)
+			if !ok {
+				return 0, errShape
+			}
+			target.SetBool(value)
+			return consumed, nil
+		}
+
+	default:
+		return nil
+	}
+}
+
+// readNullInto writes the zero value when data is null, reporting whether it did.
+func readNullInto(target reflect.Value, data []byte) (consumed int, isNull bool) {
+	if consumed, isNull = ReadNull(data); isNull {
+		target.SetZero()
+	}
+	return consumed, isNull
+}
+
+func pointerReader(pointerType reflect.Type, strict bool) (reader, error) {
+	elem := pointerType.Elem()
+
+	elemReader, err := buildReader(elem, strict)
+	if err != nil {
+		return nil, err
+	}
+
+	return func(target reflect.Value, data []byte) (int, error) {
+		if consumed, isNull := readNullInto(target, data); isNull {
+			return consumed, nil
+		}
+
+		if target.IsNil() {
+			target.Set(reflect.New(elem))
+		}
+
+		return elemReader(target.Elem(), data)
+	}, nil
+}
+
+// readByteSlice fills a byte slice.
+// Any slice of uint8 lands here, so a named form like json.RawMessage does too.
+func readByteSlice(target reflect.Value, data []byte) (consumed int, err error) {
+	if consumed, isNull := readNullInto(target, data); isNull {
+		return consumed, nil
+	}
+
+	value, consumed, ok := Bytes(data)
+	if !ok {
+		return 0, errShape
+	}
+
+	target.SetBytes(value)
+	return consumed, nil
+}
+
+// readByteArray fills a fixed-size byte array.
+// The length has to match exactly, since an array cannot grow or shrink to fit.
+func readByteArray(arrayType reflect.Type) reader {
+	length := arrayType.Len()
+	elemIsByte := arrayType.Elem() == byteType
+
+	return func(target reflect.Value, data []byte) (int, error) {
+		value, consumed, ok := BytesNoCopy(data)
+		if !ok || len(value) != length {
+			return 0, errShape
+		}
+
+		if elemIsByte {
+			reflect.Copy(target, reflect.ValueOf(value))
+			return consumed, nil
+		}
+
+		// reflect.Copy needs the element types to be the same. Same kind is not enough.
+		// So setting one by one
+		for index, b := range value {
+			target.Index(index).SetUint(uint64(b))
+		}
+		return consumed, nil
+	}
+}
+
+func sliceReader(sliceType reflect.Type, strict bool) (reader, error) {
+	// A []byte is a byte string, the same as a [N]byte, not an array of small ints.
+	if sliceType.Elem().Kind() == reflect.Uint8 {
+		return readByteSlice, nil
+	}
+
+	elemReader, err := buildReader(sliceType.Elem(), strict)
+	if err != nil {
+		return nil, err
+	}
+
+	zero := reflect.Zero(sliceType.Elem())
+
+	// One wire byte can become a whole element, so the count alone is not a safe size.
+	maxElements := maxPresizedBytes / max(1, int(sliceType.Elem().Size()))
+
+	return func(target reflect.Value, data []byte) (int, error) {
+		if consumed, isNull := readNullInto(target, data); isNull {
+			return consumed, nil
+		}
+
+		length, consumed, ok := ArrayHeader(data)
+		if !ok {
+			return 0, errShape
+		}
+
+		presized := min(length, maxElements)
+		slice := reflect.MakeSlice(sliceType, presized, presized)
+
+		for index := range length {
+			if index >= presized {
+				slice = reflect.Append(slice, zero)
+			}
+
+			used, err := elemReader(slice.Index(index), data[consumed:])
+			if err != nil {
+				return 0, fmt.Errorf("[%d]: %w", index, err)
+			}
+			consumed += used
+		}
+
+		target.Set(slice)
+		return consumed, nil
+	}, nil
+}
+
+func arrayReader(arrayType reflect.Type, strict bool) (reader, error) {
+	// A [N]byte is the same as a []byte, not an array of small ints.
+	if arrayType.Elem().Kind() == reflect.Uint8 {
+		return readByteArray(arrayType), nil
+	}
+
+	length := arrayType.Len()
+
+	elemReader, err := buildReader(arrayType.Elem(), strict)
+	if err != nil {
+		return nil, err
+	}
+
+	return func(target reflect.Value, data []byte) (int, error) {
+		count, consumed, ok := ArrayHeader(data)
+		// A fixed-size array has to match exactly
+		if !ok || count != length {
+			return 0, errShape
+		}
+
+		for index := range length {
+			used, err := elemReader(target.Index(index), data[consumed:])
+			if err != nil {
+				return 0, fmt.Errorf("[%d]: %w", index, err)
+			}
+			consumed += used
+		}
+		return consumed, nil
+	}, nil
+}
+
+func mapReader(mapType reflect.Type, strict bool) (reader, error) {
+	keyReader, err := buildReader(mapType.Key(), strict)
+	if err != nil {
+		return nil, err
+	}
+	valueReader, err := buildReader(mapType.Elem(), strict)
+	if err != nil {
+		return nil, err
+	}
+
+	maxEntries := maxPresizedBytes / max(1, int(mapType.Key().Size()+mapType.Elem().Size()))
+
+	return func(target reflect.Value, data []byte) (int, error) {
+		if consumed, isNull := readNullInto(target, data); isNull {
+			return consumed, nil
+		}
+
+		pairs, consumed, ok := MapHeader(data)
+		if !ok {
+			return 0, errShape
+		}
+
+		out := reflect.MakeMapWithSize(mapType, min(pairs, maxEntries))
+
+		key := reflect.New(mapType.Key()).Elem()
+		value := reflect.New(mapType.Elem()).Elem()
+
+		for range pairs {
+			key.SetZero()
+			value.SetZero()
+
+			used, err := keyReader(key, data[consumed:])
+			if err != nil {
+				return 0, fmt.Errorf("key: %w", err)
+			}
+			consumed += used
+
+			used, err = valueReader(value, data[consumed:])
+			if err != nil {
+				return 0, fmt.Errorf("value: %w", err)
+			}
+			consumed += used
+
+			out.SetMapIndex(key, value)
+		}
+
+		// A repeated key means the map holds fewer entries than the header counted.
+		if out.Len() != pairs {
+			return 0, errShape
+		}
+
+		target.Set(out)
+		return consumed, nil
+	}, nil
+}
+
+func interfaceReader(interfaceType reflect.Type, strict bool) reader {
+	return func(target reflect.Value, data []byte) (int, error) {
+		if consumed, isNull := readNullInto(target, data); isNull {
+			return consumed, nil
+		}
+
+		tag, consumed, ok := Tag(data)
+		if !ok {
+			return 0, errShape
+		}
+
+		concrete, known := tagTypes.Load(tag)
+		if !known {
+			return 0, errShape
+		}
+		concreteType := concrete.(reflect.Type)
+		if !reflect.PointerTo(concreteType).Implements(interfaceType) {
+			return 0, errShape
+		}
+
+		read, err := cachedReader(concreteType, strict)
+		if err != nil {
+			return 0, fmt.Errorf("tag %d (%s): %w", tag, concreteType, err)
+		}
+
+		value := reflect.New(concreteType)
+		used, err := read(value.Elem(), data[consumed:])
+		if err != nil {
+			return 0, fmt.Errorf("tag %d (%s): %w", tag, concreteType, err)
+		}
+
+		target.Set(value)
+		return consumed + used, nil
+	}
+}

--- a/encoder/cborlite/readers_kind_test.go
+++ b/encoder/cborlite/readers_kind_test.go
@@ -1,0 +1,437 @@
+package cborlite_test
+
+import (
+	"encoding/binary"
+	"encoding/json"
+	"reflect"
+	"runtime"
+	"testing"
+
+	"github.com/NethermindEth/juno/encoder/cborlite"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// One test per Go kind the engine handles, on the smallest type that exercises it.
+
+func TestUnmarshalScalars(t *testing.T) {
+	type scalars struct {
+		Number uint64
+		Small  uint8
+		Text   string
+		Flag   bool
+	}
+
+	data := cborMap(
+		cborText("Number"), []byte{0x19, 0x01, 0x00}, // 256
+		cborText("Small"), []byte{0x07},
+		cborText("Text"), cborText("hi"),
+		cborText("Flag"), []byte{cborlite.SimpleTrue},
+	)
+
+	var got scalars
+	require.NoError(t, cborlite.Unmarshal(data, &got))
+	assert.Equal(t, scalars{Number: 256, Small: 7, Text: "hi", Flag: true}, got)
+
+	t.Run("a uint that does not fit the field is rejected", func(t *testing.T) {
+		tooBig := cborMap(cborText("Small"), []byte{0x19, 0x01, 0x00}) // 256 into a uint8
+
+		var out scalars
+		assert.ErrorContains(t, cborlite.Unmarshal(tooBig, &out), "Small")
+	})
+}
+
+func TestUnmarshalPointer(t *testing.T) {
+	type inner struct{ Value uint64 }
+	type holder struct{ Ptr *inner }
+
+	t.Run("allocates and fills", func(t *testing.T) {
+		data := cborMap(cborText("Ptr"), cborMap(cborText("Value"), []byte{0x07}))
+
+		var got holder
+		require.NoError(t, cborlite.Unmarshal(data, &got))
+		require.NotNil(t, got.Ptr)
+		assert.Equal(t, uint64(7), got.Ptr.Value)
+	})
+
+	t.Run("null reads as nil, and clears what was there", func(t *testing.T) {
+		data := cborMap(cborText("Ptr"), []byte{cborlite.Null})
+
+		got := holder{Ptr: &inner{Value: 9}}
+		require.NoError(t, cborlite.Unmarshal(data, &got))
+		assert.Nil(t, got.Ptr)
+	})
+}
+
+func TestUnmarshalSlice(t *testing.T) {
+	type element struct{ Value uint64 }
+	type holder struct {
+		Elements []element
+		Numbers  []uint64
+	}
+
+	data := cborMap(
+		cborText("Elements"), cborArray(
+			cborMap(cborText("Value"), []byte{0x01}),
+			cborMap(cborText("Value"), []byte{0x02}),
+		),
+		cborText("Numbers"), cborArray([]byte{0x03}, []byte{0x04}),
+	)
+
+	var got holder
+	require.NoError(t, cborlite.Unmarshal(data, &got))
+	assert.Equal(t, []element{{Value: 1}, {Value: 2}}, got.Elements)
+	assert.Equal(t, []uint64{3, 4}, got.Numbers)
+
+	t.Run("null reads as nil, empty as empty", func(t *testing.T) {
+		data := cborMap(
+			cborText("Elements"), []byte{cborlite.Null},
+			cborText("Numbers"), cborArray(),
+		)
+
+		var got holder
+		require.NoError(t, cborlite.Unmarshal(data, &got))
+		assert.Nil(t, got.Elements)
+		assert.NotNil(t, got.Numbers)
+		assert.Empty(t, got.Numbers)
+	})
+
+	t.Run("an element that does not decode names its index", func(t *testing.T) {
+		data := cborMap(cborText("Numbers"), cborArray([]byte{0x03}, cborText("no")))
+
+		var got holder
+		err := cborlite.Unmarshal(data, &got)
+		assert.ErrorContains(t, err, "Numbers")
+		assert.ErrorContains(t, err, "[1]")
+	})
+}
+
+func TestUnmarshalMap(t *testing.T) {
+	type holder struct{ Bounds map[uint32]uint64 }
+
+	data := cborMap(cborText("Bounds"), cborMap([]byte{0x01}, []byte{0x0a}, []byte{0x02}, []byte{0x14}))
+
+	var got holder
+	require.NoError(t, cborlite.Unmarshal(data, &got))
+	assert.Equal(t, map[uint32]uint64{1: 10, 2: 20}, got.Bounds)
+
+	t.Run("null reads as nil", func(t *testing.T) {
+		data := cborMap(cborText("Bounds"), []byte{cborlite.Null})
+
+		var got holder
+		require.NoError(t, cborlite.Unmarshal(data, &got))
+		assert.Nil(t, got.Bounds)
+	})
+
+	t.Run("a key that does not decode is named", func(t *testing.T) {
+		data := cborMap(cborText("Bounds"), cborMap(cborText("no"), []byte{0x0a}))
+
+		var got holder
+		err := cborlite.Unmarshal(data, &got)
+		assert.ErrorContains(t, err, "key")
+	})
+
+	// The header counts pairs, so a key twice leaves the map shorter than it claims.
+	t.Run("declines a key given twice", func(t *testing.T) {
+		data := cborMap(cborText("Bounds"),
+			cborMap([]byte{0x01}, []byte{0x0a}, []byte{0x01}, []byte{0x14}))
+
+		var got holder
+		require.Error(t, cborlite.Unmarshal(data, &got))
+	})
+}
+
+// TestUnmarshalMapValueDoesNotInheritTheOneBefore covers the pair reader being reused
+// across entries: without a reset, a value leaving a field out keeps the last one's.
+func TestUnmarshalMapValueDoesNotInheritTheOneBefore(t *testing.T) {
+	type bounds struct {
+		Low  uint64
+		High uint64
+	}
+	type holder struct{ Bounds map[uint32]bounds }
+
+	data := cborMap(cborText("Bounds"),
+		cborMap(
+			[]byte{0x01}, cborMap(cborText("Low"), []byte{0x0a}, cborText("High"), []byte{0x14}),
+			// The second entry has no High, so it must come out zero.
+			[]byte{0x02}, cborMap(cborText("Low"), []byte{0x0b}),
+		))
+
+	var got holder
+	require.NoError(t, cborlite.Unmarshal(data, &got))
+	assert.Equal(t, map[uint32]bounds{
+		1: {Low: 10, High: 20},
+		2: {Low: 11, High: 0},
+	}, got.Bounds)
+}
+
+func TestUnmarshalArray(t *testing.T) {
+	type holder struct {
+		Address [3]byte
+		Limbs   [2]uint64
+	}
+
+	data := cborMap(
+		cborText("Address"), cborBytes(0xaa, 0xbb, 0xcc),
+		cborText("Limbs"), cborArray([]byte{0x01}, []byte{0x02}),
+	)
+
+	var got holder
+	require.NoError(t, cborlite.Unmarshal(data, &got))
+	assert.Equal(t, [3]byte{0xaa, 0xbb, 0xcc}, got.Address)
+	assert.Equal(t, [2]uint64{1, 2}, got.Limbs)
+
+	t.Run("a byte array of the wrong length is rejected", func(t *testing.T) {
+		data := cborMap(cborText("Address"), cborBytes(0xaa, 0xbb))
+
+		var got holder
+		assert.ErrorContains(t, cborlite.Unmarshal(data, &got), "Address")
+	})
+
+	// Shorter would leave elements at their zero value, longer has nowhere to go.
+	//
+	// Decoded on their own rather than as a struct field, because the count has to be
+	// what refuses these. Any container around them counts its own items, so a reader
+	// that read past a short array would be caught by that count coming up one short,
+	// and the check under test could be gone without the test noticing. At the top
+	// level only the total length is checked, and taking one item too many meets it.
+	t.Run("a fixed array whose count is not the Go length is rejected", func(t *testing.T) {
+		for name, data := range map[string][]byte{
+			"too few":  append(cborArray([]byte{0x01}), 0x02),
+			"too many": cborArray([]byte{0x01}, []byte{0x02}, []byte{0x03}),
+		} {
+			t.Run(name, func(t *testing.T) {
+				var got [2]uint64
+				assert.Error(t, cborlite.Unmarshal(data, &got))
+				assert.Zero(t, got, "a refused decode must not write the destination")
+			})
+		}
+	})
+}
+
+func TestUnmarshalByteStrings(t *testing.T) {
+	type holder struct {
+		Raw  json.RawMessage
+		Blob []byte
+	}
+
+	// A []byte and its named forms are a byte string on the wire, not an array of small
+	// ints, which is what their Go kind would suggest.
+	data := cborMap(
+		cborText("Raw"), cborBytes('{', '}'),
+		cborText("Blob"), cborBytes(0x01, 0x02),
+	)
+
+	var got holder
+	require.NoError(t, cborlite.Unmarshal(data, &got))
+	assert.Equal(t, json.RawMessage("{}"), got.Raw)
+	assert.Equal(t, []byte{0x01, 0x02}, got.Blob)
+
+	t.Run("an array where a byte string belongs is rejected", func(t *testing.T) {
+		data := cborMap(cborText("Blob"), cborArray([]byte{0x01}))
+
+		var got holder
+		assert.ErrorContains(t, cborlite.Unmarshal(data, &got), "Blob")
+	})
+
+	// The generic encoder writes null for a nil slice, and no reader in the package reads
+	// null on its own, so this is the one place that can catch the prologue going missing.
+	t.Run("null reads as nil", func(t *testing.T) {
+		data := cborMap(cborText("Blob"), []byte{null})
+
+		got := holder{Blob: []byte{0xff}}
+		require.NoError(t, cborlite.Unmarshal(data, &got))
+		assert.Nil(t, got.Blob)
+	})
+}
+
+/****************************************************
+		Interfaces, through a tag
+*****************************************************/
+
+type shape interface{ area() int }
+
+type square struct{ Side int }
+
+func (s *square) area() int { return s.Side * s.Side }
+
+type circle struct{ Radius int }
+
+func (c *circle) area() int { return 3 * c.Radius * c.Radius }
+
+const (
+	tagSquare = 70001
+	tagCircle = 70002
+)
+
+//nolint:gochecknoinits // the mapping has to exist before the first read
+func init() {
+	cborlite.RegisterTag(tagSquare, reflect.TypeFor[square]())
+	cborlite.RegisterTag(tagCircle, reflect.TypeFor[circle]())
+}
+
+func TestUnmarshalInterface(t *testing.T) {
+	type holder struct{ Shape shape }
+
+	t.Run("the tag picks the concrete type", func(t *testing.T) {
+		data := cborMap(cborText("Shape"),
+			cborTagged(tagCircle, cborMap(cborText("Radius"), head(uintMajor, 2))))
+
+		var got holder
+		require.NoError(t, cborlite.Unmarshal(data, &got))
+		require.IsType(t, &circle{}, got.Shape)
+		assert.Equal(t, 12, got.Shape.area())
+	})
+
+	t.Run("null reads as nil", func(t *testing.T) {
+		data := cborMap(cborText("Shape"), []byte{cborlite.Null})
+
+		var got holder
+		require.NoError(t, cborlite.Unmarshal(data, &got))
+		assert.Nil(t, got.Shape)
+	})
+
+	t.Run("an unregistered tag is rejected", func(t *testing.T) {
+		data := cborMap(cborText("Shape"), cborTagged(79999, cborMap()))
+
+		var got holder
+		assert.ErrorContains(t, cborlite.Unmarshal(data, &got), "Shape")
+	})
+
+	t.Run("a tag whose type does not implement the interface is rejected", func(t *testing.T) {
+		type otherHolder struct{ Value interface{ String() string } }
+
+		data := cborMap(cborText("Value"),
+			cborTagged(tagSquare, cborMap(cborText("Side"), head(uintMajor, 2))))
+
+		var got otherHolder
+		assert.Error(t, cborlite.Unmarshal(data, &got))
+	})
+
+	t.Run("something that is not a tag is rejected", func(t *testing.T) {
+		data := cborMap(cborText("Shape"), cborMap())
+
+		var got holder
+		assert.ErrorContains(t, cborlite.Unmarshal(data, &got), "Shape")
+	})
+}
+
+func TestUnmarshalSignedIntegers(t *testing.T) {
+	type holder struct {
+		Small int8
+		Wide  int64
+	}
+
+	tests := []struct {
+		name  string
+		data  []byte
+		small int8
+		wide  int64
+		ok    bool
+	}{
+		{name: "zero", data: cborMap(cborText("Wide"), []byte{0x00}), ok: true},
+		{name: "positive", data: cborMap(cborText("Wide"), []byte{0x18, 0x2a}), wide: 42, ok: true},
+		// A negative integer's argument is the magnitude minus one, so 0x20 is -1.
+		{name: "minus one", data: cborMap(cborText("Wide"), []byte{0x20}), wide: -1, ok: true},
+		{
+			name: "minus one hundred",
+			data: cborMap(cborText("Wide"), []byte{0x38, 0x63}), wide: -100, ok: true,
+		},
+		{
+			name: "the most negative int64",
+			data: cborMap(cborText("Wide"), []byte{0x3b, 0x7f, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff}),
+			wide: -1 << 63, ok: true,
+		},
+		{
+			name: "past int64 on the negative side",
+			data: cborMap(cborText("Wide"), []byte{0x3b, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff}),
+		},
+		{
+			name: "past int64 on the positive side",
+			data: cborMap(cborText("Wide"), []byte{0x1b, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff}),
+		},
+		{name: "past int8", data: cborMap(cborText("Small"), []byte{0x18, 0xff})},
+		{name: "past int8 negative", data: cborMap(cborText("Small"), []byte{0x38, 0xff})},
+		{name: "not an integer", data: cborMap(cborText("Wide"), cborText("no"))},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			var got holder
+			err := cborlite.Unmarshal(test.data, &got)
+
+			if !test.ok {
+				assert.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, test.small, got.Small)
+			assert.Equal(t, test.wide, got.Wide)
+		})
+	}
+}
+
+// namedByte is a byte under another name, which the encoder still writes as a byte
+// string. reflect.Copy refuses to mix it with byte, so the array reader has to fill one
+// element at a time or it panics.
+type namedByte byte
+
+func TestUnmarshalNamedByteSliceAndArray(t *testing.T) {
+	type holder struct {
+		Slice []namedByte
+		Array [2]namedByte
+	}
+
+	data := cborMap(
+		cborText("Slice"), cborBytes(0xaa, 0xbb),
+		cborText("Array"), cborBytes(0xcc, 0xdd),
+	)
+
+	var got holder
+	require.NoError(t, cborlite.Unmarshal(data, &got))
+	assert.Equal(t, []namedByte{0xaa, 0xbb}, got.Slice)
+	assert.Equal(t, [2]namedByte{0xcc, 0xdd}, got.Array)
+}
+
+// TestSliceDecodingDoesNotTrustTheCountForSizing pins the cap on pre-sizing. An
+// element can be one byte on the wire, so a header may claim as many elements as
+// there are bytes left; sizing the slice from that count alone let a 1 MiB buffer
+// allocate 54 MiB before a single element had been checked.
+func TestSliceDecodingDoesNotTrustTheCountForSizing(t *testing.T) {
+	const claimed = 1 << 20
+
+	// Wide enough to make the amplification obvious: the class structs are 24 to 56
+	// bytes, so a count trusted for sizing turns each input byte into a struct.
+	type wide struct{ A, B, C, D, E, F, G uint64 }
+	type holder struct{ Items []wide }
+
+	// {"Items": [<a million promised, one rejected near the front>]}
+	items := make([]byte, 0, claimed+8)
+	items = append(items, 0x80|26)
+	items = binary.BigEndian.AppendUint32(items, claimed)
+	// Three readable elements, then one every reader rejects.
+	items = append(items, 0xa0, 0xa0, 0xa0, 0x1f)
+	for len(items) < claimed+5 {
+		items = append(items, 0xa0)
+	}
+
+	data := append([]byte{
+		byte(cborlite.MapMajor) | 1,
+		byte(cborlite.StringMajor) | 5, 'I', 't', 'e', 'm', 's',
+	}, items...)
+
+	var before, after runtime.MemStats
+	runtime.GC()
+	runtime.ReadMemStats(&before)
+
+	var out holder
+	require.Error(t, cborlite.Unmarshal(data, &out), "the rejected element must fail the decode")
+
+	runtime.ReadMemStats(&after)
+	allocated := after.TotalAlloc - before.TotalAlloc
+
+	// Sizing from the count would be claimed * 56 bytes, about 56 MiB.
+	assert.Lessf(t, allocated, uint64(4<<20),
+		"allocated %d KiB from a %d KiB buffer, the count is being trusted for sizing",
+		allocated/1024, len(data)/1024)
+}

--- a/encoder/cborlite/readers_kind_test.go
+++ b/encoder/cborlite/readers_kind_test.go
@@ -1,18 +1,17 @@
 package cborlite_test
 
 import (
-	"encoding/binary"
+	"bytes"
 	"encoding/json"
+	"math"
 	"reflect"
-	"runtime"
+	"slices"
 	"testing"
 
 	"github.com/NethermindEth/juno/encoder/cborlite"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
-
-// One test per Go kind the engine handles, on the smallest type that exercises it.
 
 func TestUnmarshalScalars(t *testing.T) {
 	type scalars struct {
@@ -23,10 +22,10 @@ func TestUnmarshalScalars(t *testing.T) {
 	}
 
 	data := cborMap(
-		cborText("Number"), []byte{0x19, 0x01, 0x00}, // 256
-		cborText("Small"), []byte{0x07},
+		cborText("Number"), head(uintMajor, 256),
+		cborText("Small"), head(uintMajor, 7),
 		cborText("Text"), cborText("hi"),
-		cborText("Flag"), []byte{cborlite.SimpleTrue},
+		cborText("Flag"), []byte{simpleTrue},
 	)
 
 	var got scalars
@@ -34,7 +33,7 @@ func TestUnmarshalScalars(t *testing.T) {
 	assert.Equal(t, scalars{Number: 256, Small: 7, Text: "hi", Flag: true}, got)
 
 	t.Run("a uint that does not fit the field is rejected", func(t *testing.T) {
-		tooBig := cborMap(cborText("Small"), []byte{0x19, 0x01, 0x00}) // 256 into a uint8
+		tooBig := cborMap(cborText("Small"), head(uintMajor, 256)) // 256 into a uint8
 
 		var out scalars
 		assert.ErrorContains(t, cborlite.Unmarshal(tooBig, &out), "Small")
@@ -46,7 +45,7 @@ func TestUnmarshalPointer(t *testing.T) {
 	type holder struct{ Ptr *inner }
 
 	t.Run("allocates and fills", func(t *testing.T) {
-		data := cborMap(cborText("Ptr"), cborMap(cborText("Value"), []byte{0x07}))
+		data := cborMap(cborText("Ptr"), cborMap(cborText("Value"), head(uintMajor, 7)))
 
 		var got holder
 		require.NoError(t, cborlite.Unmarshal(data, &got))
@@ -55,7 +54,7 @@ func TestUnmarshalPointer(t *testing.T) {
 	})
 
 	t.Run("null reads as nil, and clears what was there", func(t *testing.T) {
-		data := cborMap(cborText("Ptr"), []byte{cborlite.Null})
+		data := cborMap(cborText("Ptr"), []byte{null})
 
 		got := holder{Ptr: &inner{Value: 9}}
 		require.NoError(t, cborlite.Unmarshal(data, &got))
@@ -72,10 +71,10 @@ func TestUnmarshalSlice(t *testing.T) {
 
 	data := cborMap(
 		cborText("Elements"), cborArray(
-			cborMap(cborText("Value"), []byte{0x01}),
-			cborMap(cborText("Value"), []byte{0x02}),
+			cborMap(cborText("Value"), head(uintMajor, 1)),
+			cborMap(cborText("Value"), head(uintMajor, 2)),
 		),
-		cborText("Numbers"), cborArray([]byte{0x03}, []byte{0x04}),
+		cborText("Numbers"), cborArray(head(uintMajor, 3), head(uintMajor, 4)),
 	)
 
 	var got holder
@@ -85,7 +84,7 @@ func TestUnmarshalSlice(t *testing.T) {
 
 	t.Run("null reads as nil, empty as empty", func(t *testing.T) {
 		data := cborMap(
-			cborText("Elements"), []byte{cborlite.Null},
+			cborText("Elements"), []byte{null},
 			cborText("Numbers"), cborArray(),
 		)
 
@@ -97,7 +96,7 @@ func TestUnmarshalSlice(t *testing.T) {
 	})
 
 	t.Run("an element that does not decode names its index", func(t *testing.T) {
-		data := cborMap(cborText("Numbers"), cborArray([]byte{0x03}, cborText("no")))
+		data := cborMap(cborText("Numbers"), cborArray(head(uintMajor, 3), cborText("no")))
 
 		var got holder
 		err := cborlite.Unmarshal(data, &got)
@@ -109,14 +108,17 @@ func TestUnmarshalSlice(t *testing.T) {
 func TestUnmarshalMap(t *testing.T) {
 	type holder struct{ Bounds map[uint32]uint64 }
 
-	data := cborMap(cborText("Bounds"), cborMap([]byte{0x01}, []byte{0x0a}, []byte{0x02}, []byte{0x14}))
+	data := cborMap(cborText("Bounds"), cborMap(
+		head(uintMajor, 1), head(uintMajor, 10),
+		head(uintMajor, 2), head(uintMajor, 20),
+	))
 
 	var got holder
 	require.NoError(t, cborlite.Unmarshal(data, &got))
 	assert.Equal(t, map[uint32]uint64{1: 10, 2: 20}, got.Bounds)
 
 	t.Run("null reads as nil", func(t *testing.T) {
-		data := cborMap(cborText("Bounds"), []byte{cborlite.Null})
+		data := cborMap(cborText("Bounds"), []byte{null})
 
 		var got holder
 		require.NoError(t, cborlite.Unmarshal(data, &got))
@@ -124,7 +126,7 @@ func TestUnmarshalMap(t *testing.T) {
 	})
 
 	t.Run("a key that does not decode is named", func(t *testing.T) {
-		data := cborMap(cborText("Bounds"), cborMap(cborText("no"), []byte{0x0a}))
+		data := cborMap(cborText("Bounds"), cborMap(cborText("no"), head(uintMajor, 10)))
 
 		var got holder
 		err := cborlite.Unmarshal(data, &got)
@@ -134,15 +136,13 @@ func TestUnmarshalMap(t *testing.T) {
 	// The header counts pairs, so a key twice leaves the map shorter than it claims.
 	t.Run("declines a key given twice", func(t *testing.T) {
 		data := cborMap(cborText("Bounds"),
-			cborMap([]byte{0x01}, []byte{0x0a}, []byte{0x01}, []byte{0x14}))
+			cborMap(head(uintMajor, 1), head(uintMajor, 10), head(uintMajor, 1), head(uintMajor, 20)))
 
 		var got holder
 		require.Error(t, cborlite.Unmarshal(data, &got))
 	})
 }
 
-// TestUnmarshalMapValueDoesNotInheritTheOneBefore covers the pair reader being reused
-// across entries: without a reset, a value leaving a field out keeps the last one's.
 func TestUnmarshalMapValueDoesNotInheritTheOneBefore(t *testing.T) {
 	type bounds struct {
 		Low  uint64
@@ -152,9 +152,12 @@ func TestUnmarshalMapValueDoesNotInheritTheOneBefore(t *testing.T) {
 
 	data := cborMap(cborText("Bounds"),
 		cborMap(
-			[]byte{0x01}, cborMap(cborText("Low"), []byte{0x0a}, cborText("High"), []byte{0x14}),
+			head(uintMajor, 1), cborMap(
+				cborText("Low"), head(uintMajor, 10),
+				cborText("High"), head(uintMajor, 20),
+			),
 			// The second entry has no High, so it must come out zero.
-			[]byte{0x02}, cborMap(cborText("Low"), []byte{0x0b}),
+			head(uintMajor, 2), cborMap(cborText("Low"), head(uintMajor, 11)),
 		))
 
 	var got holder
@@ -173,13 +176,22 @@ func TestUnmarshalArray(t *testing.T) {
 
 	data := cborMap(
 		cborText("Address"), cborBytes(0xaa, 0xbb, 0xcc),
-		cborText("Limbs"), cborArray([]byte{0x01}, []byte{0x02}),
+		cborText("Limbs"), cborArray(head(uintMajor, 1), head(uintMajor, 2)),
 	)
 
 	var got holder
 	require.NoError(t, cborlite.Unmarshal(data, &got))
 	assert.Equal(t, [3]byte{0xaa, 0xbb, 0xcc}, got.Address)
 	assert.Equal(t, [2]uint64{1, 2}, got.Limbs)
+
+	t.Run("null reads as the zero array", func(t *testing.T) {
+		data := cborMap(cborText("Address"), []byte{null}, cborText("Limbs"), []byte{null})
+
+		got := holder{Address: [3]byte{9, 9, 9}, Limbs: [2]uint64{9, 9}}
+		require.NoError(t, cborlite.Unmarshal(data, &got))
+		assert.Zero(t, got.Address)
+		assert.Zero(t, got.Limbs)
+	})
 
 	t.Run("a byte array of the wrong length is rejected", func(t *testing.T) {
 		data := cborMap(cborText("Address"), cborBytes(0xaa, 0xbb))
@@ -197,8 +209,8 @@ func TestUnmarshalArray(t *testing.T) {
 	// level only the total length is checked, and taking one item too many meets it.
 	t.Run("a fixed array whose count is not the Go length is rejected", func(t *testing.T) {
 		for name, data := range map[string][]byte{
-			"too few":  append(cborArray([]byte{0x01}), 0x02),
-			"too many": cborArray([]byte{0x01}, []byte{0x02}, []byte{0x03}),
+			"too few":  append(cborArray(head(uintMajor, 1)), head(uintMajor, 2)...),
+			"too many": cborArray(head(uintMajor, 1), head(uintMajor, 2), head(uintMajor, 3)),
 		} {
 			t.Run(name, func(t *testing.T) {
 				var got [2]uint64
@@ -215,8 +227,6 @@ func TestUnmarshalByteStrings(t *testing.T) {
 		Blob []byte
 	}
 
-	// A []byte and its named forms are a byte string on the wire, not an array of small
-	// ints, which is what their Go kind would suggest.
 	data := cborMap(
 		cborText("Raw"), cborBytes('{', '}'),
 		cborText("Blob"), cborBytes(0x01, 0x02),
@@ -228,14 +238,14 @@ func TestUnmarshalByteStrings(t *testing.T) {
 	assert.Equal(t, []byte{0x01, 0x02}, got.Blob)
 
 	t.Run("an array where a byte string belongs is rejected", func(t *testing.T) {
-		data := cborMap(cborText("Blob"), cborArray([]byte{0x01}))
+		data := cborMap(cborText("Blob"), cborArray(head(uintMajor, 1)))
 
 		var got holder
 		assert.ErrorContains(t, cborlite.Unmarshal(data, &got), "Blob")
 	})
 
-	// The generic encoder writes null for a nil slice, and no reader in the package reads
-	// null on its own, so this is the one place that can catch the prologue going missing.
+	// The generic encoder writes null for a nil slice, so the shape is on disk. Bytes does
+	// not read null, which is why readByteSlice opens with a prologue for it.
 	t.Run("null reads as nil", func(t *testing.T) {
 		data := cborMap(cborText("Blob"), []byte{null})
 
@@ -284,7 +294,7 @@ func TestUnmarshalInterface(t *testing.T) {
 	})
 
 	t.Run("null reads as nil", func(t *testing.T) {
-		data := cborMap(cborText("Shape"), []byte{cborlite.Null})
+		data := cborMap(cborText("Shape"), []byte{null})
 
 		var got holder
 		require.NoError(t, cborlite.Unmarshal(data, &got))
@@ -329,29 +339,29 @@ func TestUnmarshalSignedIntegers(t *testing.T) {
 		wide  int64
 		ok    bool
 	}{
-		{name: "zero", data: cborMap(cborText("Wide"), []byte{0x00}), ok: true},
-		{name: "positive", data: cborMap(cborText("Wide"), []byte{0x18, 0x2a}), wide: 42, ok: true},
+		{name: "zero", data: cborMap(cborText("Wide"), head(uintMajor, 0)), ok: true},
+		{name: "positive", data: cborMap(cborText("Wide"), head(uintMajor, 42)), wide: 42, ok: true},
 		// A negative integer's argument is the magnitude minus one, so 0x20 is -1.
-		{name: "minus one", data: cborMap(cborText("Wide"), []byte{0x20}), wide: -1, ok: true},
+		{name: "minus one", data: cborMap(cborText("Wide"), head(negIntMajor, 0)), wide: -1, ok: true},
 		{
 			name: "minus one hundred",
-			data: cborMap(cborText("Wide"), []byte{0x38, 0x63}), wide: -100, ok: true,
+			data: cborMap(cborText("Wide"), head(negIntMajor, 99)), wide: -100, ok: true,
 		},
 		{
 			name: "the most negative int64",
-			data: cborMap(cborText("Wide"), []byte{0x3b, 0x7f, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff}),
+			data: cborMap(cborText("Wide"), head(negIntMajor, math.MaxInt64)),
 			wide: -1 << 63, ok: true,
 		},
 		{
 			name: "past int64 on the negative side",
-			data: cborMap(cborText("Wide"), []byte{0x3b, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff}),
+			data: cborMap(cborText("Wide"), head(negIntMajor, math.MaxUint64)),
 		},
 		{
 			name: "past int64 on the positive side",
-			data: cborMap(cborText("Wide"), []byte{0x1b, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff}),
+			data: cborMap(cborText("Wide"), head(uintMajor, math.MaxUint64)),
 		},
-		{name: "past int8", data: cborMap(cborText("Small"), []byte{0x18, 0xff})},
-		{name: "past int8 negative", data: cborMap(cborText("Small"), []byte{0x38, 0xff})},
+		{name: "past int8", data: cborMap(cborText("Small"), head(uintMajor, 255))},
+		{name: "past int8 negative", data: cborMap(cborText("Small"), head(negIntMajor, 255))},
 		{name: "not an integer", data: cborMap(cborText("Wide"), cborText("no"))},
 	}
 
@@ -371,12 +381,9 @@ func TestUnmarshalSignedIntegers(t *testing.T) {
 	}
 }
 
-// namedByte is a byte under another name, which the encoder still writes as a byte
-// string. reflect.Copy refuses to mix it with byte, so the array reader has to fill one
-// element at a time or it panics.
-type namedByte byte
-
 func TestUnmarshalNamedByteSliceAndArray(t *testing.T) {
+	type namedByte byte
+
 	type holder struct {
 		Slice []namedByte
 		Array [2]namedByte
@@ -393,45 +400,21 @@ func TestUnmarshalNamedByteSliceAndArray(t *testing.T) {
 	assert.Equal(t, [2]namedByte{0xcc, 0xdd}, got.Array)
 }
 
-// TestSliceDecodingDoesNotTrustTheCountForSizing pins the cap on pre-sizing. An
-// element can be one byte on the wire, so a header may claim as many elements as
-// there are bytes left; sizing the slice from that count alone let a 1 MiB buffer
-// allocate 54 MiB before a single element had been checked.
 func TestSliceDecodingDoesNotTrustTheCountForSizing(t *testing.T) {
-	const claimed = 1 << 20
+	type holder struct{ Items []uint64 }
 
-	// Wide enough to make the amplification obvious: the class structs are 24 to 56
-	// bytes, so a count trusted for sizing turns each input byte into a struct.
-	type wide struct{ A, B, C, D, E, F, G uint64 }
-	type holder struct{ Items []wide }
+	// More elements than the budget holds, every one of them valid and one byte wide.
+	const claimedSize = 200_000
+	items := slices.Concat(
+		head(arrayMajor, claimedSize),
+		bytes.Repeat(head(uintMajor, 0), claimedSize),
+	)
 
-	// {"Items": [<a million promised, one rejected near the front>]}
-	items := make([]byte, 0, claimed+8)
-	items = append(items, 0x80|26)
-	items = binary.BigEndian.AppendUint32(items, claimed)
-	// Three readable elements, then one every reader rejects.
-	items = append(items, 0xa0, 0xa0, 0xa0, 0x1f)
-	for len(items) < claimed+5 {
-		items = append(items, 0xa0)
-	}
+	var got holder
+	require.NoError(t, cborlite.Unmarshal(cborMap(cborText("Items"), items), &got))
+	require.Len(t, got.Items, claimedSize)
 
-	data := append([]byte{
-		byte(cborlite.MapMajor) | 1,
-		byte(cborlite.StringMajor) | 5, 'I', 't', 'e', 'm', 's',
-	}, items...)
-
-	var before, after runtime.MemStats
-	runtime.GC()
-	runtime.ReadMemStats(&before)
-
-	var out holder
-	require.Error(t, cborlite.Unmarshal(data, &out), "the rejected element must fail the decode")
-
-	runtime.ReadMemStats(&after)
-	allocated := after.TotalAlloc - before.TotalAlloc
-
-	// Sizing from the count would be claimed * 56 bytes, about 56 MiB.
-	assert.Lessf(t, allocated, uint64(4<<20),
-		"allocated %d KiB from a %d KiB buffer, the count is being trusted for sizing",
-		allocated/1024, len(data)/1024)
+	// Decoder allocated from an internal budget, not from the claimedSize.
+	assert.Greater(t, cap(got.Items), len(got.Items),
+		"the slice was sized from the claimed count")
 }

--- a/encoder/cborlite/readers_test.go
+++ b/encoder/cborlite/readers_test.go
@@ -1,0 +1,183 @@
+package cborlite_test
+
+import (
+	"errors"
+	"math/big"
+	"testing"
+
+	"github.com/NethermindEth/juno/encoder/cborlite"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// blob reads itself from a byte string through encoding.BinaryUnmarshaler, which is the
+// interface the bloom filter of a stored header arrives on.
+type blob struct{ kept []byte }
+
+func (b *blob) UnmarshalBinary(data []byte) error {
+	if len(data) == 0 {
+		return errors.New("blob: nothing to read")
+	}
+
+	// The buffer belongs to the database, so an implementation copies what it keeps.
+	b.kept = append([]byte(nil), data...)
+	return nil
+}
+
+func TestUnmarshalBinaryUnmarshaler(t *testing.T) {
+	type holder struct{ Blob blob }
+
+	data := cborMap(cborText("Blob"), cborBytes(0x01, 0x02, 0x03))
+
+	var got holder
+	require.NoError(t, cborlite.Unmarshal(data, &got))
+	// The payload it receives is the byte string, without the header in front of it.
+	assert.Equal(t, []byte{0x01, 0x02, 0x03}, got.Blob.kept)
+
+	t.Run("an implementation that refuses declines the decode", func(t *testing.T) {
+		var got holder
+		require.Error(t, cborlite.Unmarshal(cborMap(cborText("Blob"), cborBytes()), &got))
+	})
+
+	t.Run("anything but a byte string is refused", func(t *testing.T) {
+		var got holder
+		require.Error(t, cborlite.Unmarshal(cborMap(cborText("Blob"), cborText("no")), &got))
+	})
+}
+
+/****************************************************
+		Reading yourself
+*****************************************************/
+
+// pair reads itself, the way felt.Felt does, because its encoding is not something the
+// generic walk can express.
+type pair struct{ A, B byte }
+
+var _ cborlite.PrefixUnmarshaler = (*pair)(nil)
+
+func (p *pair) UnmarshalCBORPrefix(data []byte) (int, error) {
+	value, next, ok := cborlite.BytesNoCopy(data)
+	if !ok || len(value) != 2 {
+		return 0, assert.AnError
+	}
+
+	*p = pair{A: value[0], B: value[1]}
+	return next, nil
+}
+
+// liar reports consuming more than it was given, which the engine must not trust.
+type liar struct{}
+
+func (liar) UnmarshalCBORPrefix(data []byte) (int, error) { return len(data) + 1, nil }
+
+// stallor reports success without consuming anything, which would leave a slice reading
+// every element off the same bytes.
+type stallor struct{}
+
+func (stallor) UnmarshalCBORPrefix([]byte) (int, error) { return 0, nil }
+
+func TestUnmarshalPrefixUnmarshaler(t *testing.T) {
+	type holder struct {
+		Pair pair
+		Tail string
+	}
+
+	t.Run("reads itself, and the field after it lands", func(t *testing.T) {
+		data := cborMap(
+			cborText("Pair"), cborBytes(0xaa, 0xbb),
+			cborText("Tail"), cborText("end"),
+		)
+
+		var got holder
+		require.NoError(t, cborlite.Unmarshal(data, &got))
+		assert.Equal(t, pair{A: 0xaa, B: 0xbb}, got.Pair)
+		assert.Equal(t, "end", got.Tail, "a wrong consumed count would misread this")
+	})
+
+	t.Run("its error is reported under the field name", func(t *testing.T) {
+		data := cborMap(cborText("Pair"), cborBytes(0xaa))
+
+		var got holder
+		assert.ErrorContains(t, cborlite.Unmarshal(data, &got), "Pair")
+	})
+
+	t.Run("a decoder claiming more than it was given fails", func(t *testing.T) {
+		type liarHolder struct{ Value liar }
+
+		data := cborMap(cborText("Value"), cborBytes(0xaa))
+
+		var got liarHolder
+		assert.ErrorContains(t, cborlite.Unmarshal(data, &got), "consuming")
+	})
+
+	t.Run("a decoder claiming nothing fails", func(t *testing.T) {
+		type stallHolder struct{ Values []stallor }
+
+		data := cborMap(cborText("Values"), cborArray(cborBytes(0xaa), cborBytes(0xbb)))
+
+		var got stallHolder
+		assert.ErrorContains(t, cborlite.Unmarshal(data, &got), "consuming")
+	})
+
+	t.Run("a pointer to one is allocated and filled", func(t *testing.T) {
+		type ptrHolder struct{ Pair *pair }
+
+		data := cborMap(cborText("Pair"), cborBytes(0xaa, 0xbb))
+
+		var got ptrHolder
+		require.NoError(t, cborlite.Unmarshal(data, &got))
+		require.NotNil(t, got.Pair)
+		assert.Equal(t, pair{A: 0xaa, B: 0xbb}, *got.Pair)
+	})
+}
+
+func TestUnmarshalBigIntForms(t *testing.T) {
+	type holder struct{ Value *big.Int }
+
+	want := func(s string) *big.Int {
+		value, ok := new(big.Int).SetString(s, 10)
+		require.True(t, ok)
+		return value
+	}
+
+	tests := []struct {
+		name string
+		data []byte
+		want *big.Int
+		ok   bool
+	}{
+		{name: "small unsigned", data: []byte{0x07}, want: want("7"), ok: true},
+		{name: "negative", data: []byte{0x38, 0x63}, want: want("-100"), ok: true},
+		{name: "null", data: []byte{cborlite.Null}, ok: true},
+		{
+			name: "positive bignum",
+			data: append([]byte{0xc2, 0x49, 0x01}, 0, 0, 0, 0, 0, 0, 0, 0),
+			want: want("18446744073709551616"), ok: true,
+		},
+		{name: "negative bignum", data: []byte{0xc3, 0x41, 0x01}, want: want("-2"), ok: true},
+		// The byte string is what makes this a test of the tag number. Anything else
+		// after the tag is refused for not being a byte string, whatever the number.
+		{name: "an unrelated tag", data: []byte{0xc4, 0x41, 0x01}},
+		{name: "a bignum tag without a byte string", data: []byte{0xc2, 0x01}},
+		{name: "a text string", data: cborText("no")},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			var got holder
+			err := cborlite.Unmarshal(cborMap(cborText("Value"), test.data), &got)
+
+			if !test.ok {
+				assert.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			if test.want == nil {
+				assert.Nil(t, got.Value)
+				return
+			}
+			require.NotNil(t, got.Value)
+			assert.Zerof(t, test.want.Cmp(got.Value), "want %s, got %s", test.want, got.Value)
+		})
+	}
+}

--- a/encoder/cborlite/readers_test.go
+++ b/encoder/cborlite/readers_test.go
@@ -146,19 +146,25 @@ func TestUnmarshalBigIntForms(t *testing.T) {
 		want *big.Int
 		ok   bool
 	}{
-		{name: "small unsigned", data: []byte{0x07}, want: want("7"), ok: true},
-		{name: "negative", data: []byte{0x38, 0x63}, want: want("-100"), ok: true},
-		{name: "null", data: []byte{cborlite.Null}, ok: true},
+		{name: "small unsigned", data: head(uintMajor, 7), want: want("7"), ok: true},
+		{name: "negative", data: head(negIntMajor, 99), want: want("-100"), ok: true},
+		{name: "null", data: []byte{null}, ok: true},
 		{
 			name: "positive bignum",
-			data: append([]byte{0xc2, 0x49, 0x01}, 0, 0, 0, 0, 0, 0, 0, 0),
+			data: cborTagged(tagPositiveBignum, cborBytes(beyondUint64.Bytes()...)),
 			want: want("18446744073709551616"), ok: true,
 		},
-		{name: "negative bignum", data: []byte{0xc3, 0x41, 0x01}, want: want("-2"), ok: true},
+		{
+			name: "negative bignum", data: cborTagged(tagNegativeBignum, cborBytes(0x01)),
+			want: want("-2"), ok: true,
+		},
 		// The byte string is what makes this a test of the tag number. Anything else
 		// after the tag is refused for not being a byte string, whatever the number.
-		{name: "an unrelated tag", data: []byte{0xc4, 0x41, 0x01}},
-		{name: "a bignum tag without a byte string", data: []byte{0xc2, 0x01}},
+		{name: "an unrelated tag", data: cborTagged(4, cborBytes(0x01))},
+		{
+			name: "a bignum tag without a byte string",
+			data: cborTagged(tagPositiveBignum, head(uintMajor, 1)),
+		},
 		{name: "a text string", data: cborText("no")},
 	}
 

--- a/encoder/cborlite/tags.go
+++ b/encoder/cborlite/tags.go
@@ -1,0 +1,14 @@
+package cborlite
+
+import (
+	"reflect"
+	"sync"
+)
+
+var tagTypes sync.Map // uint64 -> reflect.Type
+
+// RegisterTag records which concrete type a CBOR tag stands for.
+// The numbers come from encoder.RegisterType.
+func RegisterTag(tag uint64, concrete reflect.Type) {
+	tagTypes.Store(tag, concrete)
+}

--- a/encoder/encoder.go
+++ b/encoder/encoder.go
@@ -37,17 +37,18 @@ func initEncAndDecModes() {
 	}
 }
 
-func RegisterType(rType reflect.Type) error {
+func RegisterType(rType reflect.Type) (tag uint64, err error) {
+	tag = tagNum
 	if err := ts.Add(
 		cbor.TagOptions{EncTag: cbor.EncTagRequired, DecTag: cbor.DecTagRequired},
 		rType,
-		tagNum,
+		tag,
 	); err != nil {
-		return err
+		return 0, err
 	}
 	initEncAndDecModes()
 	tagNum++
-	return nil
+	return tag, nil
 }
 
 // Marshal returns encoding of param v

--- a/encoder/registry/registry.go
+++ b/encoder/registry/registry.go
@@ -9,6 +9,7 @@ import (
 	"github.com/NethermindEth/juno/core/trie2/triedb/pathdb"
 	"github.com/NethermindEth/juno/core/trie2/trienode"
 	"github.com/NethermindEth/juno/encoder"
+	"github.com/NethermindEth/juno/encoder/cborlite"
 )
 
 var once sync.Once
@@ -39,10 +40,11 @@ func init() {
 		}
 
 		for _, t := range types {
-			err := encoder.RegisterType(t)
+			tag, err := encoder.RegisterType(t)
 			if err != nil {
 				panic(err)
 			}
+			cborlite.RegisterTag(tag, t)
 		}
 	})
 }

--- a/encoder/registry/registry_test.go
+++ b/encoder/registry/registry_test.go
@@ -1,0 +1,67 @@
+package registry_test
+
+import (
+	"testing"
+
+	"github.com/NethermindEth/juno/core"
+	"github.com/NethermindEth/juno/core/felt"
+	"github.com/NethermindEth/juno/encoder"
+	"github.com/NethermindEth/juno/encoder/cborlite"
+	_ "github.com/NethermindEth/juno/encoder/registry"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// A tagged type is only reachable through a field whose static type is an interface.
+type transactionHolder struct{ Txn core.Transaction }
+
+func registeredTransactions(hash *felt.Felt) []core.Transaction {
+	return []core.Transaction{
+		&core.InvokeTransaction{TransactionHash: hash},
+		&core.DeclareTransaction{TransactionHash: hash},
+		&core.DeployTransaction{TransactionHash: hash},
+		&core.L1HandlerTransaction{TransactionHash: hash},
+		&core.DeployAccountTransaction{
+			DeployTransaction: core.DeployTransaction{TransactionHash: hash},
+		},
+	}
+}
+
+// TestBothDecodersLearnTheSameTags fails if a registered type reaches only the generic
+// decoder. A tag cborlite does not know makes it decline, which is silent on its own: the
+// caller falls back and only the clock says anything.
+func TestBothDecodersLearnTheSameTags(t *testing.T) {
+	hash := felt.NewFromUint64[felt.Felt](7)
+
+	// One type that cborlite reads end to end is enough to prove the tag arrived, since
+	// an unregistered one declines before reading a single field.
+	data, err := encoder.Marshal(transactionHolder{Txn: &core.InvokeTransaction{
+		TransactionHash: hash,
+	}})
+	require.NoError(t, err)
+
+	var got transactionHolder
+	require.NoError(t, cborlite.Unmarshal(data, &got),
+		"core.InvokeTransaction is registered with the generic decoder but not with cborlite")
+	require.IsType(t, &core.InvokeTransaction{}, got.Txn)
+	assert.Equal(t, hash.String(), got.Txn.Hash().String())
+}
+
+// TestNoRegisteredTransactionDecodesWrong is the invariant that matters for the fallback:
+// cborlite may decline a type, but it must never report success and hand back something
+// else. An embedded field used to do exactly that, decoding to a zero value in silence.
+func TestNoRegisteredTransactionDecodesWrong(t *testing.T) {
+	hash := felt.NewFromUint64[felt.Felt](7)
+
+	for _, txn := range registeredTransactions(hash) {
+		data, err := encoder.Marshal(transactionHolder{Txn: txn})
+		require.NoError(t, err)
+
+		var got transactionHolder
+		if err := cborlite.Unmarshal(data, &got); err != nil {
+			// Declining is fine, the caller falls back to the generic decoder.
+			continue
+		}
+		assert.Equal(t, txn, got.Txn, "%T decoded without an error but came back wrong", txn)
+	}
+}


### PR DESCRIPTION
`cborlite` has two main goals:
   - To only see a byte once. No revisiting.
   - To fill the fields you ask for and skip the rest.

Skipping is cheap. No hidden byte checks. Less CPU usage.

This unmarshaler is not exhaustive. It declines a shape it does not know.
A caller can fall back to the generic decoder. Add support when a shape needs it.

It does not check that the bytes are well formed, so it is for bytes this node wrote  and read back. Do not use it for external inputs.

**To unmarshal a new type, implement `PrefixUnmarshaler`.**

## Comparing to `fxmacker`.
`fxmacker` needs us to unmarshal ALL keys inside a SBOR object. Which created our partial objects. With `cborlite` we can actaully skip the keys we don't want.

`fxmacker` traverses every byte at least twice, to check if it's well formed than to decode. In sama cases, for types that don't say its size, `fxmacker` traverse the bytes a third time to count the byte offset.
`cborlite` only visits a byte ONCE.


## Order to review
- `decode.go`
- `cache.go`
- `readers_kind.go`
- `plan.go`

The other files' order is less relevant.


## Speedup
How to measure here. But see following PRs using `cborlite`.

- [getClass](https://github.com/NethermindEth/juno/pull/3937)


## cborlite coverage by bucket

Tested every populated bucket in a synced mainnet node with deprecated states. Tested on a random 10% population for each bucket larger than 100k. Tested all entries in the smaller ones.

For the buckets of new state, I did a static analysis of the types.

We have 2 unsupported types, and they are not accepted gracefully, with descriptive errors.
The caller can call the generic encoder afterwards. They are mapped in TODOS.

| # | Bucket | Bucket Tested | Decoded with |
|--:|---|:--|---|
| 0 | StateTrie | ✅ | Specialized Codec |
| 1 | Peer | p2p | Specialized Codec |
| 2 | ContractClassHash | ✅ | Specialized Codec |
| 3 | ContractStorage | ✅ | Specialized Codec |
| 4 | Class | ✅ | cborlite |
| 5 | ContractNonce | ✅ | Specialized Codec |
| 6 | ChainHeight | ✅ | Specialized Codec |
| 7 | BlockHeaderNumbersByHash | ✅ | Specialized Codec |
| 8 | BlockHeadersByNumber | ✅ | cborlite |
| 9 | TransactionBlockNumbersAndIndicesByHash | ✅ | Specialized Codec |
| 10 | TransactionsByBlockNumberAndIndex | folded to 40 | cborlite |
| 11 | ReceiptsByBlockNumberAndIndex | folded to 40 | cborlite |
| 12 | StateUpdatesByBlockNumber | ✅ | cborlite |
| 13 | ClassesTrie | ✅ | Specialized Codec |
| 14 | DeprecatedContractStorageHistory | ✅ | Specialized Codec |
| 15 | DeprecatedContractNonceHistory | ✅ | Specialized Codec |
| 16 | DeprecatedContractClassHashHistory | ✅ | Specialized Codec |
| 17 | ContractDeploymentHeight | ✅ | Specialized Codec |
| 18 | L1Height | ✅ | cborlite |
| 19 | DeprecatedSchemaVersion | ✅ | Specialized Codec |
| 20 | Unused | retired | — |
| 21 | BlockCommitments | ✅ | cborlite |
| 22 | Temporary | scratch | Specialized Codec |
| 23 | DeprecatedSchemaIntermediateState | ✅ | Specialized Codec |
| 24 | L1HandlerTxnHashByMsgHash | ✅ | Specialized Codec |
| 25 | MempoolHead | transient | Specialized Codec |
| 26 | MempoolTail | transient | Specialized Codec |
| 27 | MempoolLength | transient | Specialized Codec |
| 28 | MempoolNode | transient | ⚠️  Don't know yet ⚠️ |
| 29 | ClassTrie | new-state | Specialized Codec |
| 30 | ContractTrieContract | new-state | Specialized Codec |
| 31 | ContractTrieStorage | new-state | Specialized Codec |
| 32 | Contract | new-state | Specialized Codec |
| 33 | StateHashToTrieRoots | new-state (dead) | — |
| 34 | StateID | new-state | Specialized Codec |
| 35 | PersistedStateID | new-state | Specialized Codec |
| 36 | TrieJournal | ✅ | cborlite |
| 37 | AggregatedBloomFilters | ✅ | cborlite |
| 38 | RunningEventFilter | ✅ | cborlite |
| 39 | ClassCasmHashMetadata | ✅ | Specialized Codec |
| 40 | BlockTransactions | ✅ | *(mixed — fan-out ↓)* |
| 40 | ↳ BlockTransactionsIndexes | ✅ | ⚠️ Decay to Generic ⚠️ |
| 40 | ↳ Transaction (Invoke / L1Handler / Deploy / Declare) | ✅ | cborlite |
| 40 | ↳ DeployAccountTransaction | ✅ | ⚠️ Decay to Generic ⚠️  |
| 40 | ↳ TransactionReceipt | ✅ | cborlite |
| 41 | SchemaMetadata | ✅ | cborlite |
| 42 | SchemaIntermediateState | scratch | Specialized Codec |
| 43 | ContractClassHashHistory | new-state | Specialized Codec |
| 44 | ContractNonceHistory | new-state | Specialized Codec |
| 45 | ContractStorageHistory | new-state | Specialized Codec |

*Specialized Codec means it has its own methods to unmarshal itself, like felts and tries do.
