### PR TITLE
refactor(rpc): share one batch pool across the v8/v9/v10 servers

### DIFF
--- a/cmd/juno/juno.go
+++ b/cmd/juno/juno.go
@@ -282,8 +282,8 @@ const (
 	rpcMaxBatchResponseSizeUsage = "Size (in MBs) at which a batch stops being processed. " +
 		"The calls answered so far are returned, the rest are not executed. " +
 		"0 disables the limit."
-	rpcBatchConcurrencyUsage = "Maximum batch calls that run at the same time, per RPC version. " +
-		"All batch requests to a version share this limit. " +
+	rpcBatchConcurrencyUsage = "Maximum batch calls that run at the same time. " +
+		"Every batch request shares this limit, across all RPC versions. " +
 		"Default is set based on available hardware resources."
 	maxConcurrentCompilationsUsage = "Maximum concurrent Sierra compilations. " +
 		"Default is set based on available hardware resources."

--- a/jsonrpc/server.go
+++ b/jsonrpc/server.go
@@ -200,6 +200,12 @@ func (s *Server) WithListener(listener EventListener) *Server {
 	return s
 }
 
+// WithPool registers a pool
+func (s *Server) WithPool(p *pool.Pool) *Server {
+	s.pool = p
+	return s
+}
+
 // DisableBatchRequests disables batch JSON-RPC requests to the server
 func (s *Server) DisableBatchRequests(forbid bool) *Server {
 	s.disableBatchRequests = forbid

--- a/jsonrpc/server.go
+++ b/jsonrpc/server.go
@@ -188,6 +188,18 @@ func NewServer(poolMaxGoroutines int, logger log.StructuredLogger) *Server {
 	return s
 }
 
+// NewServerWithPool instantiates a JSONRPC server with pool
+func NewServerWithPool(pool *pool.Pool, logger log.StructuredLogger) *Server {
+	s := &Server{
+		logger:   logger,
+		methods:  make(map[string]Method),
+		pool:     pool,
+		listener: &SelectiveListener{},
+	}
+
+	return s
+}
+
 // WithValidator registers a validator to validate handler struct arguments
 func (s *Server) WithValidator(validator Validator) *Server {
 	s.validator = validator
@@ -197,12 +209,6 @@ func (s *Server) WithValidator(validator Validator) *Server {
 // WithListener registers an EventListener
 func (s *Server) WithListener(listener EventListener) *Server {
 	s.listener = listener
-	return s
-}
-
-// WithPool registers a pool
-func (s *Server) WithPool(p *pool.Pool) *Server {
-	s.pool = p
 	return s
 }
 

--- a/node/node.go
+++ b/node/node.go
@@ -45,6 +45,7 @@ import (
 	"github.com/NethermindEth/juno/vm"
 	"github.com/consensys/gnark-crypto/ecc/stark-curve/ecdsa"
 	"github.com/sourcegraph/conc"
+	"github.com/sourcegraph/conc/pool"
 	"go.uber.org/zap"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
@@ -541,7 +542,10 @@ func New(cfg *Config, version string, logLevel *log.Level) (*Node, error) {
 	}
 	maxBatchResponseBytes := int(cfg.RPCMaxBatchResponseSize) * db.Megabyte
 
+	batchPool := pool.New().WithMaxGoroutines(maxGoroutines)
+
 	jsonrpcServerV10 := jsonrpc.NewServer(maxGoroutines, logger).
+		WithPool(batchPool).
 		WithValidator(rpcv10.Validator()).
 		WithMaxBatchElements(int(cfg.RPCMaxBatchSize)).
 		WithMaxBatchResponseBytes(maxBatchResponseBytes).
@@ -552,6 +556,7 @@ func New(cfg *Config, version string, logLevel *log.Level) (*Node, error) {
 	}
 
 	jsonrpcServerV09 := jsonrpc.NewServer(maxGoroutines, logger).
+		WithPool(batchPool).
 		WithValidator(rpcv9.Validator()).
 		WithMaxBatchElements(int(cfg.RPCMaxBatchSize)).
 		WithMaxBatchResponseBytes(maxBatchResponseBytes).
@@ -562,6 +567,7 @@ func New(cfg *Config, version string, logLevel *log.Level) (*Node, error) {
 	}
 
 	jsonrpcServerV08 := jsonrpc.NewServer(maxGoroutines, logger).
+		WithPool(batchPool).
 		WithValidator(rpcv8.Validator()).
 		WithMaxBatchElements(int(cfg.RPCMaxBatchSize)).
 		WithMaxBatchResponseBytes(maxBatchResponseBytes).

--- a/node/node.go
+++ b/node/node.go
@@ -544,8 +544,7 @@ func New(cfg *Config, version string, logLevel *log.Level) (*Node, error) {
 
 	batchPool := pool.New().WithMaxGoroutines(maxGoroutines)
 
-	jsonrpcServerV10 := jsonrpc.NewServer(maxGoroutines, logger).
-		WithPool(batchPool).
+	jsonrpcServerV10 := jsonrpc.NewServerWithPool(batchPool, logger).
 		WithValidator(rpcv10.Validator()).
 		WithMaxBatchElements(int(cfg.RPCMaxBatchSize)).
 		WithMaxBatchResponseBytes(maxBatchResponseBytes).
@@ -555,8 +554,7 @@ func New(cfg *Config, version string, logLevel *log.Level) (*Node, error) {
 		return nil, err
 	}
 
-	jsonrpcServerV09 := jsonrpc.NewServer(maxGoroutines, logger).
-		WithPool(batchPool).
+	jsonrpcServerV09 := jsonrpc.NewServerWithPool(batchPool, logger).
 		WithValidator(rpcv9.Validator()).
 		WithMaxBatchElements(int(cfg.RPCMaxBatchSize)).
 		WithMaxBatchResponseBytes(maxBatchResponseBytes).
@@ -566,8 +564,7 @@ func New(cfg *Config, version string, logLevel *log.Level) (*Node, error) {
 		return nil, err
 	}
 
-	jsonrpcServerV08 := jsonrpc.NewServer(maxGoroutines, logger).
-		WithPool(batchPool).
+	jsonrpcServerV08 := jsonrpc.NewServerWithPool(batchPool, logger).
 		WithValidator(rpcv8.Validator()).
 		WithMaxBatchElements(int(cfg.RPCMaxBatchSize)).
 		WithMaxBatchResponseBytes(maxBatchResponseBytes).


### PR DESCRIPTION
<!-- pr-agent-generated -->
### **User description**
share one batch pool across the v8/v9/v10 servers


___

### **PR Type**
Enhancement, Documentation


___

### **Description**
- Share batch pool across RPC versions.

- Add server constructor accepting external pool.

- Update batch concurrency help text.


___



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>juno.go</strong><dd><code>Update batch concurrency usage help text</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

cmd/juno/juno.go

<ul><li>Update <code>rpcBatchConcurrencyUsage</code> text to say the limit is shared across <br>all RPC versions.</ul>


</details>


  </td>
  <td><a href="https://github.com/NethermindEth/juno/pull/4013/files#diff-e8011febe1f0287e6ed8aba108ce6e448c8db2c49f5afef912db1626eafd0ee3">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>server.go</strong><dd><code>Add server constructor with external pool</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

jsonrpc/server.go

<ul><li>Add <code>NewServerWithPool</code> constructor accepting a <code>pool.Pool</code>.<br> <li> Initialize the server using the provided pool instead of creating a <br>new one.</ul>


</details>


  </td>
  <td><a href="https://github.com/NethermindEth/juno/pull/4013/files#diff-b18e347b821e9f1511d44c3ccb83f52bfe315b2a648678802c06781bd62b8e9f">+12/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>node.go</strong><dd><code>Reuse one batch pool for all RPC servers</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

node/node.go

<ul><li>Import <code>github.com/sourcegraph/conc/pool</code>.<br> <li> Create one shared <code>batchPool</code> using <code>maxGoroutines</code>.<br> <li> Use <code>NewServerWithPool</code> for v10, v09, and v08 JSON-RPC servers.</ul>


</details>


  </td>
  <td><a href="https://github.com/NethermindEth/juno/pull/4013/files#diff-375d57e386f20eaa5f09f02bb9d28bfc48ac3dca18d0325f59492208219e5618">+6/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

