### PR TITLE
test(cbor): move CBOR internals out of core/felt

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -44,6 +44,21 @@ linters:
           deny:
             - pkg: github.com/sirupsen/logrus
               desc: use github.com/NethermindEth/juno/utils for logging
+        encoder-engine:
+          files:
+            - "!**/encoder/*.go"
+            # we need to test against fxamacker, the library that wrote every record on disk
+            - "!**/encoder/cbor/*_test.go"
+          deny:
+            - pkg: github.com/fxamacker/cbor/v2
+              desc: use github.com/NethermindEth/juno/encoder, do not use any external CBOR encoder directly
+        cbor-leaf:
+          files:
+            - "**/encoder/cbor/*.go"
+            - "!**/encoder/cbor/*_test.go"
+          deny:
+            - pkg: github.com/NethermindEth/juno
+              desc: encoder/cbor is a leaf, it must not import anything from the node
     funlen:
       lines: 120
       statements: 50

--- a/core/block_transaction_serializer.go
+++ b/core/block_transaction_serializer.go
@@ -1,7 +1,6 @@
 package core
 
 import (
-	"bytes"
 	"fmt"
 	"slices"
 
@@ -13,14 +12,11 @@ import (
 type BlockTransactionsSerializer struct{}
 
 func (BlockTransactionsSerializer) Marshal(value *BlockTransactions) ([]byte, error) {
-	var buf bytes.Buffer
-	if err := encoder.NewEncoder(&buf).Encode(value.Indexes); err != nil {
+	indexes, err := encoder.Marshal(value.Indexes)
+	if err != nil {
 		return nil, err
 	}
-	if _, err := buf.Write(value.Data); err != nil {
-		return nil, err
-	}
-	return buf.Bytes(), nil
+	return slices.Concat(indexes, value.Data), nil
 }
 
 func (BlockTransactionsSerializer) Unmarshal(data []byte, value *BlockTransactions) error {

--- a/core/block_transaction_test.go
+++ b/core/block_transaction_test.go
@@ -10,14 +10,13 @@ import (
 	"github.com/NethermindEth/juno/db/typed/partial"
 	"github.com/NethermindEth/juno/encoder"
 	_ "github.com/NethermindEth/juno/encoder/registry"
-	"github.com/fxamacker/cbor/v2"
 	"github.com/stretchr/testify/require"
 )
 
 const transactionCount = 100
 
-func toCborSeq[T any](items []T) iter.Seq2[cbor.RawMessage, error] {
-	return func(yield func(cbor.RawMessage, error) bool) {
+func toCborSeq[T any](items []T) iter.Seq2[encoder.RawMessage, error] {
+	return func(yield func(encoder.RawMessage, error) bool) {
 		for _, item := range items {
 			cbor, err := encoder.Marshal(item)
 			if err != nil {

--- a/core/felt/cbor.go
+++ b/core/felt/cbor.go
@@ -1,198 +1,34 @@
 package felt
 
 import (
-	"encoding/binary"
-	"math"
+	"github.com/NethermindEth/juno/encoder"
+	"github.com/NethermindEth/juno/encoder/cbor"
+)
 
-	"github.com/consensys/gnark-crypto/ecc/stark-curve/fp"
-	"github.com/fxamacker/cbor/v2"
+var (
+	_ encoder.SelfEncoder = (*Felt)(nil)
+	_ encoder.SelfDecoder = (*Felt)(nil)
 )
 
 // Fast, felt-specialized CBOR marshaling.
 func (z *Felt) MarshalCBOR() ([]byte, error) {
-	data := make([]byte, maxCBORFeltLen)
-	n := encodeLimbs(data, z)
-	return data[:n], nil
+	return cbor.MarshalFelt(z), nil
 }
 
 // Fast, felt-specialized CBOR unmarshaling.
 // Falls back to the generic decoder on shape mismatch
 func (z *Felt) UnmarshalCBOR(data []byte) error {
-	if decodeFelt(data, z) {
+	if cbor.UnmarshalFelt(data, z) {
 		return nil
 	}
-	return cbor.Unmarshal(data, (*fp.Element)(z))
-}
 
-const (
-	// These derive from the CBOR spec
-	// Limb types are always unsigned int
-	// The following numbers represent the unsigned integer size
-	// See: https://www.rfc-editor.org/rfc/rfc8949.html#section-3
-	cborUint8AdditionalInfo  = 24 // 1 byte follows
-	cborUint16AdditionalInfo = 25 // 2 bytes follow
-	cborUint32AdditionalInfo = 26 // 4 bytes follow
-	cborUint64AdditionalInfo = 27 // 8 bytes follow
-
-	// cborArrayMajor the major type that represents an Array
-	// Top 3 bits are the major type (4 = array), low 5 bits are the length.
-	cborArrayMajor = 4 << 5
-
-	// cborArrayHeader4 is the first byte of a CBOR array of Limbs items.
-	// 0b100_00100: an array with Limbs (4) elements.
-	cborArrayHeader4 = cborArrayMajor | Limbs
-
-	// Header + 8 bytes following
-	maxCBORUintLen = 1 + 8
-	// Header + Limbs * maxCBORUintLen
-	maxCBORFeltLen = 1 + Limbs*maxCBORUintLen
-	// Header + Limbs
-	minCBORFeltLen = 1 + Limbs
-)
-
-// encodeLimbs puts one CBOR felt to data, returning the number of bytes written.
-func encodeLimbs[F FeltLike](data []byte, value *F) int {
-	// The format is: [cborArrayHeader4] [limb 0] [limb 1] [limb 2] [limb 3].
-	data[0] = cborArrayHeader4
-
-	offset := 1
-	for limbIndex := range Limbs {
-		limb := (*value)[limbIndex]
-
-		// Starting with the most common path, which is a large limb
-		switch {
-		case limb > math.MaxUint32:
-			data[offset] = cborUint64AdditionalInfo
-			binary.BigEndian.PutUint64(data[offset+1:], limb)
-			offset += 1 + 8
-
-		case limb > math.MaxUint16:
-			data[offset] = cborUint32AdditionalInfo
-			binary.BigEndian.PutUint32(data[offset+1:], uint32(limb))
-			offset += 1 + 4
-
-		case limb > math.MaxUint8:
-			data[offset] = cborUint16AdditionalInfo
-			binary.BigEndian.PutUint16(data[offset+1:], uint16(limb))
-			offset += 1 + 2
-
-		case limb >= cborUint8AdditionalInfo:
-			data[offset] = cborUint8AdditionalInfo
-			data[offset+1] = byte(limb)
-			offset += 2
-
-		default:
-			data[offset] = byte(limb)
-			offset++
-		}
+	// An array has no unmarshal hook, so the engine cannot recurse in here.
+	// A CBOR null decodes as a no-op, so raw has to carry the current value in.
+	raw := [Limbs]uint64(*z)
+	if err := encoder.Unmarshal(data, &raw); err != nil {
+		return err
 	}
 
-	return offset
-}
-
-// decodeLimbs decodes one limb-encoded felt at data[0:],
-// returning the number of bytes consumed and a flag to signal succes.
-// It writes value only on success, so a rejected input can't partially
-// corrupt it before falling back to the generic decoder.
-func decodeLimbs[F FeltLike](data []byte, value *F) (int, bool) {
-	// The data format is: [cborArrayHeader4] [limb 0] [limb 1] [limb 2] [limb 3]
-	if len(data) == 0 || data[0] != cborArrayHeader4 {
-		return 0, false
-	}
-
-	// Header-byte offset of each limb in the all-uint64 shape; the 8-byte payload follows.
-	const (
-		limb0Header = 1
-		limb1Header = limb0Header + maxCBORUintLen
-		limb2Header = limb1Header + maxCBORUintLen
-		limb3Header = limb2Header + maxCBORUintLen
-	)
-
-	// Felts are stored in Montgomery form, so in practice every limb exceeds MaxUint32 and
-	// encodes as a full uint64, giving one fixed 37-byte shape. Decode it without the
-	// per-limb header switch; anything else falls through to the general loop.
-	if len(data) >= maxCBORFeltLen &&
-		data[limb0Header] == cborUint64AdditionalInfo &&
-		data[limb1Header] == cborUint64AdditionalInfo &&
-		data[limb2Header] == cborUint64AdditionalInfo &&
-		data[limb3Header] == cborUint64AdditionalInfo {
-		(*value)[0] = binary.BigEndian.Uint64(data[limb0Header+1 : limb1Header])
-		(*value)[1] = binary.BigEndian.Uint64(data[limb1Header+1 : limb2Header])
-		(*value)[2] = binary.BigEndian.Uint64(data[limb2Header+1 : limb3Header])
-		(*value)[3] = binary.BigEndian.Uint64(data[limb3Header+1 : maxCBORFeltLen])
-		return maxCBORFeltLen, true
-	}
-
-	return decodeVariableLimbs(data, value)
-}
-
-// decodeVariableLimbs decodes the limbs at data[1:] one header byte at a time, covering the shapes
-// the fixed-shape fast path rejects; data[0] must already be a validated array header.
-func decodeVariableLimbs[F FeltLike](data []byte, value *F) (int, bool) {
-	var limbs F
-	offset := 1
-
-	for limbIndex := range Limbs {
-		if offset >= len(data) {
-			return 0, false
-		}
-
-		headerByte := data[offset]
-		offset++
-
-		var limb uint64
-		switch {
-		case headerByte > cborUint64AdditionalInfo: // invalid header byte for uint64
-			return 0, false
-
-		case headerByte == cborUint64AdditionalInfo:
-			if offset+8 > len(data) {
-				return 0, false
-			}
-			limb = binary.BigEndian.Uint64(data[offset:])
-			offset += 8
-
-		case headerByte == cborUint32AdditionalInfo:
-			if offset+4 > len(data) {
-				return 0, false
-			}
-			limb = uint64(binary.BigEndian.Uint32(data[offset:]))
-			offset += 4
-
-		case headerByte == cborUint16AdditionalInfo:
-			if offset+2 > len(data) {
-				return 0, false
-			}
-			limb = uint64(binary.BigEndian.Uint16(data[offset:]))
-			offset += 2
-
-		case headerByte == cborUint8AdditionalInfo:
-			if offset+1 > len(data) {
-				return 0, false
-			}
-			limb = uint64(data[offset])
-			offset++
-
-		default: // headerByte < cborUint8AdditionalInfo
-			limb = uint64(headerByte)
-		}
-
-		limbs[limbIndex] = limb
-	}
-
-	*value = limbs
-	return offset, true
-}
-
-// decodeFelt decodes a single felt that must span all of data, rejecting trailing bytes.
-// It returns a flag to signal success, and writes value only on success.
-func decodeFelt(data []byte, value *Felt) bool {
-	var felt Felt
-	consumed, ok := decodeLimbs(data, &felt)
-	if !ok || consumed != len(data) {
-		return false
-	}
-
-	*value = felt
-	return true
+	*z = Felt(raw)
+	return nil
 }

--- a/core/felt/cbor_fastpath_test.go
+++ b/core/felt/cbor_fastpath_test.go
@@ -1,239 +1,61 @@
 package felt_test
 
 import (
-	"bytes"
-	"math"
-	"math/big"
-	"math/rand"
-	"os"
-	"strconv"
 	"testing"
 
 	"github.com/NethermindEth/juno/core/felt"
 	"github.com/NethermindEth/juno/encoder"
+	"github.com/NethermindEth/juno/encoder/cbor"
 	"github.com/consensys/gnark-crypto/ecc/stark-curve/fp"
 	"github.com/stretchr/testify/require"
 )
 
-// cborArrayHeader is the CBOR header byte for an array of 4 items
-const cborArrayHeader = 0x84
-
-var decodeCornerCases = []struct {
-	name string
-	data []byte
-}{
-	{"empty", []byte{}},
-	{"nil", nil},
-	{"CBOR empty array (not 4 elements)", []byte{0x80}},
-	{"four zero limbs", []byte{cborArrayHeader, 0x00, 0x00, 0x00, 0x00}},
-	{"four-limb array, missing one limb", []byte{cborArrayHeader, 0x00, 0x00, 0x00}},
-	{"four limbs plus trailing byte", []byte{cborArrayHeader, 0x00, 0x00, 0x00, 0x00, 0x00}},
-	{"three-element array", []byte{0x83, 0x00, 0x00, 0x00}},
-	{"five-element array", []byte{0x85, 0x00, 0x00, 0x00, 0x00, 0x00}},
-	{"indefinite-length array", []byte{0x9f, 0x00, 0x00, 0x00, 0x00, 0xff}},
-	{"null", []byte{0xf6}},
-	{"1-byte limb header, missing value byte", []byte{cborArrayHeader, 0x18}},
-	{"2-byte limb header, missing value bytes", []byte{cborArrayHeader, 0x19, 0x00}},
-	{"4-byte limb header, missing value bytes", []byte{cborArrayHeader, 0x1a, 0x00, 0x00, 0x00}},
-	{"8-byte limb header, missing value bytes", []byte{cborArrayHeader, 0x1b, 0, 0, 0, 0, 0, 0, 0}},
-	{"reserved unsigned-integer size code", []byte{cborArrayHeader, 0x1c, 0x00, 0x00, 0x00}},
-	{"negative one as first limb", []byte{cborArrayHeader, 0x20, 0x00, 0x00, 0x00}},
-	{"negative one as every limb", []byte{cborArrayHeader, 0x20, 0x20, 0x20, 0x20}},
-	{"float32 as first limb", []byte{cborArrayHeader, 0xfa, 0x3f, 0xc0, 0x00, 0x00, 0x00, 0x00, 0x00}},
-	{"float64 as first limb", []byte{
-		cborArrayHeader, 0xfb, 0x3f, 0xf8, 0, 0, 0, 0, 0, 0, 0x00, 0x00, 0x00,
-	}},
-}
-
-func encodeBoth(value *felt.Felt) (fast, generic []byte, err error) {
-	fast, err = value.MarshalCBOR()
-	if err != nil {
-		return nil, nil, err
-	}
-	generic, err = encoder.Marshal((*fp.Element)(value))
-	return fast, generic, err
-}
-
-func decodeBoth(data []byte) (fast, generic felt.Felt, errFast, errGeneric error) {
-	errFast = fast.UnmarshalCBOR(data)
-	errGeneric = encoder.Unmarshal(data, (*fp.Element)(&generic))
-	return fast, generic, errFast, errGeneric
-}
-
-func requireMarshalEquivalent(t *testing.T, value *felt.Felt) []byte {
+func requireAgreesWithEngine(t *testing.T, data []byte) (decoded felt.Felt, ok bool) {
 	t.Helper()
 
-	fast, generic, err := encodeBoth(value)
-	require.NoError(t, err)
-	require.Equal(t, generic, fast, "fast marshal disagrees with generic marshal")
-	return fast
-}
+	var fast, generic felt.Felt
+	errFast := fast.UnmarshalCBOR(data)
+	errGeneric := encoder.Unmarshal(data, (*fp.Element)(&generic))
 
-func requireUnmarshalEquivalent(t *testing.T, data []byte) (decoded felt.Felt, ok bool) {
-	t.Helper()
-
-	fast, generic, errFast, errGeneric := decodeBoth(data)
 	if errGeneric != nil {
-		require.Error(t, errFast, "fast decoder accepted input the generic decoder rejected: % x", data)
+		require.Error(t, errFast, "took a payload the engine refuses: % x", data)
 		return felt.Felt{}, false
 	}
-	require.NoError(t, errFast, "fast decoder rejected input the generic decoder accepted: % x", data)
-	require.True(t, fast.Equal(&generic), "decoded value mismatch for % x: fast=%s generic=%s",
+	require.NoError(t, errFast, "refused a payload the engine takes: % x", data)
+	require.True(t, fast.Equal(&generic), "read % x differently: fast=%s engine=%s",
 		data, fast.String(), generic.String())
+
 	return fast, true
 }
 
-func feltFromBigInt(n *big.Int) felt.Felt {
-	var value felt.Felt
-	value.SetBigInt(n)
-	return value
-}
+func TestFeltAccepted(t *testing.T) {
+	for _, shape := range cbor.FeltAccepted {
+		t.Run(shape.Name, func(t *testing.T) {
+			decoded, ok := requireAgreesWithEngine(t, shape.Data)
+			require.True(t, ok, "refused a payload it has to take")
 
-// fromLimbs bypasses SetBigInt's Montgomery conversion, so a small
-// argument here actually lands in a limb. SetBigInt() does not.
-func fromLimbs[F felt.FeltLike](limbs ...uint64) F {
-	var l [4]uint64
-	copy(l[:], limbs)
-	return F(fp.Element(l))
-}
-
-func TestCBORFastPathValues(t *testing.T) {
-	type valueCase struct {
-		name  string
-		value felt.Felt
-	}
-
-	cases := []valueCase{
-		{"zero", feltFromBigInt(big.NewInt(0))},
-	}
-	for _, boundary := range []struct {
-		name string
-		limb uint64
-	}{
-		{"one", 1},
-		{"largest inline", 23},
-		{"smallest 1-byte", 24},
-		{"largest 1-byte (max uint8)", math.MaxUint8},
-		{"smallest 2-byte", math.MaxUint8 + 1},
-		{"largest 2-byte (max uint16)", math.MaxUint16},
-		{"smallest 4-byte", math.MaxUint16 + 1},
-		{"largest 4-byte (max uint32)", math.MaxUint32},
-		{"smallest 8-byte", math.MaxUint32 + 1},
-		{"largest 8-byte (max uint64)", math.MaxUint64},
-	} {
-		cases = append(cases, valueCase{"limb: " + boundary.name, fromLimbs[felt.Felt](boundary.limb)})
-	}
-	cases = append(cases, valueCase{
-		"limb: boundary values spread across all four limbs",
-		fromLimbs[felt.Felt](23, math.MaxUint8, math.MaxUint16, math.MaxUint64),
-	})
-
-	// Starknet's default modulus for felts.
-	modulus, ok := new(big.Int).SetString(
-		"3618502788666131213697322783095070105623107215331596699973092056135872020481",
-		10,
-	)
-	require.True(t, ok)
-	largestFelt := new(big.Int).Sub(modulus, big.NewInt(1))
-
-	cases = append(cases,
-		valueCase{"field modulus (reduces to zero)", feltFromBigInt(modulus)},
-		valueCase{"largest valid felt (modulus - 1)", feltFromBigInt(largestFelt)},
-		valueCase{"half of largest valid felt", feltFromBigInt(new(big.Int).Rsh(largestFelt, 1))},
-	)
-
-	for _, tc := range cases {
-		t.Run(tc.name, func(t *testing.T) {
-			original := tc.value
-
-			encoded := requireMarshalEquivalent(t, &original)
-			require.NotEmpty(t, encoded)
-			require.Equal(t, byte(cborArrayHeader), encoded[0], "MarshalCBOR shape changed")
-
-			decoded, ok := requireUnmarshalEquivalent(t, encoded)
-			require.True(t, ok)
-			require.True(t, original.Equal(&decoded), "round trip changed the value")
+			written, err := decoded.MarshalCBOR()
+			require.NoError(t, err)
+			require.Equal(t, shape.Data, written, "wrote it back differently")
 		})
 	}
 }
 
-func TestCBORFastPathDecodeCornerCases(t *testing.T) {
-	for _, tc := range decodeCornerCases {
-		t.Run(tc.name, func(t *testing.T) {
-			requireUnmarshalEquivalent(t, tc.data)
+// The hook falls back to the engine, so they can never disagree.
+func TestFeltRejected(t *testing.T) {
+	for _, shape := range cbor.FeltRejected {
+		t.Run(shape.Name, func(t *testing.T) {
+			requireAgreesWithEngine(t, shape.Data)
 		})
 	}
 }
 
-// FELT_CBOR_STRESS_N=1000000000 go test ./core/felt/... -run TestCBORFastPathStress -v -timeout 2h
-func TestCBORFastPathStress(t *testing.T) {
-	raw := os.Getenv("FELT_CBOR_STRESS_N")
-	if raw == "" {
-		t.Skip("set FELT_CBOR_STRESS_N (e.g. 1000000000) to run this sweep")
-	}
-	n, err := strconv.ParseUint(raw, 10, 64)
-	require.NoError(t, err)
-
-	rng := rand.New(rand.NewSource(1))
-	const logEvery = 50_000_000
-
-	for i := range n {
-		value := fromLimbs[felt.Felt](rng.Uint64(), rng.Uint64(), rng.Uint64(), rng.Uint64())
-
-		fast, generic, err := encodeBoth(&value)
-		require.NoError(t, err)
-		require.True(t, bytes.Equal(fast, generic))
-
-		fastDecoded, genericDecoded, errFast, errGeneric := decodeBoth(fast)
-		require.NoError(t, errFast)
-		require.NoError(t, errGeneric)
-		require.True(t, fastDecoded.Equal(&genericDecoded))
-
-		if i > 0 && i%logEvery == 0 {
-			t.Logf("checked %d/%d", i, n)
-		}
-	}
-	t.Logf("checked %d random felts, 0 mismatches", n)
-}
-
-func FuzzCBORFastPathUnmarshalEquivalence(f *testing.F) {
-	for _, value := range []uint64{
-		0, 1, 23, 24, 255, 256, 65535, 65536, 1 << 32, 1 << 63,
-	} {
-		var valueFelt felt.Felt
-		valueFelt.SetUint64(value)
-
-		encoded, err := valueFelt.MarshalCBOR()
-		require.NoError(f, err)
-
-		f.Add(encoded)
-	}
-
-	for _, tc := range decodeCornerCases {
-		f.Add(tc.data)
+func FuzzFelt(f *testing.F) {
+	for _, shape := range append(cbor.FeltAccepted, cbor.FeltRejected...) {
+		f.Add(shape.Data)
 	}
 
 	f.Fuzz(func(t *testing.T, data []byte) {
-		requireUnmarshalEquivalent(t, data)
-	})
-}
-
-func FuzzCBORFastPathMarshalEquivalence(f *testing.F) {
-	f.Add(uint64(0), uint64(0), uint64(0), uint64(0))
-	f.Add(uint64(1), uint64(0), uint64(0), uint64(0))
-	f.Add(uint64(23), uint64(24), uint64(255), uint64(256))
-	f.Add(uint64(65535), uint64(65536), uint64(1)<<32, uint64(1)<<63)
-	f.Add(
-		uint64(math.MaxUint8), uint64(math.MaxUint16),
-		uint64(math.MaxUint32), uint64(math.MaxUint64),
-	)
-	f.Add(
-		uint64(math.MaxUint64), uint64(math.MaxUint64),
-		uint64(math.MaxUint64), uint64(math.MaxUint64),
-	)
-
-	f.Fuzz(func(t *testing.T, l0, l1, l2, l3 uint64) {
-		value := fromLimbs[felt.Felt](l0, l1, l2, l3)
-		requireMarshalEquivalent(t, &value)
+		requireAgreesWithEngine(t, data)
 	})
 }

--- a/core/felt/cbor_fastpath_test.go
+++ b/core/felt/cbor_fastpath_test.go
@@ -10,8 +10,8 @@ import (
 	"testing"
 
 	"github.com/NethermindEth/juno/core/felt"
+	"github.com/NethermindEth/juno/encoder"
 	"github.com/consensys/gnark-crypto/ecc/stark-curve/fp"
-	"github.com/fxamacker/cbor/v2"
 	"github.com/stretchr/testify/require"
 )
 
@@ -50,13 +50,13 @@ func encodeBoth(value *felt.Felt) (fast, generic []byte, err error) {
 	if err != nil {
 		return nil, nil, err
 	}
-	generic, err = cbor.Marshal((*fp.Element)(value))
+	generic, err = encoder.Marshal((*fp.Element)(value))
 	return fast, generic, err
 }
 
 func decodeBoth(data []byte) (fast, generic felt.Felt, errFast, errGeneric error) {
 	errFast = fast.UnmarshalCBOR(data)
-	errGeneric = cbor.Unmarshal(data, (*fp.Element)(&generic))
+	errGeneric = encoder.Unmarshal(data, (*fp.Element)(&generic))
 	return fast, generic, errFast, errGeneric
 }
 

--- a/core/felt/ctors_test.go
+++ b/core/felt/ctors_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/NethermindEth/juno/core/felt"
+	"github.com/consensys/gnark-crypto/ecc/stark-curve/fp"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -113,4 +114,12 @@ func TestRandomCtor(t *testing.T) {
 	assert.NotPanics(t, func() {
 		felt.NewRandom[feltoid]()
 	})
+}
+
+// fromLimbs bypasses SetBigInt's Montgomery conversion, so a small
+// argument here actually lands in a limb. SetBigInt() does not.
+func fromLimbs[F felt.FeltLike](limbs ...uint64) F {
+	var l [4]uint64
+	copy(l[:], limbs)
+	return F(fp.Element(l))
 }

--- a/core/felt/felt_test.go
+++ b/core/felt/felt_test.go
@@ -14,7 +14,13 @@ import (
 
 func TestFeltCbor(t *testing.T) {
 	val := felt.NewRandom[felt.Felt]()
-	encoder.TestSymmetry(t, val)
+
+	encoded, err := encoder.Marshal(val)
+	require.NoError(t, err)
+
+	var decoded felt.Felt
+	require.NoError(t, encoder.Unmarshal(encoded, &decoded))
+	assert.Equal(t, val, &decoded)
 }
 
 func TestShortString(t *testing.T) {

--- a/core/felt/felt_test.go
+++ b/core/felt/felt_test.go
@@ -3,6 +3,7 @@ package felt_test
 import (
 	"encoding"
 	"encoding/json"
+	"math/big"
 	"strings"
 	"testing"
 
@@ -394,7 +395,8 @@ func FuzzFeltUnmarshal(f *testing.F) {
 
 		reference, err := new(felt.Felt).SetString(string(data[1 : len(data)-1]))
 		require.NoError(t, err, "accepted %q that SetString rejects", data)
-		assert.True(t, decoded.Equal(reference), "input %q: got %s want %s",
+		assert.True(
+			t, decoded.Equal(reference), "input %q: got %s want %s",
 			data, decoded.String(), reference.String(),
 		)
 
@@ -405,4 +407,35 @@ func FuzzFeltUnmarshal(f *testing.F) {
 		require.NoError(t, json.Unmarshal(marshalled, &roundTrip))
 		assert.True(t, decoded.Equal(&roundTrip))
 	})
+}
+
+func TestSetBigInt(t *testing.T) {
+	// Starknet's field modulus.
+	modulus, ok := new(big.Int).SetString(
+		"3618502788666131213697322783095070105623107215331596699973092056135872020481",
+		10,
+	)
+	require.True(t, ok)
+
+	for _, test := range []struct {
+		name  string
+		value *big.Int
+		want  *felt.Felt
+	}{
+		{"zero", big.NewInt(0), new(felt.Felt)},
+		{"one", big.NewInt(1), new(felt.Felt).SetUint64(1)},
+		{"the modulus reduces to zero", modulus, new(felt.Felt)},
+		{
+			"one past the modulus wraps to one", new(big.Int).Add(modulus, big.NewInt(1)),
+			new(felt.Felt).SetUint64(1),
+		},
+		{
+			"negative one is the modulus minus one",
+			big.NewInt(-1), new(felt.Felt).SetBigInt(new(big.Int).Sub(modulus, big.NewInt(1))),
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			assert.Equal(t, test.want, new(felt.Felt).SetBigInt(test.value))
+		})
+	}
 }

--- a/core/felt/slice.go
+++ b/core/felt/slice.go
@@ -1,130 +1,31 @@
 package felt
 
 import (
-	"encoding/binary"
-	"math"
-
-	"github.com/fxamacker/cbor/v2"
+	"github.com/NethermindEth/juno/encoder"
+	"github.com/NethermindEth/juno/encoder/cbor"
 )
 
 type Slice[F FeltLike] []F
 
-const (
-	// maxCBORArrayHeaderLen: 1 major/info byte + 4 length bytes (uint32)
-	maxCBORArrayHeaderLen = 1 + 4
-
-	// cborNull is the CBOR encoding of null, which the generic encoder emits for a nil slice.
-	cborNull = 0xf6
+var (
+	_ encoder.SelfEncoder = Slice[Felt](nil)
+	_ encoder.SelfDecoder = (*Slice[Felt])(nil)
 )
 
 func (s Slice[F]) MarshalCBOR() ([]byte, error) {
-	if s == nil {
-		return []byte{cborNull}, nil
-	}
-
-	data := make([]byte, maxCBORArrayHeaderLen+len(s)*maxCBORFeltLen)
-
-	offset := encodeCBORArrayHeader(data, uint32(len(s)))
-	for idx := range s {
-		offset += encodeLimbs(data[offset:], &s[idx])
-	}
-
-	return data[:offset], nil
+	return cbor.MarshalFeltSlice(s), nil
 }
 
 func (s *Slice[F]) UnmarshalCBOR(data []byte) error {
-	size, offset, ok := decodeCBORArrayHeader(data)
-	if !ok {
-		return s.unmarshalGeneric(data)
+	if cbor.UnmarshalFeltSlice(data, (*[]F)(s)) {
+		return nil
 	}
 
-	// Checking if size was corrupted to avoid allocating a malicious amount of data
-	maxPossibleFelts := (len(data) - offset) / minCBORFeltLen
-	if size < 0 || size > maxPossibleFelts {
-		return s.unmarshalGeneric(data)
-	}
-
-	buffer := make([]F, size)
-	for i := range buffer {
-		consumed, ok := decodeLimbs(data[offset:], &buffer[i])
-		if !ok {
-			return s.unmarshalGeneric(data)
-		}
-		offset += consumed
-	}
-
-	if offset != len(data) {
-		return s.unmarshalGeneric(data)
-	}
-
-	*s = buffer
-	return nil
-}
-
-// unmarshalGeneric handles any shape the fast path does not recognise.
-func (s *Slice[F]) unmarshalGeneric(data []byte) error {
-	var buffer []F
-	if err := cbor.Unmarshal(data, &buffer); err != nil {
+	var raw []F
+	if err := encoder.Unmarshal(data, &raw); err != nil {
 		return err
 	}
 
-	*s = buffer
+	*s = raw
 	return nil
-}
-
-// encodeCBORArrayHeader writes the CBOR array header for arraySize items into data
-// starting at index 0, returning the number of bytes written.
-func encodeCBORArrayHeader(data []byte, arraySize uint32) int {
-	// Starting with the most common path, which is a small array in this case
-	switch {
-	case arraySize < cborUint8AdditionalInfo:
-		data[0] = cborArrayMajor | byte(arraySize)
-		return 1
-	case arraySize <= math.MaxUint8:
-		data[0] = cborArrayMajor | cborUint8AdditionalInfo
-		data[1] = byte(arraySize)
-		return 2
-	case arraySize <= math.MaxUint16:
-		data[0] = cborArrayMajor | cborUint16AdditionalInfo
-		binary.BigEndian.PutUint16(data[1:], uint16(arraySize))
-		return 3
-	default:
-		// The larger size should fit into an uint32, bigger arrays do not fit the memory
-		data[0] = cborArrayMajor | cborUint32AdditionalInfo
-		binary.BigEndian.PutUint32(data[1:], arraySize)
-		return maxCBORArrayHeaderLen
-	}
-}
-
-// decodeCBORArrayHeader reads a CBOR array header at data[0:],
-// returning the element count and the number of bytes consumed.
-// ok is false when the data is not a CBOR array or its length is encoded larger than a uint32
-func decodeCBORArrayHeader(data []byte) (size, offset int, ok bool) {
-	if len(data) == 0 {
-		return 0, 0, false
-	}
-
-	// majorType (first 3 bits) encodes the object type
-	majorType := data[0] & 0b1110_0000
-	if majorType != cborArrayMajor {
-		return 0, 0, false
-	}
-
-	// additionalInfo (last 5 bits) encodes the array length or how it follows
-	additionalInfo := data[0] & 0b0001_1111
-
-	// Starting with the most common path, which is a small array
-	switch {
-	case additionalInfo < cborUint8AdditionalInfo:
-		return int(additionalInfo), 1, true
-	case additionalInfo == cborUint8AdditionalInfo && len(data) >= 2:
-		return int(data[1]), 2, true
-	case additionalInfo == cborUint16AdditionalInfo && len(data) >= 3:
-		return int(binary.BigEndian.Uint16(data[1:])), 3, true
-	case additionalInfo == cborUint32AdditionalInfo && len(data) >= 5:
-		return int(binary.BigEndian.Uint32(data[1:])), maxCBORArrayHeaderLen, true
-	default:
-		// A size bigger than an uint32 is not allowed in the fast-path
-		return 0, 0, false
-	}
 }

--- a/core/felt/slice_test.go
+++ b/core/felt/slice_test.go
@@ -9,7 +9,7 @@ import (
 	"testing"
 
 	"github.com/NethermindEth/juno/core/felt"
-	"github.com/fxamacker/cbor/v2"
+	"github.com/NethermindEth/juno/encoder"
 	"github.com/stretchr/testify/require"
 )
 
@@ -52,7 +52,7 @@ func requireSliceDecodeCBOREquivalent[F felt.FeltLike](t *testing.T, data []byte
 	errFast := fast.UnmarshalCBOR(data)
 
 	var generic []F
-	errGeneric := cbor.Unmarshal(data, &generic)
+	errGeneric := encoder.Unmarshal(data, &generic)
 
 	if errGeneric != nil {
 		require.Equal(
@@ -106,7 +106,7 @@ func TestSliceRoundTripCBORBoundarySizes(t *testing.T) {
 
 			fast, err := s.MarshalCBOR()
 			require.NoError(t, err)
-			generic, err := cbor.Marshal([]felt.Felt(s))
+			generic, err := encoder.Marshal([]felt.Felt(s))
 			require.NoError(t, err)
 			require.Equal(
 				t,
@@ -129,7 +129,7 @@ func TestSliceMarshalCBORNil(t *testing.T) {
 
 	fast, err := s.MarshalCBOR()
 	require.NoError(t, err)
-	generic, err := cbor.Marshal([]felt.Felt(s))
+	generic, err := encoder.Marshal([]felt.Felt(s))
 	require.NoError(t, err)
 	require.Equal(t, generic, fast, "nil slice must marshal like the generic encoder")
 

--- a/core/felt/slice_test.go
+++ b/core/felt/slice_test.go
@@ -1,30 +1,14 @@
 package felt_test
 
 import (
-	"encoding/binary"
 	"encoding/json"
-	"math"
 	"math/rand"
-	"slices"
 	"testing"
 
 	"github.com/NethermindEth/juno/core/felt"
 	"github.com/NethermindEth/juno/encoder"
+	"github.com/NethermindEth/juno/encoder/cbor"
 	"github.com/stretchr/testify/require"
-)
-
-// CBOR initial bytes used to hand-assemble the edge-case payloads. See RFC 8949 §3.
-const (
-	cborUintZero    = 0x00 // unsigned integer 0 (not an array)
-	cborNull        = 0xf6 // null
-	cborArrayEmpty  = 0x80 // array, 0 elements
-	cborArrayOne    = 0x81 // array, 1 element
-	cborArrayTwo    = 0x82 // array, 2 elements
-	cborArrayUint8  = 0x98 // array, element count in the following uint8
-	cborArrayUint16 = 0x99 // array, element count in the following uint16
-	cborArrayUint32 = 0x9a // array, element count in the following uint32
-	cborArrayIndef  = 0x9f // indefinite-length array
-	cborBreak       = 0xff // "break" stop code, ends an indefinite-length item
 )
 
 func randomSlice[F felt.FeltLike](size int) felt.Slice[F] {
@@ -36,180 +20,86 @@ func randomSlice[F felt.FeltLike](size int) felt.Slice[F] {
 	return slice
 }
 
-func encodeFeltCBOR(t *testing.T, value felt.Felt) []byte {
-	t.Helper()
-	encoded, err := value.MarshalCBOR()
-	require.NoError(t, err)
-	return encoded
-}
-
-// requireSliceDecodeEquivalent decodes data with both the fast and generic
-// paths and asserts they agree, either on the decoded felts or on the error.
-func requireSliceDecodeCBOREquivalent[F felt.FeltLike](t *testing.T, data []byte) {
+func requireSliceAgreesWithEngine[F felt.FeltLike](
+	t *testing.T,
+	data []byte,
+) (felt.Slice[F], bool) {
 	t.Helper()
 
 	var fast felt.Slice[F]
-	errFast := fast.UnmarshalCBOR(data)
-
 	var generic []F
+	errFast := fast.UnmarshalCBOR(data)
 	errGeneric := encoder.Unmarshal(data, &generic)
 
 	if errGeneric != nil {
-		require.Equal(
-			t,
-			errGeneric,
-			errFast,
-			"fast and generic decoders disagree on the error for % x",
-			data,
-		)
-		return
+		require.Error(t, errFast, "took a payload the engine refuses: % x", data)
+		return nil, false
 	}
+	require.NoError(t, errFast, "refused a payload the engine takes: % x", data)
+	require.Equal(t, generic, []F(fast), "read % x differently", data)
 
-	require.NoError(
-		t,
-		errFast,
-		"fast decoder rejected input the generic decoder accepted: % x",
-		data,
-	)
-
-	require.Equal(t, len(generic), len(fast), "length mismatch for % x", data)
-	for i := range generic {
-		require.True(
-			t,
-			felt.Equal(&generic[i], &fast[i]),
-			"element %d mismatch for % x: generic=%v fast=%v",
-			i,
-			data,
-			generic[i],
-			fast[i],
-		)
-	}
+	return fast, true
 }
 
-func TestSliceRoundTripCBORBoundarySizes(t *testing.T) {
-	sizes := []struct {
-		name string
-		size int
-	}{
-		{"empty", 0},
-		{"one", 1},
-		{"largest inline length", 23},
-		{"smallest uint8 length", 24},
-		{"largest uint8 length", 255},
-		{"smallest uint16 length", 256},
-		{"largest uint16 length", 65535},
-		{"smallest uint32 length", 65536},
-	}
-	for _, tc := range sizes {
-		t.Run(tc.name, func(t *testing.T) {
-			s := randomSlice[felt.Felt](tc.size)
+func TestSliceAccepted(t *testing.T) {
+	for _, accepted := range cbor.FeltSliceAccepted {
+		t.Run(accepted.Name, func(t *testing.T) {
+			slice := randomSlice[felt.Felt](accepted.Size)
 
-			fast, err := s.MarshalCBOR()
+			fast, err := slice.MarshalCBOR()
 			require.NoError(t, err)
-			generic, err := encoder.Marshal([]felt.Felt(s))
+			generic, err := encoder.Marshal([]felt.Felt(slice))
 			require.NoError(t, err)
-			require.Equal(
-				t,
-				generic,
-				fast,
-				"fast marshal disagrees with generic array framing for len=%d",
-				tc.size,
-			)
+			require.Equal(t, generic, fast, "framed it differently")
 
-			requireSliceDecodeCBOREquivalent[felt.Felt](t, fast)
-			requireSliceDecodeCBOREquivalent[feltoid](t, fast)
+			decoded, ok := requireSliceAgreesWithEngine[felt.Felt](t, fast)
+			require.True(t, ok, "refused its own output")
+			require.Equal(t, slice, decoded, "round trip changed the slice")
+
+			_, ok = requireSliceAgreesWithEngine[feltoid](t, fast)
+			require.True(t, ok)
 		})
 	}
 }
 
-// A nil slice must marshal like the generic encoder (null, not an empty array)
-// and round-trip back to nil rather than an empty slice.
-func TestSliceMarshalCBORNil(t *testing.T) {
-	var s felt.Slice[felt.Felt] // nil
+// The hook falls back to the engine, so they can never disagree.
+func TestSliceRejected(t *testing.T) {
+	for _, shape := range cbor.FeltSliceRejected {
+		t.Run(shape.Name, func(t *testing.T) {
+			requireSliceAgreesWithEngine[felt.Felt](t, shape.Data)
+			requireSliceAgreesWithEngine[feltoid](t, shape.Data)
+		})
+	}
+}
 
-	fast, err := s.MarshalCBOR()
+// A nil slice writes null, not an empty array, and reads back as nil.
+func TestSliceNil(t *testing.T) {
+	var slice felt.Slice[felt.Felt]
+
+	fast, err := slice.MarshalCBOR()
 	require.NoError(t, err)
-	generic, err := encoder.Marshal([]felt.Felt(s))
+	generic, err := encoder.Marshal([]felt.Felt(slice))
 	require.NoError(t, err)
-	require.Equal(t, generic, fast, "nil slice must marshal like the generic encoder")
+	require.Equal(t, generic, fast)
 
 	var back felt.Slice[feltoid]
 	require.NoError(t, back.UnmarshalCBOR(fast))
-	require.Nil(t, back, "nil slice must round-trip back to nil, not empty")
+	require.Nil(t, back, "nil has to round trip back to nil, not empty")
 }
 
-func TestSliceDecodeCBORCornerCases(t *testing.T) {
-	feltBytes1 := encodeFeltCBOR(t, fromLimbs[felt.Felt](1))
-	feltBytes2 := encodeFeltCBOR(t, fromLimbs[felt.Felt](2))
-
-	cases := []struct {
-		name string
-		data []byte
-	}{
-		{"empty", []byte{}},
-		{"nil", nil},
-		{"null", []byte{cborNull}},
-		{"not an array (unsigned int)", []byte{cborUintZero}},
-		{"empty array", []byte{cborArrayEmpty}},
-		{"one valid felt", slices.Concat([]byte{cborArrayOne}, feltBytes1)},
-		{"two valid felts", slices.Concat([]byte{cborArrayTwo}, feltBytes1, feltBytes2)},
-		{"array of one, no element", []byte{cborArrayOne}},
-		{"array of two, second element missing", slices.Concat([]byte{cborArrayTwo}, feltBytes1)},
-		{"valid array plus trailing byte", slices.Concat(
-			[]byte{cborArrayOne},
-			feltBytes1,
-			[]byte{cborUintZero},
-		)},
-		{"element is not a felt-shaped array", []byte{cborArrayOne, cborUintZero}},
-		{"indefinite-length array", slices.Concat(
-			[]byte{cborArrayIndef},
-			feltBytes1,
-			[]byte{cborBreak},
-		)},
-		{"uint8-length header for a one-element array", slices.Concat(
-			[]byte{cborArrayUint8, 0x01},
-			feltBytes1,
-		)},
-		{"uint8-length header, missing count byte", []byte{cborArrayUint8}},
-		{"uint16-length header, truncated count", []byte{cborArrayUint16, 0x00}},
-	}
-	for _, tc := range cases {
-		t.Run(tc.name, func(t *testing.T) {
-			requireSliceDecodeCBOREquivalent[felt.Felt](t, tc.data)
-			requireSliceDecodeCBOREquivalent[feltoid](t, tc.data)
-		})
-	}
-}
-
-func TestSliceDecodeCBORRejectsOversizedHeader(t *testing.T) {
-	feltBytes := encodeFeltCBOR(t, fromLimbs[felt.Felt](1))
-
-	// cborArrayUint32 reads the element count
-	// math.MaxUint32 = ~4.29 billion elements, far more than the payload holds.
-	header := binary.BigEndian.AppendUint32([]byte{cborArrayUint32}, math.MaxUint32)
-	data := slices.Concat(header, feltBytes)
-
-	requireSliceDecodeCBOREquivalent[felt.Felt](t, data)
-	requireSliceDecodeCBOREquivalent[feltoid](t, data)
-}
-
-// FuzzSliceDecodeEquivalence fuzzes the decode path, the one that can receive
-// arbitrary bytes, to ensure it stays equivalent to the generic decoder and never panics.
-func FuzzSliceDecodeCBOREquivalence(fz *testing.F) {
-	for _, n := range []int{0, 1, 2, 23, 24, 255, 256} {
-		encoded, err := randomSlice[felt.Felt](n).MarshalCBOR()
+func FuzzSliceCBOR(fz *testing.F) {
+	for _, accepted := range cbor.FeltSliceAccepted {
+		encoded, err := randomSlice[felt.Felt](accepted.Size).MarshalCBOR()
 		require.NoError(fz, err)
 		fz.Add(encoded)
 	}
-	for _, seed := range [][]byte{
-		{cborArrayEmpty}, {cborNull}, {cborUintZero}, {cborArrayOne}, {cborArrayOne, cborUintZero}, nil,
-	} {
-		fz.Add(seed)
+	for _, rejected := range cbor.FeltSliceRejected {
+		fz.Add(rejected.Data)
 	}
 
 	fz.Fuzz(func(t *testing.T, data []byte) {
-		requireSliceDecodeCBOREquivalent[felt.Felt](t, data)
-		requireSliceDecodeCBOREquivalent[feltoid](t, data)
+		requireSliceAgreesWithEngine[felt.Felt](t, data)
+		requireSliceAgreesWithEngine[feltoid](t, data)
 	})
 }
 

--- a/core/partial_cbor.go
+++ b/core/partial_cbor.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 
 	"github.com/NethermindEth/juno/core/felt"
+	"github.com/NethermindEth/juno/encoder"
 	bloom "github.com/bits-and-blooms/bloom/v3"
 )
 
@@ -19,6 +20,11 @@ type discardedCBOR struct{}
 // errDiscardedCBORMarshal is returned when a decode-only projection is marshaled.
 var errDiscardedCBORMarshal = errors.New(
 	"core: partial CBOR projection is decode-only and must not be marshaled",
+)
+
+var (
+	_ encoder.SelfEncoder = discardedCBOR{}
+	_ encoder.SelfDecoder = discardedCBOR{}
 )
 
 func (discardedCBOR) UnmarshalCBOR([]byte) error { return nil }

--- a/core/partial_cbor_test.go
+++ b/core/partial_cbor_test.go
@@ -9,7 +9,6 @@ import (
 	"github.com/NethermindEth/juno/core/felt"
 	"github.com/NethermindEth/juno/encoder"
 	bloom "github.com/bits-and-blooms/bloom/v3"
-	cbor "github.com/fxamacker/cbor/v2"
 	"github.com/stretchr/testify/require"
 )
 
@@ -68,10 +67,8 @@ func assertProjectionsCoverSource(t *testing.T, source reflect.Type, projections
 // Non-vacuous: see TestStrictGuardCatchesKeyAsIntDrift.
 func assertProjectionsCoverEveryWireKey(t *testing.T, data []byte, projections ...any) {
 	t.Helper()
-	strict, err := cbor.DecOptions{ExtraReturnErrors: cbor.ExtraDecErrorUnknownField}.DecMode()
-	require.NoError(t, err)
 	for _, projection := range projections {
-		require.NoErrorf(t, strict.Unmarshal(data, projection),
+		require.NoErrorf(t, encoder.UnmarshalStrict(data, projection),
 			"%T leaves a wire key unmatched (field added, or a tag name/option changed)", projection)
 	}
 }
@@ -166,14 +163,11 @@ func TestStrictGuardCatchesKeyAsIntDrift(t *testing.T) {
 	// Ground truth: encode with the integer key, then strict-decode.
 	data, err := encoder.Marshal(&driftSourceKeyAsInt{A: new(felt.Felt).SetUint64(7)})
 	require.NoError(t, err)
-	strict, err := cbor.DecOptions{ExtraReturnErrors: cbor.ExtraDecErrorUnknownField}.DecMode()
-	require.NoError(t, err)
-
 	// The string-key projection does not match the integer wire key → strict decode errors.
-	require.Error(t, strict.Unmarshal(data, &driftProjectionStringKey{}),
+	require.Error(t, encoder.UnmarshalStrict(data, &driftProjectionStringKey{}),
 		"strict decode must reject an integer wire key that the projection expects as a string")
 	// The matching keyasint projection decodes cleanly.
-	require.NoError(t, strict.Unmarshal(data, &driftProjectionIntKey{}),
+	require.NoError(t, encoder.UnmarshalStrict(data, &driftProjectionIntKey{}),
 		"a projection whose keyasint matches the source must decode without error")
 }
 

--- a/core/transaction.go
+++ b/core/transaction.go
@@ -11,9 +11,9 @@ import (
 	"github.com/NethermindEth/juno/blockchain/networks"
 	"github.com/NethermindEth/juno/core/crypto"
 	"github.com/NethermindEth/juno/core/felt"
+	"github.com/NethermindEth/juno/encoder"
 	"github.com/NethermindEth/juno/l1/eth"
 	"github.com/bits-and-blooms/bloom/v3"
-	"github.com/fxamacker/cbor/v2"
 	"golang.org/x/crypto/sha3"
 )
 
@@ -196,12 +196,17 @@ func (v *TransactionVersion) AsFelt() *felt.Felt {
 	return (*felt.Felt)(v)
 }
 
+var (
+	_ encoder.SelfEncoder = (*TransactionVersion)(nil)
+	_ encoder.SelfDecoder = (*TransactionVersion)(nil)
+)
+
 func (v *TransactionVersion) MarshalCBOR() ([]byte, error) {
-	return cbor.Marshal(v.AsFelt())
+	return v.AsFelt().MarshalCBOR()
 }
 
 func (v *TransactionVersion) UnmarshalCBOR(data []byte) error {
-	return cbor.Unmarshal(data, v.AsFelt())
+	return v.AsFelt().UnmarshalCBOR(data)
 }
 
 type DeployTransaction struct {

--- a/encoder/cbor/felt.go
+++ b/encoder/cbor/felt.go
@@ -26,22 +26,9 @@ func UnmarshalFelt[F FeltLike](data []byte, value *F) bool {
 }
 
 const (
-	// These derive from the CBOR spec
-	// Limb types are always unsigned int
-	// The following numbers represent the unsigned integer size
-	// See: https://www.rfc-editor.org/rfc/rfc8949.html#section-3
-	cborUint8AdditionalInfo  = 24 // 1 byte follows
-	cborUint16AdditionalInfo = 25 // 2 bytes follow
-	cborUint32AdditionalInfo = 26 // 4 bytes follow
-	cborUint64AdditionalInfo = 27 // 8 bytes follow
-
-	// cborArrayMajor the major type that represents an Array
-	// Top 3 bits are the major type (4 = array), low 5 bits are the length.
-	cborArrayMajor = 4 << 5
-
-	// cborArrayHeader4 is the first byte of a CBOR array of Limbs items.
+	// arrayHeader4 is the first byte of a CBOR array of Limbs items.
 	// 0b100_00100: an array with Limbs (4) elements.
-	cborArrayHeader4 = cborArrayMajor | Limbs
+	arrayHeader4 = arrayMajor | Limbs
 
 	// Header + 8 bytes following
 	maxCBORUintLen = 1 + 8
@@ -53,8 +40,8 @@ const (
 
 // encodeLimbs puts one CBOR felt to data, returning the number of bytes written.
 func encodeLimbs[F FeltLike](data []byte, value *F) int {
-	// The format is: [cborArrayHeader4] [limb 0] [limb 1] [limb 2] [limb 3].
-	data[0] = cborArrayHeader4
+	// The format is: [arrayHeader4] [limb 0] [limb 1] [limb 2] [limb 3].
+	data[0] = arrayHeader4
 
 	offset := 1
 	for limbIndex := range Limbs {
@@ -63,22 +50,22 @@ func encodeLimbs[F FeltLike](data []byte, value *F) int {
 		// Starting with the most common path, which is a large limb
 		switch {
 		case limb > math.MaxUint32:
-			data[offset] = cborUint64AdditionalInfo
+			data[offset] = info8Byte
 			binary.BigEndian.PutUint64(data[offset+1:], limb)
 			offset += 1 + 8
 
 		case limb > math.MaxUint16:
-			data[offset] = cborUint32AdditionalInfo
+			data[offset] = info4Byte
 			binary.BigEndian.PutUint32(data[offset+1:], uint32(limb))
 			offset += 1 + 4
 
 		case limb > math.MaxUint8:
-			data[offset] = cborUint16AdditionalInfo
+			data[offset] = info2Byte
 			binary.BigEndian.PutUint16(data[offset+1:], uint16(limb))
 			offset += 1 + 2
 
-		case limb >= cborUint8AdditionalInfo:
-			data[offset] = cborUint8AdditionalInfo
+		case limb >= info1Byte:
+			data[offset] = info1Byte
 			data[offset+1] = byte(limb)
 			offset += 2
 
@@ -96,8 +83,8 @@ func encodeLimbs[F FeltLike](data []byte, value *F) int {
 // It writes value only on success, so a rejected input can't partially
 // corrupt it before falling back to the generic decoder.
 func decodeLimbs[F FeltLike](data []byte, value *F) (int, bool) {
-	// The data format is: [cborArrayHeader4] [limb 0] [limb 1] [limb 2] [limb 3]
-	if len(data) == 0 || data[0] != cborArrayHeader4 {
+	// The data format is: [arrayHeader4] [limb 0] [limb 1] [limb 2] [limb 3]
+	if len(data) == 0 || data[0] != arrayHeader4 {
 		return 0, false
 	}
 
@@ -113,10 +100,10 @@ func decodeLimbs[F FeltLike](data []byte, value *F) (int, bool) {
 	// encodes as a full uint64, giving one fixed 37-byte shape. Decode it without the
 	// per-limb header switch; anything else falls through to the general loop.
 	if len(data) >= maxCBORFeltLen &&
-		data[limb0Header] == cborUint64AdditionalInfo &&
-		data[limb1Header] == cborUint64AdditionalInfo &&
-		data[limb2Header] == cborUint64AdditionalInfo &&
-		data[limb3Header] == cborUint64AdditionalInfo {
+		data[limb0Header] == info8Byte &&
+		data[limb1Header] == info8Byte &&
+		data[limb2Header] == info8Byte &&
+		data[limb3Header] == info8Byte {
 		(*value)[0] = binary.BigEndian.Uint64(data[limb0Header+1 : limb1Header])
 		(*value)[1] = binary.BigEndian.Uint64(data[limb1Header+1 : limb2Header])
 		(*value)[2] = binary.BigEndian.Uint64(data[limb2Header+1 : limb3Header])
@@ -143,38 +130,38 @@ func decodeVariableLimbs[F FeltLike](data []byte, value *F) (int, bool) {
 
 		var limb uint64
 		switch {
-		case headerByte > cborUint64AdditionalInfo: // invalid header byte for uint64
+		case headerByte > info8Byte: // invalid header byte for uint64
 			return 0, false
 
-		case headerByte == cborUint64AdditionalInfo:
+		case headerByte == info8Byte:
 			if offset+8 > len(data) {
 				return 0, false
 			}
 			limb = binary.BigEndian.Uint64(data[offset:])
 			offset += 8
 
-		case headerByte == cborUint32AdditionalInfo:
+		case headerByte == info4Byte:
 			if offset+4 > len(data) {
 				return 0, false
 			}
 			limb = uint64(binary.BigEndian.Uint32(data[offset:]))
 			offset += 4
 
-		case headerByte == cborUint16AdditionalInfo:
+		case headerByte == info2Byte:
 			if offset+2 > len(data) {
 				return 0, false
 			}
 			limb = uint64(binary.BigEndian.Uint16(data[offset:]))
 			offset += 2
 
-		case headerByte == cborUint8AdditionalInfo:
+		case headerByte == info1Byte:
 			if offset+1 > len(data) {
 				return 0, false
 			}
 			limb = uint64(data[offset])
 			offset++
 
-		default: // headerByte < cborUint8AdditionalInfo
+		default: // headerByte < info1Byte
 			limb = uint64(headerByte)
 		}
 

--- a/encoder/cbor/felt.go
+++ b/encoder/cbor/felt.go
@@ -1,0 +1,199 @@
+package cbor
+
+import (
+	"encoding/binary"
+	"math"
+)
+
+// The number of 64 bit words a felt is made of.
+const Limbs = 4
+
+// FeltLike mirrors felt.FeltLike.
+type FeltLike interface {
+	~[Limbs]uint64
+}
+
+func MarshalFelt[F FeltLike](value *F) []byte {
+	data := make([]byte, maxCBORFeltLen)
+	n := encodeLimbs(data, value)
+	return data[:n]
+}
+
+// UnmarshalFelt reports whether data is a shape the fast path knows, writing value only then.
+// A caller that gets false has to decode data some other way.
+func UnmarshalFelt[F FeltLike](data []byte, value *F) bool {
+	return decodeFelt(data, value)
+}
+
+const (
+	// These derive from the CBOR spec
+	// Limb types are always unsigned int
+	// The following numbers represent the unsigned integer size
+	// See: https://www.rfc-editor.org/rfc/rfc8949.html#section-3
+	cborUint8AdditionalInfo  = 24 // 1 byte follows
+	cborUint16AdditionalInfo = 25 // 2 bytes follow
+	cborUint32AdditionalInfo = 26 // 4 bytes follow
+	cborUint64AdditionalInfo = 27 // 8 bytes follow
+
+	// cborArrayMajor the major type that represents an Array
+	// Top 3 bits are the major type (4 = array), low 5 bits are the length.
+	cborArrayMajor = 4 << 5
+
+	// cborArrayHeader4 is the first byte of a CBOR array of Limbs items.
+	// 0b100_00100: an array with Limbs (4) elements.
+	cborArrayHeader4 = cborArrayMajor | Limbs
+
+	// Header + 8 bytes following
+	maxCBORUintLen = 1 + 8
+	// Header + Limbs * maxCBORUintLen
+	maxCBORFeltLen = 1 + Limbs*maxCBORUintLen
+	// Header + Limbs
+	minCBORFeltLen = 1 + Limbs
+)
+
+// encodeLimbs puts one CBOR felt to data, returning the number of bytes written.
+func encodeLimbs[F FeltLike](data []byte, value *F) int {
+	// The format is: [cborArrayHeader4] [limb 0] [limb 1] [limb 2] [limb 3].
+	data[0] = cborArrayHeader4
+
+	offset := 1
+	for limbIndex := range Limbs {
+		limb := (*value)[limbIndex]
+
+		// Starting with the most common path, which is a large limb
+		switch {
+		case limb > math.MaxUint32:
+			data[offset] = cborUint64AdditionalInfo
+			binary.BigEndian.PutUint64(data[offset+1:], limb)
+			offset += 1 + 8
+
+		case limb > math.MaxUint16:
+			data[offset] = cborUint32AdditionalInfo
+			binary.BigEndian.PutUint32(data[offset+1:], uint32(limb))
+			offset += 1 + 4
+
+		case limb > math.MaxUint8:
+			data[offset] = cborUint16AdditionalInfo
+			binary.BigEndian.PutUint16(data[offset+1:], uint16(limb))
+			offset += 1 + 2
+
+		case limb >= cborUint8AdditionalInfo:
+			data[offset] = cborUint8AdditionalInfo
+			data[offset+1] = byte(limb)
+			offset += 2
+
+		default:
+			data[offset] = byte(limb)
+			offset++
+		}
+	}
+
+	return offset
+}
+
+// decodeLimbs decodes one limb-encoded felt at data[0:],
+// returning the number of bytes consumed and a flag to signal succes.
+// It writes value only on success, so a rejected input can't partially
+// corrupt it before falling back to the generic decoder.
+func decodeLimbs[F FeltLike](data []byte, value *F) (int, bool) {
+	// The data format is: [cborArrayHeader4] [limb 0] [limb 1] [limb 2] [limb 3]
+	if len(data) == 0 || data[0] != cborArrayHeader4 {
+		return 0, false
+	}
+
+	// Header-byte offset of each limb in the all-uint64 shape; the 8-byte payload follows.
+	const (
+		limb0Header = 1
+		limb1Header = limb0Header + maxCBORUintLen
+		limb2Header = limb1Header + maxCBORUintLen
+		limb3Header = limb2Header + maxCBORUintLen
+	)
+
+	// Felts are stored in Montgomery form, so in practice every limb exceeds MaxUint32 and
+	// encodes as a full uint64, giving one fixed 37-byte shape. Decode it without the
+	// per-limb header switch; anything else falls through to the general loop.
+	if len(data) >= maxCBORFeltLen &&
+		data[limb0Header] == cborUint64AdditionalInfo &&
+		data[limb1Header] == cborUint64AdditionalInfo &&
+		data[limb2Header] == cborUint64AdditionalInfo &&
+		data[limb3Header] == cborUint64AdditionalInfo {
+		(*value)[0] = binary.BigEndian.Uint64(data[limb0Header+1 : limb1Header])
+		(*value)[1] = binary.BigEndian.Uint64(data[limb1Header+1 : limb2Header])
+		(*value)[2] = binary.BigEndian.Uint64(data[limb2Header+1 : limb3Header])
+		(*value)[3] = binary.BigEndian.Uint64(data[limb3Header+1 : maxCBORFeltLen])
+		return maxCBORFeltLen, true
+	}
+
+	return decodeVariableLimbs(data, value)
+}
+
+// decodeVariableLimbs decodes the limbs at data[1:] one header byte at a time, covering the shapes
+// the fixed-shape fast path rejects; data[0] must already be a validated array header.
+func decodeVariableLimbs[F FeltLike](data []byte, value *F) (int, bool) {
+	var limbs F
+	offset := 1
+
+	for limbIndex := range Limbs {
+		if offset >= len(data) {
+			return 0, false
+		}
+
+		headerByte := data[offset]
+		offset++
+
+		var limb uint64
+		switch {
+		case headerByte > cborUint64AdditionalInfo: // invalid header byte for uint64
+			return 0, false
+
+		case headerByte == cborUint64AdditionalInfo:
+			if offset+8 > len(data) {
+				return 0, false
+			}
+			limb = binary.BigEndian.Uint64(data[offset:])
+			offset += 8
+
+		case headerByte == cborUint32AdditionalInfo:
+			if offset+4 > len(data) {
+				return 0, false
+			}
+			limb = uint64(binary.BigEndian.Uint32(data[offset:]))
+			offset += 4
+
+		case headerByte == cborUint16AdditionalInfo:
+			if offset+2 > len(data) {
+				return 0, false
+			}
+			limb = uint64(binary.BigEndian.Uint16(data[offset:]))
+			offset += 2
+
+		case headerByte == cborUint8AdditionalInfo:
+			if offset+1 > len(data) {
+				return 0, false
+			}
+			limb = uint64(data[offset])
+			offset++
+
+		default: // headerByte < cborUint8AdditionalInfo
+			limb = uint64(headerByte)
+		}
+
+		limbs[limbIndex] = limb
+	}
+
+	*value = limbs
+	return offset, true
+}
+
+// decodeFelt decodes a single felt that must span all of data, rejecting trailing bytes.
+// It returns a flag to signal success, and writes value only on success.
+func decodeFelt[F FeltLike](data []byte, value *F) bool {
+	var felt F
+	consumed, ok := decodeLimbs(data, &felt)
+	if !ok || consumed != len(data) {
+		return false
+	}
+
+	*value = felt
+	return true
+}

--- a/encoder/cbor/felt_test.go
+++ b/encoder/cbor/felt_test.go
@@ -1,9 +1,5 @@
 package cbor_test
 
-// TODO(granza): Build a pull of felts to test.
-// core/felt/cbor_fastpath_test.go should test them fast vs generic,
-// here should test current engine vs canonical encoder (fxmacker).
-
 import (
 	"testing"
 
@@ -14,39 +10,48 @@ import (
 
 type limbs = [cbor.Limbs]uint64
 
-var marshalFeltCases = []struct {
-	name  string
-	value limbs
-}{
-	{"zero", limbs{}},
-	{"one byte limbs", limbs{1, 2, 3, 4}},
-	{"mixed widths", limbs{24, 256, 65536, 4294967296}},
-	{"montgomery shaped", limbs{
-		18446744073709551585, 18446744073709551615, 18446744073709551615, 576460752303422960,
-	}},
+// fxamacker wrote all initial felts on disk, so we always compare against it.
+func requireAgreesWithLibrary(t *testing.T, data []byte) (decoded limbs, ok bool) {
+	t.Helper()
+
+	var fast limbs
+	if !cbor.UnmarshalFelt(data, &fast) {
+		return limbs{}, false
+	}
+
+	var canonical limbs
+	require.NoError(t, fxcbor.Unmarshal(data, &canonical),
+		"took a payload the library refuses: % x", data)
+	require.Equal(t, canonical, fast)
+
+	return fast, true
 }
 
-// fxamacker is the source of truth. It wrote every felt on disk, so engines must agree with it.
-// core/felt should not care about this assertion.
-func TestMarshalFeltMatchesFxamacker(t *testing.T) {
-	for _, test := range marshalFeltCases {
-		t.Run(test.name, func(t *testing.T) {
-			generic, err := fxcbor.Marshal(test.value)
-			require.NoError(t, err)
-			require.Equal(t, generic, cbor.MarshalFelt(&test.value))
+func TestFeltAccepted(t *testing.T) {
+	for _, shape := range cbor.FeltAccepted {
+		t.Run(shape.Name, func(t *testing.T) {
+			decoded, ok := requireAgreesWithLibrary(t, shape.Data)
+			require.True(t, ok, "refused a payload it has to take")
+			require.Equal(t, shape.Data, cbor.MarshalFelt(&decoded), "wrote it back differently")
 		})
 	}
 }
 
-func TestUnmarshalFeltMatchesFxamacker(t *testing.T) {
-	for _, test := range marshalFeltCases {
-		t.Run(test.name, func(t *testing.T) {
-			written, err := fxcbor.Marshal(test.value)
-			require.NoError(t, err)
-
-			var back limbs
-			require.True(t, cbor.UnmarshalFelt(written, &back))
-			require.Equal(t, test.value, back)
+func TestFeltRejected(t *testing.T) {
+	for _, shape := range cbor.FeltRejected {
+		t.Run(shape.Name, func(t *testing.T) {
+			_, ok := requireAgreesWithLibrary(t, shape.Data)
+			require.False(t, ok, "took a payload it has to refuse")
 		})
 	}
+}
+
+func FuzzFelt(f *testing.F) {
+	for _, shape := range append(cbor.FeltAccepted, cbor.FeltRejected...) {
+		f.Add(shape.Data)
+	}
+
+	f.Fuzz(func(t *testing.T, data []byte) {
+		requireAgreesWithLibrary(t, data)
+	})
 }

--- a/encoder/cbor/felt_test.go
+++ b/encoder/cbor/felt_test.go
@@ -1,0 +1,52 @@
+package cbor_test
+
+// TODO(granza): Build a pull of felts to test.
+// core/felt/cbor_fastpath_test.go should test them fast vs generic,
+// here should test current engine vs canonical encoder (fxmacker).
+
+import (
+	"testing"
+
+	"github.com/NethermindEth/juno/encoder/cbor"
+	fxcbor "github.com/fxamacker/cbor/v2"
+	"github.com/stretchr/testify/require"
+)
+
+type limbs = [cbor.Limbs]uint64
+
+var marshalFeltCases = []struct {
+	name  string
+	value limbs
+}{
+	{"zero", limbs{}},
+	{"one byte limbs", limbs{1, 2, 3, 4}},
+	{"mixed widths", limbs{24, 256, 65536, 4294967296}},
+	{"montgomery shaped", limbs{
+		18446744073709551585, 18446744073709551615, 18446744073709551615, 576460752303422960,
+	}},
+}
+
+// fxamacker is the source of truth. It wrote every felt on disk, so engines must agree with it.
+// core/felt should not care about this assertion.
+func TestMarshalFeltMatchesFxamacker(t *testing.T) {
+	for _, test := range marshalFeltCases {
+		t.Run(test.name, func(t *testing.T) {
+			generic, err := fxcbor.Marshal(test.value)
+			require.NoError(t, err)
+			require.Equal(t, generic, cbor.MarshalFelt(&test.value))
+		})
+	}
+}
+
+func TestUnmarshalFeltMatchesFxamacker(t *testing.T) {
+	for _, test := range marshalFeltCases {
+		t.Run(test.name, func(t *testing.T) {
+			written, err := fxcbor.Marshal(test.value)
+			require.NoError(t, err)
+
+			var back limbs
+			require.True(t, cbor.UnmarshalFelt(written, &back))
+			require.Equal(t, test.value, back)
+		})
+	}
+}

--- a/encoder/cbor/headers.go
+++ b/encoder/cbor/headers.go
@@ -1,0 +1,33 @@
+package cbor
+
+// The initial byte of every CBOR item, as RFC 8949 §3 defines it.
+const (
+	// majorMask and infoMask split that byte into major type and additional info.
+	majorMask = 0b111_00000
+	infoMask  = 0b000_11111
+
+	// Major types, the top 3 bits. Only the ones the node has to recognise are named.
+	uintMajor   = 0 << 5
+	negIntMajor = 1 << 5
+	arrayMajor  = 4 << 5
+	simpleMajor = 7 << 5
+
+	// maxInline is the largest argument that still rides inside the header byte.
+	maxInline = info1Byte - 1
+
+	// Additional info values that say how many bytes of argument follow.
+	info1Byte = 24
+	info2Byte = 25
+	info4Byte = 26
+	info8Byte = 27
+
+	// 31 in an array means "read until the break". The same 31 in a simple value is that break.
+	// 28 to 30 are reserved, and no argument width follows them.
+	// The node writes none of the three and has to refuse all of them.
+	arrayIndefinite = arrayMajor | 31
+	breakStop       = simpleMajor | 31
+	reservedInfo    = 28
+
+	// null is what the generic encoder emits for a nil slice.
+	null = simpleMajor | 22
+)

--- a/encoder/cbor/shapes.go
+++ b/encoder/cbor/shapes.go
@@ -1,0 +1,123 @@
+package cbor
+
+import (
+	"math"
+	"slices"
+)
+
+// oneFelt is what a STORED felt looks like in bytes.
+// All felts pass through the Montgomery transformation, so they are usually 37 bytes.
+var oneFelt = []byte{
+	arrayHeader4,
+	0x1b, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xe1,
+	0x1b, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+	0x1b, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+	0x1b, 0x07, 0xff, 0xff, 0xff, 0xff, 0xff, 0xfd, 0xf0,
+}
+
+// Shape is a CBOR payload, named for what makes it interesting.
+type Shape struct {
+	Name string
+	Data []byte
+}
+
+// FeltAccepted is every payload a felt decoder has to take and write back unchanged.
+var FeltAccepted = []Shape{
+	{"zero", []byte{arrayHeader4, 0x00, 0x00, 0x00, 0x00}},
+	{"all inline", []byte{arrayHeader4, 0x01, 0x02, 0x03, 0x04}},
+
+	// What a stored felt actually looks like.
+	{"montgomery shaped", oneFelt},
+
+	// Sparse: a narrow limb, zeros, then a wide one. A random felt almost never looks like this,
+	// but the two ends of the field do, in Montgomery form.
+	{"sparse, 1-byte then 2-byte", []byte{arrayHeader4, 0x18, 0x20, 0x00, 0x00, 0x19, 0x02, 0x20}},
+	{"sparse, inline then 2-byte", []byte{arrayHeader4, 0x10, 0x00, 0x00, 0x19, 0x01, 0x10}},
+
+	{"limb: one", []byte{arrayHeader4, 0x01, 0x00, 0x00, 0x00}},
+	{"limb: largest inline", []byte{arrayHeader4, 0x17, 0x00, 0x00, 0x00}},
+	{"limb: smallest 1-byte", []byte{arrayHeader4, 0x18, 0x18, 0x00, 0x00, 0x00}},
+	{"limb: largest 1-byte", []byte{arrayHeader4, 0x18, 0xff, 0x00, 0x00, 0x00}},
+	{"limb: smallest 2-byte", []byte{arrayHeader4, 0x19, 0x01, 0x00, 0x00, 0x00, 0x00}},
+	{"limb: largest 2-byte", []byte{arrayHeader4, 0x19, 0xff, 0xff, 0x00, 0x00, 0x00}},
+	{"limb: smallest 4-byte", []byte{
+		arrayHeader4, 0x1a, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00,
+	}},
+	{"limb: largest 4-byte", []byte{arrayHeader4, 0x1a, 0xff, 0xff, 0xff, 0xff, 0x00, 0x00, 0x00}},
+	{"limb: smallest 8-byte", []byte{
+		arrayHeader4, 0x1b, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+	}},
+	{"limb: largest 8-byte", []byte{
+		arrayHeader4, 0x1b, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0x00, 0x00, 0x00,
+	}},
+}
+
+// FeltRejected is every payload the fast path has to refuse.
+var FeltRejected = []Shape{
+	{"empty", []byte{}},
+	{"nil", nil},
+	{"empty array", []byte{arrayMajor}},
+	{"array of three", []byte{arrayMajor | 3, 0x00, 0x00, 0x00}},
+	{"array of five", []byte{arrayMajor | 5, 0x00, 0x00, 0x00, 0x00, 0x00}},
+	{"array of four, one limb missing", []byte{arrayHeader4, 0x00, 0x00, 0x00}},
+	{"array of four, one byte too many", []byte{arrayHeader4, 0x00, 0x00, 0x00, 0x00, 0x00}},
+	{"indefinite length", []byte{arrayIndefinite, 0x00, 0x00, 0x00, 0x00, breakStop}},
+	{"null", []byte{null}},
+
+	{"1-byte limb header, no value", []byte{arrayHeader4, uintMajor | info1Byte}},
+	{"2-byte limb header, truncated", []byte{arrayHeader4, uintMajor | info2Byte, 0x00}},
+	{"4-byte limb header, truncated", []byte{arrayHeader4, uintMajor | info4Byte, 0x00, 0x00, 0x00}},
+	{"8-byte limb header, truncated", []byte{
+		arrayHeader4, uintMajor | info8Byte, 0, 0, 0, 0, 0, 0, 0,
+	}},
+	{"reserved size code as limb", []byte{arrayHeader4, uintMajor | reservedInfo, 0x00, 0x00, 0x00}},
+
+	{"negative first limb", []byte{arrayHeader4, negIntMajor, 0x00, 0x00, 0x00}},
+	{"negative every limb", []byte{
+		arrayHeader4, negIntMajor, negIntMajor, negIntMajor, negIntMajor,
+	}},
+	{"float32 first limb", []byte{
+		arrayHeader4, simpleMajor | info4Byte, 0x3f, 0xc0, 0x00, 0x00, 0x00, 0x00, 0x00,
+	}},
+	{"float64 first limb", []byte{
+		arrayHeader4, simpleMajor | info8Byte, 0x3f, 0xf8, 0, 0, 0, 0, 0, 0, 0x00, 0x00, 0x00,
+	}},
+}
+
+// FeltSliceAccepted is every element count a slice decoder has to take and write back unchanged.
+var FeltSliceAccepted = []struct {
+	Name string
+	Size int
+}{
+	{"empty", 0},
+	{"one", 1},
+	{"two", 2},
+	{"largest inline length", maxInline},
+	{"smallest 1-byte length", info1Byte},
+	{"largest 1-byte length", math.MaxUint8},
+	{"smallest 2-byte length", math.MaxUint8 + 1},
+	{"largest 2-byte length", math.MaxUint16},
+	{"smallest 4-byte length", math.MaxUint16 + 1},
+}
+
+// FeltSliceRejected is every payload the slice fast path has to refuse.
+var FeltSliceRejected = []Shape{
+	{"empty", []byte{}},
+	{"nil", nil},
+	{"null", []byte{null}},
+	{"not an array", []byte{uintMajor}},
+	{"array of one, no element", []byte{arrayMajor | 1}},
+	{"array of two, second missing", slices.Concat([]byte{arrayMajor | 2}, oneFelt)},
+	{"one felt plus a trailing byte", slices.Concat(
+		[]byte{arrayMajor | 1}, oneFelt, []byte{uintMajor},
+	)},
+	{"element is not felt shaped", []byte{arrayMajor | 1, uintMajor}},
+	{"indefinite length", slices.Concat([]byte{arrayIndefinite}, oneFelt, []byte{breakStop})},
+	{"1-byte length header, no count", []byte{arrayMajor | info1Byte}},
+	{"2-byte length header, truncated count", []byte{arrayMajor | info2Byte, 0x00}},
+
+	// A count no payload could hold. The fast path has to notice before it allocates.
+	{"4-byte length header claiming MaxUint32 elements", slices.Concat(
+		[]byte{arrayMajor | info4Byte, 0xff, 0xff, 0xff, 0xff}, oneFelt,
+	)},
+}

--- a/encoder/cbor/slice.go
+++ b/encoder/cbor/slice.go
@@ -1,0 +1,118 @@
+package cbor
+
+import (
+	"encoding/binary"
+	"math"
+)
+
+const (
+	// maxCBORArrayHeaderLen: 1 major/info byte + 4 length bytes (uint32)
+	maxCBORArrayHeaderLen = 1 + 4
+
+	// cborNull is the CBOR encoding of null, which the generic encoder emits for a nil slice.
+	cborNull = 0xf6
+)
+
+// MarshalFeltSlice is the body of felt.Slice's MarshalCBOR.
+func MarshalFeltSlice[F FeltLike](slice []F) []byte {
+	if slice == nil {
+		return []byte{cborNull}
+	}
+
+	data := make([]byte, maxCBORArrayHeaderLen+len(slice)*maxCBORFeltLen)
+
+	offset := encodeCBORArrayHeader(data, uint32(len(slice)))
+	for idx := range slice {
+		offset += encodeLimbs(data[offset:], &slice[idx])
+	}
+
+	return data[:offset]
+}
+
+// UnmarshalFeltSlice reports whether data is a shape the fast path knows, writing slice only then.
+// A caller that gets false has to decode data some other way.
+func UnmarshalFeltSlice[F FeltLike](data []byte, slice *[]F) bool {
+	size, offset, ok := decodeCBORArrayHeader(data)
+	if !ok {
+		return false
+	}
+
+	// Checking if size was corrupted to avoid allocating a malicious amount of data
+	maxPossibleFelts := (len(data) - offset) / minCBORFeltLen
+	if size < 0 || size > maxPossibleFelts {
+		return false
+	}
+
+	buffer := make([]F, size)
+	for i := range buffer {
+		consumed, ok := decodeLimbs(data[offset:], &buffer[i])
+		if !ok {
+			return false
+		}
+		offset += consumed
+	}
+
+	if offset != len(data) {
+		return false
+	}
+
+	*slice = buffer
+	return true
+}
+
+// encodeCBORArrayHeader writes the CBOR array header for arraySize items into data
+// starting at index 0, returning the number of bytes written.
+func encodeCBORArrayHeader(data []byte, arraySize uint32) int {
+	// Starting with the most common path, which is a small array in this case
+	switch {
+	case arraySize < cborUint8AdditionalInfo:
+		data[0] = cborArrayMajor | byte(arraySize)
+		return 1
+	case arraySize <= math.MaxUint8:
+		data[0] = cborArrayMajor | cborUint8AdditionalInfo
+		data[1] = byte(arraySize)
+		return 2
+	case arraySize <= math.MaxUint16:
+		data[0] = cborArrayMajor | cborUint16AdditionalInfo
+		binary.BigEndian.PutUint16(data[1:], uint16(arraySize))
+		return 3
+	default:
+		// The larger size should fit into an uint32, bigger arrays do not fit the memory
+		data[0] = cborArrayMajor | cborUint32AdditionalInfo
+		binary.BigEndian.PutUint32(data[1:], arraySize)
+		return maxCBORArrayHeaderLen
+	}
+}
+
+// decodeCBORArrayHeader reads a CBOR array header at data[0:],
+// returning the element count and the number of bytes consumed.
+// ok is false when the data is not a CBOR array or its length is encoded larger than a uint32
+func decodeCBORArrayHeader(data []byte) (size, offset int, ok bool) {
+	if len(data) == 0 {
+		return 0, 0, false
+	}
+
+	// majorType (first 3 bits) encodes the object type
+	majorType := data[0] & 0b1110_0000
+	if majorType != cborArrayMajor {
+		return 0, 0, false
+	}
+
+	// additionalInfo (last 5 bits) encodes the array length or how it follows
+	additionalInfo := data[0] & 0b0001_1111
+
+	// Starting with the most common path, which is a small array
+	switch {
+	case additionalInfo < cborUint8AdditionalInfo:
+		return int(additionalInfo), 1, true
+	case additionalInfo == cborUint8AdditionalInfo && len(data) >= 2:
+		return int(data[1]), 2, true
+	case additionalInfo == cborUint16AdditionalInfo && len(data) >= 3:
+		return int(binary.BigEndian.Uint16(data[1:])), 3, true
+	case additionalInfo == cborUint32AdditionalInfo && len(data) >= 5:
+		return int(binary.BigEndian.Uint32(data[1:])), maxCBORArrayHeaderLen, true
+	default:
+		// A size bigger than an uint32 is not allowed in the fast-path
+		return 0, 0, false
+	}
+}

--- a/encoder/cbor/slice.go
+++ b/encoder/cbor/slice.go
@@ -8,15 +8,12 @@ import (
 const (
 	// maxCBORArrayHeaderLen: 1 major/info byte + 4 length bytes (uint32)
 	maxCBORArrayHeaderLen = 1 + 4
-
-	// cborNull is the CBOR encoding of null, which the generic encoder emits for a nil slice.
-	cborNull = 0xf6
 )
 
 // MarshalFeltSlice is the body of felt.Slice's MarshalCBOR.
 func MarshalFeltSlice[F FeltLike](slice []F) []byte {
 	if slice == nil {
-		return []byte{cborNull}
+		return []byte{null}
 	}
 
 	data := make([]byte, maxCBORArrayHeaderLen+len(slice)*maxCBORFeltLen)
@@ -65,20 +62,20 @@ func UnmarshalFeltSlice[F FeltLike](data []byte, slice *[]F) bool {
 func encodeCBORArrayHeader(data []byte, arraySize uint32) int {
 	// Starting with the most common path, which is a small array in this case
 	switch {
-	case arraySize < cborUint8AdditionalInfo:
-		data[0] = cborArrayMajor | byte(arraySize)
+	case arraySize < info1Byte:
+		data[0] = arrayMajor | byte(arraySize)
 		return 1
 	case arraySize <= math.MaxUint8:
-		data[0] = cborArrayMajor | cborUint8AdditionalInfo
+		data[0] = arrayMajor | info1Byte
 		data[1] = byte(arraySize)
 		return 2
 	case arraySize <= math.MaxUint16:
-		data[0] = cborArrayMajor | cborUint16AdditionalInfo
+		data[0] = arrayMajor | info2Byte
 		binary.BigEndian.PutUint16(data[1:], uint16(arraySize))
 		return 3
 	default:
 		// The larger size should fit into an uint32, bigger arrays do not fit the memory
-		data[0] = cborArrayMajor | cborUint32AdditionalInfo
+		data[0] = arrayMajor | info4Byte
 		binary.BigEndian.PutUint32(data[1:], arraySize)
 		return maxCBORArrayHeaderLen
 	}
@@ -93,23 +90,23 @@ func decodeCBORArrayHeader(data []byte) (size, offset int, ok bool) {
 	}
 
 	// majorType (first 3 bits) encodes the object type
-	majorType := data[0] & 0b1110_0000
-	if majorType != cborArrayMajor {
+	majorType := data[0] & majorMask
+	if majorType != arrayMajor {
 		return 0, 0, false
 	}
 
 	// additionalInfo (last 5 bits) encodes the array length or how it follows
-	additionalInfo := data[0] & 0b0001_1111
+	additionalInfo := data[0] & infoMask
 
 	// Starting with the most common path, which is a small array
 	switch {
-	case additionalInfo < cborUint8AdditionalInfo:
+	case additionalInfo < info1Byte:
 		return int(additionalInfo), 1, true
-	case additionalInfo == cborUint8AdditionalInfo && len(data) >= 2:
+	case additionalInfo == info1Byte && len(data) >= 2:
 		return int(data[1]), 2, true
-	case additionalInfo == cborUint16AdditionalInfo && len(data) >= 3:
+	case additionalInfo == info2Byte && len(data) >= 3:
 		return int(binary.BigEndian.Uint16(data[1:])), 3, true
-	case additionalInfo == cborUint32AdditionalInfo && len(data) >= 5:
+	case additionalInfo == info4Byte && len(data) >= 5:
 		return int(binary.BigEndian.Uint32(data[1:])), maxCBORArrayHeaderLen, true
 	default:
 		// A size bigger than an uint32 is not allowed in the fast-path

--- a/encoder/cbor/slice_test.go
+++ b/encoder/cbor/slice_test.go
@@ -1,10 +1,7 @@
 package cbor_test
 
-// TODO(granza): Build a pull of slices to test.
-// core/felt/slice_test.go should test them fast vs generic,
-// here should test current engine vs canonical encoder (fxmacker).
-
 import (
+	"math"
 	"testing"
 
 	"github.com/NethermindEth/juno/encoder/cbor"
@@ -12,45 +9,72 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func feltSlice(size int) []limbs {
+// fxamacker wrote all initial slices on disk, so we always compare against it.
+func requireSliceAgreesWithLibrary(t *testing.T, data []byte) (decoded []limbs, ok bool) {
+	t.Helper()
+
+	var fast []limbs
+	if !cbor.UnmarshalFeltSlice(data, &fast) {
+		return nil, false
+	}
+
+	var canonical []limbs
+	require.NoError(t, fxcbor.Unmarshal(data, &canonical),
+		"took a payload the library refuses: % x", data)
+	require.Equal(t, canonical, fast)
+
+	return fast, true
+}
+
+func TestFeltSliceAccepted(t *testing.T) {
+	for _, accepted := range cbor.FeltSliceAccepted {
+		t.Run(accepted.Name, func(t *testing.T) {
+			slice := sliceOf(accepted.Size)
+
+			canonical, err := fxcbor.Marshal(slice)
+			require.NoError(t, err)
+			require.Equal(t, canonical, cbor.MarshalFeltSlice(slice), "framed it differently")
+
+			decoded, ok := requireSliceAgreesWithLibrary(t, canonical)
+			require.True(t, ok, "refused the library's own bytes")
+			require.Equal(t, slice, decoded, "round trip changed the slice")
+		})
+	}
+}
+
+func TestFeltSliceRejected(t *testing.T) {
+	for _, rejected := range cbor.FeltSliceRejected {
+		t.Run(rejected.Name, func(t *testing.T) {
+			_, ok := requireSliceAgreesWithLibrary(t, rejected.Data)
+			require.False(t, ok, "took a payload it has to refuse")
+		})
+	}
+}
+
+// A nil slice writes null, not an empty array.
+// It is neither accepted nor rejected, it is its own case.
+func TestFeltSliceNil(t *testing.T) {
+	canonical, err := fxcbor.Marshal([]limbs(nil))
+	require.NoError(t, err)
+	require.Equal(t, canonical, cbor.MarshalFeltSlice[limbs](nil))
+}
+
+func FuzzFeltSlice(f *testing.F) {
+	for _, accepted := range cbor.FeltSliceAccepted {
+		f.Add(cbor.MarshalFeltSlice(sliceOf(accepted.Size)))
+	}
+	for _, rejected := range cbor.FeltSliceRejected {
+		f.Add(rejected.Data)
+	}
+	f.Fuzz(func(t *testing.T, data []byte) {
+		requireSliceAgreesWithLibrary(t, data)
+	})
+}
+
+func sliceOf(size int) []limbs {
 	slice := make([]limbs, size)
 	for i := range slice {
-		slice[i] = limbs{uint64(i), 1, 2, 3}
+		slice[i] = limbs{uint64(i), math.MaxUint64 - uint64(i), uint64(i) << 32, math.MaxUint32}
 	}
 	return slice
-}
-
-// 24 crosses into a uint8 length header, 256 into a uint16 one.
-var marshalFeltSliceSizes = []int{0, 1, 23, 24, 255, 256}
-
-// fxamacker is the source of truth. It wrote every slice on disk, so engines must agree with it.
-// core/slice should not care about this assertion.
-func TestMarshalFeltSliceMatchesFxamacker(t *testing.T) {
-	for _, size := range marshalFeltSliceSizes {
-		slice := feltSlice(size)
-
-		generic, err := fxcbor.Marshal(slice)
-		require.NoError(t, err)
-		require.Equal(t, generic, cbor.MarshalFeltSlice(slice), "len=%d", size)
-	}
-}
-
-func TestUnmarshalFeltSliceMatchesFxamacker(t *testing.T) {
-	for _, size := range marshalFeltSliceSizes {
-		slice := feltSlice(size)
-
-		written, err := fxcbor.Marshal(slice)
-		require.NoError(t, err)
-
-		var back []limbs
-		require.True(t, cbor.UnmarshalFeltSlice(written, &back), "len=%d", size)
-		require.Equal(t, slice, back, "len=%d", size)
-	}
-}
-
-// A nil slice marshals as null, not as an empty array, matching the library.
-func TestMarshalFeltSliceNil(t *testing.T) {
-	generic, err := fxcbor.Marshal([]limbs(nil))
-	require.NoError(t, err)
-	require.Equal(t, generic, cbor.MarshalFeltSlice[limbs](nil))
 }

--- a/encoder/cbor/slice_test.go
+++ b/encoder/cbor/slice_test.go
@@ -1,0 +1,56 @@
+package cbor_test
+
+// TODO(granza): Build a pull of slices to test.
+// core/felt/slice_test.go should test them fast vs generic,
+// here should test current engine vs canonical encoder (fxmacker).
+
+import (
+	"testing"
+
+	"github.com/NethermindEth/juno/encoder/cbor"
+	fxcbor "github.com/fxamacker/cbor/v2"
+	"github.com/stretchr/testify/require"
+)
+
+func feltSlice(size int) []limbs {
+	slice := make([]limbs, size)
+	for i := range slice {
+		slice[i] = limbs{uint64(i), 1, 2, 3}
+	}
+	return slice
+}
+
+// 24 crosses into a uint8 length header, 256 into a uint16 one.
+var marshalFeltSliceSizes = []int{0, 1, 23, 24, 255, 256}
+
+// fxamacker is the source of truth. It wrote every slice on disk, so engines must agree with it.
+// core/slice should not care about this assertion.
+func TestMarshalFeltSliceMatchesFxamacker(t *testing.T) {
+	for _, size := range marshalFeltSliceSizes {
+		slice := feltSlice(size)
+
+		generic, err := fxcbor.Marshal(slice)
+		require.NoError(t, err)
+		require.Equal(t, generic, cbor.MarshalFeltSlice(slice), "len=%d", size)
+	}
+}
+
+func TestUnmarshalFeltSliceMatchesFxamacker(t *testing.T) {
+	for _, size := range marshalFeltSliceSizes {
+		slice := feltSlice(size)
+
+		written, err := fxcbor.Marshal(slice)
+		require.NoError(t, err)
+
+		var back []limbs
+		require.True(t, cbor.UnmarshalFeltSlice(written, &back), "len=%d", size)
+		require.Equal(t, slice, back, "len=%d", size)
+	}
+}
+
+// A nil slice marshals as null, not as an empty array, matching the library.
+func TestMarshalFeltSliceNil(t *testing.T) {
+	generic, err := fxcbor.Marshal([]limbs(nil))
+	require.NoError(t, err)
+	require.Equal(t, generic, cbor.MarshalFeltSlice[limbs](nil))
+}

--- a/encoder/encoder.go
+++ b/encoder/encoder.go
@@ -1,101 +1,44 @@
+// Package encoder is the node's serialization front door. It names no format.
 package encoder
 
 import (
 	"io"
 	"reflect"
-	"sync"
-	"testing"
-
-	"github.com/fxamacker/cbor/v2"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
-var (
-	ts = cbor.NewTagSet()
-	// https://www.iana.org/assignments/cbor-tags/cbor-tags.xhtml
-	// 65536-15309735 	Unassigned
-	tagNum  uint64 = 65536
-	encMode cbor.EncMode
-	decMode cbor.DecMode
-)
-
-var initialiseEncoder sync.Once
-
-func initEncAndDecModes() {
-	var err error
-	encMode, err = cbor.CanonicalEncOptions().EncModeWithTags(ts)
-	if err != nil {
-		panic(err)
-	}
-
-	decMode, err = cbor.DecOptions{
-		MaxArrayElements: 10485760, // Set to a reasonably high value, 10MiB
-	}.DecModeWithTags(ts)
-	if err != nil {
-		panic(err)
-	}
-}
-
-func RegisterType(rType reflect.Type) error {
-	if err := ts.Add(
-		cbor.TagOptions{EncTag: cbor.EncTagRequired, DecTag: cbor.DecTagRequired},
-		rType,
-		tagNum,
-	); err != nil {
-		return err
-	}
-	initEncAndDecModes()
-	tagNum++
-	return nil
+// NewEncoder returns a new encoder
+func NewEncoder(writer io.Writer) Encoder {
+	return engine.NewEncoder(writer)
 }
 
 // Marshal returns encoding of param v
 func Marshal(v any) ([]byte, error) {
-	initialiseEncoder.Do(initEncAndDecModes)
-	return encMode.Marshal(v)
+	return engine.Marshal(v)
 }
 
 // Unmarshal decodes param v from []byte b
 func Unmarshal(b []byte, v any) error {
-	initialiseEncoder.Do(initEncAndDecModes)
-	return decMode.Unmarshal(b, v)
+	return engine.Unmarshal(b, v)
 }
 
-// UnmarshalFirst decodes the first CBOR data item into param v and returns the remaining bytes
+// UnmarshalFirst decodes the first data item into param v and returns the remaining bytes
 func UnmarshalFirst(b []byte, v any) ([]byte, error) {
-	initialiseEncoder.Do(initEncAndDecModes)
-	return decMode.UnmarshalFirst(b, v)
+	return engine.UnmarshalFirst(b, v)
 }
 
-// TestSymmetry checks if a type can be marshalled and unmarshalled with no issues
-func TestSymmetry(t *testing.T, value any) {
-	t.Helper()
-	cborBytes, err := cbor.Marshal(value)
-	require.NoError(t, err)
-
-	unmarshaled := reflect.New(reflect.TypeOf(value))
-	err = cbor.Unmarshal(cborBytes, unmarshaled.Interface())
-	require.NoError(t, err)
-	assert.Equal(t, value, unmarshaled.Elem().Interface())
+// UnmarshalStrict decodes without the node's type tags and fails on a wire key with no matching
+// field. Only projection drift tests need it.
+func UnmarshalStrict(b []byte, v any) error {
+	return engine.UnmarshalStrict(b, v)
 }
 
-type Encoder interface {
-	Encode(v any) error
+// RegisterType registers rType so it carries a tag of its own on the wire.
+// It must be called only from init in encoder/registry.
+func RegisterType(rType reflect.Type) error {
+	return engine.RegisterType(rType)
 }
 
-// NewEncoder returns a new encoder that writes to w
-func NewEncoder(w io.Writer) Encoder {
-	initialiseEncoder.Do(initEncAndDecModes)
-	return encMode.NewEncoder(w)
-}
-
-type Decoder interface {
-	Decode(v any) error
-}
-
-// NewDecoder returns a new decoder that reads from r
-func NewDecoder(r io.Reader) Decoder {
-	initialiseEncoder.Do(initEncAndDecModes)
-	return decMode.NewDecoder(r)
+// IsTypeMismatch reports a wire item that does not fit the Go type, as opposed to malformed input.
+func IsTypeMismatch(err error) bool {
+	return engine.IsTypeMismatch(err)
 }

--- a/encoder/engine.go
+++ b/encoder/engine.go
@@ -1,0 +1,23 @@
+package encoder
+
+import (
+	"io"
+	"reflect"
+)
+
+var engine Engine = newFxamackerEngine()
+
+// Engine is everything a library has to provide to be the node's codec.
+type Engine interface {
+	NewEncoder(w io.Writer) Encoder
+	Marshal(v any) ([]byte, error)
+	Unmarshal(data []byte, v any) error
+	UnmarshalFirst(data []byte, v any) ([]byte, error)
+	UnmarshalStrict(data []byte, v any) error
+	RegisterType(rType reflect.Type) error
+	IsTypeMismatch(err error) bool
+}
+
+type Encoder interface {
+	Encode(v any) error
+}

--- a/encoder/fxamacker.go
+++ b/encoder/fxamacker.go
@@ -1,0 +1,93 @@
+package encoder
+
+import (
+	"errors"
+	"io"
+	"reflect"
+
+	fxcbor "github.com/fxamacker/cbor/v2"
+)
+
+// firstTagNum sits in the range IANA leaves unassigned, 65536 to 15309735.
+// https://www.iana.org/assignments/cbor-tags/cbor-tags.xhtml
+const firstTagNum uint64 = 65536
+
+// fxamackerEngine encodes with github.com/fxamacker/cbor/v2.
+type fxamackerEngine struct {
+	tags       fxcbor.TagSet
+	tagNum     uint64
+	encMode    fxcbor.EncMode
+	decMode    fxcbor.DecMode
+	strictMode fxcbor.DecMode
+}
+
+var _ Engine = (*fxamackerEngine)(nil)
+
+func newFxamackerEngine() *fxamackerEngine {
+	c := &fxamackerEngine{tags: fxcbor.NewTagSet(), tagNum: firstTagNum}
+	c.buildModes()
+
+	var err error
+	c.strictMode, err = fxcbor.DecOptions{
+		ExtraReturnErrors: fxcbor.ExtraDecErrorUnknownField,
+	}.DecMode()
+	if err != nil {
+		panic(err)
+	}
+
+	return c
+}
+
+func (c *fxamackerEngine) buildModes() {
+	var err error
+	c.encMode, err = fxcbor.CanonicalEncOptions().EncModeWithTags(c.tags)
+	if err != nil {
+		panic(err)
+	}
+
+	c.decMode, err = fxcbor.DecOptions{
+		MaxArrayElements: 10485760, // Set to a reasonably high value, 10MiB
+	}.DecModeWithTags(c.tags)
+	if err != nil {
+		panic(err)
+	}
+}
+
+func (c *fxamackerEngine) NewEncoder(w io.Writer) Encoder {
+	return c.encMode.NewEncoder(w)
+}
+
+func (c *fxamackerEngine) Marshal(v any) ([]byte, error) {
+	return c.encMode.Marshal(v)
+}
+
+func (c *fxamackerEngine) Unmarshal(data []byte, v any) error {
+	return c.decMode.Unmarshal(data, v)
+}
+
+func (c *fxamackerEngine) UnmarshalFirst(data []byte, v any) ([]byte, error) {
+	return c.decMode.UnmarshalFirst(data, v)
+}
+
+func (c *fxamackerEngine) UnmarshalStrict(data []byte, v any) error {
+	return c.strictMode.Unmarshal(data, v)
+}
+
+// RegisterType gives a unique CBOR tag to a type.
+func (c *fxamackerEngine) RegisterType(rType reflect.Type) error {
+	if err := c.tags.Add(
+		fxcbor.TagOptions{EncTag: fxcbor.EncTagRequired, DecTag: fxcbor.DecTagRequired},
+		rType,
+		c.tagNum,
+	); err != nil {
+		return err
+	}
+	c.buildModes()
+	c.tagNum++
+	return nil
+}
+
+func (c *fxamackerEngine) IsTypeMismatch(err error) bool {
+	target := new(fxcbor.UnmarshalTypeError)
+	return errors.As(err, &target)
+}

--- a/encoder/golden_test.go
+++ b/encoder/golden_test.go
@@ -1,0 +1,218 @@
+package encoder_test
+
+import (
+	"encoding/hex"
+	"reflect"
+	"testing"
+
+	"github.com/NethermindEth/juno/consensus/starknet"
+	"github.com/NethermindEth/juno/core"
+	"github.com/NethermindEth/juno/core/felt"
+	"github.com/NethermindEth/juno/core/trie2/triedb/pathdb"
+	"github.com/NethermindEth/juno/core/trie2/trienode"
+	"github.com/NethermindEth/juno/encoder"
+	_ "github.com/NethermindEth/juno/encoder/registry"
+	"github.com/NethermindEth/juno/l1/eth"
+	bloom "github.com/bits-and-blooms/bloom/v3"
+	"github.com/stretchr/testify/require"
+)
+
+// goldenCases pins the bytes the node writes today.
+func goldenCases() []struct {
+	name  string
+	value any
+} {
+	return []struct {
+		name  string
+		value any
+	}{
+		{"DeclareTransaction", core.DeclareTransaction{}},
+		{"DeployTransaction", core.DeployTransaction{}},
+		{"InvokeTransaction", core.InvokeTransaction{}},
+		{"L1HandlerTransaction", core.L1HandlerTransaction{}},
+		{"DeployAccountTransaction", core.DeployAccountTransaction{}},
+		{"DeprecatedCairoClass", core.DeprecatedCairoClass{}},
+		{"SierraClass", core.SierraClass{}},
+		{"DeletedNode", trienode.DeletedNode{}},
+		{"LeafNode", trienode.LeafNode{}},
+		{"NonLeafNode", trienode.NonLeafNode{}},
+		{"JournalNodeSet", pathdb.JournalNodeSet{}},
+		{"DiffJournal", pathdb.DiffJournal{}},
+		{"DiskJournal", pathdb.DiskJournal{}},
+		{"DBJournal", pathdb.DBJournal{}},
+		{"WALProposal", starknet.WALProposal{}},
+		{"WALPrevote", starknet.WALPrevote{}},
+		{"WALPrecommit", starknet.WALPrecommit{}},
+		{"WALTimeout", starknet.WALTimeout{}},
+		{"Header", core.Header{}},
+		{"TransactionReceipt", core.TransactionReceipt{}},
+		{"[][]byte, the p2p shape", [][]byte{{1, 2, 3}, {4, 5}, {}}},
+		{"[]byte, the schema state", []byte{9, 8, 7}},
+		{"[][]byte nil", [][]byte(nil)},
+		{"*felt.Felt, the 37-byte shape", new(felt.Felt).SetUint64(7)},
+		{"felt.Slice, two felts", felt.Slice[felt.Felt]{
+			*new(felt.Felt).SetUint64(7),
+			*new(felt.Felt).SetUint64(8),
+		}},
+		{"felt.Slice nil", felt.Slice[felt.Felt](nil)},
+		{"encoder.RawMessage", encoder.RawMessage{0x83, 0x01, 0x02, 0x03}},
+		{"DeclaredClassDefinition, a Sierra class", populatedDeclaredClassDefinition()},
+		{"Header, populated", populatedHeader()},
+		{"InvokeTransaction, populated", populatedInvokeTransaction()},
+		{"TransactionReceipt, populated", populatedReceipt()},
+	}
+}
+
+func goldenFelt(n uint64) *felt.Felt { return new(felt.Felt).SetUint64(n) }
+
+func populatedDeclaredClassDefinition() core.DeclaredClassDefinition {
+	return core.DeclaredClassDefinition{
+		At: 777,
+		Class: &core.SierraClass{
+			Abi:             "some abi",
+			AbiHash:         goldenFelt(1),
+			Program:         []felt.Felt{*goldenFelt(2), *goldenFelt(3)},
+			ProgramHash:     goldenFelt(4),
+			SemanticVersion: "0.1.0",
+			EntryPoints: core.SierraEntryPointsByType{
+				Constructor: []core.SierraEntryPoint{{Index: 0, Selector: goldenFelt(5)}},
+				External:    []core.SierraEntryPoint{{Index: 1, Selector: goldenFelt(6)}},
+				L1Handler:   []core.SierraEntryPoint{{Index: 2, Selector: goldenFelt(7)}},
+			},
+		},
+	}
+}
+
+func populatedHeader() core.Header {
+	return core.Header{
+		Hash:             goldenFelt(1),
+		ParentHash:       goldenFelt(2),
+		Number:           3,
+		GlobalStateRoot:  goldenFelt(4),
+		SequencerAddress: goldenFelt(5),
+		TransactionCount: 6,
+		EventCount:       7,
+		Timestamp:        8,
+		ProtocolVersion:  "0.13.2",
+		EventsBloom:      bloom.New(64, 3),
+		L1GasPriceETH:    goldenFelt(9),
+		Signatures:       [][]*felt.Felt{{goldenFelt(10), goldenFelt(11)}},
+		L1GasPriceSTRK:   goldenFelt(12),
+		L1DAMode:         core.Blob,
+		L1DataGasPrice:   &core.GasPrice{PriceInWei: goldenFelt(13), PriceInFri: goldenFelt(14)},
+		L2GasPrice:       &core.GasPrice{PriceInWei: goldenFelt(15), PriceInFri: goldenFelt(16)},
+	}
+}
+
+func populatedInvokeTransaction() core.InvokeTransaction {
+	version := core.TransactionVersion(*goldenFelt(3))
+	return core.InvokeTransaction{
+		TransactionHash:       goldenFelt(1),
+		CallData:              []felt.Felt{*goldenFelt(2)},
+		TransactionSignature:  []felt.Felt{*goldenFelt(3), *goldenFelt(4)},
+		MaxFee:                goldenFelt(5),
+		ContractAddress:       goldenFelt(6),
+		Version:               &version,
+		EntryPointSelector:    goldenFelt(7),
+		Nonce:                 goldenFelt(8),
+		SenderAddress:         goldenFelt(9),
+		Tip:                   10,
+		PaymasterData:         []felt.Felt{*goldenFelt(11)},
+		AccountDeploymentData: []felt.Felt{*goldenFelt(12)},
+		NonceDAMode:           core.DAModeL2,
+		FeeDAMode:             core.DAModeL1,
+		ResourceBounds: map[core.Resource]core.ResourceBounds{
+			core.ResourceL1Gas:     {MaxAmount: 13, MaxPricePerUnit: goldenFelt(14)},
+			core.ResourceL2Gas:     {MaxAmount: 15, MaxPricePerUnit: goldenFelt(16)},
+			core.ResourceL1DataGas: {MaxAmount: 17, MaxPricePerUnit: goldenFelt(18)},
+		},
+	}
+}
+
+func populatedReceipt() core.TransactionReceipt {
+	return core.TransactionReceipt{
+		Fee:             goldenFelt(1),
+		FeeUnit:         core.STRK,
+		TransactionHash: goldenFelt(2),
+		Reverted:        true,
+		RevertReason:    "some reason",
+		Events: []*core.Event{{
+			From: goldenFelt(3),
+			Keys: []felt.Felt{*goldenFelt(4)},
+			Data: []felt.Felt{*goldenFelt(5)},
+		}},
+		L2ToL1Message: []*core.L2ToL1Message{{
+			From:    goldenFelt(6),
+			Payload: []felt.Felt{*goldenFelt(7)},
+			To:      eth.Address{0x1, 0x2},
+		}},
+		ExecutionResources: &core.ExecutionResources{
+			BuiltinInstanceCounter: core.BuiltinInstanceCounter{Pedersen: 8},
+			MemoryHoles:            9,
+			Steps:                  10,
+			DataAvailability:       &core.DataAvailability{L1Gas: 11, L1DataGas: 12},
+			TotalGasConsumed:       &core.GasConsumed{L1Gas: 13, L1DataGas: 14},
+		},
+	}
+}
+
+// maps a struct with a value that is already on disk in some node.
+//
+//nolint:lll,nolintlint // Ignore lll for literals, nolintlint because main config doesn't check tests
+var golden = map[string]string{
+	"DeclareTransaction":       "da00010000ae6354697000654e6f6e6365f6664d6178466565f66756657273696f6ef669436c61737348617368f66946656544414d6f6465006b4e6f6e636544414d6f6465006d5061796d617374657244617461f66d53656e64657241646472657373f66e5265736f75726365426f756e6473f66f5472616e73616374696f6e48617368f671436f6d70696c6564436c61737348617368f6745472616e73616374696f6e5369676e6174757265f6754163636f756e744465706c6f796d656e7444617461f6",
+	"DeployTransaction":        "da00010001a66756657273696f6ef669436c61737348617368f66f436f6e747261637441646472657373f66f5472616e73616374696f6e48617368f673436f6e7374727563746f7243616c6c44617461f673436f6e74726163744164647265737353616c74f6",
+	"InvokeTransaction":        "da00010002af6354697000654e6f6e6365f6664d6178466565f66756657273696f6ef66843616c6c44617461f66946656544414d6f6465006b4e6f6e636544414d6f6465006d5061796d617374657244617461f66d53656e64657241646472657373f66e5265736f75726365426f756e6473f66f436f6e747261637441646472657373f66f5472616e73616374696f6e48617368f672456e747279506f696e7453656c6563746f72f6745472616e73616374696f6e5369676e6174757265f6754163636f756e744465706c6f796d656e7444617461f6",
+	"L1HandlerTransaction":     "da00010003a6654e6f6e6365f66756657273696f6ef66843616c6c44617461f66f436f6e747261637441646472657373f66f5472616e73616374696f6e48617368f672456e747279506f696e7453656c6563746f72f6",
+	"DeployAccountTransaction": "da00010004ae6354697000654e6f6e6365f6664d6178466565f66756657273696f6ef669436c61737348617368f66946656544414d6f6465006b4e6f6e636544414d6f6465006d5061796d617374657244617461f66e5265736f75726365426f756e6473f66f436f6e747261637441646472657373f66f5472616e73616374696f6e48617368f673436f6e7374727563746f7243616c6c44617461f673436f6e74726163744164647265737353616c74f6745472616e73616374696f6e5369676e6174757265f6",
+	"DeprecatedCairoClass":     "da00010005a563416269f66750726f6772616d606945787465726e616c73f66a4c3148616e646c657273f66c436f6e7374727563746f7273f6",
+	"SierraClass":              "da00010006a763416269606741626948617368f66750726f6772616df668436f6d70696c6564f66b456e747279506f696e7473a36845787465726e616cf6694c3148616e646c6572f66b436f6e7374727563746f72f66b50726f6772616d48617368f66f53656d616e74696356657273696f6e60",
+	"DeletedNode":              "da00010007a0",
+	"LeafNode":                 "da00010008a0",
+	"NonLeafNode":              "da00010009a0",
+	"JournalNodeSet":           "da0001000aa1654e6f646573f6",
+	"DiffJournal":              "da0001000ba364526f6f74840000000065426c6f636b006a456e634e6f6465736574f6",
+	"DiskJournal":              "da0001000ca36249440064526f6f7484000000006a456e634e6f6465736574f6",
+	"DBJournal":                "da0001000da26756657273696f6e0069456e634c6179657273f6",
+	"WALProposal":              "da0001000ea565726f756e64006576616c7565f666686569676874006673656e64657284000000006b76616c69645f726f756e6400",
+	"WALPrevote":               "da0001000fa4626964f665726f756e640066686569676874006673656e6465728400000000",
+	"WALPrecommit":             "da00010010a4626964f665726f756e640066686569676874006673656e6465728400000000",
+	"WALTimeout":               "da0001001183000000",
+	"Header":                   "b06448617368f6664e756d62657200684c3144414d6f646500686761737072696365f66954696d657374616d70006a4576656e74436f756e74006a4c324761735072696365f66a506172656e7448617368f66a5369676e617475726573f66b4576656e7473426c6f6f6df66c67617370726963657374726bf66e4c31446174614761735072696365f66f476c6f62616c5374617465526f6f74f66f50726f746f636f6c56657273696f6e607053657175656e63657241646472657373f6705472616e73616374696f6e436f756e7400",
+	"TransactionReceipt":       "a963466565f6664576656e7473f667466565556e697400685265766572746564f46c526576657274526561736f6e606d4c31546f4c324d657373616765f66d4c32546f4c314d657373616765f66f5472616e73616374696f6e48617368f672457865637574696f6e5265736f7572636573f6",
+	"[][]byte, the p2p shape":  "834301020342040540",
+	"[]byte, the schema state": "43090807",
+	"[][]byte nil":             "f6",
+
+	"*felt.Felt, the 37-byte shape": "841bffffffffffffff211bffffffffffffffff1bffffffffffffffff1b07fffffffffff130",
+	"felt.Slice, two felts": "82841bffffffffffffff211bffffffffffffffff1bffffffffffffffff1b07fffffffffff130" +
+		"841bffffffffffffff011bffffffffffffffff1bffffffffffffffff1b07ffffffffffef10",
+	"felt.Slice nil":     "f6",
+	"encoder.RawMessage": "83010203",
+
+	"DeclaredClassDefinition, a Sierra class": "5901bd0000000000000309da00010006a76341626968736f6d65206162696741626948617368841bffffffffffffffe11bffffffffffffffff1bffffffffffffffff1b07fffffffffffdf06750726f6772616d82841bffffffffffffffc11bffffffffffffffff1bffffffffffffffff1b07fffffffffffbd0841bffffffffffffffa11bffffffffffffffff1bffffffffffffffff1b07fffffffffff9b068436f6d70696c6564f66b456e747279506f696e7473a36845787465726e616c81a265496e646578016853656c6563746f72841bffffffffffffff411bffffffffffffffff1bffffffffffffffff1b07fffffffffff350694c3148616e646c657281a265496e646578026853656c6563746f72841bffffffffffffff211bffffffffffffffff1bffffffffffffffff1b07fffffffffff1306b436f6e7374727563746f7281a265496e646578006853656c6563746f72841bffffffffffffff611bffffffffffffffff1bffffffffffffffff1b07fffffffffff5706b50726f6772616d48617368841bffffffffffffff811bffffffffffffffff1bffffffffffffffff1b07fffffffffff7906f53656d616e74696356657273696f6e65302e312e30",
+	"Header, populated":                       "b06448617368841bffffffffffffffe11bffffffffffffffff1bffffffffffffffff1b07fffffffffffdf0664e756d62657203684c3144414d6f646501686761737072696365841bfffffffffffffee11bffffffffffffffff1bffffffffffffffff1b07ffffffffffecf06954696d657374616d70086a4576656e74436f756e74076a4c324761735072696365a26a5072696365496e467269841bfffffffffffffe011bffffffffffffffff1bffffffffffffffff1b07ffffffffffde106a5072696365496e576569841bfffffffffffffe211bffffffffffffffff1bffffffffffffffff1b07ffffffffffe0306a506172656e7448617368841bffffffffffffffc11bffffffffffffffff1bffffffffffffffff1b07fffffffffffbd06a5369676e6174757265738182841bfffffffffffffec11bffffffffffffffff1bffffffffffffffff1b07ffffffffffead0841bfffffffffffffea11bffffffffffffffff1bffffffffffffffff1b07ffffffffffe8b06b4576656e7473426c6f6f6d582000000000000000400000000000000003000000000000004000000000000000006c67617370726963657374726b841bfffffffffffffe811bffffffffffffffff1bffffffffffffffff1b07ffffffffffe6906e4c31446174614761735072696365a26a5072696365496e467269841bfffffffffffffe411bffffffffffffffff1bffffffffffffffff1b07ffffffffffe2506a5072696365496e576569841bfffffffffffffe611bffffffffffffffff1bffffffffffffffff1b07ffffffffffe4706f476c6f62616c5374617465526f6f74841bffffffffffffff811bffffffffffffffff1bffffffffffffffff1b07fffffffffff7906f50726f746f636f6c56657273696f6e66302e31332e327053657175656e63657241646472657373841bffffffffffffff611bffffffffffffffff1bffffffffffffffff1b07fffffffffff570705472616e73616374696f6e436f756e7406",
+	"InvokeTransaction, populated":            "da00010002af635469700a654e6f6e6365841bffffffffffffff011bffffffffffffffff1bffffffffffffffff1b07ffffffffffef10664d6178466565841bffffffffffffff611bffffffffffffffff1bffffffffffffffff1b07fffffffffff5706756657273696f6e841bffffffffffffffa11bffffffffffffffff1bffffffffffffffff1b07fffffffffff9b06843616c6c4461746181841bffffffffffffffc11bffffffffffffffff1bffffffffffffffff1b07fffffffffffbd06946656544414d6f6465006b4e6f6e636544414d6f6465016d5061796d61737465724461746181841bfffffffffffffea11bffffffffffffffff1bffffffffffffffff1b07ffffffffffe8b06d53656e64657241646472657373841bfffffffffffffee11bffffffffffffffff1bffffffffffffffff1b07ffffffffffecf06e5265736f75726365426f756e6473a301a2694d6178416d6f756e740d6f4d61785072696365506572556e6974841bfffffffffffffe411bffffffffffffffff1bffffffffffffffff1b07ffffffffffe25002a2694d6178416d6f756e740f6f4d61785072696365506572556e6974841bfffffffffffffe011bffffffffffffffff1bffffffffffffffff1b07ffffffffffde1003a2694d6178416d6f756e74116f4d61785072696365506572556e6974841bfffffffffffffdc11bffffffffffffffff1bffffffffffffffff1b07ffffffffffd9d06f436f6e747261637441646472657373841bffffffffffffff411bffffffffffffffff1bffffffffffffffff1b07fffffffffff3506f5472616e73616374696f6e48617368841bffffffffffffffe11bffffffffffffffff1bffffffffffffffff1b07fffffffffffdf072456e747279506f696e7453656c6563746f72841bffffffffffffff211bffffffffffffffff1bffffffffffffffff1b07fffffffffff130745472616e73616374696f6e5369676e617475726582841bffffffffffffffa11bffffffffffffffff1bffffffffffffffff1b07fffffffffff9b0841bffffffffffffff811bffffffffffffffff1bffffffffffffffff1b07fffffffffff790754163636f756e744465706c6f796d656e744461746181841bfffffffffffffe811bffffffffffffffff1bffffffffffffffff1b07ffffffffffe690",
+	"TransactionReceipt, populated":           "a963466565841bffffffffffffffe11bffffffffffffffff1bffffffffffffffff1b07fffffffffffdf0664576656e747381a3644461746181841bffffffffffffff611bffffffffffffffff1bffffffffffffffff1b07fffffffffff5706446726f6d841bffffffffffffffa11bffffffffffffffff1bffffffffffffffff1b07fffffffffff9b0644b65797381841bffffffffffffff811bffffffffffffffff1bffffffffffffffff1b07fffffffffff79067466565556e697401685265766572746564f56c526576657274526561736f6e6b736f6d6520726561736f6e6d4c31546f4c324d657373616765f66d4c32546f4c314d65737361676581a362546f5401020000000000000000000000000000000000006446726f6d841bffffffffffffff411bffffffffffffffff1bffffffffffffffff1b07fffffffffff350675061796c6f616481841bffffffffffffff211bffffffffffffffff1bffffffffffffffff1b07fffffffffff1306f5472616e73616374696f6e48617368841bffffffffffffffc11bffffffffffffffff1bffffffffffffffff1b07fffffffffffbd072457865637574696f6e5265736f7572636573a56553746570730a6b4d656d6f7279486f6c6573097044617461417661696c6162696c697479a2654c314761730b694c31446174614761730c70546f74616c476173436f6e73756d6564a3654c314761730d654c3247617300694c31446174614761730e764275696c74696e496e7374616e6365436f756e746572ac6445634f700065456373646100664164644d6f6400664b656363616b00664d756c4d6f6400664f75747075740067426974776973650068506564657273656e0868506f736569646f6e006a52616e6765436865636b006c52616e6765436865636b3936006c5365676d656e744172656e6100",
+}
+
+func TestGoldenBytes(t *testing.T) {
+	for _, c := range goldenCases() {
+		t.Run(c.name, func(t *testing.T) {
+			b, err := encoder.Marshal(c.value)
+			require.NoError(t, err)
+
+			want, ok := golden[c.name]
+			require.Truef(t, ok, "no vector for %s", c.name)
+			require.Equal(t, want, hex.EncodeToString(b))
+
+			stored, err := hex.DecodeString(want)
+			require.NoError(t, err)
+
+			back := reflect.New(reflect.TypeOf(c.value))
+			require.NoError(t, encoder.Unmarshal(stored, back.Interface()))
+			require.Equal(t, c.value, back.Elem().Interface())
+		})
+	}
+	require.Len(t, golden, len(goldenCases()), "a case lost its vector")
+}

--- a/encoder/hook.go
+++ b/encoder/hook.go
@@ -1,0 +1,13 @@
+package encoder
+
+// SelfEncoder collects the encode hook of every engine.
+// A type that wants to be hand-encoded has to satisfy all of them.
+type SelfEncoder interface {
+	MarshalCBOR() ([]byte, error) // fxamacker
+}
+
+// SelfDecoder collects the decode hook of every engine.
+// A type that wants to be hand-decoded has to satisfy all of them.
+type SelfDecoder interface {
+	UnmarshalCBOR([]byte) error // fxamacker
+}

--- a/encoder/raw.go
+++ b/encoder/raw.go
@@ -1,0 +1,32 @@
+package encoder
+
+import "errors"
+
+// cborNull is what the generic encoder emits for a nil slice.
+const cborNull = 0xf6
+
+// RawMessage is an item that is already CBOR encoded.
+// Do not tag a field of this type `,omitempty`. An empty one is written as null, not dropped.
+type RawMessage []byte
+
+var (
+	_ SelfEncoder = RawMessage(nil)
+	_ SelfDecoder = (*RawMessage)(nil)
+)
+
+// Returns the same bytes
+func (m RawMessage) MarshalCBOR() ([]byte, error) {
+	if len(m) == 0 {
+		return []byte{cborNull}, nil
+	}
+	return m, nil
+}
+
+// Creates a copy of the bytes
+func (m *RawMessage) UnmarshalCBOR(data []byte) error {
+	if m == nil {
+		return errors.New("encoder.RawMessage: UnmarshalCBOR on nil pointer")
+	}
+	*m = append((*m)[:0], data...)
+	return nil
+}

--- a/encoder/raw_test.go
+++ b/encoder/raw_test.go
@@ -1,0 +1,59 @@
+package encoder_test
+
+import (
+	"testing"
+
+	"github.com/NethermindEth/juno/encoder"
+	"github.com/stretchr/testify/require"
+)
+
+// the array [1, 2, 3], already encoded
+var cborArray123 = []byte{0x83, 0x01, 0x02, 0x03}
+
+// two cborArray123 inside an array of two
+var cborTwoArrays = []byte{0x82, 0x83, 0x01, 0x02, 0x03, 0x83, 0x01, 0x02, 0x03}
+
+func TestRawMessageUnmarshalNilPointer(t *testing.T) {
+	var decoded *encoder.RawMessage
+	require.Error(t, decoded.UnmarshalCBOR(cborArray123))
+}
+
+func TestRawMessageMarshalUnchanged(t *testing.T) {
+	out, err := encoder.Marshal([]encoder.RawMessage{cborArray123, cborArray123})
+	require.NoError(t, err)
+	require.Equal(t, cborTwoArrays, out)
+}
+
+func TestRawMessageMarshalEmptyAsNull(t *testing.T) {
+	out, err := encoder.Marshal(encoder.RawMessage(nil))
+	require.NoError(t, err)
+	require.Equal(t, []byte{0xf6}, out)
+}
+
+func TestRawMessageUnmarshalUnchanged(t *testing.T) {
+	var decoded []encoder.RawMessage
+	require.NoError(t, encoder.Unmarshal(cborTwoArrays, &decoded))
+	require.Equal(t, []encoder.RawMessage{cborArray123, cborArray123}, decoded)
+}
+
+func TestRawMessageUnmarshalNullAsNull(t *testing.T) {
+	var decoded encoder.RawMessage
+	require.NoError(t, encoder.Unmarshal([]byte{0xf6}, &decoded))
+	require.Equal(t, encoder.RawMessage{0xf6}, decoded)
+}
+
+func TestRawMessageUnmarshalReplacesTarget(t *testing.T) {
+	decoded := encoder.RawMessage{0xff, 0xff, 0xff, 0xff, 0xff, 0xff}
+	require.NoError(t, encoder.Unmarshal(cborArray123, &decoded))
+	require.Equal(t, encoder.RawMessage(cborArray123), decoded)
+}
+
+func TestRawMessageUnmarshalCopies(t *testing.T) {
+	data := append([]byte{}, cborArray123...)
+
+	var decoded encoder.RawMessage
+	require.NoError(t, encoder.Unmarshal(data, &decoded))
+
+	data[1] = 0xff
+	require.Equal(t, encoder.RawMessage(cborArray123), decoded)
+}

--- a/encoder/unmarshal_first_test.go
+++ b/encoder/unmarshal_first_test.go
@@ -51,9 +51,9 @@ func testData[T any](expected T) testCase {
 	return testCaseData[T]{expected: expected}
 }
 
-func (c testCaseData[T]) encode(t *testing.T, encoder encoder.Encoder) {
+func (c testCaseData[T]) encode(t *testing.T, enc encoder.Encoder) {
 	t.Helper()
-	require.NoError(t, encoder.Encode(c.expected))
+	require.NoError(t, enc.Encode(c.expected))
 }
 
 func (c testCaseData[T]) assert(t *testing.T, data []byte) []byte {
@@ -67,7 +67,7 @@ func (c testCaseData[T]) assert(t *testing.T, data []byte) []byte {
 
 func TestUnmarshalFirst(t *testing.T) {
 	var buf bytes.Buffer
-	encoder := encoder.NewEncoder(&buf)
+	enc := encoder.NewEncoder(&buf)
 
 	testCases := []testCase{
 		testData(felt.Random[felt.Felt]()),
@@ -78,7 +78,7 @@ func TestUnmarshalFirst(t *testing.T) {
 	expectedExtraData := []byte(cryptorand.Text())
 
 	for _, testCase := range testCases {
-		testCase.encode(t, encoder)
+		testCase.encode(t, enc)
 	}
 	_, err := buf.Write(expectedExtraData)
 	require.NoError(t, err)

--- a/migration/blocktransactions/ingestor.go
+++ b/migration/blocktransactions/ingestor.go
@@ -8,10 +8,10 @@ import (
 	"github.com/NethermindEth/juno/core"
 	"github.com/NethermindEth/juno/db"
 	"github.com/NethermindEth/juno/db/typed/prefix"
+	"github.com/NethermindEth/juno/encoder"
 	"github.com/NethermindEth/juno/migration/pipeline"
 	"github.com/NethermindEth/juno/migration/semaphore"
 	"github.com/NethermindEth/juno/utils/log"
-	"github.com/fxamacker/cbor/v2"
 	"go.uber.org/zap"
 )
 
@@ -168,10 +168,12 @@ func (c *ingestor) validateCount(
 	return nil
 }
 
-func extractValues(seq iter.Seq2[prefix.Entry[[]byte], error]) iter.Seq2[cbor.RawMessage, error] {
-	return func(yield func(cbor.RawMessage, error) bool) {
+func extractValues(
+	seq iter.Seq2[prefix.Entry[[]byte], error],
+) iter.Seq2[encoder.RawMessage, error] {
+	return func(yield func(encoder.RawMessage, error) bool) {
 		for item, err := range seq {
-			if !yield(cbor.RawMessage(item.Value), err) {
+			if !yield(encoder.RawMessage(item.Value), err) {
 				return
 			}
 		}

--- a/migration/deprecated/migration.go
+++ b/migration/deprecated/migration.go
@@ -32,7 +32,6 @@ import (
 	"github.com/NethermindEth/juno/starknet"
 	"github.com/NethermindEth/juno/utils/log"
 	"github.com/bits-and-blooms/bitset"
-	"github.com/fxamacker/cbor/v2"
 	"github.com/sourcegraph/conc/pool"
 	"go.uber.org/zap"
 )
@@ -206,7 +205,7 @@ func SchemaMetadata(log log.StructuredLogger, targetDB db.KeyValueStore) (schema
 	}
 
 	err = txn.Get(db.DeprecatedSchemaIntermediateState.Key(), func(data []byte) error {
-		err := cbor.Unmarshal(data, &metadata.IntermediateState)
+		err := encoder.Unmarshal(data, &metadata.IntermediateState)
 		if err != nil {
 			// TODO: Instead of returning nil, we log the error for now to debug the issue
 			log.Error(
@@ -233,7 +232,7 @@ func updateSchemaMetadata(txn db.KeyValueWriter, schema schemaMetadata) error {
 		err     error
 	)
 	binary.BigEndian.PutUint64(version[:], schema.Version)
-	state, err = cbor.Marshal(schema.IntermediateState)
+	state, err = encoder.Marshal(schema.IntermediateState)
 	if err != nil {
 		return err
 	}
@@ -803,8 +802,8 @@ func migrateCairo1CompiledClass2(
 	err := encoder.Unmarshal(value, &class)
 	if err != nil {
 		// assumption that only Cairo0 class causes this error
-		targetErr := new(cbor.UnmarshalTypeError)
-		if errors.As(err, &targetErr) {
+		// TODO(granza): discriminate the record by its own shape, not by the error.
+		if encoder.IsTypeMismatch(err) {
 			return nil
 		}
 

--- a/p2p/codec.go
+++ b/p2p/codec.go
@@ -1,10 +1,9 @@
 package p2p
 
 import (
-	"bytes"
 	"fmt"
 
-	"github.com/fxamacker/cbor/v2"
+	"github.com/NethermindEth/juno/encoder"
 	"github.com/multiformats/go-multiaddr"
 )
 
@@ -15,18 +14,18 @@ func EncodeAddrs(addrs []multiaddr.Multiaddr) ([]byte, error) {
 		multiAddrBytes[i] = addr.Bytes()
 	}
 
-	var buf bytes.Buffer
-	if err := cbor.NewEncoder(&buf).Encode(multiAddrBytes); err != nil {
+	encoded, err := encoder.Marshal(multiAddrBytes)
+	if err != nil {
 		return nil, fmt.Errorf("encode addresses: %w", err)
 	}
 
-	return buf.Bytes(), nil
+	return encoded, nil
 }
 
 // decodeAddrs decodes a byte slice into a slice of multiaddrs
 func decodeAddrs(b []byte) ([]multiaddr.Multiaddr, error) {
 	var multiAddrBytes [][]byte
-	if err := cbor.NewDecoder(bytes.NewReader(b)).Decode(&multiAddrBytes); err != nil {
+	if err := encoder.Unmarshal(b, &multiAddrBytes); err != nil {
 		return nil, fmt.Errorf("decode addresses: %w", err)
 	}
 


### PR DESCRIPTION
`core/felt`'s CBOR tests used to had-write their own CBOR payload.

Now they grad a built-in payload and compare it against the generic path.

`encode/cbor` uses the same payload, but compares it against `fxamacker`, to ensure any new engine is compatible.
