### PR TITLE
fix(db/remote): Fix remote db issues 

### DIFF
--- a/blockchain/statebackend/deprecated.go
+++ b/blockchain/statebackend/deprecated.go
@@ -138,6 +138,8 @@ func (b *deprecatedStateBackend) RevertHead() error {
 func (b *deprecatedStateBackend) GetReverseStateDiff() (core.StateDiff, error) {
 	//nolint:staticcheck,nolintlint // used by old state
 	txn := b.database.NewIndexedBatch()
+	defer txn.Close()
+
 	blockNum, err := core.GetChainHeight(txn)
 	if err != nil {
 		return core.StateDiff{}, err

--- a/blockchain/statebackend/deprecated.go
+++ b/blockchain/statebackend/deprecated.go
@@ -1,6 +1,8 @@
 package statebackend
 
 import (
+	"errors"
+
 	"github.com/NethermindEth/juno/core"
 	"github.com/NethermindEth/juno/core/deprecatedstate"
 	"github.com/NethermindEth/juno/core/felt"
@@ -20,10 +22,12 @@ func (b *deprecatedStateBackend) HeadState() (core.StateReader, StateCloser, err
 	// Fail early if no block has been committed (no head state to open)
 	// only the key's existence matters, not the height itself.
 	if _, err := core.GetChainHeight(txn); err != nil {
-		return nil, nil, err
+		return nil, nil, errors.Join(err, txn.Close())
 	}
 
-	return deprecatedstate.New(txn), NoopStateCloser, nil
+	// The batch has to be closed: on a remote DB it is a gRPC stream, and the
+	// server holds a batch of its own open for as long as the stream lives.
+	return deprecatedstate.New(txn), txn.Close, nil
 }
 
 func (b *deprecatedStateBackend) StateAtBlockNumber(
@@ -38,7 +42,7 @@ func (b *deprecatedStateBackend) StateAtBlockNumber(
 	return deprecatedstate.NewHistory(
 		deprecatedstate.New(txn),
 		blockNumber,
-	), NoopStateCloser, nil
+	), txn.Close, nil
 }
 
 func (b *deprecatedStateBackend) StateAtBlockHash(
@@ -48,7 +52,7 @@ func (b *deprecatedStateBackend) StateAtBlockHash(
 	if blockHash.IsZero() {
 		memDB := memory.New()
 		txn := memDB.NewIndexedBatch()
-		return deprecatedstate.New(txn), NoopStateCloser, nil
+		return deprecatedstate.New(txn), txn.Close, nil
 	}
 
 	blockNumber, err := pruner.BlockNumberByHashIfStateRetained(b.database, blockHash)
@@ -60,7 +64,7 @@ func (b *deprecatedStateBackend) StateAtBlockHash(
 	return deprecatedstate.NewHistory(
 		deprecatedstate.New(txn),
 		blockNumber,
-	), NoopStateCloser, nil
+	), txn.Close, nil
 }
 
 func (b *deprecatedStateBackend) Store(

--- a/db/remote/db.go
+++ b/db/remote/db.go
@@ -11,6 +11,7 @@ import (
 	"github.com/NethermindEth/juno/db"
 	"github.com/NethermindEth/juno/grpc/gen"
 	"github.com/NethermindEth/juno/utils/log"
+	"go.uber.org/zap"
 	"google.golang.org/grpc"
 )
 
@@ -54,12 +55,19 @@ func (d *DB) Path() string {
 func (d *DB) NewTransaction(write bool) (*transaction, error) {
 	defer d.listener.OnIO(write, time.Now())
 
-	txClient, err := d.kvClient.Tx(d.ctx, grpc.MaxCallSendMsgSize(math.MaxInt), grpc.MaxCallRecvMsgSize(math.MaxInt))
+	// Every transaction owns a stream, so it needs its own context to release it.
+	ctx, cancel := context.WithCancel(d.ctx)
+	txClient, err := d.kvClient.Tx(
+		ctx,
+		grpc.MaxCallSendMsgSize(math.MaxInt),
+		grpc.MaxCallRecvMsgSize(math.MaxInt),
+	)
 	if err != nil {
+		cancel()
 		return nil, err
 	}
 
-	return &transaction{client: txClient, logger: d.logger}, nil
+	return &transaction{client: txClient, cancel: cancel, logger: d.logger}, nil
 }
 
 func (d *DB) Update(fn func(txn db.IndexedBatch) error) error {
@@ -83,10 +91,10 @@ func (d *DB) Write(fn func(w db.Batch) error) error {
 
 	batch := d.NewBatch()
 	if err := fn(batch); err != nil {
-		return err
+		return errors.Join(err, batch.Close())
 	}
 
-	return batch.Write()
+	return errors.Join(batch.Write(), batch.Close())
 }
 
 func (d *DB) Close() error {
@@ -110,6 +118,7 @@ func (d *DB) Get(key []byte, cb func(value []byte) error) error {
 	if err != nil {
 		return err
 	}
+	defer d.discard(txn)
 
 	return txn.Get(key, cb)
 }
@@ -119,6 +128,7 @@ func (d *DB) Has(key []byte) (bool, error) {
 	if err != nil {
 		return false, err
 	}
+	defer d.discard(txn)
 
 	return txn.Has(key)
 }
@@ -128,14 +138,12 @@ func (d *DB) Put(key, val []byte) error {
 }
 
 func (d *DB) NewBatch() db.Batch {
-	defer d.listener.OnIO(false, time.Now())
-
-	txClient, err := d.kvClient.Tx(d.ctx, grpc.MaxCallSendMsgSize(math.MaxInt), grpc.MaxCallRecvMsgSize(math.MaxInt))
+	txn, err := d.NewTransaction(false)
 	if err != nil {
 		panic(err)
 	}
 
-	return &transaction{client: txClient, logger: d.logger}
+	return txn
 }
 
 func (d *DB) NewBatchWithSize(size int) db.Batch {
@@ -143,14 +151,12 @@ func (d *DB) NewBatchWithSize(size int) db.Batch {
 }
 
 func (d *DB) NewIndexedBatch() db.IndexedBatch {
-	defer d.listener.OnIO(true, time.Now())
-
-	txClient, err := d.kvClient.Tx(d.ctx, grpc.MaxCallSendMsgSize(math.MaxInt), grpc.MaxCallRecvMsgSize(math.MaxInt))
+	txn, err := d.NewTransaction(true)
 	if err != nil {
 		panic(err)
 	}
 
-	return &transaction{client: txClient, logger: d.logger}
+	return txn
 }
 
 func (d *DB) NewIndexedBatchWithSize(size int) db.IndexedBatch {
@@ -163,23 +169,34 @@ func (d *DB) NewIterator(start []byte, withUpperBound bool) (db.Iterator, error)
 		return nil, err
 	}
 
-	return txn.NewIterator(start, withUpperBound)
+	it, err := txn.NewIterator(start, withUpperBound)
+	if err != nil {
+		return nil, errors.Join(err, txn.Discard())
+	}
+
+	return &ownedIterator{Iterator: it, txn: txn}, nil
 }
 
 func (d *DB) NewSnapshot() db.Snapshot {
-	defer d.listener.OnIO(false, time.Now())
-
-	txClient, err := d.kvClient.Tx(d.ctx, grpc.MaxCallSendMsgSize(math.MaxInt), grpc.MaxCallRecvMsgSize(math.MaxInt))
+	txn, err := d.NewTransaction(false)
 	if err != nil {
 		panic(err)
 	}
 
-	return &transaction{client: txClient, logger: d.logger}
+	return txn
 }
 
 func (d *DB) WithListener(listener db.EventListener) db.KeyValueStore {
 	d.listener = listener
 	return d
+}
+
+// discard releases a transaction the DB opened for a single call. A read has
+// nothing to report on close, so the error only reaches the log.
+func (d *DB) discard(txn *transaction) {
+	if err := txn.Discard(); err != nil {
+		d.logger.Debug("Discarding remote transaction", zap.Error(err))
+	}
 }
 
 func discardTxnOnPanic(txn *transaction) {

--- a/db/remote/db_test.go
+++ b/db/remote/db_test.go
@@ -2,6 +2,7 @@ package remote
 
 import (
 	"net"
+	"slices"
 	"testing"
 
 	"github.com/NethermindEth/juno/db"
@@ -79,6 +80,21 @@ func TestRemote(t *testing.T) {
 		assert.Equal(t, foundKeys, byte(3))
 	})
 
+	t.Run("first", func(t *testing.T) {
+		snap := remoteDB.NewSnapshot()
+		defer snap.Close()
+
+		it, err := snap.NewIterator(nil, false)
+		require.NoError(t, err)
+		defer it.Close()
+
+		require.True(t, it.First())
+		assert.Equal(t, []byte{0}, it.Key())
+		v, err := it.Value()
+		require.NoError(t, err)
+		assert.Equal(t, []byte{0}, v)
+	})
+
 	t.Run("seek", func(t *testing.T) {
 		snap := remoteDB.NewSnapshot()
 		defer snap.Close()
@@ -103,4 +119,56 @@ func TestRemote(t *testing.T) {
 		assert.EqualError(t, err, "read only DB")
 	})
 	grpcSrv.GracefulStop()
+}
+
+// TestRemoteIteratorBounds guards against the bounds being dropped on the wire:
+// a key sorting before the prefix and one sorting after it must not surface.
+func TestRemoteIteratorBounds(t *testing.T) {
+	memDB := memory.New()
+	require.NoError(t, memDB.Update(func(txn db.IndexedBatch) error {
+		keys := [][]byte{
+			{0x00, 0xFF},
+			{0x01, 0x00},
+			{0x01, 0x01},
+			{0x01, 0x02},
+			{0x02, 0x00},
+		}
+		for _, k := range keys {
+			if err := txn.Put(k, k); err != nil {
+				return err
+			}
+		}
+		return nil
+	}))
+
+	grpcHandler := junogrpc.New(memDB, "0.0.0")
+	grpcSrv := grpc.NewServer()
+	gen.RegisterKVServer(grpcSrv, grpcHandler)
+
+	var lc net.ListenConfig
+	l, err := lc.Listen(t.Context(), "tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	go func() {
+		require.NoError(t, grpcSrv.Serve(l))
+	}()
+	defer grpcSrv.GracefulStop()
+
+	remoteDB, err := New(
+		l.Addr().String(),
+		t.Context(),
+		log.NewNopZapLogger(),
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+	)
+	require.NoError(t, err)
+
+	// Top-level NewIterator, not a snapshot's, so this also exercises ownedIterator.
+	it, err := remoteDB.NewIterator([]byte{0x01}, true)
+	require.NoError(t, err)
+	defer it.Close()
+
+	var found [][]byte
+	for valid := it.First(); valid; valid = it.Next() {
+		found = append(found, slices.Clone(it.Key()))
+	}
+	assert.Equal(t, [][]byte{{0x01, 0x00}, {0x01, 0x01}, {0x01, 0x02}}, found)
 }

--- a/db/remote/db_test.go
+++ b/db/remote/db_test.go
@@ -125,21 +125,18 @@ func TestRemote(t *testing.T) {
 // a key sorting before the prefix and one sorting after it must not surface.
 func TestRemoteIteratorBounds(t *testing.T) {
 	memDB := memory.New()
-	require.NoError(t, memDB.Update(func(txn db.IndexedBatch) error {
-		keys := [][]byte{
-			{0x00, 0xFF},
-			{0x01, 0x00},
-			{0x01, 0x01},
-			{0x01, 0x02},
-			{0x02, 0x00},
-		}
-		for _, k := range keys {
-			if err := txn.Put(k, k); err != nil {
-				return err
-			}
-		}
-		return nil
-	}))
+	batch := memDB.NewBatch()
+	keys := [][]byte{
+		{0x00, 0xFF},
+		{0x01, 0x00},
+		{0x01, 0x01},
+		{0x01, 0x02},
+		{0x02, 0x00},
+	}
+	for _, k := range keys {
+		require.NoError(t, batch.Put(k, k))
+	}
+	require.NoError(t, batch.Write())
 
 	grpcHandler := junogrpc.New(memDB, "0.0.0")
 	grpcSrv := grpc.NewServer()

--- a/db/remote/iterator.go
+++ b/db/remote/iterator.go
@@ -3,6 +3,7 @@ package remote
 import (
 	"slices"
 
+	"github.com/NethermindEth/juno/db"
 	"github.com/NethermindEth/juno/grpc/gen"
 	"github.com/NethermindEth/juno/utils/log"
 	"go.uber.org/zap"
@@ -88,4 +89,19 @@ func (i *iterator) Seek(key []byte) bool {
 
 func (i *iterator) Close() error {
 	return i.doOpAndUpdate(gen.Op_CLOSE, nil)
+}
+
+// ownedIterator holds the only reference to its transaction, so closing it has
+// to release the stream. An iterator taken from a batch or a snapshot shares
+// that stream with its owner and must leave it alone.
+type ownedIterator struct {
+	db.Iterator
+	txn *transaction
+}
+
+// Close discards the transaction, which drops the iterator on the server too.
+// It skips [gen.Op_CLOSE]: the round trip is redundant and its error would
+// surface as a failure of the scan that has already finished.
+func (i *ownedIterator) Close() error {
+	return i.txn.Discard()
 }

--- a/db/remote/transaction.go
+++ b/db/remote/transaction.go
@@ -24,10 +24,19 @@ type transaction struct {
 	logger log.StructuredLogger
 }
 
-func (t *transaction) NewIterator(_ []byte, _ bool) (db.Iterator, error) {
-	err := t.client.Send(&gen.Cursor{
-		Op: gen.Op_OPEN,
-	})
+func (t *transaction) NewIterator(prefix []byte, withUpperBound bool) (db.Iterator, error) {
+	// The remote iterator has to be created with the same bounds as a local one,
+	// otherwise it scans the whole database and First returns a foreign key.
+	// BucketName carries the prefix and a non-empty V asks for the upper bound.
+	cursor := &gen.Cursor{
+		Op:         gen.Op_OPEN,
+		BucketName: prefix,
+	}
+	if withUpperBound {
+		cursor.V = []byte{1}
+	}
+
+	err := t.client.Send(cursor)
 	if err != nil {
 		return nil, err
 	}

--- a/db/remote/transaction.go
+++ b/db/remote/transaction.go
@@ -2,6 +2,7 @@ package remote
 
 import (
 	"bytes"
+	"context"
 	"errors"
 
 	"github.com/NethermindEth/juno/db"
@@ -21,6 +22,7 @@ var (
 
 type transaction struct {
 	client gen.KV_TxClient
+	cancel context.CancelFunc
 	logger log.StructuredLogger
 }
 
@@ -53,8 +55,13 @@ func (t *transaction) NewIterator(prefix []byte, withUpperBound bool) (db.Iterat
 	}, nil
 }
 
+// Discard releases the stream. Closing the send side lets the server return and
+// drop the batch it holds open; the cancel releases the client side, which
+// otherwise waits for the response stream to be drained to EOF.
 func (t *transaction) Discard() error {
-	return t.client.CloseSend()
+	err := t.client.CloseSend()
+	t.cancel()
+	return err
 }
 
 func (t *transaction) Commit() error {
@@ -110,4 +117,4 @@ func (t *transaction) Put(key, val []byte) error {
 func (t *transaction) Size() int    { return 0 }
 func (t *transaction) Reset()       {}
 func (t *transaction) Write() error { return nil }
-func (t *transaction) Close() error { return t.client.CloseSend() }
+func (t *transaction) Close() error { return t.Discard() }

--- a/grpc/handlers.go
+++ b/grpc/handlers.go
@@ -68,7 +68,7 @@ func (h Handler) handleTxCursor(
 
 	// open is special case: it's the only way to receive cursor id
 	if cur.Op == gen.Op_OPEN {
-		cursorID, err := tx.newCursor()
+		cursorID, err := tx.newCursor(cur.BucketName, len(cur.V) > 0)
 		if err != nil {
 			return err
 		}
@@ -95,6 +95,11 @@ func (h Handler) handleTxCursor(
 	responsePair.CursorId = cur.Cursor
 
 	switch cur.Op {
+	case gen.Op_FIRST:
+		if it.First() {
+			responsePair.K = it.Key()
+			responsePair.V, err = it.Value()
+		}
 	case gen.Op_SEEK:
 		key := slices.Concat(cur.BucketName, cur.K)
 		if it.Seek(key) {

--- a/grpc/kv.proto
+++ b/grpc/kv.proto
@@ -12,6 +12,7 @@ service KV {
 }
 
 // values from https://github.com/ledgerwatch/interfaces/blob/master/remote/kv.proto#L68
+// FIRST is the enum zero-value, so a Cursor with an unset op silently behaves as FIRST.
 enum Op {
   FIRST = 0;
   SEEK = 1;
@@ -28,7 +29,7 @@ message Cursor {
   bytes bucket_name = 2;
   uint32 cursor = 3;
   bytes k = 4;
-  bytes v = 5; // not used
+  bytes v = 5; // withUpperBound flag on OPEN; unused for other ops
 }
 
 message Pair {

--- a/grpc/tx.go
+++ b/grpc/tx.go
@@ -56,5 +56,5 @@ func (t *tx) cleanup() error {
 		err = errors.Join(err, it.Close())
 		return true
 	})
-	return err
+	return errors.Join(err, t.dbTx.Close())
 }

--- a/grpc/tx.go
+++ b/grpc/tx.go
@@ -22,8 +22,8 @@ func newTx(dbTx db.IndexedBatch) *tx {
 	}
 }
 
-func (t *tx) newCursor() (uint32, error) {
-	it, err := t.dbTx.NewIterator(nil, false)
+func (t *tx) newCursor(prefix []byte, withUpperBound bool) (uint32, error) {
+	it, err := t.dbTx.NewIterator(prefix, withUpperBound)
 	if err != nil {
 		return 0, err
 	}

--- a/node/migration.go
+++ b/node/migration.go
@@ -45,6 +45,11 @@ func migrateIfNeeded(
 	chain *blockchain.Blockchain,
 	logger log.Logger,
 ) error {
+	// A remote DB is read-only over gRPC; the node that owns it runs the migrations.
+	if config.RemoteDB != "" {
+		return nil
+	}
+
 	migrateFn := func() error {
 		// Run deprecated migrations first
 		if err := deprecated.MigrateIfNeeded(

--- a/node/migration_test.go
+++ b/node/migration_test.go
@@ -47,3 +47,9 @@ func TestMigrateIfNeeded_WrapsPruneFetchError(t *testing.T) {
 	err := migrateIfNeeded(t.Context(), memory.New(), cfg, nil, log.NewNopZapLogger())
 	require.ErrorContains(t, err, "fetching L1 head for pruning")
 }
+
+func TestMigrateIfNeeded_SkipsMigrationsForRemoteDB(t *testing.T) {
+	cfg := &Config{RemoteDB: "localhost:6064"}
+	err := migrateIfNeeded(t.Context(), memory.New(), cfg, nil, log.NewNopZapLogger())
+	require.NoError(t, err)
+}


### PR DESCRIPTION
<!-- pr-agent-generated -->
### **User description**
<!-- pr-agent-generated -->
### **User description**
1. Disable migrations for the remote DB.
2. `Op_FIRST` was not implemented. The server's cursor switch fell through to `unknown operation`, which killed the stream. Every prefixed `Scan` starts with `it.First()`, so all of them failed. 
3. Iterator bounds were dropped on the wire. db/remote's `NewIterator` discarded the prefix and the upper-bound flag, so the server opened a whole-database iterator and `First` returned a key from a foreign bucket - silently wrong scan results, not an error.
4. State reads never released their batch. `blockchain/statebackend/deprecated.go` opened an `IndexedBatch` per state read and returned `NoopStateCloser`. Free on pebble, but on a remote DB that batch is a live stream plus a pinned server-side batch.


___

### **PR Type**
Bug fix


___

### **Description**
- Fix remote DB iterator bounds and `Op_FIRST` handling

- Release transactions/batches to avoid leaked streams

- Skip migrations when using a remote DB

- Add tests for iterator bounds and migration skip


___



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><details><summary>7 files</summary><table>
<tr>
  <td><strong>deprecated.go</strong><dd><code>Close indexed batches instead of using NoopStateCloser</code>&nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/NethermindEth/juno/pull/4030/files#diff-0ca94a25c89a0875e80ff33fd26494a4d470114d9cd906153db6e7ce29bd40d7">+11/-5</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>db.go</strong><dd><code>Own transaction contexts, wrap iterators, discard unused reads</code></dd></td>
  <td><a href="https://github.com/NethermindEth/juno/pull/4030/files#diff-f32cf1232e79d8f3671ddec799d54c35af87e00352c9108f83b49e0fb1673bf2">+40/-18</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>iterator.go</strong><dd><code>Introduce ownedIterator to release transaction on close</code>&nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/NethermindEth/juno/pull/4030/files#diff-dcd55dd477d3cab27d8d2a18634ee5e3af7032f0eddcea3c6b99a382d056b3d5">+16/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>transaction.go</strong><dd><code>Send prefix/upper bound on iterator open, cancel context on discard</code></dd></td>
  <td><a href="https://github.com/NethermindEth/juno/pull/4030/files#diff-4eaa45c73173772f056521fbc23e1b132aa8e977ceec5e19c7c33d5510668e6a">+22/-6</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>handlers.go</strong><dd><code>Implement Op_FIRST and pass bucket/upper-bound on cursor open</code></dd></td>
  <td><a href="https://github.com/NethermindEth/juno/pull/4030/files#diff-45e7d52d9828e723743da8f3e919a2e274baf6bcdb78ef632d3aef57ff70ac82">+6/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>tx.go</strong><dd><code>Pass prefix/upper bound to new cursor and close batch on cleanup</code></dd></td>
  <td><a href="https://github.com/NethermindEth/juno/pull/4030/files#diff-87d453df231dd7eb0fee28554e6a6fd6c209777afa92cf94fba3165b8a8628ff">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>migration.go</strong><dd><code>Skip migrations when a remote DB is configured</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/NethermindEth/juno/pull/4030/files#diff-e4768b041890cb69567776dc605da8bd4fd096204049166ab2dfdf06f9fddb3f">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td><strong>db_test.go</strong><dd><code>Add tests for First op and iterator bounds over the wire</code>&nbsp; </dd></td>
  <td><a href="https://github.com/NethermindEth/juno/pull/4030/files#diff-ec3a16dd2ab0bfb6ef516a4eeac28b896b0ca4bde6c2c5e08ae9a2df9440ce8f">+65/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>migration_test.go</strong><dd><code>Add test verifying migrations skip for remote DB</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/NethermindEth/juno/pull/4030/files#diff-9fbee152f4ec995a509e69eea5ddbd4a80b67317e391f0ffa7352b298f71c7ab">+6/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Documentation</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>kv.proto</strong><dd><code>Document FIRST default op and repurpose bytes v field</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/NethermindEth/juno/pull/4030/files#diff-ea7947d0964cf031b7350552e8582ae891597265c6fa776da28561e47db52d1e">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___

