### PR TITLE
perf(jsonrpc): rpc request gate

### DIFF
--- a/cmd/juno/juno.go
+++ b/cmd/juno/juno.go
@@ -177,8 +177,8 @@ const (
 	defaultDBMemtableCount                    = 2
 	defaultDBCompression                      = "zstd"
 	defaultRPCRequestTimeout                  = 1 * time.Minute
-	defaultRPCMaxConcurrentRequests           = 256000
-	defaultRPCMaxQueuedRequests               = 256000
+	defaultRPCMaxConcurrentRequests           = 10_000
+	defaultRPCMaxQueuedRequests               = 10_000
 	defaultMaxConcurrentCompilations          = uint64(0)
 	defaultMaxCompilationQueue                = uint64(0)
 	defaultMaxCompilationMemory               = 4 * 1024 // MB (4 GB) per compilation process
@@ -268,9 +268,9 @@ const (
 	dbCompressionUsage = "Database compression profile. Options: zstd, snappy, minlz. " +
 		"Use zstd for low storage."
 	rpcRequestTimeoutUsage        = "Maximum time for an RPC request to complete."
-	rpcMaxConcurrentRequestsUsage = "Maximum concurrent HTTP RPC requests; 0 disables the limit."
-	rpcMaxRequestQueueUsage       = "Maximum number of HTTP RPC requests to queue after " +
-		"reaching rpc-max-concurrent-requests limit."
+	rpcMaxConcurrentRequestsUsage = "Maximum RPC calls executing concurrently. 0 disables the limit."
+	rpcMaxRequestQueueUsage = "Maximum number of RPC calls to queue after reaching " +
+		"rpc-max-concurrent-requests before rejecting."
 	maxConcurrentCompilationsUsage = "Maximum concurrent Sierra compilations. " +
 		"Default is set based on available hardware resources."
 	maxCompilationQueueUsage = "Maximum number of compilation requests to queue after " +

--- a/cmd/juno/juno.go
+++ b/cmd/juno/juno.go
@@ -177,8 +177,8 @@ const (
 	defaultDBMemtableCount                    = 2
 	defaultDBCompression                      = "zstd"
 	defaultRPCRequestTimeout                  = 1 * time.Minute
-	defaultRPCMaxConcurrentRequests           = 10_000
-	defaultRPCMaxQueuedRequests               = 10_000
+	defaultRPCMaxConcurrentRequests           = 20_000
+	defaultRPCMaxQueuedRequests               = 20_000
 	defaultMaxConcurrentCompilations          = uint64(0)
 	defaultMaxCompilationQueue                = uint64(0)
 	defaultMaxCompilationMemory               = 4 * 1024 // MB (4 GB) per compilation process
@@ -269,7 +269,7 @@ const (
 		"Use zstd for low storage."
 	rpcRequestTimeoutUsage        = "Maximum time for an RPC request to complete."
 	rpcMaxConcurrentRequestsUsage = "Maximum RPC calls executing concurrently. 0 disables the limit."
-	rpcMaxRequestQueueUsage = "Maximum number of RPC calls to queue after reaching " +
+	rpcMaxRequestQueueUsage       = "Maximum number of RPC calls to queue after reaching " +
 		"rpc-max-concurrent-requests before rejecting."
 	maxConcurrentCompilationsUsage = "Maximum concurrent Sierra compilations. " +
 		"Default is set based on available hardware resources."

--- a/cmd/juno/juno.go
+++ b/cmd/juno/juno.go
@@ -268,8 +268,10 @@ const (
 	dbCompressionUsage = "Database compression profile. Options: zstd, snappy, minlz. " +
 		"Use zstd for low storage."
 	rpcRequestTimeoutUsage        = "Maximum time for an RPC request to complete."
-	rpcMaxConcurrentRequestsUsage = "Maximum RPC calls executing concurrently. 0 disables the limit."
-	rpcMaxRequestQueueUsage       = "Maximum number of RPC calls to queue after reaching " +
+	rpcMaxConcurrentRequestsUsage = "Maximum RPC calls admitted at once, counted per call " +
+		"rather than per request so a batch cannot exceed it. Applies to HTTP and WebSocket. " +
+		"0 disables the limit."
+	rpcMaxRequestQueueUsage = "Maximum number of RPC calls to queue after reaching " +
 		"rpc-max-concurrent-requests before rejecting."
 	maxConcurrentCompilationsUsage = "Maximum concurrent Sierra compilations. " +
 		"Default is set based on available hardware resources."

--- a/cmd/juno/juno_test.go
+++ b/cmd/juno/juno_test.go
@@ -70,8 +70,8 @@ func TestConfigPrecedence(t *testing.T) {
 	defaultColour := true
 	defaultPreConfirmedPollInterval := 500 * time.Millisecond
 	defaultMaxVMs := uint(3 * runtime.GOMAXPROCS(0))
-	defaultRPCMaxConcurrentRequests := uint(10_000)
-	defaultRPCMaxRequestQueue := uint(10_000)
+	defaultRPCMaxConcurrentRequests := uint(20_000)
+	defaultRPCMaxRequestQueue := uint(20_000)
 	defaultRPCMaxBlockScan := uint(math.MaxUint)
 	defaultMaxCacheSize := uint(1024)
 	defaultMaxHandles := max(int(min(fdLimit/2, 1_048_576)), 1024)

--- a/cmd/juno/juno_test.go
+++ b/cmd/juno/juno_test.go
@@ -70,8 +70,8 @@ func TestConfigPrecedence(t *testing.T) {
 	defaultColour := true
 	defaultPreConfirmedPollInterval := 500 * time.Millisecond
 	defaultMaxVMs := uint(3 * runtime.GOMAXPROCS(0))
-	defaultRPCMaxConcurrentRequests := uint(256000)
-	defaultRPCMaxRequestQueue := uint(256000)
+	defaultRPCMaxConcurrentRequests := uint(10_000)
+	defaultRPCMaxRequestQueue := uint(10_000)
 	defaultRPCMaxBlockScan := uint(math.MaxUint)
 	defaultMaxCacheSize := uint(1024)
 	defaultMaxHandles := max(int(min(fdLimit/2, 1_048_576)), 1024)

--- a/jsonrpc/http.go
+++ b/jsonrpc/http.go
@@ -2,7 +2,6 @@ package jsonrpc
 
 import (
 	"context"
-	"errors"
 	"io"
 	"maps"
 	"net/http"
@@ -19,24 +18,17 @@ import (
 type HTTP struct {
 	rpc    *Server
 	logger log.StructuredLogger
-	// For logging busy warnings without flooding
-	sampledLogger log.StructuredLogger
 
 	listener       NewRequestListener
 	requestTimeout time.Duration
-	gate           *Gate
 }
 
 func NewHTTP(rpc *Server, logger log.StructuredLogger) *HTTP {
-	const busyLogInterval = time.Second
-
-	h := &HTTP{
-		rpc:           rpc,
-		logger:        logger,
-		listener:      &SelectiveListener{},
-		sampledLogger: log.Sampled(logger, busyLogInterval, 1, 0),
+	return &HTTP{
+		rpc:      rpc,
+		logger:   logger,
+		listener: &SelectiveListener{},
 	}
-	return h
 }
 
 // WithListener registers a NewRequestListener
@@ -50,21 +42,6 @@ func (h *HTTP) WithListener(listener NewRequestListener) *HTTP {
 func (h *HTTP) WithRequestTimeout(d time.Duration) *HTTP {
 	h.requestTimeout = d
 	return h
-}
-
-// WithGate sets an admission-control gate that bounds how many requests are
-// processed concurrently (and queued) on this handler
-func (h *HTTP) WithGate(g *Gate) *HTTP {
-	h.gate = g
-	return h
-}
-
-func (h *HTTP) logServerBusy() {
-	h.sampledLogger.Warn("Rejected RPC request: server is busy",
-		zap.Int("running", h.gate.Running()),
-		zap.Int("queued", h.gate.Queued()),
-		zap.Uint64("rejected", h.gate.Rejected()),
-	)
 }
 
 // ServeHTTP processes an incoming HTTP request
@@ -89,25 +66,6 @@ func (h *HTTP) ServeHTTP(writer http.ResponseWriter, req *http.Request) {
 	}
 
 	h.listener.OnNewRequest("any")
-
-	if h.gate != nil {
-		if err := h.gate.Acquire(ctx); err != nil {
-			if errors.Is(err, ErrServerBusy) {
-				h.logServerBusy()
-				writer.Header().Set("Retry-After", "1")
-				http.Error(writer, "Server is busy", http.StatusServiceUnavailable)
-				return
-			}
-			if errors.Is(err, context.DeadlineExceeded) {
-				writer.Header().Set("Retry-After", "1")
-				http.Error(writer, "Request timed out while queued", http.StatusServiceUnavailable)
-				return
-			}
-			// context.Canceled: the client has disconnected, so there is nobody to respond to.
-			return
-		}
-		defer h.gate.Release()
-	}
 
 	const MaxRequestBodySize = 10 * db.Megabyte
 	req.Body = http.MaxBytesReader(writer, req.Body, MaxRequestBodySize)

--- a/jsonrpc/http_test.go
+++ b/jsonrpc/http_test.go
@@ -9,16 +9,12 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"strings"
-	"sync"
 	"testing"
-	"time"
 
 	"github.com/NethermindEth/juno/jsonrpc"
 	"github.com/NethermindEth/juno/utils/log"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"go.uber.org/zap/zapcore"
-	"go.uber.org/zap/zaptest/observer"
 )
 
 func TestHTTP(t *testing.T) {
@@ -93,153 +89,6 @@ func TestHTTP(t *testing.T) {
 		})
 		assert.Len(t, listener.OnNewRequestLogs, 1)
 	})
-}
-
-func TestHTTPRequestGate(t *testing.T) {
-	started := make(chan struct{})
-	release := make(chan struct{})
-	var releaseOnce sync.Once
-	releaseAll := func() { releaseOnce.Do(func() { close(release) }) }
-
-	method := jsonrpc.Method{
-		Name: "block",
-		Handler: func() (string, *jsonrpc.Error) {
-			started <- struct{}{}
-			<-release
-			return "ok", nil
-		},
-	}
-	core, logs := observer.New(zapcore.WarnLevel)
-	logger := log.NewZapLoggerWithCore(core)
-	rpc := jsonrpc.NewServer(1, logger)
-	require.NoError(t, rpc.RegisterMethods(method))
-
-	// Gate with a single slot and no queue: one request runs, the next is rejected.
-	gate := jsonrpc.NewGate(1, 0)
-	httpHandler := jsonrpc.NewHTTP(rpc, logger).WithGate(gate)
-	srv := httptest.NewServer(httpHandler)
-	t.Cleanup(srv.Close)
-	// Registered after srv.Close so it runs first (cleanups are LIFO): it unblocks
-	// the in-flight handler so srv.Close can drain even if the test fails early.
-	t.Cleanup(releaseAll)
-
-	client := new(http.Client)
-	doPost := func() (*http.Response, error) {
-		msg := `{"jsonrpc":"2.0","method":"block","id":1}`
-		req, err := http.NewRequestWithContext(
-			t.Context(), http.MethodPost, srv.URL, bytes.NewReader([]byte(msg)),
-		)
-		if err != nil {
-			return nil, err
-		}
-		return client.Do(req)
-	}
-
-	// First request occupies the only slot and blocks in the handler.
-	firstDone := make(chan struct{})
-	go func() {
-		defer close(firstDone)
-		resp, err := doPost()
-		if assert.NoError(t, err) {
-			assert.Equal(t, http.StatusOK, resp.StatusCode)
-			assert.NoError(t, resp.Body.Close())
-		}
-	}()
-	<-started // the handler is running, so the gate slot is taken
-
-	// Second request: the gate is full, expect an immediate 503 + Retry-After.
-	resp, err := doPost()
-	require.NoError(t, err)
-	assert.Equal(t, http.StatusServiceUnavailable, resp.StatusCode)
-	assert.Equal(t, "1", resp.Header.Get("Retry-After"))
-	require.NoError(t, resp.Body.Close())
-	assert.Equal(t, uint64(1), gate.Rejected())
-	// The rejection is surfaced as a Warn log.
-	assert.Equal(t, 1, logs.FilterMessage("Rejected RPC request: server is busy").Len())
-
-	// GET "/" is never gated, even while the gate is saturated.
-	getReq, err := http.NewRequestWithContext(t.Context(), http.MethodGet, srv.URL, http.NoBody)
-	require.NoError(t, err)
-	getResp, err := client.Do(getReq)
-	require.NoError(t, err)
-	assert.Equal(t, http.StatusOK, getResp.StatusCode)
-	require.NoError(t, getResp.Body.Close())
-
-	// Release the first request and confirm it completed successfully.
-	releaseAll()
-	<-firstDone
-}
-
-func TestHTTPRequestGateTimeout(t *testing.T) {
-	started := make(chan struct{})
-	release := make(chan struct{})
-	var releaseOnce sync.Once
-	releaseAll := func() { releaseOnce.Do(func() { close(release) }) }
-
-	method := jsonrpc.Method{
-		Name: "block",
-		Handler: func() (string, *jsonrpc.Error) {
-			started <- struct{}{}
-			<-release
-			return "ok", nil
-		},
-	}
-	logger := log.NewNopZapLogger()
-	rpc := jsonrpc.NewServer(1, logger)
-	require.NoError(t, rpc.RegisterMethods(method))
-
-	// One slot plus one queue slot: the first request runs, the second queues (instead
-	// of being rejected) and then trips the request timeout while still waiting.
-	gate := jsonrpc.NewGate(1, 1)
-	httpHandler := jsonrpc.NewHTTP(rpc, logger).
-		WithGate(gate).
-		WithRequestTimeout(100 * time.Millisecond)
-	srv := httptest.NewServer(httpHandler)
-	t.Cleanup(srv.Close)
-	// Registered after srv.Close so it runs first (cleanups are LIFO): it unblocks
-	// the in-flight handler so srv.Close can drain even if the test fails early.
-	t.Cleanup(releaseAll)
-
-	client := new(http.Client)
-	doPost := func() (*http.Response, error) {
-		msg := `{"jsonrpc":"2.0","method":"block","id":1}`
-		req, err := http.NewRequestWithContext(
-			t.Context(), http.MethodPost, srv.URL, bytes.NewReader([]byte(msg)),
-		)
-		if err != nil {
-			return nil, err
-		}
-		return client.Do(req)
-	}
-
-	// First request occupies the only slot and blocks in the handler.
-	firstDone := make(chan struct{})
-	go func() {
-		defer close(firstDone)
-		resp, err := doPost()
-		if assert.NoError(t, err) {
-			assert.Equal(t, http.StatusOK, resp.StatusCode)
-			assert.NoError(t, resp.Body.Close())
-		}
-	}()
-	<-started // the handler is running, so the gate slot is taken
-
-	// Second request queues (slot busy, queue has room) and waits. Its server-side
-	// context deadline fires while still queued, so Acquire returns
-	// context.DeadlineExceeded. The client is still connected and must receive an
-	// explicit 503 rather than an empty 200 OK.
-	resp, err := doPost()
-	require.NoError(t, err)
-	assert.Equal(t, http.StatusServiceUnavailable, resp.StatusCode)
-	assert.Equal(t, "1", resp.Header.Get("Retry-After"))
-	body, err := io.ReadAll(resp.Body)
-	require.NoError(t, err)
-	assert.Contains(t, string(body), "Request timed out while queued")
-	require.NoError(t, resp.Body.Close())
-
-	// Release the first request and confirm it still completed successfully.
-	releaseAll()
-	<-firstDone
 }
 
 func TestGzipResponse(t *testing.T) {

--- a/jsonrpc/server.go
+++ b/jsonrpc/server.go
@@ -472,6 +472,8 @@ func (s *Server) logRejected(err error) {
 }
 
 // handleBatchRequest walks a batch one element at a time
+//
+//nolint:gocyclo // one loop handling every step for each request in the batch
 func (s *Server) handleBatchRequest(
 	ctx context.Context,
 	dec *json.Decoder,

--- a/jsonrpc/server.go
+++ b/jsonrpc/server.go
@@ -28,6 +28,7 @@ const (
 	MethodNotFound = -32601 // The method does not exist / is not available.
 	InvalidParams  = -32602 // Invalid method parameter(s).
 	InternalError  = -32603 // Internal JSON-RPC error.
+	ServerBusy = -32000
 )
 
 var (
@@ -97,6 +98,8 @@ func Err(code int, data any) *Error {
 		return &Error{Code: MethodNotFound, Message: "Method Not Found", Data: data}
 	case InvalidParams:
 		return &Error{Code: InvalidParams, Message: "Invalid Params", Data: data}
+	case ServerBusy:
+		return &Error{Code: ServerBusy, Message: "Server busy", Data: data}
 	default:
 		return &Error{Code: InternalError, Message: "Internal error", Data: data}
 	}
@@ -154,6 +157,7 @@ type Server struct {
 	logger               log.StructuredLogger
 	listener             EventListener
 	disableBatchRequests bool
+	callGate *Gate
 }
 
 type Validator interface {
@@ -187,6 +191,14 @@ func (s *Server) WithListener(listener EventListener) *Server {
 // DisableBatchRequests disables batch JSON-RPC requests to the server
 func (s *Server) DisableBatchRequests(forbid bool) *Server {
 	s.disableBatchRequests = forbid
+	return s
+}
+
+// WithCallGate sets an admission-control gate whose unit is a single RPC call
+// rather than a transport request, so that a batch cannot admit more work than
+// the limit
+func (s *Server) WithCallGate(g *Gate) *Server {
+	s.callGate = g
 	return s
 }
 
@@ -364,14 +376,19 @@ func (s *Server) HandleReader(ctx context.Context, reader io.Reader) ([]byte, ht
 		req := new(Request)
 		if jsonErr := dec.Decode(req); jsonErr != nil {
 			resp = new(errResponse(InvalidJSON, prettyParseError(&errorRecoverBuffer, jsonErr)))
-		} else if resObject, httpHeader, handleErr := s.handleRequest(ctx, req); handleErr != nil {
-			resp = new(errResponse(InvalidRequest, handleErr.Error()))
-			if !errors.Is(handleErr, ErrInvalidID) {
-				resp.ID = req.ID
-			}
-			header = httpHeader
+		} else if s.acquireCall(ctx) != nil {
+			resp = new(busyResponse(req.ID))
 		} else {
-			resp = resObject
+			resObject, httpHeader, handleErr := s.handleRequest(ctx, req)
+			s.releaseCall()
+			if handleErr != nil {
+				resp = new(errResponse(InvalidRequest, handleErr.Error()))
+				if !errors.Is(handleErr, ErrInvalidID) {
+					resp.ID = req.ID
+				}
+			} else {
+				resp = resObject
+			}
 			header = httpHeader
 		}
 	} else if !s.disableBatchRequests {
@@ -398,6 +415,25 @@ func (s *Server) HandleReader(ctx context.Context, reader io.Reader) ([]byte, ht
 
 	result, err := json.Marshal(resp)
 	return result, header, err
+}
+
+func (s *Server) acquireCall(ctx context.Context) error {
+	if s.callGate == nil {
+		return nil
+	}
+	return s.callGate.Acquire(ctx)
+}
+
+func (s *Server) releaseCall() {
+	if s.callGate != nil {
+		s.callGate.Release()
+	}
+}
+
+func busyResponse(id any) response {
+	resp := errResponse(ServerBusy, nil)
+	resp.ID = id
+	return resp
 }
 
 func (s *Server) handleBatchRequest(ctx context.Context, batchReq []json.RawMessage) ([]byte, http.Header, error) {
@@ -432,9 +468,15 @@ func (s *Server) handleBatchRequest(ctx context.Context, batchReq []json.RawMess
 			continue
 		}
 
+		if s.acquireCall(ctx) != nil {
+			addResponse(busyResponse(req.ID), http.Header{})
+			continue
+		}
+
 		wg.Add(1)
 		s.pool.Go(func() {
 			defer wg.Done()
+			defer s.releaseCall()
 
 			resp, header, err := s.handleRequest(ctx, req)
 			if err != nil {

--- a/jsonrpc/server.go
+++ b/jsonrpc/server.go
@@ -34,6 +34,8 @@ const (
 var (
 	ErrInvalidID = errors.New("id should be a string or an integer")
 
+	rejectionLogInterval = time.Second
+
 	bufferSize       = 128
 	contextInterface = reflect.TypeOf((*context.Context)(nil)).Elem()
 )
@@ -105,6 +107,17 @@ func Err(code int, data any) *Error {
 	}
 }
 
+func validID(id any) bool {
+	idType := reflect.TypeOf(id)
+	if idType.Kind() != reflect.String && idType.Name() != "Number" {
+		return false
+	}
+	if idType.Name() == "Number" {
+		return !strings.Contains(id.(json.Number).String(), ".")
+	}
+	return true
+}
+
 func (r *Request) isSane() error {
 	if r.Version != "2.0" {
 		return errors.New("unsupported RPC request version")
@@ -120,12 +133,8 @@ func (r *Request) isSane() error {
 		}
 	}
 
-	if r.ID != nil {
-		idType := reflect.TypeOf(r.ID)
-		floating := idType.Name() == "Number" && strings.Contains(r.ID.(json.Number).String(), ".")
-		if (idType.Kind() != reflect.String && idType.Name() != "Number") || floating {
-			return ErrInvalidID
-		}
+	if r.ID != nil && !validID(r.ID) {
+		return ErrInvalidID
 	}
 
 	return nil
@@ -158,6 +167,8 @@ type Server struct {
 	listener             EventListener
 	disableBatchRequests bool
 	callGate             *Gate
+	// For logging rejected warnings without flooding
+	sampledLogger log.StructuredLogger
 }
 
 type Validator interface {
@@ -167,10 +178,11 @@ type Validator interface {
 // NewServer instantiates a JSONRPC server
 func NewServer(poolMaxGoroutines int, logger log.StructuredLogger) *Server {
 	s := &Server{
-		logger:   logger,
-		methods:  make(map[string]Method),
-		pool:     pool.New().WithMaxGoroutines(poolMaxGoroutines),
-		listener: &SelectiveListener{},
+		logger:        logger,
+		methods:       make(map[string]Method),
+		pool:          pool.New().WithMaxGoroutines(poolMaxGoroutines),
+		listener:      &SelectiveListener{},
+		sampledLogger: log.Sampled(logger, rejectionLogInterval, 1, 0),
 	}
 
 	return s
@@ -385,11 +397,11 @@ func (s *Server) HandleReader(ctx context.Context, reader io.Reader) ([]byte, ht
 		req := new(Request)
 		if jsonErr := dec.Decode(req); jsonErr != nil {
 			resp = new(errResponse(InvalidJSON, prettyParseError(&errorRecoverBuffer, jsonErr)))
-		} else if s.acquireCall(ctx) != nil {
-			resp = new(busyResponse(req.ID))
+		} else if gateErr := s.acquireCall(ctx); gateErr != nil {
+			resp = s.rejectCall(req, gateErr)
 		} else {
+			defer s.releaseCall()
 			resObject, httpHeader, handleErr := s.handleRequest(ctx, req)
-			s.releaseCall()
 			if handleErr != nil {
 				resp = new(errResponse(InvalidRequest, handleErr.Error()))
 				if !errors.Is(handleErr, ErrInvalidID) {
@@ -431,10 +443,32 @@ func (s *Server) releaseCall() {
 	}
 }
 
-func busyResponse(id any) response {
+// rejectCall builds the reply for a call the gate turned away, and returns nil
+// when there is nobody to reply to
+func (s *Server) rejectCall(req *Request, err error) *response {
+	s.logRejected(err)
+
+	if errors.Is(err, context.Canceled) || req.ID == nil {
+		return nil
+	}
+
 	resp := errResponse(ServerBusy, nil)
-	resp.ID = id
-	return resp
+	if validID(req.ID) {
+		resp.ID = req.ID
+	}
+	return &resp
+}
+
+func (s *Server) logRejected(err error) {
+	if s.callGate == nil {
+		return
+	}
+	s.sampledLogger.Warn("Rejected RPC call: server is busy",
+		zap.String("cause", err.Error()),
+		zap.Int("running", s.callGate.Running()),
+		zap.Int("queued", s.callGate.Queued()),
+		zap.Uint64("rejected", s.callGate.Rejected()),
+	)
 }
 
 // handleBatchRequest walks a batch one element at a time
@@ -493,8 +527,10 @@ func (s *Server) handleBatchRequest(
 			continue
 		}
 
-		if s.acquireCall(ctx) != nil {
-			addResponse(busyResponse(req.ID), http.Header{})
+		if gateErr := s.acquireCall(ctx); gateErr != nil {
+			if rejected := s.rejectCall(req, gateErr); rejected != nil {
+				addResponse(rejected, http.Header{})
+			}
 			continue
 		}
 

--- a/jsonrpc/server.go
+++ b/jsonrpc/server.go
@@ -28,7 +28,7 @@ const (
 	MethodNotFound = -32601 // The method does not exist / is not available.
 	InvalidParams  = -32602 // Invalid method parameter(s).
 	InternalError  = -32603 // Internal JSON-RPC error.
-	ServerBusy = -32000
+	ServerBusy     = -32000
 )
 
 var (
@@ -157,7 +157,7 @@ type Server struct {
 	logger               log.StructuredLogger
 	listener             EventListener
 	disableBatchRequests bool
-	callGate *Gate
+	callGate             *Gate
 }
 
 type Validator interface {
@@ -173,6 +173,15 @@ func NewServer(poolMaxGoroutines int, logger log.StructuredLogger) *Server {
 		listener: &SelectiveListener{},
 	}
 
+	return s
+}
+
+// WithPool replaces the executor used to run batch elements. Passing one pool
+// to every Server bounds goroutines process-wide rather than per RPC version.
+func (s *Server) WithPool(p *pool.Pool) *Server {
+	if p != nil {
+		s.pool = p
+	}
 	return s
 }
 
@@ -392,15 +401,7 @@ func (s *Server) HandleReader(ctx context.Context, reader io.Reader) ([]byte, ht
 			header = httpHeader
 		}
 	} else if !s.disableBatchRequests {
-		var batchReq []json.RawMessage
-
-		if batchJSONErr := dec.Decode(&batchReq); batchJSONErr != nil {
-			resp = new(errResponse(InvalidJSON, prettyParseError(&errorRecoverBuffer, batchJSONErr)))
-		} else if len(batchReq) == 0 {
-			resp = new(errResponse(InvalidRequest, "empty batch"))
-		} else {
-			return s.handleBatchRequest(ctx, batchReq)
-		}
+		return s.handleBatchRequest(ctx, dec, &errorRecoverBuffer)
 	} else {
 		resp = new(errResponse(InvalidRequest, "batch requests are disabled"))
 	}
@@ -436,7 +437,22 @@ func busyResponse(id any) response {
 	return resp
 }
 
-func (s *Server) handleBatchRequest(ctx context.Context, batchReq []json.RawMessage) ([]byte, http.Header, error) {
+// handleBatchRequest walks a batch one element at a time
+func (s *Server) handleBatchRequest(
+	ctx context.Context,
+	dec *json.Decoder,
+	errorRecoverBuffer *windowBuffer,
+) ([]byte, http.Header, error) {
+	parseErr := func(err error) ([]byte, http.Header, error) {
+		resp := errResponse(InvalidJSON, prettyParseError(errorRecoverBuffer, err))
+		result, marshalErr := json.Marshal(&resp)
+		return result, http.Header{}, marshalErr
+	}
+
+	if _, err := dec.Token(); err != nil { // consumes '['
+		return parseErr(err)
+	}
+
 	var (
 		mutex     sync.Mutex
 		responses []json.RawMessage
@@ -458,7 +474,16 @@ func (s *Server) handleBatchRequest(ctx context.Context, batchReq []json.RawMess
 	defer cancel()
 
 	var wg sync.WaitGroup
-	for _, rawReq := range batchReq {
+	empty := true
+	for dec.More() {
+		empty = false
+
+		var rawReq json.RawMessage
+		if err := dec.Decode(&rawReq); err != nil {
+			wg.Wait()
+			return parseErr(err)
+		}
+
 		reqDec := json.NewDecoder(bytes.NewBuffer(rawReq))
 		reqDec.UseNumber()
 
@@ -494,6 +519,12 @@ func (s *Server) handleBatchRequest(ctx context.Context, batchReq []json.RawMess
 
 	wg.Wait()
 
+	if empty {
+		resp := errResponse(InvalidRequest, "empty batch")
+		result, err := json.Marshal(&resp)
+		return result, http.Header{}, err
+	}
+
 	// merge headers
 	finalHeaders := http.Header{}
 	for _, header := range headers {
@@ -503,7 +534,6 @@ func (s *Server) handleBatchRequest(ctx context.Context, batchReq []json.RawMess
 			}
 		}
 	}
-
 	// according to the spec if there are no response objects server must not return empty array
 	if len(responses) == 0 {
 		return nil, finalHeaders, nil

--- a/jsonrpc/server_test.go
+++ b/jsonrpc/server_test.go
@@ -954,7 +954,7 @@ func TestCallGate(t *testing.T) {
 			Name: "meet",
 			Handler: func() (int, *jsonrpc.Error) {
 				if arrived.Add(1) == concurrent {
-					close(barrier) 
+					close(barrier)
 				}
 				<-barrier
 				return 1, nil
@@ -1019,7 +1019,7 @@ func TestBatchCallGate(t *testing.T) {
 			assert.NoError(t, err)
 			done <- res
 		}()
-		
+
 		require.Eventually(t, func() bool { return entered.Load() == 1 },
 			5*time.Second, time.Millisecond)
 		close(release)

--- a/jsonrpc/server_test.go
+++ b/jsonrpc/server_test.go
@@ -1,12 +1,17 @@
 package jsonrpc_test
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
 	"io"
 	"net"
 	"net/http"
 	"strings"
+	"sync"
+	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/NethermindEth/juno/jsonrpc"
 	"github.com/NethermindEth/juno/utils/log"
@@ -868,4 +873,194 @@ func read(t *testing.T, c io.Reader, length int) string {
 func write(t *testing.T, c io.Writer, data string) {
 	_, err := c.Write([]byte(data))
 	require.NoError(t, err)
+}
+
+// bufReadWriter adapts a request body and a response buffer to io.ReadWriter so
+// that HandleReadWriter, the websocket entry point, can be driven from a test.
+type bufReadWriter struct {
+	r io.Reader
+	w bytes.Buffer
+}
+
+func (rw *bufReadWriter) Read(p []byte) (int, error)  { return rw.r.Read(p) }
+func (rw *bufReadWriter) Write(p []byte) (int, error) { return rw.w.Write(p) }
+
+func TestCallGate(t *testing.T) {
+	const one = `{"jsonrpc":"2.0","id":1,"method":"block"}`
+
+	// newBlockingServer returns a server whose "block" method reports that it
+	// was entered and then waits, so that the caller can hold a gate slot open.
+	newBlockingServer := func(t *testing.T, gate *jsonrpc.Gate) (*jsonrpc.Server, chan struct{}, chan struct{}) {
+		entered := make(chan struct{})
+		release := make(chan struct{})
+		server := jsonrpc.NewServer(4, log.NewNopZapLogger()).WithCallGate(gate)
+		require.NoError(t, server.RegisterMethods(jsonrpc.Method{
+			Name: "block",
+			Handler: func() (int, *jsonrpc.Error) {
+				entered <- struct{}{}
+				<-release
+				return 1, nil
+			},
+		}))
+		return server, entered, release
+	}
+
+	t.Run("http single request is rejected when the gate is full", func(t *testing.T) {
+		server, entered, release := newBlockingServer(t, jsonrpc.NewGate(1, 0))
+		done := make(chan struct{})
+		go func() {
+			defer close(done)
+			_, _, err := server.HandleReader(context.Background(), strings.NewReader(one))
+			assert.NoError(t, err)
+		}()
+		<-entered
+
+		res, _, err := server.HandleReader(t.Context(), strings.NewReader(one))
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"jsonrpc":"2.0","error":{"code":-32000,`+
+			`"message":"Server busy"},"id":1}`, string(res))
+
+		close(release)
+		<-done
+	})
+
+	t.Run("websocket single request is rejected too", func(t *testing.T) {
+		server, entered, release := newBlockingServer(t, jsonrpc.NewGate(1, 0))
+		done := make(chan struct{})
+		go func() {
+			defer close(done)
+			_, _, err := server.HandleReader(context.Background(), strings.NewReader(one))
+			assert.NoError(t, err)
+		}()
+		<-entered
+
+		rw := &bufReadWriter{r: strings.NewReader(one)}
+		require.NoError(t, server.HandleReadWriter(t.Context(), time.Minute, rw))
+		assert.Contains(t, rw.w.String(), `"code":-32000`)
+
+		close(release)
+		<-done
+	})
+
+	t.Run("nil gate admits concurrent calls", func(t *testing.T) {
+		const concurrent = 4
+		const meet = `{"jsonrpc":"2.0","id":1,"method":"meet"}`
+		var wg sync.WaitGroup
+		barrier := make(chan struct{})
+		var arrived atomic.Int64
+
+		server := jsonrpc.NewServer(8, log.NewNopZapLogger()).WithCallGate(nil)
+		require.NoError(t, server.RegisterMethods(jsonrpc.Method{
+			Name: "meet",
+			Handler: func() (int, *jsonrpc.Error) {
+				if arrived.Add(1) == concurrent {
+					close(barrier) 
+				}
+				<-barrier
+				return 1, nil
+			},
+		}))
+
+		for range concurrent {
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				res, _, err := server.HandleReader(context.Background(), strings.NewReader(meet))
+				assert.NoError(t, err)
+				assert.Contains(t, string(res), `"result":1`)
+			}()
+		}
+		wg.Wait()
+	})
+
+	t.Run("a malformed request does not consume a slot", func(t *testing.T) {
+		gate := jsonrpc.NewGate(1, 0)
+		server := jsonrpc.NewServer(4, log.NewNopZapLogger()).WithCallGate(gate)
+		require.NoError(t, server.RegisterMethods(jsonrpc.Method{
+			Name:    "ping",
+			Handler: func() (int, *jsonrpc.Error) { return 1, nil },
+		}))
+
+		res, _, err := server.HandleReader(t.Context(), strings.NewReader(`{bad}`))
+		require.NoError(t, err)
+		require.Contains(t, string(res), `"code":-32700`)
+
+		// The slot must be free, so a well-formed request still succeeds.
+		res, _, err = server.HandleReader(t.Context(),
+			strings.NewReader(`{"jsonrpc":"2.0","id":1,"method":"ping"}`))
+		require.NoError(t, err)
+		assert.Contains(t, string(res), `"result":1`)
+		assert.Zero(t, gate.Running())
+	})
+}
+
+func TestBatchCallGate(t *testing.T) {
+	t.Run("elements beyond the gate get a busy error, the rest succeed", func(t *testing.T) {
+		release := make(chan struct{})
+		var entered atomic.Int64
+		server := jsonrpc.NewServer(8, log.NewNopZapLogger()).
+			WithCallGate(jsonrpc.NewGate(1, 0))
+		require.NoError(t, server.RegisterMethods(jsonrpc.Method{
+			Name: "block",
+			Handler: func() (int, *jsonrpc.Error) {
+				entered.Add(1)
+				<-release
+				return 1, nil
+			},
+		}))
+
+		const three = `[{"jsonrpc":"2.0","id":1,"method":"block"},` +
+			`{"jsonrpc":"2.0","id":2,"method":"block"},` +
+			`{"jsonrpc":"2.0","id":3,"method":"block"}]`
+
+		done := make(chan []byte, 1)
+		go func() {
+			res, _, err := server.HandleReader(context.Background(), strings.NewReader(three))
+			assert.NoError(t, err)
+			done <- res
+		}()
+		
+		require.Eventually(t, func() bool { return entered.Load() == 1 },
+			5*time.Second, time.Millisecond)
+		close(release)
+
+		var out []json.RawMessage
+		require.NoError(t, json.Unmarshal(<-done, &out))
+		require.Len(t, out, 3)
+		busy := 0
+		for _, e := range out {
+			if strings.Contains(string(e), `"code":-32000`) {
+				busy++
+			}
+		}
+		assert.Equal(t, 2, busy)
+		assert.EqualValues(t, 1, entered.Load(), "only one element may have run")
+	})
+
+	t.Run("batch elements run concurrently", func(t *testing.T) {
+		const n = 4
+		var arrived atomic.Int64
+		barrier := make(chan struct{})
+		server := jsonrpc.NewServer(16, log.NewNopZapLogger()).
+			WithCallGate(jsonrpc.NewGate(64, 64))
+		require.NoError(t, server.RegisterMethods(jsonrpc.Method{
+			Name: "meet",
+			Handler: func() (int, *jsonrpc.Error) {
+				if arrived.Add(1) == n {
+					close(barrier)
+				}
+				<-barrier
+				return 1, nil
+			},
+		}))
+
+		elems := make([]string, n)
+		for i := range elems {
+			elems[i] = `{"jsonrpc":"2.0","id":1,"method":"meet"}`
+		}
+		// Deadlocks on the test timeout if the elements do not run concurrently.
+		_, _, err := server.HandleReader(t.Context(),
+			strings.NewReader("["+strings.Join(elems, ",")+"]"))
+		require.NoError(t, err)
+	})
 }

--- a/jsonrpc/server_test.go
+++ b/jsonrpc/server_test.go
@@ -890,9 +890,14 @@ func TestCallGate(t *testing.T) {
 
 	// newBlockingServer returns a server whose "block" method reports that it
 	// was entered and then waits, so that the caller can hold a gate slot open.
-	newBlockingServer := func(t *testing.T, gate *jsonrpc.Gate) (*jsonrpc.Server, chan struct{}, chan struct{}) {
+	newBlockingServer := func(t *testing.T, gate *jsonrpc.Gate) (*jsonrpc.Server, chan struct{}, func()) {
 		entered := make(chan struct{})
 		release := make(chan struct{})
+
+		var once sync.Once
+		unblock := func() { once.Do(func() { close(release) }) }
+		t.Cleanup(unblock)
+
 		server := jsonrpc.NewServer(4, log.NewNopZapLogger()).WithCallGate(gate)
 		require.NoError(t, server.RegisterMethods(jsonrpc.Method{
 			Name: "block",
@@ -902,11 +907,11 @@ func TestCallGate(t *testing.T) {
 				return 1, nil
 			},
 		}))
-		return server, entered, release
+		return server, entered, unblock
 	}
 
 	t.Run("http single request is rejected when the gate is full", func(t *testing.T) {
-		server, entered, release := newBlockingServer(t, jsonrpc.NewGate(1, 0))
+		server, entered, unblock := newBlockingServer(t, jsonrpc.NewGate(1, 0))
 		done := make(chan struct{})
 		go func() {
 			defer close(done)
@@ -920,12 +925,12 @@ func TestCallGate(t *testing.T) {
 		assert.JSONEq(t, `{"jsonrpc":"2.0","error":{"code":-32000,`+
 			`"message":"Server busy"},"id":1}`, string(res))
 
-		close(release)
+		unblock()
 		<-done
 	})
 
 	t.Run("websocket single request is rejected too", func(t *testing.T) {
-		server, entered, release := newBlockingServer(t, jsonrpc.NewGate(1, 0))
+		server, entered, unblock := newBlockingServer(t, jsonrpc.NewGate(1, 0))
 		done := make(chan struct{})
 		go func() {
 			defer close(done)
@@ -938,7 +943,7 @@ func TestCallGate(t *testing.T) {
 		require.NoError(t, server.HandleReadWriter(t.Context(), time.Minute, rw))
 		assert.Contains(t, rw.w.String(), `"code":-32000`)
 
-		close(release)
+		unblock()
 		<-done
 	})
 
@@ -997,6 +1002,10 @@ func TestCallGate(t *testing.T) {
 func TestBatchCallGate(t *testing.T) {
 	t.Run("elements beyond the gate get a busy error, the rest succeed", func(t *testing.T) {
 		release := make(chan struct{})
+		var once sync.Once
+		unblock := func() { once.Do(func() { close(release) }) }
+		t.Cleanup(unblock)
+
 		var entered atomic.Int64
 		server := jsonrpc.NewServer(8, log.NewNopZapLogger()).
 			WithCallGate(jsonrpc.NewGate(1, 0))
@@ -1022,7 +1031,7 @@ func TestBatchCallGate(t *testing.T) {
 
 		require.Eventually(t, func() bool { return entered.Load() == 1 },
 			5*time.Second, time.Millisecond)
-		close(release)
+		unblock()
 
 		var out []json.RawMessage
 		require.NoError(t, json.Unmarshal(<-done, &out))
@@ -1063,4 +1072,23 @@ func TestBatchCallGate(t *testing.T) {
 			strings.NewReader("["+strings.Join(elems, ",")+"]"))
 		require.NoError(t, err)
 	})
+}
+
+func TestCallGateReleasesOnPanic(t *testing.T) {
+	gate := jsonrpc.NewGate(1, 0)
+	server := jsonrpc.NewServer(4, log.NewNopZapLogger()).WithCallGate(gate)
+	require.NoError(t, server.RegisterMethods(jsonrpc.Method{
+		Name:    "boom",
+		Handler: func() (int, *jsonrpc.Error) { panic("handler exploded") },
+	}))
+
+	// net/http recovers per connection; mirror that so the panic does not take
+	// the test binary with it.
+	func() {
+		defer func() { require.NotNil(t, recover(), "handler was expected to panic") }()
+		_, _, _ = server.HandleReader(t.Context(),
+			strings.NewReader(`{"jsonrpc":"2.0","id":1,"method":"boom"}`))
+	}()
+
+	assert.Zero(t, gate.Running(), "slot must be released even when the handler panics")
 }

--- a/node/http.go
+++ b/node/http.go
@@ -103,30 +103,16 @@ func makeRPCOverHTTP(
 	metricsEnabled bool,
 	corsEnabled bool,
 	rpcRequestTimeout time.Duration,
-	maxConcurrentRequests uint,
-	maxRequestQueue uint,
 ) *httpService {
 	var listener jsonrpc.NewRequestListener
 	if metricsEnabled {
 		listener = makeHTTPMetrics()
 	}
 
-	// A single gate shared across all RPC servers (v8/v9/v10) so the limit
-	// protects the whole process, not each version independently. Disabled when
-	// maxConcurrentRequests is 0.
-	var gate *jsonrpc.Gate
-	if maxConcurrentRequests > 0 {
-		gate = jsonrpc.NewGate(maxConcurrentRequests, uint64(maxRequestQueue))
-		if metricsEnabled {
-			makeHTTPGateMetrics(gate)
-		}
-	}
-
 	mux := http.NewServeMux()
 	for path, server := range servers {
 		httpHandler := jsonrpc.NewHTTP(server, logger).
-			WithRequestTimeout(rpcRequestTimeout).
-			WithGate(gate)
+			WithRequestTimeout(rpcRequestTimeout)
 		if listener != nil {
 			httpHandler = httpHandler.WithListener(listener)
 		}

--- a/node/metrics.go
+++ b/node/metrics.go
@@ -26,6 +26,7 @@ const (
 	namespaceSync   = "sync"
 	namespacePruner = "pruner"
 	subsystemHTTP   = "http"
+	subsystemCalls  = "calls"
 )
 
 func makeDBMetrics() db.EventListener {
@@ -107,28 +108,28 @@ func makeHTTPMetrics() jsonrpc.NewRequestListener {
 	}
 }
 
-func makeHTTPGateMetrics(gate *jsonrpc.Gate) {
+func makeCallGateMetrics(gate *jsonrpc.Gate) {
 	active := prometheus.NewGaugeFunc(prometheus.GaugeOpts{
 		Namespace: "rpc",
-		Subsystem: subsystemHTTP,
-		Name:      "active_requests",
-		Help:      "Number of HTTP RPC requests currently being processed",
+		Subsystem: subsystemCalls,
+		Name:      "active",
+		Help:      "Number of RPC calls currently executing, across HTTP and WebSocket",
 	}, func() float64 {
 		return float64(gate.Running())
 	})
 	queued := prometheus.NewGaugeFunc(prometheus.GaugeOpts{
 		Namespace: "rpc",
-		Subsystem: subsystemHTTP,
-		Name:      "queued_requests",
-		Help:      "Number of HTTP RPC requests waiting for a processing slot",
+		Subsystem: subsystemCalls,
+		Name:      "queued",
+		Help:      "Number of RPC calls waiting for an execution slot",
 	}, func() float64 {
 		return float64(gate.Queued())
 	})
 	rejected := prometheus.NewCounterFunc(prometheus.CounterOpts{
 		Namespace: "rpc",
-		Subsystem: subsystemHTTP,
-		Name:      "rejected_requests",
-		Help:      "Total number of HTTP RPC requests rejected because the server was busy",
+		Subsystem: subsystemCalls,
+		Name:      "rejected",
+		Help:      "Total number of RPC calls rejected because the server was busy",
 	}, func() float64 {
 		return float64(gate.Rejected())
 	})

--- a/node/node.go
+++ b/node/node.go
@@ -533,9 +533,15 @@ func New(cfg *Config, version string, logLevel *log.Level) (*Node, error) {
 
 	// to improve RPC throughput we double GOMAXPROCS
 	maxGoroutines := 2 * runtime.GOMAXPROCS(0)
+	maxConcurrentCalls := uint(4 * runtime.GOMAXPROCS(0))
+	callGate := jsonrpc.NewGate(maxConcurrentCalls, uint64(16*maxConcurrentCalls))
+	if cfg.Metrics {
+		makeCallGateMetrics(callGate)
+	}
 
 	jsonrpcServerV10 := jsonrpc.NewServer(maxGoroutines, logger).
 		WithValidator(rpcv10.Validator()).
+		WithCallGate(callGate).
 		DisableBatchRequests(cfg.ForbidRPCBatchRequests)
 	methodsV10, pathV10 := rpcHandler.MethodsV0_10()
 	if err = jsonrpcServerV10.RegisterMethods(methodsV10...); err != nil {
@@ -544,6 +550,7 @@ func New(cfg *Config, version string, logLevel *log.Level) (*Node, error) {
 
 	jsonrpcServerV09 := jsonrpc.NewServer(maxGoroutines, logger).
 		WithValidator(rpcv9.Validator()).
+		WithCallGate(callGate).
 		DisableBatchRequests(cfg.ForbidRPCBatchRequests)
 	methodsV09, pathV09 := rpcHandler.MethodsV0_9()
 	if err = jsonrpcServerV09.RegisterMethods(methodsV09...); err != nil {
@@ -552,6 +559,7 @@ func New(cfg *Config, version string, logLevel *log.Level) (*Node, error) {
 
 	jsonrpcServerV08 := jsonrpc.NewServer(maxGoroutines, logger).
 		WithValidator(rpcv8.Validator()).
+		WithCallGate(callGate).
 		DisableBatchRequests(cfg.ForbidRPCBatchRequests)
 	methodsV08, pathV08 := rpcHandler.MethodsV0_8()
 	if err = jsonrpcServerV08.RegisterMethods(methodsV08...); err != nil {

--- a/node/node.go
+++ b/node/node.go
@@ -533,9 +533,8 @@ func New(cfg *Config, version string, logLevel *log.Level) (*Node, error) {
 	services = append(services, rpcHandler)
 
 	// One pool shared by every RPC server, so the goroutine bound is process-wide
-	// rather than 2*GOMAXPROCS per RPC version. To improve RPC throughput we
-	// double GOMAXPROCS
-	maxGoroutines := 2 * runtime.GOMAXPROCS(0)
+	// rather than per RPC version.
+	maxGoroutines := 6 * runtime.GOMAXPROCS(0)
 	rpcPool := pool.New().WithMaxGoroutines(maxGoroutines)
 
 	// One call gate shared by every RPC server and both transports. Its unit is a

--- a/node/node.go
+++ b/node/node.go
@@ -45,6 +45,7 @@ import (
 	"github.com/NethermindEth/juno/vm"
 	"github.com/consensys/gnark-crypto/ecc/stark-curve/ecdsa"
 	"github.com/sourcegraph/conc"
+	"github.com/sourcegraph/conc/pool"
 	"go.uber.org/zap"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
@@ -531,17 +532,26 @@ func New(cfg *Config, version string, logLevel *log.Level) (*Node, error) {
 
 	services = append(services, rpcHandler)
 
-	// to improve RPC throughput we double GOMAXPROCS
+	// One pool shared by every RPC server, so the goroutine bound is process-wide
+	// rather than 2*GOMAXPROCS per RPC version. To improve RPC throughput we
+	// double GOMAXPROCS
 	maxGoroutines := 2 * runtime.GOMAXPROCS(0)
-	maxConcurrentCalls := uint(4 * runtime.GOMAXPROCS(0))
-	callGate := jsonrpc.NewGate(maxConcurrentCalls, uint64(16*maxConcurrentCalls))
-	if cfg.Metrics {
-		makeCallGateMetrics(callGate)
+	rpcPool := pool.New().WithMaxGoroutines(maxGoroutines)
+
+	// One call gate shared by every RPC server and both transports. Its unit is a
+	// single RPC call, so a batch cannot admit more work than the limit allows.
+	var callGate *jsonrpc.Gate
+	if cfg.RPCMaxConcurrentRequests > 0 {
+		callGate = jsonrpc.NewGate(cfg.RPCMaxConcurrentRequests, uint64(cfg.RPCMaxRequestQueue))
+		if cfg.Metrics {
+			makeCallGateMetrics(callGate)
+		}
 	}
 
 	jsonrpcServerV10 := jsonrpc.NewServer(maxGoroutines, logger).
 		WithValidator(rpcv10.Validator()).
 		WithCallGate(callGate).
+		WithPool(rpcPool).
 		DisableBatchRequests(cfg.ForbidRPCBatchRequests)
 	methodsV10, pathV10 := rpcHandler.MethodsV0_10()
 	if err = jsonrpcServerV10.RegisterMethods(methodsV10...); err != nil {
@@ -551,6 +561,7 @@ func New(cfg *Config, version string, logLevel *log.Level) (*Node, error) {
 	jsonrpcServerV09 := jsonrpc.NewServer(maxGoroutines, logger).
 		WithValidator(rpcv9.Validator()).
 		WithCallGate(callGate).
+		WithPool(rpcPool).
 		DisableBatchRequests(cfg.ForbidRPCBatchRequests)
 	methodsV09, pathV09 := rpcHandler.MethodsV0_9()
 	if err = jsonrpcServerV09.RegisterMethods(methodsV09...); err != nil {
@@ -560,6 +571,7 @@ func New(cfg *Config, version string, logLevel *log.Level) (*Node, error) {
 	jsonrpcServerV08 := jsonrpc.NewServer(maxGoroutines, logger).
 		WithValidator(rpcv8.Validator()).
 		WithCallGate(callGate).
+		WithPool(rpcPool).
 		DisableBatchRequests(cfg.ForbidRPCBatchRequests)
 	methodsV08, pathV08 := rpcHandler.MethodsV0_8()
 	if err = jsonrpcServerV08.RegisterMethods(methodsV08...); err != nil {
@@ -604,8 +616,6 @@ func New(cfg *Config, version string, logLevel *log.Level) (*Node, error) {
 				cfg.Metrics,
 				cfg.RPCCorsEnable,
 				cfg.RPCRequestTimeout,
-				cfg.RPCMaxConcurrentRequests,
-				cfg.RPCMaxRequestQueue,
 			),
 		)
 	}


### PR DESCRIPTION
A JSON-RPC batch consumed a single admission slot no matter how many calls it
carried. WebSocket had no admission control at all

This replaces the transport-level gate with a call-level one, and streams the
batch decode so the whole array is never materialised


###  What changed

1. The gate moved from `HTTP` to `Server`, which sits below the HTTP/WebSocket split, so both transports are
covered by the same limit. There are two acquisition places - the single-request path and the batch dispatch loop.

2. Batches are decoded one element at a time. `handleBatchRequest` now takes the
decoder and walks the array with `dec.More()`, dispatching each element as it is
decoded. Only one `json.RawMessage` is alive at a time instead of the whole array.

3. The outer gate is removed

4. One pool shared across RPC versions. `NewServer` builds its own pool and is
called once per version. `WithPool` injects a single shared pool.


`rpc-max-concurrent-requests` now counts calls rather than transport requests


### Trade-offs

1. 503 becomes a JSON-RPC error. With the outer gate gone there is no HTTP-level
rejection: an admission failure is now `-32000` in the response body with HTTP 200.

2. A malformed batch now runs its valid prefix. We can add ability to return results for finished requests