### PR TITLE
perf(rpc): decode the block id object form in a single pass

### DIFF
--- a/rpc/v10/block_id.go
+++ b/rpc/v10/block_id.go
@@ -1,6 +1,7 @@
 package rpcv10
 
 import (
+	"bytes"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -136,37 +137,48 @@ func (b *BlockID) Number() uint64 {
 	return b.data[0]
 }
 
+type blockIDObject struct {
+	BlockHash   *felt.Felt `json:"block_hash"`
+	BlockNumber *uint64    `json:"block_number"`
+}
+
 func (b *BlockID) UnmarshalJSON(data []byte) error {
-	var blockTag string
-	if err := json.Unmarshal(data, &blockTag); err == nil {
-		switch blockTag {
-		case "latest":
-			b.typeID = latest
-		case "pre_confirmed":
-			b.typeID = preConfirmed
-		case "l1_accepted":
-			b.typeID = l1Accepted
-		default:
-			return fmt.Errorf("unknown block tag '%s'", blockTag)
-		}
-	} else {
-		jsonObject := make(map[string]json.RawMessage)
-		if err := json.Unmarshal(data, &jsonObject); err != nil {
+	trimmed := bytes.TrimLeft(data, " \t\r\n")
+	if len(trimmed) == 0 {
+		return errors.New("cannot unmarshal block id")
+	}
+
+	if trimmed[0] != '"' {
+		var object blockIDObject
+		if err := json.Unmarshal(trimmed, &object); err != nil {
 			return err
 		}
-		blockHash, ok := jsonObject["block_hash"]
-		if ok {
+		switch {
+		case object.BlockHash != nil:
 			b.typeID = hash
-			return json.Unmarshal(blockHash, &b.data)
-		}
-
-		blockNumber, ok := jsonObject["block_number"]
-		if ok {
+			b.data = *object.BlockHash
+		case object.BlockNumber != nil:
 			b.typeID = number
-			return json.Unmarshal(blockNumber, &b.data[0])
+			b.data = felt.Felt([4]uint64{*object.BlockNumber, 0, 0, 0})
+		default:
+			return errors.New("cannot unmarshal block id")
 		}
+		return nil
+	}
 
-		return errors.New("cannot unmarshal block id")
+	var blockTag string
+	if err := json.Unmarshal(trimmed, &blockTag); err != nil {
+		return err
+	}
+	switch blockTag {
+	case "latest":
+		b.typeID = latest
+	case "pre_confirmed":
+		b.typeID = preConfirmed
+	case "l1_accepted":
+		b.typeID = l1Accepted
+	default:
+		return fmt.Errorf("unknown block tag '%s'", blockTag)
 	}
 	return nil
 }

--- a/rpc/v10/block_id.go
+++ b/rpc/v10/block_id.go
@@ -137,12 +137,12 @@ func (b *BlockID) Number() uint64 {
 	return b.data[0]
 }
 
-type blockIDObject struct {
-	BlockHash   *felt.Felt `json:"block_hash"`
-	BlockNumber *uint64    `json:"block_number"`
-}
-
 func (b *BlockID) UnmarshalJSON(data []byte) error {
+	type blockIDObject struct {
+		BlockHash   *felt.Felt `json:"block_hash"`
+		BlockNumber *uint64    `json:"block_number"`
+	}
+
 	trimmed := bytes.TrimLeft(data, " \t\r\n")
 	if len(trimmed) == 0 {
 		return errors.New("cannot unmarshal block id")

--- a/rpc/v10/block_id_test.go
+++ b/rpc/v10/block_id_test.go
@@ -1,0 +1,64 @@
+package rpcv10_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/NethermindEth/juno/core/felt"
+	rpc "github.com/NethermindEth/juno/rpc/v10"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBlockIDUnmarshalJSON(t *testing.T) {
+	hash := felt.NewUnsafeFromString[felt.Felt](
+		"0x47c3637b57c2b079b93c61539950c17e868a28f46cdef28f88521067f21e943",
+	)
+
+	tests := []struct {
+		name     string
+		data     string
+		expected rpc.BlockID
+	}{
+		{"latest", `"latest"`, rpc.BlockIDLatest()},
+		{"pre_confirmed", `"pre_confirmed"`, rpc.BlockIDPreConfirmed()},
+		{"l1_accepted", `"l1_accepted"`, rpc.BlockIDL1Accepted()},
+		{"number", `{"block_number":42}`, rpc.BlockIDFromNumber(42)},
+		{"number zero", `{"block_number":0}`, rpc.BlockIDFromNumber(0)},
+		{"hash", `{"block_hash":"` + hash.String() + `"}`, rpc.BlockIDFromHash(hash)},
+		{"leading whitespace", "  \n\t" + `"latest"`, rpc.BlockIDLatest()},
+		{
+			"hash wins over number",
+			`{"block_hash":"` + hash.String() + `","block_number":42}`,
+			rpc.BlockIDFromHash(hash),
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			var blockID rpc.BlockID
+			require.NoError(t, json.Unmarshal([]byte(test.data), &blockID))
+			assert.Equal(t, test.expected, blockID)
+		})
+	}
+
+	errorTests := []struct {
+		name string
+		data string
+	}{
+		{"unknown tag", `"pending"`},
+		{"empty object", `{}`},
+		{"unknown key", `{"block_id":42}`},
+		{"bare number", `42`},
+		{"array", `[]`},
+		{"malformed hash", `{"block_hash":"not a felt"}`},
+		{"negative number", `{"block_number":-1}`},
+	}
+
+	for _, test := range errorTests {
+		t.Run("error/"+test.name, func(t *testing.T) {
+			var blockID rpc.BlockID
+			require.Error(t, json.Unmarshal([]byte(test.data), &blockID))
+		})
+	}
+}

--- a/rpc/v10/block_id_test.go
+++ b/rpc/v10/block_id_test.go
@@ -32,7 +32,11 @@ func TestBlockIDUnmarshalJSON(t *testing.T) {
 			`{"block_hash":"` + hash.String() + `","block_number":42}`,
 			rpc.BlockIDFromHash(hash),
 		},
-		{"null hash falls back to number", `{"block_hash":null,"block_number":42}`, rpc.BlockIDFromNumber(42)},
+		{
+			"null hash falls back to number",
+			`{"block_hash":null,"block_number":42}`,
+			rpc.BlockIDFromNumber(42),
+		},
 	}
 
 	for _, test := range tests {

--- a/rpc/v10/block_id_test.go
+++ b/rpc/v10/block_id_test.go
@@ -32,6 +32,7 @@ func TestBlockIDUnmarshalJSON(t *testing.T) {
 			`{"block_hash":"` + hash.String() + `","block_number":42}`,
 			rpc.BlockIDFromHash(hash),
 		},
+		{"null hash falls back to number", `{"block_hash":null,"block_number":42}`, rpc.BlockIDFromNumber(42)},
 	}
 
 	for _, test := range tests {
@@ -53,12 +54,30 @@ func TestBlockIDUnmarshalJSON(t *testing.T) {
 		{"array", `[]`},
 		{"malformed hash", `{"block_hash":"not a felt"}`},
 		{"negative number", `{"block_number":-1}`},
+		{"null hash", `{"block_hash":null}`},
+		{"null number", `{"block_number":null}`},
 	}
 
 	for _, test := range errorTests {
 		t.Run("error/"+test.name, func(t *testing.T) {
 			var blockID rpc.BlockID
 			require.Error(t, json.Unmarshal([]byte(test.data), &blockID))
+		})
+	}
+
+	// encoding/json rejects malformed input before it reaches the unmarshaler, so call it directly.
+	rawErrorTests := []struct {
+		name string
+		data string
+	}{
+		{"blank input", "  \n\t"},
+		{"unterminated tag", `"latest`},
+	}
+
+	for _, test := range rawErrorTests {
+		t.Run("error/"+test.name, func(t *testing.T) {
+			var blockID rpc.BlockID
+			require.Error(t, blockID.UnmarshalJSON([]byte(test.data)))
 		})
 	}
 }

--- a/rpc/v9/block.go
+++ b/rpc/v9/block.go
@@ -149,12 +149,12 @@ func (b *BlockID) Number() uint64 {
 	return b.data[0]
 }
 
-type blockIDObject struct {
-	BlockHash   *felt.Felt `json:"block_hash"`
-	BlockNumber *uint64    `json:"block_number"`
-}
-
 func (b *BlockID) UnmarshalJSON(data []byte) error {
+	type blockIDObject struct {
+		BlockHash   *felt.Felt `json:"block_hash"`
+		BlockNumber *uint64    `json:"block_number"`
+	}
+
 	trimmed := bytes.TrimLeft(data, " \t\r\n")
 	if len(trimmed) == 0 {
 		return errors.New("cannot unmarshal block id")

--- a/rpc/v9/block.go
+++ b/rpc/v9/block.go
@@ -1,6 +1,7 @@
 package rpcv9
 
 import (
+	"bytes"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -148,37 +149,48 @@ func (b *BlockID) Number() uint64 {
 	return b.data[0]
 }
 
+type blockIDObject struct {
+	BlockHash   *felt.Felt `json:"block_hash"`
+	BlockNumber *uint64    `json:"block_number"`
+}
+
 func (b *BlockID) UnmarshalJSON(data []byte) error {
-	var blockTag string
-	if err := json.Unmarshal(data, &blockTag); err == nil {
-		switch blockTag {
-		case "latest":
-			b.typeID = latest
-		case "pre_confirmed":
-			b.typeID = preConfirmed
-		case "l1_accepted":
-			b.typeID = l1Accepted
-		default:
-			return fmt.Errorf("unknown block tag '%s'", blockTag)
-		}
-	} else {
-		jsonObject := make(map[string]json.RawMessage)
-		if err := json.Unmarshal(data, &jsonObject); err != nil {
+	trimmed := bytes.TrimLeft(data, " \t\r\n")
+	if len(trimmed) == 0 {
+		return errors.New("cannot unmarshal block id")
+	}
+
+	if trimmed[0] != '"' {
+		var object blockIDObject
+		if err := json.Unmarshal(trimmed, &object); err != nil {
 			return err
 		}
-		blockHash, ok := jsonObject["block_hash"]
-		if ok {
+		switch {
+		case object.BlockHash != nil:
 			b.typeID = hash
-			return json.Unmarshal(blockHash, &b.data)
-		}
-
-		blockNumber, ok := jsonObject["block_number"]
-		if ok {
+			b.data = *object.BlockHash
+		case object.BlockNumber != nil:
 			b.typeID = number
-			return json.Unmarshal(blockNumber, &b.data[0])
+			b.data = felt.Felt([4]uint64{*object.BlockNumber, 0, 0, 0})
+		default:
+			return errors.New("cannot unmarshal block id")
 		}
+		return nil
+	}
 
-		return errors.New("cannot unmarshal block id")
+	var blockTag string
+	if err := json.Unmarshal(trimmed, &blockTag); err != nil {
+		return err
+	}
+	switch blockTag {
+	case "latest":
+		b.typeID = latest
+	case "pre_confirmed":
+		b.typeID = preConfirmed
+	case "l1_accepted":
+		b.typeID = l1Accepted
+	default:
+		return fmt.Errorf("unknown block tag '%s'", blockTag)
 	}
 	return nil
 }

--- a/rpc/v9/block_id_test.go
+++ b/rpc/v9/block_id_test.go
@@ -32,7 +32,11 @@ func TestBlockIDUnmarshalJSON(t *testing.T) {
 			`{"block_hash":"` + hash.String() + `","block_number":42}`,
 			rpc.BlockIDFromHash(hash),
 		},
-		{"null hash falls back to number", `{"block_hash":null,"block_number":42}`, rpc.BlockIDFromNumber(42)},
+		{
+			"null hash falls back to number",
+			`{"block_hash":null,"block_number":42}`,
+			rpc.BlockIDFromNumber(42),
+		},
 	}
 
 	for _, test := range tests {

--- a/rpc/v9/block_id_test.go
+++ b/rpc/v9/block_id_test.go
@@ -32,6 +32,7 @@ func TestBlockIDUnmarshalJSON(t *testing.T) {
 			`{"block_hash":"` + hash.String() + `","block_number":42}`,
 			rpc.BlockIDFromHash(hash),
 		},
+		{"null hash falls back to number", `{"block_hash":null,"block_number":42}`, rpc.BlockIDFromNumber(42)},
 	}
 
 	for _, test := range tests {
@@ -53,12 +54,30 @@ func TestBlockIDUnmarshalJSON(t *testing.T) {
 		{"array", `[]`},
 		{"malformed hash", `{"block_hash":"not a felt"}`},
 		{"negative number", `{"block_number":-1}`},
+		{"null hash", `{"block_hash":null}`},
+		{"null number", `{"block_number":null}`},
 	}
 
 	for _, test := range errorTests {
 		t.Run("error/"+test.name, func(t *testing.T) {
 			var blockID rpc.BlockID
 			require.Error(t, json.Unmarshal([]byte(test.data), &blockID))
+		})
+	}
+
+	// encoding/json rejects malformed input before it reaches the unmarshaler, so call it directly.
+	rawErrorTests := []struct {
+		name string
+		data string
+	}{
+		{"blank input", "  \n\t"},
+		{"unterminated tag", `"latest`},
+	}
+
+	for _, test := range rawErrorTests {
+		t.Run("error/"+test.name, func(t *testing.T) {
+			var blockID rpc.BlockID
+			require.Error(t, blockID.UnmarshalJSON([]byte(test.data)))
 		})
 	}
 }

--- a/rpc/v9/block_id_test.go
+++ b/rpc/v9/block_id_test.go
@@ -1,0 +1,64 @@
+package rpcv9_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/NethermindEth/juno/core/felt"
+	rpc "github.com/NethermindEth/juno/rpc/v9"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBlockIDUnmarshalJSON(t *testing.T) {
+	hash := felt.NewUnsafeFromString[felt.Felt](
+		"0x47c3637b57c2b079b93c61539950c17e868a28f46cdef28f88521067f21e943",
+	)
+
+	tests := []struct {
+		name     string
+		data     string
+		expected rpc.BlockID
+	}{
+		{"latest", `"latest"`, rpc.BlockIDLatest()},
+		{"pre_confirmed", `"pre_confirmed"`, rpc.BlockIDPreConfirmed()},
+		{"l1_accepted", `"l1_accepted"`, rpc.BlockIDL1Accepted()},
+		{"number", `{"block_number":42}`, rpc.BlockIDFromNumber(42)},
+		{"number zero", `{"block_number":0}`, rpc.BlockIDFromNumber(0)},
+		{"hash", `{"block_hash":"` + hash.String() + `"}`, rpc.BlockIDFromHash(hash)},
+		{"leading whitespace", "  \n\t" + `"latest"`, rpc.BlockIDLatest()},
+		{
+			"hash wins over number",
+			`{"block_hash":"` + hash.String() + `","block_number":42}`,
+			rpc.BlockIDFromHash(hash),
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			var blockID rpc.BlockID
+			require.NoError(t, json.Unmarshal([]byte(test.data), &blockID))
+			assert.Equal(t, test.expected, blockID)
+		})
+	}
+
+	errorTests := []struct {
+		name string
+		data string
+	}{
+		{"unknown tag", `"pending"`},
+		{"empty object", `{}`},
+		{"unknown key", `{"block_id":42}`},
+		{"bare number", `42`},
+		{"array", `[]`},
+		{"malformed hash", `{"block_hash":"not a felt"}`},
+		{"negative number", `{"block_number":-1}`},
+	}
+
+	for _, test := range errorTests {
+		t.Run("error/"+test.name, func(t *testing.T) {
+			var blockID rpc.BlockID
+			require.Error(t, json.Unmarshal([]byte(test.data), &blockID))
+		})
+	}
+}


### PR DESCRIPTION
<!-- pr-agent-generated -->
### **PR Type**
Enhancement, Tests


___

### **Description**
- Decode `BlockID` object JSON in one pass

- Apply same changes across RPC v9 and v10

- Add comprehensive unmarshal JSON tests

- Improve error handling for invalid inputs


___



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>block_id.go</strong><dd><code>Rewrite `BlockID` JSON unmarshal path</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

rpc/v10/block_id.go

<ul><li>Add <code>bytes</code> import and typed <code>blockIDObject</code> struct<br> <li> Trim leading whitespace before choosing parse branch<br> <li> Decode object form in a single JSON pass<br> <li> Preserve tag handling and error behavior</ul>


</details>


  </td>
  <td><a href="https://github.com/NethermindEth/juno/pull/4009/files#diff-496f68fe1f2654b52086e3947cb4ae3ac7a3f286a72336517fc9b39e3649b61d">+36/-24</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>block.go</strong><dd><code>Rewrite `BlockID` JSON unmarshal path</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

rpc/v9/block.go

<ul><li>Add <code>bytes</code> import and typed <code>blockIDObject</code> struct<br> <li> Trim leading whitespace before choosing parse branch<br> <li> Decode object form in a single JSON pass<br> <li> Preserve tag handling and error behavior</ul>


</details>


  </td>
  <td><a href="https://github.com/NethermindEth/juno/pull/4009/files#diff-3006d5a30c330e1ba9e1dcf358b810edad3cc50cfec46db77cda84b71f82138d">+36/-24</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>block_id_test.go</strong><dd><code>Add `BlockID` unmarshal JSON tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

rpc/v10/block_id_test.go

<ul><li>Add table tests for tags, hash, and number<br> <li> Verify hash precedence and null fallback<br> <li> Include malformed, unknown, and raw error cases</ul>


</details>


  </td>
  <td><a href="https://github.com/NethermindEth/juno/pull/4009/files#diff-d1c14c1a7effd76c1a6e29792134bb5e086f42c1018f4a2ab43d9d1704221bfd">+87/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>block_id_test.go</strong><dd><code>Add `BlockID` unmarshal JSON tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

rpc/v9/block_id_test.go

<ul><li>Add table tests for tags, hash, and number<br> <li> Verify hash precedence and null fallback<br> <li> Include malformed, unknown, and raw error cases</ul>


</details>


  </td>
  <td><a href="https://github.com/NethermindEth/juno/pull/4009/files#diff-ae95a0fd726be304f6f261bbcb7f9adaf0ab394b868b55d8fa0b9910208a04b4">+87/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

