### PR TITLE
perf(jemalloc): serve the VM from two arenas

### DIFF
--- a/jemalloc/jemalloc.go
+++ b/jemalloc/jemalloc.go
@@ -7,6 +7,18 @@ package jemalloc
 
 #include <jemalloc/jemalloc.h>
 
+// jemalloc defaults to 4 arenas per CPU. The default assumes a thread frees what it allocated and
+// allocates again soon, so a private arena per thread avoids locks and cross-thread traffic.
+// Juno breaks that assumption. The Go scheduler runs the next request on a different thread, and
+// the VM's allocations are far above the 32 KB thread-cache limit. Memory freed on one thread is
+// never reused by another: it is purged to the OS and page-faulted back in on the next request.
+// Pebble's block cache allocates through C.calloc and is affected the same way.
+// Two shared arenas let freed memory be reused across threads. That lowers latency and RSS.
+// The cost is more threads per arena lock. It stays small here: VM concurrency is capped by
+// max-vms and each request makes tens of large allocations, so two arenas are far from saturation,
+// while the purge and page-fault cost would be paid on every request.
+const char *malloc_conf = "narenas:2";
+
 void _refresh_jemalloc_stats() {
 	// You just need to pass something not-null into the "epoch" mallctl.
 	size_t random_something = 1;


### PR DESCRIPTION
<!-- pr-agent-generated -->
### **User description**
## Summary
- Splits jemalloc allocation for the VM across two arenas to reduce contention


___

### **PR Type**
Enhancement


___

### **Description**
- Serve VM allocations from two jemalloc arenas.

- Reduce cross-thread memory purge overhead.

- Add rationale for arena configuration.


___



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>jemalloc.go</strong><dd><code>Configure jemalloc to use two arenas</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

jemalloc/jemalloc.go

<ul><li>Adds explanation of jemalloc arena assumptions for the VM.<br> <li> Sets malloc_conf to narenas:2.<br> <li> Aims to reuse freed memory across threads.</ul>


</details>


  </td>
  <td><a href="https://github.com/NethermindEth/juno/pull/4053/files#diff-9a96bda6518c672d7ade0f741ef4e47f126a42c33eb976b559b14d0eff6c254e">+12/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

