### PR TITLE
refactor(rpc): use Height() for `latest` case in TransactionByBlockIDAndIndex

### DIFF
--- a/rpc/v10/transaction.go
+++ b/rpc/v10/transaction.go
@@ -431,11 +431,7 @@ func (h *Handler) TransactionByBlockIDAndIndex(
 
 		return AdaptTransaction(tipBlock.Transactions[txIndex], includeProofFacts), nil
 	case blockID.IsLatest():
-		header, err := h.bcReader.HeadsHeader()
-		if err != nil {
-			return Transaction{}, rpccore.ErrBlockNotFound
-		}
-		blockNumber = header.Number
+		blockNumber, err = h.bcReader.Height()
 	case blockID.IsHash():
 		blockNumber, err = h.bcReader.BlockNumberByHash(blockID.Hash())
 	case blockID.IsNumber():

--- a/rpc/v10/transaction_test.go
+++ b/rpc/v10/transaction_test.go
@@ -745,7 +745,7 @@ func TestTransactionByBlockIdAndIndex(t *testing.T) {
 	handler := rpc.New(mockReader, mockSyncReader, nil, nil)
 
 	t.Run("empty blockchain", func(t *testing.T) {
-		mockReader.EXPECT().HeadsHeader().Return(nil, errors.New("empty blockchain"))
+		mockReader.EXPECT().Height().Return(uint64(0), errors.New("empty blockchain"))
 
 		blockID := rpc.BlockIDLatest()
 		txn, rpcErr := handler.TransactionByBlockIDAndIndex(&blockID, rand.Int(), rpc.ResponseFlags{})
@@ -774,7 +774,7 @@ func TestTransactionByBlockIdAndIndex(t *testing.T) {
 	})
 
 	t.Run("negative index", func(t *testing.T) {
-		mockReader.EXPECT().HeadsHeader().Return(nil, errors.New("negative index"))
+		mockReader.EXPECT().Height().Return(uint64(0), errors.New("negative index"))
 
 		blockID := rpc.BlockIDLatest()
 		txn, rpcErr := handler.TransactionByBlockIDAndIndex(&blockID, -1, rpc.ResponseFlags{})
@@ -783,7 +783,7 @@ func TestTransactionByBlockIdAndIndex(t *testing.T) {
 	})
 
 	t.Run("invalid index", func(t *testing.T) {
-		mockReader.EXPECT().HeadsHeader().Return(latestBlock.Header, nil)
+		mockReader.EXPECT().Height().Return(latestBlockNumber, nil)
 
 		blockID := rpc.BlockIDLatest()
 		txn, rpcErr := handler.TransactionByBlockIDAndIndex(

--- a/rpc/v9/transaction.go
+++ b/rpc/v9/transaction.go
@@ -588,11 +588,7 @@ func (h *Handler) TransactionByBlockIDAndIndex(
 
 		return AdaptTransaction(tipBlock.Transactions[txIndex]), nil
 	case latest:
-		header, err := h.bcReader.HeadsHeader()
-		if err != nil {
-			return Transaction{}, rpccore.ErrBlockNotFound
-		}
-		blockNumber = header.Number
+		blockNumber, err = h.bcReader.Height()
 	case hash:
 		blockNumber, err = h.bcReader.BlockNumberByHash(blockID.Hash())
 	case number:

--- a/rpc/v9/transaction_test.go
+++ b/rpc/v9/transaction_test.go
@@ -618,7 +618,7 @@ func TestTransactionByBlockIdAndIndex(t *testing.T) {
 	handler := rpc.New(mockReader, mockSyncReader, nil, nil)
 
 	t.Run("empty blockchain", func(t *testing.T) {
-		mockReader.EXPECT().HeadsHeader().Return(nil, errors.New("empty blockchain"))
+		mockReader.EXPECT().Height().Return(uint64(0), errors.New("empty blockchain"))
 
 		blockID := blockIDLatest(t)
 		txn, rpcErr := handler.TransactionByBlockIDAndIndex(&blockID, rand.Int())
@@ -645,7 +645,7 @@ func TestTransactionByBlockIdAndIndex(t *testing.T) {
 	})
 
 	t.Run("negative index", func(t *testing.T) {
-		mockReader.EXPECT().HeadsHeader().Return(nil, errors.New("negative index"))
+		mockReader.EXPECT().Height().Return(uint64(0), errors.New("negative index"))
 
 		blockID := blockIDLatest(t)
 		txn, rpcErr := handler.TransactionByBlockIDAndIndex(&blockID, -1)
@@ -654,7 +654,7 @@ func TestTransactionByBlockIdAndIndex(t *testing.T) {
 	})
 
 	t.Run("invalid index", func(t *testing.T) {
-		mockReader.EXPECT().HeadsHeader().Return(latestBlock.Header, nil)
+		mockReader.EXPECT().Height().Return(latestBlockNumber, nil)
 
 		blockID := blockIDLatest(t)
 		txn, rpcErr := handler.TransactionByBlockIDAndIndex(&blockID, len(latestBlock.Transactions))


### PR DESCRIPTION
<!-- pr-agent-generated -->
### **PR Type**
Enhancement, Tests


___

### **Description**
- Use Height() for latest block in RPC

- Simplify latest block number resolution

- Update mocks to expect Height()

- Cover v9 and v10 handlers


___



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>transaction.go</strong><dd><code>Use Height for latest block number</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

rpc/v10/transaction.go

<ul><li>Replaced HeadsHeader call with Height for latest block case.<br> <li> Removed header lookup error handling in latest path.</ul>


</details>


  </td>
  <td><a href="https://github.com/NethermindEth/juno/pull/4005/files#diff-2bf78f588837af7f1c162dfa345c14343d7a14e81583f4830a50bedec1dd0f0c">+1/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>transaction.go</strong><dd><code>Use Height for latest block number</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

rpc/v9/transaction.go

<ul><li>Replaced HeadsHeader call with Height for latest block case.<br> <li> Removed header lookup error handling in latest path.</ul>


</details>


  </td>
  <td><a href="https://github.com/NethermindEth/juno/pull/4005/files#diff-0443bd40c3103c942c213e00cace09ed07cdcc98265eceab35301ff10c3f792c">+1/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>transaction_test.go</strong><dd><code>Update latest block mocks to Height</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

rpc/v10/transaction_test.go

<ul><li>Updated latest block mocks from HeadsHeader to Height.<br> <li> Adjusted expected return values and error cases.</ul>


</details>


  </td>
  <td><a href="https://github.com/NethermindEth/juno/pull/4005/files#diff-e32c6ad344c5456c210632c59a1059726f7847d1043256fb8567bfb51dce9ec4">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>transaction_test.go</strong><dd><code>Update latest block mocks to Height</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

rpc/v9/transaction_test.go

<ul><li>Updated latest block mocks from HeadsHeader to Height.<br> <li> Adjusted expected return values and error cases.</ul>


</details>


  </td>
  <td><a href="https://github.com/NethermindEth/juno/pull/4005/files#diff-759d9a5cf2ed2398a9be14a2b70a79cf7bd6c73b1264e7df167ec7daddd23802">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

