### PR TITLE
perf(trie): reuse stored hashes and traversed nodes in Prove

### DIFF
--- a/core/trie/proof.go
+++ b/core/trie/proof.go
@@ -67,6 +67,8 @@ func (e *Edge) String() string {
 // The result contains the proof nodes on the path from the root to the leaf.
 // The value is included in the proof if the key is present in the trie.
 // If the key is not present, the proof will contain the nodes on the path to the closest ancestor.
+// Proof hashes are taken from stored node values, so the trie's hashes must be
+// current: call Hash after the last write and before Prove.
 func (t *Trie) Prove(key *felt.Felt, proof *ProofNodeSet) error {
 	k := t.FeltToKey(key)
 
@@ -76,27 +78,68 @@ func (t *Trie) Prove(key *felt.Felt, proof *ProofNodeSet) error {
 	}
 
 	var parentKey *BitArray
+	// Parent-facing hash of the current node, computed by the previous
+	// iteration. Nil for the root, whose hash has no parent to come from.
+	var carriedHash *felt.Felt
 
+	// The proof nodes below alias felts of the nodes from nodesFromRoot, so these
+	// nodes must not go back to nodePool the way Put and Delete return theirs:
+	// reuse would overwrite hashes that the caller still holds.
 	for i, sNode := range nodesFromRoot {
-		sNodeEdge, sNodeBinary, err := storageNodeToProofNode(t, parentKey, sNode)
+		isLeaf := sNode.key.len == t.height
+
+		var sNodeEdge *Edge
+		if isEdge(parentKey, sNode) {
+			edgePath := path(sNode.key, parentKey)
+			sNodeEdge = &Edge{Path: &edgePath, Child: sNode.node.Value}
+		}
+
+		if isLeaf {
+			if sNodeEdge != nil { // Leaf Edge
+				proof.Put(edgeHash(sNodeEdge, carriedHash, t.hash), sNodeEdge)
+			}
+			break // sNode is a binary leaf otherwise; nothing to add
+		}
+
+		var onPathChild *StorageNode
+		if i+1 < len(nodesFromRoot) {
+			onPathChild = &nodesFromRoot[i+1]
+		}
+		sNodeBinary, err := binaryProofNode(t, sNode, onPathChild)
 		if err != nil {
 			return err
 		}
-		isLeaf := sNode.key.len == t.height
 
-		if sNodeEdge != nil && !isLeaf { // Internal Edge
-			proof.Put(sNodeEdge.Hash(t.hash), sNodeEdge)
-			proof.Put(sNodeBinary.Hash(t.hash), sNodeBinary)
-		} else if sNodeEdge == nil && !isLeaf { // Internal Binary
-			proof.Put(sNodeBinary.Hash(t.hash), sNodeBinary)
-		} else if sNodeEdge != nil && isLeaf { // Leaf Edge
-			proof.Put(sNodeEdge.Hash(t.hash), sNodeEdge)
-		} else if sNodeEdge == nil && sNodeBinary == nil { // sNode is a binary leaf
-			break
+		if sNodeEdge != nil { // Internal Edge
+			proof.Put(edgeHash(sNodeEdge, carriedHash, t.hash), sNodeEdge)
 		}
-		parentKey = nodesFromRoot[i].key
+		// A hashed internal node stores hash(leftHash, rightHash) as its
+		// value, so the binary hash needs no recomputation.
+		proof.Put(*sNode.node.Value, sNodeBinary)
+
+		// The on-path child's parent-facing hash is one of the two the Binary
+		// already holds, so the next iteration reuses it instead of hashing
+		// again. A nil carry makes that iteration recompute, never misreport.
+		carriedHash = nil
+		switch {
+		case onPathChild == nil:
+		case onPathChild.key.Equal(sNode.node.Left):
+			carriedHash = sNodeBinary.LeftHash
+		case onPathChild.key.Equal(sNode.node.Right):
+			carriedHash = sNodeBinary.RightHash
+		}
+		parentKey = sNode.key
 	}
 	return nil
+}
+
+// edgeHash returns the parent-facing hash of an edge node, reusing the value
+// the parent iteration already computed when there is one.
+func edgeHash(edge *Edge, carried *felt.Felt, hash crypto.HashFn) felt.Felt {
+	if carried != nil {
+		return *carried
+	}
+	return edge.Hash(hash)
 }
 
 // GetRangeProof generates a range proof for the given range of keys.
@@ -346,56 +389,46 @@ func isEdge(parentKey *BitArray, sNode StorageNode) bool {
 	return sNodeLen-parentKey.len > 1
 }
 
-// storageNodeToProofNode converts a StorageNode to the ProofNode(s).
-// Juno's Trie has nodes that are Binary AND Edge, whereas the protocol requires nodes that are Binary XOR Edge.
-// We need to convert the former to the latter for proof generation.
-func storageNodeToProofNode(tri *Trie, parentKey *BitArray, sNode StorageNode) (*Edge, *Binary, error) {
-	var edge *Edge
-	if isEdge(parentKey, sNode) {
-		edgePath := path(sNode.key, parentKey)
-		edge = &Edge{
-			Path:  &edgePath,
-			Child: sNode.node.Value,
+// binaryProofNode builds the Binary proof node of an internal StorageNode.
+// Juno's Trie has nodes that are Binary AND Edge, whereas the protocol requires
+// nodes that are Binary XOR Edge. We need to convert the former to the latter for
+// proof generation. onPathChild is the next node the traversal already read, so
+// it is not read again; only the off-path sibling costs a database lookup.
+func binaryProofNode(
+	tri *Trie, sNode StorageNode, onPathChild *StorageNode,
+) (*Binary, error) {
+	childHash := func(childKey *BitArray) (*felt.Felt, error) {
+		var child *Node
+		if onPathChild != nil && childKey.Equal(onPathChild.key) {
+			child = onPathChild.node
+		} else {
+			var err error
+			if child, err = tri.GetNodeFromKey(childKey); err != nil {
+				return nil, err
+			}
 		}
-	}
-	if sNode.key.len == tri.height { // Leaf
-		return edge, nil, nil
-	}
-	lNode, err := tri.GetNodeFromKey(sNode.node.Left)
-	if err != nil {
-		return nil, nil, err
-	}
-	rNode, err := tri.GetNodeFromKey(sNode.node.Right)
-	if err != nil {
-		return nil, nil, err
+
+		// Node.HashFromParent would cover both branches, but it returns a value:
+		// taking its address costs an allocation per non-edge child, which this
+		// avoids.
+		if isEdge(sNode.key, StorageNode{key: childKey}) {
+			edgePath := path(childKey, sNode.key)
+			wrapped := child.Hash(&edgePath, tri.hash)
+			return &wrapped, nil
+		}
+		return child.Value, nil
 	}
 
-	rightHash := rNode.Value
-	if isEdge(sNode.key, StorageNode{node: rNode, key: sNode.node.Right}) {
-		edgePath := path(sNode.node.Right, sNode.key)
-		rEdge := &Edge{
-			Path:  &edgePath,
-			Child: rNode.Value,
-		}
-		hash := rEdge.Hash(tri.hash)
-		rightHash = &hash
+	leftHash, err := childHash(sNode.node.Left)
+	if err != nil {
+		return nil, err
 	}
-	leftHash := lNode.Value
-	if isEdge(sNode.key, StorageNode{node: lNode, key: sNode.node.Left}) {
-		edgePath := path(sNode.node.Left, sNode.key)
-		lEdge := &Edge{
-			Path:  &edgePath,
-			Child: lNode.Value,
-		}
-		hash := lEdge.Hash(tri.hash)
-		leftHash = &hash
-	}
-	binary := &Binary{
-		LeftHash:  leftHash,
-		RightHash: rightHash,
+	rightHash, err := childHash(sNode.node.Right)
+	if err != nil {
+		return nil, err
 	}
 
-	return edge, binary, nil
+	return &Binary{LeftHash: leftHash, RightHash: rightHash}, nil
 }
 
 // proofToPath converts a Merkle proof to trie node path. All necessary nodes will be resolved and leave the remaining

--- a/core/trie/proof.go
+++ b/core/trie/proof.go
@@ -70,6 +70,10 @@ func (e *Edge) String() string {
 // Proof hashes are taken from stored node values, so the trie's hashes must be
 // current: call Hash after the last write and before Prove.
 func (t *Trie) Prove(key *felt.Felt, proof *ProofNodeSet) error {
+	if t.rootKeyIsDirty || len(t.dirtyNodes) > 0 {
+		return errors.New("cannot prove a trie with unhashed writes")
+	}
+
 	k := t.FeltToKey(key)
 
 	nodesFromRoot, err := t.nodesFromRoot(&k)
@@ -79,12 +83,11 @@ func (t *Trie) Prove(key *felt.Felt, proof *ProofNodeSet) error {
 
 	var parentKey *BitArray
 	// Parent-facing hash of the current node, computed by the previous
-	// iteration. Nil for the root, whose hash has no parent to come from.
+	// iteration; nil for the root.
 	var carriedHash *felt.Felt
 
-	// The proof nodes below alias felts of the nodes from nodesFromRoot, so these
-	// nodes must not go back to nodePool the way Put and Delete return theirs:
-	// reuse would overwrite hashes that the caller still holds.
+	// Proof nodes alias felts of every node read below, so none of these nodes
+	// can go back to nodePool: reuse would overwrite hashes the caller holds.
 	for i, sNode := range nodesFromRoot {
 		isLeaf := sNode.key.len == t.height
 
@@ -113,13 +116,11 @@ func (t *Trie) Prove(key *felt.Felt, proof *ProofNodeSet) error {
 		if sNodeEdge != nil { // Internal Edge
 			proof.Put(edgeHash(sNodeEdge, carriedHash, t.hash), sNodeEdge)
 		}
-		// A hashed internal node stores hash(leftHash, rightHash) as its
-		// value, so the binary hash needs no recomputation.
+		// A hashed internal node stores hash(leftHash, rightHash) as its value.
 		proof.Put(*sNode.node.Value, sNodeBinary)
 
-		// The on-path child's parent-facing hash is one of the two the Binary
-		// already holds, so the next iteration reuses it instead of hashing
-		// again. A nil carry makes that iteration recompute, never misreport.
+		// Carry the on-path child's parent-facing hash from the Binary; a nil
+		// carry only costs a recomputation, never a wrong hash.
 		carriedHash = nil
 		switch {
 		case onPathChild == nil:
@@ -408,9 +409,8 @@ func binaryProofNode(
 			}
 		}
 
-		// Node.HashFromParent would cover both branches, but it returns a value:
-		// taking its address costs an allocation per non-edge child, which this
-		// avoids.
+		// Not Node.HashFromParent: taking the address of its returned value
+		// costs an allocation per non-edge child.
 		if isEdge(sNode.key, StorageNode{key: childKey}) {
 			edgePath := path(childKey, sNode.key)
 			wrapped := child.Hash(&edgePath, tri.hash)

--- a/core/trie/proof.go
+++ b/core/trie/proof.go
@@ -383,11 +383,16 @@ func VerifyRangeProof(root, first *felt.Felt, keys, values []*felt.Felt, proof *
 
 // isEdge checks if the storage node is an edge node.
 func isEdge(parentKey *BitArray, sNode StorageNode) bool {
-	sNodeLen := sNode.key.len
+	return isEdgeKey(parentKey, sNode.key)
+}
+
+// isEdgeKey reports whether childKey hangs off parentKey via an edge, i.e. the
+// path between them is longer than the single branching bit.
+func isEdgeKey(parentKey, childKey *BitArray) bool {
 	if parentKey == nil { // Root
-		return sNodeLen != 0
+		return childKey.len != 0
 	}
-	return sNodeLen-parentKey.len > 1
+	return childKey.len-parentKey.len > 1
 }
 
 // binaryProofNode builds the Binary proof node of an internal StorageNode.
@@ -411,7 +416,7 @@ func binaryProofNode(
 
 		// Not Node.HashFromParent: taking the address of its returned value
 		// costs an allocation per non-edge child.
-		if isEdge(sNode.key, StorageNode{key: childKey}) {
+		if isEdgeKey(sNode.key, childKey) {
 			edgePath := path(childKey, sNode.key)
 			wrapped := child.Hash(&edgePath, tri.hash)
 			return &wrapped, nil

--- a/core/trie/proof.go
+++ b/core/trie/proof.go
@@ -377,7 +377,7 @@ func VerifyRangeProof(root, first *felt.Felt, keys, values []*felt.Felt, proof *
 }
 
 // isEdge reports whether the path between parentKey and childKey is longer
-// than one bit, which makes childKey an edge node.
+// than the branching bit, which the root does not have.
 func isEdge(parentKey, childKey *BitArray) bool {
 	if parentKey == nil { // Root
 		return childKey.len != 0

--- a/core/trie/proof.go
+++ b/core/trie/proof.go
@@ -67,8 +67,7 @@ func (e *Edge) String() string {
 // The result contains the proof nodes on the path from the root to the leaf.
 // The value is included in the proof if the key is present in the trie.
 // If the key is not present, the proof will contain the nodes on the path to the closest ancestor.
-// Proof hashes are taken from stored node values, so the trie's hashes must be
-// current: call Hash after the last write and before Prove.
+// Proof hashes come from stored node values: call Hash after the last write.
 func (t *Trie) Prove(key *felt.Felt, proof *ProofNodeSet) error {
 	if t.rootKeyIsDirty || len(t.dirtyNodes) > 0 {
 		return errors.New("cannot prove a trie with unhashed writes")
@@ -82,17 +81,15 @@ func (t *Trie) Prove(key *felt.Felt, proof *ProofNodeSet) error {
 	}
 
 	var parentKey *BitArray
-	// Parent-facing hash of the current node, computed by the previous
-	// iteration; nil for the root.
+	// Hash of the current node as seen by its parent; nil for the root.
 	var carriedHash *felt.Felt
 
-	// Proof nodes alias felts of every node read below, so none of these nodes
-	// can go back to nodePool: reuse would overwrite hashes the caller holds.
+	// Proof entries alias node felts, so the nodes cannot go back to nodePool.
 	for i, sNode := range nodesFromRoot {
 		isLeaf := sNode.key.len == t.height
 
 		var sNodeEdge *Edge
-		if isEdge(parentKey, sNode) {
+		if isEdge(parentKey, sNode.key) {
 			edgePath := path(sNode.key, parentKey)
 			sNodeEdge = &Edge{Path: &edgePath, Child: sNode.node.Value}
 		}
@@ -101,7 +98,7 @@ func (t *Trie) Prove(key *felt.Felt, proof *ProofNodeSet) error {
 			if sNodeEdge != nil { // Leaf Edge
 				proof.Put(edgeHash(sNodeEdge, carriedHash, t.hash), sNodeEdge)
 			}
-			break // sNode is a binary leaf otherwise; nothing to add
+			break // binary leaf; nothing to add
 		}
 
 		var onPathChild *StorageNode
@@ -119,8 +116,7 @@ func (t *Trie) Prove(key *felt.Felt, proof *ProofNodeSet) error {
 		// A hashed internal node stores hash(leftHash, rightHash) as its value.
 		proof.Put(*sNode.node.Value, sNodeBinary)
 
-		// Carry the on-path child's parent-facing hash from the Binary; a nil
-		// carry only costs a recomputation, never a wrong hash.
+		// Carry the on-path child's hash; a nil carry only costs a recomputation.
 		carriedHash = nil
 		switch {
 		case onPathChild == nil:
@@ -134,8 +130,7 @@ func (t *Trie) Prove(key *felt.Felt, proof *ProofNodeSet) error {
 	return nil
 }
 
-// edgeHash returns the parent-facing hash of an edge node, reusing the value
-// the parent iteration already computed when there is one.
+// edgeHash returns the parent-facing hash of an edge node, from carried when set.
 func edgeHash(edge *Edge, carried *felt.Felt, hash crypto.HashFn) felt.Felt {
 	if carried != nil {
 		return *carried
@@ -381,14 +376,9 @@ func VerifyRangeProof(root, first *felt.Felt, keys, values []*felt.Felt, proof *
 	return hasRightElement(rootKey, lastKey, nodes), nil
 }
 
-// isEdge checks if the storage node is an edge node.
-func isEdge(parentKey *BitArray, sNode StorageNode) bool {
-	return isEdgeKey(parentKey, sNode.key)
-}
-
-// isEdgeKey reports whether childKey hangs off parentKey via an edge, i.e. the
-// path between them is longer than the single branching bit.
-func isEdgeKey(parentKey, childKey *BitArray) bool {
+// isEdge reports whether the path between parentKey and childKey is longer
+// than one bit, which makes childKey an edge node.
+func isEdge(parentKey, childKey *BitArray) bool {
 	if parentKey == nil { // Root
 		return childKey.len != 0
 	}
@@ -396,10 +386,9 @@ func isEdgeKey(parentKey, childKey *BitArray) bool {
 }
 
 // binaryProofNode builds the Binary proof node of an internal StorageNode.
-// Juno's Trie has nodes that are Binary AND Edge, whereas the protocol requires
-// nodes that are Binary XOR Edge. We need to convert the former to the latter for
-// proof generation. onPathChild is the next node the traversal already read, so
-// it is not read again; only the off-path sibling costs a database lookup.
+// Juno trie nodes are Binary AND Edge; the protocol requires Binary XOR Edge.
+// onPathChild was already read by the traversal, so only the off-path sibling
+// costs a database lookup.
 func binaryProofNode(
 	tri *Trie, sNode StorageNode, onPathChild *StorageNode,
 ) (*Binary, error) {
@@ -414,9 +403,8 @@ func binaryProofNode(
 			}
 		}
 
-		// Not Node.HashFromParent: taking the address of its returned value
-		// costs an allocation per non-edge child.
-		if isEdgeKey(sNode.key, childKey) {
+		// Node.HashFromParent would cost an allocation per non-edge child.
+		if isEdge(sNode.key, childKey) {
 			edgePath := path(childKey, sNode.key)
 			wrapped := child.Hash(&edgePath, tri.hash)
 			return &wrapped, nil

--- a/core/trie/proof_test.go
+++ b/core/trie/proof_test.go
@@ -876,9 +876,8 @@ func TestProveErrsOnStaleHashes(t *testing.T) {
 }
 
 // TestProveSetInvariant checks every proof entry is keyed by its own hash.
-// Prove reuses stored and carried hashes instead of recomputing them, so a
-// drift between the reused values and the node contents would mis-key entries
-// and only surface at the verifier.
+// Prove reuses stored and carried hashes; a drift between them and the node
+// contents would only surface at the verifier.
 func TestProveSetInvariant(t *testing.T) {
 	t.Parallel()
 

--- a/core/trie/proof_test.go
+++ b/core/trie/proof_test.go
@@ -855,3 +855,51 @@ type keyValue struct {
 	key   *felt.Felt
 	value *felt.Felt
 }
+
+func TestProveErrsOnStaleHashes(t *testing.T) {
+	t.Parallel()
+
+	memdb := memory.New()
+	txn := memdb.NewIndexedBatch()
+	tempTrie, err := trie.NewTriePedersen(txn, []byte{0}, 251)
+	require.NoError(t, err)
+
+	key := new(felt.Felt).SetUint64(1)
+	_, err = tempTrie.Put(key, new(felt.Felt).SetUint64(2))
+	require.NoError(t, err)
+
+	err = tempTrie.Prove(key, trie.NewProofNodeSet())
+	require.EqualError(t, err, "cannot prove a trie with unhashed writes")
+
+	require.NoError(t, tempTrie.Commit())
+	require.NoError(t, tempTrie.Prove(key, trie.NewProofNodeSet()))
+}
+
+// TestProveSetInvariant checks every proof entry is keyed by its own hash.
+// Prove reuses stored and carried hashes instead of recomputing them, so a
+// drift between the reused values and the node contents would mis-key entries
+// and only surface at the verifier.
+func TestProveSetInvariant(t *testing.T) {
+	t.Parallel()
+
+	tempTrie, records := randomTrie(t, 100)
+
+	keys := make([]*felt.Felt, 0, len(records)+1)
+	for _, record := range records {
+		keys = append(keys, record.key)
+	}
+	// Non-membership proofs must hold the invariant too.
+	keys = append(keys, new(felt.Felt).SetUint64(0xdead))
+
+	for _, key := range keys {
+		proofSet := trie.NewProofNodeSet()
+		require.NoError(t, tempTrie.Prove(key, proofSet))
+
+		hashes := proofSet.Keys()
+		nodes := proofSet.List()
+		for i, node := range nodes {
+			hash := node.Hash(crypto.Pedersen)
+			require.True(t, hash.Equal(&hashes[i]), "entry %d for key %s", i, key)
+		}
+	}
+}

--- a/core/trie/proof_test.go
+++ b/core/trie/proof_test.go
@@ -963,7 +963,9 @@ func TestProveAfterDeleteToEmpty(t *testing.T) {
 	}
 	require.NoError(t, tempTrie.Commit())
 
-	require.NoError(t, tempTrie.Prove(keys[0], trie.NewProofNodeSet()))
+	proofSet := trie.NewProofNodeSet()
+	require.NoError(t, tempTrie.Prove(keys[0], proofSet))
+	require.Zero(t, proofSet.Size())
 }
 
 // TestProveSetInvariant checks every proof entry is keyed by its own hash.

--- a/core/trie/proof_test.go
+++ b/core/trie/proof_test.go
@@ -875,6 +875,97 @@ func TestProveErrsOnStaleHashes(t *testing.T) {
 	require.NoError(t, tempTrie.Prove(key, trie.NewProofNodeSet()))
 }
 
+func TestProveErrsOnUnhashedLeafUpdate(t *testing.T) {
+	t.Parallel()
+
+	memdb := memory.New()
+	txn := memdb.NewIndexedBatch()
+	tempTrie, err := trie.NewTriePedersen(txn, []byte{0}, 251)
+	require.NoError(t, err)
+
+	key := new(felt.Felt).SetUint64(1)
+	_, err = tempTrie.Put(key, new(felt.Felt).SetUint64(2))
+	require.NoError(t, err)
+	require.NoError(t, tempTrie.Commit())
+
+	_, err = tempTrie.Put(key, new(felt.Felt).SetUint64(3))
+	require.NoError(t, err)
+
+	err = tempTrie.Prove(key, trie.NewProofNodeSet())
+	require.EqualError(t, err, "cannot prove a trie with unhashed writes")
+
+	require.NoError(t, tempTrie.Commit())
+	require.NoError(t, tempTrie.Prove(key, trie.NewProofNodeSet()))
+}
+
+func TestProveAfterDelete(t *testing.T) {
+	t.Parallel()
+
+	memdb := memory.New()
+	txn := memdb.NewIndexedBatch()
+	tempTrie, err := trie.NewTriePedersen(txn, []byte{0}, 251)
+	require.NoError(t, err)
+
+	records := make([]*keyValue, 4)
+	for i := range records {
+		records[i] = &keyValue{
+			key:   new(felt.Felt).SetUint64(uint64(i)),
+			value: new(felt.Felt).SetUint64(uint64(i + 10)),
+		}
+		_, err := tempTrie.Put(records[i].key, records[i].value)
+		require.NoError(t, err)
+	}
+	require.NoError(t, tempTrie.Commit())
+
+	deleted, kept := records[0], records[3]
+	_, err = tempTrie.Put(deleted.key, new(felt.Felt))
+	require.NoError(t, err)
+
+	err = tempTrie.Prove(kept.key, trie.NewProofNodeSet())
+	require.EqualError(t, err, "cannot prove a trie with unhashed writes")
+
+	require.NoError(t, tempTrie.Commit())
+	root, err := tempTrie.Hash()
+	require.NoError(t, err)
+
+	proofSet := trie.NewProofNodeSet()
+	require.NoError(t, tempTrie.Prove(kept.key, proofSet))
+	val, err := trie.VerifyProof(&root, kept.key, proofSet, crypto.Pedersen)
+	require.NoError(t, err)
+	require.Equal(t, *kept.value, val)
+
+	proofSet = trie.NewProofNodeSet()
+	require.NoError(t, tempTrie.Prove(deleted.key, proofSet))
+	val, err = trie.VerifyProof(&root, deleted.key, proofSet, crypto.Pedersen)
+	require.NoError(t, err)
+	require.Equal(t, felt.Zero, val)
+}
+
+func TestProveAfterDeleteToEmpty(t *testing.T) {
+	t.Parallel()
+
+	memdb := memory.New()
+	txn := memdb.NewIndexedBatch()
+	tempTrie, err := trie.NewTriePedersen(txn, []byte{0}, 251)
+	require.NoError(t, err)
+
+	keys := make([]*felt.Felt, 4)
+	for i := range keys {
+		keys[i] = new(felt.Felt).SetUint64(uint64(i))
+		_, err := tempTrie.Put(keys[i], new(felt.Felt).SetUint64(1))
+		require.NoError(t, err)
+	}
+	require.NoError(t, tempTrie.Commit())
+
+	for _, key := range keys {
+		_, err := tempTrie.Put(key, new(felt.Felt))
+		require.NoError(t, err)
+	}
+	require.NoError(t, tempTrie.Commit())
+
+	require.NoError(t, tempTrie.Prove(keys[0], trie.NewProofNodeSet()))
+}
+
 // TestProveSetInvariant checks every proof entry is keyed by its own hash.
 // Prove reuses stored and carried hashes; a drift between them and the node
 // contents would only surface at the verifier.

--- a/core/trie/trie.go
+++ b/core/trie/trie.go
@@ -814,6 +814,7 @@ func (t *Trie) Hash() (felt.Felt, error) {
 	}
 
 	if t.rootKey == nil {
+		t.dirtyNodes = nil
 		return felt.Zero, nil
 	}
 


### PR DESCRIPTION
Bench results based on sepolia snapshot

| case | time/op (main) | time/op (PR) | Δ time | B/op (main) | B/op (PR) | Δ B/op | allocs/op (main) | allocs/op (PR) | Δ allocs |
|---|---|---|---|---|---|---|---|---|---|
| classes_16 | 7.718ms | 3.708ms | −51.96% | 522.1Ki | 374.6Ki | −28.25% | 8,270 | 5,844 | −29.33% |
| contracts_1 | 1.488ms | 628.2µs | −57.79% | 75.39Ki | 56.84Ki | −24.60% | 1,162 | 869 | −25.22% |
| contracts_16 | 20.469ms | 9.049ms | −55.79% | 1041.2Ki | 747.4Ki | −28.21% | 16,250 | 11,610 | −28.54% |
| storage_1x16 | 1.237ms | 660.0µs | −46.66% | 65.73Ki | 50.86Ki | −22.63% | 1,033 | 780 | −24.49% |
| storage_16x4 | 11.627ms | 5.791ms | −50.20% | 582.5Ki | 400.5Ki | −31.24% | 9,788 | 6,654 | −32.02% |
| mixed | 6.117ms | 3.146ms | −48.56% | 328.2Ki | 243.7Ki | −25.75% | 5,211 | 3,827 | −26.56% |
| **geomean** | 5.240ms | 2.516ms | **−51.99%** | 283.1Ki | 207.1Ki | **−26.84%** | 4,493 | 3,247 | **−27.74%** |


k6 results:

### Sequential latency — 1 VU × 1000 iterations (ms)

| case | avg (main) | avg (PR) | Δ avg | med (main) | med (PR) | p99 (main) | p99 (PR) |
|---|---:|---:|---:|---:|---:|---:|---:|
| default (1c/1a/1k) | 2.26 | 0.81 | −64.4% | 2.01 | 0.77 | 5.46 | 1.38 |
| classes_16 | 3.00 | 1.36 | −54.7% | 2.93 | 1.33 | 4.76 | 2.23 |
| contracts_16 | 7.53 | 2.18 | −71.0% | 7.36 | 2.16 | 13.58 | 3.57 |
| storage_16x4 | 8.55 | 2.63 | −69.2% | 8.29 | 2.58 | 13.42 | 4.11 |

### Under load — 50 VUs × 30s

| case | req/s (main) | req/s (PR) | Δ req/s | avg ms (main) | avg ms (PR) | p99 ms (main) | p99 ms (PR) |
|---|---:|---:|---:|---:|---:|---:|---:|
| default (1c/1a/1k) | 3141.5 | 6248.3 | +98.9% | 15.49 | 7.73 | 54.72 | 32.03 |
| classes_16 | 1559.2 | 2619.5 | +68.0% | 31.47 | 18.56 | 99.63 | 59.42 |
| contracts_16 | 965.8 | 2065.2 | +113.8% | 50.83 | 23.45 | 217.86 | 84.03 |
| storage_16x4 | 775.8 | 1724.7 | +122.3% | 63.33 | 28.04 | 302.05 | 117.88 |

### Overload — 500 VUs × 30s

| case | req/s (main) | req/s (PR) | Δ req/s | avg ms (main) | avg ms (PR) | p99 ms (main) | p99 ms (PR) |
|---|---:|---:|---:|---:|---:|---:|---:|
| default (1c/1a/1k) | 1381.7 | 2350.7 | +70.1% | 358.25 | 211.00 | 3208.20 | 1798.28 |
| classes_16 | 758.2 | 1120.7 | +47.8% | 649.51 | 442.25 | 5020.70 | 2626.51 |
| contracts_16 | 453.5 | 837.8 | +84.7% | 1086.21 | 590.25 | 7304.57 | 4476.50 |
| storage_16x4 | 336.1 | 681.5 | +102.7% | 1457.16 | 722.47 | 8332.13 | 5744.54 |