### PR TITLE
feat(clients/feeder): modify request behaviour through options

### DIFF
--- a/clients/feeder/feeder.go
+++ b/clients/feeder/feeder.go
@@ -144,6 +144,72 @@ func (c *Client) SetTimeouts(timeouts []time.Duration, fixed bool) {
 	c.timeouts.Store(makeTimeouts(timeouts, fixed))
 }
 
+// buildRequest constructs the GET request for queryURL with the client's
+// identification headers set.
+func (c *Client) buildRequest(ctx context.Context, queryURL *url.URL) (*http.Request, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, queryURL.String(), http.NoBody)
+	if err != nil {
+		return nil, err
+	}
+	if c.userAgent != "" {
+		req.Header.Set("User-Agent", c.userAgent)
+	}
+	if c.apiKey != "" {
+		req.Header.Set("X-Throttling-Bypass", c.apiKey)
+	}
+	return req, nil
+}
+
+// tryGet performs a single request attempt with the given timeout. It returns
+// the response body on 200, a StatusError on any other status, and transport
+// errors unchanged.
+func (c *Client) tryGet(req *http.Request, timeout time.Duration) (io.ReadCloser, error) {
+	c.client.Timeout = timeout
+	reqTimer := time.Now()
+	res, err := c.client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	c.listener.OnResponse(req.URL.Path, res.StatusCode, time.Since(reqTimer))
+	if res.StatusCode == http.StatusOK {
+		return res.Body, nil
+	}
+	res.Body.Close()
+	return nil, &StatusError{Code: res.StatusCode}
+}
+
+// logRetry reports a failed attempt, promoting the retries from debug to warn
+// once the adaptive timeout has grown past mediumGrowThreshold.
+func (c *Client) logRetry(
+	reqURL string,
+	wait time.Duration,
+	err error,
+	currentTimeout time.Duration,
+) {
+	if currentTimeout >= mediumGrowThreshold {
+		c.logger.Warn("Failed query to feeder, retrying...",
+			zap.String("req", log.SanitizeString(reqURL)),
+			zap.String("retryAfter", wait.String()),
+			zap.Error(err),
+			zap.String("newHTTPTimeout", currentTimeout.String()),
+		)
+		c.logger.Warn("Timeouts can be updated via HTTP PUT request",
+			zap.String("timeout", currentTimeout.String()),
+			zap.String("hint",
+				`Set --http-update-port and --http-update-host flags and `+
+					`make a PUT request to "/feeder/timeouts" with the specified timeouts`,
+			),
+		)
+	} else {
+		c.logger.Debug("Failed query to feeder, retrying...",
+			zap.String("req", log.SanitizeString(reqURL)),
+			zap.String("retryAfter", wait.String()),
+			zap.Error(err),
+			zap.String("newHTTPTimeout", currentTimeout.String()),
+		)
+	}
+}
+
 // get performs a "GET" http request with the given URL and returns the response body
 func (c *Client) get(
 	ctx context.Context,
@@ -155,7 +221,6 @@ func (c *Client) get(
 		opt(&cfg)
 	}
 
-	var res *http.Response
 	var err error
 	wait := time.Duration(0)
 	for range c.maxRetries + 1 {
@@ -163,42 +228,31 @@ func (c *Client) get(
 		case <-ctx.Done():
 			return nil, ctx.Err()
 		case <-time.After(wait):
-			var req *http.Request
-			req, err = http.NewRequestWithContext(ctx, http.MethodGet, queryURL.String(), http.NoBody)
-			if err != nil {
-				return nil, err
-			}
-			if c.userAgent != "" {
-				req.Header.Set("User-Agent", c.userAgent)
-			}
-			if c.apiKey != "" {
-				req.Header.Set("X-Throttling-Bypass", c.apiKey)
+			req, reqErr := c.buildRequest(ctx, queryURL)
+			if reqErr != nil {
+				return nil, reqErr
 			}
 
 			timeouts := c.timeouts.Load()
-			c.client.Timeout = timeouts.GetCurrentTimeout()
-			reqTimer := time.Now()
-			res, err = c.client.Do(req)
-			tooManyRequests, badRequest := false, false
+			var body io.ReadCloser
+			body, err = c.tryGet(req, timeouts.GetCurrentTimeout())
 			if err == nil {
-				c.listener.OnResponse(req.URL.Path, res.StatusCode, time.Since(reqTimer))
-				tooManyRequests = res.StatusCode == http.StatusTooManyRequests
-				badRequest = res.StatusCode == http.StatusBadRequest
-				if res.StatusCode == http.StatusOK {
-					timeouts.DecreaseTimeout()
-					return res.Body, nil
-				} else {
-					err = &StatusError{Code: res.StatusCode}
-				}
-
-				res.Body.Close()
+				timeouts.DecreaseTimeout()
+				return body, nil
 			}
 
-			if cfg.failFastOnBadRequest && badRequest {
+			code := 0
+			var statusErr *StatusError
+			if errors.As(err, &statusErr) {
+				code = statusErr.Code
+			}
+
+			if cfg.failFastOnBadRequest && code == http.StatusBadRequest {
 				return nil, err
 			}
 
-			if !tooManyRequests && !badRequest {
+			// 429 and 400 don't indicate a slow gateway, so they don't grow the timeout.
+			if code != http.StatusTooManyRequests && code != http.StatusBadRequest {
 				timeouts.IncreaseTimeout()
 			}
 
@@ -207,30 +261,7 @@ func (c *Client) get(
 			} else {
 				wait = min(c.backoff(wait), c.maxWait)
 			}
-
-			currentTimeout := timeouts.GetCurrentTimeout()
-			if currentTimeout >= mediumGrowThreshold {
-				c.logger.Warn("Failed query to feeder, retrying...",
-					zap.String("req", log.SanitizeString(req.URL.String())),
-					zap.String("retryAfter", wait.String()),
-					zap.Error(err),
-					zap.String("newHTTPTimeout", currentTimeout.String()),
-				)
-				c.logger.Warn("Timeouts can be updated via HTTP PUT request",
-					zap.String("timeout", currentTimeout.String()),
-					zap.String("hint",
-						`Set --http-update-port and --http-update-host flags and `+
-							`make a PUT request to "/feeder/timeouts" with the specified timeouts`,
-					),
-				)
-			} else {
-				c.logger.Debug("Failed query to feeder, retrying...",
-					zap.String("req", log.SanitizeString(req.URL.String())),
-					zap.String("retryAfter", wait.String()),
-					zap.Error(err),
-					zap.String("newHTTPTimeout", currentTimeout.String()),
-				)
-			}
+			c.logRetry(req.URL.String(), wait, err, timeouts.GetCurrentTimeout())
 		}
 	}
 	return nil, err

--- a/clients/feeder/feeder.go
+++ b/clients/feeder/feeder.go
@@ -28,6 +28,20 @@ const (
 
 var ErrDeprecatedCompiledClass = errors.New("deprecated compiled class")
 
+// ErrPreConfirmedBlockNotFound is returned by the pre-confirmed queries when
+// the gateway answers 400, meaning the requested block is not (or no longer)
+// in the pre-confirmed window.
+var ErrPreConfirmedBlockNotFound = errors.New("pre-confirmed block not found")
+
+// StatusError reports a non-OK HTTP status from the feeder gateway.
+type StatusError struct {
+	Code int
+}
+
+func (e *StatusError) Error() string {
+	return fmt.Sprintf("%d %s", e.Code, http.StatusText(e.Code))
+}
+
 type Backoff func(wait time.Duration) time.Duration
 
 type Client struct {
@@ -131,7 +145,16 @@ func (c *Client) SetTimeouts(timeouts []time.Duration, fixed bool) {
 }
 
 // get performs a "GET" http request with the given URL and returns the response body
-func (c *Client) get(ctx context.Context, queryURL *url.URL) (io.ReadCloser, error) {
+func (c *Client) get(
+	ctx context.Context,
+	queryURL *url.URL,
+	opts ...requestOption,
+) (io.ReadCloser, error) {
+	var cfg requestConfig
+	for _, opt := range opts {
+		opt(&cfg)
+	}
+
 	var res *http.Response
 	var err error
 	wait := time.Duration(0)
@@ -165,10 +188,14 @@ func (c *Client) get(ctx context.Context, queryURL *url.URL) (io.ReadCloser, err
 					timeouts.DecreaseTimeout()
 					return res.Body, nil
 				} else {
-					err = errors.New(res.Status)
+					err = &StatusError{Code: res.StatusCode}
 				}
 
 				res.Body.Close()
+			}
+
+			if cfg.failFastOnBadRequest && badRequest {
+				return nil, err
 			}
 
 			if !tooManyRequests && !badRequest {
@@ -397,8 +424,17 @@ func (c *Client) fetchPreConfirmedUpdate(
 	// PreConfirmedUpdateEnvelope intentionally has no UnmarshalJSON (see its doc),
 	// so it cannot ride the generic doRequest. Decode in a single scan, then run
 	// the same Validate + error-wrap that doRequest applies.
-	body, err := c.get(ctx, queryURL)
+	//
+	// The gateway answers 400 (never 404) when the queried block is not in the
+	// pre-confirmed window. That is deterministic, so the request fails fast
+	// instead of burning the retry budget, and the 400 surfaces as
+	// ErrPreConfirmedBlockNotFound for callers to match on.
+	body, err := c.get(ctx, queryURL, failFastOnBadRequest())
 	if err != nil {
+		var statusErr *StatusError
+		if errors.As(err, &statusErr) && statusErr.Code == http.StatusBadRequest {
+			return nil, fmt.Errorf("%w: %w", ErrPreConfirmedBlockNotFound, err)
+		}
 		return nil, err
 	}
 	defer body.Close()

--- a/clients/feeder/feeder_test.go
+++ b/clients/feeder/feeder_test.go
@@ -903,6 +903,51 @@ func TestBackoffFailure(t *testing.T) {
 	assert.Equal(t, maxRetries, try-1) // we have retried `maxRetries` times
 }
 
+func TestBadRequestRetryPolicy(t *testing.T) {
+	maxRetries := 3
+	callCount := make(map[string]int)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		callCount[r.URL.Path]++
+		w.WriteHeader(http.StatusBadRequest)
+	}))
+	t.Cleanup(srv.Close)
+	feederURL, err := url.Parse(srv.URL)
+	require.NoError(t, err)
+	client := feeder.NewClient(
+		feederURL,
+		feeder.WithBackoff(feeder.NopBackoff),
+		feeder.WithMaxRetries(maxRetries),
+		feeder.WithUserAgent(ua),
+	)
+
+	t.Run("pre-confirmed queries fail fast with a domain error", func(t *testing.T) {
+		_, _, err := client.PreConfirmedBlockLatest(t.Context(), "", 0)
+		require.ErrorIs(t, err, feeder.ErrPreConfirmedBlockNotFound)
+
+		var statusErr *feeder.StatusError
+		require.ErrorAs(t, err, &statusErr)
+		assert.Equal(t, http.StatusBadRequest, statusErr.Code)
+
+		_, err = client.PreConfirmedBlockWithIdentifier(t.Context(), "10", "", 0)
+		require.ErrorIs(t, err, feeder.ErrPreConfirmedBlockNotFound)
+
+		assert.Equal(t, 2, callCount["/get_preconfirmed_block"],
+			"a 400 on a pre-confirmed query must not be retried")
+	})
+
+	t.Run("other endpoints keep the full retry budget on 400", func(t *testing.T) {
+		_, err := client.Block(t.Context(), strconv.Itoa(0))
+		assert.EqualError(t, err, "400 Bad Request")
+		assert.NotErrorIs(t, err, feeder.ErrPreConfirmedBlockNotFound)
+
+		var statusErr *feeder.StatusError
+		require.ErrorAs(t, err, &statusErr)
+		assert.Equal(t, http.StatusBadRequest, statusErr.Code)
+
+		assert.Equal(t, maxRetries+1, callCount["/get_block"])
+	})
+}
+
 func TestCompiledClassDefinition(t *testing.T) {
 	client := feeder.NewTestClient(t, &networks.Integration)
 

--- a/clients/feeder/option.go
+++ b/clients/feeder/option.go
@@ -63,3 +63,17 @@ func WithHTTPClient(client *http.Client) Option {
 func WithTimeouts(timeouts []time.Duration, fixed bool) Option {
 	return func(o *options) { o.timeouts = makeTimeouts(timeouts, fixed) }
 }
+
+// requestConfig holds per-request overrides of the client's retry behavior.
+type requestConfig struct {
+	failFastOnBadRequest bool
+}
+
+// requestOption is a functional option applied to a single request.
+type requestOption func(*requestConfig)
+
+// failFastOnBadRequest makes get return an HTTP 400 immediately instead of
+// burning the retry budget. A 400 is deterministic — retrying cannot help.
+func failFastOnBadRequest() requestOption {
+	return func(c *requestConfig) { c.failFastOnBadRequest = true }
+}

--- a/sync/preconfirmed/poller.go
+++ b/sync/preconfirmed/poller.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/NethermindEth/juno/blockchain"
+	"github.com/NethermindEth/juno/clients/feeder"
 	"github.com/NethermindEth/juno/core"
 	"github.com/NethermindEth/juno/core/felt"
 	"github.com/NethermindEth/juno/core/pending"
@@ -141,6 +142,12 @@ func (p *Poller) tick(ctx context.Context) error {
 
 	update, updateBlockNum, err := p.dataSource.PreConfirmedBlockLatest(ctx, identifier, txCount)
 	if err != nil {
+		if errors.Is(err, feeder.ErrPreConfirmedBlockNotFound) {
+			p.logger.Debug("No pre-confirmed block in gateway window; skipping tick",
+				zap.Error(err),
+			)
+			return nil
+		}
 		return fmt.Errorf("polling latest pre-confirmed: %w", err)
 	}
 
@@ -157,6 +164,14 @@ func (p *Poller) tick(ctx context.Context) error {
 	if updateBlockNum > fromBlock {
 		err = p.backfill(ctx, oldestPreConf, mostRecent, fromBlock, identifier, txCount, updateBlockNum)
 		if err != nil {
+			if errors.Is(err, feeder.ErrPreConfirmedBlockNotFound) {
+				p.logger.Debug("Pre-confirmed block left the gateway window; skipping backfill",
+					zap.Uint64("fromBlock", fromBlock),
+					zap.Uint64("toBlock", updateBlockNum),
+					zap.Error(err),
+				)
+				return nil
+			}
 			return fmt.Errorf(
 				"backfilling from %d to %d: %w",
 				fromBlock, updateBlockNum, err,

--- a/sync/preconfirmed/poller_test.go
+++ b/sync/preconfirmed/poller_test.go
@@ -24,8 +24,6 @@ import (
 	"github.com/NethermindEth/juno/utils/log"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
-	"go.uber.org/zap/zapcore"
-	"go.uber.org/zap/zaptest/observer"
 )
 
 var feltOne = &felt.One
@@ -161,19 +159,6 @@ func wirePoller(
 	ds preconfirmed.DataSource,
 ) harness {
 	t.Helper()
-	return wirePollerWithLogger(t, bc, head, ds, log.NewNopZapLogger())
-}
-
-// wirePollerWithLogger is wirePoller with an injectable logger, for tests that
-// assert on the poller's log output.
-func wirePollerWithLogger(
-	t *testing.T,
-	bc *blockchain.Blockchain,
-	head *core.Header,
-	ds preconfirmed.DataSource,
-	logger log.StructuredLogger,
-) harness {
-	t.Helper()
 	storage := preconfirmed.NewChainStorage()
 	out := feed.New[*pending.PreConfirmed]()
 	sub := out.SubscribeKeepLast()
@@ -182,7 +167,7 @@ func wirePollerWithLogger(
 	highest := &atomic.Pointer[core.Header]{}
 	highest.Store(head)
 
-	p := preconfirmed.NewPoller(ds, storage, bc, out, highest, tickInterval, logger)
+	p := preconfirmed.NewPoller(ds, storage, bc, out, highest, tickInterval, log.NewNopZapLogger())
 	return harness{
 		poller:  p,
 		storage: storage,
@@ -587,10 +572,10 @@ func TestPollerBackfillErrorSkipsApply(t *testing.T) {
 }
 
 // The gateway answering 400 to a pre-confirmed poll surfaces as
-// feeder.ErrPreConfirmedBlockNotFound; the tick treats it as "nothing to do"
-// rather than a failure — no Warn is logged — and the next tick picks up the
-// window normally.
-func TestPollerLatestNotFoundIsQuietNoOp(t *testing.T) {
+// feeder.ErrPreConfirmedBlockNotFound; the tick treats it as "the window is
+// empty — nothing to do": it stores nothing, and the next tick picks up the
+// window normally once it opens.
+func TestPollerLatestNotFoundSkipsTickAndRecovers(t *testing.T) {
 	t.Parallel()
 	fx := newChainFixture(t)
 
@@ -605,13 +590,12 @@ func TestPollerLatestNotFoundIsQuietNoOp(t *testing.T) {
 			Return(block1, uint64(1), nil),
 	)
 
-	obsCore, logs := observer.New(zapcore.WarnLevel)
 	synctest.Test(t, func(t *testing.T) {
-		h := wirePollerWithLogger(t, fx.bc, fx.head, ds, log.NewZapLoggerWithCore(obsCore))
+		h := wirePoller(t, fx.bc, fx.head, ds)
 		go h.poller.Run(t.Context())
 		synctest.Wait()
 
-		// Tick 1: nothing in the pre-confirmed window — quiet no-op.
+		// Tick 1: nothing in the pre-confirmed window — the tick is a no-op.
 		time.Sleep(tickInterval)
 		synctest.Wait()
 		view := h.storage.SnapshotForBlock(oldestPreConfFor(h.head.Number))
@@ -622,45 +606,68 @@ func TestPollerLatestNotFoundIsQuietNoOp(t *testing.T) {
 		synctest.Wait()
 		view = h.storage.SnapshotForBlock(oldestPreConfFor(h.head.Number))
 		assertChain(t, &view, entry(1, &block1))
-
-		require.Zero(t, logs.Len(), "a pre-confirmed not-found must not log at Warn level")
 	})
 }
 
 // A block that left the pre-confirmed window mid-backfill surfaces as
 // feeder.ErrPreConfirmedBlockNotFound through backfill's wrapping; the tick
-// skips the rest of the fill quietly instead of reporting a polling failure.
-func TestPollerBackfillNotFoundSkipsQuietly(t *testing.T) {
+// abandons the rest of the fill — nothing is applied, not even the already
+// fetched latest — and the next tick reconciles the whole gap from scratch.
+func TestPollerBackfillNotFoundSkipsApplyAndRecovers(t *testing.T) {
 	t.Parallel()
 	fx := newChainFixture(t)
 
+	block1 := makeTestPreConfirmedBlock("r1", 0)
+	block2 := makeTestPreConfirmedBlock("r2", 0)
 	latestReply := makeTestPreConfirmedBlock("r3", 0)
 
 	ctrl := gomock.NewController(t)
 	ds := mocks.NewMockStarknetData(ctrl)
+	// Exactly-once, in-order expectations double as a behavioral pin: a tick
+	// that kept backfilling past the not-found would consume tick 2's
+	// expectations early and fail the script.
 	gomock.InOrder(
+		// Tick 1: latest says 3, but block 1 already left the window.
 		ds.EXPECT().
-			PreConfirmedBlockLatest(gomock.Any(), gomock.Any(), gomock.Any()).
+			PreConfirmedBlockLatest(gomock.Any(), "", uint64(0)).
 			Return(latestReply, uint64(3), nil),
 		ds.EXPECT().
-			PreConfirmedBlockByNumber(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+			PreConfirmedBlockByNumber(gomock.Any(), uint64(1), "", uint64(0)).
 			Return(nil, fmt.Errorf(
 				"polling pre-confirmed for number 1: %w", feeder.ErrPreConfirmedBlockNotFound,
 			)),
+		// Tick 2: storage is still empty, so the poller re-walks the full gap.
+		ds.EXPECT().
+			PreConfirmedBlockLatest(gomock.Any(), "", uint64(0)).
+			Return(latestReply, uint64(3), nil),
+		ds.EXPECT().
+			PreConfirmedBlockByNumber(gomock.Any(), uint64(1), "", uint64(0)).
+			Return(block1, nil),
+		ds.EXPECT().
+			PreConfirmedBlockByNumber(gomock.Any(), uint64(2), "", uint64(0)).
+			Return(block2, nil),
 	)
 
-	obsCore, logs := observer.New(zapcore.WarnLevel)
 	synctest.Test(t, func(t *testing.T) {
-		h := wirePollerWithLogger(t, fx.bc, fx.head, ds, log.NewZapLoggerWithCore(obsCore))
+		h := wirePoller(t, fx.bc, fx.head, ds)
 		go h.poller.Run(t.Context())
 		synctest.Wait()
 
+		// Tick 1: the mid-fill not-found aborts the tick before any apply.
 		time.Sleep(tickInterval)
 		synctest.Wait()
-
 		view := h.storage.SnapshotForBlock(oldestPreConfFor(h.head.Number))
 		require.Zero(t, view.Length(), "backfill skipped: nothing applied this tick")
-		require.Zero(t, logs.Len(), "a mid-backfill not-found must not log at Warn level")
+
+		// Tick 2: the full gap backfills and the latest lands on top.
+		time.Sleep(tickInterval)
+		synctest.Wait()
+		view = h.storage.SnapshotForBlock(oldestPreConfFor(h.head.Number))
+		assertChain(t, &view,
+			entry(1, &block1),
+			entry(2, &block2),
+			entry(3, &latestReply),
+		)
 	})
 }
 

--- a/sync/preconfirmed/poller_test.go
+++ b/sync/preconfirmed/poller_test.go
@@ -3,6 +3,7 @@ package preconfirmed_test
 import (
 	"context"
 	"errors"
+	"fmt"
 	"sync/atomic"
 	"testing"
 	"testing/synctest"
@@ -10,6 +11,7 @@ import (
 
 	"github.com/NethermindEth/juno/blockchain"
 	"github.com/NethermindEth/juno/blockchain/networks"
+	"github.com/NethermindEth/juno/clients/feeder"
 	"github.com/NethermindEth/juno/core"
 	"github.com/NethermindEth/juno/core/felt"
 	"github.com/NethermindEth/juno/core/pending"
@@ -22,6 +24,8 @@ import (
 	"github.com/NethermindEth/juno/utils/log"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
+	"go.uber.org/zap/zapcore"
+	"go.uber.org/zap/zaptest/observer"
 )
 
 var feltOne = &felt.One
@@ -157,6 +161,19 @@ func wirePoller(
 	ds preconfirmed.DataSource,
 ) harness {
 	t.Helper()
+	return wirePollerWithLogger(t, bc, head, ds, log.NewNopZapLogger())
+}
+
+// wirePollerWithLogger is wirePoller with an injectable logger, for tests that
+// assert on the poller's log output.
+func wirePollerWithLogger(
+	t *testing.T,
+	bc *blockchain.Blockchain,
+	head *core.Header,
+	ds preconfirmed.DataSource,
+	logger log.StructuredLogger,
+) harness {
+	t.Helper()
 	storage := preconfirmed.NewChainStorage()
 	out := feed.New[*pending.PreConfirmed]()
 	sub := out.SubscribeKeepLast()
@@ -165,7 +182,7 @@ func wirePoller(
 	highest := &atomic.Pointer[core.Header]{}
 	highest.Store(head)
 
-	p := preconfirmed.NewPoller(ds, storage, bc, out, highest, tickInterval, log.NewNopZapLogger())
+	p := preconfirmed.NewPoller(ds, storage, bc, out, highest, tickInterval, logger)
 	return harness{
 		poller:  p,
 		storage: storage,
@@ -566,6 +583,84 @@ func TestPollerBackfillErrorSkipsApply(t *testing.T) {
 
 		view := h.storage.SnapshotForBlock(oldestPreConfFor(h.head.Number))
 		require.Zero(t, view.Length(), "tick aborts before any apply when backfill errors")
+	})
+}
+
+// The gateway answering 400 to a pre-confirmed poll surfaces as
+// feeder.ErrPreConfirmedBlockNotFound; the tick treats it as "nothing to do"
+// rather than a failure — no Warn is logged — and the next tick picks up the
+// window normally.
+func TestPollerLatestNotFoundIsQuietNoOp(t *testing.T) {
+	t.Parallel()
+	fx := newChainFixture(t)
+
+	block1 := makeTestPreConfirmedBlock("r1", 0)
+
+	ctrl := gomock.NewController(t)
+	ds := mocks.NewMockStarknetData(ctrl)
+	gomock.InOrder(
+		ds.EXPECT().PreConfirmedBlockLatest(gomock.Any(), "", uint64(0)).
+			Return(nil, uint64(0), fmt.Errorf("querying: %w", feeder.ErrPreConfirmedBlockNotFound)),
+		ds.EXPECT().PreConfirmedBlockLatest(gomock.Any(), "", uint64(0)).
+			Return(block1, uint64(1), nil),
+	)
+
+	obsCore, logs := observer.New(zapcore.WarnLevel)
+	synctest.Test(t, func(t *testing.T) {
+		h := wirePollerWithLogger(t, fx.bc, fx.head, ds, log.NewZapLoggerWithCore(obsCore))
+		go h.poller.Run(t.Context())
+		synctest.Wait()
+
+		// Tick 1: nothing in the pre-confirmed window — quiet no-op.
+		time.Sleep(tickInterval)
+		synctest.Wait()
+		view := h.storage.SnapshotForBlock(oldestPreConfFor(h.head.Number))
+		require.Zero(t, view.Length())
+
+		// Tick 2: the window opened; polling proceeds normally.
+		time.Sleep(tickInterval)
+		synctest.Wait()
+		view = h.storage.SnapshotForBlock(oldestPreConfFor(h.head.Number))
+		assertChain(t, &view, entry(1, &block1))
+
+		require.Zero(t, logs.Len(), "a pre-confirmed not-found must not log at Warn level")
+	})
+}
+
+// A block that left the pre-confirmed window mid-backfill surfaces as
+// feeder.ErrPreConfirmedBlockNotFound through backfill's wrapping; the tick
+// skips the rest of the fill quietly instead of reporting a polling failure.
+func TestPollerBackfillNotFoundSkipsQuietly(t *testing.T) {
+	t.Parallel()
+	fx := newChainFixture(t)
+
+	latestReply := makeTestPreConfirmedBlock("r3", 0)
+
+	ctrl := gomock.NewController(t)
+	ds := mocks.NewMockStarknetData(ctrl)
+	gomock.InOrder(
+		ds.EXPECT().
+			PreConfirmedBlockLatest(gomock.Any(), gomock.Any(), gomock.Any()).
+			Return(latestReply, uint64(3), nil),
+		ds.EXPECT().
+			PreConfirmedBlockByNumber(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+			Return(nil, fmt.Errorf(
+				"polling pre-confirmed for number 1: %w", feeder.ErrPreConfirmedBlockNotFound,
+			)),
+	)
+
+	obsCore, logs := observer.New(zapcore.WarnLevel)
+	synctest.Test(t, func(t *testing.T) {
+		h := wirePollerWithLogger(t, fx.bc, fx.head, ds, log.NewZapLoggerWithCore(obsCore))
+		go h.poller.Run(t.Context())
+		synctest.Wait()
+
+		time.Sleep(tickInterval)
+		synctest.Wait()
+
+		view := h.storage.SnapshotForBlock(oldestPreConfFor(h.head.Number))
+		require.Zero(t, view.Length(), "backfill skipped: nothing applied this tick")
+		require.Zero(t, logs.Len(), "a mid-backfill not-found must not log at Warn level")
 	})
 }
 


### PR DESCRIPTION
<!-- pr-agent-generated -->
### **User description**
Necessary to stop backfilling pre-confirmed blocks (on sync/poller) when we request for non-existing ones.

Behaviour without this is multiple retries until a timeout is hit – disallowing the node to update his pre-confirmed change for several minutes.


___

### **PR Type**
Bug fix, Enhancement, Tests


___

### **Description**
- Stop pre-confirmed backfilling on 400 responses

- Add per-request fail-fast retry option

- Surface missing pre-confirmed block as domain error

- Add tests for retry and poller recovery


___



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>feeder.go</strong><dd><code>Add fail-fast 400 handling and status errors</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

clients/feeder/feeder.go

<ul><li>Adds <code>ErrPreConfirmedBlockNotFound</code> and <code>StatusError</code> for HTTP status <br>reporting<br> <li> Refactors <code>get</code> into <code>buildRequest</code>, <code>tryGet</code>, and <code>logRetry</code> helpers<br> <li> Supports <code>requestOption</code> to fail fast on <code>400 Bad Request</code><br> <li> Wraps pre-confirmed 400 responses as <code>ErrPreConfirmedBlockNotFound</code></ul>


</details>


  </td>
  <td><a href="https://github.com/NethermindEth/juno/pull/4017/files#diff-c7875a0a587f470324a6e4dc7813f735ddbad1e0d6ddad99bd6003a557885761">+120/-53</a></td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>poller.go</strong><dd><code>Skip poller work when pre-confirmed block missing</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

sync/preconfirmed/poller.go

<ul><li>Imports <code>feeder</code> client error package<br> <li> Skips tick when latest pre-confirmed query returns not-found<br> <li> Skips backfill when a pre-confirmed block leaves gateway window<br> <li> Logs debug messages instead of treating as fatal error</ul>


</details>


  </td>
  <td><a href="https://github.com/NethermindEth/juno/pull/4017/files#diff-7a40b50d7fa3df15162a912a2d8727ac225ffad7d9047f4e3127761ba2d9f642">+15/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>feeder_test.go</strong><dd><code>Test 400 retry policy across endpoints</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

clients/feeder/feeder_test.go

<ul><li>Adds <code>TestBadRequestRetryPolicy</code> for 400 handling<br> <li> Asserts pre-confirmed queries fail fast without extra retries<br> <li> Asserts other endpoints keep full retry budget on 400<br> <li> Checks <code>StatusError</code> and <code>ErrPreConfirmedBlockNotFound</code> wrapping</ul>


</details>


  </td>
  <td><a href="https://github.com/NethermindEth/juno/pull/4017/files#diff-ada8ad9f7998cd8be2d874e9605538aa33f4c2a0cfe7b8d16f921743073c1207">+45/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>poller_test.go</strong><dd><code>Test poller recovery after missing pre-confirmed blocks</code>&nbsp; &nbsp; </dd></summary>
<hr>

sync/preconfirmed/poller_test.go

<ul><li>Adds test for latest pre-confirmed not-found skip and recovery<br> <li> Adds test for backfill not-found aborting current tick<br> <li> Verifies next tick re-walks and applies full gap<br> <li> Uses mocked data source to pin expected calls</ul>


</details>


  </td>
  <td><a href="https://github.com/NethermindEth/juno/pull/4017/files#diff-8a8ffc51e4122274fe05c830aa8102ffaf869dc4b6cb3f28dd07b119c27ef3f9">+102/-0</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>option.go</strong><dd><code>Add per-request fail-fast request option</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

clients/feeder/option.go

<ul><li>Introduces <code>requestConfig</code> for per-request retry overrides<br> <li> Defines <code>requestOption</code> functional option type<br> <li> Adds <code>failFastOnBadRequest</code> option to stop retrying on 400</ul>


</details>


  </td>
  <td><a href="https://github.com/NethermindEth/juno/pull/4017/files#diff-fdbb3aa6f8a48f65e7819b6899450131ef3297950d540b6188b3abe4217b1a55">+14/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

