### PR TITLE
perf(rpc): limit traceTransaction replay to target

### DIFF
--- a/rpc/v10/trace.go
+++ b/rpc/v10/trace.go
@@ -174,6 +174,24 @@ func traceTransactionsWithState(
 	blockInfo *vm.BlockInfo,
 	returnInitialReads bool,
 ) ([]TracedBlockTransaction, *vm.InitialReads, http.Header, *jsonrpc.Error) {
+	return traceTransactionsWithStateOptions(
+		runner,
+		transactions,
+		executionState,
+		classLookupState,
+		blockInfo,
+		vm.TraceOptions{ReturnInitialReads: returnInitialReads},
+	)
+}
+
+func traceTransactionsWithStateOptions(
+	runner vm.VM,
+	transactions []core.Transaction,
+	executionState core.StateReader,
+	classLookupState core.StateReader,
+	blockInfo *vm.BlockInfo,
+	opts vm.TraceOptions,
+) ([]TracedBlockTransaction, *vm.InitialReads, http.Header, *jsonrpc.Error) {
 	httpHeader := defaultExecutionHeader()
 
 	declaredClasses, paidFeesOnL1, err := fetchDeclaredClassesAndL1Fees(
@@ -190,7 +208,7 @@ func traceTransactionsWithState(
 		paidFeesOnL1,
 		blockInfo,
 		executionState,
-		vm.TraceOptions{ReturnInitialReads: returnInitialReads},
+		opts,
 	)
 
 	httpHeader.Set(ExecutionStepsHeader, strconv.FormatUint(executionResult.NumSteps, 10))
@@ -205,6 +223,10 @@ func traceTransactionsWithState(
 	// Adapt traces
 	traces := make([]TracedBlockTransaction, len(executionResult.Traces))
 	for index := range executionResult.Traces {
+		transactionIndex := index
+		if opts.TraceIndex != nil {
+			transactionIndex = int(*opts.TraceIndex)
+		}
 		// Adapt vm transaction trace to rpc v10 trace and add root level execution resources
 		trace := AdaptVMTransactionTrace(&executionResult.Traces[index])
 
@@ -217,9 +239,8 @@ func traceTransactionsWithState(
 		}
 
 		traces[index] = TracedBlockTransaction{
-			TraceRoot: &trace,
-			//nolint:gosec // G602: index bounded by len(Traces) which matches len(transactions)
-			TransactionHash: transactions[index].Hash(),
+			TraceRoot:       &trace,
+			TransactionHash: transactions[transactionIndex].Hash(),
 		}
 	}
 
@@ -275,20 +296,36 @@ func (h *Handler) findAndTraceFinalisedTransaction(
 		return TransactionTrace{}, nil, rpccore.ErrInternal.CloneWithData(err)
 	}
 
-	blockTracesResp, httpHeader, rpcErr := h.traceFinalisedBlock(ctx, header, false)
+	blockTracesResp, transactions, rpcErr := h.traceFinalisedBlockSource(ctx, header, false)
 	if rpcErr != nil {
 		return TransactionTrace{}, nil, rpcErr
 	}
 
 	// txIndex comes from the tx-hash index while the traces come from a later read of the block, so
 	// confirm the trace at that index really is the transaction that was asked for.
-	blockTraces := blockTracesResp.Traces
-	if txIndex >= uint64(len(blockTraces)) ||
-		!blockTraces[txIndex].TransactionHash.Equal((*felt.Felt)(hash)) {
+	if blockTracesResp != nil {
+		blockTraces := blockTracesResp.Traces
+		if txIndex >= uint64(len(blockTraces)) ||
+			!blockTraces[txIndex].TransactionHash.Equal((*felt.Felt)(hash)) {
+			return TransactionTrace{}, nil, rpccore.ErrTxnHashNotFound
+		}
+		return *blockTraces[txIndex].TraceRoot, defaultExecutionHeader(), nil
+	}
+	if txIndex >= uint64(len(transactions)) ||
+		!transactions[txIndex].Hash().Equal((*felt.Felt)(hash)) {
 		return TransactionTrace{}, nil, rpccore.ErrTxnHashNotFound
 	}
-
-	return *blockTraces[txIndex].TraceRoot, httpHeader, nil
+	response, httpHeader, rpcErr := h.traceBlockWithVM(
+		header, transactions[:txIndex+1], false, &txIndex,
+	)
+	if rpcErr != nil {
+		return TransactionTrace{}, httpHeader, rpcErr
+	}
+	if len(response.Traces) != 1 {
+		return TransactionTrace{}, httpHeader,
+			rpccore.ErrUnexpectedError.CloneWithData("missing transaction trace")
+	}
+	return *response.Traces[0].TraceRoot, httpHeader, nil
 }
 
 // findAndTraceInPreConfirmed traces a transaction located in any block of the
@@ -356,6 +393,32 @@ func (h *Handler) traceFinalisedBlock(
 	header *core.Header,
 	returnInitialReads bool,
 ) (TraceBlockTransactionsResponse, http.Header, *jsonrpc.Error) {
+	response, transactions, rpcErr := h.traceFinalisedBlockSource(ctx, header, returnInitialReads)
+	if rpcErr != nil {
+		return TraceBlockTransactionsResponse{}, defaultExecutionHeader(), rpcErr
+	}
+	if response != nil {
+		return *response, defaultExecutionHeader(), nil
+	}
+
+	traced, httpHeader, rpcErr := h.traceBlockWithVM(
+		header, transactions, returnInitialReads, nil,
+	)
+	if rpcErr != nil {
+		return TraceBlockTransactionsResponse{}, httpHeader, rpcErr
+	}
+	h.blockTraceCache.Add(*header.Hash, traced)
+
+	return traced, httpHeader, nil
+}
+
+// traceFinalisedBlockSource returns either a materialized cached/remote response or
+// the transactions needed for a local replay.
+func (h *Handler) traceFinalisedBlockSource(
+	ctx context.Context,
+	header *core.Header,
+	returnInitialReads bool,
+) (*TraceBlockTransactionsResponse, []core.Transaction, *jsonrpc.Error) {
 	// Check if it was already traced. If the caller requested initial reads but
 	// the cached entry was produced without them, fall through to re-trace so we
 	// can populate them (cache gets overwritten below).
@@ -363,25 +426,24 @@ func (h *Handler) traceFinalisedBlock(
 	cachedResponse, hit := h.blockTraceCache.Get(cacheKey)
 	if hit && (!returnInitialReads || cachedResponse.InitialReads != nil) {
 		if returnInitialReads {
-			return cachedResponse, defaultExecutionHeader(), nil
+			return &cachedResponse, nil, nil
 		}
-		return TraceBlockTransactionsResponse{
+		response := TraceBlockTransactionsResponse{
 			Traces:       cachedResponse.Traces,
 			InitialReads: nil,
-		}, defaultExecutionHeader(), nil
+		}
+		return &response, nil, nil
 	}
 
 	fetchFromFeederGW, err := shouldFetchTracesFromFeederGateway(header, h.bcReader.Network())
 	if err != nil {
-		return TraceBlockTransactionsResponse{},
-			defaultExecutionHeader(),
-			rpccore.ErrUnexpectedError.CloneWithData(err.Error())
+		return nil, nil, rpccore.ErrUnexpectedError.CloneWithData(err.Error())
 	}
 
 	if fetchFromFeederGW {
 		traces, rpcErr := h.fetchTracesFromFeederGateway(ctx, header)
 		if rpcErr != nil {
-			return TraceBlockTransactionsResponse{}, defaultExecutionHeader(), rpcErr
+			return nil, nil, rpcErr
 		}
 
 		// The gateway never supplies initial reads, so an empty set is the final answer for these
@@ -397,27 +459,17 @@ func (h *Handler) traceFinalisedBlock(
 			response.InitialReads = nil
 		}
 
-		return response, defaultExecutionHeader(), nil
+		return &response, nil, nil
 	}
 
 	transactions, err := h.bcReader.TransactionsByBlockNumber(header.Number)
 	if err != nil {
 		if errors.Is(err, db.ErrKeyNotFound) {
-			return TraceBlockTransactionsResponse{}, defaultExecutionHeader(), rpccore.ErrBlockNotFound
+			return nil, nil, rpccore.ErrBlockNotFound
 		}
-
-		return TraceBlockTransactionsResponse{},
-			defaultExecutionHeader(),
-			rpccore.ErrInternal.CloneWithData(err)
+		return nil, nil, rpccore.ErrInternal.CloneWithData(err)
 	}
-
-	response, httpHeader, rpcErr := h.traceBlockWithVM(header, transactions, returnInitialReads)
-	if rpcErr != nil {
-		return TraceBlockTransactionsResponse{}, httpHeader, rpcErr
-	}
-	h.blockTraceCache.Add(cacheKey, response)
-
-	return response, httpHeader, nil
+	return nil, transactions, nil
 }
 
 // traceBlockWithVM traces a block using the local VM.
@@ -425,6 +477,7 @@ func (h *Handler) traceBlockWithVM(
 	header *core.Header,
 	transactions []core.Transaction,
 	returnInitialReads bool,
+	traceIndex *uint64,
 ) (TraceBlockTransactionsResponse, http.Header, *jsonrpc.Error) {
 	// Prepare execution state
 	state, closer, err := h.bcReader.StateAtBlockHash(header.ParentHash)
@@ -459,13 +512,13 @@ func (h *Handler) traceBlockWithVM(
 		return TraceBlockTransactionsResponse{}, defaultExecutionHeader(), rpcErr
 	}
 
-	traces, vmInitialReads, httpHeader, rpcErr := traceTransactionsWithState(
+	traces, vmInitialReads, httpHeader, rpcErr := traceTransactionsWithStateOptions(
 		h.vm,
 		transactions,
 		state,
 		headState,
 		&blockInfo,
-		returnInitialReads,
+		vm.TraceOptions{ReturnInitialReads: returnInitialReads, TraceIndex: traceIndex},
 	)
 	if rpcErr != nil {
 		return TraceBlockTransactionsResponse{}, httpHeader, rpcErr

--- a/rpc/v10/trace_test.go
+++ b/rpc/v10/trace_test.go
@@ -422,7 +422,9 @@ func TestTraceTransaction(t *testing.T) {
 			[]*felt.Felt{},
 			&vm.BlockInfo{Header: header},
 			gomock.Any(),
-			vm.TraceOptions{}).Return(vm.ExecutionResults{
+			gomock.Cond(func(opts vm.TraceOptions) bool {
+				return opts.TraceIndex != nil && *opts.TraceIndex == 0
+			})).Return(vm.ExecutionResults{
 			OverallFees: overallFee,
 			GasConsumed: gc,
 			Traces:      []vm.TransactionTrace{vmTrace},
@@ -630,6 +632,59 @@ func TestTraceTransaction(t *testing.T) {
 		assert.Equal(t, "0", httpHeader.Get(rpcv10.ExecutionStepsHeader))
 		assert.Equal(t, expectedRevertedTrace, trace)
 	})
+}
+
+func TestTraceTransactionReplaysOnlyThroughTarget(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	reader := mocks.NewMockReader(ctrl)
+	runner := mocks.NewMockVM(ctrl)
+	state := mocks.NewMockStateReader(ctrl)
+	header := &core.Header{
+		Hash:             felt.NewFromUint64[felt.Felt](1),
+		ParentHash:       felt.NewFromUint64[felt.Felt](2),
+		SequencerAddress: felt.NewFromUint64[felt.Felt](3),
+		L1GasPriceETH:    felt.NewFromUint64[felt.Felt](4),
+		ProtocolVersion:  "99.12.3",
+	}
+	transactions := []core.Transaction{
+		&core.InvokeTransaction{TransactionHash: felt.NewFromUint64[felt.Felt](5)},
+		&core.InvokeTransaction{TransactionHash: felt.NewFromUint64[felt.Felt](6)},
+		&core.InvokeTransaction{TransactionHash: felt.NewFromUint64[felt.Felt](7)},
+	}
+	target := (*felt.TransactionHash)(transactions[1].Hash())
+	vmTrace := readTestData[vm.TransactionTrace](t, "traces/vm_transaction_trace.json")
+
+	reader.EXPECT().Network().Return(&networks.Mainnet).AnyTimes()
+	reader.EXPECT().BlockNumberAndIndexByTxHash(target).Return(header.Number, uint64(1), nil)
+	reader.EXPECT().BlockHeaderByNumber(header.Number).Return(header, nil)
+	reader.EXPECT().TransactionsByBlockNumber(header.Number).Return(transactions, nil)
+	reader.EXPECT().StateAtBlockHash(header.ParentHash).Return(state, nopCloser, nil)
+	reader.EXPECT().HeadState().Return(state, nopCloser, nil)
+	runner.EXPECT().Trace(
+		transactions[:2], []core.ClassDefinition(nil), []*felt.Felt{},
+		&vm.BlockInfo{Header: header}, state, gomock.Any(),
+	).DoAndReturn(func(
+		_ []core.Transaction,
+		_ []core.ClassDefinition,
+		_ []*felt.Felt,
+		_ *vm.BlockInfo,
+		_ core.StateReader,
+		opts vm.TraceOptions,
+	) (vm.ExecutionResults, error) {
+		require.NotNil(t, opts.TraceIndex)
+		require.Equal(t, uint64(1), *opts.TraceIndex)
+		return vm.ExecutionResults{
+			Traces:      []vm.TransactionTrace{vmTrace},
+			GasConsumed: []core.GasConsumed{{L1Gas: 9}},
+			NumSteps:    42,
+		}, nil
+	})
+
+	handler := rpcv10.New(reader, nil, runner, log.NewNopZapLogger())
+	trace, responseHeader, rpcErr := handler.TraceTransaction(t.Context(), target)
+	require.Nil(t, rpcErr)
+	require.Equal(t, "42", responseHeader.Get(rpcv10.ExecutionStepsHeader))
+	require.Equal(t, uint64(9), trace.ExecutionResources.L1Gas)
 }
 
 func TestTraceBlockTransactions(t *testing.T) {
@@ -1497,10 +1552,8 @@ func TestTraceBlockTransactionsInitialReadsCacheCoherence(t *testing.T) {
 		}
 	}
 
-	// After TraceTransaction has cached the block without initial reads,
-	// a follow-up TraceBlockTransactions with RETURN_INITIAL_READS must
-	// re-execute the VM and return populated reads — not the empty struct
-	// that was served from the poisoned cache.
+	// A targeted TraceTransaction replay must not populate the block cache, so a
+	// follow-up request with RETURN_INITIAL_READS replays the complete block.
 	t.Run("TraceTransaction does not poison RETURN_INITIAL_READS", func(t *testing.T) {
 		t.Parallel()
 		mockCtrl := gomock.NewController(t)
@@ -1529,7 +1582,9 @@ func TestTraceBlockTransactionsInitialReadsCacheCoherence(t *testing.T) {
 		// First VM call: no initial reads requested.
 		gomock.InOrder(
 			mockVM.EXPECT().Trace(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), mockState,
-				vm.TraceOptions{},
+				gomock.Cond(func(opts vm.TraceOptions) bool {
+					return opts.TraceIndex != nil && *opts.TraceIndex == 0
+				}),
 			).Return(execResultWithReads(nil), nil),
 			// Second VM call: flag set, VM produces populated reads.
 			mockVM.EXPECT().Trace(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), mockState,

--- a/vm/rust/src/entrypoint/execute/execute.rs
+++ b/vm/rust/src/entrypoint/execute/execute.rs
@@ -3,8 +3,9 @@ use crate::{
         execute::{
             process::{determine_gas_vector_mode, process_transaction},
             utils::{
-                adjust_fee_calculation_result, append_gas_and_fee, append_initial_reads,
-                append_receipt, append_trace, parse_json, transaction_from_api,
+                adjust_fee_calculation_result, append_execution_steps, append_gas_and_fee,
+                append_initial_reads, append_receipt, append_trace, parse_json,
+                transaction_from_api,
             },
         },
         utils::build_block_context,
@@ -20,7 +21,7 @@ use crate::{
 use serde::Deserialize;
 use std::{
     collections::VecDeque,
-    ffi::{c_char, c_uchar},
+    ffi::{c_char, c_longlong, c_uchar},
 };
 
 use blockifier::state::cached_state::CachedState;
@@ -45,6 +46,7 @@ pub fn cairo_vm_execute(
     allow_binary_search: c_uchar,
     is_estimate_fee: c_uchar,
     return_initial_reads: c_uchar,
+    trace_index: c_longlong,
 ) -> Result<(), JunoError> {
     let block_info = unsafe { *block_info_ptr };
     let chain_info = unsafe { *chain_info_ptr };
@@ -78,6 +80,7 @@ pub fn cairo_vm_execute(
     let allow_binary_search = allow_binary_search == 1;
     let is_estimate_fee = is_estimate_fee == 1;
     let return_initial_reads = return_initial_reads == 1;
+    let trace_index = usize::try_from(trace_index).ok();
 
     let mut writer_buffer = Vec::with_capacity(10_000);
 
@@ -162,34 +165,43 @@ pub fn cairo_vm_execute(
             )?
         }
 
-        append_gas_and_fee(&tx_execution_info, reader_handle);
+        let append_result = trace_index.is_none_or(|index| index == txn_index);
+        if append_result {
+            append_gas_and_fee(&tx_execution_info, reader_handle);
+        }
+        append_execution_steps(&tx_execution_info, reader_handle);
 
-        let transaction_receipt = TransactionReceipt {
-            gas: tx_execution_info.receipt.gas,
-            da_gas: tx_execution_info.receipt.da_gas,
-            fee: tx_execution_info.receipt.fee,
-        };
-        append_receipt(reader_handle, &transaction_receipt, &mut writer_buffer)
-            .map_err(|err| JunoError::tx_non_execution_error(err, txn_index))?;
+        if append_result {
+            let transaction_receipt = TransactionReceipt {
+                gas: tx_execution_info.receipt.gas,
+                da_gas: tx_execution_info.receipt.da_gas,
+                fee: tx_execution_info.receipt.fee,
+            };
+            append_receipt(reader_handle, &transaction_receipt, &mut writer_buffer)
+                .map_err(|err| JunoError::tx_non_execution_error(err, txn_index))?;
 
-        let trace = new_transaction_trace(
-            &txn_and_query_bit.txn,
-            tx_execution_info,
-            &mut txn_state,
-            block_context.versioned_constants(),
-            &gas_vector_computation_mode,
-        )
-        .map_err(|err| {
-            JunoError::tx_non_execution_error(
-                format!("failed building txn state diff reason: {err:?}"),
-                txn_index,
+            let trace = new_transaction_trace(
+                &txn_and_query_bit.txn,
+                tx_execution_info,
+                &mut txn_state,
+                block_context.versioned_constants(),
+                &gas_vector_computation_mode,
             )
-        })?;
+            .map_err(|err| {
+                JunoError::tx_non_execution_error(
+                    format!("failed building txn state diff reason: {err:?}"),
+                    txn_index,
+                )
+            })?;
 
-        append_trace(reader_handle, &trace, &mut writer_buffer)
-            .map_err(|err| JunoError::tx_non_execution_error(err, txn_index))?;
+            append_trace(reader_handle, &trace, &mut writer_buffer)
+                .map_err(|err| JunoError::tx_non_execution_error(err, txn_index))?;
+        }
 
         txn_state.commit();
+        if trace_index == Some(txn_index) {
+            break;
+        }
     }
 
     if return_initial_reads {

--- a/vm/rust/src/entrypoint/execute/utils.rs
+++ b/vm/rust/src/entrypoint/execute/utils.rs
@@ -155,15 +155,6 @@ pub fn append_gas_and_fee(tx_execution_info: &TransactionExecutionInfo, reader_h
     let actual_fee: Felt = tx_execution_info.receipt.fee.0.into();
     let da_gas_l1_gas = tx_execution_info.receipt.da_gas.l1_gas.into();
     let da_gas_l1_data_gas = tx_execution_info.receipt.da_gas.l1_data_gas.into();
-    let execution_steps = tx_execution_info
-        .receipt
-        .resources
-        .computation
-        .total_extended_vm_resources()
-        .vm_resources
-        .n_steps
-        .try_into()
-        .unwrap_or(u64::MAX);
     let l1_gas_consumed = tx_execution_info.receipt.gas.l1_gas.into();
     let l1_data_gas_consumed = tx_execution_info.receipt.gas.l1_data_gas.into();
     let l2_gas_consumed = tx_execution_info.receipt.gas.l2_gas.into();
@@ -181,8 +172,21 @@ pub fn append_gas_and_fee(tx_execution_info: &TransactionExecutionInfo, reader_h
             felt_to_byte_array(&l1_data_gas_consumed).as_ptr(),
             felt_to_byte_array(&l2_gas_consumed).as_ptr(),
         );
-        JunoAddExecutionSteps(reader_handle, execution_steps)
     }
+}
+
+pub fn append_execution_steps(tx_execution_info: &TransactionExecutionInfo, reader_handle: usize) {
+    let execution_steps = tx_execution_info
+        .receipt
+        .resources
+        .computation
+        .total_extended_vm_resources()
+        .vm_resources
+        .n_steps
+        .try_into()
+        .unwrap_or(u64::MAX);
+
+    unsafe { JunoAddExecutionSteps(reader_handle, execution_steps) }
 }
 
 pub fn append_trace(

--- a/vm/rust/src/ffi_entrypoint.rs
+++ b/vm/rust/src/ffi_entrypoint.rs
@@ -129,6 +129,7 @@ pub extern "C" fn cairoVMExecute(
     allow_binary_search: c_uchar,
     is_estimate_fee: c_uchar,
     return_initial_reads: c_uchar,
+    trace_index: c_longlong,
 ) {
     panic::catch_unwind(|| {
         cairo_vm_execute(
@@ -146,6 +147,7 @@ pub extern "C" fn cairoVMExecute(
             allow_binary_search,
             is_estimate_fee,
             return_initial_reads,
+            trace_index,
         )
     })
     .map_or_else(

--- a/vm/vm.go
+++ b/vm/vm.go
@@ -55,6 +55,7 @@ type executeOptions struct {
 	AllowBinarySearch  bool
 	IsEstimateFee      bool
 	ReturnInitialReads bool
+	TraceIndex         *uint64
 }
 
 // SimulateOptions carries the flags relevant to RPC simulate.
@@ -74,6 +75,8 @@ type EstimateFeeOptions struct {
 // TraceOptions carries the flags relevant to replaying an existing block.
 type TraceOptions struct {
 	ReturnInitialReads bool
+	// TraceIndex executes through this transaction and returns only its trace.
+	TraceIndex *uint64
 }
 
 // BuildBlockOptions carries flags used when producing a block (builder or
@@ -519,6 +522,10 @@ func (v *vm) execute(
 		return ExecutionResults{}, err
 	}
 	defer inputs.free()
+	traceIndex := C.longlong(-1)
+	if opts.TraceIndex != nil {
+		traceIndex = C.longlong(*opts.TraceIndex)
+	}
 
 	C.cairoVMExecute(
 		inputs.txnsCStr, inputs.classesCStr, inputs.feesCStr,
@@ -532,6 +539,7 @@ func (v *vm) execute(
 		toUchar(opts.IsEstimateFee),
 		//nolint:gocritic // false positive: dupSubExpr with cgo toUchar(opts.ReturnInitialReads),
 		toUchar(opts.ReturnInitialReads),
+		traceIndex,
 	)
 
 	return parseExecutionResults(inputs.context)
@@ -606,6 +614,7 @@ func (v *vm) Trace(
 		executeOptions{
 			ErrStack:           true,
 			ReturnInitialReads: opts.ReturnInitialReads,
+			TraceIndex:         opts.TraceIndex,
 		},
 	)
 }

--- a/vm/vm_ffi.h
+++ b/vm/vm_ffi.h
@@ -63,11 +63,11 @@ extern void cairoVMExecute(
 	unsigned char err_stack,
 	unsigned char allow_binary_search,
 	unsigned char is_estimate_fee,
-	unsigned char return_initial_reads
+	unsigned char return_initial_reads,
+	long long trace_index
 );
 
 extern char* setVersionedConstants(char* json);
 extern void freeString(char* str);
 
 #endif // VM_FFI_H
-


### PR DESCRIPTION
### Throughput

  | VUs | Baseline | Candidate | Change |
  | ---: | ---: | ---: | ---: |
  | 1 | 4.21 req/s | 6.31 req/s | **+49.8%** |
  | 100 | 30.87 req/s | 52.26 req/s | **+69.3%** |
  | 250 | 30.41 req/s | 51.75 req/s | **+70.2%** |
  | 500 | 30.28 req/s | 52.28 req/s | **+72.6%** |

  ### Mean latency

  | VUs | Baseline | Candidate | Change |
  | ---: | ---: | ---: | ---: |
  | 1 | 237 ms | 158 ms | **-33.3%** |
  | 100 | 2.94 s | 1.72 s | **-41.4%** |
  | 250 | 6.73 s | 3.95 s | **-41.3%** |
  | 500 | 11.44 s | 6.69 s | **-41.5%** |


All high-concurrency runs used 1,000 shared requests per run and three alternating A/B rounds. The 1-VU runs used 300 shared requests per run.

