### PR TITLE
refactor: sync options

### DIFF
--- a/cmd/juno/juno.go
+++ b/cmd/juno/juno.go
@@ -20,6 +20,7 @@ import (
 	_ "github.com/NethermindEth/juno/jemalloc"
 	"github.com/NethermindEth/juno/l1/eth"
 	"github.com/NethermindEth/juno/node"
+	"github.com/NethermindEth/juno/sync"
 	"github.com/NethermindEth/juno/utils"
 	"github.com/NethermindEth/juno/utils/log"
 	"github.com/NethermindEth/juno/vm"
@@ -135,7 +136,7 @@ const (
 	defaultPprof                              = false
 	defaultPprofPort                          = 6062
 	defaultColour                             = true
-	defaultPreConfirmedPollInterval           = 500 * time.Millisecond
+	defaultPreConfirmedPollInterval           = sync.DefaultPreConfirmedPollInterval
 	defaultDisableSync                        = false
 	defaultP2p                                = false
 	defaultP2pAddr                            = ""

--- a/node/node.go
+++ b/node/node.go
@@ -448,9 +448,9 @@ func New(cfg *Config, version string, logLevel *log.Level) (*Node, error) {
 				chain,
 				feederGatewayDataSource,
 				logger,
-				cfg.PreConfirmedPollInterval,
-				dbIsRemote,
 				database,
+				sync.WithPreConfirmedPollInterval(cfg.PreConfirmedPollInterval),
+				sync.WithReadOnlyBlockchain(dbIsRemote),
 			)
 			synchronizer.WithPlugin(junoPlugin)
 		}

--- a/node/node.go
+++ b/node/node.go
@@ -448,7 +448,6 @@ func New(cfg *Config, version string, logLevel *log.Level) (*Node, error) {
 				chain,
 				feederGatewayDataSource,
 				logger,
-				database,
 				sync.WithPreConfirmedPollInterval(cfg.PreConfirmedPollInterval),
 				sync.WithReadOnlyBlockchain(dbIsRemote),
 			)

--- a/node/node_test.go
+++ b/node/node_test.go
@@ -159,7 +159,7 @@ func TestNetworkVerificationOnNonEmptyDB(t *testing.T) {
 			)
 			ctx, cancel := context.WithCancel(t.Context())
 			dataSource := sync.NewFeederGatewayDataSource(chain, adaptfeeder.New(feeder.NewTestClient(t, &network)))
-			syncer := sync.New(chain, dataSource, logger, database, sync.WithPreConfirmedPollInterval(0)).
+			syncer := sync.New(chain, dataSource, logger, sync.WithPreConfirmedPollInterval(0)).
 				WithListener(&sync.SelectiveListener{OnSyncStepDoneCb: func(op string, _ uint64, _ time.Duration) {
 					// Stop the syncer after we successfully stored block.
 					if op == sync.OpStore {

--- a/node/node_test.go
+++ b/node/node_test.go
@@ -159,7 +159,7 @@ func TestNetworkVerificationOnNonEmptyDB(t *testing.T) {
 			)
 			ctx, cancel := context.WithCancel(t.Context())
 			dataSource := sync.NewFeederGatewayDataSource(chain, adaptfeeder.New(feeder.NewTestClient(t, &network)))
-			syncer := sync.New(chain, dataSource, logger, 0, false, database).
+			syncer := sync.New(chain, dataSource, logger, database).
 				WithListener(&sync.SelectiveListener{OnSyncStepDoneCb: func(op string, _ uint64, _ time.Duration) {
 					// Stop the syncer after we successfully stored block.
 					if op == sync.OpStore {

--- a/node/node_test.go
+++ b/node/node_test.go
@@ -159,7 +159,7 @@ func TestNetworkVerificationOnNonEmptyDB(t *testing.T) {
 			)
 			ctx, cancel := context.WithCancel(t.Context())
 			dataSource := sync.NewFeederGatewayDataSource(chain, adaptfeeder.New(feeder.NewTestClient(t, &network)))
-			syncer := sync.New(chain, dataSource, logger, database).
+			syncer := sync.New(chain, dataSource, logger, database, sync.WithPreConfirmedPollInterval(0)).
 				WithListener(&sync.SelectiveListener{OnSyncStepDoneCb: func(op string, _ uint64, _ time.Duration) {
 					// Stop the syncer after we successfully stored block.
 					if op == sync.OpStore {

--- a/plugin/plugin_test.go
+++ b/plugin/plugin_test.go
@@ -47,7 +47,7 @@ func TestPlugin(t *testing.T) {
 		blockchain.WithNewState(statetestutils.UseNewState()),
 	)
 	dataSource := sync.NewFeederGatewayDataSource(bc, integGw)
-	synchronizer := sync.New(bc, dataSource, log.NewNopZapLogger(), nil).WithPlugin(plugin)
+	synchronizer := sync.New(bc, dataSource, log.NewNopZapLogger(), nil, sync.WithPreConfirmedPollInterval(0)).WithPlugin(plugin)
 
 	ctx, cancel := context.WithTimeout(t.Context(), timeout)
 	require.NoError(t, synchronizer.Run(ctx))
@@ -79,7 +79,7 @@ func TestPlugin(t *testing.T) {
 		}
 
 		dataSource := sync.NewFeederGatewayDataSource(bc, mainGw)
-		synchronizer = sync.New(bc, dataSource, log.NewNopZapLogger(), nil).WithPlugin(plugin)
+		synchronizer = sync.New(bc, dataSource, log.NewNopZapLogger(), nil, sync.WithPreConfirmedPollInterval(0)).WithPlugin(plugin)
 		ctx, cancel = context.WithTimeout(t.Context(), timeout)
 		require.NoError(t, synchronizer.Run(ctx))
 		cancel()

--- a/plugin/plugin_test.go
+++ b/plugin/plugin_test.go
@@ -47,7 +47,7 @@ func TestPlugin(t *testing.T) {
 		blockchain.WithNewState(statetestutils.UseNewState()),
 	)
 	dataSource := sync.NewFeederGatewayDataSource(bc, integGw)
-	synchronizer := sync.New(bc, dataSource, log.NewNopZapLogger(), nil, sync.WithPreConfirmedPollInterval(0)).WithPlugin(plugin)
+	synchronizer := sync.New(bc, dataSource, log.NewNopZapLogger(), sync.WithPreConfirmedPollInterval(0)).WithPlugin(plugin)
 
 	ctx, cancel := context.WithTimeout(t.Context(), timeout)
 	require.NoError(t, synchronizer.Run(ctx))
@@ -79,7 +79,7 @@ func TestPlugin(t *testing.T) {
 		}
 
 		dataSource := sync.NewFeederGatewayDataSource(bc, mainGw)
-		synchronizer = sync.New(bc, dataSource, log.NewNopZapLogger(), nil, sync.WithPreConfirmedPollInterval(0)).WithPlugin(plugin)
+		synchronizer = sync.New(bc, dataSource, log.NewNopZapLogger(), sync.WithPreConfirmedPollInterval(0)).WithPlugin(plugin)
 		ctx, cancel = context.WithTimeout(t.Context(), timeout)
 		require.NoError(t, synchronizer.Run(ctx))
 		cancel()

--- a/plugin/plugin_test.go
+++ b/plugin/plugin_test.go
@@ -47,14 +47,7 @@ func TestPlugin(t *testing.T) {
 		blockchain.WithNewState(statetestutils.UseNewState()),
 	)
 	dataSource := sync.NewFeederGatewayDataSource(bc, integGw)
-	synchronizer := sync.New(
-		bc,
-		dataSource,
-		log.NewNopZapLogger(),
-		0,
-		false,
-		nil,
-	).WithPlugin(plugin)
+	synchronizer := sync.New(bc, dataSource, log.NewNopZapLogger(), nil).WithPlugin(plugin)
 
 	ctx, cancel := context.WithTimeout(t.Context(), timeout)
 	require.NoError(t, synchronizer.Run(ctx))
@@ -86,14 +79,7 @@ func TestPlugin(t *testing.T) {
 		}
 
 		dataSource := sync.NewFeederGatewayDataSource(bc, mainGw)
-		synchronizer = sync.New(
-			bc,
-			dataSource,
-			log.NewNopZapLogger(),
-			0,
-			false,
-			nil,
-		).WithPlugin(plugin)
+		synchronizer = sync.New(bc, dataSource, log.NewNopZapLogger(), nil).WithPlugin(plugin)
 		ctx, cancel = context.WithTimeout(t.Context(), timeout)
 		require.NoError(t, synchronizer.Run(ctx))
 		cancel()

--- a/plugin/plugin_test.go
+++ b/plugin/plugin_test.go
@@ -47,7 +47,12 @@ func TestPlugin(t *testing.T) {
 		blockchain.WithNewState(statetestutils.UseNewState()),
 	)
 	dataSource := sync.NewFeederGatewayDataSource(bc, integGw)
-	synchronizer := sync.New(bc, dataSource, log.NewNopZapLogger(), sync.WithPreConfirmedPollInterval(0)).WithPlugin(plugin)
+	synchronizer := sync.New(
+		bc,
+		dataSource,
+		log.NewNopZapLogger(),
+		sync.WithPreConfirmedPollInterval(0),
+	).WithPlugin(plugin)
 
 	ctx, cancel := context.WithTimeout(t.Context(), timeout)
 	require.NoError(t, synchronizer.Run(ctx))
@@ -79,7 +84,12 @@ func TestPlugin(t *testing.T) {
 		}
 
 		dataSource := sync.NewFeederGatewayDataSource(bc, mainGw)
-		synchronizer = sync.New(bc, dataSource, log.NewNopZapLogger(), sync.WithPreConfirmedPollInterval(0)).WithPlugin(plugin)
+		synchronizer = sync.New(
+			bc,
+			dataSource,
+			log.NewNopZapLogger(),
+			sync.WithPreConfirmedPollInterval(0),
+		).WithPlugin(plugin)
 		ctx, cancel = context.WithTimeout(t.Context(), timeout)
 		require.NoError(t, synchronizer.Run(ctx))
 		cancel()

--- a/rpc/v10/storage_test.go
+++ b/rpc/v10/storage_test.go
@@ -1417,7 +1417,7 @@ func TestStorageProof_StorageRoots(t *testing.T) {
 		blockchain.WithNewState(statetestutils.UseNewState()),
 	)
 	dataSource := sync.NewFeederGatewayDataSource(bc, gw)
-	synchronizer := sync.New(bc, dataSource, logger, testDB)
+	synchronizer := sync.New(bc, dataSource, logger, testDB, sync.WithPreConfirmedPollInterval(0))
 	ctx, cancel := context.WithTimeout(t.Context(), time.Second)
 
 	require.NoError(t, synchronizer.Run(ctx))

--- a/rpc/v10/storage_test.go
+++ b/rpc/v10/storage_test.go
@@ -1417,7 +1417,7 @@ func TestStorageProof_StorageRoots(t *testing.T) {
 		blockchain.WithNewState(statetestutils.UseNewState()),
 	)
 	dataSource := sync.NewFeederGatewayDataSource(bc, gw)
-	synchronizer := sync.New(bc, dataSource, logger, testDB, sync.WithPreConfirmedPollInterval(0))
+	synchronizer := sync.New(bc, dataSource, logger, sync.WithPreConfirmedPollInterval(0))
 	ctx, cancel := context.WithTimeout(t.Context(), time.Second)
 
 	require.NoError(t, synchronizer.Run(ctx))

--- a/rpc/v10/storage_test.go
+++ b/rpc/v10/storage_test.go
@@ -1417,7 +1417,7 @@ func TestStorageProof_StorageRoots(t *testing.T) {
 		blockchain.WithNewState(statetestutils.UseNewState()),
 	)
 	dataSource := sync.NewFeederGatewayDataSource(bc, gw)
-	synchronizer := sync.New(bc, dataSource, logger, time.Duration(0), false, testDB)
+	synchronizer := sync.New(bc, dataSource, logger, testDB)
 	ctx, cancel := context.WithTimeout(t.Context(), time.Second)
 
 	require.NoError(t, synchronizer.Run(ctx))

--- a/rpc/v8/storage_test.go
+++ b/rpc/v8/storage_test.go
@@ -807,7 +807,7 @@ func TestStorageProof_StorageRoots(t *testing.T) {
 		blockchain.WithNewState(statetestutils.UseNewState()),
 	)
 	dataSource := sync.NewFeederGatewayDataSource(bc, gw)
-	synchronizer := sync.New(bc, dataSource, logger, time.Duration(0), false, testDB)
+	synchronizer := sync.New(bc, dataSource, logger, testDB)
 	ctx, cancel := context.WithTimeout(t.Context(), time.Second)
 
 	require.NoError(t, synchronizer.Run(ctx))

--- a/rpc/v8/storage_test.go
+++ b/rpc/v8/storage_test.go
@@ -807,7 +807,7 @@ func TestStorageProof_StorageRoots(t *testing.T) {
 		blockchain.WithNewState(statetestutils.UseNewState()),
 	)
 	dataSource := sync.NewFeederGatewayDataSource(bc, gw)
-	synchronizer := sync.New(bc, dataSource, logger, testDB, sync.WithPreConfirmedPollInterval(0))
+	synchronizer := sync.New(bc, dataSource, logger, sync.WithPreConfirmedPollInterval(0))
 	ctx, cancel := context.WithTimeout(t.Context(), time.Second)
 
 	require.NoError(t, synchronizer.Run(ctx))

--- a/rpc/v8/storage_test.go
+++ b/rpc/v8/storage_test.go
@@ -807,7 +807,7 @@ func TestStorageProof_StorageRoots(t *testing.T) {
 		blockchain.WithNewState(statetestutils.UseNewState()),
 	)
 	dataSource := sync.NewFeederGatewayDataSource(bc, gw)
-	synchronizer := sync.New(bc, dataSource, logger, testDB)
+	synchronizer := sync.New(bc, dataSource, logger, testDB, sync.WithPreConfirmedPollInterval(0))
 	ctx, cancel := context.WithTimeout(t.Context(), time.Second)
 
 	require.NoError(t, synchronizer.Run(ctx))

--- a/rpc/v9/storage_test.go
+++ b/rpc/v9/storage_test.go
@@ -888,7 +888,7 @@ func TestStorageProof_StorageRoots(t *testing.T) {
 		blockchain.WithNewState(statetestutils.UseNewState()),
 	)
 	dataSource := sync.NewFeederGatewayDataSource(bc, gw)
-	synchronizer := sync.New(bc, dataSource, logger, time.Duration(0), false, testDB)
+	synchronizer := sync.New(bc, dataSource, logger, testDB)
 	ctx, cancel := context.WithTimeout(t.Context(), time.Second)
 
 	require.NoError(t, synchronizer.Run(ctx))

--- a/rpc/v9/storage_test.go
+++ b/rpc/v9/storage_test.go
@@ -888,7 +888,7 @@ func TestStorageProof_StorageRoots(t *testing.T) {
 		blockchain.WithNewState(statetestutils.UseNewState()),
 	)
 	dataSource := sync.NewFeederGatewayDataSource(bc, gw)
-	synchronizer := sync.New(bc, dataSource, logger, testDB, sync.WithPreConfirmedPollInterval(0))
+	synchronizer := sync.New(bc, dataSource, logger, sync.WithPreConfirmedPollInterval(0))
 	ctx, cancel := context.WithTimeout(t.Context(), time.Second)
 
 	require.NoError(t, synchronizer.Run(ctx))

--- a/rpc/v9/storage_test.go
+++ b/rpc/v9/storage_test.go
@@ -888,7 +888,7 @@ func TestStorageProof_StorageRoots(t *testing.T) {
 		blockchain.WithNewState(statetestutils.UseNewState()),
 	)
 	dataSource := sync.NewFeederGatewayDataSource(bc, gw)
-	synchronizer := sync.New(bc, dataSource, logger, testDB)
+	synchronizer := sync.New(bc, dataSource, logger, testDB, sync.WithPreConfirmedPollInterval(0))
 	ctx, cancel := context.WithTimeout(t.Context(), time.Second)
 
 	require.NoError(t, synchronizer.Run(ctx))

--- a/sync/reorg_test.go
+++ b/sync/reorg_test.go
@@ -276,7 +276,7 @@ func setup(
 	t.Cleanup(wg.Wait)
 	t.Cleanup(cancel)
 	wg.Go(func() {
-		synchronizer := sync.New(blockchain, dataSource, logger, synchronizerDatabase, sync.WithPreConfirmedPollInterval(0))
+		synchronizer := sync.New(blockchain, dataSource, logger, sync.WithPreConfirmedPollInterval(0))
 		require.NoError(t, synchronizer.Run(ctx))
 	})
 

--- a/sync/reorg_test.go
+++ b/sync/reorg_test.go
@@ -276,7 +276,7 @@ func setup(
 	t.Cleanup(wg.Wait)
 	t.Cleanup(cancel)
 	wg.Go(func() {
-		synchronizer := sync.New(blockchain, dataSource, logger, 0, false, synchronizerDatabase)
+		synchronizer := sync.New(blockchain, dataSource, logger, synchronizerDatabase)
 		require.NoError(t, synchronizer.Run(ctx))
 	})
 

--- a/sync/reorg_test.go
+++ b/sync/reorg_test.go
@@ -276,7 +276,7 @@ func setup(
 	t.Cleanup(wg.Wait)
 	t.Cleanup(cancel)
 	wg.Go(func() {
-		synchronizer := sync.New(blockchain, dataSource, logger, synchronizerDatabase)
+		synchronizer := sync.New(blockchain, dataSource, logger, synchronizerDatabase, sync.WithPreConfirmedPollInterval(0))
 		require.NoError(t, synchronizer.Run(ctx))
 	})
 

--- a/sync/sync.go
+++ b/sync/sync.go
@@ -134,14 +134,37 @@ type Synchronizer struct {
 	currReorg *ReorgBlockRange // If nil, no reorg is happening
 }
 
+// options carries the optional Synchronizer settings; see [Option].
+type options struct {
+	preConfirmedPollInterval time.Duration
+	readOnlyBlockchain       bool
+}
+
+// Option is a functional option for configuring a Synchronizer.
+type Option func(*options)
+
+// WithPreConfirmedPollInterval sets how often the pre-confirmed poller ticks; zero disables polling.
+func WithPreConfirmedPollInterval(interval time.Duration) Option {
+	return func(o *options) { o.preConfirmedPollInterval = interval }
+}
+
+// WithReadOnlyBlockchain stops the synchronizer from writing to the blockchain.
+func WithReadOnlyBlockchain(readOnly bool) Option {
+	return func(o *options) { o.readOnlyBlockchain = readOnly }
+}
+
 func New(
 	bc *blockchain.Blockchain,
 	dataSource DataSource,
 	logger log.StructuredLogger,
-	preConfirmedPollInterval time.Duration,
-	readOnlyBlockchain bool,
 	database db.KeyValueStore,
+	opts ...Option,
 ) *Synchronizer {
+	var cfg options
+	for _, opt := range opts {
+		opt(&cfg)
+	}
+
 	s := &Synchronizer{
 		blockchain:               bc,
 		dataSource:               dataSource,
@@ -150,9 +173,9 @@ func New(
 		newHeads:                 feed.New[*core.Block](),
 		reorgFeed:                feed.New[*ReorgBlockRange](),
 		preConfirmedDataFeed:     feed.New[*pending.PreConfirmed](),
-		preConfirmedPollInterval: preConfirmedPollInterval,
+		preConfirmedPollInterval: cfg.preConfirmedPollInterval,
 		listener:                 &SelectiveListener{},
-		readOnlyBlockchain:       readOnlyBlockchain,
+		readOnlyBlockchain:       cfg.readOnlyBlockchain,
 		preConfirmed:             preconfirmed.NewChainStorage(),
 	}
 	return s

--- a/sync/sync.go
+++ b/sync/sync.go
@@ -134,6 +134,9 @@ type Synchronizer struct {
 	currReorg *ReorgBlockRange // If nil, no reorg is happening
 }
 
+// DefaultPreConfirmedPollInterval is how often the pre-confirmed poller ticks unless overridden.
+const DefaultPreConfirmedPollInterval = 500 * time.Millisecond
+
 // options carries the optional Synchronizer settings; see [Option].
 type options struct {
 	preConfirmedPollInterval time.Duration
@@ -143,7 +146,7 @@ type options struct {
 // Option is a functional option for configuring a Synchronizer.
 type Option func(*options)
 
-// WithPreConfirmedPollInterval sets how often the pre-confirmed poller ticks; zero disables polling.
+// WithPreConfirmedPollInterval overrides [DefaultPreConfirmedPollInterval]; zero disables polling.
 func WithPreConfirmedPollInterval(interval time.Duration) Option {
 	return func(o *options) { o.preConfirmedPollInterval = interval }
 }
@@ -160,7 +163,7 @@ func New(
 	database db.KeyValueStore,
 	opts ...Option,
 ) *Synchronizer {
-	var cfg options
+	cfg := options{preConfirmedPollInterval: DefaultPreConfirmedPollInterval}
 	for _, opt := range opts {
 		opt(&cfg)
 	}

--- a/sync/sync.go
+++ b/sync/sync.go
@@ -13,7 +13,6 @@ import (
 	"github.com/NethermindEth/juno/core"
 	"github.com/NethermindEth/juno/core/felt"
 	"github.com/NethermindEth/juno/core/pending"
-	"github.com/NethermindEth/juno/db"
 	"github.com/NethermindEth/juno/feed"
 	junoplugin "github.com/NethermindEth/juno/plugin"
 	"github.com/NethermindEth/juno/service"
@@ -112,7 +111,6 @@ func (n *NoopSynchronizer) PreConfirmedChain() (preconfirmed.ChainReader, error)
 // Synchronizer manages a list of StarknetData to fetch the latest blockchain updates
 type Synchronizer struct {
 	blockchain           *blockchain.Blockchain
-	db                   db.KeyValueStore
 	readOnlyBlockchain   bool
 	dataSource           DataSource
 	startingBlockNumber  atomic.Pointer[uint64]
@@ -160,7 +158,6 @@ func New(
 	bc *blockchain.Blockchain,
 	dataSource DataSource,
 	logger log.StructuredLogger,
-	database db.KeyValueStore,
 	opts ...Option,
 ) *Synchronizer {
 	cfg := options{preConfirmedPollInterval: DefaultPreConfirmedPollInterval}
@@ -171,7 +168,6 @@ func New(
 	s := &Synchronizer{
 		blockchain:               bc,
 		dataSource:               dataSource,
-		db:                       database,
 		logger:                   logger,
 		newHeads:                 feed.New[*core.Block](),
 		reorgFeed:                feed.New[*ReorgBlockRange](),
@@ -592,7 +588,7 @@ func (s *Synchronizer) StartingBlockHeader() (*core.Header, error) {
 		return nil, errors.New("starting block number is not set")
 	}
 
-	header, err := core.GetBlockHeaderByNumber(s.db, *startingBlockNumber)
+	header, err := s.blockchain.BlockHeaderByNumber(*startingBlockNumber)
 	if err != nil {
 		return nil, fmt.Errorf("getting header for block %d: %w", *startingBlockNumber, err)
 	}

--- a/sync/sync_test.go
+++ b/sync/sync_test.go
@@ -70,14 +70,7 @@ func TestSyncBlocks(t *testing.T) {
 			blockchain.WithNewState(statetestutils.UseNewState()),
 		)
 		dataSource := sync.NewFeederGatewayDataSource(bc, gw)
-		synchronizer := sync.New(
-			bc,
-			dataSource,
-			logger,
-			time.Duration(0),
-			false,
-			testDB,
-		)
+		synchronizer := sync.New(bc, dataSource, logger, testDB)
 		ctx, cancel := context.WithTimeout(t.Context(), timeout)
 
 		require.NoError(t, synchronizer.Run(ctx))
@@ -100,14 +93,7 @@ func TestSyncBlocks(t *testing.T) {
 		require.NoError(t, bc.Store(b0, &core.BlockCommitments{}, s0, nil))
 
 		dataSource := sync.NewFeederGatewayDataSource(bc, gw)
-		synchronizer := sync.New(
-			bc,
-			dataSource,
-			logger,
-			time.Duration(0),
-			false,
-			testDB,
-		)
+		synchronizer := sync.New(bc, dataSource, logger, testDB)
 		ctx, cancel := context.WithTimeout(t.Context(), timeout)
 
 		require.NoError(t, synchronizer.Run(ctx))
@@ -171,14 +157,7 @@ func TestSyncBlocks(t *testing.T) {
 			}).AnyTimes()
 
 		dataSource := sync.NewFeederGatewayDataSource(bc, mockSNData)
-		synchronizer := sync.New(
-			bc,
-			dataSource,
-			logger,
-			time.Duration(0),
-			false,
-			testDB,
-		)
+		synchronizer := sync.New(bc, dataSource, logger, testDB)
 		ctx, cancel := context.WithTimeout(t.Context(), 2*timeout)
 
 		require.NoError(t, synchronizer.Run(ctx))
@@ -211,9 +190,8 @@ func TestStartingBlockHeaderFallsBackToBlockchain(t *testing.T) {
 		bc,
 		dataSource,
 		log.NewNopZapLogger(),
-		time.Duration(0),
-		true,
 		testDB,
+		sync.WithReadOnlyBlockchain(true),
 	)
 	ctx, cancel := context.WithCancel(t.Context())
 	done := make(chan error, 1)
@@ -249,14 +227,7 @@ func TestStartingBlockHeaderCachesStoredHeader(t *testing.T) {
 		blockchain.WithNewState(statetestutils.UseNewState()),
 	)
 	dataSource := sync.NewFeederGatewayDataSource(bc, gw)
-	synchronizer := sync.New(
-		bc,
-		dataSource,
-		log.NewNopZapLogger(),
-		time.Duration(0),
-		false,
-		testDB,
-	)
+	synchronizer := sync.New(bc, dataSource, log.NewNopZapLogger(), testDB)
 
 	storedStartingBlock := make(chan struct{}, 1)
 	synchronizer.WithListener(&sync.SelectiveListener{
@@ -300,9 +271,8 @@ func TestStartingBlockHeaderNotRunning(t *testing.T) {
 		bc,
 		newTestBlockDataSource(),
 		log.NewNopZapLogger(),
-		time.Duration(0),
-		true,
 		testDB,
+		sync.WithReadOnlyBlockchain(true),
 	)
 
 	header, err := synchronizer.StartingBlockHeader()
@@ -325,9 +295,8 @@ func TestStartingBlockHeaderFallbackUnavailable(t *testing.T) {
 		bc,
 		dataSource,
 		log.NewNopZapLogger(),
-		time.Duration(0),
-		true,
 		testDB,
+		sync.WithReadOnlyBlockchain(true),
 	)
 	ctx, cancel := context.WithCancel(t.Context())
 	done := make(chan error, 1)
@@ -363,7 +332,7 @@ func TestReorg(t *testing.T) {
 		blockchain.WithNewState(statetestutils.UseNewState()),
 	)
 	dataSource := sync.NewFeederGatewayDataSource(bc, sepoliaGw)
-	synchronizer := sync.New(bc, dataSource, log.NewNopZapLogger(), 0, false, testDB)
+	synchronizer := sync.New(bc, dataSource, log.NewNopZapLogger(), testDB)
 
 	ctx, cancel := context.WithTimeout(t.Context(), timeout)
 	require.NoError(t, synchronizer.Run(ctx))
@@ -385,7 +354,7 @@ func TestReorg(t *testing.T) {
 		require.NoError(t, err)
 
 		dataSource := sync.NewFeederGatewayDataSource(bc, mainGw)
-		synchronizer = sync.New(bc, dataSource, log.NewNopZapLogger(), 0, false, testDB)
+		synchronizer = sync.New(bc, dataSource, log.NewNopZapLogger(), testDB)
 		sub := synchronizer.SubscribeReorg()
 		// Use a generous timeout with early cancellation once the expected block is stored.
 		// The reorg flow (detect mismatch → revert → re-sync 3 blocks) needs more than 1s on slow CI.
@@ -436,7 +405,7 @@ func TestSubscribeNewHeads(t *testing.T) {
 	feeder := feeder.NewTestClient(t, &network)
 	gw := adaptfeeder.New(feeder)
 	dataSource := sync.NewFeederGatewayDataSource(chain, gw)
-	syncer := sync.New(chain, dataSource, logger, 0, false, testDB)
+	syncer := sync.New(chain, dataSource, logger, testDB)
 
 	sub := syncer.SubscribeNewHeads()
 
@@ -477,7 +446,7 @@ func TestPreConfirmed(t *testing.T) {
 		require.NoError(t, err)
 		require.NoError(t, bc.Store(b0, &core.BlockCommitments{}, s0, nil))
 
-		synchronizer := sync.New(bc, nil, logger, 0, false, testDB)
+		synchronizer := sync.New(bc, nil, logger, testDB)
 		head, err := bc.HeadsHeader()
 		require.NoError(t, err)
 

--- a/sync/sync_test.go
+++ b/sync/sync_test.go
@@ -70,7 +70,7 @@ func TestSyncBlocks(t *testing.T) {
 			blockchain.WithNewState(statetestutils.UseNewState()),
 		)
 		dataSource := sync.NewFeederGatewayDataSource(bc, gw)
-		synchronizer := sync.New(bc, dataSource, logger, testDB)
+		synchronizer := sync.New(bc, dataSource, logger, testDB, sync.WithPreConfirmedPollInterval(0))
 		ctx, cancel := context.WithTimeout(t.Context(), timeout)
 
 		require.NoError(t, synchronizer.Run(ctx))
@@ -93,7 +93,7 @@ func TestSyncBlocks(t *testing.T) {
 		require.NoError(t, bc.Store(b0, &core.BlockCommitments{}, s0, nil))
 
 		dataSource := sync.NewFeederGatewayDataSource(bc, gw)
-		synchronizer := sync.New(bc, dataSource, logger, testDB)
+		synchronizer := sync.New(bc, dataSource, logger, testDB, sync.WithPreConfirmedPollInterval(0))
 		ctx, cancel := context.WithTimeout(t.Context(), timeout)
 
 		require.NoError(t, synchronizer.Run(ctx))
@@ -157,7 +157,7 @@ func TestSyncBlocks(t *testing.T) {
 			}).AnyTimes()
 
 		dataSource := sync.NewFeederGatewayDataSource(bc, mockSNData)
-		synchronizer := sync.New(bc, dataSource, logger, testDB)
+		synchronizer := sync.New(bc, dataSource, logger, testDB, sync.WithPreConfirmedPollInterval(0))
 		ctx, cancel := context.WithTimeout(t.Context(), 2*timeout)
 
 		require.NoError(t, synchronizer.Run(ctx))
@@ -191,6 +191,7 @@ func TestStartingBlockHeaderFallsBackToBlockchain(t *testing.T) {
 		dataSource,
 		log.NewNopZapLogger(),
 		testDB,
+		sync.WithPreConfirmedPollInterval(0),
 		sync.WithReadOnlyBlockchain(true),
 	)
 	ctx, cancel := context.WithCancel(t.Context())
@@ -227,7 +228,7 @@ func TestStartingBlockHeaderCachesStoredHeader(t *testing.T) {
 		blockchain.WithNewState(statetestutils.UseNewState()),
 	)
 	dataSource := sync.NewFeederGatewayDataSource(bc, gw)
-	synchronizer := sync.New(bc, dataSource, log.NewNopZapLogger(), testDB)
+	synchronizer := sync.New(bc, dataSource, log.NewNopZapLogger(), testDB, sync.WithPreConfirmedPollInterval(0))
 
 	storedStartingBlock := make(chan struct{}, 1)
 	synchronizer.WithListener(&sync.SelectiveListener{
@@ -272,6 +273,7 @@ func TestStartingBlockHeaderNotRunning(t *testing.T) {
 		newTestBlockDataSource(),
 		log.NewNopZapLogger(),
 		testDB,
+		sync.WithPreConfirmedPollInterval(0),
 		sync.WithReadOnlyBlockchain(true),
 	)
 
@@ -296,6 +298,7 @@ func TestStartingBlockHeaderFallbackUnavailable(t *testing.T) {
 		dataSource,
 		log.NewNopZapLogger(),
 		testDB,
+		sync.WithPreConfirmedPollInterval(0),
 		sync.WithReadOnlyBlockchain(true),
 	)
 	ctx, cancel := context.WithCancel(t.Context())
@@ -332,7 +335,7 @@ func TestReorg(t *testing.T) {
 		blockchain.WithNewState(statetestutils.UseNewState()),
 	)
 	dataSource := sync.NewFeederGatewayDataSource(bc, sepoliaGw)
-	synchronizer := sync.New(bc, dataSource, log.NewNopZapLogger(), testDB)
+	synchronizer := sync.New(bc, dataSource, log.NewNopZapLogger(), testDB, sync.WithPreConfirmedPollInterval(0))
 
 	ctx, cancel := context.WithTimeout(t.Context(), timeout)
 	require.NoError(t, synchronizer.Run(ctx))
@@ -354,7 +357,7 @@ func TestReorg(t *testing.T) {
 		require.NoError(t, err)
 
 		dataSource := sync.NewFeederGatewayDataSource(bc, mainGw)
-		synchronizer = sync.New(bc, dataSource, log.NewNopZapLogger(), testDB)
+		synchronizer = sync.New(bc, dataSource, log.NewNopZapLogger(), testDB, sync.WithPreConfirmedPollInterval(0))
 		sub := synchronizer.SubscribeReorg()
 		// Use a generous timeout with early cancellation once the expected block is stored.
 		// The reorg flow (detect mismatch → revert → re-sync 3 blocks) needs more than 1s on slow CI.
@@ -405,7 +408,7 @@ func TestSubscribeNewHeads(t *testing.T) {
 	feeder := feeder.NewTestClient(t, &network)
 	gw := adaptfeeder.New(feeder)
 	dataSource := sync.NewFeederGatewayDataSource(chain, gw)
-	syncer := sync.New(chain, dataSource, logger, testDB)
+	syncer := sync.New(chain, dataSource, logger, testDB, sync.WithPreConfirmedPollInterval(0))
 
 	sub := syncer.SubscribeNewHeads()
 
@@ -446,7 +449,7 @@ func TestPreConfirmed(t *testing.T) {
 		require.NoError(t, err)
 		require.NoError(t, bc.Store(b0, &core.BlockCommitments{}, s0, nil))
 
-		synchronizer := sync.New(bc, nil, logger, testDB)
+		synchronizer := sync.New(bc, nil, logger, testDB, sync.WithPreConfirmedPollInterval(0))
 		head, err := bc.HeadsHeader()
 		require.NoError(t, err)
 

--- a/sync/sync_test.go
+++ b/sync/sync_test.go
@@ -227,7 +227,12 @@ func TestStartingBlockHeaderCachesStoredHeader(t *testing.T) {
 		blockchain.WithNewState(statetestutils.UseNewState()),
 	)
 	dataSource := sync.NewFeederGatewayDataSource(bc, gw)
-	synchronizer := sync.New(bc, dataSource, log.NewNopZapLogger(), sync.WithPreConfirmedPollInterval(0))
+	synchronizer := sync.New(
+		bc,
+		dataSource,
+		log.NewNopZapLogger(),
+		sync.WithPreConfirmedPollInterval(0),
+	)
 
 	storedStartingBlock := make(chan struct{}, 1)
 	synchronizer.WithListener(&sync.SelectiveListener{
@@ -332,7 +337,12 @@ func TestReorg(t *testing.T) {
 		blockchain.WithNewState(statetestutils.UseNewState()),
 	)
 	dataSource := sync.NewFeederGatewayDataSource(bc, sepoliaGw)
-	synchronizer := sync.New(bc, dataSource, log.NewNopZapLogger(), sync.WithPreConfirmedPollInterval(0))
+	synchronizer := sync.New(
+		bc,
+		dataSource,
+		log.NewNopZapLogger(),
+		sync.WithPreConfirmedPollInterval(0),
+	)
 
 	ctx, cancel := context.WithTimeout(t.Context(), timeout)
 	require.NoError(t, synchronizer.Run(ctx))
@@ -354,7 +364,12 @@ func TestReorg(t *testing.T) {
 		require.NoError(t, err)
 
 		dataSource := sync.NewFeederGatewayDataSource(bc, mainGw)
-		synchronizer = sync.New(bc, dataSource, log.NewNopZapLogger(), sync.WithPreConfirmedPollInterval(0))
+		synchronizer = sync.New(
+			bc,
+			dataSource,
+			log.NewNopZapLogger(),
+			sync.WithPreConfirmedPollInterval(0),
+		)
 		sub := synchronizer.SubscribeReorg()
 		// Use a generous timeout with early cancellation once the expected block is stored.
 		// The reorg flow (detect mismatch → revert → re-sync 3 blocks) needs more than 1s on slow CI.

--- a/sync/sync_test.go
+++ b/sync/sync_test.go
@@ -70,7 +70,7 @@ func TestSyncBlocks(t *testing.T) {
 			blockchain.WithNewState(statetestutils.UseNewState()),
 		)
 		dataSource := sync.NewFeederGatewayDataSource(bc, gw)
-		synchronizer := sync.New(bc, dataSource, logger, testDB, sync.WithPreConfirmedPollInterval(0))
+		synchronizer := sync.New(bc, dataSource, logger, sync.WithPreConfirmedPollInterval(0))
 		ctx, cancel := context.WithTimeout(t.Context(), timeout)
 
 		require.NoError(t, synchronizer.Run(ctx))
@@ -93,7 +93,7 @@ func TestSyncBlocks(t *testing.T) {
 		require.NoError(t, bc.Store(b0, &core.BlockCommitments{}, s0, nil))
 
 		dataSource := sync.NewFeederGatewayDataSource(bc, gw)
-		synchronizer := sync.New(bc, dataSource, logger, testDB, sync.WithPreConfirmedPollInterval(0))
+		synchronizer := sync.New(bc, dataSource, logger, sync.WithPreConfirmedPollInterval(0))
 		ctx, cancel := context.WithTimeout(t.Context(), timeout)
 
 		require.NoError(t, synchronizer.Run(ctx))
@@ -157,7 +157,7 @@ func TestSyncBlocks(t *testing.T) {
 			}).AnyTimes()
 
 		dataSource := sync.NewFeederGatewayDataSource(bc, mockSNData)
-		synchronizer := sync.New(bc, dataSource, logger, testDB, sync.WithPreConfirmedPollInterval(0))
+		synchronizer := sync.New(bc, dataSource, logger, sync.WithPreConfirmedPollInterval(0))
 		ctx, cancel := context.WithTimeout(t.Context(), 2*timeout)
 
 		require.NoError(t, synchronizer.Run(ctx))
@@ -190,7 +190,6 @@ func TestStartingBlockHeaderFallsBackToBlockchain(t *testing.T) {
 		bc,
 		dataSource,
 		log.NewNopZapLogger(),
-		testDB,
 		sync.WithPreConfirmedPollInterval(0),
 		sync.WithReadOnlyBlockchain(true),
 	)
@@ -228,7 +227,7 @@ func TestStartingBlockHeaderCachesStoredHeader(t *testing.T) {
 		blockchain.WithNewState(statetestutils.UseNewState()),
 	)
 	dataSource := sync.NewFeederGatewayDataSource(bc, gw)
-	synchronizer := sync.New(bc, dataSource, log.NewNopZapLogger(), testDB, sync.WithPreConfirmedPollInterval(0))
+	synchronizer := sync.New(bc, dataSource, log.NewNopZapLogger(), sync.WithPreConfirmedPollInterval(0))
 
 	storedStartingBlock := make(chan struct{}, 1)
 	synchronizer.WithListener(&sync.SelectiveListener{
@@ -272,7 +271,6 @@ func TestStartingBlockHeaderNotRunning(t *testing.T) {
 		bc,
 		newTestBlockDataSource(),
 		log.NewNopZapLogger(),
-		testDB,
 		sync.WithPreConfirmedPollInterval(0),
 		sync.WithReadOnlyBlockchain(true),
 	)
@@ -297,7 +295,6 @@ func TestStartingBlockHeaderFallbackUnavailable(t *testing.T) {
 		bc,
 		dataSource,
 		log.NewNopZapLogger(),
-		testDB,
 		sync.WithPreConfirmedPollInterval(0),
 		sync.WithReadOnlyBlockchain(true),
 	)
@@ -335,7 +332,7 @@ func TestReorg(t *testing.T) {
 		blockchain.WithNewState(statetestutils.UseNewState()),
 	)
 	dataSource := sync.NewFeederGatewayDataSource(bc, sepoliaGw)
-	synchronizer := sync.New(bc, dataSource, log.NewNopZapLogger(), testDB, sync.WithPreConfirmedPollInterval(0))
+	synchronizer := sync.New(bc, dataSource, log.NewNopZapLogger(), sync.WithPreConfirmedPollInterval(0))
 
 	ctx, cancel := context.WithTimeout(t.Context(), timeout)
 	require.NoError(t, synchronizer.Run(ctx))
@@ -357,7 +354,7 @@ func TestReorg(t *testing.T) {
 		require.NoError(t, err)
 
 		dataSource := sync.NewFeederGatewayDataSource(bc, mainGw)
-		synchronizer = sync.New(bc, dataSource, log.NewNopZapLogger(), testDB, sync.WithPreConfirmedPollInterval(0))
+		synchronizer = sync.New(bc, dataSource, log.NewNopZapLogger(), sync.WithPreConfirmedPollInterval(0))
 		sub := synchronizer.SubscribeReorg()
 		// Use a generous timeout with early cancellation once the expected block is stored.
 		// The reorg flow (detect mismatch → revert → re-sync 3 blocks) needs more than 1s on slow CI.
@@ -408,7 +405,7 @@ func TestSubscribeNewHeads(t *testing.T) {
 	feeder := feeder.NewTestClient(t, &network)
 	gw := adaptfeeder.New(feeder)
 	dataSource := sync.NewFeederGatewayDataSource(chain, gw)
-	syncer := sync.New(chain, dataSource, logger, testDB, sync.WithPreConfirmedPollInterval(0))
+	syncer := sync.New(chain, dataSource, logger, sync.WithPreConfirmedPollInterval(0))
 
 	sub := syncer.SubscribeNewHeads()
 
@@ -449,7 +446,7 @@ func TestPreConfirmed(t *testing.T) {
 		require.NoError(t, err)
 		require.NoError(t, bc.Store(b0, &core.BlockCommitments{}, s0, nil))
 
-		synchronizer := sync.New(bc, nil, logger, testDB, sync.WithPreConfirmedPollInterval(0))
+		synchronizer := sync.New(bc, nil, logger, sync.WithPreConfirmedPollInterval(0))
 		head, err := bc.HeadsHeader()
 		require.NoError(t, err)
 


### PR DESCRIPTION
<!-- pr-agent-generated -->
### **User description**
Replaces `sync.New`'s trailing positional parameters (poll interval, read-only flag, database) with functional options, so call sites only spell out what they actually override, pre-confirmed polling now falls back to `DefaultPreConfirmedPollInterval` (500ms) instead of being passed everywhere. Also drops the redundant `db.KeyValueStore` dependency, since `StartingBlockHeader` can read the header through the blockchain the synchronizer already holds.


___

### **PR Type**
Enhancement


___

### **Description**
- Replace `sync.New` positional params with functional options

- Add `WithPreConfirmedPollInterval` and `WithReadOnlyBlockchain` options

- Default poll interval now `DefaultPreConfirmedPollInterval` (500ms)

- Drop redundant `db.KeyValueStore` dependency from `Synchronizer`

- Update all call sites and tests to use new options API


___



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>3 files</summary><table>
<tr>
  <td><strong>sync.go</strong><dd><code>Introduce functional options for Synchronizer configuration</code></dd></td>
  <td><a href="https://github.com/NethermindEth/juno/pull/4057/files#diff-f6bc9238dbb193e597b81312026a71471a91a96b5689cb6929ff79857e3a7895">+31/-9</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>node.go</strong><dd><code>Update sync.New call to use functional options</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/NethermindEth/juno/pull/4057/files#diff-375d57e386f20eaa5f09f02bb9d28bfc48ac3dca18d0325f59492208219e5618">+2/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>juno.go</strong><dd><code>Reference sync.DefaultPreConfirmedPollInterval for default config</code></dd></td>
  <td><a href="https://github.com/NethermindEth/juno/pull/4057/files#diff-e8011febe1f0287e6ed8aba108ce6e448c8db2c49f5afef912db1626eafd0ee3">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>7 files</summary><table>
<tr>
  <td><strong>node_test.go</strong><dd><code>Update synchronizer construction to use options</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/NethermindEth/juno/pull/4057/files#diff-dc4c814863b683df45708c0e8241d15e11bd148209ffd858351686929c111e2b">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>plugin_test.go</strong><dd><code>Update sync.New calls to use functional options</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/NethermindEth/juno/pull/4057/files#diff-b947de162d1c0f76edfd634a11a7b132df3d20671512152f1b50e982f94ae462">+2/-6</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>storage_test.go</strong><dd><code>Update sync.New call to use functional options</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/NethermindEth/juno/pull/4057/files#diff-afe84d84757ca325a5d2112fb8500c172c13de94df85829da6bc19d89ba9b837">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>storage_test.go</strong><dd><code>Update sync.New call to use functional options</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/NethermindEth/juno/pull/4057/files#diff-1a7c10f05c8bd4b5003c87078e3203b9ab0d80ae3904faae4b329b92f4c5ce4f">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>storage_test.go</strong><dd><code>Update sync.New call to use functional options</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/NethermindEth/juno/pull/4057/files#diff-a6ba6bebdcd11131f31b36e888dff6f1faabca0b911b25c5f85dd94d7f87f022">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>reorg_test.go</strong><dd><code>Update synchronizer setup to use functional options</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/NethermindEth/juno/pull/4057/files#diff-3b28d7f71a4d167268c503c6fb66fd736176d5e88b538f8eefbb7e86560daf31">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>sync_test.go</strong><dd><code>Update all synchronizer test constructions to use options</code></dd></td>
  <td><a href="https://github.com/NethermindEth/juno/pull/4057/files#diff-a172601c94b35aba185b9bb2ca9aebcaa7827d3374f3bcae044d5342386e590e">+24/-40</a>&nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___

