### PR TITLE
perf(jsonrpc): drop discarded allocations and chunked response

### DIFF
--- a/jsonrpc/http.go
+++ b/jsonrpc/http.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"maps"
 	"net/http"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -141,6 +142,8 @@ func (h *HTTP) ServeHTTP(writer http.ResponseWriter, req *http.Request) {
 				}
 			}()
 			ioWriter = gw
+		} else if err == nil {
+			writer.Header().Set("Content-Length", strconv.Itoa(len(resp)))
 		}
 		_, err = ioWriter.Write(resp)
 		if err != nil {

--- a/jsonrpc/http_test.go
+++ b/jsonrpc/http_test.go
@@ -272,6 +272,39 @@ func TestGzipResponse(t *testing.T) {
 	})
 }
 
+func TestContentLength(t *testing.T) {
+	logger := log.NewNopZapLogger()
+	rpc := jsonrpc.NewServer(1, logger)
+	require.NoError(t, rpc.RegisterMethods(jsonrpc.Method{
+		Name:    "echo",
+		Params:  []jsonrpc.Parameter{{Name: "msg"}},
+		Handler: func(msg string) (string, *jsonrpc.Error) { return msg, nil },
+	}))
+
+	srv := httptest.NewServer(jsonrpc.NewHTTP(rpc, logger))
+	t.Cleanup(srv.Close)
+	client := new(http.Client)
+
+	// Just over the 2 KB buffer net/http uses to infer a length on its own:
+	// below that the header is set anyway and the test would prove nothing.
+	payload := strings.Repeat("a", 2500)
+	msg := fmt.Sprintf(`{"jsonrpc":"2.0", "method":"echo", "params":[%q], "id":1}`, payload)
+	expected := int64(len(fmt.Sprintf(`{"jsonrpc":"2.0","result":%q,"id":1}`, payload)))
+
+	plain := setHeaderAndProcessRequest(client, map[string]string{"Accept-Encoding": "identity"},
+		bytes.NewReader([]byte(msg)), t, srv)
+	defer plain.Body.Close()
+	require.Empty(t, plain.TransferEncoding)
+	require.Equal(t, expected, plain.ContentLength)
+
+	// A small compressed body still gets a length of its own from net/http.
+	// What must never appear here is the uncompressed length.
+	gzipped := setHeaderAndProcessRequest(client, map[string]string{"Accept-Encoding": "gzip"},
+		bytes.NewReader([]byte(msg)), t, srv)
+	defer gzipped.Body.Close()
+	require.NotEqual(t, expected, gzipped.ContentLength)
+}
+
 func TestGzipResponseReusesWriter(t *testing.T) {
 	logger := log.NewNopZapLogger()
 	rpc := jsonrpc.NewServer(1, logger)

--- a/jsonrpc/http_test.go
+++ b/jsonrpc/http_test.go
@@ -289,20 +289,25 @@ func TestContentLength(t *testing.T) {
 	// below that the header is set anyway and the test would prove nothing.
 	payload := strings.Repeat("a", 2500)
 	msg := fmt.Sprintf(`{"jsonrpc":"2.0", "method":"echo", "params":[%q], "id":1}`, payload)
-	expected := int64(len(fmt.Sprintf(`{"jsonrpc":"2.0","result":%q,"id":1}`, payload)))
+	expected := fmt.Sprintf(`{"jsonrpc":"2.0","result":%q,"id":1}`, payload)
 
 	plain := setHeaderAndProcessRequest(client, map[string]string{"Accept-Encoding": "identity"},
 		bytes.NewReader([]byte(msg)), t, srv)
 	defer plain.Body.Close()
 	require.Empty(t, plain.TransferEncoding)
-	require.Equal(t, expected, plain.ContentLength)
+	require.Equal(t, int64(len(expected)), plain.ContentLength)
+	plainBody, err := io.ReadAll(plain.Body)
+	require.NoError(t, err)
+	require.Equal(t, expected, string(plainBody))
 
 	// A small compressed body still gets a length of its own from net/http.
 	// What must never appear here is the uncompressed length.
 	gzipped := setHeaderAndProcessRequest(client, map[string]string{"Accept-Encoding": "gzip"},
 		bytes.NewReader([]byte(msg)), t, srv)
 	defer gzipped.Body.Close()
-	require.NotEqual(t, expected, gzipped.ContentLength)
+	compressed, err := io.ReadAll(gzipped.Body)
+	require.NoError(t, err)
+	require.Equal(t, int64(len(compressed)), gzipped.ContentLength)
 }
 
 func TestGzipResponseReusesWriter(t *testing.T) {

--- a/jsonrpc/server.go
+++ b/jsonrpc/server.go
@@ -70,8 +70,8 @@ type response struct {
 	ID      any    `json:"id"`
 }
 
-func errResponse(code int, data any) *response {
-	return &response{Version: "2.0", Error: Err(code, data)}
+func errResponse(code int, data any) response {
+	return response{Version: "2.0", Error: Err(code, data)}
 }
 
 type Error struct {
@@ -363,9 +363,9 @@ func (s *Server) HandleReader(ctx context.Context, reader io.Reader) ([]byte, ht
 	if !requestIsBatch {
 		req := new(Request)
 		if jsonErr := dec.Decode(req); jsonErr != nil {
-			resp = errResponse(InvalidJSON, prettyParseError(&errorRecoverBuffer, jsonErr))
+			resp = new(errResponse(InvalidJSON, prettyParseError(&errorRecoverBuffer, jsonErr)))
 		} else if resObject, httpHeader, handleErr := s.handleRequest(ctx, req); handleErr != nil {
-			resp = errResponse(InvalidRequest, handleErr.Error())
+			resp = new(errResponse(InvalidRequest, handleErr.Error()))
 			if !errors.Is(handleErr, ErrInvalidID) {
 				resp.ID = req.ID
 			}
@@ -378,14 +378,14 @@ func (s *Server) HandleReader(ctx context.Context, reader io.Reader) ([]byte, ht
 		var batchReq []json.RawMessage
 
 		if batchJSONErr := dec.Decode(&batchReq); batchJSONErr != nil {
-			resp = errResponse(InvalidJSON, prettyParseError(&errorRecoverBuffer, batchJSONErr))
+			resp = new(errResponse(InvalidJSON, prettyParseError(&errorRecoverBuffer, batchJSONErr)))
 		} else if len(batchReq) == 0 {
-			resp = errResponse(InvalidRequest, "empty batch")
+			resp = new(errResponse(InvalidRequest, "empty batch"))
 		} else {
 			return s.handleBatchRequest(ctx, batchReq)
 		}
 	} else {
-		resp = errResponse(InvalidRequest, "batch requests are disabled")
+		resp = new(errResponse(InvalidRequest, "batch requests are disabled"))
 	}
 
 	if header == nil {
@@ -438,7 +438,7 @@ func (s *Server) handleBatchRequest(ctx context.Context, batchReq []json.RawMess
 
 			resp, header, err := s.handleRequest(ctx, req)
 			if err != nil {
-				resp = errResponse(InvalidRequest, err.Error())
+				resp = new(errResponse(InvalidRequest, err.Error()))
 				if !errors.Is(err, ErrInvalidID) {
 					resp.ID = req.ID
 				}

--- a/jsonrpc/server.go
+++ b/jsonrpc/server.go
@@ -70,6 +70,10 @@ type response struct {
 	ID      any    `json:"id"`
 }
 
+func errResponse(code int, data any) *response {
+	return &response{Version: "2.0", Error: Err(code, data)}
+}
+
 type Error struct {
 	Code    int    `json:"code"`
 	Message string `json:"message"`
@@ -349,11 +353,9 @@ func (s *Server) HandleReader(ctx context.Context, reader io.Reader) ([]byte, ht
 	var errorRecoverBuffer windowBuffer
 	bufferedReader := bufio.NewReaderSize(io.TeeReader(reader, &errorRecoverBuffer), bufferSize)
 	requestIsBatch := isBatch(bufferedReader)
-	resp := &response{
-		Version: "2.0",
-	}
 
-	header := http.Header{}
+	var resp *response
+	var header http.Header
 
 	dec := json.NewDecoder(bufferedReader)
 	dec.UseNumber()
@@ -361,12 +363,12 @@ func (s *Server) HandleReader(ctx context.Context, reader io.Reader) ([]byte, ht
 	if !requestIsBatch {
 		req := new(Request)
 		if jsonErr := dec.Decode(req); jsonErr != nil {
-			resp.Error = Err(InvalidJSON, prettyParseError(&errorRecoverBuffer, jsonErr))
+			resp = errResponse(InvalidJSON, prettyParseError(&errorRecoverBuffer, jsonErr))
 		} else if resObject, httpHeader, handleErr := s.handleRequest(ctx, req); handleErr != nil {
+			resp = errResponse(InvalidRequest, handleErr.Error())
 			if !errors.Is(handleErr, ErrInvalidID) {
 				resp.ID = req.ID
 			}
-			resp.Error = Err(InvalidRequest, handleErr.Error())
 			header = httpHeader
 		} else {
 			resp = resObject
@@ -376,14 +378,18 @@ func (s *Server) HandleReader(ctx context.Context, reader io.Reader) ([]byte, ht
 		var batchReq []json.RawMessage
 
 		if batchJSONErr := dec.Decode(&batchReq); batchJSONErr != nil {
-			resp.Error = Err(InvalidJSON, prettyParseError(&errorRecoverBuffer, batchJSONErr))
+			resp = errResponse(InvalidJSON, prettyParseError(&errorRecoverBuffer, batchJSONErr))
 		} else if len(batchReq) == 0 {
-			resp.Error = Err(InvalidRequest, "empty batch")
+			resp = errResponse(InvalidRequest, "empty batch")
 		} else {
 			return s.handleBatchRequest(ctx, batchReq)
 		}
 	} else {
-		resp.Error = Err(InvalidRequest, "batch requests are disabled")
+		resp = errResponse(InvalidRequest, "batch requests are disabled")
+	}
+
+	if header == nil {
+		header = http.Header{}
 	}
 
 	if resp == nil {

--- a/jsonrpc/server.go
+++ b/jsonrpc/server.go
@@ -428,10 +428,7 @@ func (s *Server) handleBatchRequest(ctx context.Context, batchReq []json.RawMess
 
 		req := new(Request)
 		if err := reqDec.Decode(req); err != nil {
-			addResponse(&response{
-				Version: "2.0",
-				Error:   Err(InvalidRequest, err.Error()),
-			}, http.Header{})
+			addResponse(errResponse(InvalidRequest, err.Error()), http.Header{})
 			continue
 		}
 
@@ -441,10 +438,7 @@ func (s *Server) handleBatchRequest(ctx context.Context, batchReq []json.RawMess
 
 			resp, header, err := s.handleRequest(ctx, req)
 			if err != nil {
-				resp = &response{
-					Version: "2.0",
-					Error:   Err(InvalidRequest, err.Error()),
-				}
+				resp = errResponse(InvalidRequest, err.Error())
 				if !errors.Is(err, ErrInvalidID) {
 					resp.ID = req.ID
 				}


### PR DESCRIPTION
Three small fixes:
1. Don't allocate empty `Header` twice
2. Don't build response that discarded then
3. Set `Content-Length` header to remove extra terminating chunk