### PR TITLE
 perf(jsonrpc): join batch response bytes instead of re-encoding

### DIFF
--- a/jsonrpc/server.go
+++ b/jsonrpc/server.go
@@ -535,9 +535,8 @@ func (s *Server) handleBatchRequest(ctx context.Context, batchReq []json.RawMess
 		return nil, finalHeaders, nil
 	}
 
-	result, err := json.Marshal(responses)
-
-	return result, finalHeaders, err // todo: fix batch request aggregate header
+	// todo: fix batch request aggregate header
+	return concatBatchResponses(responses), finalHeaders, nil
 }
 
 func isBatch(reader *bufio.Reader) bool {
@@ -566,6 +565,27 @@ func isNilOrEmpty(i any) (bool, error) {
 	default:
 		return false, fmt.Errorf("impossible param type: check request.isSane")
 	}
+}
+
+// concatBatchResponses builds the JSON array from elements that already valid
+// JSON, so it joins bytes instead of re-encoding. json.Marshal would run every
+// byte through compact() again, which is costly
+func concatBatchResponses(responses []json.RawMessage) []byte {
+	size := len(responses) + 1
+	for _, response := range responses {
+		size += len(response)
+	}
+
+	result := make([]byte, 0, size)
+	result = append(result, '[')
+	for i, response := range responses {
+		if i > 0 {
+			result = append(result, ',')
+		}
+		result = append(result, response...)
+	}
+
+	return append(result, ']')
 }
 
 // TODO: add recover() to catch panics from handlers/validators and return a JSON-RPC internal error

--- a/jsonrpc/server_test.go
+++ b/jsonrpc/server_test.go
@@ -1051,3 +1051,37 @@ func TestBatchResponseSizeLimit(t *testing.T) {
 		}
 	})
 }
+
+func TestBatchArrayIsByteIdenticalToJSONMarshal(t *testing.T) {
+	server := jsonrpc.NewServer(1, log.NewNopZapLogger())
+	require.NoError(t, server.RegisterMethods(jsonrpc.Method{
+		Name:    "echo",
+		Params:  []jsonrpc.Parameter{{Name: "data"}},
+		Handler: func(data string) (string, *jsonrpc.Error) { return data, nil },
+	}))
+
+	payloads := []string{
+		"<script>a && b</script>",
+		"line\u2028sep\u2029par",
+		`quote " backslash \`,
+		"",
+	}
+
+	elements := make([]string, len(payloads))
+	for i, payload := range payloads {
+		params, err := json.Marshal([]string{payload})
+		require.NoError(t, err)
+		elements[i] = fmt.Sprintf(`{"jsonrpc":"2.0","id":%d,"method":"echo","params":%s}`, i+1, params)
+	}
+
+	body, _, err := server.HandleReader(t.Context(), strings.NewReader("["+strings.Join(elements, ",")+"]"))
+	require.NoError(t, err)
+
+	var got []json.RawMessage
+	require.NoError(t, json.Unmarshal(body, &got))
+	require.Len(t, got, len(payloads))
+
+	want, err := json.Marshal(got)
+	require.NoError(t, err)
+	assert.Equal(t, string(want), string(body))
+}


### PR DESCRIPTION
<!-- pr-agent-generated -->
### **User description**
`handleBatchRequest` collects each response as a `json.RawMessage`, then packs together with `json.Marshal(responses)`. This is inefficient so this pr joins the bytes directly

  ### Numbers
k6 against a local seoplia, batch requests at 100 VUs

| method | avg batch response size | rps main | rps this pr | |
|---|---|---|---|---|
| `blockNumber` | 4 KB | 378,544 | 403,702 | +6.7% |
| `getBlockWithTxHashes` | 132 KB | 149,079 | 163,22 | +9.5% |
| `getBlockWithReceipts` | 570 KB | 90,420 | 100,113 | +10.7% |
| `getClass` (batch of 10) | 6.6 MB | 2,400 | 2,894 | +20.6% |


___

### **PR Type**
Enhancement, Tests


___

### **Description**
- Join batch JSON response bytes directly

- Avoid re-encoding batch responses in server

- Add byte-identical batch response test


___



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>server.go`</strong><dd><code>Concatenate batch response bytes manually</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

`jsonrpc/server.go`

<ul><li>Replace batch response <code>json.Marshal</code> with byte concatenation<br> <li> Add <code>concatBatchResponses</code> to build JSON array from raw messages</ul>


</details>


  </td>
  <td><a href=""></a></td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>server_test.go`</strong><dd><code>Test batch array matches JSON marshal bytes</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

`jsonrpc/server_test.go`

<ul><li>Add test asserting concatenated batch response matches <code>json.Marshal</code><br> <li> Cover special JSON escaping and empty payload cases</ul>


</details>


  </td>
  <td><a href=""></a></td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

