### PR TITLE
perf(rpc): dedupe preconfirmed subscriptions before adaptation

### DIFF
--- a/rpc/v10/subscription_receipts.go
+++ b/rpc/v10/subscription_receipts.go
@@ -107,7 +107,8 @@ func (s *receiptsSubscriberState) onNewHead(
 	head *core.Block,
 ) error {
 	// Canonical blocks are published exactly once, so they bypass the deduper.
-	for receipt := range receiptsOf(head, s.senders, TxnFinalityStatusWithoutL1(TxnAcceptedOnL2)) {
+	status := TxnFinalityStatusWithoutL1(TxnAcceptedOnL2)
+	for receipt := range receiptsOf(head, s.senders, status, nil) {
 		if err := sendTransactionReceipt(s.conn, &receipt, id); err != nil {
 			return err
 		}
@@ -125,16 +126,15 @@ func (s *receiptsSubscriberState) onPreConfirmed(
 	status := TxnFinalityStatusWithoutL1(TxnPreConfirmed)
 	// The pre_confirmed tip is re-published in full on every delta; skip already-sent
 	// receipts. A same-height round replacement changes BlockIdentifier and re-emits.
-	for receipt := range receiptsOf(block, s.senders, status) {
-		shouldSend := s.deduper.MarkSent(
+	shouldSend := func(txn core.Transaction) bool {
+		return s.deduper.MarkSent(
 			block.Number,
 			preConfirmed.BlockIdentifier,
-			(*felt.TransactionHash)(receipt.Hash),
+			(*felt.TransactionHash)(txn.Hash()),
 		)
-		if !shouldSend {
-			continue
-		}
+	}
 
+	for receipt := range receiptsOf(block, s.senders, status, shouldSend) {
 		if err := sendTransactionReceipt(s.conn, &receipt, id); err != nil {
 			return err
 		}
@@ -147,10 +147,15 @@ func receiptsOf(
 	block *core.Block,
 	senders []felt.Address,
 	finalityStatus TxnFinalityStatusWithoutL1,
+	shouldSend func(core.Transaction) bool,
 ) iter.Seq[TransactionReceiptWithBlockInfo] {
 	return func(yield func(TransactionReceiptWithBlockInfo) bool) {
 		for i, txn := range block.Transactions {
 			if !filterTxBySender(txn, senders) {
+				continue
+			}
+
+			if shouldSend != nil && !shouldSend(txn) {
 				continue
 			}
 

--- a/rpc/v10/subscription_transactions.go
+++ b/rpc/v10/subscription_transactions.go
@@ -124,7 +124,7 @@ func (s *transactionsSubscriberState) onNewHead(
 ) error {
 	// Canonical blocks are published exactly once, so they bypass the deduper.
 	status := TxnStatusWithoutL1(TxnStatusAcceptedOnL2)
-	for txn := range transactionsOf(head, s.senders, status, s.tags.IncludeProofFacts) {
+	for txn := range transactionsOf(head, s.senders, status, s.tags.IncludeProofFacts, nil) {
 		if err := sendTransaction(s.conn, txn, id); err != nil {
 			return err
 		}
@@ -142,16 +142,15 @@ func (s *transactionsSubscriberState) onPreConfirmed(
 	status := TxnStatusWithoutL1(TxnStatusPreConfirmed)
 	// The pre_confirmed tip is re-published in full on every delta; skip already-sent
 	// transactions. A same-height round replacement changes BlockIdentifier and re-emits.
-	for txn := range transactionsOf(block, s.senders, status, s.tags.IncludeProofFacts) {
-		shouldSend := s.deduper.MarkSent(
+	shouldSend := func(txn core.Transaction) bool {
+		return s.deduper.MarkSent(
 			block.Number,
 			preConfirmed.BlockIdentifier,
-			(*felt.TransactionHash)(txn.Hash),
+			(*felt.TransactionHash)(txn.Hash()),
 		)
-		if !shouldSend {
-			continue
-		}
+	}
 
+	for txn := range transactionsOf(block, s.senders, status, s.tags.IncludeProofFacts, shouldSend) {
 		if err := sendTransaction(s.conn, txn, id); err != nil {
 			return err
 		}
@@ -166,10 +165,15 @@ func transactionsOf(
 	senders []felt.Address,
 	finalityStatus TxnStatusWithoutL1,
 	includeProofFacts bool,
+	shouldSend func(core.Transaction) bool,
 ) iter.Seq[*SubscriptionNewTransaction] {
 	return func(yield func(*SubscriptionNewTransaction) bool) {
 		for _, txn := range b.Transactions {
 			if !filterTxBySender(txn, senders) {
+				continue
+			}
+
+			if shouldSend != nil && !shouldSend(txn) {
 				continue
 			}
 

--- a/rpc/v9/subscription_receipts.go
+++ b/rpc/v9/subscription_receipts.go
@@ -106,7 +106,8 @@ func (s *receiptsSubscriberState) onNewHead(
 	head *core.Block,
 ) error {
 	// Canonical blocks are published exactly once, so they bypass the deduper.
-	for receipt := range receiptsOf(head, s.senders, TxnFinalityStatusWithoutL1(TxnAcceptedOnL2)) {
+	status := TxnFinalityStatusWithoutL1(TxnAcceptedOnL2)
+	for receipt := range receiptsOf(head, s.senders, status, nil) {
 		if err := sendTransactionReceipt(s.conn, &receipt, id); err != nil {
 			return err
 		}
@@ -124,16 +125,15 @@ func (s *receiptsSubscriberState) onPreConfirmed(
 	status := TxnFinalityStatusWithoutL1(TxnPreConfirmed)
 	// The pre_confirmed tip is re-published in full on every delta; skip already-sent
 	// receipts. A same-height round replacement changes BlockIdentifier and re-emits.
-	for receipt := range receiptsOf(block, s.senders, status) {
-		shouldSend := s.deduper.MarkSent(
+	shouldSend := func(txn core.Transaction) bool {
+		return s.deduper.MarkSent(
 			block.Number,
 			preConfirmed.BlockIdentifier,
-			(*felt.TransactionHash)(receipt.Hash),
+			(*felt.TransactionHash)(txn.Hash()),
 		)
-		if !shouldSend {
-			continue
-		}
+	}
 
+	for receipt := range receiptsOf(block, s.senders, status, shouldSend) {
 		if err := sendTransactionReceipt(s.conn, &receipt, id); err != nil {
 			return err
 		}
@@ -146,10 +146,15 @@ func receiptsOf(
 	block *core.Block,
 	senders []felt.Felt,
 	finalityStatus TxnFinalityStatusWithoutL1,
+	shouldSend func(core.Transaction) bool,
 ) iter.Seq[TransactionReceiptWithBlockInfo] {
 	return func(yield func(TransactionReceiptWithBlockInfo) bool) {
 		for i, txn := range block.Transactions {
 			if !filterTxBySender(txn, senders) {
+				continue
+			}
+
+			if shouldSend != nil && !shouldSend(txn) {
 				continue
 			}
 

--- a/rpc/v9/subscription_transactions.go
+++ b/rpc/v9/subscription_transactions.go
@@ -118,7 +118,7 @@ func (s *transactionsSubscriberState) onNewHead(
 	head *core.Block,
 ) error {
 	// Canonical blocks are published exactly once, so they bypass the deduper.
-	for txn := range transactionsOf(head, s.senders, TxnStatusWithoutL1(TxnStatusAcceptedOnL2)) {
+	for txn := range transactionsOf(head, s.senders, TxnStatusWithoutL1(TxnStatusAcceptedOnL2), nil) {
 		if err := sendTransaction(s.conn, txn, id); err != nil {
 			return err
 		}
@@ -136,16 +136,15 @@ func (s *transactionsSubscriberState) onPreConfirmed(
 	status := TxnStatusWithoutL1(TxnStatusPreConfirmed)
 	// The pre_confirmed tip is re-published in full on every delta; skip already-sent
 	// transactions. A same-height round replacement changes BlockIdentifier and re-emits.
-	for txn := range transactionsOf(block, s.senders, status) {
-		shouldSend := s.deduper.MarkSent(
+	shouldSend := func(txn core.Transaction) bool {
+		return s.deduper.MarkSent(
 			block.Number,
 			preConfirmed.BlockIdentifier,
-			(*felt.TransactionHash)(txn.Hash),
+			(*felt.TransactionHash)(txn.Hash()),
 		)
-		if !shouldSend {
-			continue
-		}
+	}
 
+	for txn := range transactionsOf(block, s.senders, status, shouldSend) {
 		if err := sendTransaction(s.conn, txn, id); err != nil {
 			return err
 		}
@@ -159,10 +158,15 @@ func transactionsOf(
 	b *core.Block,
 	senders []felt.Felt,
 	finalityStatus TxnStatusWithoutL1,
+	shouldSend func(core.Transaction) bool,
 ) iter.Seq[*SubscriptionNewTransaction] {
 	return func(yield func(*SubscriptionNewTransaction) bool) {
 		for _, txn := range b.Transactions {
 			if !filterTxBySender(txn, senders) {
+				continue
+			}
+
+			if shouldSend != nil && !shouldSend(txn) {
 				continue
 			}
 


### PR DESCRIPTION
<!-- pr-agent-generated -->
### **User description**
Performs preconfirmed subscription deduplication before RPC response adaptation, avoiding unnecessary transaction and receipt object creation for entries already emitted in the same preconfirmed round.


___

### **PR Type**
Enhancement


___

### **Description**
- Dedupe preconfirmed entries before adaptation

- Avoid unnecessary transaction object creation

- Avoid unnecessary receipt object creation

- Apply pattern across RPC v9 and v10


___



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>subscription_receipts.go</strong><dd><code>Dedupe preconfirmed receipts before adaptation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

rpc/v10/subscription_receipts.go

<ul><li>Adds <code>shouldSend</code> callback to <code>receiptsOf</code><br> <li> Marks receipts as sent before adaptation<br> <li> Skips already-sent preconfirmed receipts<br> <li> Passes <code>nil</code> callback for canonical blocks</ul>


</details>


  </td>
  <td><a href="https://github.com/NethermindEth/juno/pull/4036/files#diff-69f1d96819fbbfd72e5bc5ab6a743f6be596db22bdab34e8544e1afe15274907">+12/-7</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>subscription_transactions.go</strong><dd><code>Dedupe preconfirmed transactions before adaptation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

rpc/v10/subscription_transactions.go

<ul><li>Adds <code>shouldSend</code> callback to <code>transactionsOf</code><br> <li> Marks transactions as sent before adaptation<br> <li> Uses <code>txn.Hash()</code> for deduplication<br> <li> Passes <code>nil</code> callback for canonical blocks</ul>


</details>


  </td>
  <td><a href="https://github.com/NethermindEth/juno/pull/4036/files#diff-7e4f3b01873423b28df9b73c4a9c772aa6132f7be6806560ae62d7eced375308">+11/-7</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>subscription_receipts.go</strong><dd><code>Dedupe preconfirmed receipts before adaptation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

rpc/v9/subscription_receipts.go

<ul><li>Adds <code>shouldSend</code> callback to <code>receiptsOf</code><br> <li> Marks receipts as sent before adaptation<br> <li> Skips already-sent preconfirmed receipts<br> <li> Uses <code>status</code> variable for canonical blocks</ul>


</details>


  </td>
  <td><a href="https://github.com/NethermindEth/juno/pull/4036/files#diff-8ff017a220dca1bc9f60da65e9f83422f1b124fef2cf70fec4cd18f853f4f4ab">+12/-7</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>subscription_transactions.go</strong><dd><code>Dedupe preconfirmed transactions before adaptation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

rpc/v9/subscription_transactions.go

<ul><li>Adds <code>shouldSend</code> callback to <code>transactionsOf</code><br> <li> Marks transactions as sent before adaptation<br> <li> Uses <code>txn.Hash()</code> for deduplication<br> <li> Passes <code>nil</code> callback for canonical blocks</ul>


</details>


  </td>
  <td><a href="https://github.com/NethermindEth/juno/pull/4036/files#diff-baaba2bc462fb598ab4eb3468e7f49b6065a48ae0dab9ee0fd665cf07cd41c44">+11/-7</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

