### PR TITLE
refactor(sync): move pre-confirmed logic out of sync.Sync, into preconfirmed.Poller

### DIFF
--- a/mocks/mock_synchronizer.go
+++ b/mocks/mock_synchronizer.go
@@ -56,25 +56,6 @@ func (mr *MockSyncReaderMockRecorder) HighestBlockHeader() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "HighestBlockHeader", reflect.TypeOf((*MockSyncReader)(nil).HighestBlockHeader))
 }
 
-// StartingBlockHeader mocks base method.
-func (m *MockSyncReader) StartingBlockHeader() (*core.Header, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "StartingBlockHeader")
-	ret0, _ := ret[0].(*core.Header)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// StartingBlockHeader indicates an expected call of StartingBlockHeader.
-func (mr *MockSyncReaderMockRecorder) StartingBlockHeader() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(
-		mr.mock,
-		"StartingBlockHeader",
-		reflect.TypeOf((*MockSyncReader)(nil).StartingBlockHeader),
-	)
-}
-
 // PreConfirmedChain mocks base method.
 func (m *MockSyncReader) PreConfirmedChain() (preconfirmed.ChainReader, error) {
 	m.ctrl.T.Helper()
@@ -87,11 +68,22 @@ func (m *MockSyncReader) PreConfirmedChain() (preconfirmed.ChainReader, error) {
 // PreConfirmedChain indicates an expected call of PreConfirmedChain.
 func (mr *MockSyncReaderMockRecorder) PreConfirmedChain() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(
-		mr.mock,
-		"PreConfirmedChain",
-		reflect.TypeOf((*MockSyncReader)(nil).PreConfirmedChain),
-	)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PreConfirmedChain", reflect.TypeOf((*MockSyncReader)(nil).PreConfirmedChain))
+}
+
+// StartingBlockHeader mocks base method.
+func (m *MockSyncReader) StartingBlockHeader() (*core.Header, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "StartingBlockHeader")
+	ret0, _ := ret[0].(*core.Header)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// StartingBlockHeader indicates an expected call of StartingBlockHeader.
+func (mr *MockSyncReaderMockRecorder) StartingBlockHeader() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StartingBlockHeader", reflect.TypeOf((*MockSyncReader)(nil).StartingBlockHeader))
 }
 
 // SubscribeNewHeads mocks base method.
@@ -109,10 +101,10 @@ func (mr *MockSyncReaderMockRecorder) SubscribeNewHeads() *gomock.Call {
 }
 
 // SubscribePreConfirmed mocks base method.
-func (m *MockSyncReader) SubscribePreConfirmed() sync.PreConfirmedDataSubscription {
+func (m *MockSyncReader) SubscribePreConfirmed() preconfirmed.Subscription {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SubscribePreConfirmed")
-	ret0, _ := ret[0].(sync.PreConfirmedDataSubscription)
+	ret0, _ := ret[0].(preconfirmed.Subscription)
 	return ret0
 }
 

--- a/rpc/handlers_test.go
+++ b/rpc/handlers_test.go
@@ -16,6 +16,7 @@ import (
 	rpcv8 "github.com/NethermindEth/juno/rpc/v8"
 	rpcv9 "github.com/NethermindEth/juno/rpc/v9"
 	"github.com/NethermindEth/juno/sync"
+	"github.com/NethermindEth/juno/sync/preconfirmed"
 	"github.com/NethermindEth/juno/utils/log"
 	"github.com/go-playground/validator/v10"
 	"github.com/stretchr/testify/assert"
@@ -54,7 +55,7 @@ func TestRun(t *testing.T) {
 		sync.ReorgSubscription{Subscription: reorgSub.Subscribe()},
 	).AnyTimes()
 	mockSyncReader.EXPECT().SubscribePreConfirmed().Return(
-		sync.PreConfirmedDataSubscription{Subscription: preConfirmedSub.Subscribe()},
+		preconfirmed.Subscription{Subscription: preConfirmedSub.Subscribe()},
 	).AnyTimes()
 
 	handler := &Handler{

--- a/rpc/v10/subscriptions_test.go
+++ b/rpc/v10/subscriptions_test.go
@@ -87,8 +87,8 @@ func (fs *fakeSyncer) SubscribeReorg() sync.ReorgSubscription {
 	return sync.ReorgSubscription{Subscription: fs.reorgs.Subscribe()}
 }
 
-func (fs *fakeSyncer) SubscribePreConfirmed() sync.PreConfirmedDataSubscription {
-	return sync.PreConfirmedDataSubscription{Subscription: fs.preConfirmed.Subscribe()}
+func (fs *fakeSyncer) SubscribePreConfirmed() preconfirmed.Subscription {
+	return preconfirmed.Subscription{Subscription: fs.preConfirmed.Subscribe()}
 }
 
 func (fs *fakeSyncer) StartingBlockHeader() (*core.Header, error) {

--- a/rpc/v8/subscriptions_test.go
+++ b/rpc/v8/subscriptions_test.go
@@ -454,8 +454,8 @@ func (fs *fakeSyncer) SubscribeReorg() sync.ReorgSubscription {
 	return sync.ReorgSubscription{Subscription: fs.reorgs.Subscribe()}
 }
 
-func (fs *fakeSyncer) SubscribePreConfirmed() sync.PreConfirmedDataSubscription {
-	return sync.PreConfirmedDataSubscription{Subscription: fs.preConfirmed.Subscribe()}
+func (fs *fakeSyncer) SubscribePreConfirmed() preconfirmed.Subscription {
+	return preconfirmed.Subscription{Subscription: fs.preConfirmed.Subscribe()}
 }
 
 func (fs *fakeSyncer) StartingBlockHeader() (*core.Header, error) {

--- a/rpc/v9/subscriptions_test.go
+++ b/rpc/v9/subscriptions_test.go
@@ -88,8 +88,8 @@ func (fs *fakeSyncer) SubscribeReorg() sync.ReorgSubscription {
 	return sync.ReorgSubscription{Subscription: fs.reorgs.Subscribe()}
 }
 
-func (fs *fakeSyncer) SubscribePreConfirmed() sync.PreConfirmedDataSubscription {
-	return sync.PreConfirmedDataSubscription{Subscription: fs.preConfirmed.Subscribe()}
+func (fs *fakeSyncer) SubscribePreConfirmed() preconfirmed.Subscription {
+	return preconfirmed.Subscription{Subscription: fs.preConfirmed.Subscribe()}
 }
 
 func (fs *fakeSyncer) StartingBlockHeader() (*core.Header, error) {

--- a/sequencer/sequencer.go
+++ b/sequencer/sequencer.go
@@ -233,6 +233,6 @@ func (s *Sequencer) SubscribeNewHeads() sync.NewHeadSubscription {
 	return sync.NewHeadSubscription{Subscription: s.subNewHeads.Subscribe()}
 }
 
-func (s *Sequencer) SubscribePreConfirmed() sync.PreConfirmedDataSubscription {
-	return sync.PreConfirmedDataSubscription{Subscription: s.subPreConfirmed.Subscribe()}
+func (s *Sequencer) SubscribePreConfirmed() preconfirmed.Subscription {
+	return preconfirmed.Subscription{Subscription: s.subPreConfirmed.Subscribe()}
 }

--- a/sync/data_source.go
+++ b/sync/data_source.go
@@ -10,6 +10,7 @@ import (
 	"github.com/NethermindEth/juno/db"
 	"github.com/NethermindEth/juno/starknet"
 	"github.com/NethermindEth/juno/starknetdata"
+	"github.com/NethermindEth/juno/sync/preconfirmed"
 )
 
 type CommittedBlock struct {
@@ -22,18 +23,7 @@ type CommittedBlock struct {
 type DataSource interface {
 	BlockByNumber(ctx context.Context, blockNumber uint64) (CommittedBlock, error)
 	BlockHeaderLatest(ctx context.Context) (*core.Header, error)
-	PreConfirmedBlockByNumber(
-		ctx context.Context,
-		blockNumber uint64,
-		blockIdentifier string,
-		knownTransactionCount uint64,
-	) (starknet.PreConfirmedUpdate, error)
-	PreConfirmedBlockLatest(
-		ctx context.Context,
-		blockIdentifier string,
-		knownTransactionCount uint64,
-	) (starknet.PreConfirmedUpdate, uint64, error)
-	Class(ctx context.Context, classHash *felt.Felt) (core.ClassDefinition, error)
+	preconfirmed.DataSource
 }
 
 type feederGatewayDataSource struct {

--- a/sync/helpers.go
+++ b/sync/helpers.go
@@ -4,11 +4,12 @@ import (
 	"time"
 
 	"github.com/NethermindEth/juno/blockchain"
-	"github.com/NethermindEth/juno/clients/feeder"
 	"github.com/NethermindEth/juno/core"
 	"github.com/NethermindEth/juno/core/felt"
 	"github.com/NethermindEth/juno/core/pending"
 )
+
+// NOTE(RDR): Delete this file once we drop support for RPC v8
 
 // makeStateDiffForEmptyBlock constructs a minimal state diff for an empty block.
 // It optionally writes a historical block hash mapping when blockNumber >= blockHashLag.
@@ -78,45 +79,4 @@ func MakeEmptyPendingForParent(
 		NewClasses: make(map[felt.Felt]core.ClassDefinition, 0),
 	}
 	return pending, nil
-}
-
-func MakeEmptyPreConfirmedForParent(
-	bcReader blockchain.Reader,
-	latestHeader *core.Header,
-) (pending.PreConfirmed, error) {
-	receipts := make([]*core.TransactionReceipt, 0)
-	preConfirmedBlock := &core.Block{
-		// pre_confirmed block does not have parent hash
-		Header: &core.Header{
-			SequencerAddress: latestHeader.SequencerAddress,
-			Number:           latestHeader.Number + 1,
-			Timestamp:        uint64(time.Now().Unix()),
-			ProtocolVersion:  latestHeader.ProtocolVersion,
-			EventsBloom:      core.EventsBloom(receipts),
-			L1GasPriceETH:    latestHeader.L1GasPriceETH,
-			L1GasPriceSTRK:   latestHeader.L1GasPriceSTRK,
-			L2GasPrice:       latestHeader.L2GasPrice,
-			L1DataGasPrice:   latestHeader.L1DataGasPrice,
-			L1DAMode:         latestHeader.L1DAMode,
-		},
-		Transactions: make([]core.Transaction, 0),
-		Receipts:     receipts,
-	}
-
-	stateDiff, err := makeStateDiffForEmptyBlock(bcReader, latestHeader.Number+1)
-	if err != nil {
-		return pending.PreConfirmed{}, err
-	}
-
-	preConfirmed := pending.PreConfirmed{
-		Block: preConfirmedBlock,
-		StateUpdate: &core.StateUpdate{
-			StateDiff: stateDiff,
-		},
-		NewClasses:            make(map[felt.Felt]core.ClassDefinition, 0),
-		TransactionStateDiffs: make([]*core.StateDiff, 0),
-		BlockIdentifier:       feeder.PreConfirmedBlankIdentifier,
-	}
-
-	return preConfirmed, nil
 }

--- a/sync/preconfirmed/chain_storage.go
+++ b/sync/preconfirmed/chain_storage.go
@@ -54,6 +54,7 @@ func NewChain(entries ...*pending.PreConfirmed) (ChainReader, error) {
 			return ChainReader{}, fmt.Errorf("entry %d is nil", index)
 		}
 
+		//nolint:gosec // G602 false positive: index > 0 guards entries[index-1]
 		if index > 0 && entry.Block.Number != entries[index-1].Block.Number+1 {
 			return ChainReader{}, fmt.Errorf(
 				"non-contiguous block numbers at index %d (%d after %d)",

--- a/sync/preconfirmed/poller.go
+++ b/sync/preconfirmed/poller.go
@@ -61,18 +61,16 @@ type Poller struct {
 
 func NewPoller(
 	dataSource DataSource,
-	preConfirmedChain *ChainStorage,
 	blockchain *blockchain.Blockchain,
-	feed *feed.Feed[*pending.PreConfirmed],
 	highestBlockHeader *atomic.Pointer[core.Header],
 	interval time.Duration,
 	logger log.StructuredLogger,
 ) *Poller {
 	return &Poller{
 		dataSource:         dataSource,
-		preConfirmedChain:  preConfirmedChain,
+		preConfirmedChain:  NewChainStorage(),
 		blockchain:         blockchain,
-		feed:               feed,
+		feed:               feed.New[*pending.PreConfirmed](),
 		highestBlockHeader: highestBlockHeader,
 		interval:           interval,
 		logger:             logger,
@@ -279,7 +277,9 @@ func (p *Poller) apply(
 	oldestPreConf uint64,
 	newClasses map[felt.Felt]core.ClassDefinition,
 ) error {
-	applied, err := p.preConfirmedChain.ApplyUpdate(update, blockNumber, baseTxCount, oldestPreConf, newClasses)
+	applied, err := p.preConfirmedChain.ApplyUpdate(
+		update, blockNumber, baseTxCount, oldestPreConf, newClasses,
+	)
 	if err != nil {
 		return fmt.Errorf("applying pre-confirmed update at block %d: %w", blockNumber, err)
 	}

--- a/sync/preconfirmed/poller.go
+++ b/sync/preconfirmed/poller.go
@@ -111,7 +111,7 @@ func (p *Poller) PreConfirmedChain() (ChainReader, error) {
 }
 
 // Run polls the sequencer every interval and builds the pre-confirmed chain from it.
-// If the blockchain is empty (pre-genesis) then it will stall until the genesis block
+// If the blockchain is empty (pre-genesis) then it will wait until the genesis block
 // is synced. It only stops on context cancellation.
 func (p *Poller) Run(ctx context.Context) {
 	if p.interval == 0 {
@@ -143,7 +143,9 @@ func (p *Poller) Run(ctx context.Context) {
 			height, err := p.blockchain.Height()
 			if err != nil {
 				p.logger.Error("Reading chain heigh", zap.Error(err))
+				continue
 			}
+			p.preConfirmedChain.AdvanceTo(height + 1)
 			if !p.atTip(height) {
 				continue
 			}
@@ -156,7 +158,6 @@ func (p *Poller) Run(ctx context.Context) {
 }
 
 func (p *Poller) poll(ctx context.Context, oldestPreConf uint64) error {
-	p.preConfirmedChain.AdvanceTo(oldestPreConf)
 	chain := p.preConfirmedChain.SnapshotForBlock(oldestPreConf)
 
 	var (

--- a/sync/preconfirmed/poller.go
+++ b/sync/preconfirmed/poller.go
@@ -119,7 +119,6 @@ func (p *Poller) Run(ctx context.Context) {
 		return
 	}
 	ticker := time.NewTicker(p.interval)
-	defer ticker.Stop()
 
 	// Guard to prevent the poller from initially running when we are at the genesis
 	// state. If the error is different than [db.ErrKeyNotFound] we assume the issue is

--- a/sync/preconfirmed/poller.go
+++ b/sync/preconfirmed/poller.go
@@ -20,6 +20,10 @@ import (
 	"go.uber.org/zap"
 )
 
+type Subscription struct {
+	*feed.Subscription[*pending.PreConfirmed]
+}
+
 // DataSource is the narrow surface the Poller needs from the wire side. Any
 // type implementing these methods (e.g. sync.DataSource) satisfies it.
 type DataSource interface {
@@ -47,9 +51,9 @@ type DataSource interface {
 // in apply as delta / preserve / replace.
 type Poller struct {
 	dataSource         DataSource
-	storage            *ChainStorage
+	preConfirmedChain  *ChainStorage
 	blockchain         *blockchain.Blockchain
-	out                *feed.Feed[*pending.PreConfirmed]
+	feed               *feed.Feed[*pending.PreConfirmed]
 	highestBlockHeader *atomic.Pointer[core.Header]
 	interval           time.Duration
 	logger             log.StructuredLogger
@@ -57,22 +61,53 @@ type Poller struct {
 
 func NewPoller(
 	dataSource DataSource,
-	storage *ChainStorage,
-	bc *blockchain.Blockchain,
-	out *feed.Feed[*pending.PreConfirmed],
+	preConfirmedChain *ChainStorage,
+	blockchain *blockchain.Blockchain,
+	feed *feed.Feed[*pending.PreConfirmed],
 	highestBlockHeader *atomic.Pointer[core.Header],
 	interval time.Duration,
 	logger log.StructuredLogger,
 ) *Poller {
 	return &Poller{
 		dataSource:         dataSource,
-		storage:            storage,
-		blockchain:         bc,
-		out:                out,
+		preConfirmedChain:  preConfirmedChain,
+		blockchain:         blockchain,
+		feed:               feed,
 		highestBlockHeader: highestBlockHeader,
 		interval:           interval,
 		logger:             logger,
 	}
+}
+
+func (p *Poller) Subscribe() Subscription {
+	return Subscription{p.feed.Subscribe()}
+}
+
+func (p *Poller) PreConfirmedChain() (ChainReader, error) {
+	// note(rdr): maybe querying for the height here can be skipped, since this system
+	// should be aware what is the latest block that was stored and if it is synced (the height)
+	// note(rdr): In fact, we only have blockchain here to query the height and the heads header
+	height, err := p.blockchain.Height()
+	if err != nil {
+		return ChainReader{}, err
+	}
+
+	snapshot := p.preConfirmedChain.SnapshotForBlock(height + 1)
+	if snapshot.Length() > 0 {
+		return snapshot, nil
+	}
+
+	head, err := p.blockchain.HeadsHeader()
+	if err != nil {
+		return ChainReader{}, err
+	}
+
+	emptyPreConfirmed, err := makeEmptyPreConfirmedForParent(p.blockchain, head)
+	if err != nil {
+		return ChainReader{}, err
+	}
+
+	return NewChain(&emptyPreConfirmed)
 }
 
 // Run polls the sequencer every interval and builds the pre-confirmed chain from it.
@@ -105,26 +140,25 @@ func (p *Poller) Run(ctx context.Context) {
 		case <-ctx.Done():
 			return
 		case <-ticker.C:
-			if err := p.tick(ctx); err != nil {
+			height, err := p.blockchain.Height()
+			if err != nil {
+				p.logger.Error("Reading chain heigh", zap.Error(err))
+			}
+			if !p.atTip(height) {
+				continue
+			}
+
+			if err := p.poll(ctx, height+1); err != nil {
 				p.logger.Warn("Pre-confirmed polling failed", zap.Error(err))
 			}
 		}
 	}
 }
 
-func (p *Poller) tick(ctx context.Context) error {
-	height, err := p.blockchain.Height()
-	if err != nil {
-		return fmt.Errorf("reading chain height: %w", err)
-	}
+func (p *Poller) poll(ctx context.Context, oldestPreConf uint64) error {
+	p.preConfirmedChain.AdvanceTo(oldestPreConf)
+	chain := p.preConfirmedChain.SnapshotForBlock(oldestPreConf)
 
-	oldestPreConf := height + 1
-	p.storage.AdvanceTo(oldestPreConf)
-	if !p.atTip(height) {
-		return nil
-	}
-
-	chain := p.storage.SnapshotForBlock(oldestPreConf)
 	var (
 		mostRecent *pending.PreConfirmed
 		identifier string
@@ -162,7 +196,9 @@ func (p *Poller) tick(ctx context.Context) error {
 	}
 
 	if updateBlockNum > fromBlock {
-		err = p.backfill(ctx, oldestPreConf, mostRecent, fromBlock, identifier, txCount, updateBlockNum)
+		err = p.backfill(
+			ctx, oldestPreConf, mostRecent, fromBlock, identifier, txCount, updateBlockNum,
+		)
 		if err != nil {
 			if errors.Is(err, feeder.ErrPreConfirmedBlockNotFound) {
 				p.logger.Debug("Pre-confirmed block left the gateway window; skipping backfill",
@@ -243,7 +279,7 @@ func (p *Poller) apply(
 	oldestPreConf uint64,
 	newClasses map[felt.Felt]core.ClassDefinition,
 ) error {
-	applied, err := p.storage.ApplyUpdate(update, blockNumber, baseTxCount, oldestPreConf, newClasses)
+	applied, err := p.preConfirmedChain.ApplyUpdate(update, blockNumber, baseTxCount, oldestPreConf, newClasses)
 	if err != nil {
 		return fmt.Errorf("applying pre-confirmed update at block %d: %w", blockNumber, err)
 	}
@@ -254,7 +290,7 @@ func (p *Poller) apply(
 		return nil
 	}
 	if applied != nil {
-		p.out.Send(applied)
+		p.feed.Send(applied)
 	}
 
 	return nil
@@ -359,4 +395,74 @@ func declaredClassCount(
 func (p *Poller) atTip(headNum uint64) bool {
 	highest := p.highestBlockHeader.Load()
 	return highest != nil && highest.Number <= headNum
+}
+
+func makeEmptyPreConfirmedForParent(
+	bcReader blockchain.Reader,
+	latestHeader *core.Header,
+) (pending.PreConfirmed, error) {
+	receipts := make([]*core.TransactionReceipt, 0)
+	preConfirmedBlock := &core.Block{
+		// pre_confirmed block does not have parent hash
+		Header: &core.Header{
+			SequencerAddress: latestHeader.SequencerAddress,
+			Number:           latestHeader.Number + 1,
+			Timestamp:        uint64(time.Now().Unix()),
+			ProtocolVersion:  latestHeader.ProtocolVersion,
+			EventsBloom:      core.EventsBloom(receipts),
+			L1GasPriceETH:    latestHeader.L1GasPriceETH,
+			L1GasPriceSTRK:   latestHeader.L1GasPriceSTRK,
+			L2GasPrice:       latestHeader.L2GasPrice,
+			L1DataGasPrice:   latestHeader.L1DataGasPrice,
+			L1DAMode:         latestHeader.L1DAMode,
+		},
+		Transactions: make([]core.Transaction, 0),
+		Receipts:     receipts,
+	}
+
+	stateDiff, err := makeStateDiffForEmptyBlock(bcReader, latestHeader.Number+1)
+	if err != nil {
+		return pending.PreConfirmed{}, err
+	}
+
+	preConfirmed := pending.PreConfirmed{
+		Block: preConfirmedBlock,
+		StateUpdate: &core.StateUpdate{
+			StateDiff: stateDiff,
+		},
+		NewClasses:            make(map[felt.Felt]core.ClassDefinition, 0),
+		TransactionStateDiffs: make([]*core.StateDiff, 0),
+		BlockIdentifier:       feeder.PreConfirmedBlankIdentifier,
+	}
+
+	return preConfirmed, nil
+}
+
+// makeStateDiffForEmptyBlock constructs a minimal state diff for an empty block.
+// It optionally writes a historical block hash mapping when blockNumber >= blockHashLag.
+func makeStateDiffForEmptyBlock(bc blockchain.Reader, blockNumber uint64) (*core.StateDiff, error) {
+	stateDiff := &core.StateDiff{
+		StorageDiffs:      make(map[felt.Felt]map[felt.Felt]*felt.Felt, 1),
+		Nonces:            make(map[felt.Felt]*felt.Felt, 0),
+		DeployedContracts: make(map[felt.Felt]*felt.Felt, 0),
+		DeclaredV0Classes: make([]*felt.Felt, 0),
+		DeclaredV1Classes: make(map[felt.Felt]*felt.Felt, 0),
+		ReplacedClasses:   make(map[felt.Felt]*felt.Felt, 0),
+		MigratedClasses:   make(map[felt.SierraClassHash]felt.CasmClassHash, 0),
+	}
+
+	if blockNumber < core.BlockHashLag {
+		return stateDiff, nil
+	}
+
+	targetBlock := blockNumber - core.BlockHashLag
+	blockHash, err := bc.BlockHeaderHashByNumber(targetBlock)
+	if err != nil {
+		return nil, err
+	}
+
+	stateDiff.StorageDiffs[*core.BlockHashStorageContract] = map[felt.Felt]*felt.Felt{
+		*new(felt.Felt).SetUint64(targetBlock): blockHash,
+	}
+	return stateDiff, nil
 }

--- a/sync/preconfirmed/poller.go
+++ b/sync/preconfirmed/poller.go
@@ -20,6 +20,7 @@ import (
 	"go.uber.org/zap"
 )
 
+// This is a work-around. mockgen chokes when the instantiated generic type is in the interface.
 type Subscription struct {
 	*feed.Subscription[*pending.PreConfirmed]
 }
@@ -84,7 +85,6 @@ func (p *Poller) Subscribe() Subscription {
 func (p *Poller) PreConfirmedChain() (ChainReader, error) {
 	// note(rdr): maybe querying for the height here can be skipped, since this system
 	// should be aware what is the latest block that was stored and if it is synced (the height)
-	// note(rdr): In fact, we only have blockchain here to query the height and the heads header
 	height, err := p.blockchain.Height()
 	if err != nil {
 		return ChainReader{}, err

--- a/sync/preconfirmed/poller_test.go
+++ b/sync/preconfirmed/poller_test.go
@@ -1,7 +1,6 @@
 package preconfirmed_test
 
 import (
-	"context"
 	"errors"
 	"fmt"
 	"sync/atomic"
@@ -14,10 +13,8 @@ import (
 	"github.com/NethermindEth/juno/clients/feeder"
 	"github.com/NethermindEth/juno/core"
 	"github.com/NethermindEth/juno/core/felt"
-	"github.com/NethermindEth/juno/core/pending"
 	"github.com/NethermindEth/juno/db"
 	"github.com/NethermindEth/juno/db/memory"
-	"github.com/NethermindEth/juno/feed"
 	"github.com/NethermindEth/juno/mocks"
 	"github.com/NethermindEth/juno/starknet"
 	"github.com/NethermindEth/juno/sync/preconfirmed"
@@ -142,16 +139,16 @@ func (f *chainFixture) advanceHead(t *testing.T) *core.Header {
 	return next
 }
 
+// harness is a poller wired against a blockchain and a DataSource, plus the
+// highest-known header its atTip gate reads.
 type harness struct {
 	poller  *preconfirmed.Poller
-	storage *preconfirmed.ChainStorage
-	head    *core.Header
 	highest *atomic.Pointer[core.Header]
-	sub     *feed.Subscription[*pending.PreConfirmed]
 }
 
-// wirePoller creates the in-memory bits (storage, feed, atomic header, poller)
-// against an already-constructed blockchain and DataSource.
+// wirePoller builds a poller against an already-constructed blockchain and
+// DataSource. The highest-known header starts at head, so the poller is at tip
+// unless a test moves it.
 func wirePoller(
 	t *testing.T,
 	bc *blockchain.Blockchain,
@@ -159,26 +156,23 @@ func wirePoller(
 	ds preconfirmed.DataSource,
 ) harness {
 	t.Helper()
-	storage := preconfirmed.NewChainStorage()
-	out := feed.New[*pending.PreConfirmed]()
-	sub := out.SubscribeKeepLast()
-	t.Cleanup(sub.Unsubscribe)
-
 	highest := &atomic.Pointer[core.Header]{}
 	highest.Store(head)
 
-	p := preconfirmed.NewPoller(ds, storage, bc, out, highest, tickInterval, log.NewNopZapLogger())
-	return harness{
-		poller:  p,
-		storage: storage,
-		head:    head,
-		highest: highest,
-		sub:     sub,
-	}
+	p := preconfirmed.NewPoller(ds, bc, highest, tickInterval, log.NewNopZapLogger())
+	return harness{poller: p, highest: highest}
 }
 
-// expectedEntry describes one slot of an expected chain snapshot. Used by
-// assertChain to pin down the full storage state after a tick.
+// chain reads the poller's current pre-confirmed view the way any consumer does.
+func (h harness) chain(t *testing.T) preconfirmed.ChainReader {
+	t.Helper()
+	view, err := h.poller.PreConfirmedChain()
+	require.NoError(t, err)
+	return view
+}
+
+// expectedEntry describes one slot of an expected chain view. Used by
+// assertChain to pin down the full chain after a tick.
 type expectedEntry struct {
 	number     uint64
 	identifier string
@@ -201,7 +195,16 @@ func entry(
 	return expectedEntry{number, block.BlockIdentifier, txCount}
 }
 
-// assertChain pins down a snapshot's full contents in oldest-first order.
+// blankEntry describes the placeholder PreConfirmedChain returns while nothing
+// has been polled for the slot above the canonical head: an empty block carrying
+// the blank identifier.
+//
+//nolint:unparam // number is 1 all the time by chance
+func blankEntry(number uint64) expectedEntry {
+	return expectedEntry{number: number, identifier: feeder.PreConfirmedBlankIdentifier, txCount: 0}
+}
+
+// assertChain pins down a chain view's full contents in oldest-first order.
 // Catches off-by-one length mistakes, identifier preservation/replacement,
 // and tx-count merges that a head-only check would silently miss.
 func assertChain(t *testing.T, snap *preconfirmed.ChainReader, want ...expectedEntry) {
@@ -217,7 +220,7 @@ func assertChain(t *testing.T, snap *preconfirmed.ChainReader, want ...expectedE
 	}
 }
 
-// Empty storage, sequencer at head+1: tick polls latest once and bootstraps
+// Nothing polled yet, sequencer at head+1: tick polls latest once and bootstraps
 // the chain — no backfill needed.
 func TestPollerColdBootstrapNoGap(t *testing.T) {
 	t.Parallel()
@@ -237,12 +240,12 @@ func TestPollerColdBootstrapNoGap(t *testing.T) {
 		time.Sleep(tickInterval)
 		synctest.Wait()
 
-		view := h.storage.SnapshotForBlock(oldestPreConfFor(h.head.Number))
+		view := h.chain(t)
 		assertChain(t, &view, entry(1, &block1))
 	})
 }
 
-// Empty storage, sequencer several blocks ahead of head: backfill walks the
+// Nothing polled yet, sequencer several blocks ahead of head: backfill walks the
 // intermediate heights with blank hints before applying the latest.
 func TestPollerColdBootstrapWithGap(t *testing.T) {
 	t.Parallel()
@@ -274,7 +277,7 @@ func TestPollerColdBootstrapWithGap(t *testing.T) {
 		time.Sleep(tickInterval)
 		synctest.Wait()
 
-		view := h.storage.SnapshotForBlock(oldestPreConfFor(h.head.Number))
+		view := h.chain(t)
 		assertChain(t, &view,
 			entry(1, &block1),
 			entry(2, &block2),
@@ -283,8 +286,9 @@ func TestPollerColdBootstrapWithGap(t *testing.T) {
 	})
 }
 
-// Empty blockchain (pre-genesis): Run stalls without touching the data source.
-// Once the genesis block lands, the next tick bootstraps the chain as usual.
+// Empty blockchain (pre-genesis): Run stalls without touching the data source,
+// and there is no pre-confirmed chain to read. Once the genesis block lands, the
+// next tick bootstraps the chain as usual.
 func TestPollerStallsUntilGenesis(t *testing.T) {
 	t.Parallel()
 
@@ -301,37 +305,42 @@ func TestPollerStallsUntilGenesis(t *testing.T) {
 
 	ctrl := gomock.NewController(t)
 	ds := mocks.NewMockStarknetData(ctrl)
+	// Registered before the bubble starts: gomock expectations must not be added
+	// while the poller goroutine is live (Return writes the call unlocked, which
+	// the race detector flags). Times(1) by default, so a poll before genesis
+	// would consume it and fail the post-genesis tick with an unexpected call.
+	ds.EXPECT().PreConfirmedBlockLatest(gomock.Any(), "", uint64(0)).
+		Return(block1, uint64(1), nil)
 
 	synctest.Test(t, func(t *testing.T) {
 		h := wirePoller(t, bc, genesis, ds)
 		go h.poller.Run(t.Context())
 		synctest.Wait()
 
-		// Pre-genesis ticks: no expectations are registered on the mock yet, so
-		// any data-source call fails the test. Storage must stay empty.
+		// Pre-genesis ticks: the poller stalls on its height guard. Reading the
+		// chain fails the same way that guard does.
 		time.Sleep(3 * tickInterval)
 		synctest.Wait()
-		view := h.storage.SnapshotForBlock(oldestPreConfFor(genesis.Number))
-		assertChain(t, &view)
+		_, err := h.poller.PreConfirmedChain()
+		require.ErrorIs(t, err, db.ErrKeyNotFound)
 
-		// Genesis lands; the poll expectation only exists from here on.
+		// Genesis lands.
 		require.NoError(t, core.WriteBlockHeaderByNumber(testDB, genesis))
 		require.NoError(t, core.WriteChainHeight(testDB, 0))
-		ds.EXPECT().PreConfirmedBlockLatest(gomock.Any(), "", uint64(0)).
-			Return(block1, uint64(1), nil)
 
 		// One interval for the guard to observe the new head, one more for the
 		// first real polling tick.
 		time.Sleep(2 * tickInterval)
 		synctest.Wait()
 
-		view = h.storage.SnapshotForBlock(oldestPreConfFor(genesis.Number))
+		view := h.chain(t)
 		assertChain(t, &view, entry(1, &block1))
 	})
 }
 
-// mostRecent already at target height and server returns NoChange: tick is a
-// pure no-op — no backfill, no apply, storage pointer unchanged.
+// The chain tip is already at the server's height and the server returns
+// NoChange: the tick is a pure no-op — no backfill poll, and the chain reads
+// back unchanged.
 func TestPollerSameHeightNoBackfill(t *testing.T) {
 	t.Parallel()
 	fx := newChainFixture(t)
@@ -340,30 +349,37 @@ func TestPollerSameHeightNoBackfill(t *testing.T) {
 
 	ctrl := gomock.NewController(t)
 	ds := mocks.NewMockStarknetData(ctrl)
-	ds.EXPECT().PreConfirmedBlockLatest(gomock.Any(), "r0", uint64(0)).
-		Return(starknet.PreConfirmedNoChange{}, uint64(1), nil)
+	gomock.InOrder(
+		// Tick 1: seed the chain through the wire.
+		ds.EXPECT().PreConfirmedBlockLatest(gomock.Any(), "", uint64(0)).
+			Return(seed, uint64(1), nil),
+		// Tick 2: same height, nothing new. No PreConfirmedBlockByNumber is
+		// expected, so a backfill poll would fail the test.
+		ds.EXPECT().PreConfirmedBlockLatest(gomock.Any(), "r0", uint64(0)).
+			Return(starknet.PreConfirmedNoChange{}, uint64(1), nil),
+	)
 
 	synctest.Test(t, func(t *testing.T) {
 		h := wirePoller(t, fx.bc, fx.head, ds)
-		_, err := h.storage.ApplyUpdate(seed, h.head.Number+1, 0, oldestPreConfFor(h.head.Number), nil)
-		require.NoError(t, err)
-		before := h.storage.SnapshotForBlock(oldestPreConfFor(h.head.Number))
-
 		go h.poller.Run(t.Context())
 		synctest.Wait()
 
+		// Tick 1.
 		time.Sleep(tickInterval)
 		synctest.Wait()
+		view := h.chain(t)
+		assertChain(t, &view, entry(1, &seed))
 
-		after := h.storage.SnapshotForBlock(oldestPreConfFor(h.head.Number))
-		require.Same(t, before.Head(), after.Head(),
-			"NoChange must leave the chain pointer unchanged")
-		assertChain(t, &after, entry(1, &seed))
+		// Tick 2.
+		time.Sleep(tickInterval)
+		synctest.Wait()
+		view = h.chain(t)
+		assertChain(t, &view, entry(1, &seed))
 	})
 }
 
-// mostRecent at target height and server returns a Delta enriching that
-// block: no backfill, apply merges the delta into the same slot, the stored
+// The chain tip is at the server's height and the server returns a Delta
+// enriching that block: no backfill, the delta merges into the same slot, the
 // chain still has length 1 but with the appended transactions visible.
 func TestPollerSameHeightDeltaAppliesToSlot(t *testing.T) {
 	t.Parallel()
@@ -374,28 +390,35 @@ func TestPollerSameHeightDeltaAppliesToSlot(t *testing.T) {
 
 	ctrl := gomock.NewController(t)
 	ds := mocks.NewMockStarknetData(ctrl)
-	// Delta hint matches mostRecent: identifier="r0", txCount=0.
-	ds.EXPECT().PreConfirmedBlockLatest(gomock.Any(), "r0", uint64(0)).
-		Return(delta, uint64(1), nil)
+	gomock.InOrder(
+		// Tick 1: seed the chain through the wire.
+		ds.EXPECT().PreConfirmedBlockLatest(gomock.Any(), "", uint64(0)).
+			Return(seed, uint64(1), nil),
+		// Tick 2: delta hint matches the seeded tip: identifier="r0", txCount=0.
+		ds.EXPECT().PreConfirmedBlockLatest(gomock.Any(), "r0", uint64(0)).
+			Return(delta, uint64(1), nil),
+	)
 
 	synctest.Test(t, func(t *testing.T) {
 		h := wirePoller(t, fx.bc, fx.head, ds)
-		_, err := h.storage.ApplyUpdate(seed, h.head.Number+1, 0, oldestPreConfFor(h.head.Number), nil)
-		require.NoError(t, err)
-
 		go h.poller.Run(t.Context())
 		synctest.Wait()
 
+		// Tick 1.
 		time.Sleep(tickInterval)
 		synctest.Wait()
+		view := h.chain(t)
+		assertChain(t, &view, entry(1, &seed))
 
-		// Delta preserves seed.identifier and appends its own txs to seed's.
-		view := h.storage.SnapshotForBlock(oldestPreConfFor(h.head.Number))
+		// Tick 2: delta preserves seed.identifier and appends its own txs to seed's.
+		time.Sleep(tickInterval)
+		synctest.Wait()
+		view = h.chain(t)
 		assertChain(t, &view, entry(1, &seed, &delta))
 	})
 }
 
-// Sequencer advanced by exactly one: backfill re-polls mostRecent's own height with its
+// Sequencer advanced by exactly one: backfill re-polls the tip's own height with its
 // identifier+txCount hints, and the server replies with a Delta carrying the final txs
 // appended before the next block. The delta merges into the existing slot (identifier
 // preserved, txs summed), then the new most recent is applied.
@@ -410,27 +433,33 @@ func TestPollerForwardJumpFinalisesMostRecent(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	ds := mocks.NewMockStarknetData(ctrl)
 	gomock.InOrder(
-		ds.EXPECT().
-			PreConfirmedBlockLatest(gomock.Any(), gomock.Any(), gomock.Any()).
+		// Tick 1: seed block 1.
+		ds.EXPECT().PreConfirmedBlockLatest(gomock.Any(), "", uint64(0)).
+			Return(seed, uint64(1), nil),
+		// Tick 2: the sequencer moved on to block 2.
+		ds.EXPECT().PreConfirmedBlockLatest(gomock.Any(), "r0", uint64(0)).
 			Return(block2, uint64(2), nil),
 		// Finalise poll: server replies with a Delta keyed off the stored
 		// identifier+txCount; carries any txs appended since.
-		ds.EXPECT().
-			PreConfirmedBlockByNumber(gomock.Any(), uint64(1), "r0", uint64(0)).
+		ds.EXPECT().PreConfirmedBlockByNumber(gomock.Any(), uint64(1), "r0", uint64(0)).
 			Return(finaliseDelta, nil),
 	)
 
 	synctest.Test(t, func(t *testing.T) {
 		h := wirePoller(t, fx.bc, fx.head, ds)
-		_, err := h.storage.ApplyUpdate(seed, h.head.Number+1, 0, oldestPreConfFor(h.head.Number), nil)
-		require.NoError(t, err)
-
 		go h.poller.Run(t.Context())
 		synctest.Wait()
 
+		// Tick 1.
 		time.Sleep(tickInterval)
 		synctest.Wait()
-		view := h.storage.SnapshotForBlock(oldestPreConfFor(h.head.Number))
+		view := h.chain(t)
+		assertChain(t, &view, entry(1, &seed))
+
+		// Tick 2.
+		time.Sleep(tickInterval)
+		synctest.Wait()
+		view = h.chain(t)
 		assertChain(t, &view,
 			entry(1, &seed, &finaliseDelta), // seed + delta merged at block 1
 			entry(2, &block2),
@@ -438,7 +467,7 @@ func TestPollerForwardJumpFinalisesMostRecent(t *testing.T) {
 	})
 }
 
-// Sequencer jumped multiple blocks ahead: backfill finalises mostRecent and
+// Sequencer jumped multiple blocks ahead: backfill finalises the old tip and
 // then walks every intermediate height with blank hints before applying the
 // new most recent.
 func TestPollerLargeJumpWalksGap(t *testing.T) {
@@ -454,34 +483,37 @@ func TestPollerLargeJumpWalksGap(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	ds := mocks.NewMockStarknetData(ctrl)
 	gomock.InOrder(
-		ds.EXPECT().
-			PreConfirmedBlockLatest(gomock.Any(), gomock.Any(), gomock.Any()).
+		// Tick 1: seed block 1.
+		ds.EXPECT().PreConfirmedBlockLatest(gomock.Any(), "", uint64(0)).
+			Return(seed, uint64(1), nil),
+		// Tick 2: the sequencer is at block 4.
+		ds.EXPECT().PreConfirmedBlockLatest(gomock.Any(), "r0", uint64(0)).
 			Return(block4, uint64(4), nil),
-		// Finalise mostRecent (1) with delta hints.
-		ds.EXPECT().
-			PreConfirmedBlockByNumber(gomock.Any(), uint64(1), "r0", uint64(0)).
+		// Finalise the old tip (1) with delta hints.
+		ds.EXPECT().PreConfirmedBlockByNumber(gomock.Any(), uint64(1), "r0", uint64(0)).
 			Return(finaliseReply, nil),
 		// Walk intermediate blocks 2, 3 with blank hints.
-		ds.EXPECT().
-			PreConfirmedBlockByNumber(gomock.Any(), uint64(2), "", uint64(0)).
+		ds.EXPECT().PreConfirmedBlockByNumber(gomock.Any(), uint64(2), "", uint64(0)).
 			Return(block2, nil),
-		ds.EXPECT().
-			PreConfirmedBlockByNumber(gomock.Any(), uint64(3), "", uint64(0)).
+		ds.EXPECT().PreConfirmedBlockByNumber(gomock.Any(), uint64(3), "", uint64(0)).
 			Return(block3, nil),
 	)
 
 	synctest.Test(t, func(t *testing.T) {
 		h := wirePoller(t, fx.bc, fx.head, ds)
-		_, err := h.storage.ApplyUpdate(seed, h.head.Number+1, 0, oldestPreConfFor(h.head.Number), nil)
-		require.NoError(t, err)
-
 		go h.poller.Run(t.Context())
 		synctest.Wait()
 
+		// Tick 1.
 		time.Sleep(tickInterval)
 		synctest.Wait()
+		view := h.chain(t)
+		assertChain(t, &view, entry(1, &seed))
 
-		view := h.storage.SnapshotForBlock(oldestPreConfFor(h.head.Number))
+		// Tick 2.
+		time.Sleep(tickInterval)
+		synctest.Wait()
+		view = h.chain(t)
 		assertChain(t, &view,
 			entry(1, &seed), // identifier preserved by finalise
 			entry(2, &block2),
@@ -492,7 +524,8 @@ func TestPollerLargeJumpWalksGap(t *testing.T) {
 }
 
 // highestBlockHeader sits above head (canonical sync is still catching up):
-// the atTip gate short-circuits the tick before any wire call.
+// the atTip gate short-circuits the tick before any wire call, and the chain
+// stays at the blank placeholder.
 func TestPollerNotAtTipSkipsAllWork(t *testing.T) {
 	t.Parallel()
 	fx := newChainFixture(t)
@@ -503,20 +536,20 @@ func TestPollerNotAtTipSkipsAllWork(t *testing.T) {
 
 	synctest.Test(t, func(t *testing.T) {
 		h := wirePoller(t, fx.bc, fx.head, ds)
-		h.highest.Store(&core.Header{Number: h.head.Number + 5}) // not at tip
+		h.highest.Store(&core.Header{Number: fx.head.Number + 5}) // not at tip
 
 		go h.poller.Run(t.Context())
 		synctest.Wait()
 
 		time.Sleep(tickInterval)
 		synctest.Wait()
-		view := h.storage.SnapshotForBlock(oldestPreConfFor(h.head.Number))
-		require.Zero(t, view.Length())
+		view := h.chain(t)
+		assertChain(t, &view, blankEntry(1))
 	})
 }
 
-// PreConfirmedBlockLatest errors: tick aborts immediately, no backfill or apply,
-// storage stays empty for the next tick to retry from scratch.
+// PreConfirmedBlockLatest errors: tick aborts immediately, no backfill or apply;
+// nothing is stored, so the next tick retries from scratch.
 func TestPollerLatestErrorSkipsApply(t *testing.T) {
 	t.Parallel()
 	fx := newChainFixture(t)
@@ -534,13 +567,14 @@ func TestPollerLatestErrorSkipsApply(t *testing.T) {
 		time.Sleep(tickInterval)
 		synctest.Wait()
 
-		view := h.storage.SnapshotForBlock(oldestPreConfFor(h.head.Number))
-		require.Zero(t, view.Length(), "latest error must not produce any storage state")
+		// A latest error must not produce any chain state.
+		view := h.chain(t)
+		assertChain(t, &view, blankEntry(1))
 	})
 }
 
 // backfill's per-block poll errors mid-gap: tick aborts before the final apply
-// at target, so storage remains empty (next tick reconciles).
+// at target, so nothing is stored (next tick reconciles).
 func TestPollerBackfillErrorSkipsApply(t *testing.T) {
 	t.Parallel()
 	fx := newChainFixture(t)
@@ -566,8 +600,9 @@ func TestPollerBackfillErrorSkipsApply(t *testing.T) {
 		time.Sleep(tickInterval)
 		synctest.Wait()
 
-		view := h.storage.SnapshotForBlock(oldestPreConfFor(h.head.Number))
-		require.Zero(t, view.Length(), "tick aborts before any apply when backfill errors")
+		// The tick aborts before any apply when backfill errors.
+		view := h.chain(t)
+		assertChain(t, &view, blankEntry(1))
 	})
 }
 
@@ -598,13 +633,13 @@ func TestPollerLatestNotFoundSkipsTickAndRecovers(t *testing.T) {
 		// Tick 1: nothing in the pre-confirmed window — the tick is a no-op.
 		time.Sleep(tickInterval)
 		synctest.Wait()
-		view := h.storage.SnapshotForBlock(oldestPreConfFor(h.head.Number))
-		require.Zero(t, view.Length())
+		view := h.chain(t)
+		assertChain(t, &view, blankEntry(1))
 
 		// Tick 2: the window opened; polling proceeds normally.
 		time.Sleep(tickInterval)
 		synctest.Wait()
-		view = h.storage.SnapshotForBlock(oldestPreConfFor(h.head.Number))
+		view = h.chain(t)
 		assertChain(t, &view, entry(1, &block1))
 	})
 }
@@ -636,7 +671,7 @@ func TestPollerBackfillNotFoundSkipsApplyAndRecovers(t *testing.T) {
 			Return(nil, fmt.Errorf(
 				"polling pre-confirmed for number 1: %w", feeder.ErrPreConfirmedBlockNotFound,
 			)),
-		// Tick 2: storage is still empty, so the poller re-walks the full gap.
+		// Tick 2: nothing was stored, so the poller re-walks the full gap.
 		ds.EXPECT().
 			PreConfirmedBlockLatest(gomock.Any(), "", uint64(0)).
 			Return(latestReply, uint64(3), nil),
@@ -656,13 +691,13 @@ func TestPollerBackfillNotFoundSkipsApplyAndRecovers(t *testing.T) {
 		// Tick 1: the mid-fill not-found aborts the tick before any apply.
 		time.Sleep(tickInterval)
 		synctest.Wait()
-		view := h.storage.SnapshotForBlock(oldestPreConfFor(h.head.Number))
-		require.Zero(t, view.Length(), "backfill skipped: nothing applied this tick")
+		view := h.chain(t)
+		assertChain(t, &view, blankEntry(1))
 
 		// Tick 2: the full gap backfills and the latest lands on top.
 		time.Sleep(tickInterval)
 		synctest.Wait()
-		view = h.storage.SnapshotForBlock(oldestPreConfFor(h.head.Number))
+		view = h.chain(t)
 		assertChain(t, &view,
 			entry(1, &block1),
 			entry(2, &block2),
@@ -672,8 +707,8 @@ func TestPollerBackfillNotFoundSkipsApplyAndRecovers(t *testing.T) {
 }
 
 // Across three consecutive ticks the sequencer advances one block at a time:
-// each tick finalises the prior mostRecent and lands a new most recent, so the
-// chain grows monotonically from 1 to 3 entries.
+// each tick finalises the prior tip and lands a new most recent, so the chain
+// grows monotonically from 1 to 3 entries.
 func TestPollerMultiTickExtendsChain(t *testing.T) {
 	t.Parallel()
 	fx := newChainFixture(t)
@@ -711,13 +746,13 @@ func TestPollerMultiTickExtendsChain(t *testing.T) {
 		// Tick 1.
 		time.Sleep(tickInterval)
 		synctest.Wait()
-		view1 := h.storage.SnapshotForBlock(oldestPreConfFor(h.head.Number))
+		view1 := h.chain(t)
 		assertChain(t, &view1, entry(1, &block1))
 
 		// Tick 2.
 		time.Sleep(tickInterval)
 		synctest.Wait()
-		view2 := h.storage.SnapshotForBlock(oldestPreConfFor(h.head.Number))
+		view2 := h.chain(t)
 		assertChain(t, &view2,
 			entry(1, &block1),
 			entry(2, &block2),
@@ -726,7 +761,7 @@ func TestPollerMultiTickExtendsChain(t *testing.T) {
 		// Tick 3.
 		time.Sleep(tickInterval)
 		synctest.Wait()
-		view3 := h.storage.SnapshotForBlock(oldestPreConfFor(h.head.Number))
+		view3 := h.chain(t)
 		assertChain(t, &view3,
 			entry(1, &block1),
 			entry(2, &block2),
@@ -735,55 +770,60 @@ func TestPollerMultiTickExtendsChain(t *testing.T) {
 	})
 }
 
-// Canonical head advances past one of the stored pre_confirmed entries:
-// AdvanceTo at the top of tick drops the now-committed entry from the chain,
-// leaving only entries that are still above the new head.
+// Canonical head advances past one of the stored pre_confirmed entries: the
+// next tick realigns the chain to the new head, dropping the now-committed
+// entry and leaving only entries that are still above it.
 func TestPollerHeadAdvancesDropsCommittedEntries(t *testing.T) {
 	t.Parallel()
 	fx := newChainFixture(t)
 
-	seed1 := makeTestPreConfirmedBlock("r1", 0) // will be dropped after head advances past it
+	seed1 := makeTestPreConfirmedBlock("r1", 0) // dropped once head advances past it
 	seed2 := makeTestPreConfirmedBlock("r2", 0)
 
-	var latestBlockNumber atomic.Uint64
 	ctrl := gomock.NewController(t)
 	ds := mocks.NewMockStarknetData(ctrl)
-	ds.EXPECT().PreConfirmedBlockLatest(gomock.Any(), gomock.Any(), gomock.Any()).
-		DoAndReturn(func(context.Context, string, uint64) (starknet.PreConfirmedUpdate, uint64, error) {
-			return starknet.PreConfirmedNoChange{}, latestBlockNumber.Load(), nil
-		})
+	gomock.InOrder(
+		// Tick 1: seed blocks 1 and 2 (latest at 2, backfill walks 1).
+		ds.EXPECT().PreConfirmedBlockLatest(gomock.Any(), "", uint64(0)).
+			Return(seed2, uint64(2), nil),
+		ds.EXPECT().PreConfirmedBlockByNumber(gomock.Any(), uint64(1), "", uint64(0)).
+			Return(seed1, nil),
+		// Tick 2: head is now 1; the surviving tip (block 2, "r2") is re-polled
+		// unchanged.
+		ds.EXPECT().PreConfirmedBlockLatest(gomock.Any(), "r2", uint64(0)).
+			Return(starknet.PreConfirmedNoChange{}, uint64(2), nil),
+	)
 
 	synctest.Test(t, func(t *testing.T) {
 		h := wirePoller(t, fx.bc, fx.head, ds)
-		_, err := h.storage.ApplyUpdate(seed1, h.head.Number+1, 0, oldestPreConfFor(h.head.Number), nil)
-		require.NoError(t, err)
-		_, err = h.storage.ApplyUpdate(seed2, h.head.Number+2, 0, oldestPreConfFor(h.head.Number), nil)
-		require.NoError(t, err)
-		before := h.storage.SnapshotForBlock(oldestPreConfFor(h.head.Number))
-		require.Equal(t, 2, before.Length())
-
-		// Canonical head advances by one — block head+1 is now committed.
-		newHead := fx.advanceHead(t)
-		h.highest.Store(newHead)
-		latestBlockNumber.Store(newHead.Number + 1)
-
 		go h.poller.Run(t.Context())
 		synctest.Wait()
 
+		// Tick 1.
+		time.Sleep(tickInterval)
+		synctest.Wait()
+		view := h.chain(t)
+		assertChain(t, &view, entry(1, &seed1), entry(2, &seed2))
+
+		// Canonical head advances by one — block 1 is now committed.
+		newHead := fx.advanceHead(t)
+		h.highest.Store(newHead)
+
+		// Tick 2.
 		time.Sleep(tickInterval)
 		synctest.Wait()
 
 		// seed1 committed → dropped; only seed2 remains at the new head+1.
-		view := h.storage.SnapshotForBlock(oldestPreConfFor(newHead.Number))
+		view = h.chain(t)
 		assertChain(t, &view, entry(newHead.Number+1, &seed2))
 	})
 }
 
 // Sequencer rewinds: PreConfirmedBlockLatest reports a height BELOW the chain's
-// current most recent with a new identifier (a new round started at a lower
-// slot). Tick must not backfill (target < fromBlock); apply hits the in-chain
-// replace path which truncates everything above the replaced slot and
-// installs the new block there.
+// current tip with a new identifier (a new round started at a lower slot). Tick
+// must not backfill (target < fromBlock); apply hits the in-chain replace path
+// which truncates everything above the replaced slot and installs the new block
+// there.
 func TestPollerReorgLowerHeightDifferentIdentifier(t *testing.T) {
 	t.Parallel()
 	fx := newChainFixture(t)
@@ -797,29 +837,37 @@ func TestPollerReorgLowerHeightDifferentIdentifier(t *testing.T) {
 
 	ctrl := gomock.NewController(t)
 	ds := mocks.NewMockStarknetData(ctrl)
-	// Hint matches the most recent (block 3, "r3", 0 txs) the poller would carry.
-	ds.EXPECT().PreConfirmedBlockLatest(gomock.Any(), "r3", uint64(0)).
-		Return(replacement, uint64(2), nil)
+	gomock.InOrder(
+		// Tick 1: seed blocks 1..3 (latest at 3, backfill walks 1 and 2).
+		ds.EXPECT().PreConfirmedBlockLatest(gomock.Any(), "", uint64(0)).
+			Return(seed3, uint64(3), nil),
+		ds.EXPECT().PreConfirmedBlockByNumber(gomock.Any(), uint64(1), "", uint64(0)).
+			Return(seed1, nil),
+		ds.EXPECT().PreConfirmedBlockByNumber(gomock.Any(), uint64(2), "", uint64(0)).
+			Return(seed2, nil),
+		// Tick 2: hint carries the tip (block 3, "r3", 0 txs); the server
+		// answers with a new round at block 2.
+		ds.EXPECT().PreConfirmedBlockLatest(gomock.Any(), "r3", uint64(0)).
+			Return(replacement, uint64(2), nil),
+	)
 
 	synctest.Test(t, func(t *testing.T) {
 		h := wirePoller(t, fx.bc, fx.head, ds)
-		_, err := h.storage.ApplyUpdate(seed1, h.head.Number+1, 0, oldestPreConfFor(h.head.Number), nil)
-		require.NoError(t, err)
-		_, err = h.storage.ApplyUpdate(seed2, h.head.Number+2, 0, oldestPreConfFor(h.head.Number), nil)
-		require.NoError(t, err)
-		_, err = h.storage.ApplyUpdate(seed3, h.head.Number+3, 0, oldestPreConfFor(h.head.Number), nil)
-		require.NoError(t, err)
-		before := h.storage.SnapshotForBlock(oldestPreConfFor(h.head.Number))
-		require.Equal(t, 3, before.Length())
-
 		go h.poller.Run(t.Context())
 		synctest.Wait()
 
+		// Tick 1.
+		time.Sleep(tickInterval)
+		synctest.Wait()
+		view := h.chain(t)
+		assertChain(t, &view, entry(1, &seed1), entry(2, &seed2), entry(3, &seed3))
+
+		// Tick 2.
 		time.Sleep(tickInterval)
 		synctest.Wait()
 
 		// Block 2 swapped to the new identifier; block 3 truncated.
-		view := h.storage.SnapshotForBlock(oldestPreConfFor(h.head.Number))
+		view = h.chain(t)
 		assertChain(t, &view,
 			entry(1, &seed1),
 			entry(2, &replacement),
@@ -827,6 +875,8 @@ func TestPollerReorgLowerHeightDifferentIdentifier(t *testing.T) {
 	})
 }
 
+// A new round starts at the tip's own height: the tip is replaced in place and
+// the lower entries are untouched.
 func TestPollerReorgSameHeightDifferentIdentifier(t *testing.T) {
 	t.Parallel()
 	fx := newChainFixture(t)
@@ -834,33 +884,41 @@ func TestPollerReorgSameHeightDifferentIdentifier(t *testing.T) {
 	seed1 := makeTestPreConfirmedBlock("r1", 0)
 	seed2 := makeTestPreConfirmedBlock("r2", 0)
 	seed3 := makeTestPreConfirmedBlock("r3", 0)
-	// New round at the same slot — different identifier replaces the most recent.
+	// New round at the same slot — different identifier replaces the tip.
 	replacement := makeTestPreConfirmedBlock("rZ", 0)
 
 	ctrl := gomock.NewController(t)
 	ds := mocks.NewMockStarknetData(ctrl)
-	ds.EXPECT().PreConfirmedBlockLatest(gomock.Any(), "r3", uint64(0)).
-		Return(replacement, uint64(3), nil)
+	gomock.InOrder(
+		// Tick 1: seed blocks 1..3 (latest at 3, backfill walks 1 and 2).
+		ds.EXPECT().PreConfirmedBlockLatest(gomock.Any(), "", uint64(0)).
+			Return(seed3, uint64(3), nil),
+		ds.EXPECT().PreConfirmedBlockByNumber(gomock.Any(), uint64(1), "", uint64(0)).
+			Return(seed1, nil),
+		ds.EXPECT().PreConfirmedBlockByNumber(gomock.Any(), uint64(2), "", uint64(0)).
+			Return(seed2, nil),
+		// Tick 2: same height as the tip, different identifier.
+		ds.EXPECT().PreConfirmedBlockLatest(gomock.Any(), "r3", uint64(0)).
+			Return(replacement, uint64(3), nil),
+	)
 
 	synctest.Test(t, func(t *testing.T) {
 		h := wirePoller(t, fx.bc, fx.head, ds)
-		_, err := h.storage.ApplyUpdate(seed1, h.head.Number+1, 0, oldestPreConfFor(h.head.Number), nil)
-		require.NoError(t, err)
-		_, err = h.storage.ApplyUpdate(seed2, h.head.Number+2, 0, oldestPreConfFor(h.head.Number), nil)
-		require.NoError(t, err)
-		_, err = h.storage.ApplyUpdate(seed3, h.head.Number+3, 0, oldestPreConfFor(h.head.Number), nil)
-		require.NoError(t, err)
-		before := h.storage.SnapshotForBlock(oldestPreConfFor(h.head.Number))
-		require.Equal(t, 3, before.Length())
-
 		go h.poller.Run(t.Context())
 		synctest.Wait()
 
+		// Tick 1.
+		time.Sleep(tickInterval)
+		synctest.Wait()
+		view := h.chain(t)
+		assertChain(t, &view, entry(1, &seed1), entry(2, &seed2), entry(3, &seed3))
+
+		// Tick 2.
 		time.Sleep(tickInterval)
 		synctest.Wait()
 
 		// Deepest slot replaced; lower entries and length untouched.
-		view := h.storage.SnapshotForBlock(oldestPreConfFor(h.head.Number))
+		view = h.chain(t)
 		assertChain(t, &view,
 			entry(1, &seed1),
 			entry(2, &seed2),
@@ -869,7 +927,7 @@ func TestPollerReorgSameHeightDifferentIdentifier(t *testing.T) {
 	})
 }
 
-// classesAt returns the NewClasses registered on the snapshot's slot at blockNumber.
+// classesAt returns the NewClasses registered on the view's slot at blockNumber.
 func classesAt(
 	snap *preconfirmed.ChainReader,
 	blockNumber uint64,
@@ -904,23 +962,31 @@ func TestPollerBackfillFetchesDeclaredClasses(t *testing.T) {
 
 		ctrl := gomock.NewController(t)
 		ds := mocks.NewMockStarknetData(ctrl)
-		ds.EXPECT().PreConfirmedBlockLatest(gomock.Any(), "r1", uint64(0)).
-			Return(newTip, uint64(2), nil)
-		ds.EXPECT().PreConfirmedBlockByNumber(gomock.Any(), uint64(1), "r1", uint64(0)).
-			Return(repoll, nil)
+		gomock.InOrder(
+			// Tick 1: seed the old tip.
+			ds.EXPECT().PreConfirmedBlockLatest(gomock.Any(), "", uint64(0)).
+				Return(seed, uint64(1), nil),
+			// Tick 2: forward jump; the old tip is re-polled as a new round.
+			ds.EXPECT().PreConfirmedBlockLatest(gomock.Any(), "r1", uint64(0)).
+				Return(newTip, uint64(2), nil),
+			ds.EXPECT().PreConfirmedBlockByNumber(gomock.Any(), uint64(1), "r1", uint64(0)).
+				Return(repoll, nil),
+		)
 		ds.EXPECT().Class(gomock.Any(), classHash).Return(classDef, nil)
 
 		synctest.Test(t, func(t *testing.T) {
 			h := wirePoller(t, fx.bc, fx.head, ds)
-			_, err := h.storage.ApplyUpdate(seed, h.head.Number+1, 0, oldestPreConfFor(h.head.Number), nil)
-			require.NoError(t, err)
-
 			go h.poller.Run(t.Context())
 			synctest.Wait()
+
+			// Tick 1.
+			time.Sleep(tickInterval)
+			synctest.Wait()
+			// Tick 2.
 			time.Sleep(tickInterval)
 			synctest.Wait()
 
-			view := h.storage.SnapshotForBlock(oldestPreConfFor(h.head.Number))
+			view := h.chain(t)
 			require.Equal(t, classDef, classesAt(&view, 1)[*classHash],
 				"the re-polled full block's declared class must be fetched and land on slot 1")
 		})
@@ -951,24 +1017,33 @@ func TestPollerBackfillFetchesDeclaredClasses(t *testing.T) {
 
 		ctrl := gomock.NewController(t)
 		ds := mocks.NewMockStarknetData(ctrl)
-		ds.EXPECT().PreConfirmedBlockLatest(gomock.Any(), "r1", uint64(1)).
-			Return(newTip, uint64(2), nil)
-		ds.EXPECT().PreConfirmedBlockByNumber(gomock.Any(), uint64(1), "r1", uint64(1)).
-			Return(repoll, nil)
+		gomock.InOrder(
+			// Tick 1: seed the old tip. The tick's apply of the latest does not
+			// fetch classes, so storedClass is only resolved by the re-poll below.
+			ds.EXPECT().PreConfirmedBlockLatest(gomock.Any(), "", uint64(0)).
+				Return(seed, uint64(1), nil),
+			// Tick 2: forward jump; the old tip is re-polled with delta hints.
+			ds.EXPECT().PreConfirmedBlockLatest(gomock.Any(), "r1", uint64(1)).
+				Return(newTip, uint64(2), nil),
+			ds.EXPECT().PreConfirmedBlockByNumber(gomock.Any(), uint64(1), "r1", uint64(1)).
+				Return(repoll, nil),
+		)
 		ds.EXPECT().Class(gomock.Any(), storedClass).Return(storedDef, nil)
 		ds.EXPECT().Class(gomock.Any(), deltaClass).Return(deltaDef, nil)
 
 		synctest.Test(t, func(t *testing.T) {
 			h := wirePoller(t, fx.bc, fx.head, ds)
-			_, err := h.storage.ApplyUpdate(seed, h.head.Number+1, 0, oldestPreConfFor(h.head.Number), nil)
-			require.NoError(t, err)
-
 			go h.poller.Run(t.Context())
 			synctest.Wait()
+
+			// Tick 1.
+			time.Sleep(tickInterval)
+			synctest.Wait()
+			// Tick 2.
 			time.Sleep(tickInterval)
 			synctest.Wait()
 
-			view := h.storage.SnapshotForBlock(oldestPreConfFor(h.head.Number))
+			view := h.chain(t)
 			classes := classesAt(&view, 1)
 			require.Equal(t, storedDef, classes[*storedClass],
 				"the stored tip's declared class must be recovered and fetched")
@@ -995,23 +1070,31 @@ func TestPollerBackfillFetchesDeclaredClasses(t *testing.T) {
 
 		ctrl := gomock.NewController(t)
 		ds := mocks.NewMockStarknetData(ctrl)
-		ds.EXPECT().PreConfirmedBlockLatest(gomock.Any(), "r1", uint64(1)).
-			Return(newTip, uint64(2), nil)
-		ds.EXPECT().PreConfirmedBlockByNumber(gomock.Any(), uint64(1), "r1", uint64(1)).
-			Return(starknet.PreConfirmedNoChange{}, nil)
+		gomock.InOrder(
+			// Tick 1: seed the old tip.
+			ds.EXPECT().PreConfirmedBlockLatest(gomock.Any(), "", uint64(0)).
+				Return(seed, uint64(1), nil),
+			// Tick 2: forward jump; the old tip re-poll reports no change.
+			ds.EXPECT().PreConfirmedBlockLatest(gomock.Any(), "r1", uint64(1)).
+				Return(newTip, uint64(2), nil),
+			ds.EXPECT().PreConfirmedBlockByNumber(gomock.Any(), uint64(1), "r1", uint64(1)).
+				Return(starknet.PreConfirmedNoChange{}, nil),
+		)
 		ds.EXPECT().Class(gomock.Any(), storedClass).Return(storedDef, nil)
 
 		synctest.Test(t, func(t *testing.T) {
 			h := wirePoller(t, fx.bc, fx.head, ds)
-			_, err := h.storage.ApplyUpdate(seed, h.head.Number+1, 0, oldestPreConfFor(h.head.Number), nil)
-			require.NoError(t, err)
-
 			go h.poller.Run(t.Context())
 			synctest.Wait()
+
+			// Tick 1.
+			time.Sleep(tickInterval)
+			synctest.Wait()
+			// Tick 2.
 			time.Sleep(tickInterval)
 			synctest.Wait()
 
-			view := h.storage.SnapshotForBlock(oldestPreConfFor(h.head.Number))
+			view := h.chain(t)
 			require.Equal(t, storedDef, classesAt(&view, 1)[*storedClass],
 				"the stored tip's declared class must be recovered despite a NoChange re-poll")
 		})
@@ -1032,6 +1115,9 @@ func TestPollerBroadcastsOnApply(t *testing.T) {
 
 	synctest.Test(t, func(t *testing.T) {
 		h := wirePoller(t, fx.bc, fx.head, ds)
+		sub := h.poller.Subscribe()
+		t.Cleanup(sub.Unsubscribe)
+
 		go h.poller.Run(t.Context())
 		synctest.Wait()
 
@@ -1039,7 +1125,7 @@ func TestPollerBroadcastsOnApply(t *testing.T) {
 		synctest.Wait()
 
 		select {
-		case pc := <-h.sub.Recv():
+		case pc := <-sub.Recv():
 			require.NotNil(t, pc)
 			require.Equal(t, uint64(1), pc.Block.Number)
 			require.Equal(t, "r0", pc.BlockIdentifier)
@@ -1049,7 +1135,7 @@ func TestPollerBroadcastsOnApply(t *testing.T) {
 	})
 }
 
-// NoChange must not publish anything
+// NoChange must not publish anything.
 func TestPollerSilentOnNoChange(t *testing.T) {
 	t.Parallel()
 	fx := newChainFixture(t)
@@ -1058,24 +1144,40 @@ func TestPollerSilentOnNoChange(t *testing.T) {
 
 	ctrl := gomock.NewController(t)
 	ds := mocks.NewMockStarknetData(ctrl)
-	ds.EXPECT().PreConfirmedBlockLatest(gomock.Any(), "r0", uint64(0)).
-		Return(starknet.PreConfirmedNoChange{}, uint64(1), nil)
+	gomock.InOrder(
+		// Tick 1: seed the chain through the wire.
+		ds.EXPECT().PreConfirmedBlockLatest(gomock.Any(), "", uint64(0)).
+			Return(seed, uint64(1), nil),
+		// Tick 2: nothing changed.
+		ds.EXPECT().PreConfirmedBlockLatest(gomock.Any(), "r0", uint64(0)).
+			Return(starknet.PreConfirmedNoChange{}, uint64(1), nil),
+	)
 
 	synctest.Test(t, func(t *testing.T) {
 		h := wirePoller(t, fx.bc, fx.head, ds)
-		// Seed directly through storage; this does NOT publish (only the
-		// poller's apply wrapper does Send), so the feed starts clean.
-		_, err := h.storage.ApplyUpdate(seed, h.head.Number+1, 0, oldestPreConfFor(h.head.Number), nil)
-		require.NoError(t, err)
+		sub := h.poller.Subscribe()
+		t.Cleanup(sub.Unsubscribe)
 
 		go h.poller.Run(t.Context())
 		synctest.Wait()
 
+		// Tick 1 seeds through the wire, which publishes once; drain it so the
+		// subscription starts tick 2 clean.
 		time.Sleep(tickInterval)
 		synctest.Wait()
-
 		select {
-		case pc := <-h.sub.Recv():
+		case pc := <-sub.Recv():
+			require.Equal(t, uint64(1), pc.Block.Number)
+			require.Equal(t, "r0", pc.BlockIdentifier)
+		default:
+			t.Fatal("expected the seeding tick to broadcast")
+		}
+
+		// Tick 2: NoChange.
+		time.Sleep(tickInterval)
+		synctest.Wait()
+		select {
+		case pc := <-sub.Recv():
 			t.Fatalf("did not expect a broadcast on NoChange, got %+v", pc)
 		default:
 		}

--- a/sync/sync.go
+++ b/sync/sync.go
@@ -40,6 +40,9 @@ const (
 	OpReorgCheckLocal  = "reorgCheckLocal"
 )
 
+// DefaultPreConfirmedPollInterval is how often the pre-confirmed poller ticks unless overridden.
+const DefaultPreConfirmedPollInterval = 500 * time.Millisecond
+
 // This is a work-around. mockgen chokes when the instantiated generic type is in the interface.
 type NewHeadSubscription struct {
 	*feed.Subscription[*core.Block]
@@ -104,6 +107,25 @@ func (n *NoopSynchronizer) PreConfirmedChain() (preconfirmed.ChainReader, error)
 	return preconfirmed.ChainReader{}, pending.ErrPreConfirmedNotFound
 }
 
+// options carries the optional Synchronizer settings; see [Option].
+type options struct {
+	preConfirmedPollInterval time.Duration
+	readOnlyBlockchain       bool
+}
+
+// Option is a functional option for configuring a Synchronizer.
+type Option func(*options)
+
+// WithPreConfirmedPollInterval overrides [DefaultPreConfirmedPollInterval]; zero disables polling.
+func WithPreConfirmedPollInterval(interval time.Duration) Option {
+	return func(o *options) { o.preConfirmedPollInterval = interval }
+}
+
+// WithReadOnlyBlockchain stops the synchronizer from writing to the blockchain.
+func WithReadOnlyBlockchain(readOnly bool) Option {
+	return func(o *options) { o.readOnlyBlockchain = readOnly }
+}
+
 // Synchronizer manages a list of StarknetData to fetch the latest blockchain updates
 type Synchronizer struct {
 	blockchain          *blockchain.Blockchain
@@ -124,28 +146,6 @@ type Synchronizer struct {
 	plugin      junoplugin.JunoPlugin
 
 	currReorg *ReorgBlockRange // If nil, no reorg is happening
-}
-
-// DefaultPreConfirmedPollInterval is how often the pre-confirmed poller ticks unless overridden.
-const DefaultPreConfirmedPollInterval = 500 * time.Millisecond
-
-// options carries the optional Synchronizer settings; see [Option].
-type options struct {
-	preConfirmedPollInterval time.Duration
-	readOnlyBlockchain       bool
-}
-
-// Option is a functional option for configuring a Synchronizer.
-type Option func(*options)
-
-// WithPreConfirmedPollInterval overrides [DefaultPreConfirmedPollInterval]; zero disables polling.
-func WithPreConfirmedPollInterval(interval time.Duration) Option {
-	return func(o *options) { o.preConfirmedPollInterval = interval }
-}
-
-// WithReadOnlyBlockchain stops the synchronizer from writing to the blockchain.
-func WithReadOnlyBlockchain(readOnly bool) Option {
-	return func(o *options) { o.readOnlyBlockchain = readOnly }
 }
 
 func New(
@@ -181,8 +181,7 @@ func New(
 		s.logger,
 	)
 
-	// note(rdr): this doesn't make sense
-	// I have to do, so they both share s.highestBlockHeader
+	// todo(rdr): do something about shared `highestBlockHeader`
 	s.preConfirmedPoller = poller
 
 	return s
@@ -206,33 +205,34 @@ func (s *Synchronizer) Run(ctx context.Context) error {
 	return nil
 }
 
-func (s *Synchronizer) fetcherTask(ctx context.Context, height uint64, verifiers *stream.Stream,
-	resetStreams context.CancelFunc,
+func (s *Synchronizer) fetcherTask(
+	ctx context.Context, height uint64, verifiers *stream.Stream, resetStreams context.CancelFunc,
 ) stream.Callback {
 	for {
 		select {
 		case <-ctx.Done():
 			return func() {}
 		default:
-			committedBlock, err := s.dataSource.BlockByNumber(ctx, height)
-			if err != nil {
-				if lastPossiblyValidHeight, isReorg := s.isReverting(ctx, height); isReorg {
-					return func() {
-						verifiers.Go(func() stream.Callback {
-							return func() {
-								s.revertTask(ctx, lastPossiblyValidHeight, resetStreams)
-							}
-						})
-					}
-				}
-				continue
-			}
+		}
 
-			return func() {
-				verifiers.Go(func() stream.Callback {
-					return s.verifierTask(ctx, &committedBlock, resetStreams)
-				})
+		committedBlock, err := s.dataSource.BlockByNumber(ctx, height)
+		if err != nil {
+			if lastPossiblyValidHeight, isReorg := s.isReverting(ctx, height); isReorg {
+				return func() {
+					verifiers.Go(func() stream.Callback {
+						return func() {
+							s.revertTask(ctx, lastPossiblyValidHeight, resetStreams)
+						}
+					})
+				}
 			}
+			continue
+		}
+
+		return func() {
+			verifiers.Go(func() stream.Callback {
+				return s.verifierTask(ctx, &committedBlock, resetStreams)
+			})
 		}
 	}
 }
@@ -535,15 +535,16 @@ func (s *Synchronizer) syncBlocks(syncCtx context.Context) {
 				)
 			}
 		default:
-			curHeight, curStreamCtx, curCancel := nextHeight, streamCtx, streamCancel
-			fetchers.Go(func() stream.Callback {
-				fetchTimer := time.Now()
-				cb := s.fetcherTask(curStreamCtx, curHeight, verifiers, curCancel)
-				s.listener.OnSyncStepDone(OpFetch, curHeight, time.Since(fetchTimer))
-				return cb
-			})
-			nextHeight++
 		}
+
+		curHeight, curStreamCtx, curCancel := nextHeight, streamCtx, streamCancel
+		fetchers.Go(func() stream.Callback {
+			fetchTimer := time.Now()
+			cb := s.fetcherTask(curStreamCtx, curHeight, verifiers, curCancel)
+			s.listener.OnSyncStepDone(OpFetch, curHeight, time.Since(fetchTimer))
+			return cb
+		})
+		nextHeight++
 	}
 }
 
@@ -556,7 +557,8 @@ func (s *Synchronizer) setupWorkers() (*stream.Stream, *stream.Stream) {
 	if s.catchUpMode {
 		numWorkers = maxWorkers()
 	}
-	return stream.New().WithMaxGoroutines(numWorkers), stream.New().WithMaxGoroutines(runtime.GOMAXPROCS(0))
+	return stream.New().WithMaxGoroutines(numWorkers),
+		stream.New().WithMaxGoroutines(runtime.GOMAXPROCS(0))
 }
 
 func (s *Synchronizer) revertHead(localHeader *core.Header) {
@@ -644,10 +646,8 @@ func (s *Synchronizer) pollLatest(ctx context.Context) {
 
 		select {
 		case <-ctx.Done():
-			ticker.Stop()
 			return
 		case <-ticker.C:
-			continue
 		}
 	}
 }

--- a/sync/sync.go
+++ b/sync/sync.go
@@ -172,10 +172,7 @@ func New(
 
 	poller := preconfirmed.NewPoller(
 		dataSource,
-		// note(rdr): this doesn't make sense API wise, leaving for now not to break tests
-		preconfirmed.NewChainStorage(),
 		blockchain,
-		feed.New[*pending.PreConfirmed](),
 		&s.highestBlockHeader,
 		cfg.preConfirmedPollInterval,
 		s.logger,

--- a/sync/sync.go
+++ b/sync/sync.go
@@ -53,10 +53,6 @@ type PendingTxSubscription struct {
 	*feed.Subscription[[]core.Transaction]
 }
 
-type PreConfirmedDataSubscription struct {
-	*feed.Subscription[*pending.PreConfirmed]
-}
-
 // ReorgBlockRange represents data about reorganised blocks, starting and ending block number and hash
 type ReorgBlockRange struct {
 	// StartBlockHash is the hash of the first known block of the orphaned chain
@@ -77,7 +73,7 @@ type Reader interface {
 	HighestBlockHeader() *core.Header
 	SubscribeNewHeads() NewHeadSubscription
 	SubscribeReorg() ReorgSubscription
-	SubscribePreConfirmed() PreConfirmedDataSubscription
+	SubscribePreConfirmed() preconfirmed.Subscription
 	PreConfirmedChain() (preconfirmed.ChainReader, error)
 }
 
@@ -100,8 +96,8 @@ func (n *NoopSynchronizer) SubscribeReorg() ReorgSubscription {
 	return ReorgSubscription{feed.New[*ReorgBlockRange]().Subscribe()}
 }
 
-func (n *NoopSynchronizer) SubscribePreConfirmed() PreConfirmedDataSubscription {
-	return PreConfirmedDataSubscription{feed.New[*pending.PreConfirmed]().Subscribe()}
+func (n *NoopSynchronizer) SubscribePreConfirmed() preconfirmed.Subscription {
+	return preconfirmed.Subscription{feed.New[*pending.PreConfirmed]().Subscribe()}
 }
 
 func (n *NoopSynchronizer) PreConfirmedChain() (preconfirmed.ChainReader, error) {
@@ -110,21 +106,19 @@ func (n *NoopSynchronizer) PreConfirmedChain() (preconfirmed.ChainReader, error)
 
 // Synchronizer manages a list of StarknetData to fetch the latest blockchain updates
 type Synchronizer struct {
-	blockchain           *blockchain.Blockchain
-	readOnlyBlockchain   bool
-	dataSource           DataSource
-	startingBlockNumber  atomic.Pointer[uint64]
-	startingBlockHeader  atomic.Pointer[core.Header]
-	highestBlockHeader   atomic.Pointer[core.Header]
-	newHeads             *feed.Feed[*core.Block]
-	reorgFeed            *feed.Feed[*ReorgBlockRange]
-	preConfirmedDataFeed *feed.Feed[*pending.PreConfirmed]
+	blockchain          *blockchain.Blockchain
+	readOnlyBlockchain  bool
+	dataSource          DataSource
+	startingBlockNumber atomic.Pointer[uint64]
+	startingBlockHeader atomic.Pointer[core.Header]
+	highestBlockHeader  atomic.Pointer[core.Header]
+	newHeads            *feed.Feed[*core.Block]
+	reorgFeed           *feed.Feed[*ReorgBlockRange]
 
 	logger   log.StructuredLogger
 	listener EventListener
 
-	preConfirmed             *preconfirmed.ChainStorage
-	preConfirmedPollInterval time.Duration
+	preConfirmedPoller *preconfirmed.Poller
 
 	catchUpMode bool
 	plugin      junoplugin.JunoPlugin
@@ -155,7 +149,7 @@ func WithReadOnlyBlockchain(readOnly bool) Option {
 }
 
 func New(
-	bc *blockchain.Blockchain,
+	blockchain *blockchain.Blockchain,
 	dataSource DataSource,
 	logger log.StructuredLogger,
 	opts ...Option,
@@ -166,17 +160,31 @@ func New(
 	}
 
 	s := &Synchronizer{
-		blockchain:               bc,
-		dataSource:               dataSource,
-		logger:                   logger,
-		newHeads:                 feed.New[*core.Block](),
-		reorgFeed:                feed.New[*ReorgBlockRange](),
-		preConfirmedDataFeed:     feed.New[*pending.PreConfirmed](),
-		preConfirmedPollInterval: cfg.preConfirmedPollInterval,
-		listener:                 &SelectiveListener{},
-		readOnlyBlockchain:       cfg.readOnlyBlockchain,
-		preConfirmed:             preconfirmed.NewChainStorage(),
+		blockchain:         blockchain,
+		readOnlyBlockchain: cfg.readOnlyBlockchain,
+		dataSource:         dataSource,
+		newHeads:           feed.New[*core.Block](),
+		reorgFeed:          feed.New[*ReorgBlockRange](),
+
+		logger:   logger,
+		listener: &SelectiveListener{},
 	}
+
+	poller := preconfirmed.NewPoller(
+		dataSource,
+		// note(rdr): this doesn't make sense API wise, leaving for now not to break tests
+		preconfirmed.NewChainStorage(),
+		blockchain,
+		feed.New[*pending.PreConfirmed](),
+		&s.highestBlockHeader,
+		cfg.preConfirmedPollInterval,
+		s.logger,
+	)
+
+	// note(rdr): this doesn't make sense
+	// I have to do, so they both share s.highestBlockHeader
+	s.preConfirmedPoller = poller
+
 	return s
 }
 
@@ -503,7 +511,7 @@ func (s *Synchronizer) syncBlocks(syncCtx context.Context) {
 	go s.pollLatest(syncCtx)
 
 	pollPendingWg := &stdsync.WaitGroup{}
-	pollPendingWg.Go(func() { s.pollPendingData(streamCtx) })
+	pollPendingWg.Go(func() { s.pollPreConfirmedData(streamCtx) })
 
 	for {
 		select {
@@ -520,7 +528,7 @@ func (s *Synchronizer) syncBlocks(syncCtx context.Context) {
 				streamCtx, streamCancel = context.WithCancel(syncCtx)
 				nextHeight = s.nextHeight()
 				fetchers, verifiers = s.setupWorkers()
-				pollPendingWg.Go(func() { s.pollPendingData(streamCtx) })
+				pollPendingWg.Go(func() { s.pollPreConfirmedData(streamCtx) })
 				s.logger.Warn("Restarting sync process",
 					zap.Uint64("height", nextHeight),
 					zap.Bool("catchUpMode", s.catchUpMode),
@@ -619,8 +627,8 @@ func (s *Synchronizer) SubscribeReorg() ReorgSubscription {
 	return ReorgSubscription{s.reorgFeed.Subscribe()}
 }
 
-func (s *Synchronizer) SubscribePreConfirmed() PreConfirmedDataSubscription {
-	return PreConfirmedDataSubscription{s.preConfirmedDataFeed.Subscribe()}
+func (s *Synchronizer) SubscribePreConfirmed() preconfirmed.Subscription {
+	return s.preConfirmedPoller.Subscribe()
 }
 
 func (s *Synchronizer) pollLatest(ctx context.Context) {
@@ -645,44 +653,11 @@ func (s *Synchronizer) pollLatest(ctx context.Context) {
 }
 
 func (s *Synchronizer) PreConfirmedChain() (preconfirmed.ChainReader, error) {
-	height, err := s.blockchain.Height()
-	if err != nil {
-		return preconfirmed.ChainReader{}, err
-	}
-
-	snapshot := s.preConfirmed.SnapshotForBlock(height + 1)
-	if snapshot.Length() > 0 {
-		return snapshot, nil
-	}
-
-	head, err := s.blockchain.HeadsHeader()
-	if err != nil {
-		return preconfirmed.ChainReader{}, err
-	}
-
-	emptyPreConfirmed, err := MakeEmptyPreConfirmedForParent(s.blockchain, head)
-	if err != nil {
-		return preconfirmed.ChainReader{}, err
-	}
-
-	return preconfirmed.NewChain(&emptyPreConfirmed)
+	return s.preConfirmedPoller.PreConfirmedChain()
 }
 
-// pollPendingData launches the pre_confirmed chain poller.
-func (s *Synchronizer) pollPendingData(ctx context.Context) {
-	if s.preConfirmedPollInterval == 0 {
-		s.logger.Info("Pre-confirmed block polling is disabled")
-		return
-	}
-
-	poller := preconfirmed.NewPoller(
-		s.dataSource,
-		s.preConfirmed,
-		s.blockchain,
-		s.preConfirmedDataFeed,
-		&s.highestBlockHeader,
-		s.preConfirmedPollInterval,
-		s.logger,
-	)
-	poller.Run(ctx)
+// note(rdr): shouldn't it be called pollPreconfirmedData?
+// pollPreConfirmedData launches the pre_confirmed chain poller.
+func (s *Synchronizer) pollPreConfirmedData(ctx context.Context) {
+	s.preConfirmedPoller.Run(ctx)
 }

--- a/sync/sync.go
+++ b/sync/sync.go
@@ -97,7 +97,7 @@ func (n *NoopSynchronizer) SubscribeReorg() ReorgSubscription {
 }
 
 func (n *NoopSynchronizer) SubscribePreConfirmed() preconfirmed.Subscription {
-	return preconfirmed.Subscription{feed.New[*pending.PreConfirmed]().Subscribe()}
+	return preconfirmed.Subscription{Subscription: feed.New[*pending.PreConfirmed]().Subscribe()}
 }
 
 func (n *NoopSynchronizer) PreConfirmedChain() (preconfirmed.ChainReader, error) {

--- a/sync/sync_test.go
+++ b/sync/sync_test.go
@@ -443,9 +443,9 @@ func TestPreConfirmed(t *testing.T) {
 	client := feeder.NewTestClient(t, &networks.Mainnet)
 	gw := adaptfeeder.New(client)
 
-	// The stored-snapshot fast path is covered by
-	// TestPreConfirmedChainReturnsStoredSnapshot (preconfirmed_chain_test.go),
-	// which fills the storage through Run's pre-confirmed poller.
+	// The stored-snapshot fast path is covered by the poller tests in
+	// sync/preconfirmed/poller_test.go, which fill the chain through Run's
+	// pre-confirmed poller and read it back with PreConfirmedChain.
 
 	t.Run("Returns empty pre_confirmed when nothing stored", func(t *testing.T) {
 		t.Parallel()


### PR DESCRIPTION
<!-- pr-agent-generated -->
### **PR Type**
Enhancement


___

### **Description**
- Encapsulate pre-confirmed chain logic entirely within `preconfirmed.Poller`.

- Remove pre-confirmed state fields (feeds, storage) from `sync.Synchronizer` and delegate to the poller.

- Update RPC subscriptions, mocks, and sequencer to utilize the newly defined `preconfirmed.Subscription`.

- Relocate empty pre-confirmed block helper functions from `sync/helpers.go` to the `preconfirmed` package.


___



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Tests</strong></td><td><details><summary>7 files</summary><table>
<tr>
  <td><strong>mock_synchronizer.go</strong><dd><code>Update pre-confirmed methods return types in mock synchronizer</code></dd></td>
  <td><a href="https://github.com/NethermindEth/juno/pull/4060/files#diff-4d8175566892062667c9040cfe68f1dfd1f6035390e3acb3885ea55ade891ec9">+16/-24</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>handlers_test.go</strong><dd><code>Update subscription return types in RPC handlers tests</code>&nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/NethermindEth/juno/pull/4060/files#diff-de26f5ab2708bd4e6740e52175e6a225c1e915dabdd3c1ad2fbf1458ad4d2790">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>subscriptions_test.go</strong><dd><code>Adjust fake syncer pre-confirmed subscription return type</code></dd></td>
  <td><a href="https://github.com/NethermindEth/juno/pull/4060/files#diff-2eecdbfa68ff47709d182dcf48333157f1ccc2a67c21141beee1b0cd8e9554a5">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>subscriptions_test.go</strong><dd><code>Adjust fake syncer pre-confirmed subscription return type</code></dd></td>
  <td><a href="https://github.com/NethermindEth/juno/pull/4060/files#diff-f6d39cf0455686e1b134e130d436628b649d806da1c564dd39ab1e1194266bb1">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>subscriptions_test.go</strong><dd><code>Adjust fake syncer pre-confirmed subscription return type</code></dd></td>
  <td><a href="https://github.com/NethermindEth/juno/pull/4060/files#diff-f20f563c540c470ee8be09c5e5045f3f22347b96735f569106996861801e3598">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>poller_test.go</strong><dd><code>Refactor poller tests to use updated public API</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/NethermindEth/juno/pull/4060/files#diff-8a8ffc51e4122274fe05c830aa8102ffaf869dc4b6cb3f28dd07b119c27ef3f9">+294/-192</a></td>

</tr>

<tr>
  <td><strong>sync_test.go</strong><dd><code>Update comments regarding pre-confirmed chain test coverage</code></dd></td>
  <td><a href="https://github.com/NethermindEth/juno/pull/4060/files#diff-a172601c94b35aba185b9bb2ca9aebcaa7827d3374f3bcae044d5342386e590e">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Enhancement</strong></td><td><details><summary>5 files</summary><table>
<tr>
  <td><strong>sequencer.go</strong><dd><code>Change sequencer `SubscribePreConfirmed` return type</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/NethermindEth/juno/pull/4060/files#diff-c0284677090430e07395a7ea49f75c68e228f56ce91576e8de00c277ad13b217">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>data_source.go</strong><dd><code>Embed `preconfirmed.DataSource` interface within `DataSource`</code></dd></td>
  <td><a href="https://github.com/NethermindEth/juno/pull/4060/files#diff-3f8b350066ba4862ef7970a6e1fddab3029c087263277df874ef40528dfe5182">+2/-12</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>helpers.go</strong><dd><code>Remove `MakeEmptyPreConfirmedForParent` function (moved to poller)</code></dd></td>
  <td><a href="https://github.com/NethermindEth/juno/pull/4060/files#diff-77ea214b9eba697f70bed6984f706a36af2c6caca78627eecca98f7bf7c65f17">+2/-42</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>poller.go</strong><dd><code>Encapsulate state, feeds, and chain APIs into `Poller`</code>&nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/NethermindEth/juno/pull/4060/files#diff-7a40b50d7fa3df15162a912a2d8727ac225ffad7d9047f4e3127761ba2d9f642">+132/-26</a></td>

</tr>

<tr>
  <td><strong>sync.go</strong><dd><code>Delegate pre-confirmed operations to internal `preConfirmedPoller`</code></dd></td>
  <td><a href="https://github.com/NethermindEth/juno/pull/4060/files#diff-f6bc9238dbb193e597b81312026a71471a91a96b5689cb6929ff79857e3a7895">+88/-116</a></td>

</tr>
</table></details></td></tr><tr><td><strong>Miscellaneous</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>chain_storage.go</strong><dd><code>Add linter ignore directive for gosec false positive</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/NethermindEth/juno/pull/4060/files#diff-4ad8dd47f85a8db5cf3df7f9e06a13aa0fc4ff7721e5e924b92eee079a0af026">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___

