### PR TITLE
docs: remove emojis and em-dashes from documentation

### DIFF
--- a/docs/docs/configuring.md
+++ b/docs/docs/configuring.md
@@ -2,7 +2,7 @@
 title: Configuration
 ---
 
-# Configuring Juno :gear:
+# Configuring Juno
 
 Juno can be configured using several methods, with the following order of precedence:
 

--- a/docs/docs/faq.md
+++ b/docs/docs/faq.md
@@ -2,7 +2,7 @@
 title: FAQ
 ---
 
-# Frequently Asked Questions :question:
+# Frequently Asked Questions
 
 <details>
   <summary>What is Juno?</summary>

--- a/docs/docs/hardware-requirements.md
+++ b/docs/docs/hardware-requirements.md
@@ -2,7 +2,7 @@
 title: Hardware Requirements
 ---
 
-# Hardware Requirements :computer:
+# Hardware Requirements
 
 Juno can be used either as part of a **validator** setup during Starknet staking v2 ([read more](https://nethermindeth.github.io/starknet-staking-v2/)) or as a **full node** serving RPC requests. Hardware requirements will vary depending on the intended usage.
 

--- a/docs/docs/intro.md
+++ b/docs/docs/intro.md
@@ -3,15 +3,15 @@ slug: /
 title: Introduction
 ---
 
-# Welcome to Juno :wave:
+# Welcome to Juno
 
 Juno is a Go implementation of a Starknet full-node client created by Nethermind to allow node operators to easily and reliably support the network and advance its decentralisation goals. Juno supports various node setups, from casual to production-grade indexers.
 
-- :cd: **Small database footprint**: Committed to keeping the database size as small as possible
-- :zap: **Ultra-fast synchronisation**: Limited only by your hardware and the sequencer.
-- :100: **Complete [JSON-RPC spec](https://github.com/starkware-libs/starknet-specs/tree/master) compliance**: Everything Starknet, accessible from a single point.
-- :mag_right: **Minimal RPC response latency**: Ensuring your applications run smoothly.
-- :globe_with_meridians: **Websocket interface**: For seamless real-time updates of the network.
+- **Small database footprint**: Committed to keeping the database size as small as possible
+- **Ultra-fast synchronisation**: Limited only by your hardware and the sequencer.
+- **Complete [JSON-RPC spec](https://github.com/starkware-libs/starknet-specs/tree/master) compliance**: Everything Starknet, accessible from a single point.
+- **Minimal RPC response latency**: Ensuring your applications run smoothly.
+- **Websocket interface**: For seamless real-time updates of the network.
 
 ## Getting started
 
@@ -61,11 +61,11 @@ Join our community for support, engaging discussions, and updates:
 
 We value community contributions and are eager to support your involvement. Here’s how you can contribute:
 
-- :rocket: [Run a Juno node](running-juno) to strengthen the Starknet network.
-- :star: Give Juno a [star on GitHub](https://github.com/NethermindEth/juno/stargazers).
-- :memo: Share your thoughts on [X (Twitter)](https://twitter.com/intent/tweet?url=https%3A%2F%2Fgithub.com%2FNethermindEth%2Fjuno&via=nethermindeth&text=Juno%20is%20Awesome%2C%20they%20are%20working%20hard%20to%20bring%20decentralization%20to%20StarkNet&hashtags=StarkNet%2CJuno%2CEthereum).
-- :beetle: [Report bugs](https://github.com/NethermindEth/juno/issues/new) or [suggest new features](https://github.com/NethermindEth/juno/issues/new).
-- :mega: Encourage others to explore and use Juno.
+- [Run a Juno node](running-juno) to strengthen the Starknet network.
+- Give Juno a [star on GitHub](https://github.com/NethermindEth/juno/stargazers).
+- Share your thoughts on [X (Twitter)](https://twitter.com/intent/tweet?url=https%3A%2F%2Fgithub.com%2FNethermindEth%2Fjuno&via=nethermindeth&text=Juno%20is%20Awesome%2C%20they%20are%20working%20hard%20to%20bring%20decentralization%20to%20StarkNet&hashtags=StarkNet%2CJuno%2CEthereum).
+- [Report bugs](https://github.com/NethermindEth/juno/issues/new) or [suggest new features](https://github.com/NethermindEth/juno/issues/new).
+- Encourage others to explore and use Juno.
 
 :::tip
 If you're ready to make PRs but unsure where to start, join our [Discord](https://discord.gg/TcHbSZ9ATd), and we'll guide you through some beginner-friendly issues.

--- a/docs/docs/json-rpc.md
+++ b/docs/docs/json-rpc.md
@@ -2,7 +2,7 @@
 title: JSON-RPC
 ---
 
-# JSON-RPC Interface :globe_with_meridians:
+# JSON-RPC Interface
 
 Interacting with Juno requires sending requests to specific JSON-RPC API methods. Juno supports all of [Starknet's Node API Endpoints](https://playground.open-rpc.org/?uiSchema%5BappBar%5D%5Bui:splitView%5D=false&schemaUrl=https://raw.githubusercontent.com/starkware-libs/starknet-specs/v0.10.1/api/starknet_api_openrpc.json&uiSchema%5BappBar%5D%5Bui:input%5D=false&uiSchema%5BappBar%5D%5Bui:darkMode%5D=true&uiSchema%5BappBar%5D%5Bui:examplesDropdown%5D=false) over HTTP and [WebSocket](websocket).
 

--- a/docs/docs/monitoring.md
+++ b/docs/docs/monitoring.md
@@ -2,7 +2,7 @@
 title: Monitoring
 ---
 
-# Metrics Monitoring :bar_chart:
+# Metrics Monitoring
 
 Juno uses [Prometheus](https://prometheus.io/) to monitor and collect metrics data, which you can visualise with [Grafana](https://grafana.com/). You can use these insights to understand what is happening when Juno is running.
 

--- a/docs/docs/plugins.md
+++ b/docs/docs/plugins.md
@@ -34,7 +34,7 @@ type BlockAndStateUpdate struct {
 
 **Shutdown**: Called when the Juno node is shut down. This can be used to clean up resources like database connections.
 
-**NewBlock**: Called by the synchronizer each time a new block is stored. Juno sends the block, the corresponding state update, and any new classes (as `core.ClassDefinition` values), and waits for the call to return before continuing the sync. Note that a returned error is logged but does not stop the sync — the plugin is responsible for handling its own failures.
+**NewBlock**: Called by the synchronizer each time a new block is stored. Juno sends the block, the corresponding state update, and any new classes (as `core.ClassDefinition` values), and waits for the call to return before continuing the sync. Note that a returned error is logged but does not stop the sync. The plugin is responsible for handling its own failures.
 
 **RevertBlock**: Called during a blockchain reorganization (reorg), once for each block that needs to be reverted. `reverseStateDiff` describes how to undo the block's state changes: apply its `StorageDiffs`, `Nonces`, and `ReplacedClasses` as writes, and its `DeclaredV0Classes`, `DeclaredV1Classes`, and `ReplacedClasses` as deletions. As with `NewBlock`, Juno waits for the call to return, and errors are logged without stopping the sync.
 
@@ -88,7 +88,7 @@ go build -buildmode=plugin -o ./plugin.so /path/to/your/plugin.go
 
 This command compiles the plugin into a shared object file (`plugin.so`), which can then be loaded by the Juno client.
 
-Go plugins impose strict compatibility requirements — if any of them are not met, Juno will fail to load the plugin at runtime:
+Go plugins impose strict compatibility requirements. If any of them are not met, Juno will fail to load the plugin at runtime:
 
 - The plugin must be built with the **same Go toolchain version** used to build the Juno binary.
 - The plugin must depend on the **same version of the `github.com/NethermindEth/juno` module** (and identical versions of any shared dependencies) as the running node.

--- a/docs/docs/running-juno.md
+++ b/docs/docs/running-juno.md
@@ -2,7 +2,7 @@
 title: Installation
 ---
 
-# Running Juno :rocket:
+# Running Juno
 
 ```mdx-code-block
 import Tabs from "@theme/Tabs";
@@ -11,7 +11,7 @@ import TabItem from "@theme/TabItem";
 
 You can run a Juno node using several methods:
 
-- **Docker container** or **Standalone binary** — see below
+- **Docker container** or **Standalone binary** (see below)
 - [Building from source](#building-from-source)
 - [Kubernetes with Helm](running-on-kubernetes)
 - [Google Cloud Platform (GCP)](running-on-gcp)

--- a/docs/docs/running-on-gcp.md
+++ b/docs/docs/running-on-gcp.md
@@ -2,7 +2,7 @@
 title: GCP
 ---
 
-# Running Juno on GCP :cloud:
+# Running Juno on GCP
 
 To run Juno on the Google Cloud Platform (GCP), you can use the Starknet RPC Virtual Machine (VM) developed by Nethermind.
 

--- a/docs/docs/running-on-kubernetes.md
+++ b/docs/docs/running-on-kubernetes.md
@@ -2,7 +2,7 @@
 title: Kubernetes
 ---
 
-# Running Juno on Kubernetes :wheel_of_dharma:
+# Running Juno on Kubernetes
 
 You can deploy Juno on Kubernetes using the official [Helm chart](https://github.com/NethermindEth/helm-charts/tree/main/charts/juno). The chart deploys a Juno Starknet full node as a StatefulSet with persistent storage. Optionally, a [staking validator](staking-validator) service can be enabled alongside.
 

--- a/docs/docs/snapshots.md
+++ b/docs/docs/snapshots.md
@@ -2,13 +2,13 @@
 title: Snapshot Sync
 ---
 
-# Sync from a Snapshot :camera_flash:
+# Sync from a Snapshot
 
 It is possible to avoid syncing from the beginning and waiting weeks to catch up by downloading a Juno snapshot. You're downloading a pre-synced Juno database that you can point your node to. This will reduce the syncing time to just a few hours.
 
 Snapshots are provided in a compressed `.tar.zst` format for faster downloads and reduced storage requirements. It also allows you to directly stream the decompressed file to your computer without needing to download it first.
 
-Additionally, _pruned_ snapshots are offered — they contain only the latest data, greatly reducing storage size.
+Additionally, _pruned_ snapshots are offered. They contain only the latest data, greatly reducing storage size.
 
 
 ## Network Snapshots
@@ -27,7 +27,7 @@ import TabItem from "@theme/TabItem";
 ```
 
 :::tip
-Select your network in any tab below and the rest of the page follows — the choice is synced across every command on this page.
+Select your network in any tab below and the rest of the page follows. The choice is synced across every command on this page.
 :::
 
 ## Getting snapshot sizes
@@ -188,7 +188,7 @@ sudo dnf install lftp pv
 </TabItem>
 <TabItem value="curl" label="curl">
 
-Nothing to install — `curl` is preinstalled on most systems.
+Nothing to install. `curl` is preinstalled on most systems.
 
 ---
 

--- a/docs/docs/updating.md
+++ b/docs/docs/updating.md
@@ -2,7 +2,7 @@
 title: Updating
 ---
 
-# Updating Juno :arrows_counterclockwise:
+# Updating Juno
 
 ```mdx-code-block
 import Tabs from "@theme/Tabs";

--- a/docs/docs/websocket.md
+++ b/docs/docs/websocket.md
@@ -2,7 +2,7 @@
 title: WebSockets
 ---
 
-# WebSocket Interface :globe_with_meridians:
+# WebSocket Interface
 
 Juno provides a WebSocket RPC interface that supports all of [Starknet's JSON-RPC API](https://playground.open-rpc.org/?uiSchema%5BappBar%5D%5Bui:splitView%5D=false&schemaUrl=https://raw.githubusercontent.com/starkware-libs/starknet-specs/v0.10.1/api/starknet_api_openrpc.json&uiSchema%5BappBar%5D%5Bui:input%5D=false&uiSchema%5BappBar%5D%5Bui:darkMode%5D=true&uiSchema%5BappBar%5D%5Bui:examplesDropdown%5D=false) endpoints and allows you to [subscribe to newly created blocks](#subscribe-to-newly-created-blocks).
 

--- a/docs/versioned_docs/version-0.16.0/configuring.md
+++ b/docs/versioned_docs/version-0.16.0/configuring.md
@@ -2,7 +2,7 @@
 title: Configuration
 ---
 
-# Configuring Juno :gear:
+# Configuring Juno
 
 Juno can be configured using several methods, with the following order of precedence:
 

--- a/docs/versioned_docs/version-0.16.0/faq.md
+++ b/docs/versioned_docs/version-0.16.0/faq.md
@@ -2,7 +2,7 @@
 title: FAQ
 ---
 
-# Frequently Asked Questions :question:
+# Frequently Asked Questions
 
 <details>
   <summary>What is Juno?</summary>

--- a/docs/versioned_docs/version-0.16.0/hardware-requirements.md
+++ b/docs/versioned_docs/version-0.16.0/hardware-requirements.md
@@ -2,7 +2,7 @@
 title: Hardware Requirements
 ---
 
-# Hardware Requirements :computer:
+# Hardware Requirements
 
 Juno can be used either as part of a **validator** setup during Starknet staking v2 ([read more](https://nethermindeth.github.io/starknet-staking-v2/)) or as a **full node** serving RPC requests. Hardware requirements will vary depending on the intended usage.
 

--- a/docs/versioned_docs/version-0.16.0/intro.md
+++ b/docs/versioned_docs/version-0.16.0/intro.md
@@ -3,15 +3,15 @@ slug: /
 title: Introduction
 ---
 
-# Welcome to Juno :wave:
+# Welcome to Juno
 
 Juno is a Go implementation of a Starknet full-node client created by Nethermind to allow node operators to easily and reliably support the network and advance its decentralisation goals. Juno supports various node setups, from casual to production-grade indexers.
 
-- :cd: **Small database footprint**: Committed to keeping the database size as small as possible
-- :zap: **Ultra-fast synchronisation**: Limited only by your hardware and the sequencer.
-- :100: **Complete [JSON-RPC spec](https://github.com/starkware-libs/starknet-specs/tree/master) compliance**: Everything Starknet, accessible from a single point.
-- :mag_right: **Minimal RPC response latency**: Ensuring your applications run smoothly.
-- :globe_with_meridians: **Websocket interface**: For seamless real-time updates of the network.
+- **Small database footprint**: Committed to keeping the database size as small as possible
+- **Ultra-fast synchronisation**: Limited only by your hardware and the sequencer.
+- **Complete [JSON-RPC spec](https://github.com/starkware-libs/starknet-specs/tree/master) compliance**: Everything Starknet, accessible from a single point.
+- **Minimal RPC response latency**: Ensuring your applications run smoothly.
+- **Websocket interface**: For seamless real-time updates of the network.
 
 ## Getting started
 
@@ -61,11 +61,11 @@ Join our community for support, engaging discussions, and updates:
 
 We value community contributions and are eager to support your involvement. Here’s how you can contribute:
 
-- :rocket: [Run a Juno node](running-juno) to strengthen the Starknet network.
-- :star: Give Juno a [star on GitHub](https://github.com/NethermindEth/juno/stargazers).
-- :memo: Share your thoughts on [X (Twitter)](https://twitter.com/intent/tweet?url=https%3A%2F%2Fgithub.com%2FNethermindEth%2Fjuno&via=nethermindeth&text=Juno%20is%20Awesome%2C%20they%20are%20working%20hard%20to%20bring%20decentralization%20to%20StarkNet&hashtags=StarkNet%2CJuno%2CEthereum).
-- :beetle: [Report bugs](https://github.com/NethermindEth/juno/issues/new) or [suggest new features](https://github.com/NethermindEth/juno/issues/new).
-- :mega: Encourage others to explore and use Juno.
+- [Run a Juno node](running-juno) to strengthen the Starknet network.
+- Give Juno a [star on GitHub](https://github.com/NethermindEth/juno/stargazers).
+- Share your thoughts on [X (Twitter)](https://twitter.com/intent/tweet?url=https%3A%2F%2Fgithub.com%2FNethermindEth%2Fjuno&via=nethermindeth&text=Juno%20is%20Awesome%2C%20they%20are%20working%20hard%20to%20bring%20decentralization%20to%20StarkNet&hashtags=StarkNet%2CJuno%2CEthereum).
+- [Report bugs](https://github.com/NethermindEth/juno/issues/new) or [suggest new features](https://github.com/NethermindEth/juno/issues/new).
+- Encourage others to explore and use Juno.
 
 :::tip
 If you're ready to make PRs but unsure where to start, join our [Discord](https://discord.gg/TcHbSZ9ATd), and we'll guide you through some beginner-friendly issues.

--- a/docs/versioned_docs/version-0.16.0/json-rpc.md
+++ b/docs/versioned_docs/version-0.16.0/json-rpc.md
@@ -2,7 +2,7 @@
 title: JSON-RPC
 ---
 
-# JSON-RPC Interface :globe_with_meridians:
+# JSON-RPC Interface
 
 Interacting with Juno requires sending requests to specific JSON-RPC API methods. Juno supports all of [Starknet's Node API Endpoints](https://playground.open-rpc.org/?uiSchema%5BappBar%5D%5Bui:splitView%5D=false&schemaUrl=https://raw.githubusercontent.com/starkware-libs/starknet-specs/v0.10.1/api/starknet_api_openrpc.json&uiSchema%5BappBar%5D%5Bui:input%5D=false&uiSchema%5BappBar%5D%5Bui:darkMode%5D=true&uiSchema%5BappBar%5D%5Bui:examplesDropdown%5D=false) over HTTP and [WebSocket](websocket).
 

--- a/docs/versioned_docs/version-0.16.0/monitoring.md
+++ b/docs/versioned_docs/version-0.16.0/monitoring.md
@@ -2,7 +2,7 @@
 title: Monitoring
 ---
 
-# Metrics Monitoring :bar_chart:
+# Metrics Monitoring
 
 Juno uses [Prometheus](https://prometheus.io/) to monitor and collect metrics data, which you can visualise with [Grafana](https://grafana.com/). You can use these insights to understand what is happening when Juno is running.
 

--- a/docs/versioned_docs/version-0.16.0/plugins.md
+++ b/docs/versioned_docs/version-0.16.0/plugins.md
@@ -34,7 +34,7 @@ type BlockAndStateUpdate struct {
 
 **Shutdown**: Called when the Juno node is shut down. This can be used to clean up resources like database connections.
 
-**NewBlock**: Called by the synchronizer each time a new block is stored. Juno sends the block, the corresponding state update, and any new classes (as `core.ClassDefinition` values), and waits for the call to return before continuing the sync. Note that a returned error is logged but does not stop the sync — the plugin is responsible for handling its own failures.
+**NewBlock**: Called by the synchronizer each time a new block is stored. Juno sends the block, the corresponding state update, and any new classes (as `core.ClassDefinition` values), and waits for the call to return before continuing the sync. Note that a returned error is logged but does not stop the sync. The plugin is responsible for handling its own failures.
 
 **RevertBlock**: Called during a blockchain reorganization (reorg), once for each block that needs to be reverted. `reverseStateDiff` describes how to undo the block's state changes: apply its `StorageDiffs`, `Nonces`, and `ReplacedClasses` as writes, and its `DeclaredV0Classes`, `DeclaredV1Classes`, and `ReplacedClasses` as deletions. As with `NewBlock`, Juno waits for the call to return, and errors are logged without stopping the sync.
 
@@ -88,7 +88,7 @@ go build -buildmode=plugin -o ./plugin.so /path/to/your/plugin.go
 
 This command compiles the plugin into a shared object file (`plugin.so`), which can then be loaded by the Juno client.
 
-Go plugins impose strict compatibility requirements — if any of them are not met, Juno will fail to load the plugin at runtime:
+Go plugins impose strict compatibility requirements. If any of them are not met, Juno will fail to load the plugin at runtime:
 
 - The plugin must be built with the **same Go toolchain version** used to build the Juno binary.
 - The plugin must depend on the **same version of the `github.com/NethermindEth/juno` module** (and identical versions of any shared dependencies) as the running node.

--- a/docs/versioned_docs/version-0.16.0/running-juno.md
+++ b/docs/versioned_docs/version-0.16.0/running-juno.md
@@ -2,7 +2,7 @@
 title: Installation
 ---
 
-# Running Juno :rocket:
+# Running Juno
 
 ```mdx-code-block
 import Tabs from "@theme/Tabs";
@@ -11,7 +11,7 @@ import TabItem from "@theme/TabItem";
 
 You can run a Juno node using several methods:
 
-- **Docker container** or **Standalone binary** — see below
+- **Docker container** or **Standalone binary** (see below)
 - [Building from source](#building-from-source)
 - [Kubernetes with Helm](running-on-kubernetes)
 - [Google Cloud Platform (GCP)](running-on-gcp)

--- a/docs/versioned_docs/version-0.16.0/running-on-gcp.md
+++ b/docs/versioned_docs/version-0.16.0/running-on-gcp.md
@@ -2,7 +2,7 @@
 title: GCP
 ---
 
-# Running Juno on GCP :cloud:
+# Running Juno on GCP
 
 To run Juno on the Google Cloud Platform (GCP), you can use the Starknet RPC Virtual Machine (VM) developed by Nethermind.
 

--- a/docs/versioned_docs/version-0.16.0/running-on-kubernetes.md
+++ b/docs/versioned_docs/version-0.16.0/running-on-kubernetes.md
@@ -2,7 +2,7 @@
 title: Kubernetes
 ---
 
-# Running Juno on Kubernetes :wheel_of_dharma:
+# Running Juno on Kubernetes
 
 You can deploy Juno on Kubernetes using the official [Helm chart](https://github.com/NethermindEth/helm-charts/tree/main/charts/juno). The chart deploys a Juno Starknet full node as a StatefulSet with persistent storage. Optionally, a [staking validator](staking-validator) service can be enabled alongside.
 

--- a/docs/versioned_docs/version-0.16.0/snapshots.md
+++ b/docs/versioned_docs/version-0.16.0/snapshots.md
@@ -2,13 +2,13 @@
 title: Snapshot Sync
 ---
 
-# Sync from a Snapshot :camera_flash:
+# Sync from a Snapshot
 
 It is possible to avoid syncing from the beginning and waiting weeks to catch up by downloading a Juno snapshot. You're downloading a pre-synced Juno database that you can point your node to. This will reduce the syncing time to just a few hours.
 
 Snapshots are provided in a compressed `.tar.zst` format for faster downloads and reduced storage requirements. It also allows you to directly stream the decompressed file to your computer without needing to download it first.
 
-Additionally, _pruned_ snapshots are offered — they contain only the latest data, greatly reducing storage size.
+Additionally, _pruned_ snapshots are offered. They contain only the latest data, greatly reducing storage size.
 
 
 ## Network Snapshots
@@ -27,7 +27,7 @@ import TabItem from "@theme/TabItem";
 ```
 
 :::tip
-Select your network in any tab below and the rest of the page follows — the choice is synced across every command on this page.
+Select your network in any tab below and the rest of the page follows. The choice is synced across every command on this page.
 :::
 
 ## Getting snapshot sizes
@@ -188,7 +188,7 @@ sudo dnf install lftp pv
 </TabItem>
 <TabItem value="curl" label="curl">
 
-Nothing to install — `curl` is preinstalled on most systems.
+Nothing to install. `curl` is preinstalled on most systems.
 
 ---
 

--- a/docs/versioned_docs/version-0.16.0/updating.md
+++ b/docs/versioned_docs/version-0.16.0/updating.md
@@ -2,7 +2,7 @@
 title: Updating
 ---
 
-# Updating Juno :arrows_counterclockwise:
+# Updating Juno
 
 ```mdx-code-block
 import Tabs from "@theme/Tabs";

--- a/docs/versioned_docs/version-0.16.0/websocket.md
+++ b/docs/versioned_docs/version-0.16.0/websocket.md
@@ -2,7 +2,7 @@
 title: WebSockets
 ---
 
-# WebSocket Interface :globe_with_meridians:
+# WebSocket Interface
 
 Juno provides a WebSocket RPC interface that supports all of [Starknet's JSON-RPC API](https://playground.open-rpc.org/?uiSchema%5BappBar%5D%5Bui:splitView%5D=false&schemaUrl=https://raw.githubusercontent.com/starkware-libs/starknet-specs/v0.10.1/api/starknet_api_openrpc.json&uiSchema%5BappBar%5D%5Bui:input%5D=false&uiSchema%5BappBar%5D%5Bui:darkMode%5D=true&uiSchema%5BappBar%5D%5Bui:examplesDropdown%5D=false) endpoints and allows you to [subscribe to newly created blocks](#subscribe-to-newly-created-blocks).
 


### PR DESCRIPTION
Remove emojis and em-dashes from documentation.

## Reason
Emoji are [unreliable for screen readers](https://tink.uk/accessible-emoji/), [Microsoft's style guide](https://learn.microsoft.com/en-us/style-guide/a-z-word-list-term-collections/e/emoticons-emoji) and [Google's](https://developers.google.com/style/tone) style guides push against them in technical docs. It says not to use them in serious content or to fake bullets in a list. Em-dashes are a [known AI tell](https://www.rollingstone.com/culture/culture-features/chatgpt-hypen-em-dash-ai-writing-1235314945/) and none of the docs worth benchmarking against use them (reth, geth, lighthouse, Morpho. They are zero between them across ~3,300 words).
