### PR TITLE
fix(trie2): stop hashdb dirty cache storing class nodes twice

### DIFF
--- a/core/trie2/triedb/hashdb/database.go
+++ b/core/trie2/triedb/hashdb/database.go
@@ -178,10 +178,8 @@ func (d *Database) Commit(_ *felt.StateRootHash) error {
 	d.dirtyCache.reset()
 
 	d.logger.Debug("Flushed dirty cache to disk",
-		zap.Int("nodes", nodes-d.dirtyCache.len()),
+		zap.Int("nodes", nodes),
 		zap.Duration("duration", time.Since(startTime)),
-		zap.Int("liveNodes", d.dirtyCache.len()),
-		zap.Int("liveSize", d.dirtyCache.size),
 	)
 	return nil
 }

--- a/core/trie2/triedb/hashdb/database_test.go
+++ b/core/trie2/triedb/hashdb/database_test.go
@@ -12,8 +12,10 @@ import (
 	"github.com/NethermindEth/juno/core/trie2/trieutils"
 	"github.com/NethermindEth/juno/db"
 	"github.com/NethermindEth/juno/db/memory"
+	"github.com/NethermindEth/juno/utils/log"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.uber.org/zap/zaptest/observer"
 )
 
 var (
@@ -78,6 +80,22 @@ func verifyNodeInDirtyCache(t *testing.T, database *Database, id trieutils.TrieI
 		id.Bucket() == db.ClassTrie,
 	)
 	assert.True(t, found)
+}
+
+// countEntriesWithPrefix returns the number of entries stored under the given bucket prefix.
+func countEntriesWithPrefix(t *testing.T, store db.KeyValueStore, bucket db.Bucket) int {
+	t.Helper()
+
+	it, err := store.NewIterator(bucket.Key(), true)
+	require.NoError(t, err)
+	defer it.Close()
+
+	count := 0
+	for valid := it.First(); valid; valid = it.Next() {
+		count++
+	}
+
+	return count
 }
 
 func createBinaryNodeBlob(leftHash, rightHash *felt.Felt) []byte {
@@ -282,6 +300,60 @@ func TestDatabase(t *testing.T) {
 			&storagePath,
 			storageNode,
 		)
+	})
+
+	t.Run("Commit writes class nodes only under the class trie bucket", func(t *testing.T) {
+		memDB := memory.New()
+		database := New(memDB, nil)
+
+		err := database.Update(
+			&felt.StateRootHash{},
+			&felt.StateRootHash{},
+			1,
+			createMergeNodeSet(basicClassNodes),
+			nil,
+			nil,
+		)
+		require.NoError(t, err)
+		require.NoError(t, database.Commit(&felt.StateRootHash{}))
+
+		assert.Equal(t, len(basicClassNodes), countEntriesWithPrefix(t, memDB, db.ClassTrie))
+		assert.Zero(t, countEntriesWithPrefix(t, memDB, db.ContractTrieContract))
+		assert.Zero(t, countEntriesWithPrefix(t, memDB, db.ContractTrieStorage))
+	})
+
+	t.Run("Commit writes and reports every storage node of every owner", func(t *testing.T) {
+		memDB := memory.New()
+		database := New(memDB, nil)
+
+		core, recorded := observer.New(log.DEBUG)
+		database.logger = log.NewZapLoggerWithCore(core)
+
+		owner1 := felt.FromUint64[felt.Address](11)
+		owner2 := felt.FromUint64[felt.Address](22)
+		storageNodes := map[felt.Address]map[trieutils.Path]trienode.TrieNode{
+			owner1: {leaf1Path: leaf1Node, leaf2Path: leaf2Node},
+			owner2: {leaf1Path: leaf1Node, leaf2Path: leaf2Node},
+		}
+
+		err := database.Update(
+			&felt.StateRootHash{},
+			&felt.StateRootHash{},
+			1,
+			nil,
+			createContractMergeNodeSet(storageNodes),
+			nil,
+		)
+		require.NoError(t, err)
+		require.NoError(t, database.Commit(&felt.StateRootHash{}))
+
+		assert.Equal(t, 4, countEntriesWithPrefix(t, memDB, db.ContractTrieStorage))
+		assert.Zero(t, countEntriesWithPrefix(t, memDB, db.ClassTrie))
+		assert.Zero(t, countEntriesWithPrefix(t, memDB, db.ContractTrieContract))
+
+		// The flush count must reflect the four storage nodes, not the two owners.
+		require.Equal(t, 1, recorded.Len())
+		assert.Equal(t, int64(4), recorded.All()[0].ContextMap()["nodes"])
 	})
 
 	t.Run("Update and Commit deep trie structure with edge nodes", func(t *testing.T) {

--- a/core/trie2/triedb/hashdb/dirty_cache.go
+++ b/core/trie2/triedb/hashdb/dirty_cache.go
@@ -10,7 +10,6 @@ type dirtyCache struct {
 	classNodes           map[string]trienode.TrieNode
 	contractNodes        map[string]trienode.TrieNode
 	contractStorageNodes map[felt.Address]map[string]trienode.TrieNode
-	size                 int
 }
 
 func newDirtyCache() *dirtyCache {
@@ -33,6 +32,7 @@ func (c *dirtyCache) putNode(
 
 	if isClass {
 		c.classNodes[keyStr] = node
+		return
 	}
 
 	if felt.IsZero(owner) {
@@ -73,12 +73,15 @@ func (c *dirtyCache) getNode(
 }
 
 func (c *dirtyCache) len() int {
-	return len(c.classNodes) + len(c.contractNodes) + len(c.contractStorageNodes)
+	n := len(c.classNodes) + len(c.contractNodes)
+	for _, nodes := range c.contractStorageNodes {
+		n += len(nodes)
+	}
+	return n
 }
 
 func (c *dirtyCache) reset() {
 	c.classNodes = make(map[string]trienode.TrieNode)
 	c.contractNodes = make(map[string]trienode.TrieNode)
 	c.contractStorageNodes = make(map[felt.Address]map[string]trienode.TrieNode)
-	c.size = 0
 }


### PR DESCRIPTION
`dirtyCache.putNode` dispatched on `isClass` without returning, so it fell through into the owner check below. Class nodes are always inserted with a zero owner (`Database.Update`), so every class node landed in both `classNodes` and `contractNodes`, doubling dirty-cache memory and causing `Commit` to persist each class node a second time under the `db.ContractTrieContract` prefix.

Reads were unaffected — `getNode` already early-returns on `isClass`, and disk reads are bucket-prefixed point lookups — so this was silent apart from the wasted memory, write IO, and polluted contract-trie keyspace. Adding the `return` matches the dispatch used by `getNode` and by pathdb's `nodeSet.node`.

Also fixes two accounting defects in the same struct: `len()` summed `len(contractStorageNodes)`, the owner count rather than the storage node count, and `size` was never incremented so `Commit` always logged `liveSize=0`. Drop the dead field and the log fields that only ever reported zero.