### PR TITLE
bench(corpus-gen): add support for VM based endpoints

### DIFF
--- a/bench/rpc/README.md
+++ b/bench/rpc/README.md
@@ -6,10 +6,9 @@ Sample a Starknet node into a seeded JSON-RPC corpus, then replay it with
 ## Methods
 
 Run `./build/corpus-gen --help` for the full list. One subcommand per method
-(`starknet_` prefix dropped), covering the read and trace APIs plus
-`starknet_getCompiledCasm`; the write and websocket APIs and the execution
-methods (`starknet_call`, `starknet_estimateFee`, `starknet_estimateMessageFee`,
-`starknet_simulateTransactions`, `starknet_getMessagesStatus`) are not
+(`starknet_` prefix dropped), covering the read, trace and execution APIs plus
+`starknet_getCompiledCasm`; the write and websocket APIs,
+`starknet_estimateMessageFee` and `starknet_getMessagesStatus` are not
 generated.
 
 Method-specific flags:
@@ -25,6 +24,42 @@ Method-specific flags:
 | `getEvents`       | `--addresses`                               | emitter addresses in the filter (0 = no address filter) |
 | `getEvents`       | `--keys`                                    | key counts per position, e.g. `1,0,2` (0 = wildcard; omit for no keys filter) |
 | `getStorageProof` | `--num-classes`/`--num-contracts`/`--num-keys` | trie members per request (queried at `latest`)  |
+| `estimateFee`/`simulateTransactions` | `--num-txs`          | broadcasted transactions per request, one value or `min,max` uniform draw (default 1) |
+| `estimateFee`/`simulateTransactions` | `--tx-types`         | transaction types to take from the block: `INVOKE`, `DECLARE`, `DEPLOY_ACCOUNT` (default `INVOKE,DEPLOY_ACCOUNT`) |
+| `estimateFee`     | `--skip-validate`                           | add `SKIP_VALIDATE` to `simulation_flags`          |
+| `simulateTransactions` | `--skip-validate`/`--skip-fee-charge`/`--return-initial-reads` | add those flags to `simulation_flags` |
+| execution subcommands | `--verify`                              | replay each sample against the source node and draw again when it fails (default on) |
+
+### Execution methods
+
+`estimateFee`, `simulateTransactions` and `call` sample a block N, then build the
+request from the transactions of block N+1, which ran on the state of block N:
+
+- `estimateFee` and `simulateTransactions` send a leading run of block N+1's
+  transactions. Real transactions keep their nonces and signatures valid, so
+  `SKIP_VALIDATE` stays optional. The run stops at the first transaction with a
+  version below `0x3` or a type outside `--tx-types`. A block whose run is
+  shorter than `--num-txs` is skipped.
+- `call` takes one call out of an account multicall in block N+1.
+- `--block-id latest` is not supported, because block N+1 must exist.
+- `--block-start` defaults to 10000 blocks below `--block-end`. Older ranges need
+  a node that keeps their state, and blocks before the Starknet 0.13.0 upgrade
+  carry no `0x3` transactions at all.
+- `--verify` keeps the corpus clean: `run.js` counts a JSON-RPC error as a
+  failure, and a real transaction can still revert or run short of resources
+  when it replays against the gas prices of block N. Generation therefore runs
+  execution work on the source node, and `--batch N` multiplies it by N. The
+  check only covers the source node: another node can still reject a request
+  that `--source-url` accepted.
+- `--tx-types` selects the cost class under measurement: `INVOKE` executes,
+  `DEPLOY_ACCOUNT` also runs `__validate_deploy__` and a deployment, `DECLARE`
+  compiles. It is not a filter over the block: a transaction of any other type
+  ends the run, so a narrow list draws more blocks per entry. Watch the
+  `sampling attempts` line that generation prints. `L1_HANDLER` and `DEPLOY`
+  are rejected, since the execution methods do not take them.
+- `DECLARE` sends a full contract class per transaction, which the node compiles
+  on every request. The corpus grows by ~100KB-1MB per entry, and the benchmark
+  then measures compilation instead of execution.
 
 ## Use
 

--- a/bench/rpc/cmd/corpus-gen/block_range_flags.go
+++ b/bench/rpc/cmd/corpus-gen/block_range_flags.go
@@ -1,17 +1,29 @@
 package main
 
 import (
+	"errors"
 	"fmt"
 	"math/rand/v2"
 
 	"github.com/spf13/cobra"
 )
 
-const blockEndFlag = "block-end"
+const (
+	blockStartFlag = "block-start"
+	blockEndFlag   = "block-end"
+)
+
+// defaultExecutionWindow keeps the default range of the execution methods near
+// the head, where the state they replay against is still available.
+const defaultExecutionWindow = 10000
 
 type blockRangeFlags struct {
 	Start uint64 `json:"start"`
 	End   uint64 `json:"end"`
+
+	// headroom holds blocks back from the top of the range; a sampler that
+	// reads block N+1 reserves one.
+	headroom uint64
 }
 
 func (f blockRangeFlags) sampleBlockNumber(rng *rand.Rand) uint64 {
@@ -21,7 +33,7 @@ func (f blockRangeFlags) sampleBlockNumber(rng *rand.Rand) uint64 {
 func (f *blockRangeFlags) bind(cmd *cobra.Command, client *rpcClient) {
 	cmd.Flags().Uint64Var(
 		&f.Start,
-		"block-start",
+		blockStartFlag,
 		0,
 		"Start block number to sample from (inclusive).",
 	)
@@ -36,14 +48,41 @@ func (f *blockRangeFlags) bind(cmd *cobra.Command, client *rpcClient) {
 		if err != nil {
 			return fmt.Errorf("fetch latest block number: %w", err)
 		}
+		maxEnd := latest - min(latest, f.headroom)
 		if !cmd.Flags().Changed(blockEndFlag) {
-			f.End = latest
+			f.End = maxEnd
 		}
-		if f.End > latest {
-			return fmt.Errorf("--block-end (%d) must be <= the latest block (%d)", f.End, latest)
+		if f.End > maxEnd {
+			if f.headroom == 0 {
+				return fmt.Errorf("--block-end (%d) must be <= the latest block (%d)", f.End, latest)
+			}
+			return fmt.Errorf(
+				"--block-end (%d) must be <= %d, so that the next block exists", f.End, maxEnd,
+			)
 		}
 		if f.Start > f.End {
 			return fmt.Errorf("--block-start (%d) must be <= --block-end (%d)", f.Start, f.End)
+		}
+		return nil
+	})
+}
+
+// bindExecutionRange binds the block range of an execution method: it reserves
+// the head block, since the transactions come from block N+1, and starts near
+// the head unless the caller sets --block-start.
+func bindExecutionRange(cmd *cobra.Command, client *rpcClient, args *blockIDArgs) {
+	args.headroom = 1
+	args.bind(cmd, client)
+	cmd.Flags().Lookup(blockStartFlag).Usage = fmt.Sprintf(
+		"Start block number to sample from (inclusive). Defaults to %d blocks below --block-end.",
+		defaultExecutionWindow,
+	)
+	chainPreRunE(cmd, func() error {
+		if args.BlockIDKind == blockIDLatest {
+			return errors.New("--block-id latest is not supported")
+		}
+		if !cmd.Flags().Changed(blockStartFlag) {
+			args.Start = args.End - min(args.End, defaultExecutionWindow)
 		}
 		return nil
 	})

--- a/bench/rpc/cmd/corpus-gen/block_range_flags_test.go
+++ b/bench/rpc/cmd/corpus-gen/block_range_flags_test.go
@@ -1,0 +1,41 @@
+package main
+
+import (
+	"net/http/httptest"
+	"strconv"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestExecutionRangeReservesHeadBlock(t *testing.T) {
+	server := httptest.NewServer(newFakeNode())
+	defer server.Close()
+
+	err := corpusGenError(
+		t, "estimateFee", "--block-end", strconv.Itoa(fakeLatestBlock), "--source-url", server.URL,
+	)
+	require.Contains(t, err, "--block-end (100) must be <= 99")
+}
+
+func TestExecutionRangeRejectsLatestBlockID(t *testing.T) {
+	server := httptest.NewServer(newFakeNode())
+	defer server.Close()
+
+	err := corpusGenError(t, "call", "--block-id", "latest", "--source-url", server.URL)
+	require.Contains(t, err, "--block-id latest is not supported")
+}
+
+func TestReadRangeKeepsHeadBlock(t *testing.T) {
+	server := httptest.NewServer(newFakeNode())
+	defer server.Close()
+
+	corpus := runCorpusGen(
+		t,
+		"getBlockWithTxHashes",
+		"--count", "1",
+		"--block-start", strconv.Itoa(fakeLatestBlock),
+		"--source-url", server.URL,
+	)
+	require.Len(t, corpus.Requests, 1)
+}

--- a/bench/rpc/cmd/corpus-gen/broadcasted_txs.go
+++ b/bench/rpc/cmd/corpus-gen/broadcasted_txs.go
@@ -1,0 +1,150 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"slices"
+	"strings"
+
+	"github.com/spf13/cobra"
+)
+
+const (
+	invokeTxType        = "INVOKE"
+	declareTxType       = "DECLARE"
+	deployAccountTxType = "DEPLOY_ACCOUNT"
+	deployTxType        = "DEPLOY"
+	l1HandlerTxType     = "L1_HANDLER"
+	broadcastTxVersion  = "0x3"
+
+	defaultNumTxs = 1
+)
+
+type broadcastedTxsArgs struct {
+	blockIDArgs
+	MinTxs  uint64     `json:"minTxs"`
+	MaxTxs  uint64     `json:"maxTxs"`
+	TxTypes []string   `json:"txTypes"`
+	Verify  verifyFlag `json:"verify"`
+}
+
+func (a *broadcastedTxsArgs) bind(cmd *cobra.Command, client *rpcClient) {
+	var numTxs []uint
+	cmd.Flags().UintSliceVar(
+		&numTxs,
+		"num-txs",
+		[]uint{defaultNumTxs},
+		"Broadcasted transactions per request: one value or min,max.",
+	)
+	cmd.Flags().StringSliceVar(
+		&a.TxTypes,
+		"tx-types",
+		[]string{invokeTxType, deployAccountTxType},
+		"Transaction types to take from the block: INVOKE, DECLARE or DEPLOY_ACCOUNT. "+
+			"A transaction of any other type ends the run, so a narrow list draws more blocks. "+
+			"DECLARE carries a full contract class, which the node compiles on every request.",
+	)
+	chainPreRunE(cmd, func() error {
+		if err := normalizeTxTypes(a.TxTypes); err != nil {
+			return err
+		}
+		var err error
+		a.MinTxs, a.MaxTxs, err = parseBounds("num-txs", numTxs)
+		return err
+	})
+	a.Verify.bind(cmd, client)
+	bindExecutionRange(cmd, client, &a.blockIDArgs)
+}
+
+// normalizeTxTypes upper-cases the types in place, and rejects the ones the
+// execution methods do not take.
+func normalizeTxTypes(txTypes []string) error {
+	for i, txType := range txTypes {
+		txTypes[i] = strings.ToUpper(txType)
+		switch txTypes[i] {
+		case invokeTxType, declareTxType, deployAccountTxType:
+		case deployTxType, l1HandlerTxType:
+			return fmt.Errorf("--tx-types %s cannot be broadcast", txTypes[i])
+		default:
+			return fmt.Errorf(
+				"--tx-types must be INVOKE, DECLARE or DEPLOY_ACCOUNT (got %q)", txType,
+			)
+		}
+	}
+	return nil
+}
+
+// sampleBroadcastedTxs takes a leading run of the transactions of block N+1 as
+// a broadcast against block N, whose state they ran on; real transactions keep
+// their nonces and signatures valid, so validation needs no skipping.
+func sampleBroadcastedTxs(
+	input samplerInput[broadcastedTxsArgs],
+) ([]broadcastedTx, blockID, error) {
+	args := input.args
+	blockNumber := args.sampleBlockNumber(input.rng)
+	want := int(uniformRange(input.rng, args.MinTxs, args.MaxTxs))
+
+	next := blockNumber + 1
+	block, err := input.client.blockWithTxs(input.ctx, next)
+	if err != nil {
+		return nil, nil, err
+	}
+	prefix := broadcastablePrefix(block.Transactions, args.TxTypes)
+	if len(prefix) < want {
+		return nil, nil, fmt.Errorf(
+			"broadcastable prefix of block %d is %d long, want %d: %w",
+			next, len(prefix), want, errResample,
+		)
+	}
+
+	prefix = prefix[:want]
+	for _, tx := range prefix {
+		stripResponseFields(tx)
+		if tx.text("type") != declareTxType {
+			continue
+		}
+		class, classErr := input.client.rawClassAt(input.ctx, next, tx.text("class_hash"))
+		if classErr != nil {
+			return nil, nil, classErr
+		}
+		tx["contract_class"] = class
+		delete(tx, "class_hash")
+	}
+
+	id, err := resolveBlockID(input.ctx, input.client, args.BlockIDKind, blockNumber)
+	if err != nil {
+		return nil, nil, err
+	}
+	return prefix, id, nil
+}
+
+// text returns the named field of tx, or "" when the field is absent.
+func (tx broadcastedTx) text(field string) string {
+	var value string
+	if err := json.Unmarshal(tx[field], &value); err != nil {
+		return ""
+	}
+	return value
+}
+
+// broadcastablePrefix returns the leading run of txs of the wanted types; a
+// contiguous prefix keeps the nonce of every sender in order.
+func broadcastablePrefix(txs []broadcastedTx, txTypes []string) []broadcastedTx {
+	for i, tx := range txs {
+		if !broadcastable(tx, txTypes) {
+			return txs[:i]
+		}
+	}
+	return txs
+}
+
+func broadcastable(tx broadcastedTx, txTypes []string) bool {
+	return tx.text("version") == broadcastTxVersion && slices.Contains(txTypes, tx.text("type"))
+}
+
+// stripResponseFields removes the fields that responses carry but broadcasts
+// do not; the node derives the deploy account address from the other fields.
+func stripResponseFields(tx broadcastedTx) {
+	delete(tx, "transaction_hash")
+	delete(tx, "contract_address")
+}

--- a/bench/rpc/cmd/corpus-gen/broadcasted_txs_test.go
+++ b/bench/rpc/cmd/corpus-gen/broadcasted_txs_test.go
@@ -1,0 +1,144 @@
+package main
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	invokeTx        = `{"type":"INVOKE","version":"0x3"}`
+	deployAccountTx = `{"type":"DEPLOY_ACCOUNT","version":"0x3"}`
+	declareTx       = `{"type":"DECLARE","version":"0x3"}`
+	l1HandlerTx     = `{"type":"L1_HANDLER","version":"0x0"}`
+	preV3InvokeTx   = `{"type":"INVOKE","version":"0x1"}`
+)
+
+func TestBroadcastablePrefix(t *testing.T) {
+	defaultTypes := []string{invokeTxType, deployAccountTxType}
+
+	tests := []struct {
+		name    string
+		txs     []string
+		txTypes []string
+		want    int
+	}{
+		{
+			name:    "all broadcastable",
+			txs:     []string{invokeTx, deployAccountTx},
+			txTypes: defaultTypes,
+			want:    2,
+		},
+		{
+			name:    "stops at l1 handler",
+			txs:     []string{invokeTx, l1HandlerTx, invokeTx},
+			txTypes: defaultTypes,
+			want:    1,
+		},
+		{
+			name:    "stops at pre-v3 transaction",
+			txs:     []string{invokeTx, preV3InvokeTx},
+			txTypes: defaultTypes,
+			want:    1,
+		},
+		{
+			name:    "stops at unlisted declare",
+			txs:     []string{invokeTx, declareTx, invokeTx},
+			txTypes: defaultTypes,
+			want:    1,
+		},
+		{
+			name:    "keeps listed declare",
+			txs:     []string{invokeTx, declareTx, invokeTx},
+			txTypes: []string{invokeTxType, declareTxType},
+			want:    3,
+		},
+		{
+			name:    "stops at unlisted deploy account",
+			txs:     []string{invokeTx, deployAccountTx},
+			txTypes: []string{invokeTxType},
+			want:    1,
+		},
+		{
+			name:    "first transaction not broadcastable",
+			txs:     []string{l1HandlerTx, invokeTx},
+			txTypes: defaultTypes,
+			want:    0,
+		},
+		{
+			name:    "empty block",
+			txs:     nil,
+			txTypes: defaultTypes,
+			want:    0,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			txs := make([]broadcastedTx, len(test.txs))
+			for i, encoded := range test.txs {
+				txs[i] = txFrom(t, encoded)
+			}
+			require.Len(t, broadcastablePrefix(txs, test.txTypes), test.want)
+		})
+	}
+}
+
+func TestTxTypesRejectsUnknownType(t *testing.T) {
+	err := corpusGenError(t, "estimateFee", "--tx-types", "INVOKE_FUNCTION")
+	require.Contains(t, err, `--tx-types must be INVOKE, DECLARE or DEPLOY_ACCOUNT (got "INVOKE_FUNCTION")`)
+}
+
+func TestTxTypesRejectsL1Handler(t *testing.T) {
+	err := corpusGenError(t, "simulateTransactions", "--tx-types", "invoke,l1_handler")
+	require.Contains(t, err, "--tx-types L1_HANDLER cannot be broadcast")
+}
+
+func TestStripResponseFields(t *testing.T) {
+	tx := txFrom(t, `{
+		"type": "DEPLOY_ACCOUNT",
+		"transaction_hash": "0x1",
+		"contract_address": "0x2",
+		"class_hash": "0x3"
+	}`)
+
+	stripResponseFields(tx)
+
+	require.NotContains(t, tx, "transaction_hash")
+	require.NotContains(t, tx, "contract_address")
+	require.Contains(t, tx, "class_hash")
+}
+
+func txFrom(t *testing.T, encoded string) broadcastedTx {
+	t.Helper()
+	var tx broadcastedTx
+	require.NoError(t, json.Unmarshal([]byte(encoded), &tx))
+	return tx
+}
+
+func TestExecutionParamsKeepEmptyFlags(t *testing.T) {
+	estimateFee, err := json.Marshal(estimateFeeParams{
+		Request:         []broadcastedTx{},
+		SimulationFlags: []string{},
+		BlockID:         blockNumberID{7},
+	})
+	require.NoError(t, err)
+	require.JSONEq(
+		t,
+		`{"request":[],"simulation_flags":[],"block_id":{"block_number":7}}`,
+		string(estimateFee),
+	)
+
+	simulate, err := json.Marshal(simulateTxsParams{
+		BlockID:         blockNumberID{7},
+		Transactions:    []broadcastedTx{},
+		SimulationFlags: []string{},
+	})
+	require.NoError(t, err)
+	require.JSONEq(
+		t,
+		`{"block_id":{"block_number":7},"transactions":[],"simulation_flags":[]}`,
+		string(simulate),
+	)
+}

--- a/bench/rpc/cmd/corpus-gen/call.go
+++ b/bench/rpc/cmd/corpus-gen/call.go
@@ -1,0 +1,111 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"strconv"
+
+	"github.com/spf13/cobra"
+)
+
+type callArgs struct {
+	blockIDArgs
+	Verify verifyFlag `json:"verify"`
+}
+
+func (a *callArgs) bind(cmd *cobra.Command, client *rpcClient) {
+	a.Verify.bind(cmd, client)
+	bindExecutionRange(cmd, client, &a.blockIDArgs)
+}
+
+// callSampler turns one call of an account multicall in block N+1 into a
+// request against block N, the state that call ran on.
+func callSampler(input samplerInput[callArgs]) (callParams, error) {
+	blockNumber := input.args.sampleBlockNumber(input.rng)
+	next := blockNumber + 1
+	block, err := input.client.blockWithTxs(input.ctx, next)
+	if err != nil {
+		return callParams{}, err
+	}
+
+	call, err := pickRandom(input.rng, invokeCalls(block.Transactions))
+	if err != nil {
+		return callParams{}, fmt.Errorf("no account multicall in block %d: %w", next, err)
+	}
+	id, err := resolveBlockID(input.ctx, input.client, input.args.BlockIDKind, blockNumber)
+	if err != nil {
+		return callParams{}, err
+	}
+
+	params := callParams{Request: call, BlockID: id}
+	if input.args.Verify {
+		if err := verify(input.ctx, input.client, input.method, params); err != nil {
+			return callParams{}, err
+		}
+	}
+	return params, nil
+}
+
+// callHeaderFields counts the felts that precede a call's arguments in an
+// account multicall: target address, selector and argument count.
+const callHeaderFields = 3
+
+// multicallCalls splits an account invoke's calldata into the calls it carries,
+// and returns nil for anything that is not the Cairo 1 multicall layout.
+func multicallCalls(calldata []string) []functionCall {
+	if len(calldata) == 0 {
+		return nil
+	}
+	count, ok := feltToUint(calldata[0])
+	if !ok || count > uint64((len(calldata)-1)/callHeaderFields) {
+		return nil
+	}
+
+	calls := make([]functionCall, count)
+	next := 1
+	for i := range calls {
+		if len(calldata)-next < callHeaderFields {
+			return nil
+		}
+		args, ok := feltToUint(calldata[next+2])
+		if !ok || args > uint64(len(calldata)) {
+			return nil
+		}
+		start := next + callHeaderFields
+		end := start + int(args)
+		if end > len(calldata) {
+			return nil
+		}
+		calls[i] = functionCall{
+			ContractAddress:    calldata[next],
+			EntryPointSelector: calldata[next+1],
+			Calldata:           calldata[start:end],
+		}
+		next = end
+	}
+	if next != len(calldata) {
+		return nil
+	}
+	return calls
+}
+
+// invokeCalls lists the calls carried by the invoke transactions of a block.
+func invokeCalls(txs []broadcastedTx) []functionCall {
+	var calls []functionCall
+	for _, tx := range txs {
+		if tx.text("type") != invokeTxType {
+			continue
+		}
+		var calldata []string
+		if err := json.Unmarshal(tx["calldata"], &calldata); err != nil {
+			continue
+		}
+		calls = append(calls, multicallCalls(calldata)...)
+	}
+	return calls
+}
+
+func feltToUint(value string) (uint64, bool) {
+	parsed, err := strconv.ParseUint(value, 0, 64)
+	return parsed, err == nil
+}

--- a/bench/rpc/cmd/corpus-gen/call_test.go
+++ b/bench/rpc/cmd/corpus-gen/call_test.go
@@ -1,0 +1,110 @@
+package main
+
+import (
+	"encoding/json"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestMulticallCalls(t *testing.T) {
+	tests := []struct {
+		name     string
+		calldata []string
+		want     []functionCall
+	}{
+		{
+			name:     "two calls",
+			calldata: []string{"0x2", "0xa", "0xb", "0x2", "0x1", "0x2", "0xc", "0xd", "0x0"},
+			want: []functionCall{
+				{
+					ContractAddress:    "0xa",
+					EntryPointSelector: "0xb",
+					Calldata:           []string{"0x1", "0x2"},
+				},
+				{
+					ContractAddress:    "0xc",
+					EntryPointSelector: "0xd",
+					Calldata:           []string{},
+				},
+			},
+		},
+		{
+			name:     "no calls",
+			calldata: []string{"0x0"},
+			want:     []functionCall{},
+		},
+		{
+			name:     "empty calldata",
+			calldata: nil,
+			want:     nil,
+		},
+		{
+			name:     "count exceeds calldata",
+			calldata: []string{"0x9", "0xa", "0xb", "0x0"},
+			want:     nil,
+		},
+		{
+			name:     "args exceed calldata",
+			calldata: []string{"0x1", "0xa", "0xb", "0x4", "0x1"},
+			want:     nil,
+		},
+		{
+			name:     "trailing junk",
+			calldata: []string{"0x1", "0xa", "0xb", "0x0", "0xff"},
+			want:     nil,
+		},
+		{
+			name:     "count wider than uint64",
+			calldata: []string{"0x10000000000000000", "0xa", "0xb", "0x0"},
+			want:     nil,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			require.Equal(t, test.want, multicallCalls(test.calldata))
+		})
+	}
+}
+
+func TestInvokeCalls(t *testing.T) {
+	txs := []broadcastedTx{
+		txFrom(t, `{"type":"INVOKE","version":"0x3","calldata":["0x1","0xa","0xb","0x0"]}`),
+		txFrom(t, `{"type":"DEPLOY_ACCOUNT","version":"0x3"}`),
+		txFrom(t, `{"type":"INVOKE","version":"0x3","calldata":["0xff"]}`),
+		txFrom(t, `{"type":"INVOKE","version":"0x3","calldata":["0x1","0xc","0xd","0x1","0x9"]}`),
+	}
+
+	want := []functionCall{
+		{ContractAddress: "0xa", EntryPointSelector: "0xb", Calldata: []string{}},
+		{ContractAddress: "0xc", EntryPointSelector: "0xd", Calldata: []string{"0x9"}},
+	}
+	require.Equal(t, want, invokeCalls(txs))
+}
+
+func TestCallCorpus(t *testing.T) {
+	node := newFakeNode(fakeInvokeTx, fakeL1HandlerTx)
+	server := httptest.NewServer(node)
+	defer server.Close()
+
+	corpus := runCorpusGen(t, "call", "--count", "1", "--source-url", server.URL)
+
+	require.Len(t, corpus.Requests, 1)
+	entry := corpus.Requests[0]
+	require.Equal(t, "starknet_call", entry.Method)
+
+	var params struct {
+		Request functionCall `json:"request"`
+	}
+	require.NoError(t, json.Unmarshal(entry.Params, &params))
+
+	want := functionCall{
+		ContractAddress:    "0xa",
+		EntryPointSelector: "0xb",
+		Calldata:           []string{},
+	}
+	require.Equal(t, want, params.Request)
+	require.Equal(t, 1, node.verifications())
+}

--- a/bench/rpc/cmd/corpus-gen/client.go
+++ b/bench/rpc/cmd/corpus-gen/client.go
@@ -174,3 +174,28 @@ func (c *rpcClient) blockWithReceipts(
 		blockIDParams{BlockID: blockNumberID{blockNumber}},
 	)
 }
+
+// blockWithTxs asks for proof facts as well, since they feed the invoke
+// transaction hash that validation checks.
+func (c *rpcClient) blockWithTxs(ctx context.Context, blockNumber uint64) (fullTxsBlock, error) {
+	return c.rpcCall[fullTxsBlock](
+		ctx,
+		"starknet_getBlockWithTxs",
+		blockIDParams{
+			BlockID:       blockNumberID{blockNumber},
+			ResponseFlags: []string{includeProofFactsFlag},
+		},
+	)
+}
+
+func (c *rpcClient) rawClassAt(
+	ctx context.Context,
+	blockNumber uint64,
+	classHash string,
+) (json.RawMessage, error) {
+	return c.rpcCall[json.RawMessage](
+		ctx,
+		"starknet_getClass",
+		classAtBlockParams{BlockID: blockNumberID{blockNumber}, ClassHash: classHash},
+	)
+}

--- a/bench/rpc/cmd/corpus-gen/estimate_fee.go
+++ b/bench/rpc/cmd/corpus-gen/estimate_fee.go
@@ -1,0 +1,32 @@
+package main
+
+import "github.com/spf13/cobra"
+
+type estimateFeeArgs struct {
+	broadcastedTxsArgs
+	EstimateFlags estimateFlags `json:"estimateFlags"`
+}
+
+func (a *estimateFeeArgs) bind(cmd *cobra.Command, client *rpcClient) {
+	a.EstimateFlags.bind(cmd, client)
+	a.broadcastedTxsArgs.bind(cmd, client)
+}
+
+func estimateFeeSampler(input samplerInput[estimateFeeArgs]) (estimateFeeParams, error) {
+	txs, id, err := sampleBroadcastedTxs(input.rebindArgs(&input.args.broadcastedTxsArgs))
+	if err != nil {
+		return estimateFeeParams{}, err
+	}
+
+	params := estimateFeeParams{
+		Request:         txs,
+		SimulationFlags: input.args.EstimateFlags,
+		BlockID:         id,
+	}
+	if input.args.Verify {
+		if err := verify(input.ctx, input.client, input.method, params); err != nil {
+			return estimateFeeParams{}, err
+		}
+	}
+	return params, nil
+}

--- a/bench/rpc/cmd/corpus-gen/estimate_fee_test.go
+++ b/bench/rpc/cmd/corpus-gen/estimate_fee_test.go
@@ -1,0 +1,79 @@
+package main
+
+import (
+	"encoding/json"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestEstimateFeeCorpus(t *testing.T) {
+	node := newFakeNode(fakeInvokeTx, fakeL1HandlerTx)
+	server := httptest.NewServer(node)
+	defer server.Close()
+
+	corpus := runCorpusGen(t, "estimateFee", "--count", "1", "--source-url", server.URL)
+
+	require.Len(t, corpus.Requests, 1)
+	entry := corpus.Requests[0]
+	require.Equal(t, "starknet_estimateFee", entry.Method)
+
+	var params struct {
+		Request         []map[string]json.RawMessage `json:"request"`
+		SimulationFlags []string                     `json:"simulation_flags"`
+		BlockID         struct {
+			BlockNumber uint64 `json:"block_number"`
+		} `json:"block_id"`
+	}
+	require.NoError(t, json.Unmarshal(entry.Params, &params))
+
+	require.Len(t, params.Request, 1, "the l1 handler ends the broadcastable prefix")
+	require.NotContains(t, params.Request[0], "transaction_hash")
+	require.Contains(t, params.Request[0], "signature")
+	require.Equal(t, []string{}, params.SimulationFlags)
+
+	require.Equal(t, []uint64{params.BlockID.BlockNumber + 1}, node.blocksAsked())
+	require.Equal(t, []string{includeProofFactsFlag}, node.proofFactsFlags())
+	require.Equal(t, 1, node.verifications(), "the sample is replayed against the source node")
+}
+
+func TestEstimateFeeKeepsListedDeclare(t *testing.T) {
+	node := newFakeNode(fakeDeclareTx, fakeInvokeTx)
+	server := httptest.NewServer(node)
+	defer server.Close()
+
+	corpus := runCorpusGen(
+		t, "estimateFee", "--count", "1", "--tx-types", "invoke,declare", "--source-url", server.URL,
+	)
+
+	require.Len(t, corpus.Requests, 1)
+	var params struct {
+		Request []map[string]json.RawMessage `json:"request"`
+	}
+	require.NoError(t, json.Unmarshal(corpus.Requests[0].Params, &params))
+
+	var sampling struct {
+		TxTypes []string `json:"txTypes"`
+	}
+	require.NoError(t, json.Unmarshal(corpus.Meta.Sampling, &sampling))
+	require.Equal(t, []string{invokeTxType, declareTxType}, sampling.TxTypes)
+
+	require.Len(t, params.Request, 1)
+	declare := params.Request[0]
+	require.JSONEq(t, fakeContractClass, string(declare["contract_class"]))
+	require.NotContains(t, declare, "class_hash")
+	require.Contains(t, declare, "compiled_class_hash")
+	require.Equal(t, []string{"0x9"}, node.classesAsked())
+}
+
+func TestEstimateFeeStopsAtUnlistedType(t *testing.T) {
+	node := newFakeNode(fakeDeclareTx, fakeInvokeTx)
+	server := httptest.NewServer(node)
+	defer server.Close()
+
+	err := corpusGenError(t, "estimateFee", "--count", "1", "--source-url", server.URL)
+
+	require.Contains(t, err, "is 0 long, want 1")
+	require.Empty(t, node.classesAsked())
+}

--- a/bench/rpc/cmd/corpus-gen/execution_test.go
+++ b/bench/rpc/cmd/corpus-gen/execution_test.go
@@ -1,0 +1,184 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"net/http"
+	"slices"
+	"strconv"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	fakeLatestBlock = 100
+
+	fakeInvokeTx = `{
+		"transaction_hash": "0x1",
+		"type": "INVOKE",
+		"version": "0x3",
+		"nonce": "0x7",
+		"sender_address": "0x2",
+		"signature": ["0x3"],
+		"calldata": ["0x1", "0xa", "0xb", "0x0"]
+	}`
+	fakeDeclareTx = `{
+		"transaction_hash": "0x5",
+		"type": "DECLARE",
+		"version": "0x3",
+		"nonce": "0x8",
+		"sender_address": "0x2",
+		"signature": ["0x3"],
+		"class_hash": "0x9",
+		"compiled_class_hash": "0xc"
+	}`
+	fakeL1HandlerTx = `{"transaction_hash":"0x4","type":"L1_HANDLER","version":"0x0"}`
+
+	fakeContractClass = `{"sierra_program":["0x1"],"contract_class_version":"0.1.0"}`
+)
+
+type corpusEntry struct {
+	Method string          `json:"method"`
+	Params json.RawMessage `json:"params"`
+}
+
+type corpusFile struct {
+	Meta struct {
+		Sampling json.RawMessage `json:"sampling"`
+	} `json:"meta"`
+	Requests []corpusEntry `json:"requests"`
+}
+
+func runCorpusGen(t *testing.T, args ...string) corpusFile {
+	t.Helper()
+
+	var out bytes.Buffer
+	cmd := newRootCmd()
+	cmd.SetArgs(args)
+	cmd.SetOut(&out)
+	cmd.SetErr(io.Discard)
+	require.NoError(t, cmd.Execute())
+
+	var corpus corpusFile
+	require.NoError(t, json.Unmarshal(out.Bytes(), &corpus))
+	return corpus
+}
+
+func corpusGenError(t *testing.T, args ...string) string {
+	t.Helper()
+
+	cmd := newRootCmd()
+	cmd.SetArgs(args)
+	cmd.SetOut(io.Discard)
+	cmd.SetErr(io.Discard)
+
+	err := cmd.Execute()
+	require.Error(t, err)
+	return err.Error()
+}
+
+// fakeNode answers the calls corpus-gen makes while it samples an execution
+// request, and records what it was asked for.
+type fakeNode struct {
+	txs []string
+
+	mu       sync.Mutex
+	blocks   []uint64
+	flags    []string
+	classes  []string
+	verified int
+}
+
+func newFakeNode(txs ...string) *fakeNode {
+	return &fakeNode{txs: txs}
+}
+
+func (n *fakeNode) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	var req struct {
+		Method string `json:"method"`
+		Params struct {
+			BlockID struct {
+				BlockNumber uint64 `json:"block_number"`
+			} `json:"block_id"`
+			ResponseFlags []string `json:"response_flags"`
+			ClassHash     string   `json:"class_hash"`
+		} `json:"params"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	var result string
+	switch req.Method {
+	case "starknet_specVersion":
+		result = `"0.10.0"`
+	case "starknet_blockNumber":
+		result = strconv.Itoa(fakeLatestBlock)
+	case "starknet_getBlockWithTxs":
+		n.recordBlock(req.Params.BlockID.BlockNumber, req.Params.ResponseFlags)
+		result = `{"transactions":[` + strings.Join(n.txs, ",") + `]}`
+	case "starknet_getClass":
+		n.recordClass(req.Params.ClassHash)
+		result = fakeContractClass
+	case "starknet_estimateFee", "starknet_simulateTransactions":
+		n.recordVerification()
+		result = `[]`
+	case "starknet_call":
+		n.recordVerification()
+		result = `["0x0"]`
+	default:
+		http.Error(w, "unexpected method "+req.Method, http.StatusBadRequest)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	_, _ = io.WriteString(w, `{"jsonrpc":"2.0","id":1,"result":`+result+`}`)
+}
+
+func (n *fakeNode) recordBlock(blockNumber uint64, flags []string) {
+	n.mu.Lock()
+	defer n.mu.Unlock()
+	n.blocks = append(n.blocks, blockNumber)
+	n.flags = append(n.flags, flags...)
+}
+
+func (n *fakeNode) recordClass(classHash string) {
+	n.mu.Lock()
+	defer n.mu.Unlock()
+	n.classes = append(n.classes, classHash)
+}
+
+func (n *fakeNode) recordVerification() {
+	n.mu.Lock()
+	defer n.mu.Unlock()
+	n.verified++
+}
+
+func (n *fakeNode) blocksAsked() []uint64 {
+	n.mu.Lock()
+	defer n.mu.Unlock()
+	return slices.Clone(n.blocks)
+}
+
+func (n *fakeNode) classesAsked() []string {
+	n.mu.Lock()
+	defer n.mu.Unlock()
+	return slices.Clone(n.classes)
+}
+
+func (n *fakeNode) proofFactsFlags() []string {
+	n.mu.Lock()
+	defer n.mu.Unlock()
+	return slices.Clone(n.flags)
+}
+
+func (n *fakeNode) verifications() int {
+	n.mu.Lock()
+	defer n.mu.Unlock()
+	return n.verified
+}

--- a/bench/rpc/cmd/corpus-gen/main.go
+++ b/bench/rpc/cmd/corpus-gen/main.go
@@ -95,6 +95,9 @@ func newRootCmd() *cobra.Command {
 		cfg.newSampledCmd("starknet_getStorageAt", storageAtSampler),
 		cfg.newSampledCmd("starknet_getEvents", eventsSampler),
 		cfg.newSampledCmd("starknet_getStorageProof", storageProofSampler),
+		cfg.newSampledCmd("starknet_call", callSampler),
+		cfg.newSampledCmd("starknet_estimateFee", estimateFeeSampler),
+		cfg.newSampledCmd("starknet_simulateTransactions", simulateTxsSampler),
 	)
 	cmd.AddCommand(newNoParamCmds(
 		cfg,

--- a/bench/rpc/cmd/corpus-gen/request_flags.go
+++ b/bench/rpc/cmd/corpus-gen/request_flags.go
@@ -10,36 +10,55 @@ const (
 	includeProofFactsFlag      = "INCLUDE_PROOF_FACTS"
 	includeLastUpdateBlockFlag = "INCLUDE_LAST_UPDATE_BLOCK"
 	returnInitialReadsFlag     = "RETURN_INITIAL_READS"
+	skipValidateFlag           = "SKIP_VALIDATE"
+	skipFeeChargeFlag          = "SKIP_FEE_CHARGE"
 )
 
 type txnFlags []string
 
 func (f *txnFlags) bind(cmd *cobra.Command, _ *rpcClient) {
-	addRequestFlag(cmd, (*[]string)(f), includeProofFactsFlag)
+	addRequestFlags(cmd, (*[]string)(f), includeProofFactsFlag)
 }
 
 type storageAtFlags []string
 
 func (f *storageAtFlags) bind(cmd *cobra.Command, _ *rpcClient) {
-	addRequestFlag(cmd, (*[]string)(f), includeLastUpdateBlockFlag)
+	addRequestFlags(cmd, (*[]string)(f), includeLastUpdateBlockFlag)
 }
 
 type traceFlags []string
 
 func (f *traceFlags) bind(cmd *cobra.Command, _ *rpcClient) {
-	addRequestFlag(cmd, (*[]string)(f), returnInitialReadsFlag)
+	addRequestFlags(cmd, (*[]string)(f), returnInitialReadsFlag)
 }
 
-func addRequestFlag(cmd *cobra.Command, flags *[]string, flag string) {
+type estimateFlags []string
+
+func (f *estimateFlags) bind(cmd *cobra.Command, _ *rpcClient) {
+	addRequestFlags(cmd, (*[]string)(f), skipValidateFlag)
+}
+
+type simulateFlags []string
+
+func (f *simulateFlags) bind(cmd *cobra.Command, _ *rpcClient) {
+	addRequestFlags(cmd, (*[]string)(f), skipValidateFlag, skipFeeChargeFlag, returnInitialReadsFlag)
+}
+
+func addRequestFlags(cmd *cobra.Command, flags *[]string, names ...string) {
 	*flags = []string{}
-	include := cmd.Flags().Bool(
-		strings.ToLower(strings.ReplaceAll(flag, "_", "-")),
-		false,
-		"Add the "+flag+" flag to each request.",
-	)
+	includes := make([]*bool, len(names))
+	for i, name := range names {
+		includes[i] = cmd.Flags().Bool(
+			strings.ToLower(strings.ReplaceAll(name, "_", "-")),
+			false,
+			"Add the "+name+" flag to each request.",
+		)
+	}
 	chainPreRunE(cmd, func() error {
-		if *include {
-			*flags = []string{flag}
+		for i, include := range includes {
+			if *include {
+				*flags = append(*flags, names[i])
+			}
 		}
 		return nil
 	})

--- a/bench/rpc/cmd/corpus-gen/sampler.go
+++ b/bench/rpc/cmd/corpus-gen/sampler.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"math/rand/v2"
 	"strings"
+	"sync/atomic"
 
 	"github.com/spf13/cobra"
 )
@@ -18,6 +19,7 @@ type samplerInput[T any] struct {
 	rng    *rand.Rand
 	args   *T
 	cache  *sierraCache
+	method string
 }
 
 type sampler[T, R any] func(input samplerInput[T]) (R, error)
@@ -34,6 +36,7 @@ func (input samplerInput[T]) rebindArgs[U any](args *U) samplerInput[U] {
 		rng:    input.rng,
 		args:   args,
 		cache:  input.cache,
+		method: input.method,
 	}
 }
 
@@ -60,6 +63,7 @@ func (cfg *rootConfig) newSampledCmd[T any, PT interface {
 	PT(args).bind(cmd, client)
 	cmd.RunE = func(cmd *cobra.Command, _ []string) error {
 		cache := newSierraCache()
+		var attempts atomic.Int64
 		gen := func(ctx context.Context, rng *rand.Rand) (any, error) {
 			input := samplerInput[T]{
 				ctx:    ctx,
@@ -67,14 +71,22 @@ func (cfg *rootConfig) newSampledCmd[T any, PT interface {
 				rng:    rng,
 				args:   args,
 				cache:  cache,
+				method: method,
 			}
-			result, err := resample(func() (R, error) { return sample(input) })
+			result, err := resample(func() (R, error) {
+				attempts.Add(1)
+				return sample(input)
+			})
 			if err != nil {
 				return nil, fmt.Errorf("%s: %w", method, err)
 			}
 			return result, nil
 		}
-		return runCorpus(cmd, cfg, client, method, args, gen)
+		if err := runCorpus(cmd, cfg, client, method, args, gen); err != nil {
+			return err
+		}
+		_, err := fmt.Fprintf(cmd.ErrOrStderr(), "sampling attempts: %d\n", attempts.Load())
+		return err
 	}
 	return cmd
 }
@@ -85,6 +97,7 @@ var errResample = errors.New("resample")
 // resample retries fn until it succeeds or fails with a non-errResample error.
 func resample[R any](fn func() (R, error)) (R, error) {
 	var zero R
+	var last error
 	for range maxResampleAttempts {
 		result, err := fn()
 		if err == nil {
@@ -93,8 +106,11 @@ func resample[R any](fn func() (R, error)) (R, error) {
 		if !errors.Is(err, errResample) {
 			return zero, err
 		}
+		last = err
 	}
-	return zero, fmt.Errorf("no candidate found after %d attempts", maxResampleAttempts)
+	return zero, fmt.Errorf(
+		"no candidate found after %d attempts: %w", maxResampleAttempts, last,
+	)
 }
 
 func commandName(method string) string {

--- a/bench/rpc/cmd/corpus-gen/simulate_transactions.go
+++ b/bench/rpc/cmd/corpus-gen/simulate_transactions.go
@@ -1,0 +1,32 @@
+package main
+
+import "github.com/spf13/cobra"
+
+type simulateTxsArgs struct {
+	broadcastedTxsArgs
+	SimulateFlags simulateFlags `json:"simulateFlags"`
+}
+
+func (a *simulateTxsArgs) bind(cmd *cobra.Command, client *rpcClient) {
+	a.SimulateFlags.bind(cmd, client)
+	a.broadcastedTxsArgs.bind(cmd, client)
+}
+
+func simulateTxsSampler(input samplerInput[simulateTxsArgs]) (simulateTxsParams, error) {
+	txs, id, err := sampleBroadcastedTxs(input.rebindArgs(&input.args.broadcastedTxsArgs))
+	if err != nil {
+		return simulateTxsParams{}, err
+	}
+
+	params := simulateTxsParams{
+		BlockID:         id,
+		Transactions:    txs,
+		SimulationFlags: input.args.SimulateFlags,
+	}
+	if input.args.Verify {
+		if err := verify(input.ctx, input.client, input.method, params); err != nil {
+			return simulateTxsParams{}, err
+		}
+	}
+	return params, nil
+}

--- a/bench/rpc/cmd/corpus-gen/simulate_transactions_test.go
+++ b/bench/rpc/cmd/corpus-gen/simulate_transactions_test.go
@@ -1,0 +1,33 @@
+package main
+
+import (
+	"encoding/json"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestSimulateTransactionsCorpus(t *testing.T) {
+	node := newFakeNode(fakeInvokeTx, fakeL1HandlerTx)
+	server := httptest.NewServer(node)
+	defer server.Close()
+
+	corpus := runCorpusGen(
+		t, "simulateTransactions", "--count", "1", "--source-url", server.URL, "--skip-fee-charge",
+	)
+
+	require.Len(t, corpus.Requests, 1)
+	entry := corpus.Requests[0]
+	require.Equal(t, "starknet_simulateTransactions", entry.Method)
+
+	var params struct {
+		Transactions    []map[string]json.RawMessage `json:"transactions"`
+		SimulationFlags []string                     `json:"simulation_flags"`
+	}
+	require.NoError(t, json.Unmarshal(entry.Params, &params))
+
+	require.Len(t, params.Transactions, 1)
+	require.Equal(t, []string{skipFeeChargeFlag}, params.SimulationFlags)
+	require.Equal(t, 1, node.verifications())
+}

--- a/bench/rpc/cmd/corpus-gen/types.go
+++ b/bench/rpc/cmd/corpus-gen/types.go
@@ -142,3 +142,36 @@ type receiptsBlock struct {
 		} `json:"receipt"`
 	} `json:"transactions"`
 }
+
+// Both execution methods take simulation_flags as a required param, so the
+// flag lists below marshal even when they are empty.
+type estimateFeeParams struct {
+	Request         []broadcastedTx `json:"request"`
+	SimulationFlags []string        `json:"simulation_flags"`
+	BlockID         blockID         `json:"block_id"`
+}
+
+type simulateTxsParams struct {
+	BlockID         blockID         `json:"block_id"`
+	Transactions    []broadcastedTx `json:"transactions"`
+	SimulationFlags []string        `json:"simulation_flags"`
+}
+
+type callParams struct {
+	Request functionCall `json:"request"`
+	BlockID blockID      `json:"block_id"`
+}
+
+type functionCall struct {
+	ContractAddress    string   `json:"contract_address"`
+	EntryPointSelector string   `json:"entry_point_selector"`
+	Calldata           []string `json:"calldata"`
+}
+
+// broadcastedTx is a sampled transaction kept as raw fields, so that felts
+// reach the node exactly as the source served them.
+type broadcastedTx map[string]json.RawMessage
+
+type fullTxsBlock struct {
+	Transactions []broadcastedTx `json:"transactions"`
+}

--- a/bench/rpc/cmd/corpus-gen/verify.go
+++ b/bench/rpc/cmd/corpus-gen/verify.go
@@ -1,0 +1,37 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+type verifyFlag bool
+
+func (f *verifyFlag) bind(cmd *cobra.Command, _ *rpcClient) {
+	cmd.Flags().BoolVar(
+		(*bool)(f),
+		"verify",
+		true,
+		"Replay each sampled request against the source node and draw again when it fails.",
+	)
+}
+
+// verify replays params against the source node, and asks for another draw when
+// the node rejects them; k6 counts json-rpc errors as failures, so a request
+// that reverts or runs out of resources would spoil the benchmark.
+func verify(ctx context.Context, client *rpcClient, method string, params any) error {
+	if _, err := client.rpcCall[json.RawMessage](ctx, method, params); err != nil {
+		var rpcErr *rpcError
+		// Starknet codes are positive; the reserved negative range reports a
+		// malformed request, which another draw cannot fix.
+		if errors.As(err, &rpcErr) && rpcErr.Code > 0 {
+			return fmt.Errorf("%w: %w", err, errResample)
+		}
+		return err
+	}
+	return nil
+}

--- a/bench/rpc/corpus/all.json
+++ b/bench/rpc/corpus/all.json
@@ -55,5 +55,13 @@
 
   "getEvents-blockNumber": "getEvents --block-id number",
   "getEvents-blockHash": "getEvents --block-id hash",
-  "getStorageProof": "getStorageProof"
+  "getStorageProof": "getStorageProof",
+
+  "call": "call --count 200",
+  "estimateFee": "estimateFee --count 200",
+  "estimateFee-skipValidate": "estimateFee --skip-validate --count 200",
+  "estimateFee-txs2": "estimateFee --num-txs 2 --count 200",
+  "simulateTransactions": "simulateTransactions --count 200",
+  "simulateTransactions-skipFeeCharge": "simulateTransactions --skip-fee-charge --count 200",
+  "simulateTransactions-initialReads": "simulateTransactions --return-initial-reads --count 200"
 }


### PR DESCRIPTION
<!-- pr-agent-generated -->
### **User description**
fixes: #4056


___

### **PR Type**
Enhancement, Tests


___

### **Description**
- Add execution endpoints sampling: `call`, `estimateFee`, `simulateTransactions`.

- Sample block N+1 transactions for block N execution.

- Add verification to replay samples against source node.

- Document new commands and update corpus target configs.


___



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>10 files</summary><table>
<tr>
  <td><strong>block_range_flags.go</strong><dd><code>Add execution range binding and headroom for blocks</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/NethermindEth/juno/pull/4061/files#diff-93d2c35c5c4062ff4cfe469fe803138d4e51c424078caf4839a30e805d9b7956">+44/-5</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>broadcasted_txs.go</strong><dd><code>Implement transaction sampling for broadcast endpoints</code>&nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/NethermindEth/juno/pull/4061/files#diff-dcb9bb2243c36697e7391a2e6e6db3adfb31b6c2a71fdcfcb8f61a3921708b90">+150/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>call.go</strong><dd><code>Implement starknet_call sampling from account multicalls</code>&nbsp; </dd></td>
  <td><a href="https://github.com/NethermindEth/juno/pull/4061/files#diff-8d9a715ef5b890fd64813b9e7d32fcd6a6a2c421aa064717b850c10a89844321">+117/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>client.go</strong><dd><code>Add blockWithTxs and rawClassAt RPC methods</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/NethermindEth/juno/pull/4061/files#diff-44fb8fbcaeb7154a2afff6a41f8e83a3c67e403f91fdd3b8b627329930067586">+25/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>estimate_fee.go</strong><dd><code>Implement starknet_estimateFee sampling logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/NethermindEth/juno/pull/4061/files#diff-0c7024e24eca1e830fd9d6a838b191a1eeaac01fbb563c965a2cb16b5cca7453">+32/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>request_flags.go</strong><dd><code>Add request flags for simulation endpoints</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/NethermindEth/juno/pull/4061/files#diff-220b56baa8edfd9d05e14704c3ded80fba09d81a907b9f01a1e6b46fe58873ca">+30/-11</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>sampler.go</strong><dd><code>Track and report total sampling attempts</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/NethermindEth/juno/pull/4061/files#diff-38b881639d1a0a1c5c2b0591a69ee379f543fa49f105fdab507d0c54559afc7e">+19/-3</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>simulate_transactions.go</strong><dd><code>Implement starknet_simulateTransactions sampling logic</code>&nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/NethermindEth/juno/pull/4061/files#diff-b14d91863cdb567604583c94ad0b5d864dc5395bb60012846528643fbd9d0380">+32/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>types.go</strong><dd><code>Add structures for execution parameters and calls</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/NethermindEth/juno/pull/4061/files#diff-b844945b2753ab5b32eccb6a952324469375eca006a85c3a85ce430567240023">+33/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>verify.go</strong><dd><code>Add verification replay mechanism for execution requests</code>&nbsp; </dd></td>
  <td><a href="https://github.com/NethermindEth/juno/pull/4061/files#diff-4f215a50adc6c10f9f87bb7d02b0dfe249b419c5b2fb789ea67db37b1e85deb6">+37/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>6 files</summary><table>
<tr>
  <td><strong>block_range_flags_test.go</strong><dd><code>Test execution block range constraints and logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/NethermindEth/juno/pull/4061/files#diff-1f6bd9849a3963745b237ca237b10e746f63726c9a905e50d39bd7e48da547a2">+41/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>broadcasted_txs_test.go</strong><dd><code>Test transaction broadcast prefixing and type filtering</code>&nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/NethermindEth/juno/pull/4061/files#diff-5ff54c7b6f67d6c03f04d8787942e55b8f851b3e8bfde2ccb5cddd1578c64aae">+146/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>call_test.go</strong><dd><code>Test starknet_call sampling and calldata extraction</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/NethermindEth/juno/pull/4061/files#diff-2485173515ea488cf1e5110b7d39fc24d7e353771af855ef9dc66885c2f2bc91">+110/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>estimate_fee_test.go</strong><dd><code>Test starknet_estimateFee corpus generation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/NethermindEth/juno/pull/4061/files#diff-0e597136a18e846e137aed4b5650cc2fe18bf6712c7592aba4fdce0ed0bcf49d">+79/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>execution_test.go</strong><dd><code>Add mock RPC node for execution method tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/NethermindEth/juno/pull/4061/files#diff-97e0ecf282ae45366fd8593de95fc15d07c81ee3607d4e815c430996bf060c97">+184/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>simulate_transactions_test.go</strong><dd><code>Test starknet_simulateTransactions corpus generation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/NethermindEth/juno/pull/4061/files#diff-884ebb39e0ac8252e1a729f6d307690b92d2649b7787b224c779ac4c5a870884">+33/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Configuration changes</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td><strong>main.go</strong><dd><code>Register new VM execution commands</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/NethermindEth/juno/pull/4061/files#diff-0610e2ef000a84a22e3e04c75f09467cf2113e2e7e9e44d70fc6997efe45da7e">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>all.json</strong><dd><code>Add corpus targets for the new execution commands</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/NethermindEth/juno/pull/4061/files#diff-9f1b8890392653ebb303cf092e76ebd1d76c67abfb9ad150bdb25cfb7f482f61">+9/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Documentation</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>README.md</strong><dd><code>Document execution subcommands and their flags</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/NethermindEth/juno/pull/4061/files#diff-4d9cb741ea2a49b897ce2341561fa10e4e6072e86a65e3181cae5fb3616b717e">+39/-4</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___

