### PR TITLE
refactor(cbor): `fxamacker/cbor` wrapper

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -44,6 +44,12 @@ linters:
           deny:
             - pkg: github.com/sirupsen/logrus
               desc: use github.com/NethermindEth/juno/utils for logging
+        cbor:
+          files:
+            - "!**/utils/cbor/*.go"
+          deny:
+            - pkg: github.com/fxamacker/cbor/v2
+              desc: use github.com/NethermindEth/juno/utils/cbor, do not import any CBOR library directly
     funlen:
       lines: 120
       statements: 50

--- a/core/block_transaction_test.go
+++ b/core/block_transaction_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/NethermindEth/juno/db/typed/partial"
 	"github.com/NethermindEth/juno/encoder"
 	_ "github.com/NethermindEth/juno/encoder/registry"
-	"github.com/fxamacker/cbor/v2"
+	"github.com/NethermindEth/juno/utils/cbor"
 	"github.com/stretchr/testify/require"
 )
 

--- a/core/felt/cbor.go
+++ b/core/felt/cbor.go
@@ -4,8 +4,8 @@ import (
 	"encoding/binary"
 	"math"
 
+	"github.com/NethermindEth/juno/utils/cbor"
 	"github.com/consensys/gnark-crypto/ecc/stark-curve/fp"
-	"github.com/fxamacker/cbor/v2"
 )
 
 // Fast, felt-specialized CBOR marshaling.

--- a/core/felt/cbor_fastpath_test.go
+++ b/core/felt/cbor_fastpath_test.go
@@ -10,8 +10,8 @@ import (
 	"testing"
 
 	"github.com/NethermindEth/juno/core/felt"
+	"github.com/NethermindEth/juno/utils/cbor"
 	"github.com/consensys/gnark-crypto/ecc/stark-curve/fp"
-	"github.com/fxamacker/cbor/v2"
 	"github.com/stretchr/testify/require"
 )
 

--- a/core/felt/slice.go
+++ b/core/felt/slice.go
@@ -10,7 +10,7 @@ import (
 	"math"
 	"slices"
 
-	"github.com/fxamacker/cbor/v2"
+	"github.com/NethermindEth/juno/utils/cbor"
 )
 
 type Slice[F FeltLike] []F

--- a/core/felt/slice_test.go
+++ b/core/felt/slice_test.go
@@ -12,7 +12,7 @@ import (
 	"testing"
 
 	"github.com/NethermindEth/juno/core/felt"
-	"github.com/fxamacker/cbor/v2"
+	"github.com/NethermindEth/juno/utils/cbor"
 	"github.com/stretchr/testify/require"
 )
 

--- a/core/partial_cbor_test.go
+++ b/core/partial_cbor_test.go
@@ -8,8 +8,8 @@ import (
 
 	"github.com/NethermindEth/juno/core/felt"
 	"github.com/NethermindEth/juno/encoder"
+	"github.com/NethermindEth/juno/utils/cbor"
 	bloom "github.com/bits-and-blooms/bloom/v3"
-	cbor "github.com/fxamacker/cbor/v2"
 	"github.com/stretchr/testify/require"
 )
 

--- a/core/transaction.go
+++ b/core/transaction.go
@@ -12,8 +12,8 @@ import (
 	"github.com/NethermindEth/juno/core/crypto"
 	"github.com/NethermindEth/juno/core/felt"
 	"github.com/NethermindEth/juno/l1/eth"
+	"github.com/NethermindEth/juno/utils/cbor"
 	"github.com/bits-and-blooms/bloom/v3"
-	"github.com/fxamacker/cbor/v2"
 	"golang.org/x/crypto/sha3"
 )
 

--- a/encoder/encoder.go
+++ b/encoder/encoder.go
@@ -6,7 +6,7 @@ import (
 	"sync"
 	"testing"
 
-	"github.com/fxamacker/cbor/v2"
+	"github.com/NethermindEth/juno/utils/cbor"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )

--- a/migration/blocktransactions/ingestor.go
+++ b/migration/blocktransactions/ingestor.go
@@ -10,8 +10,8 @@ import (
 	"github.com/NethermindEth/juno/db/typed/prefix"
 	"github.com/NethermindEth/juno/migration/pipeline"
 	"github.com/NethermindEth/juno/migration/semaphore"
+	"github.com/NethermindEth/juno/utils/cbor"
 	"github.com/NethermindEth/juno/utils/log"
-	"github.com/fxamacker/cbor/v2"
 	"go.uber.org/zap"
 )
 

--- a/migration/deprecated/migration.go
+++ b/migration/deprecated/migration.go
@@ -30,9 +30,9 @@ import (
 	"github.com/NethermindEth/juno/migration/deprecated/casmhashmetadata"
 	"github.com/NethermindEth/juno/migration/deprecated/l1handlermapping"
 	"github.com/NethermindEth/juno/starknet"
+	"github.com/NethermindEth/juno/utils/cbor"
 	"github.com/NethermindEth/juno/utils/log"
 	"github.com/bits-and-blooms/bitset"
-	"github.com/fxamacker/cbor/v2"
 	"github.com/sourcegraph/conc/pool"
 	"go.uber.org/zap"
 )

--- a/p2p/codec.go
+++ b/p2p/codec.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"fmt"
 
-	"github.com/fxamacker/cbor/v2"
+	"github.com/NethermindEth/juno/utils/cbor"
 	"github.com/multiformats/go-multiaddr"
 )
 

--- a/utils/cbor/cbor.go
+++ b/utils/cbor/cbor.go
@@ -1,0 +1,55 @@
+// Package cbor wraps github.com/fxamacker/cbor/v2 so the rest of the node does not name it.
+package cbor
+
+import (
+	"io"
+
+	fxcbor "github.com/fxamacker/cbor/v2"
+)
+
+type (
+	RawMessage         = fxcbor.RawMessage
+	Marshaler          = fxcbor.Marshaler
+	Unmarshaler        = fxcbor.Unmarshaler
+	UnmarshalTypeError = fxcbor.UnmarshalTypeError
+	Encoder            = fxcbor.Encoder
+	Decoder            = fxcbor.Decoder
+	EncMode            = fxcbor.EncMode
+	DecMode            = fxcbor.DecMode
+	EncOptions         = fxcbor.EncOptions
+	DecOptions         = fxcbor.DecOptions
+	TagSet             = fxcbor.TagSet
+	TagOptions         = fxcbor.TagOptions
+)
+
+const (
+	EncTagRequired = fxcbor.EncTagRequired
+	DecTagRequired = fxcbor.DecTagRequired
+
+	// ExtraDecErrorUnknownField makes a decoder fail on a wire key with no matching field.
+	ExtraDecErrorUnknownField = fxcbor.ExtraDecErrorUnknownField
+)
+
+func NewTagSet() TagSet {
+	return fxcbor.NewTagSet()
+}
+
+func CanonicalEncOptions() EncOptions {
+	return fxcbor.CanonicalEncOptions()
+}
+
+func Marshal(v any) ([]byte, error) {
+	return fxcbor.Marshal(v)
+}
+
+func Unmarshal(data []byte, v any) error {
+	return fxcbor.Unmarshal(data, v)
+}
+
+func NewEncoder(w io.Writer) *Encoder {
+	return fxcbor.NewEncoder(w)
+}
+
+func NewDecoder(r io.Reader) *Decoder {
+	return fxcbor.NewDecoder(r)
+}


### PR DESCRIPTION
The thinnest possible wrapper around `fxamacker/cbor` API withouth changing code.


I personally don't like it for three reasons:
- It smells lazy
- Its API is strongly tied to `fxamacker` behaviour.
- It is taking the same space as `encoder`, and it tends to became very similiar to it, if we want to replace it.