### PR TITLE
fix(log): Errorf logged at info level and formatted args were not spread

### DIFF
--- a/utils/log/log.go
+++ b/utils/log/log.go
@@ -233,15 +233,15 @@ func NewZapLoggerWithCore(core zapcore.Core) *ZapLogger {
 }
 
 func (l *ZapLogger) Infof(msg string, args ...any) {
-	l.sugared.Infof(msg, args)
+	l.sugared.Infof(msg, args...)
 }
 
 func (l *ZapLogger) Errorf(msg string, args ...any) {
-	l.sugared.Infof(msg, args)
+	l.sugared.Errorf(msg, args...)
 }
 
 func (l *ZapLogger) Fatalf(msg string, args ...any) {
-	l.sugared.Fatalf(msg, args)
+	l.sugared.Fatalf(msg, args...)
 }
 
 func (l *ZapLogger) Debug(msg string, fields ...zap.Field) {

--- a/utils/log/log_test.go
+++ b/utils/log/log_test.go
@@ -494,3 +494,46 @@ func TestSanitizeString(t *testing.T) {
 		})
 	}
 }
+
+func TestFormattedMethods(t *testing.T) {
+	// Regression test: Infof/Errorf/Fatalf must spread args into the format call
+	// (args... not args) and log at their own level.
+	newLogger := func(t *testing.T) (*log.ZapLogger, *observer.ObservedLogs) {
+		t.Helper()
+		core, logs := observer.New(zapcore.DebugLevel)
+		return log.NewZapLoggerWithCore(core), logs
+	}
+
+	t.Run("Infof formats args at info level", func(t *testing.T) {
+		logger, logs := newLogger(t)
+		logger.Infof("block %d took %s", 42, "3ms")
+
+		require.Equal(t, 1, logs.Len())
+		entry := logs.All()[0]
+		assert.Equal(t, zapcore.InfoLevel, entry.Level)
+		assert.Equal(t, "block 42 took 3ms", entry.Message)
+	})
+
+	t.Run("Errorf formats args at error level", func(t *testing.T) {
+		logger, logs := newLogger(t)
+		logger.Errorf("failed %s: %v", "op", fmt.Errorf("boom"))
+
+		require.Equal(t, 1, logs.Len())
+		entry := logs.All()[0]
+		assert.Equal(t, zapcore.ErrorLevel, entry.Level)
+		assert.Equal(t, "failed op: boom", entry.Message)
+	})
+
+	t.Run("Fatalf formats args at fatal level", func(t *testing.T) {
+		logger, logs := newLogger(t)
+		// Replace os.Exit with a panic so the test survives.
+		logger = logger.WithOptions(zap.WithFatalHook(zapcore.WriteThenPanic))
+
+		assert.Panics(t, func() { logger.Fatalf("fatal %d %s", 1, "x") })
+
+		require.Equal(t, 1, logs.Len())
+		entry := logs.All()[0]
+		assert.Equal(t, zapcore.FatalLevel, entry.Level)
+		assert.Equal(t, "fatal 1 x", entry.Message)
+	})
+}


### PR DESCRIPTION
<!-- pr-agent-generated -->
### **User description**
Fixes two bugs in the `pebble.Logger` methods of `ZapLogger` (`utils/log/log.go`):

- `Errorf` called `sugared.Infof`, so every error emitted through this path was logged at INFO level and dropped entirely when the log level was set to `warn` or `error`.
- `Infof`, `Errorf` and `Fatalf` passed `args` instead of `args...`, so the whole variadic slice was handed to `fmt.Sprintf` as a single argument. A call like `Errorf("failed %s: %v", "op", err)` produced `failed [op boom]: %!v(MISSING)`.


___

### **PR Type**
Bug fix, Tests


___

### **Description**
- Fix error level.

- Spread method args.

- Add regression tests.


___



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>log</strong><dd><code>Fix level and args in Zap</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

utils/log

<ul><li>Changed to use <code>Errorf</code><br> <li> <code>Infof</code>, <code>Errorf</code>, and <code>Fatalf</code> now spread <code>args</code>.</ul>


</details>


  </td>
  <td><a href=""></a></td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>log</strong><dd><code>regression</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

utils/log

<ul><li>Added <code>TestFormattedMethods</code>.<br> <li> asserts log level and formatted message.<br> <li> fatal path handled with panic hook.</ul>


</details>


  </td>
  <td><a href=""></a></td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

