### PR TITLE
ci: add path filter to docs-deploy workflow

### DIFF
--- a/.github/workflows/docs-deploy.yml
+++ b/.github/workflows/docs-deploy.yml
@@ -4,6 +4,9 @@ on:
   push:
     branches:
       - main
+    paths:
+      - 'docs/**'
+      - '.github/workflows/docs-deploy.yml'
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
Prevent docs deployment from running on every push to main. Only trigger when files under docs/ or the workflow itself change. This avoids unnecessary CI usage and GitHub Pages deployments when unrelated code changes are pushed.