### PR TITLE
perf(core): Implement `getClass` using `cborlite`

### DIFF
--- a/core/accessors.go
+++ b/core/accessors.go
@@ -8,6 +8,7 @@ import (
 	"github.com/NethermindEth/juno/core/felt"
 	"github.com/NethermindEth/juno/db"
 	"github.com/NethermindEth/juno/encoder"
+	"github.com/NethermindEth/juno/encoder/cborlite"
 	"github.com/bits-and-blooms/bloom/v3"
 )
 
@@ -53,12 +54,16 @@ func HasClass(r db.KeyValueReader, classHash *felt.Felt) (bool, error) {
 }
 
 func GetClass(r db.KeyValueReader, classHash *felt.Felt) (*DeclaredClassDefinition, error) {
-	var class *DeclaredClassDefinition
+	class := new(DeclaredClassDefinition)
 
 	err := r.Get(db.ClassKey(classHash), func(data []byte) error {
-		return encoder.Unmarshal(data, &class)
+		return cborlite.Unmarshal(data, class)
 	})
-	return class, err
+	if err != nil {
+		return nil, err
+	}
+
+	return class, nil
 }
 
 func WriteClass(w db.KeyValueWriter, classHash *felt.Felt, class *DeclaredClassDefinition) error {

--- a/core/class.go
+++ b/core/class.go
@@ -13,6 +13,7 @@ import (
 	"github.com/NethermindEth/juno/core/felt"
 	"github.com/NethermindEth/juno/db"
 	"github.com/NethermindEth/juno/encoder"
+	"github.com/NethermindEth/juno/encoder/cborlite"
 )
 
 var (
@@ -352,8 +353,17 @@ func (d *DeclaredClassDefinition) UnmarshalBinary(data []byte) error {
 		return errors.New("data too short to unmarshal DeclaredClass")
 	}
 
-	d.At = binary.BigEndian.Uint64(data[:8])
-	return encoder.Unmarshal(data[8:], &d.Class)
+	out := DeclaredClassDefinition{At: binary.BigEndian.Uint64(data[:minDeclaredClassSize])}
+	class := data[minDeclaredClassSize:]
+
+	if err := cborlite.Unmarshal(class, &out.Class); err != nil {
+		if err := encoder.Unmarshal(class, &out.Class); err != nil {
+			return err
+		}
+	}
+
+	*d = out
+	return nil
 }
 
 // ClassCasmHashMetadata tracks the CASM (Compiled Sierra) hash metadata for a class.

--- a/core/class_cbor_test.go
+++ b/core/class_cbor_test.go
@@ -1,0 +1,122 @@
+package core_test
+
+import (
+	"encoding/binary"
+	"errors"
+	"testing"
+
+	"github.com/NethermindEth/juno/blockchain/networks"
+	"github.com/NethermindEth/juno/clients/feeder"
+	"github.com/NethermindEth/juno/core"
+	"github.com/NethermindEth/juno/core/felt"
+	"github.com/NethermindEth/juno/encoder"
+	"github.com/NethermindEth/juno/encoder/cborlite"
+	adaptfeeder "github.com/NethermindEth/juno/starknetdata/feeder"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	sierraClassHash     = "0x6d8ede036bb4720e6f348643221d8672bf4f0895622c32c11e57460b3b7dffc"
+	deprecatedClassHash = "0x07db5c2c2676c2a5bfc892ee4f596b49514e3056a0eee8ad125870b4fb1dd909"
+
+	declaredClassAtSize = 8
+)
+
+func loadDeclaredClass(
+	tb testing.TB,
+	network *networks.Network,
+	classHash string,
+) *core.DeclaredClassDefinition {
+	tb.Helper()
+
+	gw := adaptfeeder.New(feeder.NewTestClient(tb, network))
+	hash := felt.UnsafeFromString[felt.Felt](classHash)
+	class, err := gw.Class(tb.Context(), &hash)
+	require.NoError(tb, err)
+
+	return &core.DeclaredClassDefinition{At: 1234, Class: class}
+}
+
+func declaredClassFixtures(tb testing.TB) []struct {
+	name     string
+	declared *core.DeclaredClassDefinition
+} {
+	tb.Helper()
+
+	return []struct {
+		name     string
+		declared *core.DeclaredClassDefinition
+	}{
+		{
+			name:     "sierra",
+			declared: loadDeclaredClass(tb, &networks.Integration, sierraClassHash),
+		},
+		{
+			name:     "deprecatedCairo",
+			declared: loadDeclaredClass(tb, &networks.Sepolia, deprecatedClassHash),
+		},
+	}
+}
+
+func decodeGeneric(data []byte, out *core.DeclaredClassDefinition) error {
+	var payload []byte
+	if err := encoder.Unmarshal(data, &payload); err != nil {
+		return err
+	}
+	if len(payload) < declaredClassAtSize {
+		return errors.New("payload too short to hold a declared class")
+	}
+
+	out.At = binary.BigEndian.Uint64(payload[:declaredClassAtSize])
+	return encoder.Unmarshal(payload[declaredClassAtSize:], &out.Class)
+}
+
+func BenchmarkDeclaredClassUnmarshal(b *testing.B) {
+	for _, fixture := range declaredClassFixtures(b) {
+		stored, err := encoder.Marshal(fixture.declared)
+		require.NoError(b, err)
+		require.Equal(b, byte(2), stored[0]>>5, "want a CBOR byte string (major 2)")
+
+		b.Run(fixture.name+"/cborlite", func(b *testing.B) {
+			b.ReportAllocs()
+			for range b.N {
+				var declared core.DeclaredClassDefinition
+				if err := cborlite.Unmarshal(stored, &declared); err != nil {
+					b.Fatal(err)
+				}
+			}
+		})
+
+		b.Run(fixture.name+"/generic", func(b *testing.B) {
+			b.ReportAllocs()
+			for range b.N {
+				var declared core.DeclaredClassDefinition
+				if err := decodeGeneric(stored, &declared); err != nil {
+					b.Fatal(err)
+				}
+			}
+		})
+	}
+}
+
+func FuzzDeclaredClassMatchesTheGenericDecoder(f *testing.F) {
+	for _, fixture := range declaredClassFixtures(f) {
+		data, err := encoder.Marshal(fixture.declared)
+		require.NoError(f, err)
+		f.Add(data)
+	}
+
+	f.Fuzz(func(t *testing.T, data []byte) {
+		var got core.DeclaredClassDefinition
+		if err := cborlite.Unmarshal(data, &got); err != nil {
+			return
+		}
+
+		var generic core.DeclaredClassDefinition
+		if err := decodeGeneric(data, &generic); err != nil {
+			return
+		}
+		assert.Equal(t, &generic, &got)
+	})
+}

--- a/core/state/accessors.go
+++ b/core/state/accessors.go
@@ -7,6 +7,7 @@ import (
 	"github.com/NethermindEth/juno/core/felt"
 	"github.com/NethermindEth/juno/db"
 	"github.com/NethermindEth/juno/encoder"
+	"github.com/NethermindEth/juno/encoder/cborlite"
 )
 
 func GetStateObject(r db.KeyValueReader, state *State, addr *felt.Felt) (*stateObject, error) {
@@ -123,7 +124,7 @@ func GetClass(r db.KeyValueReader, classHash *felt.Felt) (*core.DeclaredClassDef
 
 	var class core.DeclaredClassDefinition
 	if err := r.Get(key, func(data []byte) error {
-		return encoder.Unmarshal(data, &class)
+		return cborlite.Unmarshal(data, &class)
 	}); err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
`getClass` RPC in a saturated node is ~1.6x faster.

Considering only the decode time, decoding a large sierra is ~6x faster. deprecatedCairo is 2x faster.

| Class | Generic (fxamacker) | cborlite | Speedup |
|---|---|---|---|
| **sierra** | 601,091 ns | 97,248 ns | **6.18x** |
| | 521,248 B / 96 allocs | 250,865 B / 92 allocs | **2.08x less memory** |
| **deprecatedCairo** | 4,502 ns | 2,089 ns | **2.16x** |
| | 16,328 B / 14 allocs | 8,120 B / 11 allocs | **2.01x less memory** |

# Flame Graph (Main):
<img width="1280" height="697" alt="Screenshot 2026-08-13 at 2 51 20 AM" src="https://github.com/user-attachments/assets/442588e5-47ec-47fc-bec3-59d468c905f2" />


# Flame Graph (This PR):
<img width="1283" height="671" alt="Screenshot 2026-08-13 at 2 51 04 AM" src="https://github.com/user-attachments/assets/187e9a40-08fd-4c5e-a343-896921bea8c5" />

The `Handler.Class` used to use ~41% of CPU, now uses  only ~15%.