### PR TITLE
perf(felt): decode fixed-shape CBOR felts without per-limb dispatch

### DIFF
--- a/core/felt/cbor.go
+++ b/core/felt/cbor.go
@@ -100,18 +100,26 @@ func decodeLimbs[F FeltLike](data []byte, value *F) (int, bool) {
 		return 0, false
 	}
 
+	// Header-byte offset of each limb in the all-uint64 shape; the 8-byte payload follows.
+	const (
+		limb0Header = 1
+		limb1Header = limb0Header + maxCBORUintLen
+		limb2Header = limb1Header + maxCBORUintLen
+		limb3Header = limb2Header + maxCBORUintLen
+	)
+
 	// Felts are stored in Montgomery form, so in practice every limb exceeds MaxUint32 and
 	// encodes as a full uint64, giving one fixed 37-byte shape. Decode it without the
 	// per-limb header switch; anything else falls through to the general loop.
 	if len(data) >= maxCBORFeltLen &&
-		data[1] == cborUint64AdditionalInfo &&
-		data[10] == cborUint64AdditionalInfo &&
-		data[19] == cborUint64AdditionalInfo &&
-		data[28] == cborUint64AdditionalInfo {
-		(*value)[0] = binary.BigEndian.Uint64(data[2:])
-		(*value)[1] = binary.BigEndian.Uint64(data[11:])
-		(*value)[2] = binary.BigEndian.Uint64(data[20:])
-		(*value)[3] = binary.BigEndian.Uint64(data[29:])
+		data[limb0Header] == cborUint64AdditionalInfo &&
+		data[limb1Header] == cborUint64AdditionalInfo &&
+		data[limb2Header] == cborUint64AdditionalInfo &&
+		data[limb3Header] == cborUint64AdditionalInfo {
+		(*value)[0] = binary.BigEndian.Uint64(data[limb0Header+1 : limb1Header])
+		(*value)[1] = binary.BigEndian.Uint64(data[limb1Header+1 : limb2Header])
+		(*value)[2] = binary.BigEndian.Uint64(data[limb2Header+1 : limb3Header])
+		(*value)[3] = binary.BigEndian.Uint64(data[limb3Header+1 : maxCBORFeltLen])
 		return maxCBORFeltLen, true
 	}
 

--- a/core/felt/cbor.go
+++ b/core/felt/cbor.go
@@ -100,6 +100,21 @@ func decodeLimbs[F FeltLike](data []byte, value *F) (int, bool) {
 		return 0, false
 	}
 
+	// Felts are stored in Montgomery form, so in practice every limb exceeds MaxUint32 and
+	// encodes as a full uint64, giving one fixed 37-byte shape. Decode it without the
+	// per-limb header switch; anything else falls through to the general loop.
+	if len(data) >= maxCBORFeltLen &&
+		data[1] == cborUint64AdditionalInfo &&
+		data[10] == cborUint64AdditionalInfo &&
+		data[19] == cborUint64AdditionalInfo &&
+		data[28] == cborUint64AdditionalInfo {
+		(*value)[0] = binary.BigEndian.Uint64(data[2:])
+		(*value)[1] = binary.BigEndian.Uint64(data[11:])
+		(*value)[2] = binary.BigEndian.Uint64(data[20:])
+		(*value)[3] = binary.BigEndian.Uint64(data[29:])
+		return maxCBORFeltLen, true
+	}
+
 	var limbs F
 	offset := 1
 

--- a/core/felt/cbor.go
+++ b/core/felt/cbor.go
@@ -123,6 +123,12 @@ func decodeLimbs[F FeltLike](data []byte, value *F) (int, bool) {
 		return maxCBORFeltLen, true
 	}
 
+	return decodeVariableLimbs(data, value)
+}
+
+// decodeVariableLimbs decodes the limbs at data[1:] one header byte at a time, covering the shapes
+// the fixed-shape fast path rejects; data[0] must already be a validated array header.
+func decodeVariableLimbs[F FeltLike](data []byte, value *F) (int, bool) {
 	var limbs F
 	offset := 1
 

--- a/core/felt/felt_benchmark_test.go
+++ b/core/felt/felt_benchmark_test.go
@@ -117,3 +117,38 @@ func BenchmarkUnmarshalCBOR(b *testing.B) {
 		})
 	}
 }
+
+// BenchmarkUnmarshalCBORByWireSize decodes single felts across every CBOR wire shape a felt can
+// take, from the 5-byte zero encoding to the 37-byte all-uint64 shape that Montgomery form makes
+// near-universal in stored data.
+func BenchmarkUnmarshalCBORByWireSize(b *testing.B) {
+	cases := []struct {
+		name  string
+		limbs [4]uint64
+	}{
+		{"zero (5B)", [4]uint64{0, 0, 0, 0}},
+		{"tiny limbs (5B)", [4]uint64{1, 2, 3, 4}},
+		{"uint8 limbs (9B)", [4]uint64{200, 201, 202, 203}},
+		{"uint16 limbs (13B)", [4]uint64{40_000, 40_001, 40_002, 40_003}},
+		{"uint32 limbs (21B)", [4]uint64{1 << 30, 1 << 30, 1 << 30, 1 << 30}},
+		{"uint64 limbs (37B, canonical)", [4]uint64{1 << 40, 1 << 41, 1 << 42, 1 << 43}},
+		// Worst case for the fixed-shape fast path: three markers match before the last one
+		// fails, so it pays all four compares and then the general loop from scratch.
+		{"near miss (3 uint64 + tiny limb)", [4]uint64{1 << 40, 1 << 41, 1 << 42, 7}},
+		{"mixed limbs (tiny first)", [4]uint64{7, 1 << 40, 40_000, 200}},
+	}
+	for _, tc := range cases {
+		value := fromLimbs[felt.Felt](tc.limbs[0], tc.limbs[1], tc.limbs[2], tc.limbs[3])
+		input, err := value.MarshalCBOR()
+		if err != nil {
+			b.Fatal(err)
+		}
+		b.Run(tc.name, func(b *testing.B) {
+			b.ReportAllocs()
+			var out felt.Felt
+			for b.Loop() {
+				_ = out.UnmarshalCBOR(input)
+			}
+		})
+	}
+}

--- a/core/felt/felt_benchmark_test.go
+++ b/core/felt/felt_benchmark_test.go
@@ -123,19 +123,17 @@ func BenchmarkUnmarshalCBOR(b *testing.B) {
 // near-universal in stored data.
 func BenchmarkUnmarshalCBORByWireSize(b *testing.B) {
 	cases := []struct {
-		name  string
-		limbs [4]uint64
+		name    string
+		limbs   [4]uint64
+		wantLen int
 	}{
-		{"zero (5B)", [4]uint64{0, 0, 0, 0}},
-		{"tiny limbs (5B)", [4]uint64{1, 2, 3, 4}},
-		{"uint8 limbs (9B)", [4]uint64{200, 201, 202, 203}},
-		{"uint16 limbs (13B)", [4]uint64{40_000, 40_001, 40_002, 40_003}},
-		{"uint32 limbs (21B)", [4]uint64{1 << 30, 1 << 30, 1 << 30, 1 << 30}},
-		{"uint64 limbs (37B, canonical)", [4]uint64{1 << 40, 1 << 41, 1 << 42, 1 << 43}},
-		// Worst case for the fixed-shape fast path: three markers match before the last one
-		// fails, so it pays all four compares and then the general loop from scratch.
-		{"near miss (3 uint64 + tiny limb)", [4]uint64{1 << 40, 1 << 41, 1 << 42, 7}},
-		{"mixed limbs (tiny first)", [4]uint64{7, 1 << 40, 40_000, 200}},
+		{"zero (5B)", [4]uint64{0, 0, 0, 0}, 5},
+		{"tiny limbs (5B)", [4]uint64{1, 2, 3, 4}, 5},
+		{"uint8 limbs (9B)", [4]uint64{200, 201, 202, 203}, 9},
+		{"uint16 limbs (13B)", [4]uint64{40_000, 40_001, 40_002, 40_003}, 13},
+		{"uint32 limbs (21B)", [4]uint64{1 << 30, 1 << 30, 1 << 30, 1 << 30}, 21},
+		{"uint64 limbs (37B, canonical)", [4]uint64{1 << 40, 1 << 41, 1 << 42, 1 << 43}, 37},
+		{"mixed limbs (16B)", [4]uint64{7, 1 << 40, 40_000, 200}, 16},
 	}
 	for _, tc := range cases {
 		value := fromLimbs[felt.Felt](tc.limbs[0], tc.limbs[1], tc.limbs[2], tc.limbs[3])
@@ -143,9 +141,15 @@ func BenchmarkUnmarshalCBORByWireSize(b *testing.B) {
 		if err != nil {
 			b.Fatal(err)
 		}
+		if len(input) != tc.wantLen {
+			b.Fatalf("%s: got %d bytes, want %d", tc.name, len(input), tc.wantLen)
+		}
 		b.Run(tc.name, func(b *testing.B) {
 			b.ReportAllocs()
 			var out felt.Felt
+			if err := out.UnmarshalCBOR(input); err != nil {
+				b.Fatal(err)
+			}
 			for b.Loop() {
 				_ = out.UnmarshalCBOR(input)
 			}


### PR DESCRIPTION
### What

`decodeLimbs` now checks whether an encoded felt has the standard 37-byte layout — four limbs, each encoded as a full uint64 — and if so reads the limbs directly from fixed offsets. Anything else falls through to the existing general loop, unchanged.

### Why virtually every stored felt has this exact shape

`felt.Felt` is stored in **Montgomery form**: memory (and therefore CBOR, which dumps the limbs as-is) holds `x·2²⁵⁶ mod p`, not `x`. The multiplication fills all four limbs with full-width values regardless of how small `x` is — the felt `1` is stored as:

```
limb0=0xffffffffffffffe1  limb1=0xffffffffffffffff
limb2=0xffffffffffffffff  limb3=0x07fffffffffffdf0
```

CBOR would encode small limb values compactly, but Montgomery limbs are almost never small: each of the three lower limbs is < 2³² with probability 2⁻³², and the top limb (spanning only ~2⁵⁹, the field being 252 bits) with ~2⁻²⁷ — so a generic felt misses the shape roughly once per hundred million. The exceptions are the zero felt (`0·2²⁵⁶ mod p = 0`, always compact) and round binary constants like `2^k` / `u128::MAX`, whose sparse bit structure survives reduction by the sparse Stark prime.

### Why matching the shape is faster

The general loop must read each limb's header byte, branch on its size class, and only then knows where the next limb starts — four *dependent* decode steps, imposed by the variable-width format. When the shape check passes (one length check plus four fixed-offset byte compares), all limb positions are constants and decoding collapses into four independent 8-byte loads.

### Safety

The shape is **verified per input, never assumed** — a mismatch takes the untouched general loop, so the probability above prices only the speedup, not correctness. Fuzzed for byte-exact equivalence against the generic CBOR decoder (~40M inputs via the existing `FuzzCBORFastPathUnmarshalEquivalence` / `FuzzSliceDecodeCBOREquivalence` harnesses), zero divergences. No storage format change.

### Microbenchmarks (Apple M3 Max, medians)

Single felt by wire shape (`BenchmarkUnmarshalCBORByWireSize`, added in this PR):

| shape | before | after | Δ |
|---|---|---|---|
| **uint64 limbs (37 B — ~all stored felts)** | **6.80 ns** | **4.47 ns** | **−34%** |
| zero (5 B) | 9.21 | 9.00 | noise |
| tiny / uint8 / uint16 / uint32 limbs | 6.7–8.9 | 6.7–8.9 | noise |
| near miss (3×uint64 + tiny — worst case for the check) | 7.49 | 7.53 | noise |

Bulk decode, each path vs itself (`BenchmarkSliceDecodeBySize`, added in this PR): `felt.Slice` −13–15% across sizes 4–4096; generic `[]felt.Felt` ~−10% (both route through the same `decodeLimbs`). Bulk gains are smaller than −34% because bulk decode is partly memory-bound.

### k6 end-to-end (1 VU, 50k iterations, interleaved A/B ×3 rounds, median of rounds)

| method | med | avg | p95 | throughput |
|---|---|---|---|---|
| getBlockWithTxs | -1.3% | -2.1% | -3.3% | +1.5% |
| getBlockWithReceipts | -0.5% (within noise) | -1.0% | -1.5% | +0.3% |
| getTransactionReceipt / getTransactionByHash | ~0 (null controls: felt decode is ~0.05% of a point lookup) | | | |

Small by design at this level — a request's cost is dominated by HTTP/JSON serving and DB reads —
but consistent across every percentile on the felt-decode-heaviest method, and it compounds with
any bulk decode path (sync, filters, migrations).
